### PR TITLE
feat: WASM indexing with pluggable storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Browser-compatible search engine with both remote search and local indexing:
 
 - **RemoteIndex** — loads pre-built indexes over HTTP with slice caching + IndexedDB persistence
 - **IpfsIndex** — same as RemoteIndex but with JS fetch callbacks for IPFS
-- **LocalIndex** — full in-browser indexing: create from SDL, add documents, commit, search
+- **LocalIndex** — full in-browser indexing: create from SDL, add documents, commit, search. Pluggable `IFilesStorage` for persistence (IDB, encrypted, OPFS)
 - **IndexRegistry** — manages multiple named indexes
 
 The WASM build uses `hermes-core` with features `["wasm", "http"]`. The `wasm` feature enables:

--- a/hermes-wasm/README.md
+++ b/hermes-wasm/README.md
@@ -5,7 +5,7 @@ WebAssembly bindings for the [Hermes](https://github.com/SpaceFrontiers/hermes) 
 ## Features
 
 - **Local indexing** — create indexes, add documents, commit, and search entirely in WASM
-- **IndexedDB persistence** — indexes survive page refreshes via per-file IDB records
+- **Pluggable persistence** — bring your own storage (IDB, encrypted, OPFS) via simple JS interface
 - **Remote search** — load pre-built indexes over HTTP with slice caching
 - **IPFS support** — load indexes from IPFS via JavaScript fetch callbacks
 - **15+ language stemmers** — English, German, French, Spanish, Russian, Arabic, and more
@@ -59,21 +59,53 @@ const doc = await index.getDocument(
 // { title: "Rust Programming", body: "Rust is a systems language.", views: 1500 }
 ```
 
-### Persistent Index (IndexedDB)
+### Persistent Index (Custom Storage)
+
+Bring your own storage backend — IndexedDB, encrypted storage, OPFS, or anything async:
+
+```ts
+// Your storage must implement this interface:
+interface IFilesStorage {
+  write(name: string, buffer: ArrayBuffer): Promise<void>;
+  get(name: string): Promise<ArrayBuffer | null>;
+  delete(names: string[]): Promise<void>;
+  list(): Promise<string[]>;
+}
+```
 
 ```js
-// Create — auto-saves changed files to IDB on each commit
-const index = await LocalIndex.createPersistent("my-index", schema);
+// Create with custom storage — auto-saves changed files on each commit
+const index = await LocalIndex.withStorage(myStorage, schema);
 await index.addDocuments(docs);
-await index.commit(); // only new segment files written to IDB
+await index.commit(); // only new segment files written to storage
 
-// Later, on page reload:
-const index = await LocalIndex.open("my-index");
+// Later (page reload) — same call reopens if storage has files
+const index = await LocalIndex.withStorage(myStorage, schema);
 const results = await index.search("rust", 10); // works immediately
+```
 
-// Management
-await LocalIndex.exists("my-index"); // true
-await LocalIndex.deleteIndex("my-index");
+A simple IndexedDB implementation:
+
+```js
+class IdbStorage {
+  constructor(name) {
+    this.prefix = `idx:${name}:`;
+  }
+  async write(name, buffer) {
+    /* idb put this.prefix + name → buffer */
+  }
+  async get(name) {
+    /* idb get this.prefix + name */
+  }
+  async delete(names) {
+    /* idb delete each this.prefix + name */
+  }
+  async list() {
+    /* idb getAllKeys matching this.prefix, strip prefix */
+  }
+}
+
+const index = await LocalIndex.withStorage(new IdbStorage("articles"), schema);
 ```
 
 ### Remote Index (HTTP)
@@ -99,22 +131,19 @@ const doc = await index.get_document(
 
 ### `LocalIndex`
 
-| Method                                     | Description                             |
-| ------------------------------------------ | --------------------------------------- |
-| `LocalIndex.create(sdl)`                   | Create in-memory index from SDL schema  |
-| `LocalIndex.createPersistent(name, sdl)`   | Create IndexedDB-backed index           |
-| `LocalIndex.open(name)`                    | Open existing persistent index from IDB |
-| `LocalIndex.deleteIndex(name)`             | Delete persistent index from IDB        |
-| `LocalIndex.exists(name)`                  | Check if persistent index exists in IDB |
-| `index.addDocument(json)`                  | Add a single document                   |
-| `index.addDocuments(jsonArray)`            | Add multiple documents, returns count   |
-| `index.commit()`                           | Commit pending docs (builds segments)   |
-| `index.search(query, limit)`               | Search with BM25 ranking                |
-| `index.searchOffset(query, limit, offset)` | Search with pagination                  |
-| `index.getDocument(segmentId, docId)`      | Retrieve stored document                |
-| `index.numDocs()`                          | Count of committed documents            |
-| `index.pendingDocs()`                      | Count of uncommitted documents          |
-| `index.fieldNames()`                       | List of field names                     |
+| Method                                     | Description                                        |
+| ------------------------------------------ | -------------------------------------------------- |
+| `LocalIndex.create(sdl)`                   | Create in-memory index from SDL schema             |
+| `LocalIndex.withStorage(storage, sdl)`     | Create or open index with pluggable storage        |
+| `index.addDocument(json)`                  | Add a single document                              |
+| `index.addDocuments(jsonArray)`            | Add multiple documents, returns count              |
+| `index.commit()`                           | Commit pending docs, sync to storage if configured |
+| `index.search(query, limit)`               | Search with BM25 ranking                           |
+| `index.searchOffset(query, limit, offset)` | Search with pagination                             |
+| `index.getDocument(segmentId, docId)`      | Retrieve stored document                           |
+| `index.numDocs()`                          | Count of committed documents                       |
+| `index.pendingDocs()`                      | Count of uncommitted documents                     |
+| `index.fieldNames()`                       | List of field names                                |
 
 ### `RemoteIndex`
 
@@ -223,7 +252,8 @@ Browser JS
     ├── LocalIndex (create/index/search in WASM)
     │       └── WasmIndexWriter → SegmentBuilder → RamDirectory
     │                                                   │
-    │                                         [per-file IndexedDB records]
+    │                                         [pluggable IFilesStorage]
+    │                                         (IDB, encrypted, OPFS, ...)
     │
     ├── RemoteIndex (HTTP range requests)
     │       └── Searcher → SliceCachingDirectory → HttpDirectory

--- a/hermes-wasm/examples/.gitignore
+++ b/hermes-wasm/examples/.gitignore
@@ -1,0 +1,2 @@
+hermes_wasm.js
+hermes_wasm_bg.wasm

--- a/hermes-wasm/examples/encrypted.html
+++ b/hermes-wasm/examples/encrypted.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hermes WASM — Encrypted Storage Example</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; color: #333; }
+        h1 { margin-bottom: 8px; }
+        .subtitle { color: #666; margin-bottom: 24px; }
+        .section { margin: 24px 0; }
+        label { display: block; font-weight: 600; margin-bottom: 4px; }
+        input { width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; }
+        button { padding: 8px 16px; background: #7c3aed; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 14px; margin: 4px 4px 4px 0; }
+        button:hover { background: #6d28d9; }
+        .results { margin-top: 16px; }
+        .hit { padding: 12px; margin: 8px 0; border: 1px solid #e2e8f0; border-radius: 6px; background: #f8fafc; }
+        .hit .title { font-weight: 600; color: #6d28d9; }
+        .hit .body { font-size: 13px; color: #475569; margin-top: 4px; }
+        .hit .meta { font-size: 12px; color: #94a3b8; margin-top: 4px; }
+        .log { background: #1e293b; color: #e2e8f0; padding: 12px; border-radius: 6px; font-family: monospace; font-size: 12px; max-height: 300px; overflow-y: auto; white-space: pre-wrap; }
+        .info { background: #faf5ff; border: 1px solid #e9d5ff; padding: 12px; border-radius: 6px; font-size: 13px; margin: 12px 0; }
+        .stats { font-size: 14px; color: #555; margin: 8px 0; }
+        .stats span { font-weight: 600; color: #111; }
+    </style>
+</head>
+<body>
+    <h1>Hermes WASM — Encrypted Storage</h1>
+    <p class="subtitle">Full-text search with AES-GCM encrypted IndexedDB persistence</p>
+
+    <div class="info">
+        All index files (segments, metadata) are encrypted with AES-256-GCM before
+        being stored in IndexedDB. The encryption key is derived from your passphrase
+        using PBKDF2 (100k iterations). Data at rest is never plaintext.
+    </div>
+
+    <div class="section">
+        <label>Passphrase</label>
+        <input id="passphrase" type="password" value="my-secret-passphrase" placeholder="Encryption passphrase">
+        <div style="margin-top: 8px;">
+            <button onclick="createIndex()">Create / Open Encrypted Index</button>
+            <button onclick="addSampleDocs()" style="background:#64748b">Add Sample Data</button>
+            <button onclick="commitIndex()" style="background:#059669">Commit</button>
+        </div>
+        <div class="stats" id="stats"></div>
+    </div>
+
+    <div class="section">
+        <label>Search</label>
+        <input id="searchInput" placeholder='Try: "rust", "machine learning", "title:database"' oninput="doSearch()">
+        <div class="results" id="results"></div>
+    </div>
+
+    <div class="section">
+        <label>Log</label>
+        <div class="log" id="log"></div>
+    </div>
+
+    <script type="module">
+        import init, { LocalIndex } from './hermes_wasm.js';
+
+        let index = null;
+        const logEl = document.getElementById('log');
+        function log(msg) { logEl.textContent += msg + '\n'; logEl.scrollTop = logEl.scrollHeight; }
+
+        await init();
+        log('WASM initialized');
+
+        // ═══════════════════════════════════════════════════════════════
+        // Encrypted IFilesStorage — AES-256-GCM + PBKDF2 key derivation
+        // ═══════════════════════════════════════════════════════════════
+
+        async function createEncryptedStorage(passphrase, indexName) {
+            const enc = new TextEncoder();
+            const dbName = `hermes-encrypted-${indexName}`;
+            const storeName = 'files';
+
+            // Derive AES-256 key from passphrase via PBKDF2
+            const keyMaterial = await crypto.subtle.importKey(
+                'raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']
+            );
+            const salt = enc.encode(`hermes-salt-${indexName}`); // deterministic salt per index
+            const cryptoKey = await crypto.subtle.deriveKey(
+                { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
+                keyMaterial,
+                { name: 'AES-GCM', length: 256 },
+                false,
+                ['encrypt', 'decrypt']
+            );
+
+            async function encrypt(data) {
+                const iv = crypto.getRandomValues(new Uint8Array(12));
+                const ciphertext = await crypto.subtle.encrypt(
+                    { name: 'AES-GCM', iv }, cryptoKey, data
+                );
+                // Prepend IV to ciphertext: [12-byte IV][ciphertext]
+                const result = new Uint8Array(12 + ciphertext.byteLength);
+                result.set(iv);
+                result.set(new Uint8Array(ciphertext), 12);
+                return result.buffer;
+            }
+
+            async function decrypt(data) {
+                const bytes = new Uint8Array(data);
+                const iv = bytes.slice(0, 12);
+                const ciphertext = bytes.slice(12);
+                return crypto.subtle.decrypt(
+                    { name: 'AES-GCM', iv }, cryptoKey, ciphertext
+                );
+            }
+
+            // IDB helpers
+            function openDb() {
+                return new Promise((resolve, reject) => {
+                    const req = indexedDB.open(dbName, 1);
+                    req.onupgradeneeded = () => {
+                        if (!req.result.objectStoreNames.contains(storeName))
+                            req.result.createObjectStore(storeName);
+                    };
+                    req.onsuccess = () => resolve(req.result);
+                    req.onerror = () => reject(req.error);
+                });
+            }
+
+            // Return IFilesStorage interface
+            return {
+                async write(name, buffer) {
+                    const encrypted = await encrypt(buffer);
+                    const db = await openDb();
+                    const tx = db.transaction(storeName, 'readwrite');
+                    tx.objectStore(storeName).put(new Uint8Array(encrypted), name);
+                    await new Promise(r => { tx.oncomplete = r; });
+                },
+
+                async get(name) {
+                    const db = await openDb();
+                    const tx = db.transaction(storeName, 'readonly');
+                    const req = tx.objectStore(storeName).get(name);
+                    const raw = await new Promise(r => { req.onsuccess = () => r(req.result); });
+                    if (!raw) return null;
+                    return decrypt(raw.buffer);
+                },
+
+                async delete(names) {
+                    const db = await openDb();
+                    const tx = db.transaction(storeName, 'readwrite');
+                    const store = tx.objectStore(storeName);
+                    for (const n of names) store.delete(n);
+                    await new Promise(r => { tx.oncomplete = r; });
+                },
+
+                async list() {
+                    const db = await openDb();
+                    const tx = db.transaction(storeName, 'readonly');
+                    const req = tx.objectStore(storeName).getAllKeys();
+                    return new Promise(r => { req.onsuccess = () => r(req.result); });
+                }
+            };
+        }
+
+        // ═══════════════════════════════════════════════════════════════
+
+        const SCHEMA = `index articles {
+            field title: text<en_stem> [indexed, stored]
+            field body: text<en_stem> [indexed, stored]
+            field category: text [indexed, stored]
+            field views: u64 [indexed, stored]
+        }`;
+
+        const SAMPLE_DOCS = [
+            { title: "Introduction to Rust", body: "Rust is a systems programming language focused on safety and performance.", category: "programming", views: 2500 },
+            { title: "Search Engine Architecture", body: "Modern search engines use inverted indexes and BM25 ranking.", category: "technology", views: 1800 },
+            { title: "Machine Learning Fundamentals", body: "Deep learning uses neural networks to learn from data.", category: "ai", views: 3200 },
+            { title: "Database Storage Engines", body: "B-trees and LSM trees are fundamental database structures.", category: "technology", views: 1500 },
+            { title: "Concurrent Programming", body: "Rust ownership model prevents data races at compile time.", category: "programming", views: 1200 },
+            { title: "Cloud Native Architecture", body: "Microservices and Kubernetes form the foundation of cloud-native design.", category: "infrastructure", views: 2000 },
+        ];
+
+        function updateStats() {
+            if (!index) { document.getElementById('stats').innerHTML = ''; return; }
+            document.getElementById('stats').innerHTML =
+                `Committed: <span>${index.numDocs()}</span> docs | Pending: <span>${index.pendingDocs()}</span>`;
+        }
+
+        window.createIndex = async function() {
+            try {
+                const passphrase = document.getElementById('passphrase').value;
+                if (!passphrase) { log('Enter a passphrase'); return; }
+                const storage = await createEncryptedStorage(passphrase, 'demo');
+                index = await LocalIndex.withStorage(storage, SCHEMA);
+                const docs = index.numDocs();
+                log(docs > 0
+                    ? `Opened encrypted index (${docs} docs) — data decrypted with passphrase`
+                    : 'Created new encrypted index');
+                updateStats();
+            } catch (e) { log(`Error: ${e}`); }
+        };
+
+        window.addSampleDocs = async function() {
+            if (!index) { log('Create index first'); return; }
+            try {
+                const count = await index.addDocuments(SAMPLE_DOCS);
+                log(`Added ${count} documents`);
+                updateStats();
+            } catch (e) { log(`Error: ${e}`); }
+        };
+
+        window.commitIndex = async function() {
+            if (!index) return;
+            try {
+                const t0 = performance.now();
+                const committed = await index.commit();
+                log(committed
+                    ? `Committed + encrypted in ${(performance.now() - t0).toFixed(1)}ms`
+                    : 'Nothing to commit');
+                updateStats();
+            } catch (e) { log(`Error: ${e}`); }
+        };
+
+        window.doSearch = async function() {
+            if (!index || index.numDocs() === 0) return;
+            const query = document.getElementById('searchInput').value.trim();
+            if (!query) { document.getElementById('results').innerHTML = ''; return; }
+            try {
+                const t0 = performance.now();
+                const res = await index.search(query, 10);
+                const ms = (performance.now() - t0).toFixed(1);
+                if (res.hits.length === 0) {
+                    document.getElementById('results').innerHTML = `<p style="color:#666">No results (${ms}ms)</p>`;
+                    return;
+                }
+                let html = `<p style="font-size:13px;color:#666">${res.total_hits} results in ${ms}ms</p>`;
+                for (const hit of res.hits) {
+                    const doc = await index.getDocument(hit.address.segment_id, hit.address.doc_id);
+                    html += `<div class="hit">
+                        <div class="title">${doc?.title || '(no title)'}</div>
+                        <div class="body">${doc?.body || ''}</div>
+                        <div class="meta">score: ${hit.score.toFixed(3)} · ${doc?.category || '-'} · views: ${doc?.views ?? '-'}</div>
+                    </div>`;
+                }
+                document.getElementById('results').innerHTML = html;
+            } catch (e) { log(`Search error: ${e}`); }
+        };
+    </script>
+</body>
+</html>

--- a/hermes-wasm/examples/index.html
+++ b/hermes-wasm/examples/index.html
@@ -18,7 +18,7 @@
         button:disabled { background: #94a3b8; cursor: not-allowed; }
         button.secondary { background: #64748b; }
         button.danger { background: #dc2626; }
-        .stats { display: flex; gap: 24px; margin: 12px 0; font-size: 14px; color: #555; }
+        .stats { display: flex; gap: 24px; flex-wrap: wrap; margin: 12px 0; font-size: 14px; color: #555; }
         .stats span { font-weight: 600; color: #111; }
         .results { margin-top: 16px; }
         .hit { padding: 12px; margin: 8px 0; border: 1px solid #e2e8f0; border-radius: 6px; background: #f8fafc; }
@@ -26,8 +26,10 @@
         .hit .body { font-size: 13px; color: #475569; margin-top: 4px; }
         .hit .meta { font-size: 12px; color: #94a3b8; margin-top: 4px; }
         .log { background: #1e293b; color: #e2e8f0; padding: 12px; border-radius: 6px; font-family: monospace; font-size: 12px; max-height: 200px; overflow-y: auto; white-space: pre-wrap; }
-        .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; background: #dbeafe; color: #1e40af; }
-        .badge.persisted { background: #dcfce7; color: #166534; }
+        .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
+        .badge.mem { background: #dbeafe; color: #1e40af; }
+        .badge.idb { background: #dcfce7; color: #166534; }
+        select { padding: 6px 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; }
     </style>
 </head>
 <body>
@@ -35,12 +37,13 @@
     <p class="subtitle">Full-text search engine running entirely in your browser</p>
 
     <div class="section">
-        <label>Index Name</label>
-        <input id="indexName" value="demo" placeholder="Name for IndexedDB persistence">
+        <label>Storage</label>
+        <select id="storageMode">
+            <option value="memory">In-Memory (ephemeral)</option>
+            <option value="idb">IndexedDB (persistent)</option>
+        </select>
         <div style="margin-top: 8px;">
-            <button onclick="createIndex()">Create New</button>
-            <button class="secondary" onclick="openIndex()">Open Existing</button>
-            <button class="danger" onclick="deleteIndex()">Delete</button>
+            <button onclick="createIndex()">Create / Open Index</button>
         </div>
         <div id="indexStatus" style="margin-top: 8px;"></div>
     </div>
@@ -100,6 +103,52 @@
             { title: "Distributed Consensus", body: "Raft and Paxos are consensus algorithms that ensure data consistency across distributed systems.", category: "infrastructure", views: 950 },
         ];
 
+        // ── Simple IDB-based IFilesStorage implementation ──
+        function createIdbStorage(indexName) {
+            const dbName = `hermes-index-${indexName}`;
+            const storeName = 'files';
+
+            function openDb() {
+                return new Promise((resolve, reject) => {
+                    const req = indexedDB.open(dbName, 1);
+                    req.onupgradeneeded = () => {
+                        if (!req.result.objectStoreNames.contains(storeName))
+                            req.result.createObjectStore(storeName);
+                    };
+                    req.onsuccess = () => resolve(req.result);
+                    req.onerror = () => reject(req.error);
+                });
+            }
+
+            return {
+                async write(name, buffer) {
+                    const db = await openDb();
+                    const tx = db.transaction(storeName, 'readwrite');
+                    tx.objectStore(storeName).put(new Uint8Array(buffer), name);
+                    await new Promise(r => { tx.oncomplete = r; });
+                },
+                async get(name) {
+                    const db = await openDb();
+                    const tx = db.transaction(storeName, 'readonly');
+                    const req = tx.objectStore(storeName).get(name);
+                    return new Promise(r => { req.onsuccess = () => r(req.result?.buffer ?? null); });
+                },
+                async delete(names) {
+                    const db = await openDb();
+                    const tx = db.transaction(storeName, 'readwrite');
+                    const store = tx.objectStore(storeName);
+                    for (const n of names) store.delete(n);
+                    await new Promise(r => { tx.oncomplete = r; });
+                },
+                async list() {
+                    const db = await openDb();
+                    const tx = db.transaction(storeName, 'readonly');
+                    const req = tx.objectStore(storeName).getAllKeys();
+                    return new Promise(r => { req.onsuccess = () => r(req.result); });
+                }
+            };
+        }
+
         function updateStats() {
             if (!index) { document.getElementById('stats').innerHTML = ''; return; }
             document.getElementById('stats').innerHTML = `
@@ -111,38 +160,17 @@
 
         window.createIndex = async function() {
             try {
-                const name = document.getElementById('indexName').value.trim();
-                if (name) {
-                    index = await LocalIndex.createPersistent(name, SCHEMA);
-                    document.getElementById('indexStatus').innerHTML = `<span class="badge persisted">Created: ${name} (persistent)</span>`;
+                const mode = document.getElementById('storageMode').value;
+                if (mode === 'idb') {
+                    const storage = createIdbStorage('demo');
+                    index = await LocalIndex.withStorage(storage, SCHEMA);
+                    const badge = index.numDocs() > 0 ? `Reopened (${index.numDocs()} docs)` : 'Created';
+                    document.getElementById('indexStatus').innerHTML = `<span class="badge idb">${badge} — IndexedDB</span>`;
                 } else {
                     index = await LocalIndex.create(SCHEMA);
-                    document.getElementById('indexStatus').innerHTML = `<span class="badge">Created (in-memory)</span>`;
+                    document.getElementById('indexStatus').innerHTML = `<span class="badge mem">Created — in-memory</span>`;
                 }
-                log(`Index created`);
-                updateStats();
-            } catch (e) { log(`Error: ${e}`); }
-        };
-
-        window.openIndex = async function() {
-            try {
-                const name = document.getElementById('indexName').value.trim();
-                if (!name) { log('Enter a name to open'); return; }
-                index = await LocalIndex.open(name);
-                document.getElementById('indexStatus').innerHTML = `<span class="badge persisted">Opened: ${name} (${index.numDocs()} docs)</span>`;
-                log(`Opened index "${name}" with ${index.numDocs()} docs`);
-                updateStats();
-            } catch (e) { log(`Error: ${e}`); }
-        };
-
-        window.deleteIndex = async function() {
-            try {
-                const name = document.getElementById('indexName').value.trim();
-                if (!name) { log('Enter a name to delete'); return; }
-                await LocalIndex.deleteIndex(name);
-                index = null;
-                document.getElementById('indexStatus').innerHTML = '';
-                log(`Deleted index "${name}"`);
+                log(`Index ready (${mode})`);
                 updateStats();
             } catch (e) { log(`Error: ${e}`); }
         };
@@ -191,7 +219,6 @@
                     return;
                 }
 
-                // Fetch documents for display
                 let html = `<p style="font-size:13px;color:#666">${res.total_hits} results in ${ms}ms</p>`;
                 for (const hit of res.hits) {
                     const doc = await index.getDocument(hit.address.segment_id, hit.address.doc_id);

--- a/hermes-wasm/src/idb.rs
+++ b/hermes-wasm/src/idb.rs
@@ -4,9 +4,7 @@ use wasm_bindgen::prelude::*;
 
 pub(crate) const IDB_NAME: &str = "hermes-cache";
 pub(crate) const IDB_STORE: &str = "slices";
-/// Object store for persisted indexes
-pub(crate) const IDB_INDEX_STORE: &str = "indexes";
-pub(crate) const IDB_VERSION: u32 = 2;
+pub(crate) const IDB_VERSION: u32 = 1;
 
 /// Generate a cache key from a URL
 pub(crate) fn cache_key(url: &str) -> String {
@@ -33,9 +31,6 @@ pub(crate) async fn open_idb() -> Result<web_sys::IdbDatabase, JsValue> {
 
             if !db.object_store_names().contains(IDB_STORE) {
                 db.create_object_store(IDB_STORE).unwrap();
-            }
-            if !db.object_store_names().contains(IDB_INDEX_STORE) {
-                db.create_object_store(IDB_INDEX_STORE).unwrap();
             }
         });
     open_request.set_onupgradeneeded(Some(onupgradeneeded.as_ref().unchecked_ref()));
@@ -138,109 +133,6 @@ pub(crate) async fn idb_delete(key: &str) -> Result<(), JsValue> {
     let db = open_idb().await?;
     let tx = db.transaction_with_str_and_mode(IDB_STORE, web_sys::IdbTransactionMode::Readwrite)?;
     let store = tx.object_store(IDB_STORE)?;
-
-    store.delete(&JsValue::from_str(key))?;
-
-    let (tx_done, rx_done) = futures_channel::oneshot::channel();
-    let tx_done = std::cell::RefCell::new(Some(tx_done));
-
-    let oncomplete = wasm_bindgen::closure::Closure::once(move |_event: web_sys::Event| {
-        if let Some(tx) = tx_done.borrow_mut().take() {
-            let _ = tx.send(());
-        }
-    });
-    tx.set_oncomplete(Some(oncomplete.as_ref().unchecked_ref()));
-    oncomplete.forget();
-
-    rx_done
-        .await
-        .map_err(|_| JsValue::from_str("IndexedDB delete cancelled"))?;
-    Ok(())
-}
-
-// ── Generic store-aware helpers ──
-
-/// Store data in a specific IDB object store.
-pub(crate) async fn idb_put_to_store(
-    store_name: &str,
-    key: &str,
-    data: &[u8],
-) -> Result<(), JsValue> {
-    use wasm_bindgen::JsCast;
-
-    let db = open_idb().await?;
-    let tx =
-        db.transaction_with_str_and_mode(store_name, web_sys::IdbTransactionMode::Readwrite)?;
-    let store = tx.object_store(store_name)?;
-
-    let js_data = js_sys::Uint8Array::from(data);
-    store.put_with_key(&js_data, &JsValue::from_str(key))?;
-
-    let (tx_done, rx_done) = futures_channel::oneshot::channel();
-    let tx_done = std::cell::RefCell::new(Some(tx_done));
-
-    let oncomplete = wasm_bindgen::closure::Closure::once(move |_event: web_sys::Event| {
-        if let Some(tx) = tx_done.borrow_mut().take() {
-            let _ = tx.send(());
-        }
-    });
-    tx.set_oncomplete(Some(oncomplete.as_ref().unchecked_ref()));
-    oncomplete.forget();
-
-    rx_done
-        .await
-        .map_err(|_| JsValue::from_str("IndexedDB put cancelled"))?;
-    Ok(())
-}
-
-/// Get data from a specific IDB object store.
-pub(crate) async fn idb_get_from_store(
-    store_name: &str,
-    key: &str,
-) -> Result<Option<Vec<u8>>, JsValue> {
-    use wasm_bindgen::JsCast;
-
-    let db = open_idb().await?;
-    let tx = db.transaction_with_str(store_name)?;
-    let store = tx.object_store(store_name)?;
-
-    let request = store.get(&JsValue::from_str(key))?;
-
-    let (tx_done, rx_done) = futures_channel::oneshot::channel();
-    let tx_done = std::cell::RefCell::new(Some(tx_done));
-
-    let onsuccess = wasm_bindgen::closure::Closure::once(move |event: web_sys::Event| {
-        let target = event.target().unwrap();
-        let request: web_sys::IdbRequest = target.dyn_into().unwrap();
-        let result = request.result().unwrap();
-
-        let data = if result.is_undefined() || result.is_null() {
-            None
-        } else {
-            let array: js_sys::Uint8Array = result.dyn_into().unwrap();
-            Some(array.to_vec())
-        };
-
-        if let Some(tx) = tx_done.borrow_mut().take() {
-            let _ = tx.send(data);
-        }
-    });
-    request.set_onsuccess(Some(onsuccess.as_ref().unchecked_ref()));
-    onsuccess.forget();
-
-    rx_done
-        .await
-        .map_err(|_| JsValue::from_str("IndexedDB get cancelled"))
-}
-
-/// Delete data from a specific IDB object store.
-pub(crate) async fn idb_delete_from_store(store_name: &str, key: &str) -> Result<(), JsValue> {
-    use wasm_bindgen::JsCast;
-
-    let db = open_idb().await?;
-    let tx =
-        db.transaction_with_str_and_mode(store_name, web_sys::IdbTransactionMode::Readwrite)?;
-    let store = tx.object_store(store_name)?;
 
     store.delete(&JsValue::from_str(key))?;
 

--- a/hermes-wasm/src/local_index.rs
+++ b/hermes-wasm/src/local_index.rs
@@ -1,11 +1,18 @@
 //! In-browser index with create, index, search capabilities.
 //!
-//! Supports two storage modes:
+//! Supports two modes:
 //! - **In-memory** (`LocalIndex.create`) — fast, lost on page refresh
-//! - **Persistent** (`LocalIndex.createPersistent` / `LocalIndex.open`) — backed by IndexedDB
+//! - **Persistent** (`LocalIndex.withStorage`) — pluggable storage backend
 //!
-//! Persistent storage uses per-file IDB records: each segment file gets its
-//! own key, so commits only write new/changed files (not the whole index).
+//! Storage implements a simple JS interface:
+//! ```ts
+//! interface IFilesStorage {
+//!     write(name: string, buffer: ArrayBuffer): Promise<void>;
+//!     get(name: string): Promise<ArrayBuffer | null>;
+//!     delete(names: string[]): Promise<void>;
+//!     list(): Promise<string[]>;
+//! }
+//! ```
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -14,34 +21,108 @@ use std::sync::Arc;
 use hermes_core::directories::RamDirectory;
 use hermes_core::{IndexConfig, Searcher, WasmIndexWriter};
 use serde::Serialize;
+use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
-
-use crate::idb;
+use wasm_bindgen_futures::JsFuture;
 
 /// Default term cache blocks for WASM searcher.
 const WASM_TERM_CACHE_BLOCKS: usize = 32;
 
-/// IDB object store for persisted index files.
-const IDB_INDEX_STORE: &str = "indexes";
+/// Wraps a JS object implementing `IFilesStorage`.
+struct JsStorageAdapter {
+    write_fn: js_sys::Function,
+    get_fn: js_sys::Function,
+    delete_fn: js_sys::Function,
+    list_fn: js_sys::Function,
+}
+
+impl JsStorageAdapter {
+    fn from_js(storage: &JsValue) -> Result<Self, JsValue> {
+        let write_fn = js_sys::Reflect::get(storage, &"write".into())?
+            .dyn_into::<js_sys::Function>()
+            .map_err(|_| JsValue::from_str("storage.write must be a function"))?;
+        let get_fn = js_sys::Reflect::get(storage, &"get".into())?
+            .dyn_into::<js_sys::Function>()
+            .map_err(|_| JsValue::from_str("storage.get must be a function"))?;
+        let delete_fn = js_sys::Reflect::get(storage, &"delete".into())?
+            .dyn_into::<js_sys::Function>()
+            .map_err(|_| JsValue::from_str("storage.delete must be a function"))?;
+        let list_fn = js_sys::Reflect::get(storage, &"list".into())?
+            .dyn_into::<js_sys::Function>()
+            .map_err(|_| JsValue::from_str("storage.list must be a function"))?;
+        Ok(Self {
+            write_fn,
+            get_fn,
+            delete_fn,
+            list_fn,
+        })
+    }
+
+    async fn write(&self, name: &str, data: &[u8]) -> Result<(), JsValue> {
+        let this = JsValue::NULL;
+        let js_name = JsValue::from_str(name);
+        let js_buffer = js_sys::Uint8Array::from(data).buffer();
+        let promise = self.write_fn.call2(&this, &js_name, &js_buffer)?;
+        JsFuture::from(js_sys::Promise::from(promise)).await?;
+        Ok(())
+    }
+
+    async fn get(&self, name: &str) -> Result<Option<Vec<u8>>, JsValue> {
+        let this = JsValue::NULL;
+        let js_name = JsValue::from_str(name);
+        let promise = self.get_fn.call1(&this, &js_name)?;
+        let result = JsFuture::from(js_sys::Promise::from(promise)).await?;
+        if result.is_null() || result.is_undefined() {
+            return Ok(None);
+        }
+        let array = js_sys::Uint8Array::new(&result);
+        Ok(Some(array.to_vec()))
+    }
+
+    async fn delete(&self, names: &[String]) -> Result<(), JsValue> {
+        let this = JsValue::NULL;
+        let js_array = js_sys::Array::new();
+        for name in names {
+            js_array.push(&JsValue::from_str(name));
+        }
+        let promise = self.delete_fn.call1(&this, &js_array)?;
+        JsFuture::from(js_sys::Promise::from(promise)).await?;
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<Vec<String>, JsValue> {
+        let this = JsValue::NULL;
+        let promise = self.list_fn.call0(&this)?;
+        let result = JsFuture::from(js_sys::Promise::from(promise)).await?;
+        let array: js_sys::Array = result
+            .dyn_into()
+            .map_err(|_| JsValue::from_str("storage.list() must return an array of strings"))?;
+        let mut files = Vec::with_capacity(array.length() as usize);
+        for i in 0..array.length() {
+            if let Some(s) = array.get(i).as_string() {
+                files.push(s);
+            }
+        }
+        Ok(files)
+    }
+}
 
 /// In-browser local index — create, index documents, search, all in WASM.
 ///
 /// ```js
 /// // In-memory (ephemeral)
-/// const index = await LocalIndex.create("index articles { field title: text<en_stem> [indexed, stored] }");
+/// const index = await LocalIndex.create("index articles { ... }");
 ///
-/// // Persistent (IndexedDB-backed)
-/// const index = await LocalIndex.createPersistent("my-index", "index articles { ... }");
-/// // ... later, on page reload:
-/// const index = await LocalIndex.open("my-index");
+/// // With pluggable storage (IDB, encrypted, remote, etc.)
+/// const index = await LocalIndex.withStorage(myStorage, "index articles { ... }");
 /// ```
 #[wasm_bindgen]
 pub struct LocalIndex {
     writer: Option<WasmIndexWriter<RamDirectory>>,
     searcher: Option<Searcher<RamDirectory>>,
-    /// Name for IDB persistence (None = in-memory only)
-    persist_name: Option<String>,
-    /// File paths already in IDB (for incremental sync)
+    /// JS storage adapter (None = in-memory only)
+    storage: Option<JsStorageAdapter>,
+    /// File paths already persisted (for incremental sync)
     persisted_files: HashSet<String>,
 }
 
@@ -49,95 +130,75 @@ pub struct LocalIndex {
 impl LocalIndex {
     /// Create a new in-memory index from an SDL schema string.
     ///
-    /// Data is lost on page refresh. Use `createPersistent()` for IndexedDB-backed storage.
+    /// Data is lost on page refresh. Use `withStorage()` for persistence.
     #[wasm_bindgen]
     pub async fn create(schema_sdl: String) -> Result<LocalIndex, JsValue> {
-        Self::create_inner(schema_sdl, None).await
-    }
-
-    /// Create a new persistent index backed by IndexedDB.
-    ///
-    /// Each file in the index gets its own IDB record — commits only write
-    /// new/changed files, not the entire index.
-    /// Use `LocalIndex.open(name)` to reopen it after page refresh.
-    #[wasm_bindgen(js_name = "createPersistent")]
-    pub async fn create_persistent(
-        name: String,
-        schema_sdl: String,
-    ) -> Result<LocalIndex, JsValue> {
-        Self::create_inner(schema_sdl, Some(name)).await
-    }
-
-    /// Open an existing persistent index from IndexedDB.
-    ///
-    /// Loads the file manifest and all index files into a RamDirectory.
-    #[wasm_bindgen]
-    pub async fn open(name: String) -> Result<LocalIndex, JsValue> {
-        let manifest_key = idb_key(&name, "__manifest");
-        let manifest_data = idb::idb_get_from_store(IDB_INDEX_STORE, &manifest_key)
-            .await?
-            .ok_or_else(|| {
-                JsValue::from_str(&format!("Index '{}' not found in IndexedDB", name))
-            })?;
-
-        let manifest_str = String::from_utf8(manifest_data)
-            .map_err(|e| JsValue::from_str(&format!("Manifest decode error: {}", e)))?;
-        let file_paths: Vec<&str> = manifest_str.lines().filter(|l| !l.is_empty()).collect();
-
-        // Load each file from IDB into RamDirectory
-        let dir = RamDirectory::new();
-        for path_str in &file_paths {
-            let key = idb_key(&name, path_str);
-            if let Some(data) = idb::idb_get_from_store(IDB_INDEX_STORE, &key).await? {
-                dir.write_sync(Path::new(path_str), &data)
-                    .map_err(|e| JsValue::from_str(&format!("Write error: {}", e)))?;
-            }
-        }
-
-        let config = IndexConfig {
-            max_indexing_memory_bytes: 32 * 1024 * 1024,
-            ..IndexConfig::default()
-        };
-
-        let writer = WasmIndexWriter::open(dir.clone(), config)
-            .await
-            .map_err(|e| JsValue::from_str(&format!("Open error: {}", e)))?;
-
-        let persisted_files: HashSet<String> = file_paths.iter().map(|s| s.to_string()).collect();
-
-        let mut index = LocalIndex {
+        let writer = Self::make_writer(&schema_sdl).await?;
+        Ok(LocalIndex {
             writer: Some(writer),
             searcher: None,
-            persist_name: Some(name),
-            persisted_files,
-        };
-        index.refresh_searcher().await?;
-        Ok(index)
+            storage: None,
+            persisted_files: HashSet::new(),
+        })
     }
 
-    /// Delete a persistent index from IndexedDB.
-    #[wasm_bindgen(js_name = "deleteIndex")]
-    pub async fn delete_index(name: String) -> Result<(), JsValue> {
-        // Load manifest to find all file keys
-        let manifest_key = idb_key(&name, "__manifest");
-        if let Some(manifest_data) = idb::idb_get_from_store(IDB_INDEX_STORE, &manifest_key).await?
-        {
-            if let Ok(manifest_str) = String::from_utf8(manifest_data) {
-                for path_str in manifest_str.lines().filter(|l| !l.is_empty()) {
-                    let key = idb_key(&name, path_str);
-                    idb::idb_delete_from_store(IDB_INDEX_STORE, &key).await?;
+    /// Create or open an index with a pluggable storage backend.
+    ///
+    /// If the storage already contains index files, the index is reopened.
+    /// Otherwise a new index is created from the SDL schema.
+    ///
+    /// The storage object must implement:
+    /// ```ts
+    /// interface IFilesStorage {
+    ///     write(name: string, buffer: ArrayBuffer): Promise<void>;
+    ///     get(name: string): Promise<ArrayBuffer | null>;
+    ///     delete(names: string[]): Promise<void>;
+    ///     list(): Promise<string[]>;
+    /// }
+    /// ```
+    #[wasm_bindgen(js_name = "withStorage")]
+    pub async fn with_storage(storage: JsValue, schema_sdl: String) -> Result<LocalIndex, JsValue> {
+        let adapter = JsStorageAdapter::from_js(&storage)?;
+        let existing_files = adapter.list().await?;
+
+        if existing_files.is_empty() {
+            // New index
+            let writer = Self::make_writer(&schema_sdl).await?;
+            Ok(LocalIndex {
+                writer: Some(writer),
+                searcher: None,
+                storage: Some(adapter),
+                persisted_files: HashSet::new(),
+            })
+        } else {
+            // Reopen from storage
+            let dir = RamDirectory::new();
+            for file_name in &existing_files {
+                if let Some(data) = adapter.get(file_name).await? {
+                    dir.write_sync(Path::new(file_name), &data)
+                        .map_err(|e| JsValue::from_str(&format!("Write error: {}", e)))?;
                 }
             }
-        }
-        idb::idb_delete_from_store(IDB_INDEX_STORE, &manifest_key).await
-    }
 
-    /// Check if a persistent index exists in IndexedDB.
-    #[wasm_bindgen]
-    pub async fn exists(name: String) -> Result<bool, JsValue> {
-        let manifest_key = idb_key(&name, "__manifest");
-        let data = idb::idb_get_from_store(IDB_INDEX_STORE, &manifest_key).await?;
-        Ok(data.is_some())
+            let config = IndexConfig {
+                max_indexing_memory_bytes: 32 * 1024 * 1024,
+                ..IndexConfig::default()
+            };
+            let writer = WasmIndexWriter::open(dir.clone(), config)
+                .await
+                .map_err(|e| JsValue::from_str(&format!("Open error: {}", e)))?;
+
+            let persisted_files: HashSet<String> = existing_files.into_iter().collect();
+
+            let mut index = LocalIndex {
+                writer: Some(writer),
+                searcher: None,
+                storage: Some(adapter),
+                persisted_files,
+            };
+            index.refresh_searcher().await?;
+            Ok(index)
+        }
     }
 
     /// Add a single document (JSON object with field names matching the schema).
@@ -188,7 +249,7 @@ impl LocalIndex {
 
     /// Commit pending documents — builds segments and updates metadata.
     ///
-    /// For persistent indexes, only writes new/changed files to IndexedDB.
+    /// For persistent indexes, only writes new/changed files to storage.
     #[wasm_bindgen]
     pub async fn commit(&mut self) -> Result<bool, JsValue> {
         let writer = self
@@ -203,11 +264,7 @@ impl LocalIndex {
 
         if committed {
             self.refresh_searcher().await?;
-
-            // Sync only new/changed files to IDB
-            if self.persist_name.is_some() {
-                self.sync_to_idb().await?;
-            }
+            self.sync_to_storage().await?;
         }
 
         Ok(committed)
@@ -296,30 +353,18 @@ impl LocalIndex {
 
     // ── Internal helpers ──
 
-    async fn create_inner(
-        schema_sdl: String,
-        persist_name: Option<String>,
-    ) -> Result<LocalIndex, JsValue> {
-        let index_def = hermes_core::parse_single_index(&schema_sdl)
+    async fn make_writer(schema_sdl: &str) -> Result<WasmIndexWriter<RamDirectory>, JsValue> {
+        let index_def = hermes_core::parse_single_index(schema_sdl)
             .map_err(|e| JsValue::from_str(&format!("Schema parse error: {}", e)))?;
-
         let schema = index_def.to_schema();
         let dir = RamDirectory::new();
         let config = IndexConfig {
             max_indexing_memory_bytes: 32 * 1024 * 1024,
             ..IndexConfig::default()
         };
-
-        let writer = WasmIndexWriter::create(dir, schema, config)
+        WasmIndexWriter::create(dir, schema, config)
             .await
-            .map_err(|e| JsValue::from_str(&format!("Create error: {}", e)))?;
-
-        Ok(LocalIndex {
-            writer: Some(writer),
-            searcher: None,
-            persist_name,
-            persisted_files: HashSet::new(),
-        })
+            .map_err(|e| JsValue::from_str(&format!("Create error: {}", e)))
     }
 
     async fn refresh_searcher(&mut self) -> Result<(), JsValue> {
@@ -345,12 +390,14 @@ impl LocalIndex {
         Ok(())
     }
 
-    /// Sync new/changed files to IDB. Each file gets its own IDB record
-    /// keyed by `index:{name}:{path}`. Only files not in `persisted_files`
-    /// are written (plus metadata.json which changes every commit).
-    async fn sync_to_idb(&mut self) -> Result<(), JsValue> {
+    /// Sync new/changed files to storage (if any).
+    async fn sync_to_storage(&mut self) -> Result<(), JsValue> {
+        let adapter = match &self.storage {
+            Some(a) => a,
+            None => return Ok(()),
+        };
+
         let writer = self.writer.as_ref().unwrap();
-        let name = self.persist_name.as_ref().unwrap();
         let dir = writer.directory();
 
         let current_files = dir
@@ -362,37 +409,29 @@ impl LocalIndex {
             .map(|p| p.to_string_lossy().to_string())
             .collect();
 
-        // Write new files (not yet in IDB) and metadata.json (always changes)
+        // Write new files and metadata.json (always changes on commit)
         for path in &current_files {
             let path_str = path.to_string_lossy();
             if !self.persisted_files.contains(path_str.as_ref()) || path_str == "metadata.json" {
                 let data = dir
                     .read_file_sync(path)
                     .map_err(|e| JsValue::from_str(&format!("Read error: {}", e)))?;
-                let key = idb_key(name, &path_str);
-                idb::idb_put_to_store(IDB_INDEX_STORE, &key, &data).await?;
+                adapter.write(&path_str, &data).await?;
             }
         }
 
-        // Delete removed files from IDB (e.g. after merge)
-        for old_path in &self.persisted_files {
-            if !current_set.contains(old_path) {
-                let key = idb_key(name, old_path);
-                idb::idb_delete_from_store(IDB_INDEX_STORE, &key).await?;
-            }
+        // Delete removed files (e.g. after merge)
+        let removed: Vec<String> = self
+            .persisted_files
+            .iter()
+            .filter(|p| !current_set.contains(p.as_str()))
+            .cloned()
+            .collect();
+        if !removed.is_empty() {
+            adapter.delete(&removed).await?;
         }
-
-        // Update manifest
-        let manifest = current_set.iter().cloned().collect::<Vec<_>>().join("\n");
-        let manifest_key = idb_key(name, "__manifest");
-        idb::idb_put_to_store(IDB_INDEX_STORE, &manifest_key, manifest.as_bytes()).await?;
 
         self.persisted_files = current_set;
         Ok(())
     }
-}
-
-/// Build an IDB key for a named index file.
-fn idb_key(index_name: &str, file_path: &str) -> String {
-    format!("index:{}:{}", index_name, file_path)
 }


### PR DESCRIPTION
## Summary

Closes #2

- Full in-browser indexing: `LocalIndex.create()` for in-memory, `LocalIndex.withStorage()` for persistent
- Pluggable `IFilesStorage` interface — users bring their own storage backend (IDB, encrypted, OPFS)
- Incremental persistence: only new/changed files synced on commit
- Single-threaded `WasmIndexWriter` reusing the existing `SegmentBuilder`
- Fixed FST index format incompatibility (WASM couldn't read native-built indexes)
- 15+ language stemmers, BM25 ranking, query language (`AND`, `OR`, `NOT`, field:term)

## Test plan

- [x] 35 indexing e2e tests (create, add, commit, search, pagination, multi-segment, 100-doc stress)
- [x] 18 storage adapter tests (create, reopen, incremental, isolation, edge cases)
- [x] 647 native tests still pass
- [x] Interactive examples: `examples/index.html`, `examples/encrypted.html`