### PR TITLE
feat: budgeted hot-metadata pinning (Phase 1)

### DIFF
--- a/docs/hot-metadata-pinning.md
+++ b/docs/hot-metadata-pinning.md
@@ -1,0 +1,77 @@
+# Hot-Metadata Pinning (meta/data residency split)
+
+Status: design (2026-07-08), Phase 1 implemented.
+
+## Problem
+
+Every query must touch certain small metadata sections — BMP block-offset
+tables, sparse skip sections, doc-id maps, superblock grids. Hermes maps whole
+segment files and slices them zero-copy, so residency of those sections is
+decided by the kernel's page-cache LRU, not by us. Under memory pressure the
+kernel evicts them exactly like bulk data, and every subsequent query pays
+major faults on structures it cannot skip. This is the remaining half of the
+`slow BMP: 14116ms` pathology (block-data prefetch fixed the bulk half;
+grid/starts/doc-map faults were still unpinned).
+
+The classic production pattern for this is a **meta/data split**: each store
+keeps a small offset/index part every lookup touches (pin it in RAM) separate
+from the bulk payload (page-cache or direct I/O). Hermes already has the
+_layout_ half of this — every file is section-structured with lazy range
+reads, and some metadata is de-facto resident because it is deserialized to
+the heap (sparse dimension tables, ANN blobs after first use). What was
+missing is choosing residency for the mmap-backed metadata.
+
+## Residency of per-query structures today
+
+| Structure       | "meta" part                              | Residency                | "data" part | Residency                                    |
+| --------------- | ---------------------------------------- | ------------------------ | ----------- | -------------------------------------------- |
+| Sparse MaxScore | `DimensionTable` (SoA Vecs)              | heap (de-facto pinned)   | block data  | evictable mmap                               |
+|                 | skip section (`skip_bytes`)              | **pinnable**             |             |                                              |
+| BMP             | `block_data_starts`, `sb_grid`, doc maps | **pinnable**             | block data  | evictable (MADV_RANDOM + WILLNEED prefetch)  |
+|                 | 4-bit `grid`                             | never pinned (see below) |             |                                              |
+| Dense flat      | header + doc-id map                      | **pinnable**             | raw vectors | evictable (+ RANDOM/prefetch for ANN fields) |
+| ANN blobs       | heap after first search                  | de-facto pinned          | —           | —                                            |
+
+Sizes for a representative 18.2M-doc production segment (284,690 blocks,
+4,449 superblocks, SPLADE dims ≈ 105,879):
+
+| Structure                           | Size         | Pin priority                                 |
+| ----------------------------------- | ------------ | -------------------------------------------- |
+| BMP `block_data_starts`             | ~2.3 MB      | 1 (every scored block does an offset lookup) |
+| Sparse skip sections                | tens of MB   | 2 (every posting traversal)                  |
+| Flat + BMP doc-id maps (6 B/vector) | ~110 MB each | 3 (every top-k resolution)                   |
+| BMP `sb_grid` (dims × superblocks)  | ~470 MB      | 4 (every query dim reads a row)              |
+| BMP 4-bit `grid` (dims × blocks/2)  | ~15 GB       | **never**                                    |
+
+The 4-bit grid is meta-shaped but data-sized: it must stay evictable and is
+treated like bulk data (rows are read contiguously per query dim, so default
+readahead serves it well).
+
+## Phase 1 (implemented): budgeted metadata pinning
+
+`segment/pin.rs` defines a process-wide `PinPolicy`:
+
+- `HERMES_PIN_METADATA_BUDGET_MB` — bytes of metadata to pin **per segment**
+  (default 0 = disabled), or `set_pin_policy()` programmatically before the
+  first segment open.
+- `HERMES_PIN_MODE` — `mlock` (default; zero-copy, needs RLIMIT_MEMLOCK
+  headroom) or `copy` (heap copy; no permissions needed, duplicates bytes,
+  immune to eviction because production runs swapless).
+
+At `SegmentReader::open`, sections are pinned in the priority order above
+until the budget is exhausted. Fail-loud: mlock failure logs a warning and
+continues; `SegmentMemoryStats` carries `pin_intended_bytes` vs
+`pinned_metadata_bytes` so an operator can see the gap. Bulk data is never
+pinned.
+
+Suggested starting budget: 150–700 MB/segment depending on host RAM —
+enough for offsets + skips + doc maps everywhere, plus `sb_grid` on hosts
+that can afford it.
+
+## Phase 2 (deferred): direct-I/O cold path
+
+Bulk reads that bypass the page cache entirely (merges, cold posting/vector
+scans) so they can never evict warm pages. Requires a direct-I/O read variant
+in the `Directory` layer. The merge-side `MADV_SEQUENTIAL`/`MADV_DONTNEED`
+discipline already approximates most of the benefit; revisit only if Phase 1
+plus the existing madvise work leaves measurable eviction churn.

--- a/hermes-core/src/directories/directory.rs
+++ b/hermes-core/src/directories/directory.rs
@@ -383,6 +383,27 @@ impl OwnedBytes {
         self.madvise_range(0..self.len(), advice);
     }
 
+    /// Pin these bytes in physical memory (`mlock`). mmap-backed only —
+    /// heap memory is not evictable by the page cache. Returns whether the
+    /// lock succeeded; failure (e.g. RLIMIT_MEMLOCK) is not fatal.
+    /// Locks are released automatically when the mapping is unmapped.
+    #[cfg(feature = "native")]
+    pub fn mlock(&self) -> bool {
+        if !self.is_mmap() {
+            return false;
+        }
+        let slice = self.as_slice();
+        if slice.is_empty() {
+            return true;
+        }
+        let ptr = slice.as_ptr();
+        let len = slice.len();
+        let page_size = 4096usize;
+        let aligned_ptr = (ptr as usize) & !(page_size - 1);
+        let aligned_len = len + (ptr as usize - aligned_ptr);
+        unsafe { libc::mlock(aligned_ptr as *const libc::c_void, aligned_len) == 0 }
+    }
+
     /// Advise the kernel about the access pattern for a sub-range.
     ///
     /// The range is relative to these bytes. Same mmap-only guard as

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -2,6 +2,7 @@ mod basic;
 mod bmp;
 mod boolean;
 mod merge;
+mod pin;
 mod primary_key;
 mod range;
 mod search;

--- a/hermes-core/src/index/tests/pin.rs
+++ b/hermes-core/src/index/tests/pin.rs
@@ -1,0 +1,109 @@
+//! Hot-metadata pinning tests (segment::pin).
+//!
+//! Uses MmapDirectory so the metadata sections are genuinely mmap-backed
+//! (pinning is a no-op for heap-backed RAM directories).
+
+use std::sync::Arc;
+
+use crate::directories::MmapDirectory;
+use crate::dsl::{Document, SchemaBuilder};
+use crate::index::{Index, IndexConfig, IndexWriter};
+use crate::segment::pin::{PinMode, PinPolicy};
+use crate::segment::{SegmentId, SegmentReader};
+
+async fn build_test_index(dir: &MmapDirectory) -> (crate::dsl::Schema, u128) {
+    let mut sb = SchemaBuilder::default();
+    let sparse_cfg = crate::structures::SparseVectorConfig {
+        format: crate::structures::SparseFormat::Bmp,
+        dims: Some(1024),
+        max_weight: Some(5.0),
+        ..Default::default()
+    };
+    let sparse = sb.add_sparse_vector_field_with_config("sparse", true, true, sparse_cfg);
+    let dense = sb.add_dense_vector_field("dense", 8, true, true);
+    let schema = sb.build();
+
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+    for i in 0..300u32 {
+        let mut doc = Document::new();
+        doc.add_sparse_vector(
+            sparse,
+            vec![(i % 512, 1.0 + (i % 7) as f32), ((i + 7) % 512, 0.5)],
+        );
+        doc.add_dense_vector(dense, (0..8).map(|d| (i + d) as f32 / 300.0).collect());
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir.clone(), config).await.unwrap();
+    let segments = index.segment_readers().await.unwrap();
+    let seg_id = segments[0].meta().id;
+    (schema, seg_id)
+}
+
+/// Copy-mode pinning: metadata sections move to the heap, accounting is
+/// reported, and search results are unchanged afterwards.
+#[tokio::test]
+async fn test_pin_metadata_copy_mode_preserves_search() {
+    use crate::query::SparseVectorQuery;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = MmapDirectory::new(tmp.path());
+    let (schema, seg_id) = build_test_index(&dir).await;
+
+    let mut reader = SegmentReader::open(&dir, SegmentId(seg_id), Arc::new(schema.clone()), 64)
+        .await
+        .unwrap();
+
+    // Generous budget: everything pinnable gets pinned
+    reader.apply_pin_policy(&PinPolicy {
+        budget_bytes: 64 * 1024 * 1024,
+        mode: PinMode::Copy,
+    });
+    let stats = reader.memory_stats();
+    assert!(
+        stats.pinned_metadata_bytes > 0,
+        "BMP starts/doc-maps/sb_grid + flat doc_ids should be pinnable"
+    );
+    assert_eq!(
+        stats.pinned_metadata_bytes, stats.pin_intended_bytes,
+        "generous budget must pin everything eligible"
+    );
+
+    // Search still works on the heap-copied metadata
+    let field = schema.get_field("sparse").unwrap();
+    let query = SparseVectorQuery::new(field, vec![(3, 1.0), (10, 1.0)]);
+    let results = crate::query::search_segment_with_count(&reader, &query, 10)
+        .await
+        .unwrap()
+        .0;
+    assert!(!results.is_empty(), "search must survive pinning");
+}
+
+/// Budget exhaustion is respected and reported (fail-loud accounting).
+#[tokio::test]
+async fn test_pin_metadata_budget_exhaustion_reported() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = MmapDirectory::new(tmp.path());
+    let (schema, seg_id) = build_test_index(&dir).await;
+
+    let mut reader = SegmentReader::open(&dir, SegmentId(seg_id), Arc::new(schema), 64)
+        .await
+        .unwrap();
+
+    // Tiny budget: something must be skipped
+    let budget = 128u64;
+    reader.apply_pin_policy(&PinPolicy {
+        budget_bytes: budget,
+        mode: PinMode::Copy,
+    });
+    let stats = reader.memory_stats();
+    assert!(stats.pinned_metadata_bytes <= budget);
+    assert!(
+        stats.pin_intended_bytes > stats.pinned_metadata_bytes,
+        "tiny budget must leave a visible intended-vs-pinned gap"
+    );
+}

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -23,6 +23,8 @@ pub(crate) use reader::bmp::{
     accumulate_u4_weighted, block_term_postings, compute_block_masks_4bit, find_dim_in_block_data,
 };
 pub(crate) use reader::combine_ordinal_results;
+#[cfg(feature = "native")]
+pub mod pin;
 pub use reader::{SegmentReader, SparseIndex, VectorIndex, VectorSearchResult};
 pub use store::*;
 #[cfg(feature = "native")]

--- a/hermes-core/src/segment/pin.rs
+++ b/hermes-core/src/segment/pin.rs
@@ -1,0 +1,155 @@
+//! Hot-metadata pinning: budgeted residency for per-query-mandatory
+//! structures (a meta/data residency split).
+//!
+//! Every query must touch certain small metadata sections — BMP block-offset
+//! tables, sparse skip sections, doc-id maps, superblock grids. Under memory
+//! pressure the kernel evicts them like bulk data, and queries then pay major
+//! faults on structures they cannot skip. This module pins them, in priority
+//! order (smallest/hottest first), until a per-segment budget is exhausted.
+//!
+//! Design: `docs/hot-metadata-pinning.md`. Bulk data (BMP 4-bit grid, block
+//! data, raw vectors) is never pinned — it is covered by the
+//! `MADV_RANDOM`/`MADV_WILLNEED` discipline instead.
+
+use std::sync::OnceLock;
+
+use crate::directories::OwnedBytes;
+
+/// How pinned bytes are kept resident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinMode {
+    /// `mlock` the mmap pages in place — zero-copy, but requires
+    /// RLIMIT_MEMLOCK headroom (containers often need CAP_IPC_LOCK or an
+    /// explicit ulimit). Failures are logged and counted, never fatal.
+    Mlock,
+    /// Copy the section to the heap — no permissions needed, duplicates the
+    /// bytes. Immune to page-cache eviction (production runs swapless).
+    Copy,
+}
+
+/// Per-segment metadata pinning policy.
+#[derive(Debug, Clone, Copy)]
+pub struct PinPolicy {
+    /// Metadata bytes to pin per segment. 0 = pinning disabled (default).
+    pub budget_bytes: u64,
+    pub mode: PinMode,
+}
+
+impl PinPolicy {
+    pub const fn disabled() -> Self {
+        Self {
+            budget_bytes: 0,
+            mode: PinMode::Mlock,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.budget_bytes > 0
+    }
+
+    /// Read policy from environment:
+    /// `HERMES_PIN_METADATA_BUDGET_MB` (default 0 = off),
+    /// `HERMES_PIN_MODE` = `mlock` (default) | `copy`.
+    fn from_env() -> Self {
+        let budget_mb: u64 = std::env::var("HERMES_PIN_METADATA_BUDGET_MB")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        let mode = match std::env::var("HERMES_PIN_MODE").as_deref() {
+            Ok("copy") => PinMode::Copy,
+            Ok("mlock") | Err(_) => PinMode::Mlock,
+            Ok(other) => {
+                log::warn!("HERMES_PIN_MODE '{}' unknown; using mlock", other);
+                PinMode::Mlock
+            }
+        };
+        Self {
+            budget_bytes: budget_mb * 1024 * 1024,
+            mode,
+        }
+    }
+}
+
+static PIN_POLICY: OnceLock<PinPolicy> = OnceLock::new();
+
+/// Override the process-wide pin policy. Must be called before the first
+/// segment is opened; returns false (and warns) if the policy was already
+/// initialized.
+pub fn set_pin_policy(policy: PinPolicy) -> bool {
+    let ok = PIN_POLICY.set(policy).is_ok();
+    if !ok {
+        log::warn!("pin policy already initialized; set_pin_policy ignored");
+    }
+    ok
+}
+
+/// The process-wide pin policy (env-initialized on first use).
+pub fn pin_policy() -> &'static PinPolicy {
+    PIN_POLICY.get_or_init(PinPolicy::from_env)
+}
+
+/// Accumulates pin accounting for one segment.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PinReport {
+    /// Bytes of pinnable metadata found (regardless of budget/failures)
+    pub intended_bytes: u64,
+    /// Bytes actually pinned
+    pub pinned_bytes: u64,
+    /// Bytes skipped because the budget was exhausted
+    pub skipped_budget_bytes: u64,
+    /// Bytes where mlock failed (RLIMIT_MEMLOCK etc.)
+    pub failed_bytes: u64,
+}
+
+/// Pin one metadata section, updating `remaining` budget and the report.
+///
+/// In `Copy` mode the section is replaced with a heap copy (heap memory is
+/// not page-cache-evictable). In `Mlock` mode the mmap pages are locked in
+/// place. Non-mmap-backed sections (RAM directories) are already resident
+/// and are skipped silently.
+pub(crate) fn pin_section(
+    bytes: &mut OwnedBytes,
+    label: &str,
+    mode: PinMode,
+    remaining: &mut u64,
+    report: &mut PinReport,
+) {
+    if !bytes.is_mmap() || bytes.is_empty() {
+        return;
+    }
+    let len = bytes.len() as u64;
+    report.intended_bytes += len;
+
+    if len > *remaining {
+        report.skipped_budget_bytes += len;
+        log::debug!(
+            "[pin] budget exhausted: skipping {} ({} bytes, {} remaining)",
+            label,
+            len,
+            *remaining
+        );
+        return;
+    }
+
+    match mode {
+        PinMode::Mlock => {
+            if bytes.mlock() {
+                *remaining -= len;
+                report.pinned_bytes += len;
+            } else {
+                report.failed_bytes += len;
+                log::warn!(
+                    "[pin] mlock failed for {} ({} bytes) — check RLIMIT_MEMLOCK; \
+                     continuing unpinned",
+                    label,
+                    len
+                );
+            }
+        }
+        PinMode::Copy => {
+            *bytes = OwnedBytes::new(bytes.to_vec());
+            *remaining -= len;
+            report.pinned_bytes += len;
+        }
+    }
+}

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -330,6 +330,67 @@ impl BmpIndex {
         }
     }
 
+    /// Pin the block-offset table (priority 1: every scored block does an
+    /// offset lookup through it).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_block_starts(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        crate::segment::pin::pin_section(
+            &mut self.block_data_starts_bytes,
+            "bmp block_data_starts",
+            mode,
+            remaining,
+            report,
+        );
+    }
+
+    /// Pin the virtual-doc → (doc_id, ordinal) maps (priority 3: every
+    /// top-k resolution touches them).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_doc_maps(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        crate::segment::pin::pin_section(
+            &mut self.doc_map_ids_bytes,
+            "bmp doc_map_ids",
+            mode,
+            remaining,
+            report,
+        );
+        crate::segment::pin::pin_section(
+            &mut self.doc_map_ordinals_bytes,
+            "bmp doc_map_ordinals",
+            mode,
+            remaining,
+            report,
+        );
+    }
+
+    /// Pin the superblock grid (priority 4: every query dim reads a row).
+    /// The 4-bit block grid is deliberately never pinned (data-sized).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_sb_grid(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        crate::segment::pin::pin_section(
+            &mut self.sb_grid_bytes,
+            "bmp sb_grid",
+            mode,
+            remaining,
+            report,
+        );
+    }
+
     /// Page-level prefetch (`MADV_WILLNEED`) of a block-data byte range.
     ///
     /// Used by the BMP executor to batch-prefetch the surviving blocks of a

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -26,6 +26,11 @@ pub struct SegmentMemoryStats {
     pub dense_index_bytes: usize,
     /// Bloom filter bytes
     pub bloom_filter_bytes: usize,
+    /// Hot metadata bytes actually pinned (mlock/heap-copy) at open
+    pub pinned_metadata_bytes: u64,
+    /// Hot metadata bytes eligible for pinning (gap vs pinned = budget
+    /// exhausted or mlock failures — operator-visible)
+    pub pin_intended_bytes: u64,
 }
 
 impl SegmentMemoryStats {
@@ -154,6 +159,9 @@ pub struct SegmentReader {
     /// Allows per-field MaxScore groups within a single query to share thresholds:
     /// field A's result seeds field B's pruning on the same segment.
     shared_threshold: std::sync::atomic::AtomicU32,
+    /// Hot-metadata pin accounting (see `segment::pin`)
+    #[cfg(feature = "native")]
+    pin_report: crate::segment::pin::PinReport,
 }
 
 impl SegmentReader {
@@ -245,7 +253,8 @@ impl SegmentReader {
             log::debug!("{}", parts.join(", "));
         }
 
-        Ok(Self {
+        #[allow(unused_mut)]
+        let mut reader = Self {
             meta,
             term_dict: Arc::new(term_dict),
             postings_handle,
@@ -259,7 +268,73 @@ impl SegmentReader {
             positions_handle,
             fast_fields,
             shared_threshold: std::sync::atomic::AtomicU32::new(0),
-        })
+            #[cfg(feature = "native")]
+            pin_report: Default::default(),
+        };
+
+        // Pin hot metadata per the process-wide policy (no-op when disabled)
+        #[cfg(feature = "native")]
+        reader.apply_pin_policy(&crate::segment::pin::pin_policy().to_owned());
+
+        Ok(reader)
+    }
+
+    /// Pin per-query-mandatory metadata sections in priority order until the
+    /// budget is exhausted (see `segment::pin` and docs/hot-metadata-pinning.md).
+    ///
+    /// Priority: BMP block-offset tables → sparse skip sections → doc-id maps
+    /// → BMP superblock grids. Bulk data (4-bit grid, block data, raw vectors)
+    /// is never pinned. Fail-loud: budget exhaustion and mlock failures are
+    /// logged and visible via `SegmentMemoryStats::{pin_intended_bytes,
+    /// pinned_metadata_bytes}`.
+    #[cfg(feature = "native")]
+    pub(crate) fn apply_pin_policy(&mut self, policy: &crate::segment::pin::PinPolicy) {
+        use crate::segment::pin::PinReport;
+
+        if !policy.is_enabled() {
+            return;
+        }
+        let mut remaining = policy.budget_bytes;
+        let mut report = PinReport::default();
+
+        // Priority 1: BMP block-offset tables
+        for bmp in self.bmp_indexes.values_mut() {
+            bmp.pin_block_starts(policy.mode, &mut remaining, &mut report);
+        }
+        // Priority 2: sparse skip sections
+        for sparse in self.sparse_indexes.values_mut() {
+            sparse.pin_skip_section(policy.mode, &mut remaining, &mut report);
+        }
+        // Priority 3: doc-id maps
+        for flat in self.flat_vectors.values_mut() {
+            flat.pin_doc_ids(policy.mode, &mut remaining, &mut report);
+        }
+        for bmp in self.bmp_indexes.values_mut() {
+            bmp.pin_doc_maps(policy.mode, &mut remaining, &mut report);
+        }
+        // Priority 4: BMP superblock grids
+        for bmp in self.bmp_indexes.values_mut() {
+            bmp.pin_sb_grid(policy.mode, &mut remaining, &mut report);
+        }
+
+        if report.skipped_budget_bytes > 0 || report.failed_bytes > 0 {
+            log::warn!(
+                "[pin] segment {:016x}: pinned {}/{} bytes (budget skipped {}, mlock failed {}) —                  raise HERMES_PIN_METADATA_BUDGET_MB or RLIMIT_MEMLOCK for full coverage",
+                self.meta.id,
+                report.pinned_bytes,
+                report.intended_bytes,
+                report.skipped_budget_bytes,
+                report.failed_bytes,
+            );
+        } else if report.pinned_bytes > 0 {
+            log::info!(
+                "[pin] segment {:016x}: pinned {} bytes of hot metadata ({:?})",
+                self.meta.id,
+                report.pinned_bytes,
+                policy.mode,
+            );
+        }
+        self.pin_report = report;
     }
 
     /// Reset the per-segment threshold (call before each new search).
@@ -392,6 +467,12 @@ impl SegmentReader {
             .map(|v| v.estimated_memory_bytes())
             .sum();
 
+        #[cfg(feature = "native")]
+        let (pinned_metadata_bytes, pin_intended_bytes) =
+            (self.pin_report.pinned_bytes, self.pin_report.intended_bytes);
+        #[cfg(not(feature = "native"))]
+        let (pinned_metadata_bytes, pin_intended_bytes) = (0u64, 0u64);
+
         SegmentMemoryStats {
             segment_id: self.meta.id,
             num_docs: self.meta.num_docs,
@@ -400,6 +481,8 @@ impl SegmentReader {
             sparse_index_bytes,
             dense_index_bytes,
             bloom_filter_bytes: term_dict_stats.bloom_filter_size,
+            pinned_metadata_bytes,
+            pin_intended_bytes,
         }
     }
 

--- a/hermes-core/src/segment/reader/types.rs
+++ b/hermes-core/src/segment/reader/types.rs
@@ -343,6 +343,25 @@ pub struct SparseIndex {
 }
 
 impl SparseIndex {
+    /// Pin the skip section (priority 2: every posting traversal reads it).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_skip_section(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        let mut bytes = (*self.skip_bytes).clone();
+        crate::segment::pin::pin_section(
+            &mut bytes,
+            "sparse skip_section",
+            mode,
+            remaining,
+            report,
+        );
+        self.skip_bytes = Arc::new(bytes);
+    }
+
     /// Total postings across all dimensions (sum of per-dimension doc counts).
     /// With multi-valued fields each (doc, ordinal, dim) entry counts once.
     pub fn total_postings(&self) -> u64 {

--- a/hermes-core/src/segment/vector_data.rs
+++ b/hermes-core/src/segment/vector_data.rs
@@ -274,6 +274,24 @@ impl LazyFlatVectorData {
         })
     }
 
+    /// Pin the doc-id map (priority 3: every rerank / top-k resolution
+    /// binary-searches it).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_doc_ids(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        crate::segment::pin::pin_section(
+            &mut self.doc_ids_bytes,
+            "flat doc_ids",
+            mode,
+            remaining,
+            report,
+        );
+    }
+
     /// Advise the kernel that vector data will be accessed at random offsets.
     ///
     /// Disables kernel readahead for the raw vector region. Rerank reads


### PR DESCRIPTION
Pins per-query-mandatory metadata sections in RAM at segment open, under a per-segment byte budget, so the kernel cannot evict them under memory pressure. Completes the `slow BMP: 14116ms` fix (block-data prefetch covered the bulk half; this covers the metadata half).

## What
- New `segment/pin.rs`: process-wide `PinPolicy` from `HERMES_PIN_METADATA_BUDGET_MB` (per-segment budget, default 0 = off) and `HERMES_PIN_MODE` (`mlock` default, or `copy` for hosts without RLIMIT_MEMLOCK headroom); `set_pin_policy()` for programmatic use.
- `OwnedBytes::mlock` — page-aligned, mmap-only.
- `SegmentReader::open` pins in priority order until budget exhaustion: BMP block-offset tables → sparse skip sections → doc-id maps (flat + BMP) → BMP superblock grids. Bulk data (4-bit grid, block data, raw vectors) is never pinned.
- Fail-loud: mlock failure warns with byte counts and continues; per-segment summary log; `SegmentMemoryStats` reports `pin_intended_bytes` vs `pinned_metadata_bytes`.
- Design doc: `docs/hot-metadata-pinning.md` (incl. deferred Phase 2 direct-I/O cold path).

## Tests
- `test_pin_metadata_copy_mode_preserves_search` — pinning changes residency, not results.
- `test_pin_metadata_budget_exhaustion_reported` — tiny budget leaves visible intended-vs-pinned gap.
- Full suite green (674 passed), clippy `-D warnings` clean, wasm build unaffected (module is `cfg(native)`).

## Ops
Suggested starting point on memory-bound hosts: `HERMES_PIN_METADATA_BUDGET_MB=700 HERMES_PIN_MODE=mlock` (use `copy` in containers lacking CAP_IPC_LOCK).