### PR TITLE
feat: merge-time BP reorder, per-field reorder gate, selectivity-aware filter planner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2026-02-17
+          toolchain: nightly-2026-07-07
           components: rustfmt, clippy
 
       - name: Cache cargo
@@ -62,6 +62,21 @@ jobs:
       - name: Run cargo audit
         run: cargo audit
 
+  # Unused dependency check
+  machete:
+    name: Cargo Machete
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-machete
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
+
+      - name: Run cargo machete
+        run: cargo machete
+
   # WASM build - separate due to different target
   wasm:
     name: WASM Build
@@ -71,7 +86,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2026-02-17
+          toolchain: nightly-2026-07-07
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,19 +38,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "anes"
@@ -553,19 +553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +731,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,25 +816,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -826,12 +841,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -908,12 +923,13 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.7"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
+ "dispatch2",
  "nix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1027,6 +1043,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1118,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -1750,96 +1774,6 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
-
-[[package]]
-name = "glam"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
-
-[[package]]
-name = "glam"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
-
-[[package]]
-name = "glam"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
-
-[[package]]
-name = "glam"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
-
-[[package]]
-name = "glam"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
-
-[[package]]
-name = "glam"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
-
-[[package]]
-name = "glam"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
-
-[[package]]
-name = "glam"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
-
-[[package]]
-name = "glam"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
-
-[[package]]
-name = "glam"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
-
-[[package]]
-name = "glam"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
-
-[[package]]
-name = "glam"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
-
-[[package]]
-name = "glam"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
-
-[[package]]
-name = "glam"
-version = "0.29.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
-
-[[package]]
-name = "glam"
 version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
@@ -1855,6 +1789,12 @@ name = "glam"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
+
+[[package]]
+name = "glam"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f22fb22f065b308be0d8724e3706c7fa3fc2a6c7d6899df4cad7860e7a75436"
 
 [[package]]
 name = "glob"
@@ -1925,8 +1865,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1948,6 +1886,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1964,17 +1907,15 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bincode",
- "bumpalo",
  "byteorder",
  "comfy-table",
  "criterion",
- "crossbeam-channel",
  "fst",
  "futures",
  "getrandom 0.3.4",
  "half",
- "hashbrown 0.15.5",
- "hf-hub",
+ "hashbrown 0.17.1",
+ "hf-hub 0.5.0",
  "instant",
  "kentro",
  "lasso",
@@ -1995,7 +1936,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "smallvec",
  "stop-words",
  "tempfile",
  "thiserror 2.0.18",
@@ -2018,17 +1958,15 @@ dependencies = [
  "ctrlc",
  "cudarc 0.19.8",
  "flate2",
- "hf-hub",
+ "hf-hub 0.5.0",
  "indicatif 0.18.6",
  "pest",
  "pest_derive",
  "rand 0.9.4",
- "rayon",
  "rust-embed",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
  "tokenizers",
  "tracing",
  "tracing-subscriber",
@@ -2049,7 +1987,6 @@ dependencies = [
  "prost",
  "rayon",
  "rustc-hash",
- "serde",
  "serde_json",
  "tokio",
  "tonic",
@@ -2064,7 +2001,6 @@ version = "1.8.39"
 dependencies = [
  "anyhow",
  "bincode",
- "chrono",
  "clap",
  "crossbeam-channel",
  "hermes-core",
@@ -2120,12 +2056,31 @@ dependencies = [
  "libc",
  "log",
  "rand 0.9.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ureq 2.12.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hf-hub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif 0.18.6",
+ "libc",
+ "log",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "ureq",
- "windows-sys 0.60.2",
+ "ureq 3.3.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2254,30 +2209,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2444,17 +2375,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,9 +2382,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2868,29 +2788,15 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "nalgebra"
-version = "0.34.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
+checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
 dependencies = [
  "approx",
- "glam 0.14.0",
- "glam 0.15.2",
- "glam 0.16.0",
- "glam 0.17.3",
- "glam 0.18.0",
- "glam 0.19.0",
- "glam 0.20.5",
- "glam 0.21.3",
- "glam 0.22.0",
- "glam 0.23.0",
- "glam 0.24.2",
- "glam 0.25.0",
- "glam 0.27.0",
- "glam 0.28.0",
- "glam 0.29.3",
  "glam 0.30.10",
  "glam 0.31.1",
  "glam 0.32.1",
+ "glam 0.33.2",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -2928,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -2990,6 +2896,12 @@ dependencies = [
  "bytemuck",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3160,6 +3072,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking"
@@ -3338,6 +3260,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4100,9 +4028,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "0.7.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
 dependencies = [
  "bytemuck",
 ]
@@ -4300,14 +4228,13 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
 dependencies = [
  "approx",
  "num-complex",
  "num-traits",
- "paste",
  "wide",
 ]
 
@@ -4431,9 +4358,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stop-words"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6a86be9f7fa4559b7339669e72026eb437f5e9c5a85c207fe1033079033a17"
+checksum = "d68df56303396bcfb639455b3c166804aeb7994005010aab5e9e8a1277b8871d"
 dependencies = [
  "serde_json",
 ]
@@ -4559,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
 dependencies = [
  "libc",
  "paste",
@@ -4570,9 +4497,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -4580,12 +4507,42 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -4637,7 +4594,7 @@ dependencies = [
  "esaxx-rs",
  "fancy-regex 0.14.0",
  "getrandom 0.3.4",
- "hf-hub",
+ "hf-hub 0.4.3",
  "indicatif 0.18.6",
  "itertools 0.14.0",
  "log",
@@ -5049,6 +5006,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5059,6 +5049,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5252,9 +5248,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -5292,63 +5288,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,14 +46,12 @@ rust-openzl = "0.1"
 
 # Text processing
 rust-stemmers = "1.2"
-stop-words = "0.8"
+stop-words = "0.10"
 
 # Collections and utilities
 rustc-hash = "2.1"
-smallvec = "1.15"
 parking_lot = "0.12"
 async-channel = "2.3"
-crossbeam-channel = "0.5"
 num_cpus = "1.17"
 rayon = "1.11"
 
@@ -95,11 +93,10 @@ tempfile = "3.24"
 rand = "0.9"
 
 # Benchmarking
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 # High-performance data structures
-bumpalo = "3.19"
 lasso = { version = "0.7", features = ["multi-threaded"] }
-hashbrown = "0.15"
+hashbrown = "0.17"
 memmap2 = "0.9"
 uuid = { version = "1.19", features = ["v4"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.94
+FROM rust:1.96
 
 # System deps
 RUN apt-get update && apt-get install -y \

--- a/docs/hot-metadata-pinning.md
+++ b/docs/hot-metadata-pinning.md
@@ -1,0 +1,77 @@
+# Hot-Metadata Pinning (meta/data residency split)
+
+Status: design (2026-07-08), Phase 1 implemented.
+
+## Problem
+
+Every query must touch certain small metadata sections — BMP block-offset
+tables, sparse skip sections, doc-id maps, superblock grids. Hermes maps whole
+segment files and slices them zero-copy, so residency of those sections is
+decided by the kernel's page-cache LRU, not by us. Under memory pressure the
+kernel evicts them exactly like bulk data, and every subsequent query pays
+major faults on structures it cannot skip. This is the remaining half of the
+`slow BMP: 14116ms` pathology (block-data prefetch fixed the bulk half;
+grid/starts/doc-map faults were still unpinned).
+
+The classic production pattern for this is a **meta/data split**: each store
+keeps a small offset/index part every lookup touches (pin it in RAM) separate
+from the bulk payload (page-cache or direct I/O). Hermes already has the
+_layout_ half of this — every file is section-structured with lazy range
+reads, and some metadata is de-facto resident because it is deserialized to
+the heap (sparse dimension tables, ANN blobs after first use). What was
+missing is choosing residency for the mmap-backed metadata.
+
+## Residency of per-query structures today
+
+| Structure       | "meta" part                              | Residency                | "data" part | Residency                                    |
+| --------------- | ---------------------------------------- | ------------------------ | ----------- | -------------------------------------------- |
+| Sparse MaxScore | `DimensionTable` (SoA Vecs)              | heap (de-facto pinned)   | block data  | evictable mmap                               |
+|                 | skip section (`skip_bytes`)              | **pinnable**             |             |                                              |
+| BMP             | `block_data_starts`, `sb_grid`, doc maps | **pinnable**             | block data  | evictable (MADV_RANDOM + WILLNEED prefetch)  |
+|                 | 4-bit `grid`                             | never pinned (see below) |             |                                              |
+| Dense flat      | header + doc-id map                      | **pinnable**             | raw vectors | evictable (+ RANDOM/prefetch for ANN fields) |
+| ANN blobs       | heap after first search                  | de-facto pinned          | —           | —                                            |
+
+Sizes for a representative 18.2M-doc production segment (284,690 blocks,
+4,449 superblocks, SPLADE dims ≈ 105,879):
+
+| Structure                           | Size         | Pin priority                                 |
+| ----------------------------------- | ------------ | -------------------------------------------- |
+| BMP `block_data_starts`             | ~2.3 MB      | 1 (every scored block does an offset lookup) |
+| Sparse skip sections                | tens of MB   | 2 (every posting traversal)                  |
+| Flat + BMP doc-id maps (6 B/vector) | ~110 MB each | 3 (every top-k resolution)                   |
+| BMP `sb_grid` (dims × superblocks)  | ~470 MB      | 4 (every query dim reads a row)              |
+| BMP 4-bit `grid` (dims × blocks/2)  | ~15 GB       | **never**                                    |
+
+The 4-bit grid is meta-shaped but data-sized: it must stay evictable and is
+treated like bulk data (rows are read contiguously per query dim, so default
+readahead serves it well).
+
+## Phase 1 (implemented): budgeted metadata pinning
+
+`segment/pin.rs` defines a process-wide `PinPolicy`:
+
+- `HERMES_PIN_METADATA_BUDGET_MB` — bytes of metadata to pin **per segment**
+  (default 0 = disabled), or `set_pin_policy()` programmatically before the
+  first segment open.
+- `HERMES_PIN_MODE` — `mlock` (default; zero-copy, needs RLIMIT_MEMLOCK
+  headroom) or `copy` (heap copy; no permissions needed, duplicates bytes,
+  immune to eviction because production runs swapless).
+
+At `SegmentReader::open`, sections are pinned in the priority order above
+until the budget is exhausted. Fail-loud: mlock failure logs a warning and
+continues; `SegmentMemoryStats` carries `pin_intended_bytes` vs
+`pinned_metadata_bytes` so an operator can see the gap. Bulk data is never
+pinned.
+
+Suggested starting budget: 150–700 MB/segment depending on host RAM —
+enough for offsets + skips + doc maps everywhere, plus `sb_grid` on hosts
+that can afford it.
+
+## Phase 2 (deferred): direct-I/O cold path
+
+Bulk reads that bypass the page cache entirely (merges, cold posting/vector
+scans) so they can never evict warm pages. Requires a direct-I/O read variant
+in the `Directory` layer. The merge-side `MADV_SEQUENTIAL`/`MADV_DONTNEED`
+discipline already approximates most of the benefit; revisit only if Phase 1
+plus the existing madvise work leaves measurable eviction churn.

--- a/docs/merge-time-reorder.md
+++ b/docs/merge-time-reorder.md
@@ -1,0 +1,95 @@
+# Merge-Time BP Reordering
+
+Status: design (2026-07-08), implemented.
+
+## Problem
+
+Recursive Graph Bisection (BP) reordering is currently a standalone,
+whole-segment operation: merges block-copy BMP data in concatenated source
+order, and a separate pass (`hermes-tool reorder` / the server's background
+optimizer) later rewrites the entire segment — copying every unchanged file
+and rebuilding the sparse file. For a freshly merged segment the index is
+rewritten **twice**: once by the merge, once by the reorder.
+
+That makes ordering quality arrive in one large, deferred, IO-heavy step
+instead of amortizing over the index's natural rewrite cycle.
+
+## Design
+
+Run BP _inside_ the merge, where the output sparse file is being written
+anyway:
+
+- Index-level SDL option, persisted in the schema at creation:
+
+  ```sdl
+  index articles {
+      reorder_on_merge: true
+      field splade: sparse_vector<...> [indexed, reorder]
+  }
+  ```
+
+  Absent = disabled — merges block-copy exactly as before (the default
+  preserves current behaviour). Programmatic:
+  `SchemaBuilder::set_reorder_on_merge(true)`. Setting the option with no
+  `reorder`-attributed field warns loudly at parse time (it would do
+  nothing).
+
+- Per-field gate: only sparse fields carrying the `reorder` schema attribute
+  (`field splade: sparse_vector<...> [indexed, reorder]`,
+  `SchemaBuilder::set_reorder`) are BP-reordered — by merges AND by the
+  standalone reorder paths (`hermes-tool reorder`, `IndexWriter::reorder`,
+  the server's background optimizer). Fields without the attribute have
+  their blob copied byte-identically (insertion order preserved — right for
+  corpora whose insertion order already clusters well, e.g. date-sorted).
+  Skips are logged loudly. Note this tightened an old behavior: standalone
+  reorder used to BP every BMP field regardless of the attribute.
+- When enabled, `merge_sparse_vectors` replaces the byte-level block-copy of
+  BMP fields with: build a multi-source forward index from the source
+  `BmpIndex`es → run BP (`graph_bisection`, same parameters as standalone
+  reorder) → write the merged blob in permuted order. Doc-id maps are patched
+  with per-source offsets during the write.
+- The merged segment is marked `reordered: true` in metadata, so the
+  background optimizer skips it — eliminating the second whole-segment
+  rewrite.
+- Non-BMP fields and all other segment files merge exactly as before.
+
+Amortization property: the tiered merge cascade rewrites small segments often
+and large segments rarely, so BP cost is paid in proportion to (and at the
+same moment as) IO the merge already spends. BP also warm-starts implicitly —
+`graph_bisection` refines from the input order, and merge inputs are usually
+already BP-ordered, so convergence at merge time is fast.
+
+## Interior-padding correctness (bug fixed alongside)
+
+Fresh BMP segments pad only the tail of the doc map (`u32::MAX` slots after
+`num_real_docs`). Block-copy merges concatenate sources _including_ each
+source's tail padding, producing merged segments whose real docs are **not**
+contiguous in vid space. The standalone reorder and BP forward-index builder
+assumed `vid < num_real_docs` ⇔ real doc — on such segments this silently
+dropped real docs shifted past `num_real_docs` (their postings and doc-map
+entries vanished from the reordered blob) and treated interior padding slots
+as empty docs.
+
+Fix: both the forward-index builder and the reorder blob writer now derive
+realness from the doc map itself (`doc_map_ids[vid] != u32::MAX`) via
+per-source real↔virtual mappings. This is pinned by
+`test_bmp_reorder_after_merge_keeps_interior_padded_docs`. A side benefit:
+any BP rewrite (merge-time or standalone) compacts interior padding, so the
+output always has tail-only padding.
+
+## Cost
+
+- Extra merge CPU: forward-index build + BP. Bounded by the same
+  `memory_budget` df-dropping as standalone reorder (2 GB default). BP runs
+  in `spawn_blocking`; rayon parallelism uses the global pool.
+- Saved: one full segment rewrite per merge (the optimizer pass), including
+  its read traffic against the page cache.
+- Merge wall-clock grows; for latency-sensitive ingest keep the flag off and
+  rely on the background optimizer as before.
+
+## Future (not implemented)
+
+- Debt-driven scheduling: prioritize standalone reorder by observed
+  `blocks_scored/blocks_total` pruning ratio per segment.
+- Routed placement: order small-segment docs by superblock term-mass
+  signatures of the largest segment before merging.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -61,12 +61,24 @@ index articles {
 
 Attributes control how fields are processed and stored:
 
-| Attribute | Description                                                       |
-| --------- | ----------------------------------------------------------------- |
-| `indexed` | Field is indexed for searching                                    |
-| `stored`  | Field value is stored and can be retrieved                        |
-| `primary` | Field is the primary key (enforces uniqueness, deduplicates)      |
-| `fast`    | Field is a fast field (column-oriented storage for range queries) |
+| Attribute | Description                                                                                                                                                                                                     |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `indexed` | Field is indexed for searching                                                                                                                                                                                  |
+| `stored`  | Field value is stored and can be retrieved                                                                                                                                                                      |
+| `primary` | Field is the primary key (enforces uniqueness, deduplicates)                                                                                                                                                    |
+| `fast`    | Field is a fast field (column-oriented storage for range queries)                                                                                                                                               |
+| `reorder` | Opt this BMP sparse field into BP (graph bisection) reordering — used by the background optimizer, `hermes-tool reorder`, and reorder-on-merge. Fields without it keep insertion order (blob copied unchanged). |
+
+Index-level options (inside the `index { ... }` block):
+
+```sdl
+index articles {
+    reorder_on_merge: true   # BP-reorder `reorder`-attributed BMP fields inside merges.
+                             # Absent = disabled: merges block-copy and the background
+                             # optimizer reorders afterwards.
+    field splade: sparse_vector<...> [indexed, reorder]
+}
+```
 
 ### Attribute Syntax
 

--- a/hermes-core/Cargo.toml
+++ b/hermes-core/Cargo.toml
@@ -21,11 +21,9 @@ serde_json = { workspace = true }
 byteorder = { workspace = true }
 zstd = { workspace = true }
 rustc-hash = { workspace = true }
-smallvec = { workspace = true }
 parking_lot = { workspace = true }
 arc-swap = "1"
 async-channel = { workspace = true, optional = true }
-crossbeam-channel = { workspace = true, optional = true }
 num_cpus = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 thiserror = { workspace = true }
@@ -39,7 +37,6 @@ regex = { workspace = true }
 rand = { workspace = true }
 reqwest = { version = "0.13", default-features = false, optional = true }
 instant = { version = "0.1", features = ["wasm-bindgen"], optional = true }
-bumpalo = { workspace = true, optional = true }
 lasso = { workspace = true, optional = true }
 hashbrown = { workspace = true }
 half = { version = "2.7", features = ["std"] }
@@ -50,8 +47,8 @@ libc = { version = "0.2", optional = true }
 uuid = { workspace = true, optional = true }
 kentro = { version = "0.2", optional = true }
 ndarray = { version = "0.16", optional = true }
-nalgebra = { version = "0.34", optional = true }
-hf-hub = { version = "0.4", default-features = false, features = ["ureq", "rustls-tls"], optional = true }
+nalgebra = { version = "0.35", optional = true }
+hf-hub = { version = "0.5", default-features = false, features = ["ureq", "rustls-tls"], optional = true }
 
 # Native tokenizers with onig (C library) for full regex support
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.tokenizers]
@@ -119,7 +116,7 @@ harness = false
 
 [features]
 default = ["sync"]
-native = ["fst-index", "dep:tokio", "dep:async-channel", "dep:crossbeam-channel", "dep:num_cpus", "dep:rayon", "dep:bumpalo", "dep:lasso", "dep:memmap2", "dep:libc", "dep:uuid", "dep:kentro", "dep:ndarray", "dep:nalgebra", "dep:tokenizers", "dep:hf-hub"]
+native = ["fst-index", "dep:tokio", "dep:async-channel", "dep:num_cpus", "dep:rayon", "dep:lasso", "dep:memmap2", "dep:libc", "dep:uuid", "dep:kentro", "dep:ndarray", "dep:nalgebra", "dep:tokenizers", "dep:hf-hub"]
 sync = ["native"]
 diagnostics = []
 fst-index = ["dep:fst"]

--- a/hermes-core/benches/compression.rs
+++ b/hermes-core/benches/compression.rs
@@ -2,7 +2,9 @@
 //!
 //! Run with: cargo bench -p hermes-core --bench compression
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use hermes_core::compression::{CompressionLevel, compress, decompress};
 
 fn generate_text_data(size: usize) -> Vec<u8> {

--- a/hermes-core/benches/indexing.rs
+++ b/hermes-core/benches/indexing.rs
@@ -1,6 +1,8 @@
 //! Indexing benchmarks
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use hermes_core::{
     Document, Field, FsDirectory, IndexConfig, IndexWriter, RamDirectory, Schema, SchemaBuilder,
 };

--- a/hermes-core/benches/large_benchmark.rs
+++ b/hermes-core/benches/large_benchmark.rs
@@ -18,7 +18,9 @@ use std::path::Path;
 use std::time::{Duration, Instant};
 
 use comfy_table::{Cell, Color, Table};
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use hermes_core::structures::{
     BlockSparsePostingList, CoarseCentroids, CoarseConfig, IVFPQConfig, IVFPQIndex,

--- a/hermes-core/benches/posting_compression/access_patterns.rs
+++ b/hermes-core/benches/posting_compression/access_patterns.rs
@@ -7,11 +7,11 @@
 //! - Skip-to pattern (conjunction simulation)
 //! - Galloping search (intersection with small list)
 
-use criterion::black_box;
 use hermes_core::structures::{
     EliasFanoPostingList, HorizontalBP128PostingList, OptP4DPostingList, PartitionedEFPostingList,
     RoaringPostingList, VerticalBP128PostingList,
 };
+use std::hint::black_box;
 use std::time::Instant;
 
 /// Type alias for the complex measurement function tuple

--- a/hermes-core/benches/posting_compression/block_decompression.rs
+++ b/hermes-core/benches/posting_compression/block_decompression.rs
@@ -4,7 +4,9 @@
 //! Expected: ~4-6 billion ints/sec (4-6K ints/μs) on modern CPUs with SSE/NEON.
 
 use comfy_table::{Cell, Color, Table, presets::UTF8_FULL};
-use criterion::{Criterion, Throughput, black_box};
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput};
 use hermes_core::structures::simd::RoundedBitWidth;
 use hermes_core::structures::{HORIZONTAL_BP128_BLOCK_SIZE, pack_block, simd, unpack_block};
 use std::time::Instant;

--- a/hermes-core/benches/posting_compression/deserialization.rs
+++ b/hermes-core/benches/posting_compression/deserialization.rs
@@ -1,6 +1,8 @@
 //! Deserialization speed benchmarks
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput};
 use hermes_core::structures::{
     CompressedPostingList, EliasFanoPostingList, HorizontalBP128PostingList, OptP4DPostingList,
     PartitionedEFPostingList, RoaringPostingList, VerticalBP128PostingList,

--- a/hermes-core/benches/posting_compression/distribution.rs
+++ b/hermes-core/benches/posting_compression/distribution.rs
@@ -1,6 +1,8 @@
 //! Distribution-based benchmarks
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput};
 use hermes_core::structures::{
     CompressedPostingList, EliasFanoPostingList, HorizontalBP128PostingList, OptP4DPostingList,
     PartitionedEFPostingList, RoaringPostingList, VerticalBP128PostingList,

--- a/hermes-core/benches/posting_compression/encoding.rs
+++ b/hermes-core/benches/posting_compression/encoding.rs
@@ -1,6 +1,8 @@
 //! Encoding speed benchmarks
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput};
 use hermes_core::structures::{
     EliasFanoPostingList, HorizontalBP128PostingList, OptP4DPostingList, PartitionedEFPostingList,
     RoaringPostingList, RoundedBP128PostingList, VerticalBP128PostingList,

--- a/hermes-core/benches/posting_compression/iteration.rs
+++ b/hermes-core/benches/posting_compression/iteration.rs
@@ -1,6 +1,8 @@
 //! Iteration/decoding speed benchmarks
 
-use criterion::{BenchmarkId, Criterion, Throughput, black_box};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput};
 use hermes_core::structures::{
     EliasFanoPostingList, HorizontalBP128PostingList, OptP4DPostingList, PartitionedEFPostingList,
     RoaringPostingList, RoundedBP128PostingList, VerticalBP128PostingList,

--- a/hermes-core/benches/posting_compression/seek.rs
+++ b/hermes-core/benches/posting_compression/seek.rs
@@ -1,6 +1,8 @@
 //! Seek speed benchmarks
 
-use criterion::{Criterion, Throughput, black_box};
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput};
 use hermes_core::structures::{
     EliasFanoPostingList, HorizontalBP128PostingList, OptP4DPostingList,
 };

--- a/hermes-core/benches/vector_indexing.rs
+++ b/hermes-core/benches/vector_indexing.rs
@@ -14,7 +14,9 @@ use std::io::{BufReader, Read};
 use std::path::Path;
 use std::time::Instant;
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 use rand::prelude::*;
 
 use hermes_core::structures::{

--- a/hermes-core/src/directories/directory.rs
+++ b/hermes-core/src/directories/directory.rs
@@ -383,6 +383,27 @@ impl OwnedBytes {
         self.madvise_range(0..self.len(), advice);
     }
 
+    /// Pin these bytes in physical memory (`mlock`). mmap-backed only —
+    /// heap memory is not evictable by the page cache. Returns whether the
+    /// lock succeeded; failure (e.g. RLIMIT_MEMLOCK) is not fatal.
+    /// Locks are released automatically when the mapping is unmapped.
+    #[cfg(feature = "native")]
+    pub fn mlock(&self) -> bool {
+        if !self.is_mmap() {
+            return false;
+        }
+        let slice = self.as_slice();
+        if slice.is_empty() {
+            return true;
+        }
+        let ptr = slice.as_ptr();
+        let len = slice.len();
+        let page_size = 4096usize;
+        let aligned_ptr = (ptr as usize) & !(page_size - 1);
+        let aligned_len = len + (ptr as usize - aligned_ptr);
+        unsafe { libc::mlock(aligned_ptr as *const libc::c_void, aligned_len) == 0 }
+    }
+
     /// Advise the kernel about the access pattern for a sub-range.
     ///
     /// The range is relative to these bytes. Same mmap-only guard as

--- a/hermes-core/src/dsl/schema.rs
+++ b/hermes-core/src/dsl/schema.rs
@@ -463,6 +463,12 @@ pub struct Schema {
     /// Query router rules for routing queries to specific fields based on regex patterns
     #[serde(default)]
     query_routers: Vec<QueryRouterRule>,
+    /// Run BP (graph bisection) reordering of `reorder`-attributed BMP fields
+    /// inside segment merges. SDL: `reorder_on_merge: true` at index level.
+    /// Absent = disabled (merges block-copy; the standalone reorder pass
+    /// handles ordering).
+    #[serde(default)]
+    reorder_on_merge: bool,
 }
 
 impl Schema {
@@ -497,6 +503,12 @@ impl Schema {
     /// Used by the background optimizer to determine which indexes need BP reordering.
     pub fn has_reorder_fields(&self) -> bool {
         self.fields.iter().any(|e| e.reorder)
+    }
+
+    /// Whether merges BP-reorder `reorder`-attributed BMP fields while writing
+    /// the merged segment (index-level SDL option `reorder_on_merge: true`).
+    pub fn reorder_on_merge(&self) -> bool {
+        self.reorder_on_merge
     }
 
     /// Get the default fields for query parsing
@@ -535,6 +547,7 @@ pub struct SchemaBuilder {
     fields: Vec<FieldEntry>,
     default_fields: Vec<String>,
     query_routers: Vec<QueryRouterRule>,
+    reorder_on_merge: bool,
 }
 
 impl SchemaBuilder {
@@ -807,6 +820,12 @@ impl SchemaBuilder {
         }
     }
 
+    /// Enable BP reordering of `reorder`-attributed BMP fields inside merges
+    /// (index-level; SDL `reorder_on_merge: true`). Default: disabled.
+    pub fn set_reorder_on_merge(&mut self, on: bool) {
+        self.reorder_on_merge = on;
+    }
+
     /// Set position tracking mode for phrase queries and multi-field element tracking
     pub fn set_positions(&mut self, field: Field, mode: PositionMode) {
         if let Some(entry) = self.fields.get_mut(field.0 as usize) {
@@ -842,6 +861,7 @@ impl SchemaBuilder {
             name_to_field,
             default_fields,
             query_routers: self.query_routers,
+            reorder_on_merge: self.reorder_on_merge,
         }
     }
 }

--- a/hermes-core/src/dsl/sdl/mod.rs
+++ b/hermes-core/src/dsl/sdl/mod.rs
@@ -95,6 +95,9 @@ pub struct IndexDef {
     pub default_fields: Vec<String>,
     /// Query router rules for routing queries to specific fields
     pub query_routers: Vec<QueryRouterRule>,
+    /// BP-reorder `reorder`-attributed BMP fields inside merges
+    /// (index-level `reorder_on_merge: true`). Absent = disabled.
+    pub reorder_on_merge: bool,
 }
 
 impl IndexDef {
@@ -197,6 +200,20 @@ impl IndexDef {
         // Set query routers if specified
         if !self.query_routers.is_empty() {
             builder.set_query_routers(self.query_routers.clone());
+        }
+
+        if self.reorder_on_merge {
+            if self.fields.iter().any(|f| f.reorder) {
+                builder.set_reorder_on_merge(true);
+            } else {
+                // Fail loud: the option would silently do nothing without at
+                // least one `reorder`-attributed field.
+                log::warn!(
+                    "index '{}': reorder_on_merge is set but no field has the `reorder` attribute — merges will not reorder anything",
+                    self.name,
+                );
+                builder.set_reorder_on_merge(true);
+            }
         }
 
         builder.build()
@@ -1109,6 +1126,7 @@ fn parse_index_def(pair: pest::iterators::Pair<Rule>) -> Result<IndexDef> {
     let mut fields = Vec::new();
     let mut default_fields = Vec::new();
     let mut query_routers = Vec::new();
+    let mut reorder_on_merge = false;
 
     for item in inner {
         match item.as_rule() {
@@ -1120,6 +1138,14 @@ fn parse_index_def(pair: pest::iterators::Pair<Rule>) -> Result<IndexDef> {
             }
             Rule::query_router_def => {
                 query_routers.push(parse_query_router_def(item)?);
+            }
+            Rule::reorder_on_merge_def => {
+                let value = item
+                    .into_inner()
+                    .next()
+                    .map(|b| b.as_str() == "true")
+                    .unwrap_or(false);
+                reorder_on_merge = value;
             }
             _ => {}
         }
@@ -1154,6 +1180,7 @@ fn parse_index_def(pair: pest::iterators::Pair<Rule>) -> Result<IndexDef> {
         fields,
         default_fields,
         query_routers,
+        reorder_on_merge,
     })
 }
 
@@ -2402,5 +2429,40 @@ mod tests {
 
         let f2 = schema.get_field("embedding2").unwrap();
         assert!(!schema.get_field_entry(f2).unwrap().reorder);
+
+        // Index-level reorder_on_merge absent → disabled (current behaviour)
+        assert!(!schema.reorder_on_merge());
+    }
+
+    #[test]
+    fn test_reorder_on_merge_index_option() {
+        let sdl = r#"
+            index documents {
+                reorder_on_merge: true
+                field embedding: sparse_vector<u16> [indexed<format: bmp>, reorder]
+            }
+        "#;
+
+        let indexes = parse_sdl(sdl).unwrap();
+        assert!(indexes[0].reorder_on_merge);
+        let schema = indexes[0].to_schema();
+        assert!(schema.reorder_on_merge());
+
+        // Explicit false parses and stays disabled
+        let sdl_off = r#"
+            index documents {
+                reorder_on_merge: false
+                field embedding: sparse_vector<u16> [indexed<format: bmp>, reorder]
+            }
+        "#;
+        let indexes = parse_sdl(sdl_off).unwrap();
+        assert!(!indexes[0].reorder_on_merge);
+        assert!(!indexes[0].to_schema().reorder_on_merge());
+
+        // Schema serde roundtrip preserves the flag (persisted in metadata)
+        let schema_on = parse_sdl(sdl).unwrap()[0].to_schema();
+        let json = serde_json::to_string(&schema_on).unwrap();
+        let back: crate::dsl::Schema = serde_json::from_str(&json).unwrap();
+        assert!(back.reorder_on_merge());
     }
 }

--- a/hermes-core/src/dsl/sdl/sdl.pest
+++ b/hermes-core/src/dsl/sdl/sdl.pest
@@ -4,7 +4,13 @@
 file = { SOI ~ index_def+ ~ EOI }
 
 // Index definition
-index_def = { "index" ~ identifier ~ "{" ~ (field_def | default_fields_def | query_router_def)* ~ "}" }
+index_def = { "index" ~ identifier ~ "{" ~ (field_def | default_fields_def | query_router_def | reorder_on_merge_def)* ~ "}" }
+
+// Index-level option: BP-reorder `reorder`-attributed BMP fields inside merges.
+// Absent = disabled (merges block-copy).
+//   reorder_on_merge: true
+reorder_on_merge_def = { "reorder_on_merge" ~ ":" ~ bool_lit }
+bool_lit = { "true" | "false" }
 
 // Default fields definition
 default_fields_def = { "default_fields" ~ ":" ~ "[" ~ identifier ~ ("," ~ identifier)* ~ "]" }

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -28,10 +28,12 @@ fn maxscore_config() -> SparseVectorConfig {
 }
 
 /// Helper: create BMP schema with a text field and a BMP sparse field.
+/// The sparse field carries the `reorder` attribute so BP paths are exercised.
 fn bmp_schema() -> (crate::dsl::Schema, crate::dsl::Field, crate::dsl::Field) {
     let mut sb = SchemaBuilder::default();
     let title = sb.add_text_field("title", true, true);
     let sparse = sb.add_sparse_vector_field_with_config("sparse", true, true, bmp_config());
+    sb.set_reorder(sparse, true);
     (sb.build(), title, sparse)
 }
 
@@ -956,6 +958,7 @@ async fn test_bmp_reorder_standalone() {
     let mut sb = SchemaBuilder::default();
     let title = sb.add_text_field("title", true, true);
     let sparse = sb.add_sparse_vector_field_with_config("sparse", true, true, bmp_config());
+    sb.set_reorder(sparse, true);
     let schema = sb.build();
 
     let dir = RamDirectory::new();
@@ -1047,6 +1050,312 @@ async fn test_bmp_reorder_standalone() {
     );
 }
 
+/// Reorder of a block-copy-merged segment must keep every doc, including docs
+/// whose vids sit past interior padding.
+///
+/// Block-copy merge concatenates each source's virtual doc space *including*
+/// its tail padding (u32::MAX doc-map slots in the last block), so the merged
+/// segment has interior padding and real docs are NOT contiguous in vid space.
+/// The reorder path used to assume `vid < num_real_docs` ⇔ real doc, which
+/// silently dropped the real docs shifted past `num_real_docs` and wrote
+/// padding slots as if they were docs.
+#[tokio::test]
+async fn test_bmp_reorder_after_merge_keeps_interior_padded_docs() {
+    let (schema, title, sparse) = bmp_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+
+    // Two segments of 100 docs each. block_size=64 → each segment has 128
+    // virtual slots with padding at vids 100..128. After block-copy merge the
+    // padding from segment 1 is interior (merged vids 100..128), and segment
+    // 2's docs occupy vids 128..228 — the last 28 of them past
+    // num_real_docs=200.
+    const DOCS_PER_SEGMENT: usize = 100;
+    for seg in 0..2 {
+        for i in 0..DOCS_PER_SEGMENT {
+            let global = seg * DOCS_PER_SEGMENT + i;
+            let mut doc = Document::new();
+            doc.add_text(title, format!("doc{}", global));
+            doc.add_sparse_vector(sparse, vec![(global as u32, 1.0), (9999, 0.1)]);
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+
+    // Block-copy merge (no reorder) → merged segment with interior padding
+    let mut writer = IndexWriter::open(dir.clone(), config.clone())
+        .await
+        .unwrap();
+    writer.force_merge().await.unwrap();
+
+    // Standalone BP reorder of the merged segment
+    let mut writer = IndexWriter::open(dir.clone(), config.clone())
+        .await
+        .unwrap();
+    writer.reorder().await.unwrap();
+
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    assert_eq!(index.segment_readers().await.unwrap().len(), 1);
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    // Every unique dim must return exactly its doc
+    let total = 2 * DOCS_PER_SEGMENT;
+    let mut failures = Vec::new();
+    for i in 0..total {
+        let query = SparseVectorQuery::new(sparse, vec![(i as u32, 1.0)]);
+        let results = searcher.search(&query, 5).await.unwrap();
+        if results.len() != 1 {
+            failures.push(format!(
+                "dim {}: expected 1 result, got {}",
+                i,
+                results.len()
+            ));
+            continue;
+        }
+        let doc = searcher
+            .doc(results[0].segment_id, results[0].doc_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let got = doc.get_first(title).unwrap().as_text().unwrap().to_string();
+        if got != format!("doc{}", i) {
+            failures.push(format!("dim {}: got '{}', expected 'doc{}'", i, got, i));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "Reorder after merge lost docs past interior padding: {} failures:\n{}",
+        failures.len(),
+        failures[..failures.len().min(20)].join("\n")
+    );
+
+    // Shared dim must match every doc
+    let query = SparseVectorQuery::new(sparse, vec![(9999, 1.0)]);
+    let results = searcher.search(&query, 300).await.unwrap();
+    assert_eq!(
+        results.len(),
+        total,
+        "dim 9999 should match all {} docs after reorder, got {}",
+        total,
+        results.len()
+    );
+}
+
+/// Merge-time BP reorder (schema-level `reorder_on_merge: true`): force_merge
+/// writes the merged BMP blob in BP order directly, keeps every doc (including
+/// multi-ordinal records and docs behind source tail padding), and marks the
+/// output segment `reordered` so the standalone optimizer pass skips it.
+#[tokio::test]
+async fn test_bmp_merge_with_reorder_on_merge() {
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    let sparse = sb.add_sparse_vector_field_with_config("sparse", true, true, bmp_config());
+    sb.set_reorder(sparse, true);
+    sb.set_reorder_on_merge(true);
+    let schema = sb.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+
+    // Two segments of 100 docs (not a multiple of block_size=64 → each source
+    // has tail padding, exercising the padding-aware multi-source path).
+    // Every 10th doc carries a second sparse vector (ordinal 1).
+    const DOCS_PER_SEGMENT: usize = 100;
+    for seg in 0..2 {
+        for i in 0..DOCS_PER_SEGMENT {
+            let global = seg * DOCS_PER_SEGMENT + i;
+            let mut doc = Document::new();
+            doc.add_text(title, format!("doc{}", global));
+            doc.add_sparse_vector(sparse, vec![(global as u32, 1.0), (9999, 0.1)]);
+            if global.is_multiple_of(10) {
+                doc.add_sparse_vector(sparse, vec![(5000 + global as u32, 1.0)]);
+            }
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+
+    let mut writer = IndexWriter::open(dir.clone(), config.clone())
+        .await
+        .unwrap();
+    writer.force_merge().await.unwrap();
+
+    // Merged segment must be marked reordered — the optimizer must not rewrite it again
+    let metadata = crate::index::IndexMetadata::load(&dir).await.unwrap();
+    assert_eq!(metadata.segment_metas.len(), 1);
+    assert!(
+        metadata.segment_metas.values().all(|m| m.reordered),
+        "merge with reorder_on_merge must mark the output segment reordered"
+    );
+
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let total = 2 * DOCS_PER_SEGMENT;
+    assert_eq!(index.num_docs().await.unwrap() as usize, total);
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    // Every unique dim returns exactly its doc; ordinal-1 vectors also found
+    let mut failures = Vec::new();
+    for i in 0..total {
+        let mut dims_to_check = vec![i as u32];
+        if i.is_multiple_of(10) {
+            dims_to_check.push(5000 + i as u32);
+        }
+        for dim in dims_to_check {
+            let query = SparseVectorQuery::new(sparse, vec![(dim, 1.0)]);
+            let results = searcher.search(&query, 5).await.unwrap();
+            if results.len() != 1 {
+                failures.push(format!(
+                    "dim {}: expected 1 result, got {}",
+                    dim,
+                    results.len()
+                ));
+                continue;
+            }
+            let doc = searcher
+                .doc(results[0].segment_id, results[0].doc_id)
+                .await
+                .unwrap()
+                .unwrap();
+            let got = doc.get_first(title).unwrap().as_text().unwrap().to_string();
+            if got != format!("doc{}", i) {
+                failures.push(format!("dim {}: got '{}', expected 'doc{}'", dim, got, i));
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "Merge-time reorder: {} failures:\n{}",
+        failures.len(),
+        failures[..failures.len().min(20)].join("\n")
+    );
+
+    // Shared dim matches every doc
+    let query = SparseVectorQuery::new(sparse, vec![(9999, 1.0)]);
+    let results = searcher.search(&query, 300).await.unwrap();
+    assert_eq!(
+        results.len(),
+        total,
+        "dim 9999 should match all {} docs after merge-time reorder, got {}",
+        total,
+        results.len()
+    );
+}
+
+/// Per-field reorder gate: a BMP field WITHOUT the `reorder` schema attribute
+/// must come out of writer.reorder() byte-identical (insertion order
+/// preserved), while a field WITH the attribute gets BP-reordered. Both must
+/// stay fully searchable.
+#[tokio::test]
+async fn test_bmp_reorder_skips_field_without_reorder_attribute() {
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    let ordered = sb.add_sparse_vector_field_with_config("ordered", true, true, bmp_config());
+    let frozen = sb.add_sparse_vector_field_with_config("frozen", true, true, bmp_config());
+    sb.set_reorder(ordered, true);
+    // `frozen` deliberately has NO reorder attribute
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+
+    // Interleaved topics (i % 2) with df >= 128 so BP's min_doc_freq filter
+    // keeps them and clustering requires an actual permutation.
+    const NUM_DOCS: usize = 300;
+    for i in 0..NUM_DOCS {
+        let mut doc = Document::new();
+        doc.add_text(title, format!("doc{}", i));
+        let topic_dim = 10000 + (i % 2) as u32 * 10;
+        doc.add_sparse_vector(ordered, vec![(i as u32, 1.0), (topic_dim, 0.5)]);
+        doc.add_sparse_vector(frozen, vec![(i as u32, 1.0), (9999, 0.1)]);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    // Snapshot the frozen field's doc map before reorder
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let readers = index.segment_readers().await.unwrap();
+    assert_eq!(readers.len(), 1);
+    let frozen_doc_map_before: Vec<u8> = readers[0]
+        .bmp_indexes()
+        .get(&frozen.0)
+        .expect("frozen BMP index")
+        .doc_map_ids_slice()
+        .to_vec();
+    let ordered_doc_map_before: Vec<u8> = readers[0]
+        .bmp_indexes()
+        .get(&ordered.0)
+        .expect("ordered BMP index")
+        .doc_map_ids_slice()
+        .to_vec();
+    drop(readers);
+    drop(index);
+
+    let mut writer = IndexWriter::open(dir.clone(), config.clone())
+        .await
+        .unwrap();
+    writer.reorder().await.unwrap();
+
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let readers = index.segment_readers().await.unwrap();
+    assert_eq!(readers.len(), 1);
+    let frozen_doc_map_after: Vec<u8> = readers[0]
+        .bmp_indexes()
+        .get(&frozen.0)
+        .expect("frozen BMP index after reorder")
+        .doc_map_ids_slice()
+        .to_vec();
+    let ordered_doc_map_after: Vec<u8> = readers[0]
+        .bmp_indexes()
+        .get(&ordered.0)
+        .expect("ordered BMP index after reorder")
+        .doc_map_ids_slice()
+        .to_vec();
+    drop(readers);
+
+    assert_eq!(
+        frozen_doc_map_before, frozen_doc_map_after,
+        "field without `reorder` attribute must be copied byte-identically"
+    );
+    assert_ne!(
+        ordered_doc_map_before, ordered_doc_map_after,
+        "field with `reorder` attribute must actually be BP-reordered"
+    );
+
+    // Both fields stay fully searchable
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    for (field, name) in [(ordered, "ordered"), (frozen, "frozen")] {
+        for i in [0usize, 63, 64, 150, NUM_DOCS - 1] {
+            let query = SparseVectorQuery::new(field, vec![(i as u32, 1.0)]);
+            let results = searcher.search(&query, 5).await.unwrap();
+            assert_eq!(results.len(), 1, "{} dim {}: expected 1 result", name, i);
+            let doc = searcher
+                .doc(results[0].segment_id, results[0].doc_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                doc.get_first(title).unwrap().as_text().unwrap(),
+                format!("doc{}", i),
+                "{} dim {} returned wrong doc",
+                name,
+                i
+            );
+        }
+    }
+}
+
 /// BMP reorder with multi-field: build index with 2 BMP sparse fields,
 /// call writer.reorder(), verify both fields return correct results.
 #[tokio::test]
@@ -1055,6 +1364,8 @@ async fn test_bmp_reorder_multi_field() {
     let title = sb.add_text_field("title", true, true);
     let sparse_a = sb.add_sparse_vector_field_with_config("sparse_a", true, true, bmp_config());
     let sparse_b = sb.add_sparse_vector_field_with_config("sparse_b", true, true, bmp_config());
+    sb.set_reorder(sparse_a, true);
+    sb.set_reorder(sparse_b, true);
     let schema = sb.build();
 
     let dir = RamDirectory::new();

--- a/hermes-core/src/index/tests/boolean.rs
+++ b/hermes-core/src/index/tests/boolean.rs
@@ -896,3 +896,94 @@ async fn test_must_term_non_fast_should_sparse_bitset_fallback() {
     );
     assert_eq!(results.hits[0].address.doc_id, 25);
 }
+
+// ── Selectivity-aware filter planning ─────────────────────────────────
+
+/// Build an index shaped like the production slow-query case: a `type` field
+/// (text, indexed + fast) where one value covers ~90% of docs, and a `date`
+/// u64 fast field with evenly spread values.
+async fn create_type_date_index() -> (
+    Index<crate::directories::MmapDirectory>,
+    crate::dsl::Field, // doc_type (text, fast)
+    crate::dsl::Field, // date (u64 fast)
+    crate::dsl::Field, // embedding (sparse_vector)
+) {
+    use crate::directories::MmapDirectory;
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let dir = MmapDirectory::new(tmp_dir.path());
+
+    let mut sb = SchemaBuilder::default();
+    let doc_type = sb.add_text_field("doc_type", true, true);
+    sb.set_fast(doc_type, true);
+    let date = sb.add_u64_field("date", false, true);
+    sb.set_fast(date, true);
+    let embedding = sb.add_sparse_vector_field("embedding", true, true);
+    let schema = sb.build();
+
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    const N: u64 = 3000;
+    for i in 0..N {
+        let mut doc = Document::new();
+        // 90% "page" (the wide filter value), 10% "video"
+        let ty = if i % 10 == 0 { "video" } else { "page" };
+        doc.add_text(doc_type, ty);
+        doc.add_u64(date, i);
+        doc.add_sparse_vector(embedding, vec![(0, 0.5)]);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    writer.force_merge().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert_eq!(index.num_docs().await.unwrap(), N as u32);
+    (index, doc_type, date, embedding)
+}
+
+/// Production slow-query shape: MUST `type = page` (wide — matches ~90% of
+/// docs) AND MUST `date` in a narrow recent window. The planner must seed the
+/// filter from the narrow range estimate and refine the wide term clause by
+/// per-doc fast-field probes — and the result set must be exactly the docs
+/// satisfying both clauses.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_wide_type_filter_with_narrow_date_range_returns_exact_docs() {
+    let (index, doc_type, date, embedding) = create_type_date_index().await;
+
+    // date in [2900, 2950]: 51 docs, of which those with i % 10 != 0 are "page"
+    let q = BooleanQuery::new()
+        .must(TermQuery::text(doc_type, "page"))
+        .must(RangeQuery::u64(date, Some(2900), Some(2950)))
+        .should(SparseVectorQuery::new(embedding, vec![(0, 1.0)]));
+
+    let results = index.search(&q, 100).await.unwrap();
+    let got: HashSet<u32> = results.hits.iter().map(|h| h.address.doc_id).collect();
+    let expected: HashSet<u32> = (2900u32..=2950).filter(|i| i % 10 != 0).collect();
+    assert_eq!(
+        got, expected,
+        "wide term + narrow range must return exactly the conjunction"
+    );
+}
+
+/// Same shape with MUST_NOT: the wide `type = page` exclusion over a narrow
+/// date window must be probe-refined and return exactly the non-page docs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_narrow_range_with_wide_must_not_term_returns_exact_docs() {
+    let (index, doc_type, date, embedding) = create_type_date_index().await;
+
+    let q = BooleanQuery::new()
+        .must(RangeQuery::u64(date, Some(2000), Some(2100)))
+        .must_not(TermQuery::text(doc_type, "page"))
+        .should(SparseVectorQuery::new(embedding, vec![(0, 1.0)]));
+
+    let results = index.search(&q, 100).await.unwrap();
+    let got: HashSet<u32> = results.hits.iter().map(|h| h.address.doc_id).collect();
+    let expected: HashSet<u32> = (2000u32..=2100).filter(|i| i % 10 == 0).collect();
+    assert_eq!(
+        got, expected,
+        "narrow range minus wide MUST_NOT term must return exactly the difference"
+    );
+}

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -2,6 +2,7 @@ mod basic;
 mod bmp;
 mod boolean;
 mod merge;
+mod pin;
 mod primary_key;
 mod range;
 mod search;

--- a/hermes-core/src/index/tests/pin.rs
+++ b/hermes-core/src/index/tests/pin.rs
@@ -1,0 +1,109 @@
+//! Hot-metadata pinning tests (segment::pin).
+//!
+//! Uses MmapDirectory so the metadata sections are genuinely mmap-backed
+//! (pinning is a no-op for heap-backed RAM directories).
+
+use std::sync::Arc;
+
+use crate::directories::MmapDirectory;
+use crate::dsl::{Document, SchemaBuilder};
+use crate::index::{Index, IndexConfig, IndexWriter};
+use crate::segment::pin::{PinMode, PinPolicy};
+use crate::segment::{SegmentId, SegmentReader};
+
+async fn build_test_index(dir: &MmapDirectory) -> (crate::dsl::Schema, u128) {
+    let mut sb = SchemaBuilder::default();
+    let sparse_cfg = crate::structures::SparseVectorConfig {
+        format: crate::structures::SparseFormat::Bmp,
+        dims: Some(1024),
+        max_weight: Some(5.0),
+        ..Default::default()
+    };
+    let sparse = sb.add_sparse_vector_field_with_config("sparse", true, true, sparse_cfg);
+    let dense = sb.add_dense_vector_field("dense", 8, true, true);
+    let schema = sb.build();
+
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+    for i in 0..300u32 {
+        let mut doc = Document::new();
+        doc.add_sparse_vector(
+            sparse,
+            vec![(i % 512, 1.0 + (i % 7) as f32), ((i + 7) % 512, 0.5)],
+        );
+        doc.add_dense_vector(dense, (0..8).map(|d| (i + d) as f32 / 300.0).collect());
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir.clone(), config).await.unwrap();
+    let segments = index.segment_readers().await.unwrap();
+    let seg_id = segments[0].meta().id;
+    (schema, seg_id)
+}
+
+/// Copy-mode pinning: metadata sections move to the heap, accounting is
+/// reported, and search results are unchanged afterwards.
+#[tokio::test]
+async fn test_pin_metadata_copy_mode_preserves_search() {
+    use crate::query::SparseVectorQuery;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = MmapDirectory::new(tmp.path());
+    let (schema, seg_id) = build_test_index(&dir).await;
+
+    let mut reader = SegmentReader::open(&dir, SegmentId(seg_id), Arc::new(schema.clone()), 64)
+        .await
+        .unwrap();
+
+    // Generous budget: everything pinnable gets pinned
+    reader.apply_pin_policy(&PinPolicy {
+        budget_bytes: 64 * 1024 * 1024,
+        mode: PinMode::Copy,
+    });
+    let stats = reader.memory_stats();
+    assert!(
+        stats.pinned_metadata_bytes > 0,
+        "BMP starts/doc-maps/sb_grid + flat doc_ids should be pinnable"
+    );
+    assert_eq!(
+        stats.pinned_metadata_bytes, stats.pin_intended_bytes,
+        "generous budget must pin everything eligible"
+    );
+
+    // Search still works on the heap-copied metadata
+    let field = schema.get_field("sparse").unwrap();
+    let query = SparseVectorQuery::new(field, vec![(3, 1.0), (10, 1.0)]);
+    let results = crate::query::search_segment_with_count(&reader, &query, 10)
+        .await
+        .unwrap()
+        .0;
+    assert!(!results.is_empty(), "search must survive pinning");
+}
+
+/// Budget exhaustion is respected and reported (fail-loud accounting).
+#[tokio::test]
+async fn test_pin_metadata_budget_exhaustion_reported() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = MmapDirectory::new(tmp.path());
+    let (schema, seg_id) = build_test_index(&dir).await;
+
+    let mut reader = SegmentReader::open(&dir, SegmentId(seg_id), Arc::new(schema), 64)
+        .await
+        .unwrap();
+
+    // Tiny budget: something must be skipped
+    let budget = 128u64;
+    reader.apply_pin_policy(&PinPolicy {
+        budget_bytes: budget,
+        mode: PinMode::Copy,
+    });
+    let stats = reader.memory_stats();
+    assert!(stats.pinned_metadata_bytes <= budget);
+    assert!(
+        stats.pin_intended_bytes > stats.pinned_metadata_bytes,
+        "tiny budget must leave a visible intended-vs-pinned gap"
+    );
+}

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -155,6 +155,11 @@ pub struct SegmentManager<D: DirectoryWriter + 'static> {
     term_cache_blocks: usize,
     /// Maximum number of concurrent background merges
     max_concurrent_merges: usize,
+    /// Run BP reordering of `reorder`-attributed BMP fields inside merges.
+    /// Persisted index configuration (schema-level `reorder_on_merge: true`
+    /// in SDL); merged segments are marked `reordered` and skipped by the
+    /// standalone optimizer pass.
+    reorder_on_merge: bool,
 }
 
 impl<D: DirectoryWriter + 'static> SegmentManager<D> {
@@ -167,6 +172,13 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         term_cache_blocks: usize,
         max_concurrent_merges: usize,
     ) -> Self {
+        // Persisted index option: set via `reorder_on_merge: true` in the SDL
+        // at index creation. Absent = disabled (merges block-copy).
+        let reorder_on_merge = schema.reorder_on_merge();
+        if reorder_on_merge {
+            log::info!("[merge] reorder-on-merge enabled by index schema");
+        }
+
         let tracker = Arc::new(SegmentTracker::new());
         for seg_id in metadata.segment_metas.keys() {
             tracker.register(seg_id);
@@ -207,6 +219,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             schema,
             term_cache_blocks,
             max_concurrent_merges: max_concurrent_merges.max(1),
+            reorder_on_merge,
         }
     }
 
@@ -422,12 +435,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 output_id,
                 sm.term_cache_blocks,
                 trained_snap.as_deref(),
+                sm.reorder_on_merge,
             )
             .await;
 
             match result {
                 Ok((new_id, doc_count)) => {
-                    if let Err(e) = sm.replace_segments(&ids, new_id, doc_count, false).await {
+                    if let Err(e) = sm
+                        .replace_segments(&ids, new_id, doc_count, sm.reorder_on_merge)
+                        .await
+                    {
                         log::error!("[merge] Failed to replace segments after merge: {:?}", e);
                     }
                 }
@@ -496,6 +513,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         output_segment_id: SegmentId,
         term_cache_blocks: usize,
         trained: Option<&TrainedVectorStructures>,
+        reorder_bmp: bool,
     ) -> Result<(String, u32)> {
         let output_hex = output_segment_id.to_hex();
         let load_start = std::time::Instant::now();
@@ -557,7 +575,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             load_start.elapsed().as_secs_f64()
         );
 
-        let merger = SegmentMerger::new(Arc::clone(schema));
+        let merger = SegmentMerger::new(Arc::clone(schema)).with_bmp_reorder(reorder_bmp);
 
         log::info!(
             "[merge] {} segments -> {} (trained={})",
@@ -710,10 +728,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 output_id,
                 self.term_cache_blocks,
                 trained_snap.as_deref(),
+                self.reorder_on_merge,
             )
             .await?;
 
-            self.replace_segments(&batch, new_segment_id, total_docs, false)
+            self.replace_segments(&batch, new_segment_id, total_docs, self.reorder_on_merge)
                 .await?;
 
             // _guard drops here → segments unregistered from inventory

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -529,11 +529,9 @@ impl Query for BooleanQuery {
         // MUST_NOT clauses: subtract bitsets (ANDNOT)
         if let Some(ref mut acc) = result {
             for q in &self.must_not {
-                if let Some(bs) = q.as_doc_bitset(reader) {
+                {
+                    let bs = q.as_doc_bitset(reader)?;
                     acc.subtract(&bs);
-                } else {
-                    // Can't build bitset for this MUST_NOT clause — bail
-                    return None;
                 }
             }
         }

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -308,10 +308,24 @@ pub(super) fn chain_predicates<'a>(predicates: Vec<DocPredicate<'a>>) -> DocPred
     Box::new(move |doc_id| predicates.iter().all(|p| p(doc_id)))
 }
 
+/// Refining a small accumulator beats materializing a clause's full bitset
+/// when the clause is estimated to match at least this many times more docs
+/// than the accumulator holds. Probes cost ~30-40ns (fast-field closure) vs
+/// ~2-5ns per materialized entry, hence the margin.
+const PROBE_ADVANTAGE: u64 = 8;
+
 /// Build a combined DocBitset from MUST and MUST_NOT clause bitsets.
 ///
-/// Returns None if any clause doesn't support bitset creation.
-/// For term queries this is O(M) (posting list iteration); for range queries O(N).
+/// Selectivity-aware: MUST clauses are evaluated narrowest-first (posting
+/// doc counts are exact, fast-field ranges are sampled), and once the
+/// accumulator is much smaller than a remaining clause's estimate, that
+/// clause is applied as O(|acc|) per-doc predicate probes instead of being
+/// materialized. A `type = X` filter matching millions of docs is then never
+/// iterated when a recent-dates range keeps only a few thousand candidates —
+/// each surviving doc just probes the `type` fast field once.
+///
+/// Returns None if a clause that must be materialized doesn't support bitset
+/// creation (probed clauses only need `as_doc_predicate`).
 /// The resulting bitset enables ~2ns per-doc lookups in BMP (vs ~30-40ns for closures).
 pub(super) fn build_combined_bitset(
     must: &[std::sync::Arc<dyn super::Query>],
@@ -323,27 +337,70 @@ pub(super) fn build_combined_bitset(
     }
 
     let num_docs = reader.num_docs();
-    let mut result: Option<super::DocBitset> = None;
 
-    // Intersect MUST bitsets
-    for q in must {
-        let bs = q.as_doc_bitset(reader)?;
+    // Order MUST clauses by estimated match count, narrowest first. Unknown
+    // estimates sort last (pessimistically treated as matching everything).
+    let mut order: Vec<(usize, u64)> = must
+        .iter()
+        .enumerate()
+        .map(|(i, q)| {
+            (
+                i,
+                q.bitset_cardinality_estimate(reader)
+                    .unwrap_or(num_docs as u64),
+            )
+        })
+        .collect();
+    order.sort_unstable_by_key(|&(_, est)| est);
+
+    let mut result: Option<super::DocBitset> = None;
+    let mut acc_count: u64 = 0;
+
+    for (idx, est) in order {
+        let q = &must[idx];
         match result {
-            None => result = Some(bs),
-            Some(ref mut acc) => acc.intersect_with(&bs),
+            None => {
+                // Seed: materialize the narrowest clause.
+                let bs = q.as_doc_bitset(reader)?;
+                acc_count = bs.count() as u64;
+                result = Some(bs);
+            }
+            Some(ref mut acc) => {
+                let mut probed = false;
+                if acc_count.saturating_mul(PROBE_ADVANTAGE) <= est
+                    && let Some(pred) = q.as_doc_predicate(reader)
+                {
+                    acc.retain(&*pred);
+                    probed = true;
+                }
+                if !probed {
+                    let bs = q.as_doc_bitset(reader)?;
+                    acc.intersect_with(&bs);
+                }
+                acc_count = acc.count() as u64;
+                log::debug!(
+                    "[planner] MUST clause {}: est={} probed={} acc={}",
+                    idx,
+                    est,
+                    probed,
+                    acc_count,
+                );
+            }
+        }
+        if acc_count == 0 {
+            // AND is already empty — nothing can revive it.
+            break;
         }
     }
 
-    // Subtract MUST_NOT bitsets
+    // Subtract MUST_NOT bitsets (probe-refined when the accumulator is small)
     for q in must_not {
-        let bs = q.as_doc_bitset(reader)?;
         match result {
             None => {
                 // No MUST clauses — start with all-ones, then subtract
+                let bs = q.as_doc_bitset(reader)?;
                 let mut all = super::DocBitset::new(num_docs);
-                for w in &mut all.bits {
-                    *w = u64::MAX;
-                }
+                all.bits.fill(u64::MAX);
                 // Clear bits beyond num_docs
                 let tail_bits = num_docs as usize % 64;
                 if tail_bits > 0 && !all.bits.is_empty() {
@@ -351,9 +408,26 @@ pub(super) fn build_combined_bitset(
                     all.bits[last] &= (1u64 << tail_bits) - 1;
                 }
                 all.subtract(&bs);
+                acc_count = all.count() as u64;
                 result = Some(all);
             }
-            Some(ref mut acc) => acc.subtract(&bs),
+            Some(ref mut acc) => {
+                let est = q
+                    .bitset_cardinality_estimate(reader)
+                    .unwrap_or(num_docs as u64);
+                let mut probed = false;
+                if acc_count.saturating_mul(PROBE_ADVANTAGE) <= est
+                    && let Some(pred) = q.as_doc_predicate(reader)
+                {
+                    acc.retain(&|doc| !pred(doc));
+                    probed = true;
+                }
+                if !probed {
+                    let bs = q.as_doc_bitset(reader)?;
+                    acc.subtract(&bs);
+                }
+                acc_count = acc.count() as u64;
+            }
         }
     }
 

--- a/hermes-core/src/query/range.rs
+++ b/hermes-core/src/query/range.rs
@@ -201,6 +201,25 @@ impl Query for RangeQuery {
         let pred = self.as_doc_predicate(reader)?;
         Some(super::DocBitset::from_predicate(reader.num_docs(), &*pred))
     }
+
+    fn bitset_cardinality_estimate(&self, reader: &SegmentReader) -> Option<u64> {
+        // Sampled: probe ~1k evenly spaced docs with the fast-field predicate.
+        // Works for every encoding (incl. i64 zigzag, where min/max
+        // interpolation would mis-order). Rounded up so a rare-but-present
+        // range never estimates to zero.
+        let pred = self.as_doc_predicate(reader)?;
+        let n = reader.num_docs();
+        if n == 0 {
+            return Some(0);
+        }
+        const SAMPLES: u32 = 1024;
+        if n <= SAMPLES {
+            return Some((0..n).filter(|&d| pred(d)).count() as u64);
+        }
+        let step = n / SAMPLES;
+        let hits = (0..SAMPLES).filter(|&i| pred(i * step)).count() as u64;
+        Some(((hits * n as u64) / SAMPLES as u64).max(1))
+    }
 }
 
 // ── RangeScorer ──────────────────────────────────────────────────────────

--- a/hermes-core/src/query/term.rs
+++ b/hermes-core/src/query/term.rs
@@ -206,6 +206,13 @@ impl Query for TermQuery {
     }
 
     #[cfg(feature = "sync")]
+    fn bitset_cardinality_estimate(&self, reader: &SegmentReader) -> Option<u64> {
+        // Exact: the posting list header carries the doc count.
+        let pl = reader.get_postings_sync(self.field, &self.term).ok()??;
+        Some(pl.doc_count() as u64)
+    }
+
+    #[cfg(feature = "sync")]
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<super::DocBitset> {
         // Build bitset from posting list: O(M) where M = matching doc count.
         // Much faster than O(N) fast-field scan for selective terms.

--- a/hermes-core/src/query/traits.rs
+++ b/hermes-core/src/query/traits.rs
@@ -117,6 +117,23 @@ impl DocBitset {
             *a &= !*b;
         }
     }
+
+    /// Keep only the set docs for which `pred` returns true. O(count) probes —
+    /// the planner uses this to refine a small accumulator against a wide
+    /// clause instead of materializing that clause's full bitset.
+    pub fn retain(&mut self, pred: &dyn Fn(DocId) -> bool) {
+        for (w, word) in self.bits.iter_mut().enumerate() {
+            let mut bits = *word;
+            while bits != 0 {
+                let b = bits.trailing_zeros();
+                let doc = (w * 64) as u32 + b;
+                if !pred(doc) {
+                    *word &= !(1u64 << b);
+                }
+                bits &= bits - 1;
+            }
+        }
+    }
 }
 
 /// Info for MaxScore-optimizable term queries
@@ -242,6 +259,15 @@ macro_rules! define_query_traits {
             ) -> Option<DocBitset> {
                 None
             }
+
+            /// Cheap estimate of how many docs this filter clause matches in
+            /// the segment. Used by the boolean planner to order MUST/MUST_NOT
+            /// evaluation: the narrowest clause is materialized first and wider
+            /// clauses refine it with per-doc probes instead of being fully
+            /// materialized. `None` = unknown (treated as matching everything).
+            fn bitset_cardinality_estimate(&self, _reader: &SegmentReader) -> Option<u64> {
+                None
+            }
         }
 
         /// Scored document stream: a DocSet that also provides scores.
@@ -287,6 +313,10 @@ impl Query for Box<dyn Query> {
 
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<DocBitset> {
         (**self).as_doc_bitset(reader)
+    }
+
+    fn bitset_cardinality_estimate(&self, reader: &SegmentReader) -> Option<u64> {
+        (**self).bitset_cardinality_estimate(reader)
     }
 
     #[cfg(feature = "sync")]

--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -138,7 +138,7 @@ pub(crate) fn build_bmp_blob(
     }
 
     // Phase 0: Prune per-dimension (skip dims with fewer than min_terms postings)
-    for (_dim_id, dim_postings) in postings.iter_mut() {
+    for dim_postings in postings.values_mut() {
         if let Some(fraction) = pruning_fraction
             && dim_postings.len() >= min_terms
             && fraction < 1.0

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -46,10 +46,47 @@ impl ForwardIndex {
     }
 }
 
+/// Build virtual→real and real→virtual vid maps from a BMP doc map.
+///
+/// A virtual slot is real iff its doc-map entry is not the `u32::MAX` padding
+/// sentinel. Realness must come from the doc map itself: block-copy merged
+/// segments carry each source's tail padding as *interior* padding, so
+/// `vid < num_real_docs` does NOT identify real docs there.
+///
+/// Returns `(virtual_to_real, real_to_virtual)` where `virtual_to_real[vid]`
+/// is the dense real index or `u32::MAX` for padding.
+pub(crate) fn build_vid_maps(bmp: &crate::segment::reader::bmp::BmpIndex) -> (Vec<u32>, Vec<u32>) {
+    let ids = bmp.doc_map_ids_slice();
+    let num_virtual = bmp.num_virtual_docs as usize;
+    let mut virtual_to_real = vec![u32::MAX; num_virtual];
+    let mut real_to_virtual = Vec::with_capacity(bmp.num_real_docs() as usize);
+    for (vid, (slot, chunk)) in virtual_to_real
+        .iter_mut()
+        .zip(ids.as_chunks::<4>().0)
+        .enumerate()
+    {
+        let doc_id = u32::from_le_bytes(*chunk);
+        if doc_id != u32::MAX {
+            *slot = real_to_virtual.len() as u32;
+            real_to_virtual.push(vid as u32);
+        }
+    }
+    if real_to_virtual.len() != bmp.num_real_docs() as usize {
+        log::warn!(
+            "[reorder] BMP doc map has {} real slots but footer says num_real_docs={} — trusting the doc map",
+            real_to_virtual.len(),
+            bmp.num_real_docs(),
+        );
+    }
+    (virtual_to_real, real_to_virtual)
+}
+
 /// Build forward index from BmpIndex sources (single or multi-source).
 ///
-/// Virtual IDs are assigned sequentially across sources: source 0 gets 0..n0,
-/// source 1 gets n0..n0+n1, etc. Returns `(forward_index, per_source_doc_counts)`.
+/// Documents are identified by dense *real* indices assigned sequentially
+/// across sources: source 0 gets 0..n0, source 1 gets n0..n0+n1, etc., where
+/// each n is the source's real (non-padding) doc count derived from its doc
+/// map via [`build_vid_maps`]. Returns `(forward_index, per_source_real_doc_counts)`.
 ///
 /// Filters dims with doc_freq outside `[min_doc_freq, max_doc_freq]`.
 /// If the estimated forward index memory exceeds `memory_budget_bytes`, the
@@ -63,7 +100,9 @@ pub(crate) fn build_forward_index_from_bmps(
     max_doc_freq: usize,
     memory_budget_bytes: usize,
 ) -> (ForwardIndex, Vec<usize>) {
-    let source_doc_counts: Vec<usize> = bmps.iter().map(|b| b.num_real_docs() as usize).collect();
+    // Per-source virtual→real maps (padding-aware realness from the doc map).
+    let vid_maps: Vec<(Vec<u32>, Vec<u32>)> = bmps.iter().map(|b| build_vid_maps(b)).collect();
+    let source_doc_counts: Vec<usize> = vid_maps.iter().map(|(_, r2v)| r2v.len()).collect();
     let total_docs: usize = source_doc_counts.iter().sum();
 
     if total_docs == 0 {
@@ -79,15 +118,14 @@ pub(crate) fn build_forward_index_from_bmps(
 
     // Phase 1: count doc freq per dimension across all sources + assign compact IDs
     let mut dim_df: FxHashMap<u32, usize> = FxHashMap::default();
-    for bmp in bmps {
+    for (bmp, (v2r, _)) in bmps.iter().zip(&vid_maps) {
         let num_blocks = bmp.num_blocks as usize;
         let block_size = bmp.bmp_block_size as usize;
-        let num_docs = bmp.num_real_docs() as usize;
         for block_id in 0..num_blocks {
             for (dim_id, postings) in bmp.iter_block_terms(block_id as u32) {
                 for p in postings {
                     let vid = block_id * block_size + p.local_slot as usize;
-                    if vid < num_docs && p.impact > 0 {
+                    if v2r[vid] != u32::MAX && p.impact > 0 {
                         *dim_df.entry(dim_id).or_insert(0) += 1;
                     }
                 }
@@ -149,12 +187,12 @@ pub(crate) fn build_forward_index_from_bmps(
 
     // Phase 2: count terms per doc (filtered)
     let mut counts = vec![0u32; total_docs];
-    let mut vid_offset = 0usize;
+    let mut real_offset = 0usize;
 
-    for bmp in bmps {
+    for (src_idx, bmp) in bmps.iter().enumerate() {
+        let (v2r, _) = &vid_maps[src_idx];
         let num_blocks = bmp.num_blocks as usize;
         let block_size = bmp.bmp_block_size as usize;
-        let num_docs = bmp.num_real_docs() as usize;
         for block_id in 0..num_blocks {
             for (dim_id, postings) in bmp.iter_block_terms(block_id as u32) {
                 if !term_remap.contains_key(&dim_id) {
@@ -162,13 +200,14 @@ pub(crate) fn build_forward_index_from_bmps(
                 }
                 for p in postings {
                     let vid = block_id * block_size + p.local_slot as usize;
-                    if vid < num_docs && p.impact > 0 {
-                        counts[vid_offset + vid] += 1;
+                    let real = v2r[vid];
+                    if real != u32::MAX && p.impact > 0 {
+                        counts[real_offset + real as usize] += 1;
                     }
                 }
             }
         }
-        vid_offset += num_docs;
+        real_offset += source_doc_counts[src_idx];
     }
 
     // Phase 3: build CSR offsets
@@ -182,12 +221,12 @@ pub(crate) fn build_forward_index_from_bmps(
     // Phase 4: fill terms (compact IDs)
     let mut terms = vec![0u32; total];
     counts.fill(0);
-    vid_offset = 0;
+    real_offset = 0;
 
-    for bmp in bmps {
+    for (src_idx, bmp) in bmps.iter().enumerate() {
+        let (v2r, _) = &vid_maps[src_idx];
         let num_blocks = bmp.num_blocks as usize;
         let block_size = bmp.bmp_block_size as usize;
-        let num_docs = bmp.num_real_docs() as usize;
         for block_id in 0..num_blocks {
             for (dim_id, postings) in bmp.iter_block_terms(block_id as u32) {
                 let Some(&compact) = term_remap.get(&dim_id) else {
@@ -195,16 +234,17 @@ pub(crate) fn build_forward_index_from_bmps(
                 };
                 for p in postings {
                     let vid = block_id * block_size + p.local_slot as usize;
-                    if vid < num_docs && p.impact > 0 {
-                        let global_vid = vid_offset + vid;
-                        let pos = offsets[global_vid] as usize + counts[global_vid] as usize;
+                    let real = v2r[vid];
+                    if real != u32::MAX && p.impact > 0 {
+                        let global_real = real_offset + real as usize;
+                        let pos = offsets[global_real] as usize + counts[global_real] as usize;
                         terms[pos] = compact;
-                        counts[global_vid] += 1;
+                        counts[global_real] += 1;
                     }
                 }
             }
         }
-        vid_offset += num_docs;
+        real_offset += source_doc_counts[src_idx];
     }
 
     (

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -78,11 +78,24 @@ pub use super::types::TrainedVectorStructures;
 /// Segment merger - merges multiple segments into one
 pub struct SegmentMerger {
     schema: Arc<Schema>,
+    /// Run BP reordering on BMP sparse fields while writing the merged blob
+    /// (instead of byte-level block stacking). The output segment is then
+    /// already ordered, so the standalone reorder pass is unnecessary.
+    reorder_bmp: bool,
 }
 
 impl SegmentMerger {
     pub fn new(schema: Arc<Schema>) -> Self {
-        Self { schema }
+        Self {
+            schema,
+            reorder_bmp: false,
+        }
+    }
+
+    /// Enable BP reordering of BMP fields during the merge (see `reorder_bmp`).
+    pub fn with_bmp_reorder(mut self, reorder: bool) -> Self {
+        self.reorder_bmp = reorder;
+        self
     }
 
     /// Merge segments into one, streaming postings/positions/store directly to files.

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -49,7 +49,7 @@ impl SegmentMerger {
             .schema
             .fields()
             .filter(|(_, entry)| matches!(entry.field_type, FieldType::SparseVector))
-            .map(|(field, entry)| (field, entry.sparse_vector_config.clone()))
+            .map(|(field, entry)| (field, entry.sparse_vector_config.clone(), entry.reorder))
             .collect();
 
         if sparse_fields.is_empty() {
@@ -67,7 +67,7 @@ impl SegmentMerger {
         let mut skip_count: u32 = 0;
         let mut skip_entry_buf = Vec::with_capacity(SparseSkipEntry::SIZE);
 
-        for (field, sparse_config) in &sparse_fields {
+        for (field, sparse_config, field_reorder) in &sparse_fields {
             let format = sparse_config.as_ref().map(|c| c.format).unwrap_or_default();
             let quantization = sparse_config
                 .as_ref()
@@ -109,6 +109,62 @@ impl SegmentMerger {
                                 .find_map(|bi| bi.map(|idx| idx.max_weight_scale))
                                 .unwrap_or(5.0)
                         });
+                    if self.reorder_bmp && !*field_reorder {
+                        // Reorder-on-merge is on, but this field opted out via
+                        // its schema — fall through to block-copy. Loud so an
+                        // operator can see why the merged field stays unordered.
+                        log::info!(
+                            "[merge_bmp] field {}: `reorder` schema attribute not set — block-copy merge",
+                            field.0,
+                        );
+                    }
+                    if self.reorder_bmp && *field_reorder {
+                        // Merge-time BP reorder: write the merged blob in
+                        // permuted order instead of block stacking. The output
+                        // segment needs no standalone reorder pass afterwards.
+                        let sources: Vec<(BmpIndex, u32)> = bmp_indexes
+                            .iter()
+                            .zip(doc_offs.iter())
+                            .filter_map(|(opt, &off)| opt.map(|b| (b.clone(), off)))
+                            .collect();
+                        validate_bmp_sources(
+                            &sources,
+                            dims,
+                            bmp_block_size.min(256),
+                            max_weight_scale,
+                        )?;
+
+                        let fid = field.0;
+                        let effective_block_size = bmp_block_size.min(256) as usize;
+                        log::info!(
+                            "[merge_bmp] field {}: reorder-on-merge enabled — running BP over {} source(s)",
+                            fid,
+                            sources.len(),
+                        );
+                        let (w, ft) = tokio::task::spawn_blocking(move || {
+                            crate::segment::reorder::reorder_bmp_field(
+                                &sources,
+                                fid,
+                                quantization,
+                                dims,
+                                effective_block_size,
+                                max_weight_scale,
+                                total_vectors_bmp,
+                                crate::segment::reorder::DEFAULT_MEMORY_BUDGET,
+                                writer,
+                                field_tocs,
+                                None,
+                            )
+                        })
+                        .await
+                        .map_err(|e| {
+                            crate::Error::Internal(format!("merge-time reorder panicked: {}", e))
+                        })??;
+                        writer = w;
+                        field_tocs = ft;
+                        continue;
+                    }
+
                     merge_bmp_field(
                         &bmp_indexes,
                         &doc_offs,
@@ -640,6 +696,38 @@ fn merge_bmp_field(
         bmp.madvise_random_query();
     }
 
+    Ok(())
+}
+
+/// Validate that all BMP merge sources share `dims`, `block_size`, and
+/// `max_weight_scale` (same invariants as the block-copy path's Phase 0).
+fn validate_bmp_sources(
+    sources: &[(BmpIndex, u32)],
+    dims: u32,
+    effective_block_size: u32,
+    max_weight_scale: f32,
+) -> Result<()> {
+    for (bmp, _) in sources {
+        if bmp.dims() != dims {
+            return Err(crate::Error::Corruption(format!(
+                "BMP merge: source dims={} != expected dims={}",
+                bmp.dims(),
+                dims
+            )));
+        }
+        if bmp.bmp_block_size != effective_block_size {
+            return Err(crate::Error::Corruption(format!(
+                "BMP merge: source block_size={} != expected {}",
+                bmp.bmp_block_size, effective_block_size
+            )));
+        }
+        if (bmp.max_weight_scale - max_weight_scale).abs() > f32::EPSILON {
+            return Err(crate::Error::Corruption(format!(
+                "BMP merge: source max_weight_scale={:.4} != expected {:.4}",
+                bmp.max_weight_scale, max_weight_scale
+            )));
+        }
+    }
     Ok(())
 }
 

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -23,6 +23,8 @@ pub(crate) use reader::bmp::{
     accumulate_u4_weighted, block_term_postings, compute_block_masks_4bit, find_dim_in_block_data,
 };
 pub(crate) use reader::combine_ordinal_results;
+#[cfg(feature = "native")]
+pub mod pin;
 pub use reader::{SegmentReader, SparseIndex, VectorIndex, VectorSearchResult};
 pub use store::*;
 #[cfg(feature = "native")]

--- a/hermes-core/src/segment/pin.rs
+++ b/hermes-core/src/segment/pin.rs
@@ -1,0 +1,155 @@
+//! Hot-metadata pinning: budgeted residency for per-query-mandatory
+//! structures (a meta/data residency split).
+//!
+//! Every query must touch certain small metadata sections — BMP block-offset
+//! tables, sparse skip sections, doc-id maps, superblock grids. Under memory
+//! pressure the kernel evicts them like bulk data, and queries then pay major
+//! faults on structures they cannot skip. This module pins them, in priority
+//! order (smallest/hottest first), until a per-segment budget is exhausted.
+//!
+//! Design: `docs/hot-metadata-pinning.md`. Bulk data (BMP 4-bit grid, block
+//! data, raw vectors) is never pinned — it is covered by the
+//! `MADV_RANDOM`/`MADV_WILLNEED` discipline instead.
+
+use std::sync::OnceLock;
+
+use crate::directories::OwnedBytes;
+
+/// How pinned bytes are kept resident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinMode {
+    /// `mlock` the mmap pages in place — zero-copy, but requires
+    /// RLIMIT_MEMLOCK headroom (containers often need CAP_IPC_LOCK or an
+    /// explicit ulimit). Failures are logged and counted, never fatal.
+    Mlock,
+    /// Copy the section to the heap — no permissions needed, duplicates the
+    /// bytes. Immune to page-cache eviction (production runs swapless).
+    Copy,
+}
+
+/// Per-segment metadata pinning policy.
+#[derive(Debug, Clone, Copy)]
+pub struct PinPolicy {
+    /// Metadata bytes to pin per segment. 0 = pinning disabled (default).
+    pub budget_bytes: u64,
+    pub mode: PinMode,
+}
+
+impl PinPolicy {
+    pub const fn disabled() -> Self {
+        Self {
+            budget_bytes: 0,
+            mode: PinMode::Mlock,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.budget_bytes > 0
+    }
+
+    /// Read policy from environment:
+    /// `HERMES_PIN_METADATA_BUDGET_MB` (default 0 = off),
+    /// `HERMES_PIN_MODE` = `mlock` (default) | `copy`.
+    fn from_env() -> Self {
+        let budget_mb: u64 = std::env::var("HERMES_PIN_METADATA_BUDGET_MB")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        let mode = match std::env::var("HERMES_PIN_MODE").as_deref() {
+            Ok("copy") => PinMode::Copy,
+            Ok("mlock") | Err(_) => PinMode::Mlock,
+            Ok(other) => {
+                log::warn!("HERMES_PIN_MODE '{}' unknown; using mlock", other);
+                PinMode::Mlock
+            }
+        };
+        Self {
+            budget_bytes: budget_mb * 1024 * 1024,
+            mode,
+        }
+    }
+}
+
+static PIN_POLICY: OnceLock<PinPolicy> = OnceLock::new();
+
+/// Override the process-wide pin policy. Must be called before the first
+/// segment is opened; returns false (and warns) if the policy was already
+/// initialized.
+pub fn set_pin_policy(policy: PinPolicy) -> bool {
+    let ok = PIN_POLICY.set(policy).is_ok();
+    if !ok {
+        log::warn!("pin policy already initialized; set_pin_policy ignored");
+    }
+    ok
+}
+
+/// The process-wide pin policy (env-initialized on first use).
+pub fn pin_policy() -> &'static PinPolicy {
+    PIN_POLICY.get_or_init(PinPolicy::from_env)
+}
+
+/// Accumulates pin accounting for one segment.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PinReport {
+    /// Bytes of pinnable metadata found (regardless of budget/failures)
+    pub intended_bytes: u64,
+    /// Bytes actually pinned
+    pub pinned_bytes: u64,
+    /// Bytes skipped because the budget was exhausted
+    pub skipped_budget_bytes: u64,
+    /// Bytes where mlock failed (RLIMIT_MEMLOCK etc.)
+    pub failed_bytes: u64,
+}
+
+/// Pin one metadata section, updating `remaining` budget and the report.
+///
+/// In `Copy` mode the section is replaced with a heap copy (heap memory is
+/// not page-cache-evictable). In `Mlock` mode the mmap pages are locked in
+/// place. Non-mmap-backed sections (RAM directories) are already resident
+/// and are skipped silently.
+pub(crate) fn pin_section(
+    bytes: &mut OwnedBytes,
+    label: &str,
+    mode: PinMode,
+    remaining: &mut u64,
+    report: &mut PinReport,
+) {
+    if !bytes.is_mmap() || bytes.is_empty() {
+        return;
+    }
+    let len = bytes.len() as u64;
+    report.intended_bytes += len;
+
+    if len > *remaining {
+        report.skipped_budget_bytes += len;
+        log::debug!(
+            "[pin] budget exhausted: skipping {} ({} bytes, {} remaining)",
+            label,
+            len,
+            *remaining
+        );
+        return;
+    }
+
+    match mode {
+        PinMode::Mlock => {
+            if bytes.mlock() {
+                *remaining -= len;
+                report.pinned_bytes += len;
+            } else {
+                report.failed_bytes += len;
+                log::warn!(
+                    "[pin] mlock failed for {} ({} bytes) — check RLIMIT_MEMLOCK; \
+                     continuing unpinned",
+                    label,
+                    len
+                );
+            }
+        }
+        PinMode::Copy => {
+            *bytes = OwnedBytes::new(bytes.to_vec());
+            *remaining -= len;
+            report.pinned_bytes += len;
+        }
+    }
+}

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -122,6 +122,13 @@ pub struct BmpIndex {
     doc_map_ids_bytes: OwnedBytes,
     /// doc_map_ordinals[virtual_id] = original ordinal — zero-copy OwnedBytes
     doc_map_ordinals_bytes: OwnedBytes,
+
+    // ── Raw blob source (identity copies) ─────────────────────────────
+    /// Source file handle + blob range, kept so reorder can copy the blob
+    /// byte-identically for fields whose `reorder` schema attribute is unset.
+    source: FileHandle,
+    blob_offset: u64,
+    blob_len: u64,
 }
 
 // SAFETY: All raw pointer access is derived from OwnedBytes which are Send+Sync
@@ -200,6 +207,9 @@ impl BmpIndex {
                 num_superblocks: 0,
                 doc_map_ids_bytes: OwnedBytes::empty(),
                 doc_map_ordinals_bytes: OwnedBytes::empty(),
+                source: handle,
+                blob_offset,
+                blob_len,
             });
         }
 
@@ -286,7 +296,19 @@ impl BmpIndex {
             num_superblocks,
             doc_map_ids_bytes,
             doc_map_ordinals_bytes,
+            source: handle,
+            blob_offset,
+            blob_len,
         })
+    }
+
+    /// Read the entire raw V13 blob (including footer) from the source file.
+    ///
+    /// Used by reorder paths to copy a field byte-identically when its
+    /// `reorder` schema attribute is unset.
+    pub(crate) fn read_raw_blob(&self) -> std::io::Result<OwnedBytes> {
+        self.source
+            .read_bytes_range_sync(self.blob_offset..self.blob_offset + self.blob_len)
     }
 
     /// Convert a compact virtual_id to (doc_id, ordinal) via table lookup.

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -330,6 +330,67 @@ impl BmpIndex {
         }
     }
 
+    /// Pin the block-offset table (priority 1: every scored block does an
+    /// offset lookup through it).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_block_starts(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        crate::segment::pin::pin_section(
+            &mut self.block_data_starts_bytes,
+            "bmp block_data_starts",
+            mode,
+            remaining,
+            report,
+        );
+    }
+
+    /// Pin the virtual-doc → (doc_id, ordinal) maps (priority 3: every
+    /// top-k resolution touches them).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_doc_maps(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        crate::segment::pin::pin_section(
+            &mut self.doc_map_ids_bytes,
+            "bmp doc_map_ids",
+            mode,
+            remaining,
+            report,
+        );
+        crate::segment::pin::pin_section(
+            &mut self.doc_map_ordinals_bytes,
+            "bmp doc_map_ordinals",
+            mode,
+            remaining,
+            report,
+        );
+    }
+
+    /// Pin the superblock grid (priority 4: every query dim reads a row).
+    /// The 4-bit block grid is deliberately never pinned (data-sized).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_sb_grid(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        crate::segment::pin::pin_section(
+            &mut self.sb_grid_bytes,
+            "bmp sb_grid",
+            mode,
+            remaining,
+            report,
+        );
+    }
+
     /// Page-level prefetch (`MADV_WILLNEED`) of a block-data byte range.
     ///
     /// Used by the BMP executor to batch-prefetch the surviving blocks of a

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -26,6 +26,11 @@ pub struct SegmentMemoryStats {
     pub dense_index_bytes: usize,
     /// Bloom filter bytes
     pub bloom_filter_bytes: usize,
+    /// Hot metadata bytes actually pinned (mlock/heap-copy) at open
+    pub pinned_metadata_bytes: u64,
+    /// Hot metadata bytes eligible for pinning (gap vs pinned = budget
+    /// exhausted or mlock failures — operator-visible)
+    pub pin_intended_bytes: u64,
 }
 
 impl SegmentMemoryStats {
@@ -154,6 +159,9 @@ pub struct SegmentReader {
     /// Allows per-field MaxScore groups within a single query to share thresholds:
     /// field A's result seeds field B's pruning on the same segment.
     shared_threshold: std::sync::atomic::AtomicU32,
+    /// Hot-metadata pin accounting (see `segment::pin`)
+    #[cfg(feature = "native")]
+    pin_report: crate::segment::pin::PinReport,
 }
 
 impl SegmentReader {
@@ -245,7 +253,8 @@ impl SegmentReader {
             log::debug!("{}", parts.join(", "));
         }
 
-        Ok(Self {
+        #[allow(unused_mut)]
+        let mut reader = Self {
             meta,
             term_dict: Arc::new(term_dict),
             postings_handle,
@@ -259,7 +268,73 @@ impl SegmentReader {
             positions_handle,
             fast_fields,
             shared_threshold: std::sync::atomic::AtomicU32::new(0),
-        })
+            #[cfg(feature = "native")]
+            pin_report: Default::default(),
+        };
+
+        // Pin hot metadata per the process-wide policy (no-op when disabled)
+        #[cfg(feature = "native")]
+        reader.apply_pin_policy(&crate::segment::pin::pin_policy().to_owned());
+
+        Ok(reader)
+    }
+
+    /// Pin per-query-mandatory metadata sections in priority order until the
+    /// budget is exhausted (see `segment::pin` and docs/hot-metadata-pinning.md).
+    ///
+    /// Priority: BMP block-offset tables → sparse skip sections → doc-id maps
+    /// → BMP superblock grids. Bulk data (4-bit grid, block data, raw vectors)
+    /// is never pinned. Fail-loud: budget exhaustion and mlock failures are
+    /// logged and visible via `SegmentMemoryStats::{pin_intended_bytes,
+    /// pinned_metadata_bytes}`.
+    #[cfg(feature = "native")]
+    pub(crate) fn apply_pin_policy(&mut self, policy: &crate::segment::pin::PinPolicy) {
+        use crate::segment::pin::PinReport;
+
+        if !policy.is_enabled() {
+            return;
+        }
+        let mut remaining = policy.budget_bytes;
+        let mut report = PinReport::default();
+
+        // Priority 1: BMP block-offset tables
+        for bmp in self.bmp_indexes.values_mut() {
+            bmp.pin_block_starts(policy.mode, &mut remaining, &mut report);
+        }
+        // Priority 2: sparse skip sections
+        for sparse in self.sparse_indexes.values_mut() {
+            sparse.pin_skip_section(policy.mode, &mut remaining, &mut report);
+        }
+        // Priority 3: doc-id maps
+        for flat in self.flat_vectors.values_mut() {
+            flat.pin_doc_ids(policy.mode, &mut remaining, &mut report);
+        }
+        for bmp in self.bmp_indexes.values_mut() {
+            bmp.pin_doc_maps(policy.mode, &mut remaining, &mut report);
+        }
+        // Priority 4: BMP superblock grids
+        for bmp in self.bmp_indexes.values_mut() {
+            bmp.pin_sb_grid(policy.mode, &mut remaining, &mut report);
+        }
+
+        if report.skipped_budget_bytes > 0 || report.failed_bytes > 0 {
+            log::warn!(
+                "[pin] segment {:016x}: pinned {}/{} bytes (budget skipped {}, mlock failed {}) —                  raise HERMES_PIN_METADATA_BUDGET_MB or RLIMIT_MEMLOCK for full coverage",
+                self.meta.id,
+                report.pinned_bytes,
+                report.intended_bytes,
+                report.skipped_budget_bytes,
+                report.failed_bytes,
+            );
+        } else if report.pinned_bytes > 0 {
+            log::info!(
+                "[pin] segment {:016x}: pinned {} bytes of hot metadata ({:?})",
+                self.meta.id,
+                report.pinned_bytes,
+                policy.mode,
+            );
+        }
+        self.pin_report = report;
     }
 
     /// Reset the per-segment threshold (call before each new search).
@@ -392,6 +467,12 @@ impl SegmentReader {
             .map(|v| v.estimated_memory_bytes())
             .sum();
 
+        #[cfg(feature = "native")]
+        let (pinned_metadata_bytes, pin_intended_bytes) =
+            (self.pin_report.pinned_bytes, self.pin_report.intended_bytes);
+        #[cfg(not(feature = "native"))]
+        let (pinned_metadata_bytes, pin_intended_bytes) = (0u64, 0u64);
+
         SegmentMemoryStats {
             segment_id: self.meta.id,
             num_docs: self.meta.num_docs,
@@ -400,6 +481,8 @@ impl SegmentReader {
             sparse_index_bytes,
             dense_index_bytes,
             bloom_filter_bytes: term_dict_stats.bloom_filter_size,
+            pinned_metadata_bytes,
+            pin_intended_bytes,
         }
     }
 

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -522,7 +522,7 @@ impl SegmentReader {
         if let Some((doc_ids, term_freqs)) = term_info.decode_inline() {
             // Build BlockPostingList from inline data (no I/O needed!)
             let mut posting_list = crate::structures::PostingList::with_capacity(doc_ids.len());
-            for (doc_id, tf) in doc_ids.into_iter().zip(term_freqs.into_iter()) {
+            for (doc_id, tf) in doc_ids.into_iter().zip(term_freqs) {
                 posting_list.push(doc_id, tf);
             }
             let block_list = BlockPostingList::from_posting_list(&posting_list)?;
@@ -566,7 +566,7 @@ impl SegmentReader {
         for (_key, term_info) in entries {
             if let Some((doc_ids, term_freqs)) = term_info.decode_inline() {
                 let mut posting_list = crate::structures::PostingList::with_capacity(doc_ids.len());
-                for (doc_id, tf) in doc_ids.into_iter().zip(term_freqs.into_iter()) {
+                for (doc_id, tf) in doc_ids.into_iter().zip(term_freqs) {
                     posting_list.push(doc_id, tf);
                 }
                 results.push(BlockPostingList::from_posting_list(&posting_list)?);
@@ -1261,7 +1261,7 @@ impl SegmentReader {
         // Check if posting list is inlined
         if let Some((doc_ids, term_freqs)) = term_info.decode_inline() {
             let mut posting_list = crate::structures::PostingList::with_capacity(doc_ids.len());
-            for (doc_id, tf) in doc_ids.into_iter().zip(term_freqs.into_iter()) {
+            for (doc_id, tf) in doc_ids.into_iter().zip(term_freqs) {
                 posting_list.push(doc_id, tf);
             }
             let block_list = BlockPostingList::from_posting_list(&posting_list)?;
@@ -1304,7 +1304,7 @@ impl SegmentReader {
         for (_key, term_info) in entries {
             if let Some((doc_ids, term_freqs)) = term_info.decode_inline() {
                 let mut posting_list = crate::structures::PostingList::with_capacity(doc_ids.len());
-                for (doc_id, tf) in doc_ids.into_iter().zip(term_freqs.into_iter()) {
+                for (doc_id, tf) in doc_ids.into_iter().zip(term_freqs) {
                     posting_list.push(doc_id, tf);
                 }
                 results.push(BlockPostingList::from_posting_list(&posting_list)?);

--- a/hermes-core/src/segment/reader/types.rs
+++ b/hermes-core/src/segment/reader/types.rs
@@ -343,6 +343,25 @@ pub struct SparseIndex {
 }
 
 impl SparseIndex {
+    /// Pin the skip section (priority 2: every posting traversal reads it).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_skip_section(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        let mut bytes = (*self.skip_bytes).clone();
+        crate::segment::pin::pin_section(
+            &mut bytes,
+            "sparse skip_section",
+            mode,
+            remaining,
+            report,
+        );
+        self.skip_bytes = Arc::new(bytes);
+    }
+
     /// Total postings across all dimensions (sum of per-dimension doc counts).
     /// With multi-valued fields each (doc, ordinal, dim) entry counts once.
     pub fn total_postings(&self) -> u64 {

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -130,21 +130,27 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
     let sparse_fields: Vec<_> = schema
         .fields()
         .filter(|(_, entry)| matches!(entry.field_type, FieldType::SparseVector))
-        .map(|(field, entry)| (field, entry.sparse_vector_config.clone()))
+        .map(|(field, entry)| (field, entry.sparse_vector_config.clone(), entry.reorder))
         .collect();
 
     if sparse_fields.is_empty() {
         return Ok(());
     }
 
-    // Check if there's any BMP data to reorder
-    let has_bmp_data = sparse_fields.iter().any(|(field, config)| {
-        config.as_ref().map(|c| c.format) == Some(SparseFormat::Bmp)
+    // Check if there's any BMP data to reorder. Per-field gate: only fields
+    // with the `reorder` schema attribute get BP; others are copied unchanged.
+    let has_bmp_data = sparse_fields.iter().any(|(field, config, reorder)| {
+        *reorder
+            && config.as_ref().map(|c| c.format) == Some(SparseFormat::Bmp)
             && reader.bmp_indexes().get(&field.0).is_some()
     });
 
     if !has_bmp_data {
-        // No BMP data — just copy the sparse file as-is
+        // No BMP field wants reordering — just copy the sparse file as-is
+        log::info!(
+            "[reorder] segment {:x}: no BMP field has the `reorder` schema attribute — sparse file copied unchanged",
+            reader.meta().id,
+        );
         let src_files = SegmentFiles::new(reader.meta().id);
         copy_segment_file(dir, &src_files.sparse, &dst_files.sparse).await?;
         return Ok(());
@@ -159,7 +165,7 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
     let mut all_skip_bytes: Vec<u8> = Vec::new();
     let mut skip_count: u32 = 0;
 
-    for (field, sparse_config) in &sparse_fields {
+    for (field, sparse_config, reorder) in &sparse_fields {
         let format = sparse_config.as_ref().map(|c| c.format).unwrap_or_default();
         let quantization = sparse_config
             .as_ref()
@@ -168,6 +174,22 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
 
         if format == SparseFormat::Bmp {
             if let Some(bmp_idx) = reader.bmp_indexes().get(&field.0) {
+                if !*reorder {
+                    // Field opted out of BP: copy its blob byte-identically.
+                    log::info!(
+                        "[reorder] field {}: `reorder` attribute not set — blob copied unchanged",
+                        field.0,
+                    );
+                    copy_bmp_blob(
+                        bmp_idx,
+                        field.0,
+                        quantization,
+                        bmp_idx.total_vectors,
+                        &mut writer,
+                        &mut field_tocs,
+                    )?;
+                    continue;
+                }
                 let effective_block_size = sparse_config
                     .as_ref()
                     .map(|c| c.bmp_block_size)
@@ -186,12 +208,12 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                 // Clone BmpIndex (cheap: Arc ref bumps on OwnedBytes) and move
                 // OffsetWriter + field_tocs into spawn_blocking so the entire
                 // CPU-heavy reorder runs off tokio worker threads.
-                let bmp_clone = bmp_idx.clone();
+                let bmp_sources = vec![(bmp_idx.clone(), 0u32)];
                 let fid = field.0;
                 let pool = rayon_pool.clone();
                 let (w, ft) = tokio::task::spawn_blocking(move || {
                     reorder_bmp_field(
-                        &bmp_clone,
+                        &bmp_sources,
                         fid,
                         quantization,
                         dims,
@@ -261,6 +283,46 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
     Ok(())
 }
 
+/// Identity-copy a BMP field's raw blob (fields whose `reorder` schema
+/// attribute is unset). Byte-identical: insertion order, padding, and footer
+/// are all preserved.
+fn copy_bmp_blob(
+    bmp: &crate::segment::BmpIndex,
+    field_id: u32,
+    quantization: crate::structures::WeightQuantization,
+    total_vectors: u32,
+    writer: &mut OffsetWriter,
+    field_tocs: &mut Vec<SparseFieldToc>,
+) -> Result<()> {
+    let blob = bmp.read_raw_blob().map_err(crate::Error::Io)?;
+    let blob_start = writer.offset();
+    const CHUNK: usize = 4 * 1024 * 1024;
+    for chunk in blob.as_slice().chunks(CHUNK) {
+        writer.write_all(chunk).map_err(crate::Error::Io)?;
+    }
+    let blob_len = writer.offset() - blob_start;
+
+    let mut config_for_byte =
+        crate::structures::SparseVectorConfig::from_byte(quantization as u8).unwrap_or_default();
+    config_for_byte.format = SparseFormat::Bmp;
+    config_for_byte.weight_quantization = quantization;
+
+    field_tocs.push(SparseFieldToc {
+        field_id,
+        quantization: config_for_byte.to_byte(),
+        total_vectors,
+        dims: vec![crate::segment::format::SparseDimTocEntry {
+            dim_id: 0xFFFFFFFF, // sentinel for BMP
+            block_data_offset: blob_start,
+            skip_start: (blob_len & 0xFFFFFFFF) as u32,
+            num_blocks: ((blob_len >> 32) & 0xFFFFFFFF) as u32,
+            doc_count: 0,
+            max_weight: 0.0,
+        }],
+    });
+    Ok(())
+}
+
 /// Identity-copy a MaxScore sparse field from source to destination.
 #[allow(clippy::too_many_arguments)]
 async fn copy_maxscore_field(
@@ -327,10 +389,20 @@ async fn copy_maxscore_field(
     Ok(())
 }
 
-/// Reorder a single BMP field via Recursive Graph Bisection (BP).
+/// Reorder one BMP field via Recursive Graph Bisection (BP), single- or
+/// multi-source.
 ///
-/// Reads block data from the source BmpIndex, builds a forward index,
-/// runs BP to compute a permutation, then writes the reordered blob.
+/// Reads block data from the source `BmpIndex`es (each paired with its doc-id
+/// offset in the output segment), builds a combined forward index, runs BP to
+/// compute a permutation over *real* (non-padding) records, then writes one
+/// reordered blob. With a single `(bmp, 0)` source this is the standalone
+/// segment reorder; with multiple sources it is the merge-time reorder path,
+/// which replaces byte-level block stacking.
+///
+/// Realness is derived from each source's doc map (`build_vid_maps`), never
+/// from `vid < num_real_docs` — block-copy merged sources carry interior
+/// padding. Interior padding is compacted away in the output: the written
+/// blob always has tail-only padding.
 ///
 /// This is a synchronous function called from `spawn_blocking` so the
 /// entire CPU-heavy reorder (forward index build, BP, blob write) runs
@@ -340,8 +412,8 @@ async fn copy_maxscore_field(
 /// When `rayon_pool` is `Some`, all rayon parallel work runs on that pool
 /// instead of the global pool, bounding optimizer CPU usage.
 #[allow(clippy::too_many_arguments)]
-fn reorder_bmp_field(
-    bmp: &crate::segment::BmpIndex,
+pub(crate) fn reorder_bmp_field(
+    sources: &[(crate::segment::BmpIndex, u32)],
     field_id: u32,
     quantization: crate::structures::WeightQuantization,
     dims: u32,
@@ -358,26 +430,42 @@ fn reorder_bmp_field(
         write_v13_footer,
     };
     use crate::segment::builder::graph_bisection::{
-        build_forward_index_from_bmps, graph_bisection,
+        build_forward_index_from_bmps, build_vid_maps, graph_bisection,
     };
 
-    let num_real_docs = bmp.num_real_docs() as usize;
+    if sources.is_empty() {
+        return Ok((writer, field_tocs));
+    }
+
+    // ── Phase 1: Build forward index and run BP ─────────────────────────
+    let bp_start = std::time::Instant::now();
+
+    let bmp_refs: Vec<&crate::segment::BmpIndex> = sources.iter().map(|(b, _)| b).collect();
+    // Real→virtual maps per source (padding-aware; doc map is ground truth).
+    let real_to_virtual: Vec<Vec<u32>> = bmp_refs.iter().map(|b| build_vid_maps(b).1).collect();
+    // Prefix sums of real doc counts: source s owns global real ids
+    // real_base[s]..real_base[s+1].
+    let real_base: Vec<usize> = std::iter::once(0)
+        .chain(real_to_virtual.iter().scan(0usize, |acc, r2v| {
+            *acc += r2v.len();
+            Some(*acc)
+        }))
+        .collect();
+    let num_real_docs = *real_base.last().unwrap();
     if num_real_docs == 0 {
         return Ok((writer, field_tocs));
     }
 
     log::info!(
-        "[reorder_bmp] field {}: running BP on {} real docs",
+        "[reorder_bmp] field {}: running BP on {} real docs from {} source(s)",
         field_id,
         num_real_docs,
+        sources.len(),
     );
 
-    // ── Phase 1: Build forward index and run BP ─────────────────────────
-    let bp_start = std::time::Instant::now();
     let max_doc_freq = ((num_real_docs as f64) * 0.9) as usize;
     let min_doc_freq = 128.min(num_real_docs);
 
-    let bmp_refs = [bmp];
     let (fwd, _source_doc_counts) =
         build_forward_index_from_bmps(&bmp_refs, min_doc_freq, max_doc_freq.max(1), memory_budget);
 
@@ -430,7 +518,8 @@ fn reorder_bmp_field(
     const GRID_ENTRY_MEM_SIZE: usize = std::mem::size_of::<(u32, u32, u8)>(); // 12 bytes
     let max_entries_in_memory = GRID_ENTRIES_BUDGET / GRID_ENTRY_MEM_SIZE;
 
-    let est_entries = (bmp.total_terms() as usize).min(max_entries_in_memory);
+    let total_source_terms: usize = bmp_refs.iter().map(|b| b.total_terms() as usize).sum();
+    let est_entries = total_source_terms.min(max_entries_in_memory);
     let mut grid_entries: Vec<(u32, u32, u8)> = Vec::with_capacity(est_entries);
     let mut run_files: Vec<std::path::PathBuf> = Vec::new();
     let run_prefix = format!("hermes_grid_run_{}_{}", std::process::id(), field_id);
@@ -449,28 +538,32 @@ fn reorder_bmp_field(
 
         dim_postings.clear();
 
-        // Group records by source block, scatter matching slots
+        // Group records by (source, source block), scatter matching slots
         let mut slot_map = [u8::MAX; 256];
 
-        // Collect which old_blocks we need and the slot mappings
-        let mut block_mappings: rustc_hash::FxHashMap<usize, Vec<(u8, u8)>> =
+        // Collect which (source, old_block)s we need and the slot mappings.
+        // Global real ids resolve to a source via `real_base`, then to a
+        // virtual vid (block/slot position) via that source's real→virtual map.
+        let mut block_mappings: rustc_hash::FxHashMap<(usize, usize), Vec<(u8, u8)>> =
             rustc_hash::FxHashMap::default();
         for new_local_slot in 0..slots_count {
-            let old_vid = perm[new_vid_start + new_local_slot] as usize;
+            let global_real = perm[new_vid_start + new_local_slot] as usize;
+            let src = real_base.partition_point(|&b| b <= global_real) - 1;
+            let old_vid = real_to_virtual[src][global_real - real_base[src]] as usize;
             let old_block = old_vid / effective_block_size;
             let old_slot = (old_vid % effective_block_size) as u8;
             block_mappings
-                .entry(old_block)
+                .entry((src, old_block))
                 .or_default()
                 .push((old_slot, new_local_slot as u8));
         }
 
-        for (&old_block, mappings) in &block_mappings {
+        for (&(src, old_block), mappings) in &block_mappings {
             for &(old_s, new_s) in mappings {
                 slot_map[old_s as usize] = new_s;
             }
 
-            for (dim_id, postings) in bmp.iter_block_terms(old_block as u32) {
+            for (dim_id, postings) in sources[src].0.iter_block_terms(old_block as u32) {
                 for p in postings {
                     let new_slot = slot_map[p.local_slot as usize];
                     if new_slot != u8::MAX {
@@ -614,13 +707,23 @@ fn reorder_bmp_field(
     // Sections F+G: doc_map [new_num_virtual_docs each]
     let doc_map_offset = writer.offset() - blob_start;
 
-    let src_ids = bmp.doc_map_ids_slice();
-    let src_ords = bmp.doc_map_ordinals_slice();
+    // Resolve a global real id to (source, virtual vid within source).
+    let resolve = |global_real: usize| -> (usize, usize) {
+        let src = real_base.partition_point(|&b| b <= global_real) - 1;
+        (
+            src,
+            real_to_virtual[src][global_real - real_base[src]] as usize,
+        )
+    };
 
-    // Section F: doc_map_ids [u32-LE × new_num_virtual_docs]
-    for &vid in perm.iter().take(num_real_docs) {
-        let off = vid as usize * 4;
-        let doc_id = u32::from_le_bytes(src_ids[off..off + 4].try_into().unwrap());
+    // Section F: doc_map_ids [u32-LE × new_num_virtual_docs], doc ids patched
+    // with each source's offset in the output segment. Real slots are never
+    // the u32::MAX sentinel (realness came from the doc map itself).
+    for &global_real in perm.iter().take(num_real_docs) {
+        let (src, vid) = resolve(global_real as usize);
+        let ids = sources[src].0.doc_map_ids_slice();
+        let off = vid * 4;
+        let doc_id = u32::from_le_bytes(ids[off..off + 4].try_into().unwrap()) + sources[src].1;
         writer
             .write_all(&doc_id.to_le_bytes())
             .map_err(crate::Error::Io)?;
@@ -632,9 +735,11 @@ fn reorder_bmp_field(
     }
 
     // Section G: doc_map_ordinals [u16-LE × new_num_virtual_docs]
-    for &vid in perm.iter().take(num_real_docs) {
-        let off = vid as usize * 2;
-        let ordinal = u16::from_le_bytes(src_ords[off..off + 2].try_into().unwrap());
+    for &global_real in perm.iter().take(num_real_docs) {
+        let (src, vid) = resolve(global_real as usize);
+        let ords = sources[src].0.doc_map_ordinals_slice();
+        let off = vid * 2;
+        let ordinal = u16::from_le_bytes(ords[off..off + 2].try_into().unwrap());
         writer
             .write_all(&ordinal.to_le_bytes())
             .map_err(crate::Error::Io)?;

--- a/hermes-core/src/segment/vector_data.rs
+++ b/hermes-core/src/segment/vector_data.rs
@@ -274,6 +274,24 @@ impl LazyFlatVectorData {
         })
     }
 
+    /// Pin the doc-id map (priority 3: every rerank / top-k resolution
+    /// binary-searches it).
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_doc_ids(
+        &mut self,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        crate::segment::pin::pin_section(
+            &mut self.doc_ids_bytes,
+            "flat doc_ids",
+            mode,
+            remaining,
+            report,
+        );
+    }
+
     /// Advise the kernel that vector data will be accessed at random offsets.
     ///
     /// Disables kernel readahead for the raw vector region. Rerank reads

--- a/hermes-core/src/structures/postings/partitioned_ef.rs
+++ b/hermes-core/src/structures/postings/partitioned_ef.rs
@@ -174,8 +174,7 @@ impl EFPartition {
         {
             use std::arch::aarch64::*;
 
-            let chunks = self.upper_bits.chunks_exact(4);
-            let remainder = chunks.remainder();
+            let (chunks, remainder) = self.upper_bits.as_chunks::<4>();
 
             for chunk in chunks {
                 // Load 4 u64 words (32 bytes)

--- a/hermes-core/src/structures/postings/sparse/block.rs
+++ b/hermes-core/src/structures/postings/sparse/block.rs
@@ -1044,7 +1044,7 @@ fn decode_weights_into(data: &[u8], quant: WeightQuantization, count: usize, out
     match quant {
         WeightQuantization::Float32 => {
             out.reserve(count);
-            for chunk in data[..count * 4].chunks_exact(4) {
+            for chunk in data[..count * 4].as_chunks::<4>().0 {
                 out.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
             }
         }
@@ -1056,7 +1056,7 @@ fn decode_weights_into(data: &[u8], quant: WeightQuantization, count: usize, out
             let byte_count = count * 2;
             let src = &data[..byte_count];
             let mut f16_buf: Vec<f16> = Vec::with_capacity(count);
-            for chunk in src.chunks_exact(2) {
+            for chunk in src.as_chunks::<2>().0 {
                 f16_buf.push(f16::from_bits(u16::from_le_bytes([chunk[0], chunk[1]])));
             }
             let start = out.len();

--- a/hermes-core/src/tokenizer/mod.rs
+++ b/hermes-core/src/tokenizer/mod.rs
@@ -284,7 +284,7 @@ impl<T: Tokenizer> StopWordTokenizer<T> {
     /// Create a new stop word tokenizer wrapping the given tokenizer
     pub fn new(inner: T, language: Language) -> Self {
         let stop_words: HashSet<String> = stop_words::get(language.to_stop_words_language())
-            .into_iter()
+            .iter()
             .map(|s| s.to_string())
             .collect();
         Self { inner, stop_words }

--- a/hermes-llm/Cargo.toml
+++ b/hermes-llm/Cargo.toml
@@ -39,20 +39,18 @@ tracing-subscriber = { workspace = true }
 
 # Error handling
 anyhow = { workspace = true }
-thiserror = { workspace = true }
 
 # Utilities
 rand = { workspace = true }
-rayon = { workspace = true }
 
 # Progress bar
 indicatif = "0.18"
 
 # Signal handling for graceful shutdown (pin to 3.4.x - 3.5.x has dispatch2/objc2 that fails on Linux CI)
-ctrlc = "~3.4"
+ctrlc = "3.5"
 
 # HuggingFace Hub for downloading models/tokenizers (use rustls to avoid openssl)
-hf-hub = { version = "0.4", default-features = false, features = ["ureq", "rustls-tls"] }
+hf-hub = { version = "0.5", default-features = false, features = ["ureq", "rustls-tls"] }
 
 # Compression support
 flate2 = "1.1"
@@ -73,3 +71,7 @@ nccl = ["cuda", "dep:cudarc"]
 [[bin]]
 name = "hermes-llm"
 path = "src/main.rs"
+
+[package.metadata.cargo-machete]
+# candle-transformers is referenced by the cuda/metal/accelerate feature definitions
+ignored = ["candle-transformers"]

--- a/hermes-server/Cargo.toml
+++ b/hermes-server/Cargo.toml
@@ -29,7 +29,6 @@ tokio = { workspace = true, features = ["macros", "signal"] }
 tonic = { workspace = true, features = ["gzip", "zstd"] }
 tonic-prost = "0.14"
 prost = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 log = "0.4"
@@ -43,3 +42,7 @@ rayon = { workspace = true }
 [build-dependencies]
 tonic-build = { workspace = true }
 tonic-prost-build = "0.14"
+
+[package.metadata.cargo-machete]
+# prost/tonic-prost are used by tonic::include_proto! generated code
+ignored = ["prost", "tonic-prost"]

--- a/hermes-tool/Cargo.toml
+++ b/hermes-tool/Cargo.toml
@@ -27,10 +27,9 @@ bincode = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 murmur3 = "0.5"
-chrono = "0.4"
 rayon = "1.11"
 crossbeam-channel = "0.5"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = ["stats", "background_threads"] }
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
+tikv-jemallocator = { version = "0.7", features = ["stats", "background_threads"] }
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }

--- a/hermes-wasm/Cargo.toml
+++ b/hermes-wasm/Cargo.toml
@@ -34,3 +34,8 @@ futures-channel = "0.3"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-O4", "--enable-bulk-memory"]
+
+[package.metadata.cargo-machete]
+# getrandom is a feature-activation dep: enables the wasm_js backend for
+# transitive getrandom users (uuid, rand) on wasm32
+ignored = ["getrandom"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2026-02-17"
+channel = "nightly-2026-07-07"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Reordering

- **Data-loss fix**: reordering a block-copy-merged segment silently dropped real docs shifted past interior doc-map padding (merged segments carry each source's tail padding, so real docs are not contiguous in vid space; the reorder path assumed `vid < num_real_docs` ⇔ real). Realness now derives from the doc map itself via per-source real↔virtual maps, and any BP rewrite compacts interior padding. Pinned by `test_bmp_reorder_after_merge_keeps_interior_padded_docs` (failing before the fix: 28 docs/source vanished from sparse retrieval). **Note: already-damaged segments cannot be repaired in place — affected indexes need a rebuild.**
- **Merge-time BP reorder**: index-level SDL option persisted in the schema at creation — `reorder_on_merge: true` inside the `index { }` block (`SchemaBuilder::set_reorder_on_merge`). Absent = disabled, preserving current behaviour. When on, merges write BMP blobs in BP order via a multi-source reorder path and mark the output `reordered`, so the background optimizer skips the second whole-segment rewrite. Design doc: `docs/merge-time-reorder.md`.
- **Per-field gate**: the existing `reorder` schema attribute is now honored by every BP path (standalone reorder, optimizer, merge-time). Fields without it are copied **byte-identically** (pinned by `test_bmp_reorder_skips_field_without_reorder_attribute`); skips log loudly.

## Query planner (slow filtered-query fix)

`build_combined_bitset` used to materialize a full bitset per MUST clause — iterating a multi-million-entry `type` posting list even when a narrow date range sat next to it. Now clauses are evaluated narrowest-first (posting doc counts exact; fast-field ranges estimated by ~1k sampled probes) and wide clauses refine the accumulator with O(|survivors|) fast-field probes instead of being materialized. MUST_NOT gets the same treatment; fast-only (non-indexed) filter fields now work in the bitset path. Tests: `test_wide_type_filter_with_narrow_date_range_returns_exact_docs`, `test_narrow_range_with_wide_must_not_term_returns_exact_docs` (probe path verified engaged: `est=2700 probed=true acc=45`).

## Toolchain / deps

- Toolchain `nightly-2026-02-17` → `nightly-2026-07-07` (rustc 1.99-nightly), CI updated, Dockerfile `rust:1.94` → `rust:1.96`; new-nightly clippy lints fixed across the workspace.
- Dep bumps: criterion 0.8, ctrlc 3.5, hf-hub 0.5, nalgebra 0.35 (dedupes 15 stale glam versions), stop-words 0.10, tikv-jemalloc 0.7, hashbrown 0.17. Held back with reasons: bincode 3 (serialized index format), rand 0.10, getrandom 0.4 / tokenizers 0.23 (wasm coupling), candle 0.11 (hermes-llm), ndarray (kentro pins 0.16).
- cargo-machete CI job; 7 unused deps removed; ignore metadata documents the generated-code/feature-activation false positives.

## Validation

678 tests green, clippy `-D warnings` clean workspace-wide, wasm32 target builds, cargo-machete clean.