### PR TITLE
Index label on directory read and cold write metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -25,10 +25,12 @@ degradation) has relied on debug log lines (`slow BMP: ...ms, sbs=, blocks=`)
 ## Metric set
 
 Histograms are seconds unless noted. `field` labels are **field names** and
-every schema-scoped metric also carries an **`index` label** (the registry
-index name, embedded in the schema at creation; "unknown" for pre-existing
-indexes until recreated). Only `hermes_directory_read_*` and
-`hermes_cold_write_bytes_total` lack the index label (no schema in scope).
+**every metric carries an `index` label** (the registry index name, embedded
+in the schema at creation; "unknown" for pre-existing indexes until recreated
+or patched — see below). Directory-layer metrics (`hermes_directory_read_*`,
+`hermes_cold_write_bytes_total`) have no schema in scope, so the label is
+attached late: `Index::open`/`create` call `Directory::set_index_label`
+on the index's directory instance once the schema is loaded.
 
 | Metric                                                    | Type                | Labels                                                              | Meaning                                                                                                                                                                                                                                          |
 | --------------------------------------------------------- | ------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -43,10 +45,10 @@ indexes until recreated). Only `hermes_directory_read_*` and
 | `hermes_dense_rerank_resolve_duration_seconds`            | histogram           | `field`                                                             | doc→flat-slot indirection (flat store is not reordered)                                                                                                                                                                                          |
 | `hermes_dense_rerank_read_duration_seconds`               | histogram           | `field`                                                             | raw-vector reads within rerank (page-fault sensitive)                                                                                                                                                                                            |
 | `hermes_dense_rerank_vectors`                             | histogram           | `field`                                                             | candidates reranked per query                                                                                                                                                                                                                    |
-| `hermes_directory_read_duration_seconds`                  | histogram           | `op` (`lazy_range`)                                                 | Directory-layer read latency — only Lazy handles (HTTP/custom `read_fn`) do real IO here; mmap slices are zero-copy and their fault latency lands inside the phase histograms                                                                    |
-| `hermes_directory_read_bytes`                             | histogram           | `op`                                                                | read sizes                                                                                                                                                                                                                                       |
+| `hermes_directory_read_duration_seconds`                  | histogram           | `index`, `op` (`lazy_range`)                                        | Directory-layer read latency — only Lazy handles (HTTP/custom `read_fn`) do real IO here; mmap slices are zero-copy and their fault latency lands inside the phase histograms                                                                    |
+| `hermes_directory_read_bytes`                             | histogram           | `index`, `op`                                                       | read sizes                                                                                                                                                                                                                                       |
 | `hermes_store_get_duration_seconds`                       | histogram           | `index`                                                             | document store fetch (decompression + faults), single- and multi-field paths                                                                                                                                                                     |
-| `hermes_cold_write_bytes_total`                           | counter             | —                                                                   | merge/reorder bytes written via the page-cache-dropping cold path (`docs/cold-io.md`)                                                                                                                                                            |
+| `hermes_cold_write_bytes_total`                           | counter             | `index`                                                             | merge/reorder bytes written via the page-cache-dropping cold path (`docs/cold-io.md`)                                                                                                                                                            |
 | `hermes_reorder_granularity_total`                        | counter             | `field`, `granularity` (`records`/`blocks`)                         | reorder passes by chosen granularity (`docs/block-level-reorder.md`)                                                                                                                                                                             |
 | `hermes_reorder_coherence`                                | histogram           | `field`                                                             | raw block coherence d (avg records per block×dim pair) measured at each reorder decision                                                                                                                                                         |
 | `hermes_reorder_coherence_norm`                           | histogram           | `field`                                                             | normalized coherence, 0 = random order, 1 = as coherent as the dim-frequency distribution allows — this drives the `Auto` decision (threshold 0.5)                                                                                               |
@@ -56,6 +58,22 @@ indexes until recreated). Only `hermes_directory_read_*` and
 Skip-ratio note: ratios are derived in PromQL
 (`rate(scored) / (rate(scored) + rate(skipped))`) rather than emitted, so
 they aggregate correctly across instances and windows.
+
+### Pre-existing indexes and `index="unknown"`
+
+Indexes created before the label shipped have no `index_name` in their
+stored schema. Recreate them, or patch the stored metadata in place. Do it
+with the server stopped (or the index not open for writing) — the server
+rewrites `metadata.json` on commit/merge and would overwrite a live patch:
+
+```bash
+cd <data_dir>/<index_name>
+jq --arg name "<index_name>" '.schema.index_name = $name' metadata.json \
+  > metadata.json.patched && mv metadata.json.patched metadata.json
+```
+
+Note: `metadata.json.tmp` is reserved for crash recovery — never use it as
+a scratch name.
 
 ## Dashboard
 

--- a/grafana/dashboard.json
+++ b/grafana/dashboard.json
@@ -1157,7 +1157,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, op) (rate(hermes_directory_read_duration_seconds_bucket{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.95, sum by (le, op) (rate(hermes_directory_read_duration_seconds_bucket{index=~\"$index\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
           "legendFormat": "p95 {{op}}",
           "refId": "A",
           "range": true
@@ -1167,7 +1167,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le, op) (rate(hermes_directory_read_duration_seconds_bucket{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
+          "expr": "histogram_quantile(0.99, sum by (le, op) (rate(hermes_directory_read_duration_seconds_bucket{index=~\"$index\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
           "legendFormat": "p99 {{op}}",
           "refId": "B",
           "range": true
@@ -1219,7 +1219,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (op) (rate(hermes_directory_read_bytes_sum{namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
+          "expr": "sum by (op) (rate(hermes_directory_read_bytes_sum{index=~\"$index\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
           "legendFormat": "{{op}}",
           "refId": "A",
           "range": true

--- a/hermes-core/src/directories/cold_io.rs
+++ b/hermes-core/src/directories/cold_io.rs
@@ -57,10 +57,12 @@ pub(crate) struct ColdStreamingWriter {
     /// Start of the region not yet dropped from cache (linux windowed drop).
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     drop_cursor: u64,
+    /// Index name for the `hermes_cold_write_bytes_total` metric label.
+    label: std::sync::Arc<str>,
 }
 
 impl ColdStreamingWriter {
-    pub(crate) fn new(file: std::fs::File) -> Self {
+    pub(crate) fn new(file: std::fs::File, label: std::sync::Arc<str>) -> Self {
         log_mode_once();
         #[cfg(target_os = "macos")]
         {
@@ -79,6 +81,7 @@ impl ColdStreamingWriter {
             written: 0,
             writeback_cursor: 0,
             drop_cursor: 0,
+            label,
         }
     }
 
@@ -179,7 +182,7 @@ impl StreamingWriter for ColdStreamingWriter {
         self.flush_buf()?;
         self.file.sync_all()?;
         self.maybe_drop(true);
-        crate::observe::cold_write(self.written as usize);
+        crate::observe::cold_write(&self.label, self.written as usize);
         log::debug!(
             "[cold_io] wrote {:.1} MB with page cache dropped behind the cursor",
             self.written as f64 / (1024.0 * 1024.0)
@@ -203,7 +206,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("cold.bin");
         let file = std::fs::File::create(&path).unwrap();
-        let mut writer: Box<dyn StreamingWriter> = Box::new(ColdStreamingWriter::new(file));
+        let mut writer: Box<dyn StreamingWriter> =
+            Box::new(ColdStreamingWriter::new(file, std::sync::Arc::from("test")));
 
         let mut expected: Vec<u8> = Vec::new();
         // Small writes

--- a/hermes-core/src/directories/directory.rs
+++ b/hermes-core/src/directories/directory.rs
@@ -54,7 +54,37 @@ enum FileHandleInner {
         read_fn: RangeReadFn,
         offset: u64,
         len: u64,
+        /// Index name for the `hermes_directory_read_*` metric labels.
+        label: Arc<str>,
     },
+}
+
+/// Late-bound index name for Directory-layer metric labels
+/// (`hermes_directory_read_*`, `hermes_cold_write_bytes_total`).
+///
+/// Directories are constructed before the schema is loaded, so the label is
+/// attached afterwards: `Index::open`/`create` call
+/// `Directory::set_index_label(schema.index_label())` on the index's
+/// directory instance. Reads happen at handle/writer creation, not per IO.
+#[derive(Clone, Debug)]
+pub struct IndexLabel(Arc<std::sync::RwLock<Arc<str>>>);
+
+impl Default for IndexLabel {
+    fn default() -> Self {
+        Self(Arc::new(std::sync::RwLock::new(Arc::from("unknown"))))
+    }
+}
+
+impl IndexLabel {
+    /// Current label ("unknown" until set).
+    pub fn get(&self) -> Arc<str> {
+        self.0.read().expect("IndexLabel lock poisoned").clone()
+    }
+
+    /// Set the label (idempotent; last write wins).
+    pub fn set(&self, label: &str) {
+        *self.0.write().expect("IndexLabel lock poisoned") = Arc::from(label);
+    }
 }
 
 impl std::fmt::Debug for FileHandle {
@@ -94,13 +124,21 @@ impl FileHandle {
     }
 
     /// Create a lazy file handle from an async range-read callback.
-    /// Only async reads are available.
+    /// Only async reads are available. Reads emit `hermes_directory_read_*`
+    /// with `index="unknown"` — use [`FileHandle::lazy_labeled`] when the
+    /// owning index is known.
     pub fn lazy(len: u64, read_fn: RangeReadFn) -> Self {
+        Self::lazy_labeled(len, read_fn, Arc::from("unknown"))
+    }
+
+    /// [`FileHandle::lazy`] with an index name for metric labels.
+    pub fn lazy_labeled(len: u64, read_fn: RangeReadFn, label: Arc<str>) -> Self {
         Self {
             inner: FileHandleInner::Lazy {
                 read_fn,
                 offset: 0,
                 len,
+                label,
             },
         }
     }
@@ -152,6 +190,7 @@ impl FileHandle {
                 read_fn,
                 offset,
                 len,
+                label,
             } => {
                 let new_offset = offset + range.start;
                 let new_len = range.end - range.start;
@@ -168,6 +207,7 @@ impl FileHandle {
                         read_fn: Arc::clone(read_fn),
                         offset: new_offset,
                         len: new_len,
+                        label: Arc::clone(label),
                     },
                 }
             }
@@ -209,6 +249,7 @@ impl FileHandle {
                 read_fn,
                 offset,
                 len,
+                label,
             } => {
                 if range.end > *len {
                     return Err(io::Error::new(
@@ -224,7 +265,7 @@ impl FileHandle {
                 let t = crate::observe::Timer::start();
                 let result = (read_fn)(abs_start..abs_end).await;
                 if let Ok(bytes) = &result {
-                    crate::observe::directory_read("lazy_range", t.secs(), bytes.len());
+                    crate::observe::directory_read(label, "lazy_range", t.secs(), bytes.len());
                 }
                 result
             }
@@ -478,6 +519,13 @@ pub trait Directory: Send + Sync + 'static {
     /// For mmap directories this returns an Inline handle (sync-capable).
     /// For HTTP/filesystem directories this returns a Lazy handle.
     async fn open_lazy(&self, path: &Path) -> io::Result<FileHandle>;
+
+    /// Attach the owning index's name for Directory-layer metric labels
+    /// (`hermes_directory_read_*`, `hermes_cold_write_bytes_total`).
+    /// Called by `Index::open`/`create` once the schema is loaded; wrappers
+    /// forward to their inner directory. Default: no-op (directories that
+    /// emit no Directory-layer metrics, e.g. RamDirectory).
+    fn set_index_label(&self, _label: &str) {}
 }
 
 /// Async directory trait for reading index files (WASM version - no Send requirement)
@@ -501,6 +549,10 @@ pub trait Directory: 'static {
 
     /// Open a file handle that fetches ranges on demand.
     async fn open_lazy(&self, path: &Path) -> io::Result<FileHandle>;
+
+    /// Attach the owning index's name for Directory-layer metric labels.
+    /// No-op default; metrics are native-only but the label is harmless.
+    fn set_index_label(&self, _label: &str) {}
 }
 
 /// A writer for incrementally writing data to a directory file.
@@ -776,6 +828,7 @@ impl DirectoryWriter for RamDirectory {
 #[derive(Debug, Clone)]
 pub struct FsDirectory {
     root: PathBuf,
+    label: IndexLabel,
 }
 
 #[cfg(feature = "native")]
@@ -783,6 +836,7 @@ impl FsDirectory {
     pub fn new(root: impl AsRef<Path>) -> Self {
         Self {
             root: root.as_ref().to_path_buf(),
+            label: IndexLabel::default(),
         }
     }
 
@@ -861,7 +915,15 @@ impl Directory for FsDirectory {
             })
         });
 
-        Ok(FileHandle::lazy(file_size, read_fn))
+        Ok(FileHandle::lazy_labeled(
+            file_size,
+            read_fn,
+            self.label.get(),
+        ))
+    }
+
+    fn set_index_label(&self, label: &str) {
+        self.label.set(label);
     }
 }
 
@@ -912,7 +974,10 @@ impl DirectoryWriter for FsDirectory {
             tokio::fs::create_dir_all(parent).await?;
         }
         let file = std::fs::File::create(&full_path)?;
-        Ok(Box::new(super::ColdStreamingWriter::new(file)))
+        Ok(Box::new(super::ColdStreamingWriter::new(
+            file,
+            self.label.get(),
+        )))
     }
 }
 
@@ -998,6 +1063,10 @@ impl<D: Directory> Directory for CachingDirectory<D> {
     async fn open_lazy(&self, path: &Path) -> io::Result<FileHandle> {
         // For caching directory, delegate to inner - caching happens at read_range level
         self.inner.open_lazy(path).await
+    }
+
+    fn set_index_label(&self, label: &str) {
+        self.inner.set_index_label(label);
     }
 }
 

--- a/hermes-core/src/directories/http.rs
+++ b/hermes-core/src/directories/http.rs
@@ -91,17 +91,14 @@ pub struct HttpDirectory {
     cache: RwLock<HashMap<PathBuf, Arc<Vec<u8>>>>,
     /// Network statistics tracker
     stats: Arc<StatsTracker>,
+    /// Index name for Directory-layer metric labels
+    label: super::IndexLabel,
 }
 
 impl HttpDirectory {
     /// Create a new HTTP directory pointing to the given base URL
     pub fn new(base_url: impl Into<String>) -> Self {
-        Self {
-            base_url: base_url.into(),
-            client: reqwest::Client::new(),
-            cache: RwLock::new(HashMap::new()),
-            stats: Arc::new(StatsTracker::new()),
-        }
+        Self::with_client(base_url, reqwest::Client::new())
     }
 
     /// Create with a custom reqwest client
@@ -111,6 +108,7 @@ impl HttpDirectory {
             client,
             cache: RwLock::new(HashMap::new()),
             stats: Arc::new(StatsTracker::new()),
+            label: super::IndexLabel::default(),
         }
     }
 
@@ -340,7 +338,15 @@ impl Directory for HttpDirectory {
             })
         });
 
-        Ok(FileHandle::lazy(file_size, read_fn))
+        Ok(FileHandle::lazy_labeled(
+            file_size,
+            read_fn,
+            self.label.get(),
+        ))
+    }
+
+    fn set_index_label(&self, label: &str) {
+        self.label.set(label);
     }
 }
 

--- a/hermes-core/src/directories/mmap.rs
+++ b/hermes-core/src/directories/mmap.rs
@@ -29,6 +29,7 @@ use super::{
 /// No application-level cache - the OS page cache handles this efficiently.
 pub struct MmapDirectory {
     root: PathBuf,
+    label: super::IndexLabel,
 }
 
 impl MmapDirectory {
@@ -36,6 +37,7 @@ impl MmapDirectory {
     pub fn new(root: impl AsRef<Path>) -> Self {
         Self {
             root: root.as_ref().to_path_buf(),
+            label: super::IndexLabel::default(),
         }
     }
 
@@ -61,6 +63,8 @@ impl Clone for MmapDirectory {
     fn clone(&self) -> Self {
         Self {
             root: self.root.clone(),
+            // Shared, so a label set on any clone is visible on all
+            label: self.label.clone(),
         }
     }
 }
@@ -119,6 +123,10 @@ impl Directory for MmapDirectory {
         // This eliminates the async callback overhead entirely for mmap paths
         self.open_read(path).await
     }
+
+    fn set_index_label(&self, label: &str) {
+        self.label.set(label);
+    }
 }
 
 #[async_trait]
@@ -167,7 +175,10 @@ impl DirectoryWriter for MmapDirectory {
             tokio::fs::create_dir_all(parent).await?;
         }
         let file = std::fs::File::create(&full_path)?;
-        Ok(Box::new(super::ColdStreamingWriter::new(file)))
+        Ok(Box::new(super::ColdStreamingWriter::new(
+            file,
+            self.label.get(),
+        )))
     }
 }
 

--- a/hermes-core/src/directories/mod.rs
+++ b/hermes-core/src/directories/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use directory::FileStreamingWriter;
 #[cfg(feature = "native")]
 pub use directory::FsDirectory;
 pub use directory::{
-    CachingDirectory, Directory, DirectoryWriter, FileHandle, OwnedBytes, RamDirectory,
+    CachingDirectory, Directory, DirectoryWriter, FileHandle, IndexLabel, OwnedBytes, RamDirectory,
     RangeReadFn, StreamingWriter,
 };
 #[cfg(feature = "http")]

--- a/hermes-core/src/directories/slice_cache.rs
+++ b/hermes-core/src/directories/slice_cache.rs
@@ -272,6 +272,8 @@ pub struct SliceCachingDirectory<D: Directory> {
     current_bytes: Arc<RwLock<usize>>,
     /// Global access counter for LRU
     access_counter: Arc<RwLock<u64>>,
+    /// Index name for Directory-layer metric labels (also forwarded to inner)
+    label: super::IndexLabel,
 }
 
 impl<D: Directory> SliceCachingDirectory<D> {
@@ -284,6 +286,7 @@ impl<D: Directory> SliceCachingDirectory<D> {
             max_bytes,
             current_bytes: Arc::new(RwLock::new(0)),
             access_counter: Arc::new(RwLock::new(0)),
+            label: super::IndexLabel::default(),
         }
     }
 
@@ -721,7 +724,16 @@ impl<D: Directory> Directory for SliceCachingDirectory<D> {
             })
         });
 
-        Ok(FileHandle::lazy(file_size, read_fn))
+        Ok(FileHandle::lazy_labeled(
+            file_size,
+            read_fn,
+            self.label.get(),
+        ))
+    }
+
+    fn set_index_label(&self, label: &str) {
+        self.label.set(label);
+        self.inner.set_index_label(label);
     }
 }
 

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -127,6 +127,8 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
     pub async fn create(directory: D, schema: Schema, config: IndexConfig) -> Result<Self> {
         let directory = Arc::new(directory);
         let schema = Arc::new(schema);
+        // Directory-layer metrics (cold writes, lazy reads) carry the index label
+        directory.set_index_label(schema.index_label());
         let metadata = IndexMetadata::new((*schema).clone());
 
         let segment_manager = Arc::new(crate::merge::SegmentManager::new(
@@ -157,6 +159,8 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
         // Load metadata (includes schema)
         let metadata = IndexMetadata::load(directory.as_ref()).await?;
         let schema = Arc::new(metadata.schema.clone());
+        // Directory-layer metrics (cold writes, lazy reads) carry the index label
+        directory.set_index_label(schema.index_label());
 
         let segment_manager = Arc::new(crate::merge::SegmentManager::new(
             Arc::clone(&directory),

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -1688,8 +1688,10 @@ async fn test_bmp_multi_ordinal_clustering() {
 }
 
 /// Metrics emission: a BMP search must record the Prometheus metrics
-/// documented in docs/metrics.md, including the doc-map indirection counters.
-/// Only compiled with the `metrics` feature (cargo test --features metrics).
+/// documented in docs/metrics.md, including the doc-map indirection counters,
+/// and Directory-layer metrics (cold writes) must carry the index label set
+/// at Index open. Only compiled with the `metrics` feature
+/// (cargo test --features metrics).
 #[cfg(feature = "metrics")]
 #[tokio::test]
 async fn test_bmp_query_emits_prometheus_metrics() {
@@ -1700,18 +1702,27 @@ async fn test_bmp_query_emits_prometheus_metrics() {
     // Global install: first (and only) metrics test in the process.
     recorder.install().expect("install debugging recorder");
 
-    let (schema, _title, sparse) = bmp_schema();
-    let dir = RamDirectory::new();
+    let (mut schema, _title, sparse) = bmp_schema();
+    schema.set_index_name("metrics_test");
+    // MmapDirectory (the production directory) so merge outputs go through
+    // the cold streaming writer.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = crate::directories::MmapDirectory::new(tmp.path());
     let config = IndexConfig::default();
     let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
         .await
         .unwrap();
-    for i in 0..200u32 {
-        let mut doc = Document::new();
-        doc.add_sparse_vector(sparse, vec![(i, 1.0), (9999, 0.1)]);
-        writer.add_document(doc).unwrap();
+    for seg in 0..2u32 {
+        for i in 0..200u32 {
+            let mut doc = Document::new();
+            doc.add_sparse_vector(sparse, vec![(seg * 200 + i, 1.0), (9999, 0.1)]);
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
     }
-    writer.commit().await.unwrap();
+    // Two segments → merge → cold write of the merged segment.
+    writer.force_merge().await.unwrap();
+    drop(writer);
 
     let index = Index::open(dir, config).await.unwrap();
     let reader = index.reader().await.unwrap();
@@ -1720,24 +1731,29 @@ async fn test_bmp_query_emits_prometheus_metrics() {
     let results = searcher.search(&query, 10).await.unwrap();
     assert!(!results.is_empty());
 
-    let names: std::collections::HashSet<String> = snapshotter
-        .snapshot()
-        .into_vec()
-        .into_iter()
-        .map(|(key, _, _, _)| key.key().name().to_string())
-        .collect();
+    // The recorder is global and other tests run concurrently, so assert
+    // per-metric that an emission with THIS index's label exists — including
+    // the Directory-layer cold write, whose label is attached late via
+    // Directory::set_index_label. "unknown" here = label-plumbing regression.
+    let snapshot = snapshotter.snapshot().into_vec();
     for expected in [
         "hermes_bmp_query_duration_seconds",
         "hermes_bmp_blocks_scored_total",
         "hermes_bmp_superblocks_visited_total",
         "hermes_bmp_docmap_lookups_total",
         "hermes_bmp_docmap_lookups_per_query",
+        "hermes_cold_write_bytes_total",
     ] {
         assert!(
-            names.contains(expected),
-            "metric '{}' not emitted; got: {:?}",
+            snapshot.iter().any(|(key, _, _, _)| {
+                let key = key.key();
+                key.name() == expected
+                    && key
+                        .labels()
+                        .any(|l| l.key() == "index" && l.value() == "metrics_test")
+            }),
+            "metric '{}' not emitted with index=\"metrics_test\"",
             expected,
-            names
         );
     }
 }

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -126,6 +126,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     ) -> Result<Self> {
         let directory = Arc::new(directory);
         let schema = Arc::new(schema);
+        // Directory-layer metrics (cold writes, lazy reads) carry the index label
+        directory.set_index_label(schema.index_label());
         let metadata = super::IndexMetadata::new((*schema).clone());
 
         let segment_manager = Arc::new(crate::merge::SegmentManager::new(
@@ -161,6 +163,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let directory = Arc::new(directory);
         let metadata = super::IndexMetadata::load(directory.as_ref()).await?;
         let schema = Arc::new(metadata.schema.clone());
+        // Directory-layer metrics (cold writes, lazy reads) carry the index label
+        directory.set_index_label(schema.index_label());
 
         let segment_manager = Arc::new(crate::merge::SegmentManager::new(
             Arc::clone(&directory),

--- a/hermes-core/src/observe.rs
+++ b/hermes-core/src/observe.rs
@@ -107,9 +107,12 @@ mod imp {
     }
 
     /// One Directory-layer read completed.
-    pub fn directory_read(op: &'static str, secs: f64, bytes: usize) {
-        metrics::histogram!("hermes_directory_read_duration_seconds", "op" => op).record(secs);
-        metrics::histogram!("hermes_directory_read_bytes", "op" => op).record(bytes as f64);
+    pub fn directory_read(index: &str, op: &'static str, secs: f64, bytes: usize) {
+        let index = index.to_owned();
+        metrics::histogram!("hermes_directory_read_duration_seconds", "index" => index.clone(), "op" => op)
+            .record(secs);
+        metrics::histogram!("hermes_directory_read_bytes", "index" => index, "op" => op)
+            .record(bytes as f64);
     }
 
     /// One document store fetch completed.
@@ -119,8 +122,9 @@ mod imp {
     }
 
     /// A cold (page-cache-dropping) writer finished one file.
-    pub fn cold_write(bytes: usize) {
-        metrics::counter!("hermes_cold_write_bytes_total").increment(bytes as u64);
+    pub fn cold_write(index: &str, bytes: usize) {
+        metrics::counter!("hermes_cold_write_bytes_total", "index" => index.to_owned())
+            .increment(bytes as u64);
     }
 
     /// One reorder granularity decision was made (Auto or explicit).
@@ -172,11 +176,11 @@ mod imp {
     #[inline(always)]
     pub fn dense_rerank(_: &str, _: &str, _: f64, _: f64, _: f64, _: usize) {}
     #[inline(always)]
-    pub fn directory_read(_: &'static str, _: f64, _: usize) {}
+    pub fn directory_read(_: &str, _: &'static str, _: f64, _: usize) {}
     #[inline(always)]
     pub fn store_get(_: &str, _: f64) {}
     #[inline(always)]
-    pub fn cold_write(_: usize) {}
+    pub fn cold_write(_: &str, _: usize) {}
     #[inline(always)]
     pub fn reorder_granularity(_: &str, _: &str, _: &'static str) {}
     #[inline(always)]


### PR DESCRIPTION
Closes the last unlabeled gap in the metric set: `hermes_directory_read_{duration_seconds,bytes}` and `hermes_cold_write_bytes_total` now carry `index` like every other metric.

Directories are constructed before the schema is loaded, so the label is **late-bound**: `Index`/`IndexWriter` `open`/`create` call the new `Directory::set_index_label(schema.index_label())` on the index's directory instance. Lazy file handles (Fs/HTTP/slice-cache) and cold streaming writers (Fs/Mmap) capture the label at creation — no per-IO cost. Wrapper directories (`CachingDirectory`, `SliceCachingDirectory`) forward to their inner. `FileHandle::lazy` keeps its signature (labels `unknown`); labeled construction goes through `FileHandle::lazy_labeled`.

Also:
- Dashboard directory-read panels filter on `$index`
- docs/metrics.md: label table updated; new section documenting the `metadata.json` patch for pre-existing indexes reporting `index="unknown"`

Tests: the metrics emission test now runs on `MmapDirectory` with a real merge and asserts `hermes_cold_write_bytes_total` (+ BMP set) is emitted with the real index label, pinning the late-binding plumbing. 691 core tests pass; clippy `-D warnings` clean (metrics+http); wasm target compiles.