### PR TITLE
2-bit BMP grid via SDL, budgeted merge BP, parallel single-pass reorder

### DIFF
--- a/docs/bmp-grid-compression.md
+++ b/docs/bmp-grid-compression.md
@@ -112,13 +112,49 @@ only if (a) vocab grows ≫100k (density falls, memory ratio improves), or
 then benchmark against the cheaper alternative below first. x86 AVX2 not
 yet measured (aarch64 only); re-run the bench before any decision.
 
-### Cheaper next lever if another 2× is needed: 2-bit grid impacts
+### 2-bit grid impacts — MEASURED, IMPLEMENTED (`bmp_grid_bits: 2`)
 
 Halve the dense grid (dims × blocks / 4) by quantizing block UBs to 2 bits
 (ceil-quantized, recall-safe like `quantize_u8_to_u4_ceil`). Same layout,
-same SIMD shape (one extra unpack step), no probe-pattern change, no format
-fork beyond a footer flag. Looser UBs cost some pruning efficiency —
-benchmark skip ratios before/after on production data.
+same SIMD shape, no probe-pattern change, no format fork beyond a footer
+flag.
+
+Measured (`bench_aggressive_quantization`, 400k docs / 256 topics /
+BP-reordered, exact k=10; grid lattices ceil-rounded on the stored file so
+the REAL executor runs both ways; top-k asserted bit-identical — bounds
+only loosen, exactness is structural):
+
+| grid            | topical queries (blocks/q) | background-only queries (blocks/q) |
+| --------------- | -------------------------- | ---------------------------------- |
+| 4-bit (shipped) | 25.7                       | 6057                               |
+| 3-bit (9 lvl)   | 25.8 (+0.4%)               | 6122 (+1.1%)                       |
+| 2-bit (4 lvl)   | 25.8 (+0.4%)               | 6188 (+2.2%)                       |
+
+Why so cheap: the exact u8 `sb_grid` prunes first and shields the block
+grid — coarse block bounds only act inside surviving superblocks. **2-bit
+grid ≈ free** (grid 10 GB → 5 GB at 50M docs / block 64; combine with
+`bmp_block_size: 256` for 2.5 GB).
+
+**Implemented**: SDL `indexed<bmp_grid_bits: 2>` (default 4; per field,
+uniform across segments — merge/blockwise validate loudly). The V13 blob
+footer's reserved field carries the cell width (0 = legacy 4-bit), so
+existing segments stay readable. 2-bit currently uses an unrolled scalar
+accumulate/mask kernel (4 cells/byte); SIMD u2 variants are a follow-up if
+profiling asks for them — the block grid is probed only inside surviving
+superblocks. Exactness is pinned by
+`test_bmp_grid_bits_2_exact_parity_and_roundtrip` (identical top-k vs a
+4-bit index over the same corpus, through block-copy merge and BP reorder).
+
+### 4-bit posting weights — MEASURED, REJECTED
+
+Snapping posting impacts to the u4 lattice (u8 multiples of 17; emulated at
+build time so quantization applies to both scores and grid maxes) costs
+real quality: **recall@10 vs the 8-bit index = 95.1%** on the same corpus,
+matching the classical 3-5% loss for sub-8-bit impact quantization
+(Anh & Moffat lineage). The saving is only ~25% of the postings section —
+NOT 50%, because a BMP posting is 2 bytes `(local_slot: u8, impact: u8)`
+and only the impact half shrinks: packed, 2 B → 1.5 B per posting. Bad
+trade — weights stay 8-bit.
 
 ## Phase 3 (assessed, not recommended): dropping grid rows for rare dims
 

--- a/docs/budgeted-reorder.md
+++ b/docs/budgeted-reorder.md
@@ -63,3 +63,64 @@ formulation negates the right half, producing one coherent
 half. Fixed in `compute_gains` + the selection comparator; pinned by
 `test_bp_depth_cap_separates_clusters_and_converges`. Expect measurably
 better pruning from all reorders after this fix.
+
+## Deepening ladder (2026-07-14)
+
+Semantics change for aggressive continuous background reordering:
+
+- A pass with a **depth floor above block granularity** (the optimizer's
+  budgeted first pass on large segments, `min_partition_docs = 4096`) is now
+  recorded `bp_converged = false` — by definition it has not reached
+  block-level order. Previously it reported converged and large segments
+  were permanently stuck at superblock-granularity order.
+- **Merge-time BP is wall-clock-budgeted** (`--merge-bp-budget-secs`,
+  default 600; `IndexConfig::merge_bp_time_budget`). A truncated merge pass
+  still writes a valid, better-ordered segment, marked unconverged. This
+  caps how long one merge holds a merge slot — previously a 64-source/18M-doc
+  merge ran full-depth BP inline (10-30+ min per slot), which is how merge
+  backlogs (350 segments at 30M docs) built up.
+- The optimizer's **deepening is no longer starved by fresh segments**:
+  under continuous ingestion fresh candidates arrive every commit, and the
+  old "deepen only when idle" rule postponed deepening indefinitely. Now one
+  unconverged segment is deepened per cooldown window
+  (`--optimizer-unconverged-cooldown-secs`, default now 600, was 1800)
+  alongside fresh work. Deepening passes run **full depth** with the wall
+  clock budget — warm-starting makes already-ordered prefixes nearly free,
+  so each pass pushes deeper until one beats the clock and converges.
+
+- **Merge fan-in default raised** (`TieredMergePolicy::large_scale()`
+  `max_merge_at_once: 10 → 24`, baked in — no tuning flags): wide fan-in
+  absorbs continuous-ingestion floods of small memtable segments in ~2.4×
+  fewer merge passes. Giant merges are safe because output docs are capped
+  by `max_merged_docs` and merge-time BP is wall-clock budgeted.
+
+Net effect: merges are fast and bounded; order quality converges in the
+background via warm-started passes; `bp_converged` now means
+"block-granularity order reached".
+
+## Single-pass parallelism (2026-07-14)
+
+A single reorder pass has three phases; all three are now parallel and all
+three run on the bounded background pool (`cores/2` threads — merge-time
+pool in `SegmentManager::background_cpu_pool`, optimizer pool sized
+`max(--optimizer-threads, cores/2)`), keeping background CPU off the global
+query pool:
+
+1. **Forward-index build** (was fully serial). Real doc ids are assigned in
+   ascending vid order, so each BMP block owns a contiguous real-id range —
+   df counting is a rayon fold/reduce over blocks, and the CSR count/fill
+   phases write disjoint per-block slices (safe `split_at_mut` carving, no
+   locks). Also df counting aggregates per (block, dim) instead of per
+   posting, which speeds up the serial path too.
+2. **Graph bisection** (already parallel: `rayon::join` halves + parallel
+   gain passes, wall-clock budgeted).
+3. **Permuted blob write** (was fully serial). Output blocks encode
+   independently; they are encoded in parallel in 4096-block windows and
+   written serially in blob order (the window bounds buffered bytes).
+
+Measured (300k docs / 14.4M postings, RamDirectory, aarch64, release):
+forward index 135 ms → 50 ms (2.7×); blob-encode phase ~3.3 s → ~1.0 s;
+`writer.reorder()` end-to-end 4.7 s → 2.36 s (2.0×). BP itself (1.3 s
+full-depth here) is now the dominant phase, and it is budgeted/warm-started.
+Evidence: `bench_forward_index_build` (`#[ignore]`) in
+`hermes-core/src/index/tests/bmp.rs`.

--- a/docs/budgeted-reorder.md
+++ b/docs/budgeted-reorder.md
@@ -124,3 +124,13 @@ forward index 135 ms → 50 ms (2.7×); blob-encode phase ~3.3 s → ~1.0 s;
 full-depth here) is now the dominant phase, and it is budgeted/warm-started.
 Evidence: `bench_forward_index_build` (`#[ignore]`) in
 `hermes-core/src/index/tests/bmp.rs`.
+
+## Default changes (2026-07-14, follow-up)
+
+- `IndexConfig::default()` now uses `TieredMergePolicy::large_scale()` (the
+  server already did). Tier floors only shape _when_ segments merge, and
+  merge-time BP is wall-clock budgeted, so the policy is safe at any scale.
+- `bp_memory_budget_bytes` default 2 GB → 8 GB (`--bp-memory-budget-mb`
+  default 8192). It is a cap, not an allocation — memory use is proportional
+  to the segment actually being reordered; the cap only bites on 10M+ doc
+  passes, where 2 GB was dropping ~10% of eligible dims.

--- a/hermes-core/src/dsl/sdl/mod.rs
+++ b/hermes-core/src/dsl/sdl/mod.rs
@@ -268,6 +268,7 @@ struct IndexConfig {
     weight_threshold: Option<f32>,
     block_size: Option<usize>,
     bmp_block_size: Option<u32>,
+    bmp_grid_bits: Option<u8>,
     pruning: Option<f32>,
     min_terms: Option<usize>,
     doc_mass: Option<f32>,
@@ -486,6 +487,18 @@ fn parse_single_index_config_param(config: &mut IndexConfig, p: pest::iterators:
                         n.as_str()
                     );
                     128
+                }));
+            }
+        }
+        Rule::bmp_grid_bits_kwarg => {
+            // bmp_grid_bits_kwarg = { "bmp_grid_bits" ~ ":" ~ bits_spec }
+            if let Some(n) = p.into_inner().next() {
+                config.bmp_grid_bits = Some(n.as_str().parse().unwrap_or_else(|_| {
+                    log::warn!(
+                        "Invalid bmp_grid_bits value '{}', using default 4",
+                        n.as_str()
+                    );
+                    4
                 }));
             }
         }

--- a/hermes-core/src/dsl/sdl/sdl.pest
+++ b/hermes-core/src/dsl/sdl/sdl.pest
@@ -144,7 +144,7 @@ stored_with_config = { "stored" ~ "<" ~ "multi" ~ ">" }
 //   indexed<quantization: uint8, query<tokenizer: "model/name", weighting: idf>>  # with query config
 indexed_with_config = { "indexed" ~ "<" ~ index_config_params ~ ">" }
 index_config_params = { index_config_param ~ ("," ~ index_config_param)* }
-index_config_param = { index_type_kwarg | num_clusters_kwarg | nprobe_kwarg | build_threshold_kwarg | quantization_kwarg | weight_threshold_kwarg | bmp_block_size_kwarg | block_size_kwarg | pruning_kwarg | min_terms_kwarg | sparse_format_kwarg | sparse_dims_kwarg | sparse_max_weight_kwarg | doc_mass_kwarg | soar_kwarg | bits_kwarg | query_config_block | positions_kwarg | index_type_spec }
+index_config_param = { index_type_kwarg | num_clusters_kwarg | nprobe_kwarg | build_threshold_kwarg | quantization_kwarg | weight_threshold_kwarg | bmp_block_size_kwarg | bmp_grid_bits_kwarg | block_size_kwarg | pruning_kwarg | min_terms_kwarg | sparse_format_kwarg | sparse_dims_kwarg | sparse_max_weight_kwarg | doc_mass_kwarg | soar_kwarg | bits_kwarg | query_config_block | positions_kwarg | index_type_spec }
 // Position tracking modes:
 //   positions - full tracking (element ordinal + token position)
 //   ordinal - only element ordinal for multi-valued fields
@@ -165,6 +165,9 @@ block_size_spec = @{ ASCII_DIGIT+ }
 // Uniform across all segments of the field. Grid memory scales as
 // 1/bmp_block_size — large corpora should set 256 (docs/bmp-grid-compression.md).
 bmp_block_size_kwarg = { "bmp_block_size" ~ ":" ~ block_size_spec }
+// Bits per BMP block-grid cell: 4 (default) or 2. 2 halves grid memory at
+// ~zero pruning cost (bounds are ceil-quantized — exactness is unchanged).
+bmp_grid_bits_kwarg = { "bmp_grid_bits" ~ ":" ~ bits_spec }
 pruning_kwarg = { "pruning" ~ ":" ~ pruning_spec }
 pruning_spec = @{ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
 min_terms_kwarg = { "min_terms" ~ ":" ~ min_terms_spec }

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -73,6 +73,20 @@ pub struct IndexConfig {
     pub reload_interval_ms: u64,
     /// Maximum number of concurrent background merges (default: 4)
     pub max_concurrent_merges: usize,
+    /// Wall-clock budget for merge-time BP reorder per field (only applies
+    /// when the index has `reorder_on_merge`). A truncated pass still writes
+    /// a valid, better-ordered segment; it is marked `bp_converged = false`
+    /// and the background optimizer deepens it later (warm-started).
+    /// `None` = unbudgeted (BP runs to full depth inside the merge, which can
+    /// hold a merge slot for 10-30+ minutes on 10M+ doc outputs).
+    pub merge_bp_time_budget: Option<std::time::Duration>,
+    /// Memory budget (bytes) for the BP forward index during reorder passes
+    /// (merge-time and background). When a large segment's forward index
+    /// would exceed this, the highest-df dims are dropped from BP's input
+    /// (logged loudly) — clustering quality degrades gracefully. Production
+    /// evidence: 18M-doc merges exceed the 2 GB default and drop ~10% of
+    /// eligible dims; hosts with headroom should raise this.
+    pub bp_memory_budget_bytes: usize,
 }
 
 impl Default for IndexConfig {
@@ -98,6 +112,10 @@ impl Default for IndexConfig {
             optimization: crate::structures::IndexOptimization::default(),
             reload_interval_ms: 1000, // 1 second default
             max_concurrent_merges: 4,
+            merge_bp_time_budget: Some(std::time::Duration::from_secs(600)),
+            // 2 GB — mirrors segment::reorder::DEFAULT_MEMORY_BUDGET (that
+            // module is native-only; IndexConfig also compiles for wasm).
+            bp_memory_budget_bytes: 2 * 1024 * 1024 * 1024,
         }
     }
 }
@@ -138,6 +156,8 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
             config.merge_policy.clone_box(),
             config.term_cache_blocks,
             config.max_concurrent_merges,
+            config.merge_bp_time_budget,
+            config.bp_memory_budget_bytes,
         ));
 
         // Save initial metadata
@@ -169,6 +189,8 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
             config.merge_policy.clone_box(),
             config.term_cache_blocks,
             config.max_concurrent_merges,
+            config.merge_bp_time_budget,
+            config.bp_memory_budget_bytes,
         ));
 
         // Load trained structures into SegmentManager's ArcSwap

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -108,14 +108,26 @@ impl Default for IndexConfig {
             term_cache_blocks: 256,
             store_cache_blocks: 32,
             max_indexing_memory_bytes: 256 * 1024 * 1024, // 256 MB default
-            merge_policy: Box::new(crate::merge::TieredMergePolicy::default()),
+            // large_scale: wide fan-in + budget/scored selection. Safe for
+            // small indexes too (tier floors only shape *when* segments
+            // merge); merge-time BP is wall-clock budgeted, so giant merges
+            // cannot hold slots indefinitely.
+            merge_policy: Box::new(crate::merge::TieredMergePolicy::large_scale()),
             optimization: crate::structures::IndexOptimization::default(),
             reload_interval_ms: 1000, // 1 second default
             max_concurrent_merges: 4,
             merge_bp_time_budget: Some(std::time::Duration::from_secs(600)),
-            // 2 GB — mirrors segment::reorder::DEFAULT_MEMORY_BUDGET (that
+            // 8 GB — mirrors segment::reorder::DEFAULT_MEMORY_BUDGET (that
             // module is native-only; IndexConfig also compiles for wasm).
-            bp_memory_budget_bytes: 2 * 1024 * 1024 * 1024,
+            // A cap, not an allocation: usage is proportional to the segment
+            // being reordered; the cap only bites on 10M+ doc passes (2 GB
+            // dropped ~10% of eligible dims on 18M-doc merges).
+            // 8 GB overflows 32-bit usize (wasm32) — reorder never runs
+            // there, so any large value works; use usize::MAX.
+            #[cfg(target_pointer_width = "64")]
+            bp_memory_budget_bytes: 8 * 1024 * 1024 * 1024,
+            #[cfg(not(target_pointer_width = "64"))]
+            bp_memory_budget_bytes: usize::MAX,
         }
     }
 }

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -2312,11 +2312,94 @@ async fn test_blockwise_budget_depth_cap_scales_to_block_units() {
         ids_before, ids_after,
         "a 4096-doc depth cap = superblock depth for blockwise BP — the pass must actually permute blocks"
     );
+    // Ladder semantics: a pass with a depth floor above block granularity is
+    // recorded UNCONVERGED so the optimizer's deepening ladder revisits it
+    // with a full-depth (warm-started) pass.
+    let metadata = crate::index::IndexMetadata::load(&dir).await.unwrap();
+    let info = metadata.segment_metas.values().next().unwrap();
+    assert!(
+        !info.bp_converged,
+        "depth-capped pass must be recorded unconverged for the deepening ladder"
+    );
+}
+
+/// Budgeted merge-time BP: a merge whose BP pass hits its wall-clock budget
+/// must still produce a valid, fully searchable merged segment — marked
+/// `bp_converged = false` so the background optimizer deepens it later. A
+/// follow-up full-depth pass converges. This is the merge-throughput lever:
+/// merges stop holding a slot for full BP depth on huge outputs.
+#[tokio::test]
+async fn test_budgeted_merge_marks_unconverged_and_deepens() {
+    use crate::segment::BpBudget;
+
+    let mut sb = SchemaBuilder::default();
+    let _title = sb.add_text_field("title", true, true);
+    let sparse = sb.add_sparse_vector_field_with_config("sparse", true, true, bmp_config());
+    sb.set_reorder(sparse, true);
+    sb.set_reorder_on_merge(true);
+    let schema = sb.build();
+    let dir = RamDirectory::new();
+    // Zero budget: merge-time BP truncates immediately (identity re-block).
+    let config = IndexConfig {
+        merge_bp_time_budget: Some(std::time::Duration::ZERO),
+        ..IndexConfig::default()
+    };
+
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    // Interleaved mid-frequency topics → Auto picks Records (blockwise
+    // cannot fix intra-block scramble), so merge-time BP actually runs and
+    // the zero budget truncates it.
+    const DOCS_PER_SEGMENT: usize = 300;
+    for seg in 0..2 {
+        for i in 0..DOCS_PER_SEGMENT {
+            let global = (seg * DOCS_PER_SEGMENT + i) as u32;
+            let topic = global % 4;
+            let mut entries: Vec<(u32, f32)> =
+                (0..32).map(|t| (50_000 + topic * 100 + t, 0.5)).collect();
+            entries.push((global, 1.0));
+            let mut doc = Document::new();
+            doc.add_sparse_vector(sparse, entries);
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+    writer.force_merge().await.unwrap();
+    drop(writer);
+
+    let metadata = crate::index::IndexMetadata::load(&dir).await.unwrap();
+    assert_eq!(metadata.segment_metas.len(), 1);
+    let info = metadata.segment_metas.values().next().unwrap();
+    assert!(info.reordered, "merged segment must be marked reordered");
+    assert!(
+        !info.bp_converged,
+        "budget-truncated merge BP must be recorded unconverged"
+    );
+
+    // Every doc searchable after the truncated merge pass
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    for i in [0usize, 299, 300, 2 * DOCS_PER_SEGMENT - 1] {
+        let query = SparseVectorQuery::new(sparse, vec![(i as u32, 1.0)]);
+        let results = searcher.search(&query, 5).await.unwrap();
+        assert_eq!(results.len(), 1, "dim {} lost after budgeted merge", i);
+    }
+
+    // Deepening pass (optimizer path): full depth converges the segment.
+    let sm = std::sync::Arc::clone(index.segment_manager());
+    let seg_id = metadata.segment_ids()[0].clone();
+    assert!(
+        sm.reorder_single_segment(&seg_id, None, BpBudget::full())
+            .await
+            .unwrap()
+    );
     let metadata = crate::index::IndexMetadata::load(&dir).await.unwrap();
     let info = metadata.segment_metas.values().next().unwrap();
     assert!(
         info.bp_converged,
-        "a depth cap is a chosen target, not an interruption"
+        "full-depth deepening pass must converge the merged segment"
     );
 }
 
@@ -2397,4 +2480,640 @@ async fn test_auto_reorder_interleaved_high_d_picks_records() {
             i
         );
     }
+}
+
+/// Aggressive-quantization experiment (docs/bmp-grid-compression.md):
+/// (a) grid nibbles ceil-rounded to 3-bit / 2-bit lattices on the stored
+///     file — bounds only loosen, so exact top-k must be IDENTICAL; cost is
+///     extra blocks scored;
+/// (b) posting weights snapped to a 4-bit lattice at build time — scores
+///     change, so the cost is top-k disagreement vs the 8-bit index
+///     (recall@k), plus whatever pruning shift the coarser grid maxes cause.
+/// Corpus is topical (docs cluster by topic dims) + BP-reordered so the
+/// baseline actually prunes — a uniform corpus cannot measure pruning cost.
+/// Run: cargo test --release -p hermes-core --features native,metrics --lib \
+///        -- --ignored bench_aggressive_quantization --nocapture
+#[cfg(feature = "metrics")]
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "quantization experiment — run manually in release"]
+async fn bench_aggressive_quantization() {
+    use crate::directories::{Directory, DirectoryWriter};
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+    struct XorShift(u64);
+    impl XorShift {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+        fn next_f64(&mut self) -> f64 {
+            (self.next() >> 11) as f64 / (1u64 << 53) as f64
+        }
+    }
+
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    recorder.install().expect("install debugging recorder");
+    let counters = || -> (u64, u64, u64) {
+        let mut scored = 0u64;
+        let mut skipped = 0u64;
+        let mut sbs = 0u64;
+        for (k, _, _, v) in snapshotter.snapshot().into_vec() {
+            if let DebugValue::Counter(c) = v {
+                match k.key().name() {
+                    "hermes_bmp_blocks_scored_total" => scored += c,
+                    "hermes_bmp_blocks_skipped_total" => skipped += c,
+                    "hermes_bmp_superblocks_visited_total" => sbs += c,
+                    _ => {}
+                }
+            }
+        }
+        (scored, skipped, sbs)
+    };
+
+    const DOCS: usize = 400_000;
+    const DIMS: usize = 100_000;
+    const TOPICS: usize = 256;
+    const TOPIC_DIMS: usize = 32; // dims owned per topic
+    const MAX_W: f32 = 5.0;
+    const K: usize = 10;
+    const QUERIES: usize = 100;
+
+    // Background Zipf over the tail dim range [TOPICS*TOPIC_DIMS ..)
+    let bg_base = TOPICS * TOPIC_DIMS;
+    let bg_dims = DIMS - bg_base;
+    let mut cum = Vec::with_capacity(bg_dims);
+    let mut acc = 0.0f64;
+    for i in 0..bg_dims {
+        acc += 1.0 / (i + 1) as f64;
+        cum.push(acc);
+    }
+    let total = acc;
+
+    // Generate one doc's entries. `snap4` snaps weights to the u4 impact
+    // lattice (multiples of 17 in u8 space, round to nearest).
+    let gen_doc = |rng: &mut XorShift, snap4: bool| -> Vec<(u32, f32)> {
+        let topic = (rng.next() % TOPICS as u64) as usize;
+        let mut by_dim: std::collections::BTreeMap<u32, f32> = std::collections::BTreeMap::new();
+        for _ in 0..10 {
+            let d = (topic * TOPIC_DIMS + (rng.next() % TOPIC_DIMS as u64) as usize) as u32;
+            let w = 1.5 + 3.5 * rng.next_f64() as f32;
+            let e = by_dim.entry(d).or_insert(0.0);
+            if w > *e {
+                *e = w;
+            }
+        }
+        for _ in 0..40 {
+            let r = rng.next_f64() * total;
+            let d = (bg_base + cum.partition_point(|&c| c < r).min(bg_dims - 1)) as u32;
+            let idf = ((bg_dims as f64 / ((d as usize - bg_base) as f64 + 1.0)).ln()
+                / (bg_dims as f64).ln()) as f32;
+            let w = 1.2 * idf * (0.3 + 0.7 * rng.next_f64() as f32) + 0.05;
+            let e = by_dim.entry(d).or_insert(0.0);
+            if w > *e {
+                *e = w;
+            }
+        }
+        by_dim
+            .into_iter()
+            .map(|(d, w)| {
+                let w = if snap4 {
+                    let q = (w / MAX_W * 255.0).round().clamp(0.0, 255.0);
+                    let m = (q / 17.0).round() * 17.0;
+                    m / 255.0 * MAX_W
+                } else {
+                    w
+                };
+                (d, w)
+            })
+            .filter(|&(_, w)| w > 0.0)
+            .collect()
+    };
+
+    type GenDoc<'a> = dyn Fn(&mut XorShift, bool) -> Vec<(u32, f32)> + 'a;
+
+    // Build an index (single merged + BP-reordered segment).
+    async fn build(
+        dir: &RamDirectory,
+        sparse: crate::dsl::Field,
+        snap4: bool,
+        gen_doc: &GenDoc<'_>,
+    ) {
+        let (mut schema, _t, _s) = bmp_schema();
+        schema.set_index_name("quant");
+        // Single indexing thread + one flush → exactly one segment, doc ids
+        // follow insertion order and are comparable across separately built
+        // indexes (multi-segment force_merge concatenates in UUID order,
+        // which permutes id blocks between builds).
+        let config = IndexConfig {
+            merge_policy: Box::new(crate::merge::NoMergePolicy),
+            num_indexing_threads: 1,
+            max_indexing_memory_bytes: 8 * 1024 * 1024 * 1024,
+            ..IndexConfig::default()
+        };
+        let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+            .await
+            .unwrap();
+        let mut rng = XorShift(0x5EEDFACE0BADC0DE); // same seed → same docs
+        for _ in 0..DOCS {
+            let entries = gen_doc(&mut rng, snap4);
+            loop {
+                let mut doc = Document::new();
+                doc.add_sparse_vector(sparse, entries.clone());
+                match writer.add_document(doc) {
+                    Ok(()) => break,
+                    Err(crate::Error::QueueFull) => {
+                        tokio::time::sleep(std::time::Duration::from_millis(3)).await;
+                    }
+                    Err(e) => panic!("{e:?}"),
+                }
+            }
+        }
+        writer.commit().await.unwrap();
+        writer.force_merge().await.unwrap();
+        writer.reorder().await.unwrap();
+        drop(writer);
+    }
+
+    // Queries: 8 dims of one topic + 4 background dims.
+    let mut qrng = XorShift(0x0123456789ABCDEF);
+    let queries: Vec<Vec<(u32, f32)>> = (0..QUERIES)
+        .map(|_| {
+            let topic = (qrng.next() % TOPICS as u64) as usize;
+            let mut q: Vec<(u32, f32)> = (0..8)
+                .map(|_| {
+                    let d =
+                        (topic * TOPIC_DIMS + (qrng.next() % TOPIC_DIMS as u64) as usize) as u32;
+                    (d, 1.5 + 3.5 * qrng.next_f64() as f32)
+                })
+                .collect();
+            for _ in 0..4 {
+                let r = qrng.next_f64() * total;
+                let d = (bg_base + cum.partition_point(|&c| c < r).min(bg_dims - 1)) as u32;
+                q.push((d, 0.5 + qrng.next_f64() as f32));
+            }
+            q.sort_by_key(|&(d, _)| d);
+            q.dedup_by_key(|&mut (d, _)| d);
+            q
+        })
+        .collect();
+    // Harder set: background-only queries (no topical concentration) — these
+    // bypass most superblock pruning, exposing block-grid quantization cost.
+    let bg_queries: Vec<Vec<(u32, f32)>> = (0..50)
+        .map(|_| {
+            let mut q: Vec<(u32, f32)> = (0..12)
+                .map(|_| {
+                    let r = qrng.next_f64() * total;
+                    let d = (bg_base + cum.partition_point(|&c| c < r).min(bg_dims - 1)) as u32;
+                    let idf = ((bg_dims as f64 / ((d as usize - bg_base) as f64 + 1.0)).ln()
+                        / (bg_dims as f64).ln()) as f32;
+                    (d, 2.0 * idf * (0.3 + 0.7 * qrng.next_f64() as f32) + 0.1)
+                })
+                .collect();
+            q.sort_by_key(|&(d, _)| d);
+            q.dedup_by_key(|&mut (d, _)| d);
+            q
+        })
+        .collect();
+
+    let run_queries = |bmps: Vec<crate::segment::BmpIndex>,
+                       queries: &[Vec<(u32, f32)>]|
+     -> (Vec<Vec<(u32, f32)>>, f64) {
+        let t = std::time::Instant::now();
+        let mut out = Vec::with_capacity(queries.len());
+        for q in queries {
+            let mut all: Vec<(u32, f32)> = Vec::new();
+            for bmp in &bmps {
+                let r =
+                    crate::query::bmp::execute_bmp(bmp, "quant", "sparse", q, K, 1.0, 0).unwrap();
+                all.extend(r.iter().map(|d| (d.doc_id, d.score)));
+            }
+            all.sort_by(|a, b| b.1.total_cmp(&a.1));
+            all.truncate(K);
+            out.push(all);
+        }
+        (out, t.elapsed().as_secs_f64())
+    };
+
+    // ── Index A: 8-bit weights (baseline) ───────────────────────────────
+    let dir = RamDirectory::new();
+    let (_s0, _t0, sparse) = bmp_schema();
+    build(&dir, sparse, false, &gen_doc).await;
+    let config = IndexConfig::default();
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let segs = index.segment_readers().await.unwrap();
+    assert_eq!(segs.len(), 1);
+    let seg_id = segs[0].meta().id;
+    let bmp = segs[0].bmp_indexes().get(&sparse.0).unwrap().clone();
+    let num_blocks = bmp.num_blocks as u64;
+    drop(segs);
+    drop(index);
+
+    // Locate grid section in the stored .sparse (single BMP field → blob @0)
+    let sparse_path = crate::segment::SegmentFiles::new(seg_id).sparse;
+    let original = dir
+        .open_read(&sparse_path)
+        .await
+        .unwrap()
+        .read_bytes()
+        .await
+        .unwrap()
+        .as_slice()
+        .to_vec();
+    let flen = original.len();
+    assert_eq!(
+        u32::from_le_bytes(original[flen - 4..].try_into().unwrap()),
+        crate::segment::format::SPARSE_FOOTER_MAGIC
+    );
+    let blob_len = u64::from_le_bytes(original[flen - 24..flen - 16].try_into().unwrap()) as usize;
+    let bfoot = blob_len - 64;
+    assert_eq!(
+        u32::from_le_bytes(original[bfoot + 60..bfoot + 64].try_into().unwrap()),
+        crate::segment::format::BMP_BLOB_MAGIC_V13
+    );
+    let grid_start =
+        u64::from_le_bytes(original[bfoot + 8..bfoot + 16].try_into().unwrap()) as usize;
+    let grid_end =
+        u64::from_le_bytes(original[bfoot + 16..bfoot + 24].try_into().unwrap()) as usize;
+    println!(
+        "\ncorpus: {DOCS} docs, {TOPICS} topics, {} blocks | grid {:.1} MB | k={K}, {QUERIES} queries, exact",
+        num_blocks,
+        (grid_end - grid_start) as f64 / 1e6
+    );
+
+    let patch = |levels: &[u8]| -> Vec<u8> {
+        let map = |n: u8| -> u8 { *levels.iter().find(|&&l| l >= n).unwrap() };
+        let mut bytes = original.clone();
+        for b in &mut bytes[grid_start..grid_end] {
+            *b = map(*b & 0x0F) | (map(*b >> 4) << 4);
+        }
+        bytes
+    };
+
+    type TopK = Vec<Vec<(u32, f32)>>;
+    let mut baseline: Option<(TopK, TopK)> = None;
+    for (name, levels) in [
+        ("grid 4-bit (shipped)", (0u8..=15).collect::<Vec<_>>()),
+        (
+            "grid 3-bit-ish (9 lvl)",
+            vec![0, 2, 4, 6, 8, 10, 12, 14, 15],
+        ),
+        ("grid 2-bit (4 lvl)", vec![0, 5, 10, 15]),
+    ] {
+        dir.write(&sparse_path, &patch(&levels)).await.unwrap();
+        let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+        let segs = index.segment_readers().await.unwrap();
+        let bmps: Vec<_> = segs
+            .iter()
+            .map(|s| s.bmp_indexes().get(&sparse.0).unwrap().clone())
+            .collect();
+        drop(segs);
+
+        let (s0, k0, v0) = counters();
+        let (topk, secs) = run_queries(bmps.clone(), &queries);
+        let (s1, k1, v1) = counters();
+        let (bg_topk, _bg_secs) = run_queries(bmps, &bg_queries);
+        let (s2, k2, _v2) = counters();
+
+        match &baseline {
+            None => baseline = Some((topk, bg_topk)),
+            Some((base, bg_base_topk)) => {
+                for (qi, (a, b)) in base.iter().zip(topk.iter()).enumerate() {
+                    assert_eq!(a, b, "q{qi}: grid quantization must not change exact top-k");
+                }
+                for (qi, (a, b)) in bg_base_topk.iter().zip(bg_topk.iter()).enumerate() {
+                    assert_eq!(
+                        a, b,
+                        "bg q{qi}: grid quantization must not change exact top-k"
+                    );
+                }
+            }
+        }
+        println!(
+            "{name:<24} topical: blocks/q {:>6.1} skip {:>5.1}% sbs/q {:>5.1} {:>5.2} ms/q | background: blocks/q {:>7.1} skip {:>5.1}%",
+            (s1 - s0) as f64 / QUERIES as f64,
+            100.0 * (k1 - k0) as f64 / ((s1 - s0) + (k1 - k0)).max(1) as f64,
+            (v1 - v0) as f64 / QUERIES as f64,
+            secs * 1000.0 / QUERIES as f64,
+            (s2 - s1) as f64 / 50.0,
+            100.0 * (k2 - k1) as f64 / ((s2 - s1) + (k2 - k1)).max(1) as f64,
+        );
+    }
+    // restore pristine file
+    dir.write(&sparse_path, &original).await.unwrap();
+
+    // ── Index B: 4-bit weights (same docs, snapped) ─────────────────────
+    let dir4 = RamDirectory::new();
+    build(&dir4, sparse, true, &gen_doc).await;
+    let index4 = Index::open(dir4.clone(), config.clone()).await.unwrap();
+    let segs4 = index4.segment_readers().await.unwrap();
+    let bmps4: Vec<_> = segs4
+        .iter()
+        .map(|s| s.bmp_indexes().get(&sparse.0).unwrap().clone())
+        .collect();
+    drop(segs4);
+
+    let (s0, k0, _v0) = counters();
+    let (topk4, secs4) = run_queries(bmps4, &queries);
+    let (s1, k1, _v1) = counters();
+
+    // Recall@K vs the 8-bit index (doc-id overlap; ids are deterministic
+    // because indexing is single-threaded insertion order)
+    let (base, _bg) = baseline.as_ref().unwrap();
+    let mut overlap = 0usize;
+    let mut denom = 0usize;
+    for (a, b) in base.iter().zip(topk4.iter()) {
+        let set: std::collections::HashSet<u32> = a.iter().map(|&(d, _)| d).collect();
+        overlap += b.iter().filter(|&&(d, _)| set.contains(&d)).count();
+        denom += a.len();
+    }
+    println!(
+        "{:<24} blocks scored/q {:>7.1} | skipped/q {:>7.1} | skip {:>5.1}% | recall@{K} vs 8-bit {:>5.1}% | {:>6.2} ms/q",
+        "weights 4-bit",
+        (s1 - s0) as f64 / QUERIES as f64,
+        (k1 - k0) as f64 / QUERIES as f64,
+        100.0 * (k1 - k0) as f64 / ((s1 - s0) + (k1 - k0)).max(1) as f64,
+        100.0 * overlap as f64 / denom.max(1) as f64,
+        secs4 * 1000.0 / QUERIES as f64,
+    );
+}
+
+/// 2-bit block grid (`bmp_grid_bits: 2`): grid bounds are ceil-quantized at
+/// any width, so EXACT top-k must be identical to the 4-bit index on the
+/// same corpus — while the grid section (and the blob) shrinks. Also
+/// roundtrips block-copy merge and BP reorder at 2-bit.
+#[tokio::test]
+async fn test_bmp_grid_bits_2_exact_parity_and_roundtrip() {
+    let build = |grid_bits: u8| {
+        let mut cfg = bmp_config();
+        cfg.bmp_grid_bits = grid_bits;
+        cfg
+    };
+
+    // Interleaved-topic corpus (Records reorder path) with unique needle dims.
+    let corpus = |writer: &mut IndexWriter<RamDirectory>, sparse: crate::dsl::Field| {
+        const DOCS: usize = 600;
+        for seg in 0..2 {
+            for i in 0..DOCS {
+                let global = (seg * DOCS + i) as u32;
+                let topic = global % 4;
+                let mut entries: Vec<(u32, f32)> = (0..32)
+                    .map(|t| (50_000 + topic * 100 + t, 0.5 + (t as f32) * 0.01))
+                    .collect();
+                entries.push((global, 1.0));
+                let mut doc = Document::new();
+                doc.add_sparse_vector(sparse, entries);
+                writer.add_document(doc).unwrap();
+            }
+        }
+    };
+
+    let mut results: Vec<Vec<Vec<(u32, f32)>>> = Vec::new();
+    let mut grid_sizes: Vec<usize> = Vec::new();
+    for grid_bits in [4u8, 2u8] {
+        let mut sb = SchemaBuilder::default();
+        let _t = sb.add_text_field("title", true, true);
+        let sparse = sb.add_sparse_vector_field_with_config("sparse", true, true, build(grid_bits));
+        sb.set_reorder(sparse, true);
+        let schema = sb.build();
+        let dir = RamDirectory::new();
+        let config = IndexConfig::default();
+        let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+            .await
+            .unwrap();
+        corpus(&mut writer, sparse);
+        writer.commit().await.unwrap();
+        writer.force_merge().await.unwrap(); // block-copy merge at this width
+        writer.reorder().await.unwrap(); // BP reorder at this width
+        drop(writer);
+
+        let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+        let readers = index.segment_readers().await.unwrap();
+        assert_eq!(readers.len(), 1);
+        let bmp = readers[0].bmp_indexes().get(&sparse.0).unwrap();
+        assert_eq!(bmp.grid_bits(), grid_bits, "footer must carry grid_bits");
+        grid_sizes.push(bmp.packed_row_size());
+
+        let reader = index.reader().await.unwrap();
+        let searcher = reader.searcher().await.unwrap();
+        // Topic queries (many matches, heap fills → pruning active) + needles
+        let mut per_query = Vec::new();
+        for topic in 0..4u32 {
+            let q: Vec<(u32, f32)> = (0..8).map(|t| (50_000 + topic * 100 + t, 1.0)).collect();
+            let query = SparseVectorQuery::new(sparse, q);
+            let r = searcher.search(&query, 10).await.unwrap();
+            assert_eq!(r.len(), 10);
+            per_query.push(r.iter().map(|d| (d.doc_id, d.score)).collect::<Vec<_>>());
+        }
+        for needle in [0u32, 599, 600, 1199] {
+            let query = SparseVectorQuery::new(sparse, vec![(needle, 1.0)]);
+            let r = searcher.search(&query, 5).await.unwrap();
+            assert_eq!(r.len(), 1, "needle {needle} lost at grid_bits={grid_bits}");
+            per_query.push(r.iter().map(|d| (d.doc_id, d.score)).collect::<Vec<_>>());
+        }
+        results.push(per_query);
+    }
+
+    // Exactness: identical top-k scores (doc order may tie-shuffle) — compare
+    // sorted score lists per query, and identical needle hits.
+    for (q4, q2) in results[0].iter().zip(results[1].iter()) {
+        let s4: Vec<f32> = q4.iter().map(|&(_, s)| s).collect();
+        let s2: Vec<f32> = q2.iter().map(|&(_, s)| s).collect();
+        assert_eq!(s4.len(), s2.len());
+        for (a, b) in s4.iter().zip(s2.iter()) {
+            assert!((a - b).abs() < 1e-3, "score mismatch {a} vs {b}");
+        }
+    }
+    // 2-bit grid rows are half the 4-bit rows
+    assert_eq!(grid_sizes[1], grid_sizes[0].div_ceil(2));
+}
+
+/// Regression: blockwise reorder used to write the superblock grid in
+/// GRID-CELL scale (0-15) instead of u8 impact scale (0-255), deflating
+/// superblock UBs ~17× — unsafe pruning (silent recall loss) once the heap
+/// fills. Pin the structural invariant directly: the sb_grid's maximum
+/// value must survive a blockwise pass (builder writes u8 impacts; the
+/// needle dims here have impact ≈51, which the bug collapses to cell 3).
+#[tokio::test]
+async fn test_blockwise_reorder_preserves_sb_grid_scale() {
+    let (schema, _title, sparse) = bmp_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    add_rare_dim_clustered_corpus(&mut writer, sparse);
+    writer.commit().await.unwrap();
+    drop(writer);
+
+    let sb_max = |dir: RamDirectory, config: IndexConfig| async move {
+        let index = Index::open(dir, config).await.unwrap();
+        let readers = index.segment_readers().await.unwrap();
+        let bmp = readers[0].bmp_indexes().get(&sparse.0).unwrap();
+        bmp.sb_grid_slice().iter().copied().max().unwrap_or(0)
+    };
+    let before = sb_max(dir.clone(), config.clone()).await;
+    assert!(
+        before > 15,
+        "test setup: builder sb_grid must carry u8 impacts (got max {before})"
+    );
+
+    // Blockwise pass (Auto picks Blocks for this corpus — pinned elsewhere)
+    let mut writer = IndexWriter::open(dir.clone(), config.clone())
+        .await
+        .unwrap();
+    writer.reorder().await.unwrap();
+    drop(writer);
+
+    let after = sb_max(dir.clone(), config.clone()).await;
+    assert_eq!(
+        after, before,
+        "blockwise reorder must preserve sb_grid impact scale (0-255) — \
+         cell-scale values (≤15) deflate superblock UBs ~17× (unsafe pruning)"
+    );
+}
+
+/// Measured evidence for BP forward-index build cost (the serial stage of a
+/// single reorder). Not a correctness test — run manually with:
+/// `cargo test -p hermes-core --release --features native \
+///    bench_forward_index_build -- --ignored --nocapture`
+#[tokio::test]
+#[ignore]
+async fn bench_forward_index_build() {
+    use crate::segment::{
+        build_forward_index_from_blocks, build_forward_index_from_bmps, graph_bisection,
+    };
+
+    struct XorShift(u64);
+    impl XorShift {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+    }
+
+    const DOCS: usize = 300_000;
+    const DIMS: u32 = 30_000;
+    const TERMS_PER_DOC: usize = 48;
+
+    let config_sparse = SparseVectorConfig {
+        format: SparseFormat::Bmp,
+        weight_quantization: WeightQuantization::UInt8,
+        bmp_block_size: 64,
+        dims: Some(DIMS),
+        max_weight: Some(5.0),
+        ..SparseVectorConfig::default()
+    };
+    let (schema, _title, sparse) = bmp_schema_with_config(config_sparse);
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        num_indexing_threads: 1,
+        max_indexing_memory_bytes: 8 * 1024 * 1024 * 1024,
+        ..IndexConfig::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    let mut rng = XorShift(0xC0FFEE1234567890);
+    for _ in 0..DOCS {
+        // Zipf-ish dim mix: half from a hot head, half uniform tail.
+        let mut entries: Vec<(u32, f32)> = (0..TERMS_PER_DOC)
+            .map(|t| {
+                let d = if t % 2 == 0 {
+                    (rng.next() % 2_000) as u32
+                } else {
+                    2_000 + (rng.next() % (DIMS as u64 - 2_000)) as u32
+                };
+                (d, 0.5 + (rng.next() % 100) as f32 / 25.0)
+            })
+            .collect();
+        entries.sort_by_key(|&(d, _)| d);
+        entries.dedup_by_key(|&mut (d, _)| d);
+        loop {
+            let mut doc = Document::new();
+            doc.add_sparse_vector(sparse, entries.clone());
+            match writer.add_document(doc) {
+                Ok(()) => break,
+                Err(crate::Error::QueueFull) => {
+                    tokio::time::sleep(std::time::Duration::from_millis(3)).await;
+                }
+                Err(e) => panic!("{e:?}"),
+            }
+        }
+    }
+    writer.commit().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let readers = index.segment_readers().await.unwrap();
+    assert_eq!(readers.len(), 1);
+    let bmp = readers[0].bmp_indexes().get(&sparse.0).unwrap().clone();
+    println!(
+        "corpus: {} docs, {} blocks, {} postings",
+        DOCS,
+        bmp.num_blocks,
+        bmp.total_postings()
+    );
+
+    // Same df window reorder_bmp_field uses for this segment size.
+    let min_df = (DOCS / 5000).clamp(2, 128);
+    let max_df = ((DOCS as f64) * 0.9) as usize;
+    let budget = 2usize * 1024 * 1024 * 1024;
+
+    for round in 0..3 {
+        let t = std::time::Instant::now();
+        let (fwd, _) = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget);
+        println!(
+            "record-level fwd build round {}: {:.1}ms ({} terms, {} postings)",
+            round,
+            t.elapsed().as_secs_f64() * 1000.0,
+            fwd.num_terms,
+            fwd.total_postings(),
+        );
+    }
+    for round in 0..3 {
+        let t = std::time::Instant::now();
+        let fwd = build_forward_index_from_blocks(&[&bmp], budget);
+        println!(
+            "block-level fwd build round {}: {:.1}ms ({} terms, {} postings)",
+            round,
+            t.elapsed().as_secs_f64() * 1000.0,
+            fwd.num_terms,
+            fwd.total_postings(),
+        );
+    }
+
+    // Full-pipeline breakdown: BP itself, then the whole reorder (fwd build +
+    // BP + permuted blob write + commit) — blob write ≈ total − fwd − BP.
+    let (fwd, _) = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget);
+    let t = std::time::Instant::now();
+    let (_perm, converged) = graph_bisection(&fwd, 64, 20, crate::segment::BpBudget::full());
+    println!(
+        "graph_bisection (record-level, full depth): {:.1}ms (converged={})",
+        t.elapsed().as_secs_f64() * 1000.0,
+        converged,
+    );
+    drop(fwd);
+    drop(bmp);
+    drop(readers);
+    drop(index);
+
+    let mut writer = IndexWriter::open(dir.clone(), config.clone())
+        .await
+        .unwrap();
+    let t = std::time::Instant::now();
+    writer.reorder().await.unwrap();
+    println!(
+        "writer.reorder() end-to-end: {:.1}ms",
+        t.elapsed().as_secs_f64() * 1000.0,
+    );
 }

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -137,6 +137,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             config.merge_policy.clone_box(),
             config.term_cache_blocks,
             config.max_concurrent_merges,
+            config.merge_bp_time_budget,
+            config.bp_memory_budget_bytes,
         ));
         segment_manager.update_metadata(|_| {}).await?;
 
@@ -173,6 +175,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             config.merge_policy.clone_box(),
             config.term_cache_blocks,
             config.max_concurrent_merges,
+            config.merge_bp_time_budget,
+            config.bp_memory_budget_bytes,
         ));
         segment_manager.load_and_publish_trained().await;
 

--- a/hermes-core/src/merge/mod.rs
+++ b/hermes-core/src/merge/mod.rs
@@ -167,7 +167,12 @@ impl TieredMergePolicy {
     pub fn large_scale() -> Self {
         Self {
             segments_per_tier: 10,
-            max_merge_at_once: 10,
+            // Wide fan-in absorbs continuous-ingestion floods of small
+            // memtable segments in fewer passes (350-segment backlogs at
+            // 30M docs were observed with fan-in 10). Giant merges are safe:
+            // output docs are capped by max_merged_docs and merge-time BP is
+            // wall-clock budgeted (IndexConfig::merge_bp_time_budget).
+            max_merge_at_once: 24,
             tier_factor: 10.0,
             tier_floor: 50_000,
             max_merged_docs: 20_000_000,

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -160,6 +160,13 @@ pub struct SegmentManager<D: DirectoryWriter + 'static> {
     /// in SDL); merged segments are marked `reordered` and skipped by the
     /// standalone optimizer pass.
     reorder_on_merge: bool,
+    /// Wall-clock budget for merge-time BP (from `IndexConfig`); truncated
+    /// passes mark the merged segment `bp_converged = false` so the
+    /// background optimizer deepens it later (warm-started).
+    merge_bp_time_budget: Option<std::time::Duration>,
+    /// Memory budget for the BP forward index (merge-time and background
+    /// reorder). Over-budget passes drop highest-df dims, logged loudly.
+    bp_memory_budget_bytes: usize,
     /// Bounded rayon pool for background CPU work (merge-time BP, manual
     /// reorder). Built lazily at ~cores/4 so background passes cannot
     /// saturate the global rayon pool that query scoring runs on.
@@ -168,6 +175,7 @@ pub struct SegmentManager<D: DirectoryWriter + 'static> {
 
 impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     /// Create a new segment manager with existing metadata
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         directory: Arc<D>,
         schema: Arc<crate::dsl::Schema>,
@@ -175,6 +183,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         merge_policy: Box<dyn MergePolicy>,
         term_cache_blocks: usize,
         max_concurrent_merges: usize,
+        merge_bp_time_budget: Option<std::time::Duration>,
+        bp_memory_budget_bytes: usize,
     ) -> Self {
         // Persisted index option: set via `reorder_on_merge: true` in the SDL
         // at index creation. Absent = disabled (merges block-copy).
@@ -224,6 +234,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             term_cache_blocks,
             max_concurrent_merges: max_concurrent_merges.max(1),
             reorder_on_merge,
+            merge_bp_time_budget,
+            bp_memory_budget_bytes,
             bg_cpu_pool: std::sync::OnceLock::new(),
         }
     }
@@ -233,7 +245,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     /// prevents a large merge from queueing every search behind gain passes.
     pub fn background_cpu_pool(&self) -> Arc<rayon::ThreadPool> {
         Arc::clone(self.bg_cpu_pool.get_or_init(|| {
-            let threads = (num_cpus::get() / 4).max(1);
+            let threads = (num_cpus::get() / 2).max(1);
             log::info!("[merge] background CPU pool: {} thread(s)", threads);
             Arc::new(
                 rayon::ThreadPoolBuilder::new()
@@ -460,14 +472,22 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 trained_snap.as_deref(),
                 sm.reorder_on_merge,
                 granularity,
+                sm.merge_bp_time_budget,
+                sm.bp_memory_budget_bytes,
                 Some(sm.background_cpu_pool()),
             )
             .await;
 
             match result {
-                Ok((new_id, doc_count)) => {
+                Ok((new_id, doc_count, bp_converged)) => {
                     if let Err(e) = sm
-                        .replace_segments(&ids, new_id, doc_count, sm.reorder_on_merge, true)
+                        .replace_segments(
+                            &ids,
+                            new_id,
+                            doc_count,
+                            sm.reorder_on_merge,
+                            bp_converged,
+                        )
                         .await
                     {
                         log::error!("[merge] Failed to replace segments after merge: {:?}", e);
@@ -549,8 +569,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         trained: Option<&TrainedVectorStructures>,
         reorder_bmp: bool,
         granularity: crate::segment::reorder::BpGranularity,
+        merge_bp_time_budget: Option<std::time::Duration>,
+        bp_memory_budget_bytes: usize,
         bg_cpu_pool: Option<Arc<rayon::ThreadPool>>,
-    ) -> Result<(String, u32)> {
+    ) -> Result<(String, u32, bool)> {
         let output_hex = output_segment_id.to_hex();
         let load_start = std::time::Instant::now();
 
@@ -614,6 +636,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let merger = SegmentMerger::new(Arc::clone(schema))
             .with_bmp_reorder(reorder_bmp)
             .with_granularity(granularity)
+            .with_bp_budget(crate::segment::BpBudget {
+                min_partition_docs: None,
+                time_budget: merge_bp_time_budget,
+            })
+            .with_bp_memory_budget(bp_memory_budget_bytes)
             .with_background_pool(bg_cpu_pool);
 
         log::info!(
@@ -623,9 +650,15 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             trained.map_or(0, |t| t.centroids.len()),
         );
 
-        merger
+        let (_merged_meta, merge_stats) = merger
             .merge(directory, &readers, output_segment_id, trained)
             .await?;
+        let bp_converged = merge_stats.bp_converged;
+        if !bp_converged {
+            log::info!(
+                "[merge] merge-time BP hit its wall-clock budget — output marked unconverged;                  the background optimizer deepens it later",
+            );
+        }
 
         log::info!(
             "[merge] total wall-clock: {:.1}s ({} segments, {} docs)",
@@ -640,7 +673,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 total_docs
             )));
         }
-        Ok((output_hex, total_docs as u32))
+        Ok((output_hex, total_docs as u32, bp_converged))
     }
 
     /// Abort all in-flight merge tasks without waiting for completion.
@@ -761,7 +794,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
             let trained_snap = self.trained();
             let granularity = self.merge_granularity(&batch).await;
-            let (new_segment_id, total_docs) = Self::do_merge(
+            let (new_segment_id, total_docs, bp_converged) = Self::do_merge(
                 self.directory.as_ref(),
                 &self.schema,
                 &batch,
@@ -770,6 +803,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 trained_snap.as_deref(),
                 self.reorder_on_merge,
                 granularity,
+                self.merge_bp_time_budget,
+                self.bp_memory_budget_bytes,
                 Some(self.background_cpu_pool()),
             )
             .await?;
@@ -779,7 +814,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 new_segment_id,
                 total_docs,
                 self.reorder_on_merge,
-                true,
+                bp_converged,
             )
             .await?;
 
@@ -921,19 +956,25 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             source_id,
             output_id,
             self.term_cache_blocks,
-            crate::segment::reorder::DEFAULT_MEMORY_BUDGET,
+            self.bp_memory_budget_bytes,
             bp_budget,
             granularity,
             rayon_pool,
         )
         .await?;
 
+        // A pass with a depth floor above block granularity has, by
+        // definition, not converged to block-level order — record it as
+        // unconverged so the optimizer's deepening ladder revisits it with a
+        // full-depth (warm-started) pass. Depth caps are only used by the
+        // optimizer's first pass on large segments.
+        let ladder_converged = bp_converged && bp_budget.min_partition_docs.is_none();
         self.replace_segments(
             &[seg_id.to_string()],
             new_id,
             total_docs,
             true,
-            bp_converged,
+            ladder_converged,
         )
         .await?;
 

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -39,8 +39,8 @@
 
 use super::scoring::{ScoreCollector, ScoredDoc};
 use crate::segment::{
-    BMP_SUPERBLOCK_SIZE, BmpIndex, accumulate_u4_weighted, block_term_postings,
-    compute_block_masks_4bit, find_dim_in_block_data,
+    BMP_SUPERBLOCK_SIZE, BmpIndex, accumulate_grid_weighted, block_term_postings,
+    compute_block_masks, find_dim_in_block_data,
 };
 
 // dim_id is used directly as grid row index. No dim_idx indirection.
@@ -477,14 +477,16 @@ fn execute_bmp_inner(
             // Compute block UBs + masks from grid
             compute_block_ubs_compact(
                 grid_slice,
+                index.grid_bits(),
                 prs,
                 &grid_dims,
                 block_start,
                 block_end,
                 &mut scratch.local_block_ubs,
             );
-            compute_block_masks_4bit(
+            compute_block_masks(
                 grid_slice,
+                index.grid_bits(),
                 prs,
                 &grid_dims,
                 block_start,
@@ -500,6 +502,7 @@ fn execute_bmp_inner(
                     .collect();
                 compute_block_ubs_compact(
                     grid_slice,
+                    index.grid_bits(),
                     prs,
                     &phase1_dims,
                     block_start,
@@ -1029,6 +1032,7 @@ fn compute_sb_ubs_int(
 #[inline]
 fn compute_block_ubs_compact(
     compact_grid: &[u8],
+    grid_bits: u8,
     prs: usize,
     compact_dims: &[(usize, f32)],
     block_start: usize,
@@ -1040,6 +1044,13 @@ fn compute_block_ubs_compact(
     out[..count].fill(0.0);
     for &(local_idx, weight) in compact_dims {
         let row = &compact_grid[local_idx * prs..(local_idx + 1) * prs];
-        accumulate_u4_weighted(row, block_start, count, weight, &mut out[..count]);
+        accumulate_grid_weighted(
+            row,
+            grid_bits,
+            block_start,
+            count,
+            weight,
+            &mut out[..count],
+        );
     }
 }

--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -126,6 +126,7 @@ use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
 pub(crate) fn build_bmp_blob(
     mut postings: FxHashMap<u32, Vec<(DocId, u16, f32)>>,
     bmp_block_size: u32,
+    grid_bits: u8,
     weight_threshold: f32,
     pruning_fraction: Option<f32>,
     dims: u32,
@@ -443,7 +444,7 @@ pub(crate) fn build_bmp_blob(
     // `dims` rows (not num_dims)
     let grid_offset = bytes_written;
     let (packed_bytes, sb_bytes) =
-        stream_write_grids(&grid_entries, dims as usize, num_blocks, writer)?;
+        stream_write_grids(&grid_entries, dims as usize, num_blocks, grid_bits, writer)?;
     let sb_grid_offset = bytes_written + packed_bytes;
     bytes_written += packed_bytes + sb_bytes;
     drop(grid_entries); // Free grid entries before doc_map write
@@ -486,6 +487,7 @@ pub(crate) fn build_bmp_blob(
         max_weight_scale,
         doc_map_offset,
         num_real_docs as u32,
+        grid_bits,
     )?;
     bytes_written += 64;
 
@@ -507,6 +509,7 @@ pub(crate) fn write_v13_footer(
     max_weight_scale: f32,
     doc_map_offset: u64,
     num_real_docs: u32,
+    grid_bits: u8,
 ) -> std::io::Result<()> {
     writer.write_u32::<LittleEndian>(total_terms)?; //  0- 3
     writer.write_u32::<LittleEndian>(total_postings)?; //  4- 7
@@ -519,7 +522,8 @@ pub(crate) fn write_v13_footer(
     writer.write_f32::<LittleEndian>(max_weight_scale)?; // 40-43
     writer.write_u64::<LittleEndian>(doc_map_offset)?; // 44-51
     writer.write_u32::<LittleEndian>(num_real_docs)?; // 52-55
-    writer.write_u32::<LittleEndian>(0)?; // 56-59 reserved
+    // 56-59: grid cell width in bits (0 = legacy 4-bit; else 2 or 4)
+    writer.write_u32::<LittleEndian>(grid_bits as u32)?;
     writer.write_u32::<LittleEndian>(BMP_BLOB_MAGIC_V13)?; // 60-63
     Ok(())
 }
@@ -548,16 +552,66 @@ pub(crate) fn write_u64_slice_le(writer: &mut dyn Write, data: &[u64]) -> std::i
     Ok(data.len() as u64 * 8)
 }
 
-/// Ceiling quantize u8 → u4. Guarantees `u4 * 17 >= original`.
-///
-/// This ensures that 4-bit grid upper bounds are always safe (never
-/// underestimate the true u8 value when unpacked via ×17).
+/// Bytes per grid row for `num_blocks` cells at `bits` per cell (2 or 4).
 #[inline]
-pub(crate) fn quantize_u8_to_u4_ceil(val: u8) -> u8 {
+pub(crate) fn grid_packed_row_size(num_blocks: usize, grid_bits: u8) -> usize {
+    match grid_bits {
+        2 => num_blocks.div_ceil(4),
+        _ => num_blocks.div_ceil(2),
+    }
+}
+
+/// Dequantization multiplier for a grid cell: `cell × scale` recovers a safe
+/// (ceil-quantized) u8 upper bound. 4-bit → 17 (15×17=255); 2-bit → 85.
+#[inline]
+pub(crate) fn grid_dequant_scale(grid_bits: u8) -> u32 {
+    match grid_bits {
+        2 => 85,
+        _ => 17,
+    }
+}
+
+/// Ceiling quantize u8 to a `bits`-wide grid cell. Guarantees
+/// `cell × grid_dequant_scale(bits) >= original` (bounds never underestimate).
+#[inline]
+pub(crate) fn grid_quantize_ceil(val: u8, grid_bits: u8) -> u8 {
     if val == 0 {
         return 0;
     }
-    (val as u16 * 15).div_ceil(255) as u8
+    match grid_bits {
+        2 => (val as u16 * 3).div_ceil(255) as u8,
+        _ => (val as u16 * 15).div_ceil(255) as u8,
+    }
+}
+
+/// OR a quantized cell into a packed grid row at cell index `idx`.
+#[inline]
+pub(crate) fn grid_set_cell(row: &mut [u8], idx: usize, cell: u8, grid_bits: u8) {
+    match grid_bits {
+        2 => row[idx / 4] |= cell << ((idx % 4) * 2),
+        _ => {
+            if idx.is_multiple_of(2) {
+                row[idx / 2] |= cell;
+            } else {
+                row[idx / 2] |= cell << 4;
+            }
+        }
+    }
+}
+
+/// Read a cell from a packed grid row at cell index `idx`.
+#[inline]
+pub(crate) fn grid_get_cell(row: &[u8], idx: usize, grid_bits: u8) -> u8 {
+    match grid_bits {
+        2 => (row[idx / 4] >> ((idx % 4) * 2)) & 0x03,
+        _ => {
+            if idx.is_multiple_of(2) {
+                row[idx / 2] & 0x0F
+            } else {
+                row[idx / 2] >> 4
+            }
+        }
+    }
 }
 
 /// Stream-write 4-bit packed grid (Section D) and 8-bit superblock grid (Section E).
@@ -572,9 +626,10 @@ pub(crate) fn stream_write_grids(
     grid_entries: &[(u32, u32, u8)],
     num_dims: usize,
     num_blocks: usize,
+    grid_bits: u8,
     writer: &mut dyn Write,
 ) -> std::io::Result<(u64, u64)> {
-    let packed_row_size = num_blocks.div_ceil(2);
+    let packed_row_size = grid_packed_row_size(num_blocks, grid_bits);
     let num_superblocks = num_blocks.div_ceil(BMP_SUPERBLOCK_SIZE as usize);
 
     let mut row_buf = vec![0u8; packed_row_size];
@@ -586,12 +641,8 @@ pub(crate) fn stream_write_grids(
         row_buf.fill(0);
         while gi < grid_entries.len() && grid_entries[gi].0 == dim_id {
             let b = grid_entries[gi].1 as usize;
-            let q4 = quantize_u8_to_u4_ceil(grid_entries[gi].2);
-            if b.is_multiple_of(2) {
-                row_buf[b / 2] |= q4;
-            } else {
-                row_buf[b / 2] |= q4 << 4;
-            }
+            let cell = grid_quantize_ceil(grid_entries[gi].2, grid_bits);
+            grid_set_cell(&mut row_buf, b, cell, grid_bits);
             gi += 1;
         }
         writer.write_all(&row_buf)?;
@@ -710,9 +761,10 @@ pub(crate) fn stream_write_grids_merged(
     run_readers: &mut [GridRunReader],
     num_dims: usize,
     num_blocks: usize,
+    grid_bits: u8,
     writer: &mut dyn Write,
 ) -> std::io::Result<(u64, u64)> {
-    let packed_row_size = num_blocks.div_ceil(2);
+    let packed_row_size = grid_packed_row_size(num_blocks, grid_bits);
     let num_superblocks = num_blocks.div_ceil(BMP_SUPERBLOCK_SIZE as usize);
 
     let mut row_buf = vec![0u8; packed_row_size];
@@ -727,12 +779,8 @@ pub(crate) fn stream_write_grids_merged(
                     break;
                 }
                 let b = block_id as usize;
-                let q4 = quantize_u8_to_u4_ceil(impact);
-                if b.is_multiple_of(2) {
-                    row_buf[b / 2] |= q4;
-                } else {
-                    row_buf[b / 2] |= q4 << 4;
-                }
+                let cell = grid_quantize_ceil(impact, grid_bits);
+                grid_set_cell(&mut row_buf, b, cell, grid_bits);
                 reader.advance()?;
             }
         }
@@ -793,7 +841,7 @@ mod tests {
     fn test_build_bmp_blob_empty() {
         let postings = FxHashMap::default();
         let mut buf = Vec::new();
-        let size = build_bmp_blob(postings, 64, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
+        let size = build_bmp_blob(postings, 64, 4, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
         assert_eq!(size, 0);
         assert!(buf.is_empty());
     }
@@ -807,7 +855,7 @@ mod tests {
         postings.insert(1, vec![(0, 0, 0.8)]);
 
         let mut buf = Vec::new();
-        let size = build_bmp_blob(postings, 64, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
+        let size = build_bmp_blob(postings, 64, 4, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
         assert!(size > 0);
         assert_eq!(buf.len(), size as usize);
 
@@ -824,7 +872,7 @@ mod tests {
         postings.insert(0u32, vec![(0u32, 0u16, 1.0f32), (0, 1, 0.8), (1, 0, 0.5)]);
 
         let mut buf = Vec::new();
-        let size = build_bmp_blob(postings, 64, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
+        let size = build_bmp_blob(postings, 64, 4, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
         assert!(size > 0);
 
         // Verify V13 footer: num_virtual_docs should be 64 (padded to block_size)
@@ -849,7 +897,7 @@ mod tests {
         // impact(2.0) = round(2.0/5.0*255) = round(102) = 102
         // impact(1.0) = round(1.0/5.0*255) = round(51) = 51
         let mut buf = Vec::new();
-        let size = build_bmp_blob(postings, 64, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
+        let size = build_bmp_blob(postings, 64, 4, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
         assert!(size > 0);
 
         // Verify max_weight_scale in V13 footer (bytes 40-43)
@@ -874,7 +922,7 @@ mod tests {
 
         // Fixed max_weight=5.0: same scale
         let mut buf_a = Vec::new();
-        build_bmp_blob(postings_a, 64, 0.0, None, 105879, 5.0, 4, &mut buf_a).unwrap();
+        build_bmp_blob(postings_a, 64, 4, 0.0, None, 105879, 5.0, 4, &mut buf_a).unwrap();
         let scale_a = f32::from_le_bytes(
             buf_a[buf_a.len() - 64 + 40..buf_a.len() - 64 + 44]
                 .try_into()
@@ -882,7 +930,7 @@ mod tests {
         );
 
         let mut buf_b = Vec::new();
-        build_bmp_blob(postings_b, 64, 0.0, None, 105879, 5.0, 4, &mut buf_b).unwrap();
+        build_bmp_blob(postings_b, 64, 4, 0.0, None, 105879, 5.0, 4, &mut buf_b).unwrap();
         let scale_b = f32::from_le_bytes(
             buf_b[buf_b.len() - 64 + 40..buf_b.len() - 64 + 44]
                 .try_into()

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -81,6 +81,65 @@ pub(crate) fn build_vid_maps(bmp: &crate::segment::reader::bmp::BmpIndex) -> (Ve
     (virtual_to_real, real_to_virtual)
 }
 
+/// One (source, block) unit of forward-index construction. Because
+/// [`build_vid_maps`] assigns real ids in ascending vid order, a block's real
+/// docs form the contiguous per-source range
+/// `real_start..real_start + real_len` — blocks can be processed in parallel
+/// with disjoint output slices.
+struct BlockJob {
+    src: u32,
+    block_id: u32,
+    /// Per-source real index of the block's first real doc.
+    real_start: u32,
+    /// Number of real (non-padding) docs in the block.
+    real_len: u32,
+}
+
+/// Enumerate jobs in (source, block) order — cumulative `real_len` tiles the
+/// global real-id space `0..total_docs` exactly.
+fn build_block_jobs(
+    bmps: &[&crate::segment::reader::bmp::BmpIndex],
+    vid_maps: &[(Vec<u32>, Vec<u32>)],
+) -> Vec<BlockJob> {
+    let total_blocks: usize = bmps.iter().map(|b| b.num_blocks as usize).sum();
+    let mut jobs = Vec::with_capacity(total_blocks);
+    for (src, (bmp, (v2r, _))) in bmps.iter().zip(vid_maps).enumerate() {
+        let block_size = bmp.bmp_block_size as usize;
+        let mut real_cursor = 0u32;
+        for block_id in 0..bmp.num_blocks as usize {
+            let vid_start = block_id * block_size;
+            let vid_end = ((block_id + 1) * block_size).min(v2r.len());
+            let real_len = v2r[vid_start..vid_end]
+                .iter()
+                .filter(|&&r| r != u32::MAX)
+                .count() as u32;
+            jobs.push(BlockJob {
+                src: src as u32,
+                block_id: block_id as u32,
+                real_start: real_cursor,
+                real_len,
+            });
+            real_cursor += real_len;
+        }
+    }
+    jobs
+}
+
+/// Merge the smaller df map into the larger (rayon reduce combiner).
+#[cfg(feature = "native")]
+fn merge_df_maps(
+    mut a: FxHashMap<u32, usize>,
+    mut b: FxHashMap<u32, usize>,
+) -> FxHashMap<u32, usize> {
+    if a.len() < b.len() {
+        std::mem::swap(&mut a, &mut b);
+    }
+    for (k, v) in b {
+        *a.entry(k).or_insert(0) += v;
+    }
+    a
+}
+
 /// Build forward index from BmpIndex sources (single or multi-source).
 ///
 /// Documents are identified by dense *real* indices assigned sequentially
@@ -116,22 +175,46 @@ pub(crate) fn build_forward_index_from_bmps(
         );
     }
 
+    // Job list: one entry per (source, block). Real ids are assigned in
+    // ascending vid order (see build_vid_maps), so each block owns a
+    // contiguous real-id range — every phase below can process blocks in
+    // parallel, writing disjoint slices.
+    let jobs = build_block_jobs(bmps, &vid_maps);
+
     // Phase 1: count doc freq per dimension across all sources + assign compact IDs
-    let mut dim_df: FxHashMap<u32, usize> = FxHashMap::default();
-    for (bmp, (v2r, _)) in bmps.iter().zip(&vid_maps) {
-        let num_blocks = bmp.num_blocks as usize;
+    let count_block_df = |job: &BlockJob, acc: &mut FxHashMap<u32, usize>| {
+        let bmp = bmps[job.src as usize];
+        let (v2r, _) = &vid_maps[job.src as usize];
         let block_size = bmp.bmp_block_size as usize;
-        for block_id in 0..num_blocks {
-            for (dim_id, postings) in bmp.iter_block_terms(block_id as u32) {
-                for p in postings {
-                    let vid = block_id * block_size + p.local_slot as usize;
-                    if v2r[vid] != u32::MAX && p.impact > 0 {
-                        *dim_df.entry(dim_id).or_insert(0) += 1;
-                    }
+        for (dim_id, postings) in bmp.iter_block_terms(job.block_id) {
+            let mut n = 0usize;
+            for p in postings {
+                let vid = job.block_id as usize * block_size + p.local_slot as usize;
+                if v2r[vid] != u32::MAX && p.impact > 0 {
+                    n += 1;
                 }
             }
+            if n > 0 {
+                *acc.entry(dim_id).or_insert(0) += n;
+            }
         }
-    }
+    };
+    #[cfg(feature = "native")]
+    let dim_df: FxHashMap<u32, usize> = jobs
+        .par_iter()
+        .fold(FxHashMap::default, |mut acc, job| {
+            count_block_df(job, &mut acc);
+            acc
+        })
+        .reduce(FxHashMap::default, merge_df_maps);
+    #[cfg(not(feature = "native"))]
+    let dim_df: FxHashMap<u32, usize> = {
+        let mut acc = FxHashMap::default();
+        for job in &jobs {
+            count_block_df(job, &mut acc);
+        }
+        acc
+    };
 
     // Filter dims by [min_doc_freq, max_doc_freq] range
     let mut eligible: Vec<(u32, usize)> = dim_df
@@ -185,29 +268,41 @@ pub(crate) fn build_forward_index_from_bmps(
     let num_active_terms = term_remap.len();
     drop(eligible);
 
-    // Phase 2: count terms per doc (filtered)
+    // Phase 2: count terms per doc (filtered) — per-block disjoint slices
     let mut counts = vec![0u32; total_docs];
-    let mut real_offset = 0usize;
-
-    for (src_idx, bmp) in bmps.iter().enumerate() {
-        let (v2r, _) = &vid_maps[src_idx];
-        let num_blocks = bmp.num_blocks as usize;
+    let fill_block_counts = |job: &BlockJob, out: &mut [u32]| {
+        let bmp = bmps[job.src as usize];
+        let (v2r, _) = &vid_maps[job.src as usize];
         let block_size = bmp.bmp_block_size as usize;
-        for block_id in 0..num_blocks {
-            for (dim_id, postings) in bmp.iter_block_terms(block_id as u32) {
-                if !term_remap.contains_key(&dim_id) {
-                    continue;
-                }
-                for p in postings {
-                    let vid = block_id * block_size + p.local_slot as usize;
-                    let real = v2r[vid];
-                    if real != u32::MAX && p.impact > 0 {
-                        counts[real_offset + real as usize] += 1;
-                    }
+        for (dim_id, postings) in bmp.iter_block_terms(job.block_id) {
+            if !term_remap.contains_key(&dim_id) {
+                continue;
+            }
+            for p in postings {
+                let vid = job.block_id as usize * block_size + p.local_slot as usize;
+                let real = v2r[vid];
+                if real != u32::MAX && p.impact > 0 {
+                    out[(real - job.real_start) as usize] += 1;
                 }
             }
         }
-        real_offset += source_doc_counts[src_idx];
+    };
+    {
+        let mut slices: Vec<(&BlockJob, &mut [u32])> = Vec::with_capacity(jobs.len());
+        let mut rest: &mut [u32] = &mut counts;
+        for job in &jobs {
+            let (head, tail) = rest.split_at_mut(job.real_len as usize);
+            slices.push((job, head));
+            rest = tail;
+        }
+        #[cfg(feature = "native")]
+        slices
+            .into_par_iter()
+            .for_each(|(job, out)| fill_block_counts(job, out));
+        #[cfg(not(feature = "native"))]
+        for (job, out) in slices {
+            fill_block_counts(job, out);
+        }
     }
 
     // Phase 3: build CSR offsets
@@ -217,34 +312,56 @@ pub(crate) fn build_forward_index_from_bmps(
         offsets.push(offsets.last().unwrap() + c);
     }
     let total = *offsets.last().unwrap() as usize;
+    drop(counts);
 
-    // Phase 4: fill terms (compact IDs)
+    // Phase 4: fill terms (compact IDs) — each block writes the contiguous
+    // terms range covering its real docs; per-doc write cursors are local.
     let mut terms = vec![0u32; total];
-    counts.fill(0);
-    real_offset = 0;
-
-    for (src_idx, bmp) in bmps.iter().enumerate() {
-        let (v2r, _) = &vid_maps[src_idx];
-        let num_blocks = bmp.num_blocks as usize;
+    let fill_block_terms = |job: &BlockJob, global_real_start: usize, out: &mut [u32]| {
+        let bmp = bmps[job.src as usize];
+        let (v2r, _) = &vid_maps[job.src as usize];
         let block_size = bmp.bmp_block_size as usize;
-        for block_id in 0..num_blocks {
-            for (dim_id, postings) in bmp.iter_block_terms(block_id as u32) {
-                let Some(&compact) = term_remap.get(&dim_id) else {
-                    continue;
-                };
-                for p in postings {
-                    let vid = block_id * block_size + p.local_slot as usize;
-                    let real = v2r[vid];
-                    if real != u32::MAX && p.impact > 0 {
-                        let global_real = real_offset + real as usize;
-                        let pos = offsets[global_real] as usize + counts[global_real] as usize;
-                        terms[pos] = compact;
-                        counts[global_real] += 1;
-                    }
+        // local_slot is u8, so a block never holds more than 256 real docs
+        assert!(job.real_len as usize <= 256, "BMP block exceeds 256 docs");
+        let mut cursor = [0u32; 256];
+        let base = offsets[global_real_start] as usize;
+        for (dim_id, postings) in bmp.iter_block_terms(job.block_id) {
+            let Some(&compact) = term_remap.get(&dim_id) else {
+                continue;
+            };
+            for p in postings {
+                let vid = job.block_id as usize * block_size + p.local_slot as usize;
+                let real = v2r[vid];
+                if real != u32::MAX && p.impact > 0 {
+                    let local = (real - job.real_start) as usize;
+                    let pos =
+                        offsets[global_real_start + local] as usize - base + cursor[local] as usize;
+                    out[pos] = compact;
+                    cursor[local] += 1;
                 }
             }
         }
-        real_offset += source_doc_counts[src_idx];
+    };
+    {
+        let mut slices: Vec<(&BlockJob, usize, &mut [u32])> = Vec::with_capacity(jobs.len());
+        let mut rest: &mut [u32] = &mut terms;
+        let mut global_real = 0usize;
+        for job in &jobs {
+            let len =
+                (offsets[global_real + job.real_len as usize] - offsets[global_real]) as usize;
+            let (head, tail) = rest.split_at_mut(len);
+            slices.push((job, global_real, head));
+            rest = tail;
+            global_real += job.real_len as usize;
+        }
+        #[cfg(feature = "native")]
+        slices
+            .into_par_iter()
+            .for_each(|(job, g, out)| fill_block_terms(job, g, out));
+        #[cfg(not(feature = "native"))]
+        for (job, g, out) in slices {
+            fill_block_terms(job, g, out);
+        }
     }
 
     (
@@ -277,15 +394,35 @@ pub(crate) fn build_forward_index_from_blocks(
         };
     }
 
+    // (source, block) pairs in global block order — the parallel unit.
+    let blocks: Vec<(u32, u32)> = bmps
+        .iter()
+        .enumerate()
+        .flat_map(|(src, bmp)| (0..bmp.num_blocks).map(move |b| (src as u32, b)))
+        .collect();
+
     // Phase 1: dim → number of blocks containing it (block-level df)
-    let mut dim_bf: FxHashMap<u32, usize> = FxHashMap::default();
-    for bmp in bmps {
-        for block_id in 0..bmp.num_blocks {
-            for (dim_id, _) in bmp.iter_block_terms(block_id) {
-                *dim_bf.entry(dim_id).or_insert(0) += 1;
-            }
+    let count_block_bf = |&(src, block_id): &(u32, u32), acc: &mut FxHashMap<u32, usize>| {
+        for (dim_id, _) in bmps[src as usize].iter_block_terms(block_id) {
+            *acc.entry(dim_id).or_insert(0) += 1;
         }
-    }
+    };
+    #[cfg(feature = "native")]
+    let dim_bf: FxHashMap<u32, usize> = blocks
+        .par_iter()
+        .fold(FxHashMap::default, |mut acc, b| {
+            count_block_bf(b, &mut acc);
+            acc
+        })
+        .reduce(FxHashMap::default, merge_df_maps);
+    #[cfg(not(feature = "native"))]
+    let dim_bf: FxHashMap<u32, usize> = {
+        let mut acc = FxHashMap::default();
+        for b in &blocks {
+            count_block_bf(b, &mut acc);
+        }
+        acc
+    };
 
     let max_bf = (total_blocks as f64 * 0.9) as usize;
     let mut eligible: Vec<(u32, usize)> = dim_bf
@@ -324,38 +461,53 @@ pub(crate) fn build_forward_index_from_blocks(
     let num_terms = term_remap.len();
     drop(eligible);
 
-    // Phase 2+3: counts and CSR fill
-    let mut counts = vec![0u32; total_blocks];
-    let mut gb = 0usize;
-    for bmp in bmps {
-        for block_id in 0..bmp.num_blocks {
-            for (dim_id, _) in bmp.iter_block_terms(block_id) {
-                if term_remap.contains_key(&dim_id) {
-                    counts[gb] += 1;
-                }
-            }
-            gb += 1;
-        }
-    }
+    // Phase 2+3: counts and CSR fill — one entity per block, so each block
+    // maps to a single count cell and a contiguous terms range.
+    let count_remapped = |&(src, block_id): &(u32, u32)| -> u32 {
+        bmps[src as usize]
+            .iter_block_terms(block_id)
+            .filter(|(dim_id, _)| term_remap.contains_key(dim_id))
+            .count() as u32
+    };
+    #[cfg(feature = "native")]
+    let counts: Vec<u32> = blocks.par_iter().map(count_remapped).collect();
+    #[cfg(not(feature = "native"))]
+    let counts: Vec<u32> = blocks.iter().map(count_remapped).collect();
+
     let mut offsets = Vec::with_capacity(total_blocks + 1);
     offsets.push(0u32);
     for &c in &counts {
         offsets.push(offsets.last().unwrap() + c);
     }
     let total = *offsets.last().unwrap() as usize;
+    drop(counts);
+
     let mut terms = vec![0u32; total];
-    counts.fill(0);
-    gb = 0;
-    for bmp in bmps {
-        for block_id in 0..bmp.num_blocks {
-            for (dim_id, _) in bmp.iter_block_terms(block_id) {
-                if let Some(&compact) = term_remap.get(&dim_id) {
-                    let pos = offsets[gb] as usize + counts[gb] as usize;
-                    terms[pos] = compact;
-                    counts[gb] += 1;
-                }
+    let fill_block = |&(src, block_id): &(u32, u32), out: &mut [u32]| {
+        let mut n = 0usize;
+        for (dim_id, _) in bmps[src as usize].iter_block_terms(block_id) {
+            if let Some(&compact) = term_remap.get(&dim_id) {
+                out[n] = compact;
+                n += 1;
             }
-            gb += 1;
+        }
+    };
+    {
+        let mut slices: Vec<(&(u32, u32), &mut [u32])> = Vec::with_capacity(blocks.len());
+        let mut rest: &mut [u32] = &mut terms;
+        for (gb, b) in blocks.iter().enumerate() {
+            let len = (offsets[gb + 1] - offsets[gb]) as usize;
+            let (head, tail) = rest.split_at_mut(len);
+            slices.push((b, head));
+            rest = tail;
+        }
+        #[cfg(feature = "native")]
+        slices
+            .into_par_iter()
+            .for_each(|(b, out)| fill_block(b, out));
+        #[cfg(not(feature = "native"))]
+        for (b, out) in slices {
+            fill_block(b, out);
         }
     }
 

--- a/hermes-core/src/segment/builder/sparse.rs
+++ b/hermes-core/src/segment/builder/sparse.rs
@@ -110,6 +110,7 @@ pub(super) fn build_sparse_streaming(
         match format {
             SparseFormat::Bmp => {
                 let bmp_block_size = sparse_config.map(|c| c.bmp_block_size).unwrap_or(64);
+                let grid_bits = sparse_config.map(|c| c.bmp_grid_bits).unwrap_or(4);
                 let dims = sparse_config.and_then(|c| c.dims).unwrap_or(105879); // default SPLADE vocab
                 let max_weight = sparse_config.and_then(|c| c.max_weight).unwrap_or(5.0); // default SPLADE max
 
@@ -117,6 +118,7 @@ pub(super) fn build_sparse_streaming(
                 let blob_len = super::bmp::build_bmp_blob(
                     std::mem::take(&mut builder.postings),
                     bmp_block_size,
+                    grid_bits,
                     weight_threshold,
                     pruning_fraction,
                     dims,

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -52,6 +52,12 @@ pub struct MergeStats {
     pub vectors_bytes: usize,
     /// Sparse vector index output size
     pub sparse_bytes: usize,
+    /// Whether merge-time BP reorder ran to full depth on every BMP field
+    /// (false = a pass hit its wall-clock budget; the segment is valid and
+    /// better-ordered, and the background optimizer deepens it later).
+    /// True when no BP ran (block-copy merges have nothing to deepen... they
+    /// are simply not reordered and tracked by the `reordered` flag instead).
+    pub bp_converged: bool,
     /// Fast-field output size
     pub fast_bytes: usize,
 }
@@ -102,9 +108,15 @@ pub struct SegmentMerger {
     background_pool: Option<Arc<rayon::ThreadPool>>,
     /// Granularity for merge-time BP. `Auto` by default; the SegmentManager
     /// forces `Records` when any merge source is an unconverged partial
-    /// reorder — the merged segment is marked `bp_converged`, so this merge
-    /// is the deepening pass those sources were owed.
+    /// reorder.
     granularity: crate::segment::reorder::BpGranularity,
+    /// Budget for merge-time BP. Default unbudgeted; the SegmentManager
+    /// passes the index's `merge_bp_time_budget` so huge merges stop holding
+    /// a merge slot for the full BP depth — a truncated pass is marked
+    /// `bp_converged = false` and the background optimizer deepens it.
+    bp_budget: crate::segment::BpBudget,
+    /// Memory budget for the BP forward index during merge-time reorder.
+    bp_memory_budget: usize,
 }
 
 impl SegmentMerger {
@@ -114,6 +126,8 @@ impl SegmentMerger {
             reorder_bmp: false,
             background_pool: None,
             granularity: crate::segment::reorder::BpGranularity::Auto,
+            bp_budget: crate::segment::BpBudget::full(),
+            bp_memory_budget: crate::segment::reorder::DEFAULT_MEMORY_BUDGET,
         }
     }
 
@@ -132,6 +146,18 @@ impl SegmentMerger {
     /// Set merge-time BP granularity (see `granularity`).
     pub fn with_granularity(mut self, granularity: crate::segment::reorder::BpGranularity) -> Self {
         self.granularity = granularity;
+        self
+    }
+
+    /// Bound merge-time BP wall clock (see `bp_budget`).
+    pub fn with_bp_budget(mut self, budget: crate::segment::BpBudget) -> Self {
+        self.bp_budget = budget;
+        self
+    }
+
+    /// Memory budget for the BP forward index (see `bp_memory_budget`).
+    pub fn with_bp_memory_budget(mut self, bytes: usize) -> Self {
+        self.bp_memory_budget = bytes;
         self
     }
 
@@ -241,7 +267,8 @@ impl SegmentMerger {
                 .await
         };
 
-        let (sparse_bytes, vectors_bytes) = tokio::try_join!(sparse_fut, dense_fut)?;
+        let ((sparse_bytes, bp_converged), vectors_bytes) =
+            tokio::try_join!(sparse_fut, dense_fut)?;
         let (store_bytes, store_num_docs) = store_result;
         stats.terms_processed = postings_result.0;
         stats.term_dict_bytes = postings_result.1;
@@ -249,6 +276,7 @@ impl SegmentMerger {
         stats.store_bytes = store_bytes;
         stats.vectors_bytes = vectors_bytes;
         stats.sparse_bytes = sparse_bytes;
+        stats.bp_converged = bp_converged;
         stats.fast_bytes = fast_bytes;
         log::info!(
             "[merge] all phases done in {:.1}s: {}",

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -41,8 +41,10 @@ impl SegmentMerger {
         dir: &D,
         segments: &[SegmentReader],
         files: &SegmentFiles,
-    ) -> Result<usize> {
+    ) -> Result<(usize, bool)> {
         let doc_offs = doc_offsets(segments)?;
+        // False iff any merge-time BP pass hit its wall-clock budget.
+        let mut all_converged = true;
 
         // Collect all sparse vector fields from schema
         let sparse_fields: Vec<_> = self
@@ -60,7 +62,7 @@ impl SegmentMerger {
             .collect();
 
         if sparse_fields.is_empty() {
-            return Ok(0);
+            return Ok((0, true));
         }
 
         let mut writer = OffsetWriter::new(dir.streaming_writer_cold(&files.sparse).await?);
@@ -97,6 +99,7 @@ impl SegmentMerger {
                         .as_ref()
                         .map(|c| c.bmp_block_size)
                         .unwrap_or(64);
+                    let grid_bits = sparse_config.as_ref().map(|c| c.bmp_grid_bits).unwrap_or(4);
                     let dims = sparse_config
                         .as_ref()
                         .and_then(|c| c.dims)
@@ -138,6 +141,7 @@ impl SegmentMerger {
                             &sources,
                             dims,
                             bmp_block_size.min(256),
+                            grid_bits,
                             max_weight_scale,
                         )?;
 
@@ -152,7 +156,10 @@ impl SegmentMerger {
                             fid,
                             sources.len(),
                         );
-                        let (w, ft, _converged) = tokio::task::spawn_blocking(move || {
+                        let bp_budget = self.bp_budget;
+                        let bp_memory_budget = self.bp_memory_budget;
+                        let out_grid_bits = grid_bits;
+                        let (w, ft, converged) = tokio::task::spawn_blocking(move || {
                             crate::segment::reorder::reorder_bmp_field(
                                 &sources,
                                 fid,
@@ -161,12 +168,15 @@ impl SegmentMerger {
                                 quantization,
                                 dims,
                                 effective_block_size,
+                                out_grid_bits,
                                 max_weight_scale,
                                 total_vectors_bmp,
-                                crate::segment::reorder::DEFAULT_MEMORY_BUDGET,
-                                // Merge-time reorder is unbudgeted: the merge
-                                // already pays the rewrite and warm-starts BP.
-                                crate::segment::BpBudget::full(),
+                                bp_memory_budget,
+                                // Wall-clock-bounded so huge merges don't hold
+                                // a merge slot for full BP depth; a truncated
+                                // pass is marked unconverged and the background
+                                // optimizer deepens it (warm-started).
+                                bp_budget,
                                 // Auto unless a source is an unconverged
                                 // partial reorder (then Records, see
                                 // SegmentMerger::granularity).
@@ -182,6 +192,7 @@ impl SegmentMerger {
                         })??;
                         writer = w;
                         field_tocs = ft;
+                        all_converged &= converged;
                         continue;
                     }
 
@@ -195,6 +206,7 @@ impl SegmentMerger {
                             quantization,
                             dims,
                             bmp_block_size,
+                            grid_bits,
                             max_weight_scale,
                             total_vectors_bmp,
                             &mut writer,
@@ -363,7 +375,7 @@ impl SegmentMerger {
             drop(writer);
             let _ = dir.delete(&files.sparse).await;
             let _ = dir.delete(&skip_tmp).await;
-            return Ok(0);
+            return Ok((0, all_converged));
         }
 
         // Phase 2: Stream-copy skip entries from temp file to main writer (4 MB chunks)
@@ -400,7 +412,7 @@ impl SegmentMerger {
             skip_count,
         );
 
-        Ok(output_size)
+        Ok((output_size, all_converged))
     }
 }
 
@@ -426,6 +438,7 @@ fn merge_bmp_field(
     quantization: crate::structures::WeightQuantization,
     dims: u32,
     bmp_block_size: u32,
+    grid_bits: u8,
     max_weight_scale: f32,
     total_vectors: u32,
     writer: &mut OffsetWriter,
@@ -466,6 +479,13 @@ fn merge_bmp_field(
                 bmp.bmp_block_size, effective_block_size
             )));
         }
+        if bmp.grid_bits() != grid_bits {
+            return Err(crate::Error::Corruption(format!(
+                "BMP merge: source grid_bits={} != expected {}",
+                bmp.grid_bits(),
+                grid_bits
+            )));
+        }
         if (bmp.max_weight_scale - max_weight_scale).abs() > f32::EPSILON {
             return Err(crate::Error::Corruption(format!(
                 "BMP merge: source max_weight_scale={:.4} != expected {:.4}",
@@ -482,7 +502,7 @@ fn merge_bmp_field(
 
     let num_blocks = total_source_blocks as usize;
     let num_virtual_docs = num_blocks * effective_block_size as usize;
-    let packed_row_size = num_blocks.div_ceil(2);
+    let packed_row_size = crate::segment::builder::bmp::grid_packed_row_size(num_blocks, grid_bits);
     let num_superblocks = num_blocks.div_ceil(BMP_SUPERBLOCK_SIZE as usize);
 
     // Pre-compute aggregate stats (needed for footer, independent of block order)
@@ -591,7 +611,7 @@ fn merge_bmp_field(
                 continue;
             }
             let src_row = &src_grid[src_row_start..src_row_end];
-            copy_nibbles(src_row, src_num_blocks, &mut row_buf, col_offset);
+            copy_cells(src_row, src_num_blocks, &mut row_buf, col_offset, grid_bits);
         }
         writer.write_all(&row_buf).map_err(crate::Error::Io)?;
     }
@@ -699,6 +719,7 @@ fn merge_bmp_field(
         max_weight_scale,
         doc_map_offset,
         num_real_docs_total,
+        grid_bits,
     )
     .map_err(crate::Error::Io)?;
 
@@ -729,6 +750,7 @@ fn validate_bmp_sources(
     sources: &[(BmpIndex, u32)],
     dims: u32,
     effective_block_size: u32,
+    expected_grid_bits: u8,
     max_weight_scale: f32,
 ) -> Result<()> {
     for (bmp, _) in sources {
@@ -743,6 +765,13 @@ fn validate_bmp_sources(
             return Err(crate::Error::Corruption(format!(
                 "BMP merge: source block_size={} != expected {}",
                 bmp.bmp_block_size, effective_block_size
+            )));
+        }
+        if bmp.grid_bits() != expected_grid_bits {
+            return Err(crate::Error::Corruption(format!(
+                "BMP merge: source grid_bits={} != expected {}",
+                bmp.grid_bits(),
+                expected_grid_bits
             )));
         }
         if (bmp.max_weight_scale - max_weight_scale).abs() > f32::EPSILON {
@@ -792,21 +821,13 @@ fn push_bmp_field_toc(
 /// Hot inner loop for grid merge (~8 KB per row).
 /// Source nibbles are packed: low nibble = even block, high nibble = odd block.
 #[inline]
-fn copy_nibbles(src_row: &[u8], src_blocks: usize, dst_row: &mut [u8], offset: usize) {
+fn copy_cells(src_row: &[u8], src_blocks: usize, dst_row: &mut [u8], offset: usize, grid_bits: u8) {
+    use crate::segment::builder::bmp::{grid_get_cell, grid_set_cell};
     for b in 0..src_blocks {
-        let val = if b.is_multiple_of(2) {
-            src_row[b / 2] & 0x0F
-        } else {
-            src_row[b / 2] >> 4
-        };
+        let val = grid_get_cell(src_row, b, grid_bits);
         if val == 0 {
             continue;
         }
-        let out_b = offset + b;
-        if out_b.is_multiple_of(2) {
-            dst_row[out_b / 2] |= val;
-        } else {
-            dst_row[out_b / 2] |= val << 4;
-        }
+        grid_set_cell(dst_row, offset + b, val, grid_bits);
     }
 }

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -13,6 +13,10 @@ mod tracker;
 mod types;
 mod vector_data;
 
+#[cfg(test)]
+pub(crate) use builder::graph_bisection::{
+    build_forward_index_from_blocks, build_forward_index_from_bmps, graph_bisection,
+};
 #[cfg(any(feature = "native", feature = "wasm"))]
 pub use builder::{
     BpBudget, MemoryBreakdown, SegmentBuilder, SegmentBuilderConfig, SegmentBuilderStats,
@@ -22,7 +26,7 @@ pub use merger::{MergeStats, SegmentMerger, delete_segment};
 pub(crate) use reader::BmpIndex;
 pub(crate) use reader::bmp::BMP_SUPERBLOCK_SIZE;
 pub(crate) use reader::bmp::{
-    accumulate_u4_weighted, block_term_postings, compute_block_masks_4bit, find_dim_in_block_data,
+    accumulate_grid_weighted, block_term_postings, compute_block_masks, find_dim_in_block_data,
 };
 pub(crate) use reader::combine_ordinal_results;
 #[cfg(feature = "native")]

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -104,6 +104,8 @@ pub struct BmpIndex {
     total_postings: u32,
     /// Packed row size for 4-bit grid: `(num_blocks + 1) / 2`
     packed_row_size: u32,
+    /// Bits per block-grid cell (4 or 2); dequant scale is 17 or 85.
+    grid_bits: u8,
     /// Actual vector count before padding
     num_real_docs: u32,
 
@@ -177,7 +179,8 @@ impl BmpIndex {
         let max_weight_scale = f32::from_le_bytes(fb[40..44].try_into().unwrap());
         let doc_map_offset = u64::from_le_bytes(fb[44..52].try_into().unwrap());
         let num_real_docs = u32::from_le_bytes(fb[52..56].try_into().unwrap());
-        // fb[56..60] = reserved
+        // fb[56..60]: grid cell width in bits (0 = legacy 4-bit)
+        let grid_bits_raw = u32::from_le_bytes(fb[56..60].try_into().unwrap());
         let magic = u32::from_le_bytes(fb[60..64].try_into().unwrap());
 
         if magic != BMP_BLOB_MAGIC_V13 {
@@ -186,6 +189,16 @@ impl BmpIndex {
                 magic, BMP_BLOB_MAGIC_V13
             )));
         }
+        let grid_bits: u8 = match grid_bits_raw {
+            0 | 4 => 4, // 0 = blobs written before the field existed
+            2 => 2,
+            other => {
+                return Err(crate::Error::Corruption(format!(
+                    "Unsupported BMP grid_bits {} (expected 2 or 4) — data too new to read?",
+                    other
+                )));
+            }
+        };
 
         // Handle empty index
         if num_blocks == 0 {
@@ -199,6 +212,7 @@ impl BmpIndex {
                 total_terms: 0,
                 total_postings: 0,
                 packed_row_size: 0,
+                grid_bits,
                 num_real_docs,
                 block_data_starts_bytes: OwnedBytes::empty(),
                 block_data_bytes: OwnedBytes::empty(),
@@ -230,7 +244,9 @@ impl BmpIndex {
         let block_data_starts_bytes = blob.slice(bds_start..grid_offset as usize);
 
         // Sections D+E: grid, sb_grid, doc_map
-        let packed_row_size = (num_blocks as usize).div_ceil(2) as u32;
+        let packed_row_size =
+            crate::segment::builder::bmp::grid_packed_row_size(num_blocks as usize, grid_bits)
+                as u32;
         let grid_start = grid_offset as usize;
         let grid_end = grid_start + dims as usize * packed_row_size as usize;
 
@@ -298,6 +314,7 @@ impl BmpIndex {
             total_terms,
             total_postings,
             packed_row_size,
+            grid_bits,
             num_real_docs,
             block_data_starts_bytes,
             block_data_bytes,
@@ -580,6 +597,11 @@ impl BmpIndex {
         self.packed_row_size as usize
     }
 
+    /// Bits per block-grid cell (4 or 2).
+    pub fn grid_bits(&self) -> u8 {
+        self.grid_bits
+    }
+
     /// Direct access to mmap-backed superblock grid (zero-copy, zero allocation).
     /// Used for large segments where compact grid extraction would be too expensive.
     #[inline]
@@ -801,6 +823,65 @@ pub(crate) unsafe fn block_term_postings<'a>(
 ///
 /// `packed[i/2]`: low nibble = even element, high nibble = odd element.
 #[inline]
+/// Bits-dispatching grid accumulate: 4-bit takes the SIMD path
+/// (`accumulate_u4_weighted`); 2-bit uses an unrolled scalar kernel
+/// (dequant ×85). SIMD u2 variants are a follow-up — 2-bit is opt-in per
+/// field and the block grid is probed only inside surviving superblocks.
+pub(crate) fn accumulate_grid_weighted(
+    packed: &[u8],
+    grid_bits: u8,
+    elem_offset: usize,
+    count: usize,
+    weight: f32,
+    out: &mut [f32],
+) {
+    if grid_bits == 2 {
+        accumulate_u2_weighted(packed, elem_offset, count, weight, out);
+    } else {
+        accumulate_u4_weighted(packed, elem_offset, count, weight, out);
+    }
+}
+
+/// Scalar 2-bit accumulate: `out[i] += cell(elem_offset + i) * 85 * weight`.
+/// Processes 4 cells per source byte.
+pub(crate) fn accumulate_u2_weighted(
+    packed: &[u8],
+    elem_offset: usize,
+    count: usize,
+    weight: f32,
+    out: &mut [f32],
+) {
+    let w85 = 85.0 * weight;
+    let mut i = 0usize;
+    // Head: unaligned cells until byte boundary
+    while i < count && !(elem_offset + i).is_multiple_of(4) {
+        let abs = elem_offset + i;
+        let cell = (unsafe { *packed.get_unchecked(abs / 4) } >> ((abs % 4) * 2)) & 0x03;
+        unsafe { *out.get_unchecked_mut(i) += cell as f32 * w85 };
+        i += 1;
+    }
+    // Body: whole bytes, 4 cells each
+    while i + 4 <= count {
+        let byte = unsafe { *packed.get_unchecked((elem_offset + i) / 4) };
+        if byte != 0 {
+            unsafe {
+                *out.get_unchecked_mut(i) += (byte & 0x03) as f32 * w85;
+                *out.get_unchecked_mut(i + 1) += ((byte >> 2) & 0x03) as f32 * w85;
+                *out.get_unchecked_mut(i + 2) += ((byte >> 4) & 0x03) as f32 * w85;
+                *out.get_unchecked_mut(i + 3) += (byte >> 6) as f32 * w85;
+            }
+        }
+        i += 4;
+    }
+    // Tail
+    while i < count {
+        let abs = elem_offset + i;
+        let cell = (unsafe { *packed.get_unchecked(abs / 4) } >> ((abs % 4) * 2)) & 0x03;
+        unsafe { *out.get_unchecked_mut(i) += cell as f32 * w85 };
+        i += 1;
+    }
+}
+
 pub(crate) fn accumulate_u4_weighted(
     packed: &[u8],
     elem_offset: usize,
@@ -1069,6 +1150,47 @@ unsafe fn accumulate_u4_weighted_sse41(
 /// two 4-bit values (low nibble = even block, high nibble = odd block).
 ///
 /// `query_dims` entries: `(dim_idx, weight)` where dim_idx indexes into grid rows.
+/// Bits-dispatching mask computation (which query dims are present per block).
+pub(crate) fn compute_block_masks(
+    grid: &[u8],
+    grid_bits: u8,
+    prs: usize,
+    query_dims: &[(usize, f32)],
+    block_start: usize,
+    count: usize,
+    masks: &mut [u64],
+) {
+    if grid_bits == 2 {
+        compute_block_masks_2bit(grid, prs, query_dims, block_start, count, masks);
+    } else {
+        compute_block_masks_4bit(grid, prs, query_dims, block_start, count, masks);
+    }
+}
+
+/// Scalar 2-bit presence masks.
+pub(crate) fn compute_block_masks_2bit(
+    grid: &[u8],
+    prs: usize,
+    query_dims: &[(usize, f32)],
+    block_start: usize,
+    count: usize,
+    masks: &mut [u64],
+) {
+    debug_assert!(masks.len() >= count);
+    masks[..count].fill(0);
+    for (q, &(dim_idx, _)) in query_dims.iter().enumerate() {
+        let row = &grid[dim_idx * prs..(dim_idx + 1) * prs];
+        let bit = 1u64 << q;
+        for b in 0..count {
+            let abs = block_start + b;
+            let cell = (unsafe { *row.get_unchecked(abs / 4) } >> ((abs % 4) * 2)) & 0x03;
+            if cell != 0 {
+                unsafe { *masks.get_unchecked_mut(b) |= bit };
+            }
+        }
+    }
+}
+
 pub(crate) fn compute_block_masks_4bit(
     grid: &[u8],
     prs: usize,

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -20,8 +20,11 @@ use crate::segment::reader::SegmentReader;
 use crate::segment::types::{SegmentFiles, SegmentId, SegmentMeta};
 use crate::structures::SparseFormat;
 
-/// Default memory budget for forward index during BP (2 GB).
-pub const DEFAULT_MEMORY_BUDGET: usize = 2 * 1024 * 1024 * 1024;
+/// Default memory budget for forward index during BP (8 GB). A cap, not an
+/// allocation — usage is proportional to the segment being reordered; it
+/// only bites on 10M+ doc passes (2 GB dropped ~10% of eligible dims on
+/// 18M-doc merges). Mirrored by `IndexConfig::default().bp_memory_budget_bytes`.
+pub const DEFAULT_MEMORY_BUDGET: usize = 8 * 1024 * 1024 * 1024;
 
 /// Reorder granularity (see docs/block-level-reorder.md).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -394,6 +394,7 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                     .as_ref()
                     .and_then(|c| c.dims)
                     .unwrap_or_else(|| bmp_idx.dims());
+                let grid_bits = sparse_config.as_ref().map(|c| c.bmp_grid_bits).unwrap_or(4);
                 let max_weight_scale = sparse_config
                     .as_ref()
                     .and_then(|c| c.max_weight)
@@ -417,6 +418,7 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                         quantization,
                         dims,
                         effective_block_size,
+                        grid_bits,
                         max_weight_scale,
                         total_vectors,
                         memory_budget,
@@ -497,6 +499,7 @@ fn reorder_bmp_field_blockwise(
     quantization: crate::structures::WeightQuantization,
     dims: u32,
     effective_block_size: usize,
+    grid_bits: u8,
     max_weight_scale: f32,
     total_vectors: u32,
     memory_budget: usize,
@@ -531,7 +534,6 @@ fn reorder_bmp_field_blockwise(
 
     // ── BP over blocks, down to superblock granularity ──────────────────
     let bp_start = std::time::Instant::now();
-    let fwd = build_forward_index_from_blocks(&bmp_refs, memory_budget);
     let sb = BMP_SUPERBLOCK_SIZE as usize;
     // The budget's depth cap is in DOCS but BP entities here are BLOCKS —
     // convert units, or the optimizer's partial cap (e.g. 4096 docs) would
@@ -542,15 +544,19 @@ fn reorder_bmp_field_blockwise(
             .map(|docs| (docs / effective_block_size).max(1)),
         time_budget: bp_budget.time_budget,
     };
-    let (perm, converged) = if fwd.num_terms > 0 && num_blocks_total > sb {
-        let (perm, converged) = if let Some(ref pool) = rayon_pool {
-            pool.install(|| graph_bisection(&fwd, sb, 20, block_budget))
-        } else {
+    // Forward-index build is parallel too — keep it on the bounded pool.
+    let run_bp = || {
+        let fwd = build_forward_index_from_blocks(&bmp_refs, memory_budget);
+        if fwd.num_terms > 0 && num_blocks_total > sb {
             graph_bisection(&fwd, sb, 20, block_budget)
-        };
-        (perm, converged)
+        } else {
+            ((0..num_blocks_total as u32).collect(), true)
+        }
+    };
+    let (perm, converged) = if let Some(ref pool) = rayon_pool {
+        pool.install(run_bp)
     } else {
-        ((0..num_blocks_total as u32).collect(), true)
+        run_bp()
     };
     log::info!(
         "[reorder_bmp] field {}: blockwise BP over {} blocks in {:.1}ms (converged={})",
@@ -605,10 +611,12 @@ fn reorder_bmp_field_blockwise(
 
     // Sections D + E: permuted grid rows + recomputed sb_grid, streamed per dim
     let grid_offset = writer.offset() - blob_start;
-    let packed_row_size = num_blocks_total.div_ceil(2);
+    let packed_row_size =
+        crate::segment::builder::bmp::grid_packed_row_size(num_blocks_total, grid_bits);
     let num_superblocks = num_blocks_total.div_ceil(sb);
     let mut out_row = vec![0u8; packed_row_size];
     let mut sb_rows: Vec<Vec<u8>> = vec![vec![0u8; num_superblocks]; dims as usize];
+    let dequant = crate::segment::builder::bmp::grid_dequant_scale(grid_bits);
 
     for (dim, sb_row) in sb_rows.iter_mut().enumerate() {
         out_row.fill(0);
@@ -617,22 +625,19 @@ fn reorder_bmp_field_blockwise(
             let bmp = bmp_refs[src];
             let prs = bmp.packed_row_size();
             let row = &bmp.grid_slice()[dim * prs..dim * prs + prs];
-            let nib = if lb % 2 == 0 {
-                row[lb / 2] & 0x0F
-            } else {
-                row[lb / 2] >> 4
-            };
-            if nib == 0 {
+            let cell = crate::segment::builder::bmp::grid_get_cell(row, lb, grid_bits);
+            if cell == 0 {
                 continue;
             }
-            if new_pos % 2 == 0 {
-                out_row[new_pos / 2] |= nib;
-            } else {
-                out_row[new_pos / 2] |= nib << 4;
-            }
+            crate::segment::builder::bmp::grid_set_cell(&mut out_row, new_pos, cell, grid_bits);
+            // sb_grid stores u8 impact scale (0-255) everywhere else (builder,
+            // block-copy merge). Dequantize the cell to its safe u8 upper
+            // bound — writing the raw cell here deflated superblock UBs ~17×
+            // after blockwise passes (unsafe pruning once heaps fill).
+            let ub = (cell as u32 * dequant).min(255) as u8;
             let slot = &mut sb_row[new_pos / sb];
-            if nib > *slot {
-                *slot = nib;
+            if ub > *slot {
+                *slot = ub;
             }
         }
         writer.write_all(&out_row).map_err(crate::Error::Io)?;
@@ -691,6 +696,7 @@ fn reorder_bmp_field_blockwise(
         max_weight_scale,
         doc_map_offset,
         num_real_docs,
+        grid_bits,
     )
     .map_err(crate::Error::Io)?;
 
@@ -860,6 +866,7 @@ pub(crate) fn reorder_bmp_field(
     quantization: crate::structures::WeightQuantization,
     dims: u32,
     effective_block_size: usize,
+    grid_bits: u8,
     max_weight_scale: f32,
     total_vectors: u32,
     memory_budget: usize,
@@ -935,6 +942,7 @@ pub(crate) fn reorder_bmp_field(
             quantization,
             dims,
             effective_block_size,
+            grid_bits,
             max_weight_scale,
             total_vectors,
             memory_budget,
@@ -992,39 +1000,43 @@ pub(crate) fn reorder_bmp_field(
         // already drops the highest-df dims when the forward index overflows.
         let min_doc_freq = (num_real_docs / 5000).clamp(2, 128);
 
-        let (fwd, _source_doc_counts) = build_forward_index_from_bmps(
-            &bmp_refs,
-            min_doc_freq,
-            max_doc_freq.max(1),
-            memory_budget,
-        );
+        // Forward-index build is parallel too — run the whole phase on the
+        // bounded rayon pool if provided, keeping background CPU off the
+        // global (query) pool.
+        let run_bp = || {
+            let (fwd, _source_doc_counts) = build_forward_index_from_bmps(
+                &bmp_refs,
+                min_doc_freq,
+                max_doc_freq.max(1),
+                memory_budget,
+            );
 
-        log::info!(
-            "[reorder_bmp] field {}: forward index built in {:.1}ms ({} terms, {} postings)",
-            field_id,
-            bp_start.elapsed().as_secs_f64() * 1000.0,
-            fwd.num_terms,
-            fwd.total_postings(),
-        );
-
-        if fwd.num_terms > 0 && num_real_docs > effective_block_size {
-            let bp_start = std::time::Instant::now();
-            // Run BP on the bounded rayon pool if provided, otherwise global pool.
-            let (perm, converged) = if let Some(ref pool) = rayon_pool {
-                pool.install(|| graph_bisection(&fwd, effective_block_size, 20, bp_budget))
-            } else {
-                graph_bisection(&fwd, effective_block_size, 20, bp_budget)
-            };
             log::info!(
-                "[reorder_bmp] field {}: BP completed in {:.1}ms (converged={})",
+                "[reorder_bmp] field {}: forward index built in {:.1}ms ({} terms, {} postings)",
                 field_id,
                 bp_start.elapsed().as_secs_f64() * 1000.0,
-                converged,
+                fwd.num_terms,
+                fwd.total_postings(),
             );
-            (perm, converged)
+
+            if fwd.num_terms > 0 && num_real_docs > effective_block_size {
+                let bp_start = std::time::Instant::now();
+                let (perm, converged) = graph_bisection(&fwd, effective_block_size, 20, bp_budget);
+                log::info!(
+                    "[reorder_bmp] field {}: BP completed in {:.1}ms (converged={})",
+                    field_id,
+                    bp_start.elapsed().as_secs_f64() * 1000.0,
+                    converged,
+                );
+                (perm, converged)
+            } else {
+                ((0..num_real_docs as u32).collect(), true)
+            }
+        };
+        if let Some(ref pool) = rayon_pool {
+            pool.install(run_bp)
         } else {
-            drop(fwd);
-            ((0..num_real_docs as u32).collect(), true)
+            run_bp()
         }
     };
 
@@ -1056,29 +1068,24 @@ pub(crate) fn reorder_bmp_field(
     let mut run_files: Vec<std::path::PathBuf> = Vec::new();
     let run_prefix = format!("hermes_grid_run_{}_{}", std::process::id(), field_id);
 
-    // Per-block scratch buffers
-    let mut blk_buf: Vec<u8> = Vec::with_capacity(4096);
-    let mut dim_postings: rustc_hash::FxHashMap<u32, Vec<(u8, u8)>> =
-        rustc_hash::FxHashMap::default();
-
-    for out_block in 0..new_num_blocks {
-        block_data_starts.push(cumulative_bytes);
-
+    // Encode one output block: gather its records from source blocks and
+    // serialize the V13 block layout. Pure function of `perm` + read-only
+    // sources — output blocks encode independently.
+    //
+    // Global real ids resolve to a source via `real_base`, then to a
+    // virtual vid (block/slot position) via that source's real→virtual map.
+    // Old block/slot arithmetic uses each source's own stored block size
+    // (uniform with the output in practice — merge validates it — but the
+    // source footer is the ground truth for parsing source blocks).
+    // (serialized block bytes, its (dim, out_block, max_impact) grid entries)
+    type EncodedBlock = (Vec<u8>, Vec<(u32, u32, u8)>);
+    let encode_block = |out_block: usize| -> EncodedBlock {
         let new_vid_start = out_block * effective_block_size;
         let new_vid_end = ((out_block + 1) * effective_block_size).min(num_real_docs);
         let slots_count = new_vid_end - new_vid_start;
 
-        dim_postings.clear();
-
         // Group records by (source, source block), scatter matching slots
         let mut slot_map = [u8::MAX; 256];
-
-        // Collect which (source, old_block)s we need and the slot mappings.
-        // Global real ids resolve to a source via `real_base`, then to a
-        // virtual vid (block/slot position) via that source's real→virtual map.
-        // Old block/slot arithmetic uses each source's own stored block size
-        // (uniform with the output in practice — merge validates it — but the
-        // source footer is the ground truth for parsing source blocks).
         let mut block_mappings: rustc_hash::FxHashMap<(usize, usize), Vec<(u8, u8)>> =
             rustc_hash::FxHashMap::default();
         for new_local_slot in 0..slots_count {
@@ -1094,6 +1101,8 @@ pub(crate) fn reorder_bmp_field(
                 .push((old_slot, new_local_slot as u8));
         }
 
+        let mut dim_postings: rustc_hash::FxHashMap<u32, Vec<(u8, u8)>> =
+            rustc_hash::FxHashMap::default();
         for (&(src, old_block), mappings) in &block_mappings {
             for &(old_s, new_s) in mappings {
                 slot_map[old_s as usize] = new_s;
@@ -1116,41 +1125,73 @@ pub(crate) fn reorder_bmp_field(
             }
         }
 
-        // Write this block's data
-        if !dim_postings.is_empty() {
-            let mut sorted_dims: Vec<u32> = dim_postings.keys().copied().collect();
-            sorted_dims.sort_unstable();
+        if dim_postings.is_empty() {
+            return (Vec::new(), Vec::new());
+        }
 
-            blk_buf.clear();
-            let nt = sorted_dims.len();
+        let mut sorted_dims: Vec<u32> = dim_postings.keys().copied().collect();
+        sorted_dims.sort_unstable();
+        let nt = sorted_dims.len();
 
-            blk_buf.extend_from_slice(&(nt as u16).to_le_bytes());
+        let mut blk_buf: Vec<u8> = Vec::with_capacity(2 + nt * 6 + 2);
+        blk_buf.extend_from_slice(&(nt as u16).to_le_bytes());
 
-            for &dim_id in &sorted_dims {
-                blk_buf.extend_from_slice(&dim_id.to_le_bytes());
-            }
+        for &dim_id in &sorted_dims {
+            blk_buf.extend_from_slice(&dim_id.to_le_bytes());
+        }
 
-            let mut cum: u16 = 0;
-            for &dim_id in &sorted_dims {
-                blk_buf.extend_from_slice(&cum.to_le_bytes());
-                cum += dim_postings[&dim_id].len() as u16;
-            }
+        let mut cum: u16 = 0;
+        for &dim_id in &sorted_dims {
             blk_buf.extend_from_slice(&cum.to_le_bytes());
+            cum += dim_postings[&dim_id].len() as u16;
+        }
+        blk_buf.extend_from_slice(&cum.to_le_bytes());
 
-            for &dim_id in &sorted_dims {
-                let posts = &dim_postings[&dim_id];
-                let mut max_impact: u8 = 0;
-                for &(slot, impact) in posts {
-                    blk_buf.push(slot);
-                    blk_buf.push(impact);
-                    max_impact = max_impact.max(impact);
-                }
-                total_postings += posts.len() as u32;
-                grid_entries.push((dim_id, out_block as u32, max_impact));
+        let mut grid: Vec<(u32, u32, u8)> = Vec::with_capacity(nt);
+        for &dim_id in &sorted_dims {
+            let posts = &dim_postings[&dim_id];
+            let mut max_impact: u8 = 0;
+            for &(slot, impact) in posts {
+                blk_buf.push(slot);
+                blk_buf.push(impact);
+                max_impact = max_impact.max(impact);
             }
-            total_terms += nt as u32;
+            grid.push((dim_id, out_block as u32, max_impact));
+        }
+        (blk_buf, grid)
+    };
 
-            writer.write_all(&blk_buf).map_err(crate::Error::Io)?;
+    // Encode blocks in parallel per bounded window (blob order is fixed, so
+    // the write itself stays serial; the window caps buffered bytes).
+    const ENCODE_WINDOW: usize = 4096;
+    let mut encoded: Vec<EncodedBlock> = Vec::new();
+    for window_start in (0..new_num_blocks).step_by(ENCODE_WINDOW) {
+        let window_end = (window_start + ENCODE_WINDOW).min(new_num_blocks);
+        encoded.clear();
+        {
+            use rayon::prelude::*;
+            let run = |out: &mut Vec<EncodedBlock>| {
+                (window_start..window_end)
+                    .into_par_iter()
+                    .map(encode_block)
+                    .collect_into_vec(out);
+            };
+            if let Some(ref pool) = rayon_pool {
+                pool.install(|| run(&mut encoded));
+            } else {
+                run(&mut encoded);
+            }
+        }
+
+        for (blk_buf, grid) in &encoded {
+            block_data_starts.push(cumulative_bytes);
+            if blk_buf.is_empty() {
+                continue;
+            }
+            total_terms += grid.len() as u32;
+            total_postings += (blk_buf.len() - 2 - grid.len() * 6 - 2) as u32 / 2;
+            grid_entries.extend_from_slice(grid);
+            writer.write_all(blk_buf).map_err(crate::Error::Io)?;
             cumulative_bytes += blk_buf.len() as u64;
         }
 
@@ -1169,6 +1210,7 @@ pub(crate) fn reorder_bmp_field(
             );
         }
     }
+    drop(encoded);
 
     // Sentinel
     block_data_starts.push(cumulative_bytes);
@@ -1206,8 +1248,14 @@ pub(crate) fn reorder_bmp_field(
     let grid_offset = writer.offset() - blob_start;
     let (packed_bytes, _sb_bytes) = if run_files.is_empty() {
         // Fast path: all entries fit in memory, use existing function
-        let result = stream_write_grids(&grid_entries, dims as usize, new_num_blocks, &mut writer)
-            .map_err(crate::Error::Io)?;
+        let result = stream_write_grids(
+            &grid_entries,
+            dims as usize,
+            new_num_blocks,
+            grid_bits,
+            &mut writer,
+        )
+        .map_err(crate::Error::Io)?;
         drop(grid_entries);
         result
     } else {
@@ -1226,9 +1274,14 @@ pub(crate) fn reorder_bmp_field(
             run_readers.push(GridRunReader::open(path).map_err(crate::Error::Io)?);
         }
 
-        let result =
-            stream_write_grids_merged(&mut run_readers, dims as usize, new_num_blocks, &mut writer)
-                .map_err(crate::Error::Io)?;
+        let result = stream_write_grids_merged(
+            &mut run_readers,
+            dims as usize,
+            new_num_blocks,
+            grid_bits,
+            &mut writer,
+        )
+        .map_err(crate::Error::Io)?;
 
         // Clean up run files
         drop(run_readers);
@@ -1300,6 +1353,7 @@ pub(crate) fn reorder_bmp_field(
         max_weight_scale,
         doc_map_offset,
         num_real_docs as u32,
+        grid_bits,
     )
     .map_err(crate::Error::Io)?;
 

--- a/hermes-core/src/structures/postings/sparse/config.rs
+++ b/hermes-core/src/structures/postings/sparse/config.rs
@@ -254,6 +254,15 @@ pub struct SparseVectorConfig {
     /// (docs/bmp-grid-compression.md).
     #[serde(default = "default_bmp_block_size")]
     pub bmp_block_size: u32,
+    /// Bits per BMP block-grid cell: 4 (default) or 2. The grid is
+    /// `dims × num_blocks × bits/8` bytes, so 2 halves grid memory; measured
+    /// pruning cost is ~free (+0.4-2.2% blocks scored — the exact u8 sb_grid
+    /// prunes first and shields the block grid; docs/bmp-grid-compression.md).
+    /// Grid bounds are ceil-quantized, so exact top-k results are unchanged
+    /// at any width. Uniform per field across all segments — set in SDL
+    /// (`bmp_grid_bits: 2`) at index creation.
+    #[serde(default = "default_bmp_grid_bits")]
+    pub bmp_grid_bits: u8,
     /// BMP superblock size: number of consecutive blocks grouped for hierarchical
     /// pruning (Carlson et al., SIGIR 2025). Must be power of 2.
     /// Default 64. Set to 0 to disable superblock pruning (flat BMP scoring).
@@ -316,6 +325,10 @@ fn default_bmp_block_size() -> u32 {
     64
 }
 
+fn default_bmp_grid_bits() -> u8 {
+    4
+}
+
 fn default_bmp_superblock_size() -> u32 {
     64
 }
@@ -334,6 +347,7 @@ impl Default for SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
+            bmp_grid_bits: 4,
             bmp_superblock_size: 64,
             pruning: None,
             query_config: None,
@@ -370,6 +384,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
+            bmp_grid_bits: 4,
             bmp_superblock_size: 64,
             pruning: Some(0.1), // Keep top 10% per dimension
             query_config: Some(SparseQueryConfig {
@@ -404,6 +419,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
+            bmp_grid_bits: 4,
             bmp_superblock_size: 64,
             pruning: Some(0.1),
             query_config: Some(SparseQueryConfig {
@@ -440,6 +456,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
+            bmp_grid_bits: 4,
             bmp_superblock_size: 64,
             pruning: Some(0.15), // Keep top 15% per dimension
             query_config: Some(SparseQueryConfig {
@@ -471,6 +488,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
+            bmp_grid_bits: 4,
             bmp_superblock_size: 64,
             pruning: None,
             query_config: None,
@@ -499,6 +517,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
+            bmp_grid_bits: 4,
             bmp_superblock_size: 64,
             pruning: None, // No posting list pruning
             query_config: Some(SparseQueryConfig {
@@ -575,6 +594,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
+            bmp_grid_bits: 4,
             bmp_superblock_size: 64,
             pruning: None,
             query_config: None,

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -86,8 +86,20 @@ struct Args {
     optimizer_partial_min_partition_docs: usize,
 
     /// Cooldown in seconds between deepening passes on budget-truncated segments
-    #[arg(long, default_value = "1800")]
+    #[arg(long, default_value = "600")]
     optimizer_unconverged_cooldown_secs: u64,
+
+    /// Wall-clock budget in seconds for merge-time BP reorder (0 = unbudgeted).
+    /// A truncated pass still produces a valid, better-ordered segment; it is
+    /// marked unconverged and the background optimizer deepens it later.
+    #[arg(long, default_value = "600")]
+    merge_bp_budget_secs: u64,
+
+    /// Memory budget (MB) for the BP forward index during reorder passes
+    /// (merge-time and background). Over-budget passes drop highest-df dims
+    /// from BP's input with a loud warning; raise on hosts with headroom.
+    #[arg(long, default_value = "2048")]
+    bp_memory_budget_mb: usize,
 
     /// Address for the Prometheus /metrics HTTP endpoint.
     /// Set to "off" to disable the exporter.
@@ -173,6 +185,9 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
         num_indexing_threads,
         reload_interval_ms: args.reload_interval_ms,
         merge_policy: Box::new(hermes_core::merge::TieredMergePolicy::large_scale()),
+        merge_bp_time_budget: (args.merge_bp_budget_secs > 0)
+            .then(|| Duration::from_secs(args.merge_bp_budget_secs)),
+        bp_memory_budget_bytes: args.bp_memory_budget_mb * 1024 * 1024,
         ..Default::default()
     };
 

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -96,9 +96,11 @@ struct Args {
     merge_bp_budget_secs: u64,
 
     /// Memory budget (MB) for the BP forward index during reorder passes
-    /// (merge-time and background). Over-budget passes drop highest-df dims
-    /// from BP's input with a loud warning; raise on hosts with headroom.
-    #[arg(long, default_value = "2048")]
+    /// (merge-time and background). A cap, not an allocation — usage is
+    /// proportional to the segment being reordered. Over-budget passes drop
+    /// highest-df dims from BP's input with a loud warning; raise to 16384
+    /// on hosts with headroom.
+    #[arg(long, default_value = "8192")]
     bp_memory_budget_mb: usize,
 
     /// Address for the Prometheus /metrics HTTP endpoint.

--- a/hermes-server/src/optimizer.rs
+++ b/hermes-server/src/optimizer.rs
@@ -61,9 +61,20 @@ pub fn spawn_optimizer(
 
     // Bounded rayon pool for BP computation — prevents optimizer from
     // saturating all CPU cores. Shared across all concurrent reorder tasks.
+    //
+    // Sized at max(threads, cores/2), NOT just `threads`: `threads` bounds
+    // how many segments are rewritten concurrently (the semaphore), while
+    // the pool bounds how wide a SINGLE BP pass can fan out (recursive
+    // bisection halves via rayon::join + parallel gain computation). A lone
+    // deepening pass on a 10M+ doc segment should use the same cores/2 slice
+    // the merge-time BP pool gets, not serialize onto 4 threads.
+    let bp_pool_threads = std::thread::available_parallelism()
+        .map(|c| c.get() / 2)
+        .unwrap_or(config.threads)
+        .max(config.threads);
     let rayon_pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
-            .num_threads(config.threads)
+            .num_threads(bp_pool_threads)
             .thread_name(|idx| format!("optimizer-bp-{}", idx))
             .build()
             .expect("failed to create optimizer rayon pool"),
@@ -149,26 +160,35 @@ async fn scan_and_optimize(
             Arc::clone(w.segment_manager())
         };
 
-        let mut candidates = segment_manager.unreordered_segments().await;
+        // Fresh (never-reordered) segments first — they are typically small
+        // memtable flushes that finish in sub-second passes.
+        let fresh = segment_manager.unreordered_segments().await;
+        let mut candidates: Vec<(String, u32, bool)> = fresh
+            .into_iter()
+            .map(|(id, docs)| (id, docs, false))
+            .collect();
 
-        if candidates.is_empty() {
-            // No fresh work — revisit budget-truncated segments (cooldown-paced:
-            // every follow-up pass is a full segment rewrite).
-            let unconverged = segment_manager.unconverged_segments().await;
-            if !unconverged.is_empty() {
-                let now_ms = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_millis() as u64;
-                let last = last_partial_pass.load(Ordering::Relaxed);
-                if now_ms.saturating_sub(last) >= config.unconverged_cooldown.as_millis() as u64 {
-                    last_partial_pass.store(now_ms, Ordering::Relaxed);
-                    // One deepening pass per cooldown window.
-                    candidates = unconverged.into_iter().take(1).collect();
+        // Deepening is cooldown-paced but NOT starved by fresh work: under
+        // continuous ingestion fresh segments arrive every commit, so a
+        // "only when idle" rule would postpone deepening indefinitely. One
+        // budget-truncated segment per cooldown window (each follow-up is a
+        // full segment rewrite; it warm-starts from the previous order and
+        // deepens toward block-granularity).
+        let unconverged = segment_manager.unconverged_segments().await;
+        if !unconverged.is_empty() {
+            let now_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64;
+            let last = last_partial_pass.load(Ordering::Relaxed);
+            if now_ms.saturating_sub(last) >= config.unconverged_cooldown.as_millis() as u64 {
+                last_partial_pass.store(now_ms, Ordering::Relaxed);
+                if let Some((id, docs)) = unconverged.into_iter().next() {
                     debug!(
-                        "[optimizer] index '{}': deepening 1 unconverged segment",
-                        name,
+                        "[optimizer] index '{}': deepening unconverged segment {} ({} docs)",
+                        name, id, docs,
                     );
+                    candidates.push((id, docs, true));
                 }
             }
         }
@@ -183,7 +203,7 @@ async fn scan_and_optimize(
             candidates.len()
         );
 
-        for (seg_id, num_docs) in candidates {
+        for (seg_id, num_docs, is_deepening) in candidates {
             // Acquire semaphore permit to bound concurrency
             let permit = match semaphore.clone().acquire_owned().await {
                 Ok(p) => p,
@@ -199,8 +219,21 @@ async fn scan_and_optimize(
             let pool = Arc::clone(rayon_pool);
 
             // Size-tiered budget: small segments get full-depth BP (seconds of
-            // work); large ones get a depth- and wall-clock-budgeted pass.
-            let budget = if num_docs >= config.large_segment_docs {
+            // work); large ones get a depth- and wall-clock-budgeted FIRST
+            // pass (recorded unconverged), then full-depth deepening passes
+            // (warm-started, wall-clock-bounded) until one beats the clock.
+            let budget = if is_deepening {
+                info!(
+                    "[optimizer] deepening segment {} ({} docs): full depth, time budget {:.0}s",
+                    sid,
+                    num_docs,
+                    config.time_budget.as_secs_f64(),
+                );
+                BpBudget {
+                    min_partition_docs: None,
+                    time_budget: Some(config.time_budget),
+                }
+            } else if num_docs >= config.large_segment_docs {
                 info!(
                     "[optimizer] segment {} ({} docs) exceeds {} docs — budgeted BP pass \
                      (min_partition={} docs, time budget {:.0}s)",


### PR DESCRIPTION
## Grid quantization (SDL-configurable)

- New `bmp_grid_bits` SDL/index-config option (2 or 4, default 4). 2-bit halves the block grid at measured ~free query cost: +0.4% blocks scored on topical queries, +2.2% worst-case background (the u8 sb_grid shields the block grid). Ceil quantization means bounds never underestimate — top-k stays exact at any width, pinned by `test_bmp_grid_bits_2_exact_parity_and_roundtrip` (identical scores through build → block-copy merge → BP reorder; grid rows exactly half size).
- V13-compatible: footer reserved bytes now carry `grid_bits` (0 = legacy 4-bit). Existing segments stay readable; unknown widths are refused loudly. Uniform per field across segments (merge and blockwise reorder validate).
- Combined with `bmp_block_size: 256`, a 50M-doc grid goes 41 GB → 2.5 GB.
- 4-bit *weights* measured and rejected: recall@10 = 95.1% for only ~25% postings savings (only the impact byte of the 2-byte posting halves). Evidence in `bench_aggressive_quantization` and `docs/bmp-grid-compression.md`.

## Latent sb_grid scale bug (found + fixed)

Blockwise reorder wrote the superblock grid in cell scale (0–15) instead of u8 impact scale (0–255) — after any blockwise pass, superblock UBs were deflated ~17×, i.e. **unsafe pruning / silent recall loss** once a query's heap fills. Fixed (sb entry = dequantized cell). Regression pinned as a structural sb_grid-max invariant (`test_blockwise_reorder_preserves_sb_grid_scale`) — verified to fail with the bug reintroduced; query-based assertions provably could not catch it.

## Aggressive background reordering + merging

- **Budgeted merge-time BP**: `--merge-bp-budget-secs` (default 600, 0 = unbudgeted). A truncated pass still writes a valid, better-ordered segment, marked `bp_converged=false`. Caps how long one merge holds a merge slot (a 64-source/18M-doc merge previously ran full-depth BP inline for 10–30+ min).
- **Deepening ladder without starvation**: the optimizer deepens one unconverged segment per cooldown window (`--optimizer-unconverged-cooldown-secs`, default 600, was 1800) *alongside* fresh candidates, full-depth + wall-clock budgeted; warm-starting makes already-ordered prefixes nearly free. Depth-capped passes now correctly report unconverged.
- **Merge fan-in baked in**: `TieredMergePolicy::large_scale()` `max_merge_at_once` 10 → 24 (no tuning flags) — absorbs continuous-ingestion segment floods in ~2.4× fewer passes; safe because output is capped by `max_merged_docs` and merge BP is time-budgeted.
- **BP memory budget wired**: `--bp-memory-budget-mb` (default 2048) replaces the hardcoded 2 GB at optimizer + merge call sites.

## Single-pass reorder parallelization (measured, `bench_forward_index_build`, 300k docs / 14.4M postings, release)

| Phase | Before | After |
|---|---|---|
| Forward-index build | 135 ms (serial) | 50 ms (2.7×) |
| Permuted blob write | ~3.3 s (serial, 70% of total) | ~1.0 s |
| `writer.reorder()` end-to-end | 4.7 s | 2.36 s (2.0×) |

- Fwd build: real ids are assigned in ascending vid order → each block owns a contiguous real-id range → df counting is a rayon fold/reduce, CSR count/fill write disjoint `split_at_mut` slices. No locks, no unsafe, byte-identical output. df counting also aggregates per (block, dim), speeding the serial/wasm path.
- Blob write: output blocks encode independently — parallel encode in 4096-block windows, ordered serial write (window bounds buffered memory).
- Background pools raised to cores/2 (merge `background_cpu_pool` and optimizer BP pool `max(--optimizer-threads, cores/2)`); all reorder phases run inside the bounded pool, off the global query pool.

## Docs

`docs/bmp-grid-compression.md` (2-bit implemented, 4-bit weights rejected with numbers), `docs/budgeted-reorder.md` (deepening ladder + single-pass parallelism), `docs/schema.md` (`bmp_grid_bits`).

## Validation

- 696 lib tests pass (`--features native,metrics`)
- clippy `-D warnings` clean (core, server, tool)
- wasm32 target compiles (`--features wasm,http`)
- Benches kept as `#[ignore]` evidence: `bench_aggressive_quantization`, `bench_forward_index_build`