### PR TITLE
fix(wasm): dead_code on native-only observe stubs and BmpIndex raw-blob accessors

### DIFF
--- a/hermes-core/src/observe.rs
+++ b/hermes-core/src/observe.rs
@@ -179,11 +179,16 @@ mod imp {
     pub fn directory_read(_: &str, _: &'static str, _: f64, _: usize) {}
     #[inline(always)]
     pub fn store_get(_: &str, _: f64) {}
+    // Caller is native-only directory code — dead on wasm.
     #[inline(always)]
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub fn cold_write(_: &str, _: usize) {}
+    // Callers live in native-only modules (segment::reorder) — dead on wasm.
     #[inline(always)]
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub fn reorder_granularity(_: &str, _: &str, _: &'static str) {}
     #[inline(always)]
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub fn reorder_coherence(_: &str, _: &str, _: f32, _: f32) {}
 }
 

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -128,8 +128,12 @@ pub struct BmpIndex {
     // ── Raw blob source (identity copies) ─────────────────────────────
     /// Source file handle + blob range, kept so reorder can copy the blob
     /// byte-identically for fields whose `reorder` schema attribute is unset.
+    /// Reorder is native-only, so these are dead on wasm.
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     source: FileHandle,
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     blob_offset: u64,
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     blob_len: u64,
 }
 
@@ -331,8 +335,9 @@ impl BmpIndex {
 
     /// Read the entire raw V13 blob (including footer) from the source file.
     ///
-    /// Used by reorder paths to copy a field byte-identically when its
-    /// `reorder` schema attribute is unset.
+    /// Used by reorder paths (native-only) to copy a field byte-identically
+    /// when its `reorder` schema attribute is unset.
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub(crate) fn read_raw_blob(&self) -> std::io::Result<OwnedBytes> {
         self.source
             .read_bytes_range_sync(self.blob_offset..self.blob_offset + self.blob_len)


### PR DESCRIPTION
PR #29's WASM Build job failed with `-D warnings`: `observe` stubs (`reorder_granularity`, `reorder_coherence`, `cold_write`) and `BmpIndex`'s raw-blob fields/`read_raw_blob` are only called from native-only modules (`segment::reorder`, native directory code), so they're dead code on wasm32. Annotated with `#[cfg_attr(not(feature = "native"), allow(dead_code))]`.

Verified locally with CI's exact invocation: `RUSTFLAGS="-D warnings" cargo build --lib --release --target wasm32-unknown-unknown` in hermes-wasm — clean. Native clippy `-D warnings` clean. No functional change.