### PR TITLE
fix: BMP V14 — u32 posting prefix sums (u16 overflowed on 256-doc blocks, prod SIGSEGV)

### DIFF
--- a/docs/bmp-grid-compression.md
+++ b/docs/bmp-grid-compression.md
@@ -5,7 +5,7 @@ MADV_RANDOM on the grid) implemented; Phase 2 (sparse grid) **benchmarked
 and rejected at current scale** — see measurements; Phase 3 (dim pruning)
 assessed — not recommended.
 
-## Memory anatomy of a BMP V13 segment
+## Memory anatomy of a BMP segment (V13/V14)
 
 Everything is mmap-backed (page cache, not heap), but resident-set pressure
 is real on memory-bound deployments. Per field, per segment:

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -2733,7 +2733,7 @@ async fn bench_aggressive_quantization() {
     let bfoot = blob_len - 64;
     assert_eq!(
         u32::from_le_bytes(original[bfoot + 60..bfoot + 64].try_into().unwrap()),
-        crate::segment::format::BMP_BLOB_MAGIC_V13
+        crate::segment::format::BMP_BLOB_MAGIC_V14
     );
     let grid_start =
         u64::from_le_bytes(original[bfoot + 8..bfoot + 16].try_into().unwrap()) as usize;
@@ -3116,4 +3116,75 @@ async fn bench_forward_index_build() {
         "writer.reorder() end-to-end: {:.1}ms",
         t.elapsed().as_secs_f64() * 1000.0,
     );
+}
+
+/// Regression: a block with more than 65,535 postings overflowed the u16
+/// posting prefix sums at build time (bmp_block_size=256 × ~300-dim docs
+/// hits this in production), silently corrupting the block; the reader's
+/// `end - start` then underflowed into a wild posting slice — SIGSEGV in
+/// the BP forward-index build (optimizer-bp threads). V14 stores num_terms
+/// and prefix sums as u32.
+#[tokio::test]
+async fn test_bmp_block_posting_overflow_256() {
+    // 256 docs × 301 dims each → 77,056 postings in block 0 (> u16::MAX).
+    // Needle dims (50_000 + d) sort after the shared mass, so their prefix
+    // offsets exceed 65,535 — exactly where the u16 wrap corrupted reads.
+    let config = SparseVectorConfig {
+        format: SparseFormat::Bmp,
+        weight_quantization: WeightQuantization::UInt8,
+        bmp_block_size: 256,
+        dims: Some(100_000),
+        max_weight: Some(5.0),
+        ..SparseVectorConfig::default()
+    };
+    let (schema, _title, sparse) = bmp_schema_with_config(config);
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    for d in 0..256u32 {
+        let mut entries: Vec<(u32, f32)> = (0..300u32)
+            .map(|t| (t, 0.5 + (t % 40) as f32 * 0.1))
+            .collect();
+        entries.push((50_000 + d, 4.0)); // needle, one per doc
+        let mut doc = Document::new();
+        doc.add_sparse_vector(sparse, entries);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let readers = index.segment_readers().await.unwrap();
+    assert_eq!(readers.len(), 1);
+    let bmp = readers[0].bmp_indexes().get(&sparse.0).unwrap();
+    assert!(
+        bmp.total_postings() > u16::MAX as u64,
+        "test setup must overflow u16 postings per block (got {})",
+        bmp.total_postings()
+    );
+
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    // Every needle dim must resolve to exactly its doc with the exact score.
+    for d in [0u32, 100, 255] {
+        let query = SparseVectorQuery::new(sparse, vec![(50_000 + d, 1.0)]);
+        let r = searcher.search(&query, 5).await.unwrap();
+        assert_eq!(r.len(), 1, "needle {d} lost past the 65,535th posting");
+        assert_eq!(r[0].doc_id, d);
+    }
+    // Shared dims still score correctly across the whole block.
+    let query = SparseVectorQuery::new(sparse, vec![(0, 1.0), (299, 1.0)]);
+    let r = searcher.search(&query, 10).await.unwrap();
+    assert_eq!(r.len(), 10);
+
+    // BP forward-index build over the oversized block must not read wild
+    // slices (this is the exact prod crash path).
+    let (fwd, _) =
+        crate::segment::build_forward_index_from_bmps(&[bmp], 2, 1_000_000, 2 * 1024 * 1024 * 1024);
+    // Needle dims have df=1 and are correctly filtered by min_doc_freq=2;
+    // the 300 shared dims × 256 docs must all survive — reading them walks
+    // every posting slice past the old u16 wrap point.
+    assert_eq!(fwd.total_postings(), 300 * 256);
 }

--- a/hermes-core/src/observe.rs
+++ b/hermes-core/src/observe.rs
@@ -179,11 +179,16 @@ mod imp {
     pub fn directory_read(_: &str, _: &'static str, _: f64, _: usize) {}
     #[inline(always)]
     pub fn store_get(_: &str, _: f64) {}
+    // Caller is native-only directory code — dead on wasm.
     #[inline(always)]
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub fn cold_write(_: &str, _: usize) {}
+    // Callers live in native-only modules (segment::reorder) — dead on wasm.
     #[inline(always)]
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub fn reorder_granularity(_: &str, _: &str, _: &'static str) {}
     #[inline(always)]
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub fn reorder_coherence(_: &str, _: &str, _: f32, _: f32) {}
 }
 

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -683,7 +683,7 @@ fn zero_touched_acc(acc: &mut [u32], touched: &[u64; 4]) {
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
 fn score_block_bsearch_int(
-    num_terms: u16,
+    num_terms: u32,
     dim_ptr: *const u8,
     ps_ptr: *const u8,
     post_ptr: *const u8,

--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -37,12 +37,12 @@
 //! Section G:  doc_map_ordinals   [u16-LE × num_virtual_docs]
 //!
 //! Per-block data layout (for non-empty blocks):
-//!   num_terms: u16                                    offset 0
-//!   term_dim_ids: [u32-LE × num_terms]                offset 2
-//!   posting_starts: [u16-LE × (num_terms + 1)]        relative cumulative counts
+//!   num_terms: u32                                    offset 0
+//!   term_dim_ids: [u32-LE × num_terms]                offset 4
+//!   posting_starts: [u32-LE × (num_terms + 1)]        relative cumulative counts
 //!   postings: [(u8, u8) × total_block_postings]       BmpPosting pairs
 //!
-//! BMP V13 Footer (64 bytes):
+//! BMP V14 Footer (64 bytes):
 //!   total_terms: u32              //  0- 3  (stats only)
 //!   total_postings: u32           //  4- 7  (stats only)
 //!   grid_offset: u64              //  8-15  (byte offset of Section D)
@@ -93,7 +93,7 @@ impl VidLookup {
 }
 
 use crate::DocId;
-use crate::segment::format::BMP_BLOB_MAGIC_V13;
+use crate::segment::format::BMP_BLOB_MAGIC_V14;
 use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
 
 /// Build a BMP V13 blob from per-dimension postings.
@@ -375,19 +375,21 @@ pub(crate) fn build_bmp_blob(
             blk_buf.clear();
             let nt = blk_dim_ids.len();
 
-            // num_terms (u16)
-            blk_buf.extend_from_slice(&(nt as u16).to_le_bytes());
+            // num_terms (u32)
+            blk_buf.extend_from_slice(&(nt as u32).to_le_bytes());
 
             // term_dim_ids [u32 × nt]
             for &did in &blk_dim_ids {
                 blk_buf.extend_from_slice(&did.to_le_bytes());
             }
 
-            // posting_starts [u16 × (nt + 1)] — relative cumulative
-            let mut cum: u16 = 0;
+            // posting_starts [u32 × (nt + 1)] — relative cumulative.
+            // u32, not u16: a 256-doc block of ~300-dim docs exceeds 65,535
+            // postings, and the old u16 sums wrapped silently (V13 → V14).
+            let mut cum: u32 = 0;
             for &count in &blk_posting_counts {
                 blk_buf.extend_from_slice(&cum.to_le_bytes());
-                cum += count;
+                cum += count as u32;
             }
             blk_buf.extend_from_slice(&cum.to_le_bytes());
 
@@ -474,7 +476,7 @@ pub(crate) fn build_bmp_blob(
     drop(vid_pairs); // Free after last use (~6 bytes × num_real_docs)
 
     // BMP V13 Footer (64 bytes)
-    write_v13_footer(
+    write_bmp_footer(
         writer,
         total_terms,
         total_postings,
@@ -496,7 +498,7 @@ pub(crate) fn build_bmp_blob(
 
 /// Write the BMP V13 footer (64 bytes).
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn write_v13_footer(
+pub(crate) fn write_bmp_footer(
     writer: &mut dyn Write,
     total_terms: u32,
     total_postings: u32,
@@ -524,7 +526,7 @@ pub(crate) fn write_v13_footer(
     writer.write_u32::<LittleEndian>(num_real_docs)?; // 52-55
     // 56-59: grid cell width in bits (0 = legacy 4-bit; else 2 or 4)
     writer.write_u32::<LittleEndian>(grid_bits as u32)?;
-    writer.write_u32::<LittleEndian>(BMP_BLOB_MAGIC_V13)?; // 60-63
+    writer.write_u32::<LittleEndian>(BMP_BLOB_MAGIC_V14)?; // 60-63
     Ok(())
 }
 
@@ -862,7 +864,7 @@ mod tests {
         // Verify V13 footer magic (last 4 bytes of 64-byte footer)
         let footer_start = buf.len() - 4;
         let magic = u32::from_le_bytes(buf[footer_start..].try_into().unwrap());
-        assert_eq!(magic, BMP_BLOB_MAGIC_V13);
+        assert_eq!(magic, BMP_BLOB_MAGIC_V14);
     }
 
     #[test]

--- a/hermes-core/src/segment/format.rs
+++ b/hermes-core/src/segment/format.rs
@@ -93,15 +93,21 @@ pub const SPARSE_FOOTER_MAGIC: u32 = 0x34525053;
 
 /// Magic number for BMP V13 blob footer ("BMP3" in LE)
 ///
+/// V14 changes from V13:
+/// - **u32 num_terms and u32 posting prefix sums** per block (were u16):
+///   blocks with >65,535 postings (bmp_block_size 256 × ~300-dim docs)
+///   silently wrapped the u16 prefix sums, corrupting the block and
+///   producing wild posting slices at read time. No compatibility shim —
+///   V13 and older segments must be rebuilt.
+///
 /// V13 changes from V12:
 /// - **Recursive Graph Bisection (BP)** replaces SimHash for document ordering
 /// - **Section H removed**: no per-block SimHash (BP needs no stored metadata)
 /// - **64-byte footer** (was 72): `block_simhash_offset` field removed
-/// - V12 segments are incompatible — must rebuild
-pub const BMP_BLOB_MAGIC_V13: u32 = 0x33504D42;
+pub const BMP_BLOB_MAGIC_V14: u32 = 0x34504D42;
 
-/// BMP V13 blob footer size: 64 bytes
-pub const BMP_BLOB_FOOTER_SIZE_V13: usize = 64;
+/// BMP V14 blob footer size: 64 bytes (unchanged from V13)
+pub const BMP_BLOB_FOOTER_SIZE_V14: usize = 64;
 
 /// V3 footer size: skip_offset(8) + toc_offset(8) + num_fields(4) + magic(4) = 24
 pub const SPARSE_FOOTER_SIZE: u64 = 24;

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -444,7 +444,7 @@ fn merge_bmp_field(
     writer: &mut OffsetWriter,
     field_tocs: &mut Vec<SparseFieldToc>,
 ) -> Result<()> {
-    use crate::segment::builder::bmp::write_v13_footer;
+    use crate::segment::builder::bmp::write_bmp_footer;
     use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
 
     let effective_block_size = bmp_block_size.min(256);
@@ -706,7 +706,7 @@ fn merge_bmp_field(
     }
 
     // ── Phase 6: Write V13 footer (64 bytes) ────────────────────────────
-    write_v13_footer(
+    write_bmp_footer(
         writer,
         total_terms,
         total_postings,

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -157,18 +157,18 @@ impl BmpIndex {
         _total_docs: u32,
         total_vectors: u32,
     ) -> crate::Result<Self> {
-        use crate::segment::format::{BMP_BLOB_FOOTER_SIZE_V13, BMP_BLOB_MAGIC_V13};
+        use crate::segment::format::{BMP_BLOB_FOOTER_SIZE_V14, BMP_BLOB_MAGIC_V14};
 
-        if blob_len < BMP_BLOB_FOOTER_SIZE_V13 as u64 {
+        if blob_len < BMP_BLOB_FOOTER_SIZE_V14 as u64 {
             return Err(crate::Error::Corruption(
                 "BMP blob too small for V13 footer".into(),
             ));
         }
 
         // Read the footer (last 64 bytes of the blob)
-        let footer_start = blob_offset + blob_len - BMP_BLOB_FOOTER_SIZE_V13 as u64;
+        let footer_start = blob_offset + blob_len - BMP_BLOB_FOOTER_SIZE_V14 as u64;
         let footer_bytes = handle
-            .read_bytes_range_sync(footer_start..footer_start + BMP_BLOB_FOOTER_SIZE_V13 as u64)
+            .read_bytes_range_sync(footer_start..footer_start + BMP_BLOB_FOOTER_SIZE_V14 as u64)
             .map_err(crate::Error::Io)?;
         let fb = footer_bytes.as_slice();
 
@@ -187,10 +187,12 @@ impl BmpIndex {
         let grid_bits_raw = u32::from_le_bytes(fb[56..60].try_into().unwrap());
         let magic = u32::from_le_bytes(fb[60..64].try_into().unwrap());
 
-        if magic != BMP_BLOB_MAGIC_V13 {
+        if magic != BMP_BLOB_MAGIC_V14 {
             return Err(crate::Error::Corruption(format!(
-                "Invalid BMP blob magic: {:#x} (expected BMP3 {:#x})",
-                magic, BMP_BLOB_MAGIC_V13
+                "Invalid BMP blob magic: {:#x} (expected BMP4 {:#x}). V13 and \
+                 older segments use u16 posting prefix sums that overflow on \
+                 large blocks — rebuild the index with this version.",
+                magic, BMP_BLOB_MAGIC_V14
             )));
         }
         let grid_bits: u8 = match grid_bits_raw {
@@ -232,7 +234,7 @@ impl BmpIndex {
         }
 
         // Read entire blob (excluding footer) as one OwnedBytes — zero-copy mmap slice
-        let data_len = blob_len - BMP_BLOB_FOOTER_SIZE_V13 as u64;
+        let data_len = blob_len - BMP_BLOB_FOOTER_SIZE_V14 as u64;
         let blob = handle
             .read_bytes_range_sync(blob_offset..blob_offset + data_len)
             .map_err(crate::Error::Io)?;
@@ -479,7 +481,7 @@ impl BmpIndex {
     ///
     /// Returns `(0, null, null, null)` for empty blocks.
     #[inline(always)]
-    pub(crate) fn parse_block(&self, block_id: u32) -> (u16, *const u8, *const u8, *const u8) {
+    pub(crate) fn parse_block(&self, block_id: u32) -> (u32, *const u8, *const u8, *const u8) {
         let (start, end) = self.block_data_range(block_id);
         if start == end {
             return (0, std::ptr::null(), std::ptr::null(), std::ptr::null());
@@ -490,11 +492,12 @@ impl BmpIndex {
                 .as_ptr()
                 .add(start as usize)
         };
-        let num_terms = unsafe { u16::from_le((base as *const u16).read_unaligned()) };
-        let dim_ptr = unsafe { base.add(2) };
+        let num_terms = unsafe { u32::from_le((base as *const u32).read_unaligned()) };
+        let dim_ptr = unsafe { base.add(4) };
         // Always u32 dim IDs (4 bytes each)
         let ps_ptr = unsafe { dim_ptr.add(num_terms as usize * 4) };
-        let post_ptr = unsafe { ps_ptr.add((num_terms as usize + 1) * 2) };
+        // u32 prefix sums (V14): u16 wrapped past 65,535 postings per block
+        let post_ptr = unsafe { ps_ptr.add((num_terms as usize + 1) * 4) };
         (num_terms, dim_ptr, ps_ptr, post_ptr)
     }
 
@@ -712,8 +715,8 @@ pub struct BlockTermIter<'a> {
     dim_ptr: *const u8,
     ps_ptr: *const u8,
     post_ptr: *const u8,
-    num_terms: u16,
-    current: u16,
+    num_terms: u32,
+    current: u32,
     // lifetime marker for the underlying BmpIndex data
     _marker: std::marker::PhantomData<&'a ()>,
 }
@@ -764,9 +767,9 @@ impl<'a> ExactSizeIterator for BlockTermIter<'a> {}
 #[inline(always)]
 pub(crate) fn find_dim_in_block_data(
     dim_ptr: *const u8,
-    num_terms: u16,
+    num_terms: u32,
     dim_id: u32,
-) -> Option<u16> {
+) -> Option<u32> {
     let count = num_terms as usize;
     if count == 0 {
         return None;
@@ -779,7 +782,7 @@ pub(crate) fn find_dim_in_block_data(
         let val = unsafe { read_u32_unchecked(dim_ptr, mid) };
         match val.cmp(&dim_id) {
             std::cmp::Ordering::Less => lo = mid + 1,
-            std::cmp::Ordering::Equal => return Some(mid as u16),
+            std::cmp::Ordering::Equal => return Some(mid as u32),
             std::cmp::Ordering::Greater => hi = mid,
         }
     }
@@ -788,7 +791,7 @@ pub(crate) fn find_dim_in_block_data(
 
 /// Get postings for a local term index within a parsed block.
 ///
-/// `ps_ptr` points to the block's posting_starts array [u16 × (num_terms + 1)].
+/// `ps_ptr` points to the block's posting_starts array [u32 × (num_terms + 1)].
 /// `post_ptr` points to the block's postings array [(u8, u8) × total].
 ///
 /// # Safety
@@ -798,16 +801,20 @@ pub(crate) fn find_dim_in_block_data(
 pub(crate) unsafe fn block_term_postings<'a>(
     ps_ptr: *const u8,
     post_ptr: *const u8,
-    local_term: u16,
+    local_term: u32,
 ) -> &'a [BmpPosting] {
-    let start_p = ps_ptr.add(local_term as usize * 2);
-    let end_p = ps_ptr.add((local_term as usize + 1) * 2);
-    let start = u16::from_le((start_p as *const u16).read_unaligned()) as usize;
-    let end = u16::from_le((end_p as *const u16).read_unaligned()) as usize;
-    let count = end - start;
-    if count == 0 {
+    let start_p = ps_ptr.add(local_term as usize * 4);
+    let end_p = ps_ptr.add((local_term as usize + 1) * 4);
+    let start = u32::from_le((start_p as *const u32).read_unaligned()) as usize;
+    let end = u32::from_le((end_p as *const u32).read_unaligned()) as usize;
+    // Prefix sums are cumulative — a non-monotonic pair means the block is
+    // corrupt. Never build a wild slice from it (`end - start` underflow on
+    // wrapped V13 data was a production SIGSEGV).
+    debug_assert!(end >= start, "corrupt BMP block: prefix sums not monotonic");
+    if end <= start {
         return &[];
     }
+    let count = end - start;
     // SAFETY: BmpPosting is #[repr(C)] with align=1 (two u8 fields).
     let ptr = post_ptr.add(start * 2) as *const BmpPosting;
     std::slice::from_raw_parts(ptr, count)

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -128,8 +128,12 @@ pub struct BmpIndex {
     // ── Raw blob source (identity copies) ─────────────────────────────
     /// Source file handle + blob range, kept so reorder can copy the blob
     /// byte-identically for fields whose `reorder` schema attribute is unset.
+    /// Reorder is native-only, so these are dead on wasm.
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     source: FileHandle,
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     blob_offset: u64,
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     blob_len: u64,
 }
 
@@ -331,8 +335,9 @@ impl BmpIndex {
 
     /// Read the entire raw V13 blob (including footer) from the source file.
     ///
-    /// Used by reorder paths to copy a field byte-identically when its
-    /// `reorder` schema attribute is unset.
+    /// Used by reorder paths (native-only) to copy a field byte-identically
+    /// when its `reorder` schema attribute is unset.
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub(crate) fn read_raw_blob(&self) -> std::io::Result<OwnedBytes> {
         self.source
             .read_bytes_range_sync(self.blob_offset..self.blob_offset + self.blob_len)

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -511,7 +511,7 @@ fn reorder_bmp_field_blockwise(
     mut field_tocs: Vec<SparseFieldToc>,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
 ) -> Result<(OffsetWriter, Vec<SparseFieldToc>, bool)> {
-    use crate::segment::builder::bmp::write_v13_footer;
+    use crate::segment::builder::bmp::write_bmp_footer;
     use crate::segment::builder::graph_bisection::{
         build_forward_index_from_blocks, graph_bisection,
     };
@@ -686,7 +686,7 @@ fn reorder_bmp_field_blockwise(
     }
 
     // Footer
-    write_v13_footer(
+    write_bmp_footer(
         &mut writer,
         total_terms as u32,
         total_postings as u32,
@@ -880,8 +880,8 @@ pub(crate) fn reorder_bmp_field(
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
 ) -> Result<(OffsetWriter, Vec<SparseFieldToc>, bool)> {
     use crate::segment::builder::bmp::{
-        GridRunReader, stream_write_grids, stream_write_grids_merged, write_grid_run,
-        write_v13_footer,
+        GridRunReader, stream_write_grids, stream_write_grids_merged, write_bmp_footer,
+        write_grid_run,
     };
     use crate::segment::builder::graph_bisection::{
         build_forward_index_from_bmps, build_vid_maps, graph_bisection,
@@ -1136,17 +1136,18 @@ pub(crate) fn reorder_bmp_field(
         sorted_dims.sort_unstable();
         let nt = sorted_dims.len();
 
-        let mut blk_buf: Vec<u8> = Vec::with_capacity(2 + nt * 6 + 2);
-        blk_buf.extend_from_slice(&(nt as u16).to_le_bytes());
+        let mut blk_buf: Vec<u8> = Vec::with_capacity(4 + nt * 8 + 4);
+        blk_buf.extend_from_slice(&(nt as u32).to_le_bytes());
 
         for &dim_id in &sorted_dims {
             blk_buf.extend_from_slice(&dim_id.to_le_bytes());
         }
 
-        let mut cum: u16 = 0;
+        // u32 prefix sums (V14): u16 wrapped past 65,535 postings per block
+        let mut cum: u32 = 0;
         for &dim_id in &sorted_dims {
             blk_buf.extend_from_slice(&cum.to_le_bytes());
-            cum += dim_postings[&dim_id].len() as u16;
+            cum += dim_postings[&dim_id].len() as u32;
         }
         blk_buf.extend_from_slice(&cum.to_le_bytes());
 
@@ -1192,7 +1193,8 @@ pub(crate) fn reorder_bmp_field(
                 continue;
             }
             total_terms += grid.len() as u32;
-            total_postings += (blk_buf.len() - 2 - grid.len() * 6 - 2) as u32 / 2;
+            // layout: 4 (nt) + nt*4 (dims) + (nt+1)*4 (prefix) + postings*2
+            total_postings += ((blk_buf.len() - 8 - grid.len() * 8) / 2) as u32;
             grid_entries.extend_from_slice(grid);
             writer.write_all(blk_buf).map_err(crate::Error::Io)?;
             cumulative_bytes += blk_buf.len() as u64;
@@ -1343,7 +1345,7 @@ pub(crate) fn reorder_bmp_field(
     }
 
     // V13 footer (64 bytes)
-    write_v13_footer(
+    write_bmp_footer(
         &mut writer,
         total_terms,
         total_postings,


### PR DESCRIPTION
## The crash

Production `hermes-server` went into CrashLoopBackOff (exit 139/SIGSEGV) seconds after startup, every restart, in `optimizer-bp-*` threads — the BP deepening pass over a 7.96M-doc merged segment. dmesg showed the same faulting instruction offset across every crash with page-aligned fault addresses; symbolized against the published binary, it lands in the forward-index build fold.

## Root cause

The BMP block format stored per-block posting prefix sums as **u16**. The crashing segment averages **21,563 postings per block** (`bmp_block_size: 256`, ~84-300 dims/doc); blocks with more than 65,535 postings silently wrapped `cum += count` at build time (release wrap; debug builds panic — see reproduction). At read time `block_term_postings` computed `end - start` on a wrapped pair → usize underflow → a multi-exabyte "slice" → sequential read off the end of the mmap → SIGSEGV. Queries rarely touch the wrapped tail terms; the BP forward-index build walks **every term of every block**, so it hit the corruption deterministically within seconds.

## Fix (no backward compat, per request)

- **Format V14** (magic `0x34504D42` "BMP4"): per-block `num_terms` and posting prefix sums are **u32** (were u16). Readers loudly refuse V13 and older with an actionable message — segments must be rebuilt.
- **Reader hardening**: `block_term_postings` refuses non-monotonic prefix sums (`debug_assert` + empty slice) instead of fabricating a wild slice, so corrupt data can never again turn into a wild read.
- **Regression test first**: `test_bmp_block_posting_overflow_256` builds a 77,056-posting block (256 docs × 301 dims), asserts exact needle search for dims sorted past the old wrap point, and runs the BP forward-index build over the oversized block (the exact prod crash path). Reproduced before the fix: `attempt to add with overflow` at the u16 accumulation (`builder/bmp.rs:390`).

Size cost: +2 bytes per (block, term) for the wider prefix sums, +2 bytes per block header — noise next to the postings payload.

## Validation

- 697 lib tests pass (`--features native,metrics`), including the new regression
- clippy `-D warnings` clean (core, server, tool); wasm32 clean under `RUSTFLAGS="-D warnings"`

## Deploy note

Existing V13 indexes will be refused at load with a "rebuild the index" error — recreate the daily indexes after deploying this build.