### PR TITLE
chore: sweep stale V13 labels in BMP logs and comments to V14

### DIFF
--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -1,4 +1,4 @@
-//! BMP (Block-Max Pruning) index builder for sparse vectors — **V13 format**.
+//! BMP (Block-Max Pruning) index builder for sparse vectors — **V14 format**.
 //!
 //! Builds a block-at-a-time (BAAT) index using **compact virtual coordinates**:
 //! sequential IDs are assigned to unique `(doc_id, ordinal)` pairs. A lookup
@@ -25,7 +25,7 @@
 //! - **64-byte footer** (was 72): `block_simhash_offset` field removed
 //! - V12 segments are incompatible — must rebuild
 //!
-//! ## BMP V13 Blob Layout (data-first, block-interleaved)
+//! ## BMP V14 Blob Layout (data-first, block-interleaved)
 //!
 //! ```text
 //! Section B:  block_data         [per-block interleaved data]   variable-length
@@ -96,7 +96,7 @@ use crate::DocId;
 use crate::segment::format::BMP_BLOB_MAGIC_V14;
 use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
 
-/// Build a BMP V13 blob from per-dimension postings.
+/// Build a BMP V14 blob from per-dimension postings.
 ///
 /// **Takes ownership** of the postings HashMap. All per-dim Vecs are moved
 /// out of the HashMap into `dim_vecs` before the K-way merge starts, and
@@ -412,7 +412,7 @@ pub(crate) fn build_bmp_blob(
     grid_entries.sort_unstable();
 
     log::info!(
-        "[bmp_build] V13 vectors={} padded={} blocks={} dims={} \
+        "[bmp_build] V14 vectors={} padded={} blocks={} dims={} \
          terms={} postings={} grid_entries={}",
         num_real_docs,
         num_virtual_docs,
@@ -475,7 +475,7 @@ pub(crate) fn build_bmp_blob(
 
     drop(vid_pairs); // Free after last use (~6 bytes × num_real_docs)
 
-    // BMP V13 Footer (64 bytes)
+    // BMP V14 Footer (64 bytes)
     write_bmp_footer(
         writer,
         total_terms,
@@ -496,7 +496,7 @@ pub(crate) fn build_bmp_blob(
     Ok(bytes_written)
 }
 
-/// Write the BMP V13 footer (64 bytes).
+/// Write the BMP V14 footer (64 bytes).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn write_bmp_footer(
     writer: &mut dyn Write,
@@ -861,7 +861,7 @@ mod tests {
         assert!(size > 0);
         assert_eq!(buf.len(), size as usize);
 
-        // Verify V13 footer magic (last 4 bytes of 64-byte footer)
+        // Verify V14 footer magic (last 4 bytes of 64-byte footer)
         let footer_start = buf.len() - 4;
         let magic = u32::from_le_bytes(buf[footer_start..].try_into().unwrap());
         assert_eq!(magic, BMP_BLOB_MAGIC_V14);
@@ -877,7 +877,7 @@ mod tests {
         let size = build_bmp_blob(postings, 64, 4, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
         assert!(size > 0);
 
-        // Verify V13 footer: num_virtual_docs should be 64 (padded to block_size)
+        // Verify V14 footer: num_virtual_docs should be 64 (padded to block_size)
         // 3 real docs padded to 64
         let footer_start = buf.len() - 64;
         let fb = &buf[footer_start..];
@@ -902,7 +902,7 @@ mod tests {
         let size = build_bmp_blob(postings, 64, 4, 0.0, None, 105879, 5.0, 4, &mut buf).unwrap();
         assert!(size > 0);
 
-        // Verify max_weight_scale in V13 footer (bytes 40-43)
+        // Verify max_weight_scale in V14 footer (bytes 40-43)
         let footer_start = buf.len() - 64;
         let fb = &buf[footer_start..];
         let scale = f32::from_le_bytes(fb[40..44].try_into().unwrap());

--- a/hermes-core/src/segment/format.rs
+++ b/hermes-core/src/segment/format.rs
@@ -91,7 +91,7 @@ pub fn read_dense_toc(
 /// Field header: field_id(4) + quant(1) + num_dims(4) + total_vectors(4) = 13B
 pub const SPARSE_FOOTER_MAGIC: u32 = 0x34525053;
 
-/// Magic number for BMP V13 blob footer ("BMP3" in LE)
+/// Magic number for BMP V14 blob footer ("BMP4" in LE)
 ///
 /// V14 changes from V13:
 /// - **u32 num_terms and u32 posting prefix sums** per block (were u16):

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -416,9 +416,9 @@ impl SegmentMerger {
     }
 }
 
-/// Merge BMP fields with **streaming block-copy V13 format**.
+/// Merge BMP fields with **streaming block-copy V14 format**.
 ///
-/// V13 block-copy merge: all segments share the same `dims`, `bmp_block_size`,
+/// V14 block-copy merge: all segments share the same `dims`, `bmp_block_size`,
 /// and `max_weight_scale`, so blocks are self-contained and can be copied directly.
 ///
 /// Phases:
@@ -427,7 +427,7 @@ impl SegmentMerger {
 /// 3. Stream Section D (packed_grid) — one row at a time
 /// 4. Write Section E (sb_grid) — one row at a time
 /// 5. Stream Section F+G (doc_map) — bulk copy with offset patching
-/// 6. Write V13 footer (64 bytes)
+/// 6. Write V14 footer (64 bytes)
 ///
 /// Peak memory: row_buf (~4 MB) + sb_row (~120 KB) + id_buf (256 KB) + tiny Vecs.
 #[allow(clippy::too_many_arguments)]
@@ -705,7 +705,7 @@ fn merge_bmp_field(
         }
     }
 
-    // ── Phase 6: Write V13 footer (64 bytes) ────────────────────────────
+    // ── Phase 6: Write V14 footer (64 bytes) ────────────────────────────
     write_bmp_footer(
         writer,
         total_terms,

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -1,6 +1,6 @@
-//! BMP (Block-Max Pruning) index reader for sparse vectors — **V13 zero-copy**.
+//! BMP (Block-Max Pruning) index reader for sparse vectors — **V14 zero-copy**.
 //!
-//! V13 uses fixed `dims` (vocabulary size) and dim_id directly in per-block data.
+//! V14 uses fixed `dims` (vocabulary size) and dim_id directly in per-block data.
 //! Grid is indexed by dim_id as row index (no Section C dim_ids array).
 //! Data-first layout: block data (Section B) appears before block_data_starts
 //! (Section A). The reader derives the Section A offset from
@@ -73,9 +73,9 @@ unsafe fn read_u64_unchecked(base: *const u8, idx: usize) -> u64 {
     }
 }
 
-/// BMP V13 index for a single sparse field — fully zero-copy mmap-backed.
+/// BMP V14 index for a single sparse field — fully zero-copy mmap-backed.
 ///
-/// V13 format with Recursive Graph Bisection (BP) document ordering.
+/// V14 format with Recursive Graph Bisection (BP) document ordering.
 ///
 /// All data sections are `OwnedBytes` slices into the same underlying mmap Arc.
 /// No heap allocation — the superblock grid is persisted on disk and loaded as
@@ -143,12 +143,12 @@ pub struct BmpIndex {
 // inherits Send+Sync automatically through its fields.
 
 impl BmpIndex {
-    /// Parse a BMP V13 blob from the given file handle.
+    /// Parse a BMP V14 blob from the given file handle.
     ///
     /// Reads the 64-byte footer, then acquires the entire blob as a single
     /// `OwnedBytes` and slices it into zero-copy sections.
     ///
-    /// V13 data-first layout: Section B (per-block interleaved data) first,
+    /// V14 data-first layout: Section B (per-block interleaved data) first,
     /// then Section A (block_data_starts with u64 entries), grids, doc_map.
     pub fn parse(
         handle: FileHandle,
@@ -161,7 +161,7 @@ impl BmpIndex {
 
         if blob_len < BMP_BLOB_FOOTER_SIZE_V14 as u64 {
             return Err(crate::Error::Corruption(
-                "BMP blob too small for V13 footer".into(),
+                "BMP blob too small for V14 footer".into(),
             ));
         }
 
@@ -294,7 +294,7 @@ impl BmpIndex {
         }
 
         log::debug!(
-            "BMP V13 index loaded: num_blocks={}, num_superblocks={}, dims={}, bmp_block_size={}, \
+            "BMP V14 index loaded: num_blocks={}, num_superblocks={}, dims={}, bmp_block_size={}, \
              num_virtual_docs={}, num_real_docs={}, max_weight_scale={:.4}, postings={}, \
              packed_row_size={}, block_data={}B, doc_map={}B",
             num_blocks,
@@ -335,7 +335,7 @@ impl BmpIndex {
         })
     }
 
-    /// Read the entire raw V13 blob (including footer) from the source file.
+    /// Read the entire raw V14 blob (including footer) from the source file.
     ///
     /// Used by reorder paths (native-only) to copy a field byte-identically
     /// when its `reorder` schema attribute is unset.

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -1072,7 +1072,7 @@ pub(crate) fn reorder_bmp_field(
     let run_prefix = format!("hermes_grid_run_{}_{}", std::process::id(), field_id);
 
     // Encode one output block: gather its records from source blocks and
-    // serialize the V13 block layout. Pure function of `perm` + read-only
+    // serialize the V14 block layout. Pure function of `perm` + read-only
     // sources — output blocks encode independently.
     //
     // Global real ids resolve to a source via `real_base`, then to a
@@ -1344,7 +1344,7 @@ pub(crate) fn reorder_bmp_field(
             .map_err(crate::Error::Io)?;
     }
 
-    // V13 footer (64 bytes)
+    // V14 footer (64 bytes)
     write_bmp_footer(
         &mut writer,
         total_terms,


### PR DESCRIPTION
Follow-up to #31: the loaded data was already V14 (magic-verified at open), but the `BMP V13 index loaded` log line and ~20 comments still said V13. Comment/log-string change only — no behavior.