### PR TITLE
fix(sdl): apply bmp_grid_bits to the field config — it parsed but was silently dropped

### DIFF
--- a/docs/budgeted-reorder.md
+++ b/docs/budgeted-reorder.md
@@ -130,8 +130,9 @@ Evidence: `bench_forward_index_build` (`#[ignore]`) in
 - `IndexConfig::default()` now uses `TieredMergePolicy::large_scale()` (the
   server already did). Tier floors only shape _when_ segments merge, and
   merge-time BP is wall-clock budgeted, so the policy is safe at any scale.
-- `bp_memory_budget_bytes` default 2 GB → 16 GB (`--bp-memory-budget-mb`
-  default 16384). It is a cap, not an allocation — memory use is proportional
-  to the segment actually being reordered (~4 B/posting + ~28 B/doc); the cap
-  only bites on ~4-billion-posting passes, where 2 GB was dropping ~10% of
-  eligible dims on 18M-doc merges.
+- `bp_memory_budget_bytes` default 2 GB → 24 GB (`--bp-memory-budget-mb`
+  default 24576). It is a cap, not an allocation — memory use is proportional
+  to the segment actually being reordered (~4 B/posting + ~28 B/doc). Sized
+  from prod evidence: a 58M-doc / 5B-posting pass estimated 20.1 GB; smaller
+  budgets trimmed it by dropping highest-df dims (2 GB dropped ~10% of
+  eligible dims on 18M-doc merges).

--- a/docs/budgeted-reorder.md
+++ b/docs/budgeted-reorder.md
@@ -130,7 +130,8 @@ Evidence: `bench_forward_index_build` (`#[ignore]`) in
 - `IndexConfig::default()` now uses `TieredMergePolicy::large_scale()` (the
   server already did). Tier floors only shape _when_ segments merge, and
   merge-time BP is wall-clock budgeted, so the policy is safe at any scale.
-- `bp_memory_budget_bytes` default 2 GB → 8 GB (`--bp-memory-budget-mb`
-  default 8192). It is a cap, not an allocation — memory use is proportional
-  to the segment actually being reordered; the cap only bites on 10M+ doc
-  passes, where 2 GB was dropping ~10% of eligible dims.
+- `bp_memory_budget_bytes` default 2 GB → 16 GB (`--bp-memory-budget-mb`
+  default 16384). It is a cap, not an allocation — memory use is proportional
+  to the segment actually being reordered (~4 B/posting + ~28 B/doc); the cap
+  only bites on ~4-billion-posting passes, where 2 GB was dropping ~10% of
+  eligible dims on 18M-doc merges.

--- a/hermes-core/src/dsl/sdl/mod.rs
+++ b/hermes-core/src/dsl/sdl/mod.rs
@@ -921,6 +921,17 @@ fn apply_index_config_to_sparse_vector(config: &mut SparseVectorConfig, idx_cfg:
         }
         config.bmp_block_size = adjusted;
     }
+    if let Some(bits) = idx_cfg.bmp_grid_bits {
+        if bits == 2 || bits == 4 {
+            config.bmp_grid_bits = bits;
+        } else {
+            log::warn!(
+                "bmp_grid_bits {} unsupported (must be 2 or 4), using 4",
+                bits
+            );
+            config.bmp_grid_bits = 4;
+        }
+    }
     if let Some(p) = idx_cfg.pruning {
         let clamped = p.clamp(0.0, 1.0);
         if (clamped - p).abs() > f32::EPSILON {
@@ -1628,6 +1639,29 @@ mod tests {
         // Default block size stays 64
         let config2 = indexes[0].fields[1].sparse_vector_config.as_ref().unwrap();
         assert_eq!(config2.bmp_block_size, 64);
+    }
+
+    /// Regression: `bmp_grid_bits` parsed but was never applied to the field
+    /// config — SDL said 2, segments silently built 4-bit grids.
+    #[test]
+    fn test_sparse_vector_bmp_grid_bits() {
+        let sdl = r#"
+            index documents {
+                field emb: sparse_vector<u32> [indexed<format: bmp, dims: 105879, bmp_block_size: 256, bmp_grid_bits: 2>]
+                field emb2: sparse_vector<u32> [indexed<format: bmp, dims: 30522>]
+                field emb3: sparse_vector<u32> [indexed<format: bmp, dims: 30522, bmp_grid_bits: 3>]
+            }
+        "#;
+
+        let indexes = parse_sdl(sdl).unwrap();
+        let config1 = indexes[0].fields[0].sparse_vector_config.as_ref().unwrap();
+        assert_eq!(config1.bmp_grid_bits, 2);
+        // Default stays 4
+        let config2 = indexes[0].fields[1].sparse_vector_config.as_ref().unwrap();
+        assert_eq!(config2.bmp_grid_bits, 4);
+        // Unsupported width falls back to 4 with a warning
+        let config3 = indexes[0].fields[2].sparse_vector_config.as_ref().unwrap();
+        assert_eq!(config3.bmp_grid_bits, 4);
     }
 
     #[test]

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -117,15 +117,16 @@ impl Default for IndexConfig {
             reload_interval_ms: 1000, // 1 second default
             max_concurrent_merges: 4,
             merge_bp_time_budget: Some(std::time::Duration::from_secs(600)),
-            // 8 GB — mirrors segment::reorder::DEFAULT_MEMORY_BUDGET (that
+            // 16 GB — mirrors segment::reorder::DEFAULT_MEMORY_BUDGET (that
             // module is native-only; IndexConfig also compiles for wasm).
             // A cap, not an allocation: usage is proportional to the segment
-            // being reordered; the cap only bites on 10M+ doc passes (2 GB
-            // dropped ~10% of eligible dims on 18M-doc merges).
-            // 8 GB overflows 32-bit usize (wasm32) — reorder never runs
+            // being reordered (~4 B/posting + ~28 B/doc); the cap only bites
+            // on ~4B-posting passes (2 GB dropped ~10% of eligible dims on
+            // 18M-doc merges).
+            // 16 GB overflows 32-bit usize (wasm32) — reorder never runs
             // there, so any large value works; use usize::MAX.
             #[cfg(target_pointer_width = "64")]
-            bp_memory_budget_bytes: 8 * 1024 * 1024 * 1024,
+            bp_memory_budget_bytes: 16 * 1024 * 1024 * 1024,
             #[cfg(not(target_pointer_width = "64"))]
             bp_memory_budget_bytes: usize::MAX,
         }

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -117,16 +117,16 @@ impl Default for IndexConfig {
             reload_interval_ms: 1000, // 1 second default
             max_concurrent_merges: 4,
             merge_bp_time_budget: Some(std::time::Duration::from_secs(600)),
-            // 16 GB — mirrors segment::reorder::DEFAULT_MEMORY_BUDGET (that
+            // 24 GB — mirrors segment::reorder::DEFAULT_MEMORY_BUDGET (that
             // module is native-only; IndexConfig also compiles for wasm).
             // A cap, not an allocation: usage is proportional to the segment
-            // being reordered (~4 B/posting + ~28 B/doc); the cap only bites
-            // on ~4B-posting passes (2 GB dropped ~10% of eligible dims on
-            // 18M-doc merges).
-            // 16 GB overflows 32-bit usize (wasm32) — reorder never runs
+            // being reordered (~4 B/posting + ~28 B/doc). Sized from prod
+            // evidence: a 58M-doc/5B-posting pass estimated 20.1 GB, which
+            // 8/16 GB budgets trimmed by dropping highest-df dims.
+            // 24 GB overflows 32-bit usize (wasm32) — reorder never runs
             // there, so any large value works; use usize::MAX.
             #[cfg(target_pointer_width = "64")]
-            bp_memory_budget_bytes: 16 * 1024 * 1024 * 1024,
+            bp_memory_budget_bytes: 24 * 1024 * 1024 * 1024,
             #[cfg(not(target_pointer_width = "64"))]
             bp_memory_budget_bytes: usize::MAX,
         }

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3188,3 +3188,70 @@ async fn test_bmp_block_posting_overflow_256() {
     // every posting slice past the old u16 wrap point.
     assert_eq!(fwd.total_postings(), 300 * 256);
 }
+
+/// Regression: the optimizer's reorder candidates are scanned long before the
+/// pass runs (hours behind under load). If a merge consumes the candidate in
+/// the meantime, the reorder must SKIP it — the inventory guard only covers
+/// concurrent work, not stale candidates. Before the fix, a stale reorder of
+/// a merged-away segment (files still on disk, held by a searcher snapshot)
+/// succeeded and re-inserted a duplicate copy of its docs next to the merge
+/// output; when the files were already deleted it surfaced as
+/// "failed to reorder ...: No such file or directory" in prod.
+#[tokio::test]
+async fn test_reorder_skips_segment_consumed_by_merge() {
+    let (schema, _title, sparse) = bmp_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+    // One Index instance throughout: searcher snapshot, force_merge, and the
+    // stale reorder must all share the same SegmentManager/tracker, as in the
+    // server — that is what keeps the merged-away files on disk (deferred
+    // deletion), the dangerous variant of the race.
+    let index = Index::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    let mut writer = index.writer();
+    // Two commits → two segments
+    for seg in 0..2 {
+        for i in 0..300u32 {
+            let mut doc = Document::new();
+            doc.add_sparse_vector(sparse, vec![(seg * 1000 + i, 1.0), (50_000 + i % 7, 0.5)]);
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+
+    let segs = index.segment_readers().await.unwrap();
+    assert_eq!(segs.len(), 2);
+    let victim = crate::segment::SegmentId(segs[0].meta().id).to_hex();
+    let total_docs: u32 = segs.iter().map(|s| s.num_docs()).sum();
+    drop(segs);
+
+    // Hold a searcher snapshot so the merged-away source files stay on disk.
+    let reader = index.reader().await.unwrap();
+    let _searcher = reader.searcher().await.unwrap();
+
+    writer.force_merge().await.unwrap();
+
+    // Stale candidate: reorder the segment the merge just consumed.
+    let reordered = index
+        .segment_manager()
+        .reorder_single_segment(&victim, None, crate::segment::BpBudget::full())
+        .await
+        .unwrap();
+    assert!(
+        !reordered,
+        "stale reorder of a merged-away segment must skip"
+    );
+
+    // No duplicate docs may appear.
+    let index2 = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let segs2 = index2.segment_readers().await.unwrap();
+    let total_after: u32 = segs2.iter().map(|s| s.num_docs()).sum();
+    assert_eq!(
+        total_after, total_docs,
+        "reordering a merged-away segment duplicated its documents"
+    );
+}

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -524,6 +524,22 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
         {
             let mut st = self.state.lock().await;
+            // Every source must still be live: callers hold the inventory
+            // guard, so a missing source means a stale merge/reorder whose
+            // input was already replaced — adding the output would duplicate
+            // its documents. The orphaned output files are swept by
+            // cleanup_orphan_segments.
+            let missing: Vec<&String> = old_ids
+                .iter()
+                .filter(|id| !st.metadata.has_segment(id))
+                .collect();
+            if !missing.is_empty() {
+                return Err(Error::Corruption(format!(
+                    "replace_segments: source segment(s) {:?} not in metadata — \
+                     refusing to add output {} (would duplicate documents)",
+                    missing, new_id
+                )));
+            }
             // Compute generation from parents before removing them
             let parent_gen = old_ids
                 .iter()
@@ -949,6 +965,22 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 return Ok(false);
             }
         };
+
+        // The inventory guard only excludes CONCURRENT merges. Candidates are
+        // scanned ahead of time and can go stale: a merge may have consumed
+        // this segment since. Its files may even still be on disk (deferred
+        // deletion under a searcher snapshot) — reordering them would
+        // re-insert a duplicate copy of docs the merge output already holds.
+        {
+            let st = self.state.lock().await;
+            if !st.metadata.has_segment(seg_id) {
+                log::info!(
+                    "[optimizer] segment {} no longer in metadata (merged away), skipping reorder",
+                    seg_id
+                );
+                return Ok(false);
+            }
+        }
 
         let (new_id, total_docs, bp_converged) = crate::segment::reorder::reorder_segment(
             self.directory.as_ref(),

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -20,11 +20,12 @@ use crate::segment::reader::SegmentReader;
 use crate::segment::types::{SegmentFiles, SegmentId, SegmentMeta};
 use crate::structures::SparseFormat;
 
-/// Default memory budget for forward index during BP (8 GB). A cap, not an
-/// allocation — usage is proportional to the segment being reordered; it
-/// only bites on 10M+ doc passes (2 GB dropped ~10% of eligible dims on
-/// 18M-doc merges). Mirrored by `IndexConfig::default().bp_memory_budget_bytes`.
-pub const DEFAULT_MEMORY_BUDGET: usize = 8 * 1024 * 1024 * 1024;
+/// Default memory budget for forward index during BP (16 GB). A cap, not an
+/// allocation — usage is proportional to the segment being reordered
+/// (~4 B/posting + ~28 B/doc); it only bites on ~4B-posting passes (2 GB
+/// dropped ~10% of eligible dims on 18M-doc merges). Mirrored by
+/// `IndexConfig::default().bp_memory_budget_bytes`.
+pub const DEFAULT_MEMORY_BUDGET: usize = 16 * 1024 * 1024 * 1024;
 
 /// Reorder granularity (see docs/block-level-reorder.md).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -20,12 +20,13 @@ use crate::segment::reader::SegmentReader;
 use crate::segment::types::{SegmentFiles, SegmentId, SegmentMeta};
 use crate::structures::SparseFormat;
 
-/// Default memory budget for forward index during BP (16 GB). A cap, not an
+/// Default memory budget for forward index during BP (24 GB). A cap, not an
 /// allocation — usage is proportional to the segment being reordered
-/// (~4 B/posting + ~28 B/doc); it only bites on ~4B-posting passes (2 GB
-/// dropped ~10% of eligible dims on 18M-doc merges). Mirrored by
+/// (~4 B/posting + ~28 B/doc). Sized from prod evidence: a 58M-doc /
+/// 5B-posting pass estimated 20.1 GB, which smaller budgets trimmed by
+/// dropping highest-df dims. Mirrored by
 /// `IndexConfig::default().bp_memory_budget_bytes`.
-pub const DEFAULT_MEMORY_BUDGET: usize = 16 * 1024 * 1024 * 1024;
+pub const DEFAULT_MEMORY_BUDGET: usize = 24 * 1024 * 1024 * 1024;
 
 /// Reorder granularity (see docs/block-level-reorder.md).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -98,9 +98,8 @@ struct Args {
     /// Memory budget (MB) for the BP forward index during reorder passes
     /// (merge-time and background). A cap, not an allocation — usage is
     /// proportional to the segment being reordered. Over-budget passes drop
-    /// highest-df dims from BP's input with a loud warning; raise to 16384
-    /// on hosts with headroom.
-    #[arg(long, default_value = "8192")]
+    /// highest-df dims from BP's input with a loud warning.
+    #[arg(long, default_value = "16384")]
     bp_memory_budget_mb: usize,
 
     /// Address for the Prometheus /metrics HTTP endpoint.

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -99,7 +99,7 @@ struct Args {
     /// (merge-time and background). A cap, not an allocation — usage is
     /// proportional to the segment being reordered. Over-budget passes drop
     /// highest-df dims from BP's input with a loud warning.
-    #[arg(long, default_value = "16384")]
+    #[arg(long, default_value = "24576")]
     bp_memory_budget_mb: usize,
 
     /// Address for the Prometheus /metrics HTTP endpoint.


### PR DESCRIPTION
The SDL parse arm stored `bmp_grid_bits` in the intermediate index config, but the apply section never copied it into `SparseVectorConfig` (unlike `bmp_block_size` right above) — so `bmp_grid_bits: 2` silently built 4-bit grids. Caught in prod logs: 262 blocks → `packed_row_size=131` = ceil(262/2) = 4-bit, on an index whose SDL says 2.

Now applied with validation: 2 or 4; anything else warns loudly and uses 4.

Regression `test_sparse_vector_bmp_grid_bits` reproduced the drop first (parsed 2 → applied 4), now pins parse→config for 2, the default 4, and invalid 3 → warn + 4.

698 tests pass, clippy `-D warnings` clean.

**Deploy note:** existing segments of the affected index are 4-bit (correct, just not compressed); after this ships, the next index recreation with `bmp_grid_bits: 2` in SDL will actually produce 2-bit grids (~half the grid memory).

---

**Also in this PR:** default BP memory budget raised 8 GB → 16 GB (`--bp-memory-budget-mb` default 16384, `IndexConfig.bp_memory_budget_bytes`, `DEFAULT_MEMORY_BUDGET`). Cap-not-allocation semantics unchanged; full-fidelity BP now covers up to ~4-billion-posting passes before dim-dropping kicks in (with the loud warning).

---

**Also in this PR:** fix for the stale-reorder race behind prod's `[optimizer] failed to reorder segment ...: No such file or directory` — optimizer candidates scanned before a merge consumed the segment proceeded anyway (the inventory guard only excludes concurrent work). Benign variant: loud ENOENT. Dangerous variant: with the merged-away files still on disk (deferred deletion under a searcher snapshot) the reorder succeeded and re-inserted duplicate documents. Now: liveness check after the guard (skip + info log), and `replace_segments` refuses missing sources (Corruption error). Regression test reproduced the duplication first.