### PR TITLE
Weight tying, MAL position_encoding/embeddings parsing, retriever-100m preset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Hermes is a high-performance, embeddable full-text search engine written in Rust
 - **hermes-client-python**: Python gRPC client
 - **hermes-web**: Vue.js web UI
 
-LLM pipeline: `hermes-llm export --model <preset|.mal>` emits a JSON config → `hermes-train train` produces safetensors → `hermes-llm generate` serves them. Tensor names are a shared contract (`embedding.*`, `layers.{i}.attention.*` or `layers.{i}.ssm.*`, `layers.{i}.feed_forward.*`, `final_norm.*`, `lm_head.*`) — keep hermes-train/src/hermes_train/{config,model}.py in lockstep with hermes-llm/src/{mal/mod.rs,model.rs}.
+LLM pipeline: `hermes-llm export --model <preset|.mal>` emits a JSON config → `hermes-train train` produces safetensors → `hermes-llm generate` serves them. Tensor names are a shared contract (`embedding.*`, `layers.{i}.attention.*` or `layers.{i}.ssm.*`, `layers.{i}.feed_forward.*`, `final_norm.*`, `lm_head.*` — absent when embeddings.tie_weights) — keep hermes-train/src/hermes_train/{config,model}.py in lockstep with hermes-llm/src/{mal/mod.rs,model.rs}.
 
 MAL supports hybrid Transformer+Mamba models: an `ssm { state_dim, conv_kernel, expand, dt_rank }` def makes a block a Mamba (selective state-space) block, and `pattern: [mamba_block, mamba_block, attn_block]` in a model cycles block types across num_layers (see `well-known/hybrid_tiny.mal`). Both sides implement Mamba-1: PyTorch trains with a reference fp32 scan (fused mamba-ssm kernels optional on CUDA), Candle serves with a sequential scan.
 

--- a/hermes-llm/src/mal/mal.pest
+++ b/hermes-llm/src/mal/mal.pest
@@ -214,7 +214,7 @@ num_heads_prop = { ("num_heads" | "n_heads" | "attention_heads") ~ ":" ~ integer
 num_kv_heads_prop = { ("num_kv_heads" | "kv_heads") ~ ":" ~ integer }
 
 // RoPE configuration
-rope_theta_prop = { "rope_theta" ~ ":" ~ number }
+rope_theta_prop = { ("rope_theta" | "theta") ~ ":" ~ number }
 rope_scaling_prop = { "rope_scaling" ~ ":" ~ number }
 
 // Normalization

--- a/hermes-llm/src/mal/mod.rs
+++ b/hermes-llm/src/mal/mod.rs
@@ -583,6 +583,30 @@ fn parse_model_prop(
                     def.pattern = Some(blocks);
                 }
             }
+            Rule::embeddings_prop => {
+                for param in inner.into_inner() {
+                    for child in param.into_inner() {
+                        match child.as_rule() {
+                            Rule::tie_weights_prop => {
+                                if let Some(val) = child.into_inner().next() {
+                                    def.embeddings.tie_weights = val.as_str() == "true";
+                                }
+                            }
+                            Rule::dropout_prop => {
+                                if let Some(val) = child.into_inner().next() {
+                                    def.embeddings.dropout = val.as_str().parse()?;
+                                }
+                            }
+                            Rule::scale_prop => {
+                                if let Some(val) = child.into_inner().next() {
+                                    def.embeddings.scale = Some(val.as_str().parse()?);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
             Rule::description_prop => {
                 if let Some(val) = inner.into_inner().next() {
                     let s = val.as_str();
@@ -685,6 +709,57 @@ fn parse_attention_def(pair: pest::iterators::Pair<Rule>) -> Result<AttentionDef
     Ok(def)
 }
 
+/// Parse a position-encoding config (rope { theta, scaling } | alibi | learned | none)
+fn parse_position_encoding(pair: pest::iterators::Pair<Rule>) -> Result<PositionEncoding> {
+    // position_encoding_config contains one of the variant configs; the bare
+    // "none" literal produces no inner pair.
+    let Some(config) = pair.into_inner().next() else {
+        return Ok(PositionEncoding::None);
+    };
+    match config.as_rule() {
+        Rule::rope_config => {
+            let mut theta = 10000.0;
+            let mut scaling = None;
+            for param in config.into_inner() {
+                for inner in param.into_inner() {
+                    match inner.as_rule() {
+                        Rule::rope_theta_prop | Rule::rope_base_prop => {
+                            if let Some(val) = inner.into_inner().next() {
+                                theta = val.as_str().parse()?;
+                            }
+                        }
+                        Rule::rope_scaling_prop => {
+                            if let Some(val) = inner.into_inner().next() {
+                                scaling = Some(val.as_str().parse()?);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(PositionEncoding::Rope { theta, scaling })
+        }
+        Rule::alibi_config => {
+            let learned_slopes = config.as_str().contains("learned");
+            Ok(PositionEncoding::Alibi { learned_slopes })
+        }
+        Rule::learned_config => {
+            let mut max_positions = 0;
+            for param in config.into_inner() {
+                for inner in param.into_inner() {
+                    if inner.as_rule() == Rule::max_positions_prop
+                        && let Some(val) = inner.into_inner().next()
+                    {
+                        max_positions = val.as_str().parse()?;
+                    }
+                }
+            }
+            Ok(PositionEncoding::Learned { max_positions })
+        }
+        _ => Ok(PositionEncoding::None),
+    }
+}
+
 /// Parse attention properties
 fn parse_attention_prop(pair: pest::iterators::Pair<Rule>, def: &mut AttentionDef) -> Result<()> {
     for inner in pair.into_inner() {
@@ -722,6 +797,11 @@ fn parse_attention_prop(pair: pest::iterators::Pair<Rule>, def: &mut AttentionDe
             Rule::window_size_prop => {
                 if let Some(val) = inner.into_inner().next() {
                     def.window_size = Some(val.as_str().parse()?);
+                }
+            }
+            Rule::position_encoding_prop => {
+                if let Some(config) = inner.into_inner().next() {
+                    def.position_encoding = parse_position_encoding(config)?;
                 }
             }
             _ => {}
@@ -1132,6 +1212,71 @@ mod tests {
 
         let def = parse_mal(mal).unwrap();
         assert_eq!(def.vocab_size, 1000);
+    }
+
+    #[test]
+    fn test_parse_position_encoding_and_tie_weights() {
+        let mal = r#"
+            attention pe_attn {
+                num_heads: 8
+                position_encoding: rope { theta: 100000.0 }
+            }
+
+            ffn pe_ffn {
+                hidden_dim: 1024
+            }
+
+            block pe_block {
+                attention: pe_attn
+                ffn: pe_ffn
+            }
+
+            model pe_test {
+                vocab_size: 1000
+                hidden_size: 256
+                num_layers: 2
+                block: pe_block
+                embeddings {
+                    tie_weights: true
+                }
+            }
+        "#;
+
+        let def = parse_mal(mal).unwrap();
+        assert_eq!(def.rope_theta(), 100000.0, "theta must not be dropped");
+        assert!(
+            def.embeddings.tie_weights,
+            "tie_weights must not be dropped"
+        );
+
+        // Alternate spellings and variants
+        let mal2 = r#"
+            attention a { rope_theta: 500000.0 }
+        "#;
+        // rope_theta at attention level requires position_encoding wrapper;
+        // bare form is not part of the grammar — this should fail to parse
+        assert!(
+            parse_mal_full(mal2).is_err() || {
+                let f = parse_mal_full(mal2).unwrap();
+                f.attentions.is_empty()
+            }
+        );
+
+        let mal3 = r#"
+            attention nopos { position_encoding: none }
+            ffn f { hidden_dim: 64 }
+            block b { attention: nopos
+                      ffn: f }
+            model m { vocab_size: 100
+                      hidden_size: 64
+                      num_layers: 1
+                      block: b }
+        "#;
+        let def3 = parse_mal(mal3).unwrap();
+        assert!(matches!(
+            def3.block.attention.position_encoding,
+            PositionEncoding::None
+        ));
     }
 
     #[test]

--- a/hermes-llm/src/model.rs
+++ b/hermes-llm/src/model.rs
@@ -859,7 +859,9 @@ pub struct Transformer {
     embedding: Embedding,
     layers: Vec<TransformerBlock>,
     final_norm: Norm,
-    lm_head: Linear,
+    /// None when embeddings.tie_weights: logits are projected through the
+    /// embedding matrix and no lm_head.weight tensor exists in checkpoints.
+    lm_head: Option<Linear>,
     rope: RotaryEmbedding,
     config: ModelDef,
 }
@@ -910,7 +912,15 @@ impl Transformer {
             norm_block.use_bias(),
             vb.pp("final_norm"),
         )?;
-        let lm_head = linear_no_bias(config.hidden_size, config.vocab_size, vb.pp("lm_head"))?;
+        let lm_head = if config.embeddings.tie_weights {
+            None
+        } else {
+            Some(linear_no_bias(
+                config.hidden_size,
+                config.vocab_size,
+                vb.pp("lm_head"),
+            )?)
+        };
         let rope =
             RotaryEmbedding::new(rope_head_dim, config.max_seq_len, rope_theta, vb.device())?;
         Ok(Self {
@@ -949,7 +959,21 @@ impl Transformer {
         }
 
         let x = self.final_norm.forward(&x)?;
-        self.lm_head.forward(&x)
+        self.project_logits(&x)
+    }
+
+    /// Project hidden states to vocab logits — through lm_head, or through
+    /// the (live, load-aware) embedding matrix when weights are tied.
+    fn project_logits(&self, x: &Tensor) -> Result<Tensor> {
+        match &self.lm_head {
+            Some(head) => head.forward(x),
+            None => {
+                let (b, l, h) = x.dims3()?;
+                let w = self.embedding.embeddings(); // [V, h]
+                let logits = x.reshape((b * l, h))?.matmul(&w.t()?)?;
+                logits.reshape((b, l, w.dim(0)?))
+            }
+        }
     }
 
     pub fn config(&self) -> &ModelDef {
@@ -997,7 +1021,7 @@ impl Transformer {
         state.pos += seq_len;
 
         let x = self.final_norm.forward(&x)?;
-        self.lm_head.forward(&x)
+        self.project_logits(&x)
     }
 }
 
@@ -1076,6 +1100,26 @@ mod tests {
             assert!(names.contains(&format!("layers.{i}.attention.q_proj.weight")));
             assert!(!names.contains(&format!("layers.{i}.ssm.in_proj.weight")));
         }
+    }
+
+    #[test]
+    fn test_tied_embeddings() {
+        let mut config = get_builtin_model("hybrid-tiny").unwrap();
+        config.vocab_size = 128;
+        config.embeddings.tie_weights = true;
+
+        let device = Device::Cpu;
+        let var_map = VarMap::new();
+        let vb = VarBuilder::from_varmap(&var_map, DType::F32, &device);
+        let model = Transformer::new(&config, vb).unwrap();
+
+        // No lm_head tensor when tied
+        let names: Vec<String> = var_map.data().lock().unwrap().keys().cloned().collect();
+        assert!(!names.iter().any(|n| n.starts_with("lm_head")));
+
+        let ids = Tensor::zeros((1, 6), DType::U32, &device).unwrap();
+        let logits = model.forward(&ids, 0, false).unwrap();
+        assert_eq!(logits.dims3().unwrap(), (1, 6, 128));
     }
 
     #[test]

--- a/hermes-llm/well-known/retriever_100m.mal
+++ b/hermes-llm/well-known/retriever_100m.mal
@@ -1,0 +1,58 @@
+# ~107M hybrid retriever model (Jamba-style 2:1 SSM:attention)
+#
+# Sized for the agentic-retriever use case: coherent within the
+# query/tool-call/synthesis domain, cheap to serve inside Hermes.
+# - Deep-narrow (24 x 512): better than wide-shallow at this scale
+# - Attention layers are GLOBAL (no window): they carry exact recall /
+#   needle lookup, which windowing would destroy; only 1/3 of layers
+#   pay KV-cache cost
+# - Mamba layers carry the bulk of sequence modeling at O(1)/token
+#   with a fixed-size persistent state
+
+attention retr_attn {
+    num_heads: 8
+    num_kv_heads: 4
+    bias: false
+    position_encoding: rope { theta: 100000.0 }
+}
+
+ssm retr_ssm {
+    state_dim: 16
+    conv_kernel: 4
+    expand: 2
+}
+
+ffn retr_ffn {
+    hidden_dim: 1536
+    activation: swiglu
+    bias: false
+}
+
+block attn_block {
+    attention: retr_attn
+    ffn: retr_ffn
+    norm: rmsnorm { eps: 1e-5 }
+    norm_position: pre
+    residual: true
+}
+
+block mamba_block {
+    ssm: retr_ssm
+    ffn: retr_ffn
+    norm: rmsnorm { eps: 1e-5 }
+    norm_position: pre
+    residual: true
+}
+
+model retriever-100m {
+    description: "Hybrid Mamba+attention retriever model, ~107M params (tied embeddings)"
+    vocab_size: 32768
+    max_seq_len: 8192
+    hidden_size: 512
+    num_layers: 24
+    block: attn_block
+    pattern: [mamba_block, mamba_block, attn_block]
+    embeddings {
+        tie_weights: true
+    }
+}

--- a/hermes-train/src/hermes_train/model.py
+++ b/hermes-train/src/hermes_train/model.py
@@ -385,14 +385,23 @@ class Transformer(nn.Module):
             for i in range(config.num_layers)
         )
         self.final_norm = make_norm(config, config.block_for_layer(0))
-        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        # Tied embeddings: no lm_head parameter at all (matches the Candle
+        # side — tied checkpoints contain no lm_head.weight tensor)
+        self.lm_head = (
+            None
+            if config.embeddings.tie_weights
+            else nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        )
         self.rope = RotaryEmbedding(rope_head_dim, config.max_seq_len, rope_theta)
 
     def forward(self, input_ids: Tensor, start_pos: int = 0) -> Tensor:
         x = self.embedding(input_ids)
         for layer in self.layers:
             x = layer(x, self.rope, start_pos)
-        return self.lm_head(self.final_norm(x))
+        x = self.final_norm(x)
+        if self.lm_head is None:
+            return F.linear(x, self.embedding.weight)
+        return self.lm_head(x)
 
     def num_parameters(self) -> int:
         return sum(p.numel() for p in self.parameters())

--- a/hermes-train/tests/test_model.py
+++ b/hermes-train/tests/test_model.py
@@ -258,6 +258,33 @@ def test_hybrid_forward_and_train_step(hybrid_config):
     )
 
 
+def test_tied_embeddings(hybrid_config, tmp_path):
+    from safetensors.torch import load_file, save_file
+
+    hybrid_config.embeddings.tie_weights = True
+    model = Transformer(hybrid_config)
+    keys = model.state_dict().keys()
+    assert not any(k.startswith("lm_head") for k in keys)
+
+    ids = torch.randint(0, hybrid_config.vocab_size, (1, 8))
+    logits = model(ids)
+    assert logits.shape == (1, 8, hybrid_config.vocab_size)
+
+    # Roundtrip without lm_head tensor
+    path = tmp_path / "tied.safetensors"
+    save_file({k: v.contiguous() for k, v in model.state_dict().items()}, str(path))
+    model2 = Transformer(hybrid_config)
+    model2.load_state_dict(load_file(str(path)), strict=True)
+    model.eval(), model2.eval()
+    with torch.no_grad():
+        assert torch.allclose(model(ids), model2(ids))
+
+    # Gradients flow to the shared matrix from both ends
+    loss = cross_entropy_loss(model(ids), ids)
+    loss.backward()
+    assert model.embedding.weight.grad is not None
+
+
 def test_fused_kernel_dispatch(hybrid_config):
     """Off-CUDA the reference scan must be used; fused path needs mamba-ssm."""
     from hermes_train import model as model_mod

--- a/hermes-train/uv.lock
+++ b/hermes-train/uv.lock
@@ -228,7 +228,7 @@ wheels = [
 
 [[package]]
 name = "hermes-train"
-version = "1.8.34"
+version = "1.8.54"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## What

- **MAL parser fixes** (bug class: grammar accepted, AST builder dropped):
  - `position_encoding: rope { theta: ... }` / `alibi` / `learned` / `none` now parse into `AttentionDef` (previously theta was silently stuck at 10000); `theta` accepted as alias for `rope_theta`
  - model-level `embeddings { tie_weights, dropout, scale }` now parses (previously silently dropped)
  - failing tests written first per repo rules
- **Weight tying, both engines**: `embeddings.tie_weights` makes logits project through the embedding matrix. Tied checkpoints contain **no `lm_head.weight` tensor** — naming contract updated in CLAUDE.md. Candle reads the live embedding var (load-aware); PyTorch uses `F.linear(x, embedding.weight)` so no shared-tensor issue with safetensors.
- **`retriever-100m` preset**: 106.8M params (exact count from constructed model) — 24×512 deep-narrow, `[mamba, mamba, attn]`×8, GQA kv=4, global attention (retrieval needs exact recall — no windowing), RoPE θ=1e5, ctx 8192, tied embeddings (saves 16.8M vs untied).

## Verification

- Rust: 13/13 tests (incl. new tied-embeddings + position_encoding parse tests), clippy `-D warnings` clean
- Python: 13/13 pytest (tied naming/roundtrip/grad-flow test added), ruff clean
- Cross-engine: tied hybrid trained 60 steps → greedy decode **identical token-for-token** between `hermes-llm generate` (Candle) and PyTorch