### PR TITLE
Adopt 2026 training practices: WSD, document masking, curriculum stages, QK-Norm

### DIFF
--- a/hermes-llm/src/mal/mal.pest
+++ b/hermes-llm/src/mal/mal.pest
@@ -64,12 +64,14 @@ attention_prop = {
     bias_prop |
     position_encoding_prop |
     window_size_prop |
-    causal_prop
+    causal_prop |
+    qk_norm_prop
 }
 
 head_dim_prop = { "head_dim" ~ ":" ~ integer }
 window_size_prop = { "window_size" ~ ":" ~ integer }
 causal_prop = { "causal" ~ ":" ~ boolean }
+qk_norm_prop = { "qk_norm" ~ ":" ~ boolean }
 
 // Position encoding: rope, alibi, learned, or none
 position_encoding_prop = { "position_encoding" ~ ":" ~ position_encoding_config }

--- a/hermes-llm/src/mal/mod.rs
+++ b/hermes-llm/src/mal/mod.rs
@@ -101,6 +101,9 @@ pub struct AttentionDef {
     pub position_encoding: PositionEncoding,
     pub window_size: Option<usize>,
     pub causal: bool,
+    /// Per-head RMSNorm on Q and K before RoPE (OLMo2/Gemma-style stabilizer)
+    #[serde(default)]
+    pub qk_norm: bool,
 }
 
 impl Default for AttentionDef {
@@ -115,6 +118,7 @@ impl Default for AttentionDef {
             position_encoding: PositionEncoding::default(),
             window_size: None,
             causal: true,
+            qk_norm: false,
         }
     }
 }
@@ -804,6 +808,11 @@ fn parse_attention_prop(pair: pest::iterators::Pair<Rule>, def: &mut AttentionDe
                     def.position_encoding = parse_position_encoding(config)?;
                 }
             }
+            Rule::qk_norm_prop => {
+                if let Some(val) = inner.into_inner().next() {
+                    def.qk_norm = val.as_str() == "true";
+                }
+            }
             _ => {}
         }
     }
@@ -1244,6 +1253,24 @@ mod tests {
 
         let def = parse_mal(mal).unwrap();
         assert_eq!(def.rope_theta(), 100000.0, "theta must not be dropped");
+
+        // qk_norm parses and lands
+        let with_qk = parse_mal(
+            r#"
+            attention qk { num_heads: 4
+                           qk_norm: true }
+            ffn f { hidden_dim: 64 }
+            block b { attention: qk
+                      ffn: f }
+            model m { vocab_size: 100
+                      hidden_size: 64
+                      num_layers: 1
+                      block: b }
+        "#,
+        )
+        .unwrap();
+        assert!(with_qk.block.attention.qk_norm);
+
         assert!(
             def.embeddings.tie_weights,
             "tie_weights must not be dropped"

--- a/hermes-llm/src/model.rs
+++ b/hermes-llm/src/model.rs
@@ -168,6 +168,9 @@ pub struct MultiHeadAttention {
     k_proj: Linear,
     v_proj: Linear,
     o_proj: Linear,
+    /// Per-head RMSNorm over head_dim, applied to Q/K before RoPE (qk_norm)
+    q_norm: Option<RMSNorm>,
+    k_norm: Option<RMSNorm>,
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -199,12 +202,22 @@ impl MultiHeadAttention {
                 linear_no_bias(hidden_size, hidden_size, vb.pp("o_proj"))?,
             )
         };
+        let (q_norm, k_norm) = if block.attention.qk_norm {
+            (
+                Some(RMSNorm::new(head_dim, block.norm_eps(), vb.pp("q_norm"))?),
+                Some(RMSNorm::new(head_dim, block.norm_eps(), vb.pp("k_norm"))?),
+            )
+        } else {
+            (None, None)
+        };
         let dropout = Dropout::new(block.dropout as f32);
         Ok(Self {
             q_proj,
             k_proj,
             v_proj,
             o_proj,
+            q_norm,
+            k_norm,
             num_heads,
             num_kv_heads,
             head_dim,
@@ -212,6 +225,14 @@ impl MultiHeadAttention {
             window_size: block.attention.window_size,
             causal: block.attention.causal,
         })
+    }
+
+    /// Apply QK-Norm (when configured) to per-head Q/K, pre-RoPE.
+    fn apply_qk_norm(&self, q: Tensor, k: Tensor) -> Result<(Tensor, Tensor)> {
+        match (&self.q_norm, &self.k_norm) {
+            (Some(qn), Some(kn)) => Ok((qn.forward(&q)?, kn.forward(&k)?)),
+            _ => Ok((q, k)),
+        }
     }
 
     pub fn forward(
@@ -236,6 +257,7 @@ impl MultiHeadAttention {
         let k = k.transpose(1, 2)?.contiguous()?;
         let v = v.transpose(1, 2)?.contiguous()?;
 
+        let (q, k) = self.apply_qk_norm(q, k)?;
         let (q, k) = rope.apply(&q, &k, start_pos)?;
 
         // Repeat KV heads for GQA (Grouped Query Attention)
@@ -344,6 +366,7 @@ impl MultiHeadAttention {
             .transpose(1, 2)?
             .contiguous()?;
 
+        let (q, k) = self.apply_qk_norm(q, k)?;
         let (q, k) = rope.apply(&q, &k, start_pos)?;
 
         // Append to cache (pre-GQA-repeat, [B, n_kv, T, hd])
@@ -1100,6 +1123,65 @@ mod tests {
             assert!(names.contains(&format!("layers.{i}.attention.q_proj.weight")));
             assert!(!names.contains(&format!("layers.{i}.ssm.in_proj.weight")));
         }
+    }
+
+    #[test]
+    fn test_qk_norm_tensors_and_stateful_parity() {
+        let mut config = get_builtin_model("hybrid-tiny").unwrap();
+        config.vocab_size = 128;
+        config.block.attention.qk_norm = true;
+        if let Some(pattern) = config.pattern.as_mut() {
+            for b in pattern.iter_mut() {
+                b.attention.qk_norm = true;
+            }
+        }
+
+        let device = Device::Cpu;
+        let var_map = VarMap::new();
+        let vb = VarBuilder::from_varmap(&var_map, DType::F32, &device);
+        let model = Transformer::new(&config, vb).unwrap();
+
+        let names: std::collections::HashSet<String> =
+            var_map.data().lock().unwrap().keys().cloned().collect();
+        // Attention layers (2, 5 in the [ssm,ssm,attn] pattern) get q/k norms
+        assert!(names.contains("layers.2.attention.q_norm.weight"));
+        assert!(names.contains("layers.5.attention.k_norm.weight"));
+        assert!(!names.contains("layers.0.attention.q_norm.weight")); // ssm layer
+
+        // Stateful decode still matches stateless with qk-norm active
+        let ids: Vec<u32> = (0..10).map(|i| (i * 5 + 1) % 128).collect();
+        let full = Tensor::new(ids.as_slice(), &device)
+            .unwrap()
+            .unsqueeze(0)
+            .unwrap();
+        let full_logits = model.forward(&full, 0, false).unwrap();
+
+        let mut state = model.make_state(1, &device).unwrap();
+        let prefill = Tensor::new(&ids[..9], &device)
+            .unwrap()
+            .unsqueeze(0)
+            .unwrap();
+        model.forward_with_state(&prefill, &mut state).unwrap();
+        let step = Tensor::new(&ids[9..], &device)
+            .unwrap()
+            .unsqueeze(0)
+            .unwrap();
+        let step_logits = model.forward_with_state(&step, &mut state).unwrap();
+
+        let a: Vec<f32> = step_logits.flatten_all().unwrap().to_vec1().unwrap();
+        let b: Vec<f32> = full_logits
+            .narrow(1, 9, 1)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1()
+            .unwrap();
+        let max_diff = a
+            .iter()
+            .zip(&b)
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0f32, f32::max);
+        assert!(max_diff < 1e-4, "qk-norm stateful diverges: {max_diff}");
     }
 
     #[test]

--- a/hermes-llm/well-known/retriever_100m.mal
+++ b/hermes-llm/well-known/retriever_100m.mal
@@ -13,6 +13,7 @@ attention retr_attn {
     num_heads: 8
     num_kv_heads: 4
     bias: false
+    qk_norm: true
     position_encoding: rope { theta: 100000.0 }
 }
 

--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -38,9 +38,23 @@ hermes-llm generate --checkpoint checkpoints/weights.safetensors \
 - **Optimizer**: Muon (Newton–Schulz orthogonalized momentum) for 2D weight
   matrices, AdamW for embeddings/norms/head — the hybrid scheme used by
   Kimi K2 / GLM-scale runs
-- **Schedule**: cosine with linear warmup
+- **Schedule**: WSD (warmup–stable–decay, the 2026 default) or cosine via
+  `--schedule`; the flat plateau makes run extension and curricula sane
 - **Data**: JSONL with a `text` field; `.gz` / `.zst` supported; documents are
   tokenized, EOS-joined and packed into fixed windows
+- **Document masking** (default on): attention is block-diagonal across
+  packed-document boundaries, SSM recurrent state resets at doc starts, and
+  the reference path uses a segment-aware causal conv — doc 2 is provably
+  independent of doc 1 (tested). The fused CUDA kernel (Mamba-1) has no
+  `seq_idx`, so under the fused path SSM state crosses boundaries
+  (warned once); attention layers still mask correctly. `--no-doc-masking`
+  disables.
+- **Curriculum stages**: repeat `-d` — each file trains sequentially under
+  one LR schedule, so with WSD the decay lands on your final
+  (highest-quality / task-specific) stage
+- **QK-Norm**: `qk_norm: true` in a MAL attention def adds per-head RMSNorm
+  on Q/K before RoPE (OLMo2/Gemma-style stabilizer); tensors
+  `layers.{i}.attention.{q,k}_norm.weight` in both engines
 - **Checkpoints**: `weights.safetensors` (Candle-compatible names) +
   `training_state.json`; Ctrl+C saves and exits, `--resume` continues
 - **Distributed**: DDP via `torchrun` (gradient sync); FSDP is a planned upgrade

--- a/hermes-train/src/hermes_train/cli.py
+++ b/hermes-train/src/hermes_train/cli.py
@@ -18,23 +18,28 @@ def cmd_train(args: argparse.Namespace) -> int:
 
     config = ModelDef.from_json(args.config)
 
+    data_files = args.data or []
+
     if Path(args.tokenizer).exists():
         tokenizer = Tokenizer.from_file(args.tokenizer)
-    elif args.data:
+    elif data_files:
         print("Tokenizer not found, training a new one...")
-        tokenizer = train_bpe([args.data], args.tokenizer)
+        tokenizer = train_bpe([data_files[0]], args.tokenizer)
     else:
         print("error: --data required to train a tokenizer", file=sys.stderr)
         return 1
     config.vocab_size = tokenizer.vocab_size
     print(f"Tokenizer vocab size: {tokenizer.vocab_size}")
 
-    if args.data:
-        dataset = Dataset.from_file(args.data, tokenizer, args.seq_len)
+    # Each -d file is a curriculum stage, trained sequentially under one
+    # LR schedule (WSD keeps this sane: decay only hits the final stage).
+    if data_files:
+        datasets = [Dataset.from_file(p, tokenizer, args.seq_len) for p in data_files]
     else:
         print("Loading dataset from stdin...")
-        dataset = Dataset.from_stdin(tokenizer, args.seq_len)
-    print(f"Dataset size: {len(dataset.tokens)} tokens")
+        datasets = [Dataset.from_stdin(tokenizer, args.seq_len)]
+    for i, ds in enumerate(datasets):
+        print(f"Stage {i + 1}: {len(ds.tokens)} tokens")
 
     trainer = Trainer(
         config,
@@ -42,21 +47,34 @@ def cmd_train(args: argparse.Namespace) -> int:
         grad_clip=args.grad_clip,
         grad_accum_steps=args.grad_accum,
         warmup_steps=args.warmup_steps,
+        schedule=args.schedule,
+        doc_masking=not args.no_doc_masking,
     )
-    loader = DataLoader(
-        dataset,
-        args.batch_size,
-        shuffle=True,
-        rank=trainer.rank,
-        world_size=trainer.world_size,
-    )
-    print(f"Number of batches: {loader.num_batches()}")
+    loaders = [
+        DataLoader(
+            ds,
+            args.batch_size,
+            shuffle=True,
+            rank=trainer.rank,
+            world_size=trainer.world_size,
+        )
+        for ds in datasets
+    ]
+    total_steps = (
+        sum(loader.num_batches() for loader in loaders) // args.grad_accum
+    ) * args.epochs
 
     output = Path(args.output)
     output.mkdir(parents=True, exist_ok=True)
 
     resume_state = None
     if args.resume:
+        if len(loaders) > 1:
+            print(
+                "warning: --resume with multiple stages restarts from stage 1 "
+                "(cross-stage positions are not checkpointed)",
+                file=sys.stderr,
+            )
         resume_state = trainer.load_training_state(output)
         if resume_state is None:
             print("No resumable state found, starting fresh")
@@ -76,13 +94,20 @@ def cmd_train(args: argparse.Namespace) -> int:
         raw["vocab_size"] = tokenizer.vocab_size
         (output / "config.json").write_text(json.dumps(raw, indent=2))
 
-    completed = trainer.train(
-        loader,
-        args.epochs,
-        checkpoint_dir=output,
-        resume_state=resume_state,
-        max_steps=args.max_steps,
-    )
+    completed = True
+    for stage, loader in enumerate(loaders):
+        if len(loaders) > 1:
+            print(f"=== Stage {stage + 1}/{len(loaders)} ===")
+        completed = trainer.train(
+            loader,
+            args.epochs,
+            checkpoint_dir=output,
+            resume_state=resume_state if stage == 0 else None,
+            total_steps=total_steps,
+            max_steps=args.max_steps,
+        )
+        if not completed:
+            break
     if completed:
         if trainer.is_main:
             trainer.save_training_state(output, epoch=args.epochs, batch_position=0)
@@ -141,7 +166,22 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument("-t", "--tokenizer", required=True, help="Path to tokenizer.json")
     p.add_argument(
-        "-d", "--data", help="Training JSONL (.gz/.zst ok); stdin if omitted"
+        "-d",
+        "--data",
+        action="append",
+        help="Training JSONL (.gz/.zst ok); repeat for curriculum stages "
+        "trained sequentially; stdin if omitted",
+    )
+    p.add_argument(
+        "--schedule",
+        choices=["wsd", "cosine"],
+        default="wsd",
+        help="LR schedule (default: warmup-stable-decay)",
+    )
+    p.add_argument(
+        "--no-doc-masking",
+        action="store_true",
+        help="Let attention/SSM state cross packed-document boundaries",
     )
     p.add_argument("-o", "--output", default="checkpoints")
     p.add_argument("-b", "--batch-size", type=int, default=32)

--- a/hermes-train/src/hermes_train/config.py
+++ b/hermes-train/src/hermes_train/config.py
@@ -27,6 +27,8 @@ class AttentionDef:
     )
     window_size: int | None = None
     causal: bool = True
+    # Per-head RMSNorm on Q/K before RoPE (OLMo2/Gemma-style stabilizer)
+    qk_norm: bool = False
 
 
 @dataclass

--- a/hermes-train/src/hermes_train/data.py
+++ b/hermes-train/src/hermes_train/data.py
@@ -50,9 +50,12 @@ def _iter_texts(lines: Iterator[str]) -> Iterator[str]:
 class Dataset:
     """Flat EOS-joined token stream with fixed-window sampling."""
 
-    def __init__(self, tokens: np.ndarray, seq_len: int) -> None:
+    def __init__(
+        self, tokens: np.ndarray, seq_len: int, eos_token_id: int | None = None
+    ) -> None:
         self.tokens = tokens.astype(np.uint32, copy=False)
         self.seq_len = seq_len
+        self.eos_token_id = eos_token_id
 
     @classmethod
     def _from_lines(
@@ -62,7 +65,11 @@ class Dataset:
         for text in _iter_texts(lines):
             all_tokens.extend(tokenizer.encode(text))
             all_tokens.append(tokenizer.eos_token_id)
-        return cls(np.array(all_tokens, dtype=np.uint32), seq_len)
+        return cls(
+            np.array(all_tokens, dtype=np.uint32),
+            seq_len,
+            eos_token_id=tokenizer.eos_token_id,
+        )
 
     @classmethod
     def from_files(
@@ -87,11 +94,21 @@ class Dataset:
         return max(0, len(self.tokens) - self.seq_len)
 
     def get_batch(
-        self, indices: np.ndarray, device: torch.device
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+        self, indices: np.ndarray, device: torch.device, with_doc_ids: bool = False
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
         windows = np.stack([self.tokens[i : i + self.seq_len + 1] for i in indices])
         batch = torch.from_numpy(windows.astype(np.int64)).to(device)
-        return batch[:, :-1].contiguous(), batch[:, 1:].contiguous()
+        inputs = batch[:, :-1].contiguous()
+
+        doc_ids = None
+        if with_doc_ids and self.eos_token_id is not None:
+            # Token t belongs to document number = EOS count before position t
+            # within the window (EOS closes its document).
+            is_eos = (inputs == self.eos_token_id).long()
+            doc_ids = torch.zeros_like(inputs)
+            doc_ids[:, 1:] = is_eos[:, :-1].cumsum(dim=1)
+
+        return inputs, batch[:, 1:].contiguous(), doc_ids
 
 
 class DataLoader:

--- a/hermes-train/src/hermes_train/model.py
+++ b/hermes-train/src/hermes_train/model.py
@@ -5,17 +5,18 @@ the Candle ``VarMap`` names — checkpoints flow both ways with zero conversion:
 
     embedding.weight
     layers.{i}.attention.{q,k,v,o}_proj.weight[/bias]
+    layers.{i}.attention.{q,k}_norm.weight        (when qk_norm)
+    layers.{i}.ssm.{in,x,dt,out}_proj/conv1d/A_log/D  (Mamba blocks)
     layers.{i}.feed_forward.{gate,up,down}_proj.weight[/bias]
     layers.{i}.attn_norm.weight[/bias]
     layers.{i}.ffn_norm.weight[/bias]
     final_norm.weight[/bias]
-    lm_head.weight
+    lm_head.weight                                (absent when tie_weights)
 
 Math parity notes (vs model.rs):
 - RoPE is NeoX-style rotate-half with cos/sin duplicated across the head dim.
 - Norms compute in fp32 and cast back, like the Candle impls.
 - FFN activation mirrors model.rs: SiLU when SwiGLU, exact (erf) GELU otherwise.
-- lm_head is never weight-tied (Candle side keeps it separate).
 """
 
 from __future__ import annotations
@@ -122,8 +123,21 @@ class MultiHeadAttention(nn.Module):
         self.k_proj = nn.Linear(hidden, kv_dim, bias=bias)
         self.v_proj = nn.Linear(hidden, kv_dim, bias=bias)
         self.o_proj = nn.Linear(hidden, hidden, bias=bias)
+        # QK-Norm: per-head RMSNorm over head_dim, pre-RoPE
+        self.q_norm = (
+            RMSNorm(self.head_dim, block.norm_eps) if block.attention.qk_norm else None
+        )
+        self.k_norm = (
+            RMSNorm(self.head_dim, block.norm_eps) if block.attention.qk_norm else None
+        )
 
-    def forward(self, x: Tensor, rope: RotaryEmbedding, start_pos: int = 0) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        rope: RotaryEmbedding,
+        start_pos: int = 0,
+        doc_ids: Tensor | None = None,
+    ) -> Tensor:
         bsz, seq_len, _ = x.shape
 
         q = (
@@ -142,6 +156,9 @@ class MultiHeadAttention(nn.Module):
             .transpose(1, 2)
         )
 
+        if self.q_norm is not None:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
         q, k = rope(q, k, start_pos)
 
         # GQA: repeat KV heads
@@ -152,13 +169,21 @@ class MultiHeadAttention(nn.Module):
 
         attn_mask = None
         is_causal = self.causal and seq_len > 1
-        if self.window_size is not None and seq_len > 1:
-            # Combined causal + sliding-window additive mask
+        if seq_len > 1 and (self.window_size is not None or doc_ids is not None):
+            # Combined causal + sliding-window + document-boundary mask
             i = torch.arange(seq_len, device=x.device).unsqueeze(1)
             j = torch.arange(seq_len, device=x.device).unsqueeze(0)
-            allowed = (i - j).abs() <= self.window_size
+            allowed = torch.ones(seq_len, seq_len, dtype=torch.bool, device=x.device)
             if self.causal:
                 allowed &= j <= i
+            if self.window_size is not None:
+                allowed &= (i - j).abs() <= self.window_size
+            if doc_ids is not None:
+                # Block-diagonal: attention never crosses packed-document
+                # boundaries. [B, 1, S, S]
+                same_doc = doc_ids.unsqueeze(2) == doc_ids.unsqueeze(1)
+                allowed = allowed.unsqueeze(0) & same_doc
+                allowed = allowed.unsqueeze(1)
             attn_mask = torch.where(allowed, 0.0, float("-inf")).to(q.dtype)
             is_causal = False
 
@@ -245,21 +270,53 @@ class MambaMixer(nn.Module):
         with torch.no_grad():
             self.dt_proj.bias.copy_(inv_softplus_dt)
 
-    def forward(self, x: Tensor) -> Tensor:
-        if _selective_scan_fn is not None and x.is_cuda:
-            return self._forward_fused(x)
-        return self._forward_reference(x)
+    _warned_fused_doc_masking = False
 
-    def _forward_reference(self, x: Tensor) -> Tensor:
+    def forward(self, x: Tensor, doc_ids: Tensor | None = None) -> Tensor:
+        if _selective_scan_fn is not None and x.is_cuda:
+            if doc_ids is not None and not MambaMixer._warned_fused_doc_masking:
+                import warnings
+
+                warnings.warn(
+                    "fused selective_scan_fn does not support document-boundary "
+                    "state resets (Mamba-1 kernel has no seq_idx); SSM state "
+                    "crosses packed-document boundaries — attention layers still "
+                    "mask correctly",
+                    stacklevel=2,
+                )
+                MambaMixer._warned_fused_doc_masking = True
+            return self._forward_fused(x)
+        return self._forward_reference(x, doc_ids)
+
+    def _segment_conv(self, xs: Tensor, doc_ids: Tensor) -> Tensor:
+        """Depthwise causal conv that never mixes across document boundaries
+        (reference equivalent of the fused kernels' seq_idx)."""
+        _, _, seq_len = xs.shape
+        w = self.conv1d.weight  # [di, 1, k]
+        out = torch.zeros_like(xs)
+        for j in range(self.conv_kernel):
+            shift = self.conv_kernel - 1 - j  # source offset t-shift
+            x_sh = F.pad(xs, (shift, 0))[..., :seq_len]
+            if shift > 0:
+                same = torch.zeros(doc_ids.shape, dtype=torch.bool, device=xs.device)
+                same[:, shift:] = doc_ids[:, shift:] == doc_ids[:, :-shift]
+                x_sh = x_sh * same.unsqueeze(1)
+            out = out + w[:, 0, j].view(1, -1, 1) * x_sh
+        return out + self.conv1d.bias.view(1, -1, 1)
+
+    def _forward_reference(self, x: Tensor, doc_ids: Tensor | None = None) -> Tensor:
         _, seq_len, _ = x.shape
         in_dtype = x.dtype
 
         xz = self.in_proj(x)
         xs, z = xz.chunk(2, dim=-1)
 
-        # Depthwise causal conv over time
+        # Depthwise causal conv over time (segment-aware under doc masking)
         xs = xs.transpose(1, 2)  # [B, di, L]
-        xs = self.conv1d(F.pad(xs, (self.conv_kernel - 1, 0)))[..., :seq_len]
+        if doc_ids is not None:
+            xs = self._segment_conv(xs, doc_ids)
+        else:
+            xs = self.conv1d(F.pad(xs, (self.conv_kernel - 1, 0)))[..., :seq_len]
         xs = F.silu(xs.transpose(1, 2))  # [B, L, di]
 
         # Input-dependent Δ, B, C — scan in fp32
@@ -276,9 +333,20 @@ class MambaMixer(nn.Module):
         delta_a = torch.exp(delta.unsqueeze(-1) * a)  # [B, L, di, N]
         delta_bx = delta.unsqueeze(-1) * b_mat.unsqueeze(2) * xs_f.unsqueeze(-1)
 
+        # Document-boundary state resets: zero h where a new packed document
+        # starts, so recurrent memory never crosses documents.
+        reset = None
+        if doc_ids is not None:
+            starts = torch.ones_like(doc_ids, dtype=torch.bool)
+            starts[:, 1:] = doc_ids[:, 1:] != doc_ids[:, :-1]
+            starts[:, 0] = False  # h is already zero at t=0
+            reset = (~starts).float().unsqueeze(-1).unsqueeze(-1)  # [B, L, 1, 1]
+
         h = x.new_zeros(x.shape[0], self.d_inner, self.state_dim, dtype=torch.float32)
         ys = []
         for t in range(seq_len):
+            if reset is not None:
+                h = h * reset[:, t]
             h = delta_a[:, t] * h + delta_bx[:, t]
             ys.append((h * c_mat[:, t].unsqueeze(1)).sum(-1))
         y = torch.stack(ys, dim=1)  # [B, L, di]
@@ -339,19 +407,31 @@ class TransformerBlock(nn.Module):
         self.pre_norm = block.norm_position == "Pre"
         self.use_residual = block.residual
 
-    def _mix(self, x: Tensor, rope: RotaryEmbedding, start_pos: int) -> Tensor:
+    def _mix(
+        self,
+        x: Tensor,
+        rope: RotaryEmbedding,
+        start_pos: int,
+        doc_ids: Tensor | None,
+    ) -> Tensor:
         if self.ssm is not None:
-            return self.ssm(x)
-        return self.attention(x, rope, start_pos)
+            return self.ssm(x, doc_ids)
+        return self.attention(x, rope, start_pos, doc_ids)
 
-    def forward(self, x: Tensor, rope: RotaryEmbedding, start_pos: int = 0) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        rope: RotaryEmbedding,
+        start_pos: int = 0,
+        doc_ids: Tensor | None = None,
+    ) -> Tensor:
         if self.pre_norm:
-            h = self._mix(self.attn_norm(x), rope, start_pos)
+            h = self._mix(self.attn_norm(x), rope, start_pos, doc_ids)
             x = x + h if self.use_residual else h
             h = self.feed_forward(self.ffn_norm(x))
             return x + h if self.use_residual else h
         else:
-            h = self._mix(x, rope, start_pos)
+            h = self._mix(x, rope, start_pos, doc_ids)
             x = self.attn_norm(x + h if self.use_residual else h)
             h = self.feed_forward(x)
             return self.ffn_norm(x + h if self.use_residual else h)
@@ -362,6 +442,9 @@ class Transformer(nn.Module):
         super().__init__()
         self.config = config
         self.embedding = nn.Embedding(config.vocab_size, config.hidden_size)
+        # GPT-style init: nn.Embedding's default N(0,1) explodes initial
+        # logits (badly so with tied weights — init loss ~2x ln(V))
+        nn.init.normal_(self.embedding.weight, std=0.02)
 
         # Shared RoPE table: all attention blocks must agree (mirrors model.rs)
         attn_blocks = [
@@ -394,10 +477,15 @@ class Transformer(nn.Module):
         )
         self.rope = RotaryEmbedding(rope_head_dim, config.max_seq_len, rope_theta)
 
-    def forward(self, input_ids: Tensor, start_pos: int = 0) -> Tensor:
+    def forward(
+        self,
+        input_ids: Tensor,
+        start_pos: int = 0,
+        doc_ids: Tensor | None = None,
+    ) -> Tensor:
         x = self.embedding(input_ids)
         for layer in self.layers:
-            x = layer(x, self.rope, start_pos)
+            x = layer(x, self.rope, start_pos, doc_ids)
         x = self.final_norm(x)
         if self.lm_head is None:
             return F.linear(x, self.embedding.weight)

--- a/hermes-train/src/hermes_train/train.py
+++ b/hermes-train/src/hermes_train/train.py
@@ -52,6 +52,27 @@ def get_lr_with_warmup(
     return min_lr + coeff * (max_lr - min_lr)
 
 
+def get_lr_wsd(
+    step: int,
+    warmup_steps: int,
+    max_lr: float,
+    min_lr: float,
+    total_steps: int,
+    decay_frac: float = 0.1,
+) -> float:
+    """Warmup-Stable-Decay: flat peak LR for the bulk of training, cosine
+    decay only over the final `decay_frac` of steps. Makes mid-run extension
+    and multi-stage curricula sane (the 2026 default over cosine)."""
+    if step < warmup_steps:
+        return max_lr * (step / max(warmup_steps, 1))
+    decay_start = int(total_steps * (1.0 - decay_frac))
+    if step < decay_start:
+        return max_lr
+    decay_ratio = (step - decay_start) / max(total_steps - decay_start, 1)
+    coeff = 0.5 * (1.0 + math.cos(math.pi * min(decay_ratio, 1.0)))
+    return min_lr + coeff * (max_lr - min_lr)
+
+
 class Trainer:
     def __init__(
         self,
@@ -61,6 +82,8 @@ class Trainer:
         grad_clip: float = 1.0,
         grad_accum_steps: int = 1,
         warmup_steps: int = 1000,
+        schedule: str = "wsd",  # wsd | cosine
+        doc_masking: bool = True,
         device: torch.device | None = None,
     ) -> None:
         self.config = config
@@ -69,6 +92,8 @@ class Trainer:
         self.grad_clip = grad_clip
         self.grad_accum_steps = grad_accum_steps
         self.warmup_steps = warmup_steps
+        self.schedule = schedule
+        self.doc_masking = doc_masking
         self.global_step = 0
         self.interrupted = False
 
@@ -129,7 +154,8 @@ class Trainer:
             print(f"Frozen {frozen} parameter tensors")
 
     def _set_lr(self, total_steps: int) -> float:
-        lr = get_lr_with_warmup(
+        schedule_fn = get_lr_wsd if self.schedule == "wsd" else get_lr_with_warmup
+        lr = schedule_fn(
             self.global_step, self.warmup_steps, self.lr, self.lr * 0.1, total_steps
         )
         scale = lr / self.lr
@@ -140,13 +166,16 @@ class Trainer:
         return lr
 
     def _forward_loss(
-        self, input_ids: torch.Tensor, targets: torch.Tensor
+        self,
+        input_ids: torch.Tensor,
+        targets: torch.Tensor,
+        doc_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if self.autocast_dtype is not None:
             with torch.autocast(self.device.type, dtype=self.autocast_dtype):
-                logits = self.ddp_model(input_ids)
+                logits = self.ddp_model(input_ids, doc_ids=doc_ids)
                 return cross_entropy_loss(logits, targets)
-        logits = self.ddp_model(input_ids)
+        logits = self.ddp_model(input_ids, doc_ids=doc_ids)
         return cross_entropy_loss(logits, targets)
 
     def train(
@@ -202,10 +231,10 @@ class Trainer:
                     pbar.close()
                     return False
 
-                input_ids, targets = train_loader.dataset.get_batch(
-                    batch_indices, self.device
+                input_ids, targets, doc_ids = train_loader.dataset.get_batch(
+                    batch_indices, self.device, with_doc_ids=self.doc_masking
                 )
-                loss = self._forward_loss(input_ids, targets)
+                loss = self._forward_loss(input_ids, targets, doc_ids)
                 (loss / self.grad_accum_steps).backward()
                 accumulated_loss += loss.item()
 

--- a/hermes-train/tests/test_model.py
+++ b/hermes-train/tests/test_model.py
@@ -258,6 +258,71 @@ def test_hybrid_forward_and_train_step(hybrid_config):
     )
 
 
+def test_qk_norm(hybrid_config):
+    for b in hybrid_config.pattern:
+        b.attention.qk_norm = True
+    model = Transformer(hybrid_config)
+    keys = model.state_dict().keys()
+    # Attention layers (2, 5 under [ssm, ssm, attn]) get per-head norms
+    assert "layers.2.attention.q_norm.weight" in keys
+    assert "layers.5.attention.k_norm.weight" in keys
+    assert "layers.0.attention.q_norm.weight" not in keys  # ssm layer
+    # Weight is per-head-dim (32/4 heads = 8)
+    assert model.state_dict()["layers.2.attention.q_norm.weight"].shape == (8,)
+    out = model(torch.randint(0, hybrid_config.vocab_size, (2, 12)))
+    assert out.isfinite().all()
+
+
+def test_wsd_schedule():
+    from hermes_train.train import get_lr_wsd
+
+    total, warmup = 1000, 100
+    assert get_lr_wsd(0, warmup, 1.0, 0.1, total) == 0.0
+    assert get_lr_wsd(50, warmup, 1.0, 0.1, total) == pytest.approx(0.5)
+    # Stable plateau covers the bulk
+    for step in (100, 400, 899):
+        assert get_lr_wsd(step, warmup, 1.0, 0.1, total) == 1.0
+    # Decay tail reaches min
+    assert get_lr_wsd(1000, warmup, 1.0, 0.1, total) == pytest.approx(0.1)
+    assert 0.1 < get_lr_wsd(950, warmup, 1.0, 0.1, total) < 1.0
+
+
+def test_document_masking(hybrid_config):
+    """Positions past the conv tail in doc 2 must be independent of doc 1."""
+    from hermes_train.data import Dataset
+
+    eos = 0
+    # Two windows: identical after the boundary, different before it
+    a = np.array([5, 6, 7, eos, 10, 11, 12, 13, 14, 15], dtype=np.uint32)
+    b = np.array([8, 9, 3, eos, 10, 11, 12, 13, 14, 15], dtype=np.uint32)
+
+    ds = Dataset(a, seq_len=9, eos_token_id=eos)
+    ids_a, _, doc_a = ds.get_batch(
+        np.array([0]), torch.device("cpu"), with_doc_ids=True
+    )
+    assert doc_a.tolist() == [[0, 0, 0, 0, 1, 1, 1, 1, 1]]
+
+    torch.manual_seed(0)
+    model = Transformer(hybrid_config)
+    model.eval()
+    ids_b = torch.from_numpy(b[:9].astype("int64")).unsqueeze(0)
+
+    with torch.no_grad():
+        la = model(ids_a, doc_ids=doc_a)
+        lb = model(ids_b, doc_ids=doc_a)  # same boundary structure
+        la_nomask = model(ids_a)
+        lb_nomask = model(ids_b)
+
+    # Segment conv + SSM reset + attention mask → all of doc 2 is isolated
+    boundary = 4
+    isolated = slice(boundary, 9)
+    assert torch.allclose(la[:, isolated], lb[:, isolated], atol=1e-5), (
+        "doc 2 logits must not depend on doc 1 content"
+    )
+    # Sanity: without masking they DO depend on doc 1
+    assert not torch.allclose(la_nomask[:, isolated], lb_nomask[:, isolated], atol=1e-5)
+
+
 def test_tied_embeddings(hybrid_config, tmp_path):
     from safetensors.torch import load_file, save_file
 
@@ -283,6 +348,11 @@ def test_tied_embeddings(hybrid_config, tmp_path):
     loss = cross_entropy_loss(model(ids), ids)
     loss.backward()
     assert model.embedding.weight.grad is not None
+
+    # Sane init: tied logits shouldn't explode initial loss far past ln(V)
+    import math
+
+    assert loss.item() < math.log(hybrid_config.vocab_size) * 1.5
 
 
 def test_fused_kernel_dispatch(hybrid_config):


### PR DESCRIPTION
Follow-up to #35, implementing the 'adopt now' items from the SOTA research pass.

## What

- **WSD schedule** (new default; `--schedule cosine` reverts): flat peak LR, decay over the final 10% — the 2026 standard, and what makes multi-stage curricula correct
- **Document masking** (default on; `--no-doc-masking` disables): attention is block-diagonal across packed-doc boundaries, SSM hidden state resets at doc starts, and the reference scan uses a **segment-aware causal conv** (equivalent of the fused kernels' `seq_idx`). Test proves doc-2 logits are bit-independent of doc-1 content through the full hybrid stack. Honest caveat: the fused Mamba-1 kernel has no `seq_idx`, so SSM state crosses boundaries on the fused path (warns once); attention still masks correctly there
- **Curriculum stages**: `-d stage1.jsonl -d stage2.jsonl` trains sequentially under one schedule — WSD decay lands on the final, highest-quality stage (the 'save the best data for the end' recipe)
- **QK-Norm**: `qk_norm: true` in MAL attention defs → per-head RMSNorm on Q/K pre-RoPE, both engines, tensors `layers.{i}.attention.{q,k}_norm.weight`; stateful decode parity verified
- **Init fix** found by the stage smoke-test: `nn.Embedding` N(0,1) default exploded initial loss to ~17 (vs ln|V|≈8.3) through the tied head; GPT-style std=0.02 init, with a regression test
- `retriever-100m` now: qk_norm on, **106.83M params** exact

## Verification
- Rust 14/14 (qk_norm parse, tensor names, qk-norm stateful parity), clippy clean
- Python 16/16 (WSD schedule values, doc-isolation proof, qk-norm naming, init sanity), ruff clean
- Multi-stage + WSD smoke-trained end-to-end on the Shakespeare demo corpus