### PR TITLE
GPT-NeoX 50K tokenizer + special-token resolution for retriever-100m

### DIFF
--- a/hermes-llm/well-known/retriever_100m.mal
+++ b/hermes-llm/well-known/retriever_100m.mal
@@ -46,8 +46,8 @@ block mamba_block {
 }
 
 model retriever-100m {
-    description: "Hybrid Mamba+attention retriever model, ~107M params (tied embeddings)"
-    vocab_size: 32768
+    description: "Hybrid Mamba+attention retriever model, ~115M params (tied embeddings, GPT-NeoX 50K vocab)"
+    vocab_size: 50277
     max_seq_len: 8192
     hidden_size: 512
     num_layers: 24

--- a/hermes-train/src/hermes_train/tokenizer.py
+++ b/hermes-train/src/hermes_train/tokenizer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from tokenizers import Tokenizer as HfTokenizer
@@ -11,16 +12,26 @@ SPECIAL_TOKENS = ["<pad>", "<bos>", "<eos>", "<unk>"]
 
 
 class Tokenizer:
+    # Common special-token spellings across tokenizer families
+    _EOS_NAMES = ("<eos>", "<|endoftext|>", "</s>", "<|end_of_text|>", "<|eot_id|>")
+    _PAD_NAMES = ("<pad>", "<|padding|>", "<|pad|>")
+    _BOS_NAMES = ("<bos>", "<|begin_of_text|>", "<s>", "<|startoftext|>")
+
     def __init__(self, inner: HfTokenizer) -> None:
         self.inner = inner
         vocab_size = inner.get_vocab_size(True)
-        self.pad_token_id = self._special_id("<pad>", 0)
-        self.bos_token_id = self._special_id("<bos>", 1)
-        self.eos_token_id = self._special_id("<eos>", min(2, vocab_size - 1))
+        # EOS is load-bearing (document joins, doc-masking boundaries, stop):
+        # resolve it from known names before falling back to a raw id.
+        self.eos_token_id = self._first_id(self._EOS_NAMES, min(2, vocab_size - 1))
+        self.pad_token_id = self._first_id(self._PAD_NAMES, self.eos_token_id)
+        self.bos_token_id = self._first_id(self._BOS_NAMES, self.eos_token_id)
 
-    def _special_id(self, token: str, default: int) -> int:
-        token_id = self.inner.token_to_id(token)
-        return token_id if token_id is not None else default
+    def _first_id(self, names: tuple[str, ...], default: int) -> int:
+        for name in names:
+            token_id = self.inner.token_to_id(name)
+            if token_id is not None:
+                return token_id
+        return default
 
     @classmethod
     def from_file(cls, path: str | Path) -> Tokenizer:
@@ -60,11 +71,23 @@ def train_bpe(
         special_tokens=special_tokens or SPECIAL_TOKENS,
     )
 
-    def line_iterator():
+    def text_iterator():
+        # Accept JSONL ({"text": ...}) or plain text, streamed line by line so
+        # a multi-GB corpus never loads into memory at once.
         for path in inputs:
             with open_text(path) as f:
-                yield from (line for line in f if line.strip())
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    if line[0] == "{":
+                        try:
+                            yield json.loads(line).get("text", "")
+                            continue
+                        except json.JSONDecodeError:
+                            pass
+                    yield line
 
-    tokenizer.train_from_iterator(line_iterator(), trainer)
+    tokenizer.train_from_iterator(text_iterator(), trainer)
     tokenizer.save(output_path, pretty=True)
     return Tokenizer.from_file(output_path)

--- a/hermes-train/tests/test_model.py
+++ b/hermes-train/tests/test_model.py
@@ -273,6 +273,47 @@ def test_qk_norm(hybrid_config):
     assert out.isfinite().all()
 
 
+def test_tokenizer_special_name_resolution(tmp_path):
+    """EOS/PAD must resolve from family-specific special-token names, not
+    fall back to arbitrary ids (breaks doc masking + generation stop)."""
+    from hermes_train.tokenizer import Tokenizer
+    from tokenizers import Tokenizer as HfTok
+    from tokenizers import decoders, models, pre_tokenizers, trainers
+
+    # Build a small tokenizer whose specials use GPT-NeoX-style names
+    hf = HfTok(models.BPE())
+    hf.pre_tokenizer = pre_tokenizers.ByteLevel()
+    hf.decoder = decoders.ByteLevel()
+    tr = trainers.BpeTrainer(
+        vocab_size=300, special_tokens=["<|endoftext|>", "<|padding|>"]
+    )
+    hf.train_from_iterator(["lorem ipsum dolor sit amet " * 50], tr)
+    path = tmp_path / "neox.json"
+    hf.save(str(path))
+
+    tok = Tokenizer.from_file(path)
+    assert tok.eos_token_id == hf.token_to_id("<|endoftext|>")
+    assert tok.pad_token_id == hf.token_to_id("<|padding|>")
+
+
+def test_train_bpe_extracts_jsonl_text(tmp_path):
+    """train_bpe must tokenize the `text` field, not raw JSON syntax."""
+    import json as _json
+
+    from hermes_train.tokenizer import train_bpe
+
+    src = tmp_path / "corpus.jsonl"
+    with open(src, "w") as f:
+        for _ in range(50):
+            f.write(_json.dumps({"text": "the quick brown fox " * 20}) + "\n")
+    tok = train_bpe([str(src)], str(tmp_path / "tok.json"), vocab_size=280)
+    vocab = tok.inner.get_vocab()
+    # JSON structural tokens must not dominate the learned vocab
+    assert not any(t.strip("Ġ") in ('{"text":', '"text"') for t in vocab)
+    ids = tok.encode("the quick brown fox")
+    assert 0 < len(ids) < 10  # merged well, not char-level
+
+
 def test_wsd_schedule():
     from hermes_train.train import get_lr_wsd
 


### PR DESCRIPTION
Prep for the retriever-100m training run:
- Switch retriever-100m to the **GPT-NeoX-20B tokenizer** (50K vocab, byte-level BPE) — right-sized vs frontier 128-200K tokenizers for a small model; embedding table stays 22% of the 115.8M params
- Tokenizer wrapper resolves EOS/PAD/BOS from family special-token names (`<|endoftext|>`, `<|padding|>`, ...); GPT-NeoX EOS=0, not the old fallback id 2 (a real token) which would break doc masking + generation stop
- `train_bpe` extracts JSONL `text` (was tokenizing raw JSON), streamed
- tests for both

18/18 Python, Rust preset test green.