### PR TITLE
fix: delete partial outputs of failed merges/reorders + periodic orphan sweep

### DIFF
--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3255,3 +3255,96 @@ async fn test_reorder_skips_segment_consumed_by_merge() {
         "reordering a merged-away segment duplicated its documents"
     );
 }
+
+/// Regression: failed merge/reorder passes leaked their partial output
+/// files — a panicking deepening pass copied ~66 GiB per attempt and the
+/// files were never deleted (1.7 TB of orphans accumulated overnight in
+/// production; 108 orphan segments vs 7 live). Pins both defenses:
+/// a failed reorder deletes its output, and `cleanup_orphan_segments`
+/// sweeps stray segment files while leaving live segments intact.
+#[tokio::test]
+async fn test_failed_reorder_leaves_no_orphan_files() {
+    use crate::directories::Directory;
+
+    let (schema, _title, sparse) = bmp_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+    let index = Index::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    let mut writer = index.writer();
+    for i in 0..200u32 {
+        let mut doc = Document::new();
+        doc.add_sparse_vector(sparse, vec![(i, 1.0), (50_000 + i % 5, 0.5)]);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    async fn seg_files(dir: &RamDirectory) -> Vec<String> {
+        let mut ids: Vec<String> = dir
+            .list_files(std::path::Path::new(""))
+            .await
+            .unwrap()
+            .into_iter()
+            .filter_map(|p| {
+                let n = p.to_string_lossy().to_string();
+                n.starts_with("seg_").then(|| n[4..36].to_string())
+            })
+            .collect();
+        ids.sort();
+        ids.dedup();
+        ids
+    }
+
+    let victim = {
+        let segs = index.segment_readers().await.unwrap();
+        crate::segment::SegmentId(segs[0].meta().id).to_hex()
+    };
+
+    // Failed pass must not leave output files: delete the source's files
+    // (still in metadata — prod's ENOENT state) and reorder it.
+    crate::segment::delete_segment(&dir, crate::segment::SegmentId::from_hex(&victim).unwrap())
+        .await
+        .unwrap();
+    let before = seg_files(&dir).await;
+    let err = index
+        .segment_manager()
+        .reorder_single_segment(&victim, None, crate::segment::BpBudget::full())
+        .await;
+    assert!(err.is_err(), "reorder of a fileless segment must fail");
+    assert_eq!(
+        seg_files(&dir).await,
+        before,
+        "failed reorder must delete its partial output files"
+    );
+
+    // Sweep: stray segment files (failed-pass leftovers) are deleted...
+    let orphan_hex = "00000000000000000000000000000abc";
+    use crate::directories::DirectoryWriter;
+    dir.write(
+        std::path::Path::new(&format!("seg_{orphan_hex}.store")),
+        b"junk",
+    )
+    .await
+    .unwrap();
+    dir.write(
+        std::path::Path::new(&format!("seg_{orphan_hex}.sparse")),
+        b"junk",
+    )
+    .await
+    .unwrap();
+    let swept = index
+        .segment_manager()
+        .cleanup_orphan_segments()
+        .await
+        .unwrap();
+    assert!(swept >= 1, "orphan sweep must delete stray segment files");
+    let after = seg_files(&dir).await;
+    assert!(
+        !after.contains(&orphan_hex.to_string()),
+        "orphan files must be gone"
+    );
+}

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -499,6 +499,9 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                         ids,
                         e
                     );
+                    // Delete whatever the failed merge wrote — partial
+                    // outputs are invisible to metadata and leak disk.
+                    let _ = crate::segment::delete_segment(sm.directory.as_ref(), output_id).await;
                 }
             }
             // _guard drops here → segment IDs unregistered from inventory
@@ -810,7 +813,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
             let trained_snap = self.trained();
             let granularity = self.merge_granularity(&batch).await;
-            let (new_segment_id, total_docs, bp_converged) = Self::do_merge(
+            let merge_result = Self::do_merge(
                 self.directory.as_ref(),
                 &self.schema,
                 &batch,
@@ -823,7 +826,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 self.bp_memory_budget_bytes,
                 Some(self.background_cpu_pool()),
             )
-            .await?;
+            .await;
+            let (new_segment_id, total_docs, bp_converged) = match merge_result {
+                Ok(v) => v,
+                Err(e) => {
+                    // Delete the failed merge's partial output (leaks disk).
+                    let _ =
+                        crate::segment::delete_segment(self.directory.as_ref(), output_id).await;
+                    return Err(e);
+                }
+            };
 
             self.replace_segments(
                 &batch,
@@ -982,7 +994,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             }
         }
 
-        let (new_id, total_docs, bp_converged) = crate::segment::reorder::reorder_segment(
+        let reorder_result = crate::segment::reorder::reorder_segment(
             self.directory.as_ref(),
             &self.schema,
             source_id,
@@ -993,7 +1005,18 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             granularity,
             rayon_pool,
         )
-        .await?;
+        .await;
+        let (new_id, total_docs, bp_converged) = match reorder_result {
+            Ok(v) => v,
+            Err(e) => {
+                // A failed pass may have copied tens of GB of files before
+                // dying (panicked BP passes leaked 1.7 TB of partial outputs
+                // overnight in production) — delete the output before
+                // propagating.
+                let _ = crate::segment::delete_segment(self.directory.as_ref(), output_id).await;
+                return Err(e);
+            }
+        };
 
         // A pass with a depth floor above block granularity has, by
         // definition, not converged to block-level order — record it as

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -28,6 +28,26 @@ use crate::structures::SparseFormat;
 /// `IndexConfig::default().bp_memory_budget_bytes`.
 pub const DEFAULT_MEMORY_BUDGET: usize = 24 * 1024 * 1024 * 1024;
 
+/// Unique prefix for a pass's spilled grid-run temp files.
+///
+/// MUST be unique per pass, not per (process, field): in a container the
+/// server is always PID 1 and every index's sparse field tends to share the
+/// same field id, so the old `pid_field` scheme collided across concurrent
+/// reorders (documents + social both spilling field 3) — passes overwrote
+/// each other's runs and deleted them on completion, failing the other pass
+/// with ENOENT after it had already copied tens of GB (orphaned outputs
+/// filled the production disk overnight).
+fn grid_run_prefix(field_id: u32) -> String {
+    static GRID_RUN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = GRID_RUN_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    format!(
+        "hermes_grid_run_{}_{}_{}",
+        std::process::id(),
+        field_id,
+        seq
+    )
+}
+
 /// Reorder granularity (see docs/block-level-reorder.md).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum BpGranularity {
@@ -1071,7 +1091,7 @@ pub(crate) fn reorder_bmp_field(
     let est_entries = total_source_terms.min(max_entries_in_memory);
     let mut grid_entries: Vec<(u32, u32, u8)> = Vec::with_capacity(est_entries);
     let mut run_files: Vec<std::path::PathBuf> = Vec::new();
-    let run_prefix = format!("hermes_grid_run_{}_{}", std::process::id(), field_id);
+    let run_prefix = grid_run_prefix(field_id);
 
     // Encode one output block: gather its records from source blocks and
     // serialize the V14 block layout. Pure function of `perm` + read-only
@@ -1396,4 +1416,20 @@ pub(crate) fn reorder_bmp_field(
     );
 
     Ok((writer, field_tocs, converged))
+}
+
+#[cfg(test)]
+mod grid_run_prefix_tests {
+    /// Regression: run prefixes were `pid_field` — identical for every pass
+    /// in a container (PID 1) reordering the same field id, so concurrent
+    /// passes clobbered and deleted each other's spill files (prod ENOENT).
+    #[test]
+    fn test_grid_run_prefix_unique_per_pass() {
+        let a = super::grid_run_prefix(3);
+        let b = super::grid_run_prefix(3);
+        assert_ne!(
+            a, b,
+            "two passes over the same field must not share spill files"
+        );
+    }
 }

--- a/hermes-server/src/optimizer.rs
+++ b/hermes-server/src/optimizer.rs
@@ -141,11 +141,6 @@ async fn scan_and_optimize(
             }
         };
 
-        // Skip indexes without reorder fields
-        if !index.schema().has_reorder_fields() {
-            continue;
-        }
-
         let writer = match registry.get_writer(&name).await {
             Ok(w) => w,
             Err(e) => {
@@ -159,6 +154,24 @@ async fn scan_and_optimize(
             let w = writer.read().await;
             Arc::clone(w.segment_manager())
         };
+
+        // Sweep orphan segment files (outputs of failed/panicked merges and
+        // reorders — observed leaking 1.7 TB overnight). In-flight outputs
+        // are protected by the merge inventory. Runs for every index, not
+        // just reorder-enabled ones: merges can fail anywhere.
+        match segment_manager.cleanup_orphan_segments().await {
+            Ok(0) => {}
+            Ok(n) => warn!(
+                "[optimizer] swept {} orphan segment(s) in '{}' (failed merge/reorder outputs)",
+                n, name
+            ),
+            Err(e) => debug!("[optimizer] orphan sweep failed for '{}': {}", name, e),
+        }
+
+        // Skip indexes without reorder fields
+        if !index.schema().has_reorder_fields() {
+            continue;
+        }
 
         // Fresh (never-reordered) segments first — they are typically small
         // memtable flushes that finish in sub-second passes.


### PR DESCRIPTION
Prod `/data2` hit 97% (1.9 TB index dir, 155 GiB live): failed/panicked reorder passes (the #34 u32 CSR panic) each copied ~66 GiB of segment files and died, the optimizer retried every cooldown, and nothing ever deleted the partial outputs — **108 orphan segments totaling 1,743 GiB** vs 7 live segments. (Emergency cleanup already freed 1.48 TB on the box with a 2h in-flight mtime guard.)

Three defenses:
1. `reorder_single_segment`, `spawn_merge`, and `force_merge` delete the pre-generated output segment's files when the pass fails (best-effort, covers panics — they surface as `Err` through the pool wrapper).
2. `cleanup_orphan_segments` existed but had **zero callers in the server** — the optimizer now sweeps every index once per scan interval. In-flight outputs remain protected by the merge inventory; sweeps that delete anything log loudly.
3. Regression test pins both: a failed reorder leaves the directory file-set unchanged, and the sweep removes stray `seg_` files while leaving live segments intact.

701 tests pass, clippy `-D warnings` clean.

---

**Root cause of the overnight failures found (second commit):** the failing passes were NOT the u32 CSR panic (1.8.54 was deployed) — spill-run temp files were named `hermes_grid_run_{pid}_{field}_{n}.tmp`, and in a container PID is always 1 while both indexes' sparse field is field 3, so **concurrent spilling reorders used identical temp file names**: they overwrote each other's runs and deleted them on completion → ENOENT at the k-way merge, seconds after 'spilled grid run N' (confirmed live: container /tmp full of `hermes_grid_run_1_3_*.tmp`). Each such failure orphaned the 36–66 GiB it had already copied. Prefix now carries a process-wide sequence; regression test pins uniqueness.