### PR TITLE
fix(docker): pinned stable builder — glibc mismatch broke the 1.8.55 image

### DIFF
--- a/hermes-server/Dockerfile
+++ b/hermes-server/Dockerfile
@@ -1,5 +1,11 @@
 # Build stage
-FROM rustlang/rust:nightly-slim AS builder
+# Fully pinned builder: exact Rust version AND the same Debian release as
+# the runtime stage below. The previous `rustlang/rust:nightly-slim` was a
+# moving tag on BOTH axes — when upstream rebased it from bookworm to
+# trixie (glibc 2.38), the binary stopped loading on the bookworm runtime
+# ("GLIBC_2.38 not found", prod CrashLoopBackOff 2026-07-15). The server
+# needs no nightly features; it builds on stable.
+FROM rust:1.96-slim-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
The 1.8.55 image CrashLoopBackOops at startup: `GLIBC_2.38 not found`.

`rustlang/rust:nightly-slim` is a moving tag on two axes — Rust toolchain *and* Debian base. Upstream rebased it from bookworm to trixie (glibc 2.38) between yesterday's and today's publishes, while the runtime stage is `debian:bookworm-slim` (glibc 2.36). No repo change was involved.

Fix: the server needs no nightly features (verified: `cargo +stable build -p hermes-server --release` succeeds on 1.96) — builder is now `rust:1.96-slim-bookworm`, an exact version on the same Debian release as the runtime. Immune to both kinds of upstream drift.

Prod is rolled back to the pinned 1.8.54 digest and healthy. After this merges + publishes, flip the deployment back to `:latest`.