### PR TITLE
Fix orphan segment cleanup and reorder requeue loop

### DIFF
--- a/docs/budgeted-reorder.md
+++ b/docs/budgeted-reorder.md
@@ -40,12 +40,14 @@ cold-IO writer, so at least they no longer evict the cache.
 - Larger: budgeted pass — depth capped at
   `--optimizer-partial-min-partition-docs` (default 4096) and wall-clock
   capped at `--optimizer-time-budget-secs` (default 600).
-- Unconverged segments (deadline fired) are revisited only when no
-  never-reordered work exists, at most one per
-  `--optimizer-unconverged-cooldown-secs` (default 1800) — each follow-up is
-  a full segment rewrite, so deepening is deliberately paced.
-- Merge-time reorder stays unbudgeted: the merge already pays the rewrite
-  and BP warm-starts from the (usually ordered) inputs.
+- Unconverged segments (deadline fired) are revisited alongside fresh work,
+  with at most one deepening pass active globally. After it completes, the
+  next pass waits `--optimizer-unconverged-cooldown-secs` (default 600).
+  Starting cooldown at completion is important because a full sparse rewrite
+  can outlast the BP deadline; starting it at launch caused the replacement
+  segment to be requeued immediately.
+- Merge-time reorder uses its own `--merge-bp-budget-secs` deadline. A
+  truncated output joins the same paced deepening ladder.
 
 Observability: `converged` in reorder logs, `bp_converged` in metadata, and
 the Grafana superblock/block skip-ratio panels are the quality metric — a
@@ -87,6 +89,10 @@ Semantics change for aggressive continuous background reordering:
   alongside fresh work. Deepening passes run **full depth** with the wall
   clock budget — warm-starting makes already-ordered prefixes nearly free,
   so each pass pushes deeper until one beats the clock and converges.
+  Only one deepening pass runs at a time, and its cooldown starts when the
+  complete rewrite finishes (success, error, cancellation, or panic), not
+  when it starts. This prevents long passes from continuously replacing and
+  immediately requeueing their own unconverged output.
 
 - **Merge fan-in default raised** (`TieredMergePolicy::large_scale()`
   `max_merge_at_once: 10 → 24`, baked in — no tuning flags): wide fan-in

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3235,6 +3235,24 @@ async fn test_reorder_skips_segment_consumed_by_merge() {
 
     writer.force_merge().await.unwrap();
 
+    // The replaced sources are absent from metadata but still protected by
+    // `_searcher`. Orphan cleanup must not bypass that deferred-deletion
+    // lifetime (production used to sweep these and log them as failed output).
+    let swept = index
+        .segment_manager()
+        .cleanup_orphan_segments()
+        .await
+        .unwrap();
+    assert_eq!(swept, 0, "snapshot-deferred sources are not orphans");
+    use crate::directories::Directory;
+    let files = dir.list_files(std::path::Path::new("")).await.unwrap();
+    assert!(
+        files
+            .iter()
+            .any(|path| path.to_string_lossy().contains(&victim)),
+        "snapshot must keep the retired source files alive"
+    );
+
     // Stale candidate: reorder the segment the merge just consumed.
     let reordered = index
         .segment_manager()

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -118,6 +118,39 @@ impl Drop for MergeGuard {
     }
 }
 
+/// Deletes an uncommitted merge/reorder output if its task unwinds.
+///
+/// Normal `Result::Err` paths delete outputs synchronously so callers observe
+/// a clean directory before returning. This guard covers the path those
+/// branches cannot: a panic after output files have been created. The cleanup
+/// callback re-checks metadata before deleting, so a panic after a successful
+/// metadata commit cannot remove a live segment.
+struct OutputCleanupGuard {
+    segment_id: SegmentId,
+    cleanup: Option<Arc<dyn Fn(SegmentId) + Send + Sync>>,
+}
+
+impl OutputCleanupGuard {
+    fn new(segment_id: SegmentId, cleanup: Arc<dyn Fn(SegmentId) + Send + Sync>) -> Self {
+        Self {
+            segment_id,
+            cleanup: Some(cleanup),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.cleanup = None;
+    }
+}
+
+impl Drop for OutputCleanupGuard {
+    fn drop(&mut self) {
+        if let Some(cleanup) = self.cleanup.take() {
+            cleanup(self.segment_id);
+        }
+    }
+}
+
 /// All mutable state behind the single async Mutex.
 struct ManagerState {
     metadata: IndexMetadata,
@@ -255,6 +288,50 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     .expect("failed to build background CPU pool"),
             )
         }))
+    }
+
+    /// Arm unwind cleanup for an output that is not visible in metadata yet.
+    fn output_cleanup_guard(self: &Arc<Self>, output_id: SegmentId) -> OutputCleanupGuard {
+        let manager = Arc::clone(self);
+        let cleanup: Arc<dyn Fn(SegmentId) + Send + Sync> = Arc::new(move |segment_id| {
+            let Ok(handle) = tokio::runtime::Handle::try_current() else {
+                log::warn!(
+                    "[segment_cleanup] runtime unavailable; partial output {} will be swept on startup",
+                    segment_id.to_hex(),
+                );
+                return;
+            };
+
+            let manager = Arc::clone(&manager);
+            handle.spawn(async move {
+                manager
+                    .delete_output_if_unregistered(segment_id, "task unwind")
+                    .await;
+            });
+        });
+
+        OutputCleanupGuard::new(output_id, cleanup)
+    }
+
+    /// Delete a failed output only if metadata did not make it live.
+    ///
+    /// `replace_segments` can fail while saving metadata. Rechecking under
+    /// `state` prevents cleanup from deleting an output that the in-memory
+    /// metadata already committed despite the reported I/O error.
+    async fn delete_output_if_unregistered(&self, output_id: SegmentId, reason: &str) {
+        let output_hex = output_id.to_hex();
+        let st = self.state.lock().await;
+        if st.metadata.has_segment(&output_hex) {
+            return;
+        }
+
+        log::warn!(
+            "[segment_cleanup] deleting uncommitted output {} after {}",
+            output_hex,
+            reason,
+        );
+        let _ = crate::segment::delete_segment(self.directory.as_ref(), output_id).await;
+        drop(st);
     }
 
     // ========================================================================
@@ -460,6 +537,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
         Some(tokio::spawn(async move {
             let _guard = guard;
+            let mut output_cleanup = sm.output_cleanup_guard(output_id);
 
             let trained_snap = sm.trained();
             let granularity = sm.merge_granularity(&ids).await;
@@ -480,7 +558,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
             match result {
                 Ok((new_id, doc_count, bp_converged)) => {
-                    if let Err(e) = sm
+                    match sm
                         .replace_segments(
                             &ids,
                             new_id,
@@ -490,7 +568,13 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                         )
                         .await
                     {
-                        log::error!("[merge] Failed to replace segments after merge: {:?}", e);
+                        Ok(()) => output_cleanup.disarm(),
+                        Err(e) => {
+                            sm.delete_output_if_unregistered(output_id, "replacement failure")
+                                .await;
+                            output_cleanup.disarm();
+                            log::error!("[merge] Failed to replace segments after merge: {:?}", e);
+                        }
                     }
                 }
                 Err(e) => {
@@ -502,6 +586,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     // Delete whatever the failed merge wrote — partial
                     // outputs are invisible to metadata and leak disk.
                     let _ = crate::segment::delete_segment(sm.directory.as_ref(), output_id).await;
+                    output_cleanup.disarm();
                 }
             }
             // _guard drops here → segment IDs unregistered from inventory
@@ -523,9 +608,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         reordered: bool,
         bp_converged: bool,
     ) -> Result<()> {
-        self.tracker.register(&new_id);
-
-        {
+        let ready_to_delete = {
             let mut st = self.state.lock().await;
             // Every source must still be live: callers hold the inventory
             // guard, so a missing source means a stale merge/reorder whose
@@ -543,6 +626,12 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     missing, new_id
                 )));
             }
+
+            // Register while holding `state`: snapshot acquisition follows
+            // the same state -> tracker lock order, so no reader can observe
+            // the new metadata ID before the tracker knows about it.
+            self.tracker.register(&new_id);
+
             // Compute generation from parents before removing them
             let parent_gen = old_ids
                 .iter()
@@ -565,9 +654,13 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             );
             // Mutation + persist must be atomic — keep under lock
             st.metadata.save(self.directory.as_ref()).await?;
-        }
 
-        let ready_to_delete = self.tracker.mark_for_deletion(old_ids);
+            // Keep `state` locked until retired sources enter the tracker.
+            // Otherwise orphan cleanup can observe them in the gap where they
+            // are absent from metadata but not yet marked as snapshot-deferred.
+            self.tracker.mark_for_deletion(old_ids)
+        };
+
         for segment_id in ready_to_delete {
             let _ = crate::segment::delete_segment(self.directory.as_ref(), segment_id).await;
         }
@@ -799,10 +892,19 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             let output_id = SegmentId::new();
             let output_hex = output_id.to_hex();
 
-            // Register batch + output in inventory so maybe_merge skips them.
+            // Register batch + output under `state`, matching orphan cleanup's
+            // deletion barrier and preventing a stale batch from starting.
             let mut all_ids = batch.clone();
             all_ids.push(output_hex);
-            let _guard = match self.merge_inventory.try_register(all_ids) {
+            let guard = {
+                let st = self.state.lock().await;
+                batch
+                    .iter()
+                    .all(|id| st.metadata.has_segment(id))
+                    .then(|| self.merge_inventory.try_register(all_ids))
+                    .flatten()
+            };
+            let _guard = match guard {
                 Some(g) => g,
                 None => {
                     // A background merge slipped in — wait for it, then retry the loop
@@ -810,6 +912,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     continue;
                 }
             };
+            let mut output_cleanup = self.output_cleanup_guard(output_id);
 
             let trained_snap = self.trained();
             let granularity = self.merge_granularity(&batch).await;
@@ -833,18 +936,27 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     // Delete the failed merge's partial output (leaks disk).
                     let _ =
                         crate::segment::delete_segment(self.directory.as_ref(), output_id).await;
+                    output_cleanup.disarm();
                     return Err(e);
                 }
             };
 
-            self.replace_segments(
-                &batch,
-                new_segment_id,
-                total_docs,
-                self.reorder_on_merge,
-                bp_converged,
-            )
-            .await?;
+            if let Err(e) = self
+                .replace_segments(
+                    &batch,
+                    new_segment_id,
+                    total_docs,
+                    self.reorder_on_merge,
+                    bp_converged,
+                )
+                .await
+            {
+                self.delete_output_if_unregistered(output_id, "replacement failure")
+                    .await;
+                output_cleanup.disarm();
+                return Err(e);
+            }
+            output_cleanup.disarm();
 
             // _guard drops here → segments unregistered from inventory
         }
@@ -969,21 +1081,13 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let source_ids = [seg_id.to_string()];
         let granularity = self.merge_granularity(&source_ids).await;
 
+        // Register while holding `state`, matching orphan cleanup's deletion
+        // barrier. Candidates are scanned ahead of time and can go stale: a
+        // merge may have consumed this segment since. Its files may even still
+        // be on disk (deferred deletion under a searcher snapshot) — reordering
+        // them would re-insert a duplicate copy of docs the merge output holds.
         let all_ids = vec![seg_id.to_string(), output_hex];
-        let _guard = match self.merge_inventory.try_register(all_ids) {
-            Some(g) => g,
-            None => {
-                log::debug!("[optimizer] segment {} in active merge, skipping", seg_id);
-                return Ok(false);
-            }
-        };
-
-        // The inventory guard only excludes CONCURRENT merges. Candidates are
-        // scanned ahead of time and can go stale: a merge may have consumed
-        // this segment since. Its files may even still be on disk (deferred
-        // deletion under a searcher snapshot) — reordering them would
-        // re-insert a duplicate copy of docs the merge output already holds.
-        {
+        let _guard = {
             let st = self.state.lock().await;
             if !st.metadata.has_segment(seg_id) {
                 log::info!(
@@ -992,7 +1096,17 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 );
                 return Ok(false);
             }
-        }
+
+            match self.merge_inventory.try_register(all_ids) {
+                Some(guard) => guard,
+                None => {
+                    log::debug!("[optimizer] segment {} in active merge, skipping", seg_id);
+                    return Ok(false);
+                }
+            }
+        };
+
+        let mut output_cleanup = self.output_cleanup_guard(output_id);
 
         let reorder_result = crate::segment::reorder::reorder_segment(
             self.directory.as_ref(),
@@ -1014,6 +1128,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 // overnight in production) — delete the output before
                 // propagating.
                 let _ = crate::segment::delete_segment(self.directory.as_ref(), output_id).await;
+                output_cleanup.disarm();
                 return Err(e);
             }
         };
@@ -1024,38 +1139,32 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         // full-depth (warm-started) pass. Depth caps are only used by the
         // optimizer's first pass on large segments.
         let ladder_converged = bp_converged && bp_budget.min_partition_docs.is_none();
-        self.replace_segments(
-            &[seg_id.to_string()],
-            new_id,
-            total_docs,
-            true,
-            ladder_converged,
-        )
-        .await?;
+        if let Err(e) = self
+            .replace_segments(
+                &[seg_id.to_string()],
+                new_id,
+                total_docs,
+                true,
+                ladder_converged,
+            )
+            .await
+        {
+            self.delete_output_if_unregistered(output_id, "replacement failure")
+                .await;
+            output_cleanup.disarm();
+            return Err(e);
+        }
+        output_cleanup.disarm();
 
         Ok(true)
     }
 
     /// Clean up orphan segment files not registered in metadata.
     ///
-    /// Non-blocking: reads both metadata and `merge_inventory` to determine which
-    /// segments are legitimate. In-flight merge outputs are protected by the inventory.
+    /// Non-blocking: reads metadata, `merge_inventory`, and snapshot-deferred
+    /// deletions to determine which segments are legitimate. In-flight outputs
+    /// and retired sources still held by readers are both protected.
     pub async fn cleanup_orphan_segments(&self) -> Result<usize> {
-        // Read BOTH sets under the same state lock to prevent TOCTOU:
-        // without this, a merge completing between the two reads could make
-        // its output segment invisible to both sets → wrongly deleted.
-        let (registered_set, in_merge_set) = {
-            let st = self.state.lock().await;
-            let registered = st
-                .metadata
-                .segment_metas
-                .keys()
-                .cloned()
-                .collect::<HashSet<String>>();
-            let in_merge = self.merge_inventory.snapshot();
-            (registered, in_merge)
-        };
-
         let mut orphan_ids: HashSet<String> = HashSet::new();
 
         if let Ok(entries) = self.directory.list_files(std::path::Path::new("")).await {
@@ -1063,20 +1172,36 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 let filename = entry.to_string_lossy();
                 if filename.starts_with("seg_") && filename.len() > 37 {
                     let hex_part = &filename[4..36];
-                    if !registered_set.contains(hex_part) && !in_merge_set.contains(hex_part) {
-                        orphan_ids.insert(hex_part.to_string());
-                    }
+                    orphan_ids.insert(hex_part.to_string());
                 }
             }
         }
 
         let mut deleted = 0;
         for hex_id in &orphan_ids {
-            if let Some(segment_id) = SegmentId::from_hex(hex_id)
-                && crate::segment::delete_segment(self.directory.as_ref(), segment_id)
+            // Revalidate immediately before deletion and keep `state` locked
+            // through the delete. All merge/reorder output registration also
+            // follows state -> inventory, so no new output can appear between
+            // this check and deletion.
+            let st = self.state.lock().await;
+            if st.metadata.has_segment(hex_id)
+                || self.merge_inventory.contains(hex_id)
+                || self.tracker.is_pending_deletion(hex_id)
+            {
+                continue;
+            }
+
+            let removed = if let Some(segment_id) = SegmentId::from_hex(hex_id) {
+                crate::segment::delete_segment(self.directory.as_ref(), segment_id)
                     .await
                     .is_ok()
-            {
+            } else {
+                false
+            };
+            // Make the deletion barrier explicit: output registration cannot
+            // proceed until the filesystem operation above has completed.
+            drop(st);
+            if removed {
                 deleted += 1;
             }
         }
@@ -1088,6 +1213,43 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[test]
+    fn output_cleanup_guard_runs_during_panic_unwind() {
+        let cleaned = Arc::new(AtomicBool::new(false));
+        let cleaned_in_callback = Arc::clone(&cleaned);
+        let cleanup: Arc<dyn Fn(SegmentId) + Send + Sync> = Arc::new(move |_| {
+            cleaned_in_callback.store(true, Ordering::SeqCst);
+        });
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = OutputCleanupGuard::new(SegmentId::new(), cleanup);
+            panic!("simulated reorder panic");
+        }));
+
+        assert!(result.is_err());
+        assert!(
+            cleaned.load(Ordering::SeqCst),
+            "partial output cleanup must run during unwind"
+        );
+    }
+
+    #[test]
+    fn output_cleanup_guard_disarms_after_commit() {
+        let cleaned = Arc::new(AtomicBool::new(false));
+        let cleaned_in_callback = Arc::clone(&cleaned);
+        let cleanup: Arc<dyn Fn(SegmentId) + Send + Sync> = Arc::new(move |_| {
+            cleaned_in_callback.store(true, Ordering::SeqCst);
+        });
+
+        {
+            let mut guard = OutputCleanupGuard::new(SegmentId::new(), cleanup);
+            guard.disarm();
+        }
+
+        assert!(!cleaned.load(Ordering::SeqCst));
+    }
 
     #[test]
     fn test_inventory_guard_drop_unregisters() {

--- a/hermes-server/src/optimizer.rs
+++ b/hermes-server/src/optimizer.rs
@@ -6,9 +6,8 @@
 //!
 //! Only indexes with `reorder` fields in their schema are considered.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use hermes_core::segment::BpBudget;
 use log::{debug, info, warn};
@@ -39,6 +38,57 @@ pub struct OptimizerConfig {
     pub unconverged_cooldown: Duration,
 }
 
+/// Global gate for expensive full-depth deepening passes.
+///
+/// Segment IDs change after every successful rewrite, so a per-ID cooldown
+/// cannot follow a segment lineage. The gate enforces the documented policy
+/// directly: at most one deepening pass is active, followed by a cooldown
+/// measured from completion. Measuring from start caused passes longer than
+/// the cooldown to requeue their replacement immediately and overlap another
+/// lineage, keeping background BP busy continuously.
+#[derive(Default)]
+struct DeepeningGate {
+    state: Mutex<DeepeningGateState>,
+}
+
+#[derive(Default)]
+struct DeepeningGateState {
+    in_flight: bool,
+    last_finished: Option<Instant>,
+}
+
+impl DeepeningGate {
+    fn try_acquire(self: &Arc<Self>, cooldown: Duration) -> Option<DeepeningPermit> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        if state.in_flight
+            || state
+                .last_finished
+                .is_some_and(|finished| finished.elapsed() < cooldown)
+        {
+            return None;
+        }
+
+        state.in_flight = true;
+        Some(DeepeningPermit {
+            gate: Arc::clone(self),
+        })
+    }
+}
+
+/// Completion-based permit. Drop runs on success, error, cancellation, and
+/// panic unwind, so the gate cannot become permanently wedged.
+struct DeepeningPermit {
+    gate: Arc<DeepeningGate>,
+}
+
+impl Drop for DeepeningPermit {
+    fn drop(&mut self) {
+        let mut state = self.gate.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.last_finished = Some(Instant::now());
+        state.in_flight = false;
+    }
+}
+
 /// Spawn the background optimizer loop.
 ///
 /// Returns a `JoinHandle` that runs until the server shuts down.
@@ -59,8 +109,8 @@ pub fn spawn_optimizer(
 
     let semaphore = Arc::new(Semaphore::new(config.threads));
 
-    // Bounded rayon pool for BP computation — prevents optimizer from
-    // saturating all CPU cores. Shared across all concurrent reorder tasks.
+    // Dedicated bounded rayon pool for BP computation, shared across all
+    // concurrent reorder tasks.
     //
     // Sized at max(threads, cores/2), NOT just `threads`: `threads` bounds
     // how many segments are rewritten concurrently (the semaphore), while
@@ -95,19 +145,13 @@ async fn optimizer_loop(
     // Initial delay: let the server finish startup before scanning.
     tokio::time::sleep(Duration::from_secs(5)).await;
 
-    // Unix millis of the last budgeted pass that may need a follow-up —
-    // paces warm-started deepening passes (each is a full segment rewrite).
-    let last_partial_pass = Arc::new(AtomicU64::new(0));
+    // A timed-out pass replaces its source with a new unconverged segment ID.
+    // Gate that lineage globally and start its cooldown only when work ends.
+    let deepening_gate = Arc::new(DeepeningGate::default());
 
     loop {
-        if let Err(e) = scan_and_optimize(
-            &registry,
-            &semaphore,
-            &rayon_pool,
-            &config,
-            &last_partial_pass,
-        )
-        .await
+        if let Err(e) =
+            scan_and_optimize(&registry, &semaphore, &rayon_pool, &config, &deepening_gate).await
         {
             warn!("[optimizer] scan failed: {}", e);
         }
@@ -127,7 +171,7 @@ async fn scan_and_optimize(
     semaphore: &Arc<Semaphore>,
     rayon_pool: &Arc<rayon::ThreadPool>,
     config: &OptimizerConfig,
-    last_partial_pass: &Arc<AtomicU64>,
+    deepening_gate: &Arc<DeepeningGate>,
 ) -> Result<(), tonic::Status> {
     let index_names = registry.list_indexes().await?;
 
@@ -176,9 +220,9 @@ async fn scan_and_optimize(
         // Fresh (never-reordered) segments first — they are typically small
         // memtable flushes that finish in sub-second passes.
         let fresh = segment_manager.unreordered_segments().await;
-        let mut candidates: Vec<(String, u32, bool)> = fresh
+        let mut candidates: Vec<(String, u32, Option<DeepeningPermit>)> = fresh
             .into_iter()
-            .map(|(id, docs)| (id, docs, false))
+            .map(|(id, docs)| (id, docs, None))
             .collect();
 
         // Deepening is cooldown-paced but NOT starved by fresh work: under
@@ -188,22 +232,14 @@ async fn scan_and_optimize(
         // full segment rewrite; it warm-starts from the previous order and
         // deepens toward block-granularity).
         let unconverged = segment_manager.unconverged_segments().await;
-        if !unconverged.is_empty() {
-            let now_ms = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as u64;
-            let last = last_partial_pass.load(Ordering::Relaxed);
-            if now_ms.saturating_sub(last) >= config.unconverged_cooldown.as_millis() as u64 {
-                last_partial_pass.store(now_ms, Ordering::Relaxed);
-                if let Some((id, docs)) = unconverged.into_iter().next() {
-                    debug!(
-                        "[optimizer] index '{}': deepening unconverged segment {} ({} docs)",
-                        name, id, docs,
-                    );
-                    candidates.push((id, docs, true));
-                }
-            }
+        if let Some((id, docs)) = unconverged.into_iter().next()
+            && let Some(permit) = deepening_gate.try_acquire(config.unconverged_cooldown)
+        {
+            debug!(
+                "[optimizer] index '{}': deepening unconverged segment {} ({} docs)",
+                name, id, docs,
+            );
+            candidates.push((id, docs, Some(permit)));
         }
 
         if candidates.is_empty() {
@@ -216,7 +252,8 @@ async fn scan_and_optimize(
             candidates.len()
         );
 
-        for (seg_id, num_docs, is_deepening) in candidates {
+        for (seg_id, num_docs, deepening_permit) in candidates {
+            let is_deepening = deepening_permit.is_some();
             // Acquire semaphore permit to bound concurrency
             let permit = match semaphore.clone().acquire_owned().await {
                 Ok(p) => p,
@@ -266,6 +303,9 @@ async fn scan_and_optimize(
 
             tokio::spawn(async move {
                 let _permit = permit;
+                // Starts cooldown when the task finishes, not when it was
+                // queued. Also releases the in-flight gate on panic unwind.
+                let _deepening_permit = deepening_permit;
                 let start = std::time::Instant::now();
 
                 match sm.reorder_single_segment(&sid, Some(pool), budget).await {
@@ -295,4 +335,32 @@ async fn scan_and_optimize(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deepening_gate_blocks_overlap_and_cools_down_from_completion() {
+        let gate = Arc::new(DeepeningGate::default());
+
+        let first = gate
+            .try_acquire(Duration::from_secs(60))
+            .expect("first pass should start");
+        assert!(
+            gate.try_acquire(Duration::ZERO).is_none(),
+            "a second deepening pass must not overlap"
+        );
+
+        drop(first);
+        assert!(
+            gate.try_acquire(Duration::from_secs(60)).is_none(),
+            "cooldown must begin when the pass completes"
+        );
+        assert!(
+            gate.try_acquire(Duration::ZERO).is_some(),
+            "the gate should reopen after its cooldown"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- protect snapshot-deferred source segments from orphan sweeping and revalidate deletion against current metadata and merge inventory
- clean failed and panicked merge/reorder outputs with an unwind-safe guard
- serialize output registration with cleanup to close the deletion race
- allow only one unconverged deepening pass at a time and start its cooldown when the full rewrite finishes

No CPU-width cap is added. A configured 48-thread BP pass can still use 48 threads while active, but replacement outputs can no longer immediately overlap or requeue continuously.

## Production diagnosis
Rotated pod logs showed successful replacement chains with no panic or merge failure. The orphan sweeper deleted the same retired source batches that the snapshot tracker still held. Separately, 600-second BP deadlines produced unconverged replacement IDs, while cooldown was measured from launch; rewrites lasted longer than cooldown and their replacements were immediately selected again.

## Validation
- cargo test -p hermes-core --features native --lib: 703 passed, 7 ignored
- cargo test -p hermes-server: 2 passed
- strict hermes-core and hermes-server clippy passed; one unrelated existing too-many-arguments lint was allowed for the core run
- CI-style hermes-wasm build passed
- cargo fmt and git diff checks passed