### PR TITLE
Fix CubeCL cargo-machete false positive

### DIFF
--- a/hermes-llm/Cargo.toml
+++ b/hermes-llm/Cargo.toml
@@ -62,3 +62,8 @@ cuda = ["dep:burn-cuda", "dep:burn-cubecl", "dep:cubecl"]
 [[bin]]
 name = "hermes-llm"
 path = "src/main.rs"
+
+[package.metadata.cargo-machete]
+# `#[cube]` macro expansion requires the direct crate even though static source
+# analysis only sees it behind the GPU feature gates.
+ignored = ["cubecl"]


### PR DESCRIPTION
The Burn selective-scan kernel uses the direct `cubecl` crate through `#[cube]` expansion behind GPU feature gates. Cargo Machete cannot see that generated use, so document the dependency in package metadata.

Verified with:
- `cargo machete`
- `cargo check -p hermes-llm --all-features`
