### PR TITLE
fix(docker): include all workspace crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,6 +147,13 @@ jobs:
       - name: Wait for crates.io index
         run: sleep 30
 
+      - name: Publish hermes-mal
+        run: cargo publish -p hermes-mal --no-verify
+        continue-on-error: true
+
+      - name: Wait for crates.io index
+        run: sleep 30
+
       - name: Publish hermes-llm
         run: cargo publish -p hermes-llm --no-verify
         continue-on-error: true

--- a/hermes-server/Dockerfile
+++ b/hermes-server/Dockerfile
@@ -20,6 +20,9 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY hermes-core ./hermes-core
 COPY hermes-llm ./hermes-llm
+COPY hermes-mal ./hermes-mal
+COPY hermes-mal-py ./hermes-mal-py
+COPY hermes-train ./hermes-train
 COPY hermes-server ./hermes-server
 COPY hermes-tool ./hermes-tool
 COPY hermes-wasm ./hermes-wasm


### PR DESCRIPTION
## Summary
- copy every Cargo workspace member into the Docker builder context
- publish `hermes-mal` before dependent `hermes-llm` releases
- restore complete container and crates.io publishing after the MAL/training workspace expansion

## Failures fixed
- publish run 29404415531: Docker build could not find `/app/hermes-mal/Cargo.toml`
- the same run: `hermes-llm 1.8.58` could not resolve unpublished `hermes-mal` and was masked by `continue-on-error`

## Validation
- Dockerfile now covers all members listed in `[workspace].members`
- release dependency ordering is core → MAL → LLM → train/server/tool
- definitive container build will run in the Docker publisher (local Docker daemon is unavailable)