### PR TITLE
fix(train): saturate CUDA training kernels

### DIFF
--- a/hermes-llm/README.md
+++ b/hermes-llm/README.md
@@ -17,17 +17,18 @@ cargo build --release -p hermes-llm --features metal
 cargo build --release -p hermes-llm --features cuda
 ```
 
-Burn supplies embeddings, linear layers, normalization, grouped convolution,
-attention, and its optimized CubeCL kernels. Hermes adds one custom CubeCL
-operation for Mamba selective scan because Burn does not provide that operation.
-GPU tensors stay in the Burn/CubeCL runtime throughout inference.
+Burn supplies embeddings, linear layers, normalization, attention, and its
+optimized CubeCL kernels. Hermes adds fused CubeCL operators for Mamba's
+selective scan and depthwise convolution; Burn has no selective scan, while its
+generic grouped-convolution gradient launches once per channel. GPU tensors stay
+in the Burn/CubeCL runtime throughout inference and training.
 
 ## Generate text
 
 ```bash
 hermes-llm generate \
-  --checkpoint checkpoints/weights.safetensors \
-  --config checkpoints/config.json \
+  --checkpoint checkpoint/weights.safetensors \
+  --config checkpoint/config.json \
   --tokenizer tokenizer.json \
   --prompt "Once upon a time" \
   --max-tokens 100 \

--- a/hermes-llm/src/burn_model/attention.rs
+++ b/hermes-llm/src/burn_model/attention.rs
@@ -88,21 +88,28 @@ impl<B: Backend> MultiHeadAttention<B> {
         }
     }
 
-    fn apply_qk_norm(&self, q: Tensor<B, 4>, k: Tensor<B, 4>) -> (Tensor<B, 4>, Tensor<B, 4>) {
-        match (&self.q_norm, &self.k_norm) {
-            (Some(qn), Some(kn)) => (qn.forward(q), kn.forward(k)),
-            _ => (q, k),
-        }
-    }
-
-    /// Project x -> per-head Q,K,V, each [B, H|n_kv, S, head_dim].
-    fn qkv(&self, x: Tensor<B, 3>) -> (Tensor<B, 4>, Tensor<B, 4>, Tensor<B, 4>) {
+    /// Project and position per-head Q, K, and V tensors.
+    fn project_qkv(
+        &self,
+        x: Tensor<B, 3>,
+        rope: &RotaryEncoding<B>,
+        start_pos: usize,
+    ) -> (Tensor<B, 4>, Tensor<B, 4>, Tensor<B, 4>) {
         let [b, s, _] = x.dims();
         let split =
             |t: Tensor<B, 3>, heads: usize| t.reshape([b, s, heads, self.head_dim]).swap_dims(1, 2);
         let q = split(self.q_proj.forward(x.clone()), self.num_heads);
         let k = split(self.k_proj.forward(x.clone()), self.num_kv_heads);
         let v = split(self.v_proj.forward(x), self.num_kv_heads);
+        let (q, k) = match (&self.q_norm, &self.k_norm) {
+            (Some(q_norm), Some(k_norm)) => (q_norm.forward(q), k_norm.forward(k)),
+            _ => (q, k),
+        };
+        let (q, k) = if self.use_rope {
+            (rope.apply(q, start_pos), rope.apply(k, start_pos))
+        } else {
+            (q, k)
+        };
         (q, k, v)
     }
 
@@ -208,13 +215,7 @@ impl<B: Backend> MultiHeadAttention<B> {
         rope: &RotaryEncoding<B>,
         start_pos: usize,
     ) -> Tensor<B, 3> {
-        let (q, k, v) = self.qkv(x);
-        let (q, k) = self.apply_qk_norm(q, k);
-        let (q, k) = if self.use_rope {
-            (rope.apply(q, start_pos), rope.apply(k, start_pos))
-        } else {
-            (q, k)
-        };
+        let (q, k, v) = self.project_qkv(x, rope, start_pos);
         let out = self.sdpa(q, self.repeat_kv(k), self.repeat_kv(v), start_pos);
         self.o_proj.forward(self.merge_heads(out))
     }
@@ -228,13 +229,7 @@ impl<B: Backend> MultiHeadAttention<B> {
         start_pos: usize,
         cache: &mut AttnCache<B>,
     ) -> Tensor<B, 3> {
-        let (q, k, v) = self.qkv(x);
-        let (q, k) = self.apply_qk_norm(q, k);
-        let (q, k) = if self.use_rope {
-            (rope.apply(q, start_pos), rope.apply(k, start_pos))
-        } else {
-            (q, k)
-        };
+        let (q, k, v) = self.project_qkv(x, rope, start_pos);
 
         // Append to cache (pre-GQA-repeat).
         let k = match cache.k.take() {

--- a/hermes-llm/src/burn_model/backend.rs
+++ b/hermes-llm/src/burn_model/backend.rs
@@ -1,12 +1,12 @@
-//! Compile-time inference backend selection.
+//! Compile-time Burn backend selection.
 //!
 //! One compute stack, three targets, chosen at compile time by cargo feature:
 //! - `metal`   → wgpu (Metal on macOS, Vulkan/DX elsewhere)
 //! - `cuda`    → CUDA
-//! - neither             → ndarray (CPU; also the test/parity backend)
+//! - neither   → ndarray (CPU; also the test/parity backend)
 
-/// The active Burn backend for inference. Inference-only — never wrapped in
-/// `Autodiff` (no training graph, so no autodiff overhead).
+/// Active compute backend. `hermes-train` wraps it in Burn Autodiff; inference
+/// uses it directly without a training graph.
 #[cfg(feature = "metal")]
 pub type Backend = burn_wgpu::Wgpu;
 

--- a/hermes-llm/src/burn_model/block.rs
+++ b/hermes-llm/src/burn_model/block.rs
@@ -66,33 +66,41 @@ impl<B: MambaBackend> TransformerBlock<B> {
         }
     }
 
+    fn forward_with_mixer(
+        &self,
+        x: Tensor<B, 3>,
+        mut mix: impl FnMut(Tensor<B, 3>) -> Tensor<B, 3>,
+    ) -> Tensor<B, 3> {
+        let x = match self.norm_position {
+            NormPosition::Pre => {
+                let branch = mix(self.attn_norm.forward(x.clone()));
+                self.residual(x, branch)
+            }
+            NormPosition::Post => {
+                let branch = mix(x.clone());
+                self.attn_norm.forward(self.residual(x, branch))
+            }
+        };
+
+        match self.norm_position {
+            NormPosition::Pre => {
+                let branch = self.feed_forward.forward(self.ffn_norm.forward(x.clone()));
+                self.residual(x, branch)
+            }
+            NormPosition::Post => {
+                let branch = self.feed_forward.forward(x.clone());
+                self.ffn_norm.forward(self.residual(x, branch))
+            }
+        }
+    }
+
     pub fn forward(
         &self,
         x: Tensor<B, 3>,
         rope: &RotaryEncoding<B>,
         start_pos: usize,
     ) -> Tensor<B, 3> {
-        let x = match self.norm_position {
-            NormPosition::Pre => {
-                let h = self.mix(self.attn_norm.forward(x.clone()), rope, start_pos);
-                self.residual(x, h)
-            }
-            NormPosition::Post => {
-                let h = self.mix(x.clone(), rope, start_pos);
-                self.attn_norm.forward(self.residual(x, h))
-            }
-        };
-
-        match self.norm_position {
-            NormPosition::Pre => {
-                let h = self.feed_forward.forward(self.ffn_norm.forward(x.clone()));
-                self.residual(x, h)
-            }
-            NormPosition::Post => {
-                let h = self.feed_forward.forward(x.clone());
-                self.ffn_norm.forward(self.residual(x, h))
-            }
-        }
+        self.forward_with_mixer(x, |x| self.mix(x, rope, start_pos))
     }
 
     pub fn make_state(&self, batch: usize, device: &Device<B>) -> LayerState<B> {
@@ -110,39 +118,13 @@ impl<B: MambaBackend> TransformerBlock<B> {
         start_pos: usize,
         state: &mut LayerState<B>,
     ) -> Tensor<B, 3> {
-        let mix = |h: Tensor<B, 3>, state: &mut LayerState<B>| match (
-            &self.attention,
-            &self.ssm,
-            state,
-        ) {
+        self.forward_with_mixer(x, |x| match (&self.attention, &self.ssm, &mut *state) {
             (Some(attention), None, LayerState::Attn(cache)) => {
-                attention.forward_cached(h, rope, start_pos, cache)
+                attention.forward_cached(x, rope, start_pos, cache)
             }
-            (None, Some(ssm), LayerState::Mamba(mamba)) => ssm.forward_with_state(h, Some(mamba)),
+            (None, Some(ssm), LayerState::Mamba(mamba)) => ssm.forward_with_state(x, Some(mamba)),
             _ => panic!("layer state type does not match the configured mixer type"),
-        };
-
-        let x = match self.norm_position {
-            NormPosition::Pre => {
-                let h = mix(self.attn_norm.forward(x.clone()), state);
-                self.residual(x, h)
-            }
-            NormPosition::Post => {
-                let h = mix(x.clone(), state);
-                self.attn_norm.forward(self.residual(x, h))
-            }
-        };
-
-        match self.norm_position {
-            NormPosition::Pre => {
-                let h = self.feed_forward.forward(self.ffn_norm.forward(x.clone()));
-                self.residual(x, h)
-            }
-            NormPosition::Post => {
-                let h = self.feed_forward.forward(x.clone());
-                self.ffn_norm.forward(self.residual(x, h))
-            }
-        }
+        })
     }
 }
 

--- a/hermes-llm/src/burn_model/conv.rs
+++ b/hermes-llm/src/burn_model/conv.rs
@@ -156,6 +156,7 @@ mod gpu {
     use burn_cubecl::{CubeBackend, CubeRuntime};
 
     use super::{DepthwiseConv1dBackend, DepthwiseConv1dGradients};
+    use crate::burn_model::cube_tensor::{empty_like, into_contiguous};
 
     const ELEMENTWISE_THREADS: u32 = 256;
     const REDUCTION_THREADS: u32 = 32;
@@ -268,19 +269,6 @@ mod gpu {
         }
     }
 
-    fn contiguous<R: CubeRuntime>(tensor: CubeTensor<R>) -> CubeTensor<R> {
-        burn_cubecl::kernel::into_contiguous(tensor)
-    }
-
-    fn empty<R: CubeRuntime>(like: &CubeTensor<R>, shape: Shape) -> CubeTensor<R> {
-        burn_cubecl::ops::numeric::empty_device_contiguous_dtype(
-            like.client.clone(),
-            like.device.clone(),
-            shape,
-            like.dtype,
-        )
-    }
-
     impl<R, I, BT> DepthwiseConv1dBackend for CubeBackend<R, f32, I, BT>
     where
         R: CubeRuntime,
@@ -298,10 +286,10 @@ mod gpu {
             assert_eq!(group_channels, 1);
             assert!(input_len >= kernel_size);
             let output_len = input_len - kernel_size + 1;
-            let input = contiguous(input);
-            let weight = contiguous(weight);
-            let bias = contiguous(bias);
-            let output = empty(&input, Shape::new([batch, channels, output_len]));
+            let input = into_contiguous(input);
+            let weight = into_contiguous(weight);
+            let bias = into_contiguous(bias);
+            let output = empty_like(&input, Shape::new([batch, channels, output_len]));
             let total = (batch * channels * output_len) as u32;
             let client = input.client.clone();
             depthwise_conv1d_forward::launch::<R>(
@@ -329,12 +317,12 @@ mod gpu {
             let [_, _, kernel_size] = weight.meta.shape.dims();
             let [_, _, output_len] = grad.meta.shape.dims();
             assert_eq!(output_len, input_len - kernel_size + 1);
-            let input = contiguous(input);
-            let weight = contiguous(weight);
-            let grad = contiguous(grad);
-            let grad_input = empty(&input, Shape::new([batch, channels, input_len]));
-            let grad_weight = empty(&weight, Shape::new([channels, 1, kernel_size]));
-            let grad_bias = empty(&weight, Shape::new([channels]));
+            let input = into_contiguous(input);
+            let weight = into_contiguous(weight);
+            let grad = into_contiguous(grad);
+            let grad_input = empty_like(&input, Shape::new([batch, channels, input_len]));
+            let grad_weight = empty_like(&weight, Shape::new([channels, 1, kernel_size]));
+            let grad_bias = empty_like(&weight, Shape::new([channels]));
             let client = input.client.clone();
 
             let input_total = (batch * channels * input_len) as u32;
@@ -382,19 +370,7 @@ mod tests {
     use burn_wgpu::Wgpu;
 
     use super::depthwise_conv1d;
-
-    fn values(len: usize, scale: f32) -> Vec<f32> {
-        (0..len).map(|i| (i as f32 * scale).sin() * 0.25).collect()
-    }
-
-    fn max_diff(lhs: TensorData, rhs: TensorData) -> f32 {
-        lhs.to_vec::<f32>()
-            .unwrap()
-            .into_iter()
-            .zip(rhs.to_vec::<f32>().unwrap())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0, f32::max)
-    }
+    use crate::burn_model::test_support::{max_diff, values};
 
     #[test]
     fn fused_depthwise_conv1d_matches_ndarray_forward_and_backward() {
@@ -404,10 +380,10 @@ mod tests {
         let gpu = Default::default();
         let (batch, channels, input_len, kernel_size) = (2, 3, 7, 3);
         let output_len = input_len - kernel_size + 1;
-        let input_data = values(batch * channels * input_len, 0.13);
-        let weight_data = values(channels * kernel_size, 0.19);
-        let bias_data = values(channels, 0.23);
-        let output_weights = values(batch * channels * output_len, 0.29);
+        let input_data = values(batch * channels * input_len, 0.13, 0.0);
+        let weight_data = values(channels * kernel_size, 0.19, 0.0);
+        let bias_data = values(channels, 0.23, 0.0);
+        let output_weights = values(batch * channels * output_len, 0.29, 0.0);
 
         macro_rules! run {
             ($backend:ty, $device:expr) => {{

--- a/hermes-llm/src/burn_model/conv.rs
+++ b/hermes-llm/src/burn_model/conv.rs
@@ -1,0 +1,452 @@
+//! Fused depthwise Conv1d used by Mamba blocks.
+//!
+//! Burn's generic grouped-convolution weight gradient launches one convolution
+//! per group. Mamba has one group per channel, so GPU training uses dedicated
+//! CubeCL kernels while CPU keeps Burn's reference implementation.
+
+use burn::prelude::*;
+use burn::tensor::ops::ConvOptions;
+use burn::tensor::{TensorMetadata, TensorPrimitive, ops::FloatTensor};
+use burn_autodiff::Autodiff;
+use burn_autodiff::checkpoint::{base::Checkpointer, strategy::CheckpointStrategy};
+use burn_autodiff::grads::Gradients;
+use burn_autodiff::ops::{Backward, Ops, OpsKind};
+
+#[derive(Clone, Debug)]
+#[doc(hidden)]
+pub struct DepthwiseConv1dGradients<B: Backend> {
+    input: FloatTensor<B>,
+    weight: FloatTensor<B>,
+    bias: FloatTensor<B>,
+}
+
+pub trait DepthwiseConv1dBackend: Backend {
+    fn depthwise_conv1d_inner(
+        input: FloatTensor<Self>,
+        weight: FloatTensor<Self>,
+        bias: FloatTensor<Self>,
+    ) -> FloatTensor<Self> {
+        let channels = input.shape()[1];
+        Self::conv1d(
+            input,
+            weight,
+            Some(bias),
+            ConvOptions::new([1], [0], [1], channels),
+        )
+    }
+
+    fn depthwise_conv1d_backward(
+        input: FloatTensor<Self>,
+        weight: FloatTensor<Self>,
+        grad: FloatTensor<Self>,
+    ) -> DepthwiseConv1dGradients<Self> {
+        let channels = input.shape()[1];
+        let input_grad = Self::conv1d_x_backward(
+            input.clone(),
+            weight.clone(),
+            grad.clone(),
+            ConvOptions::new([1], [0], [1], channels),
+        );
+        let weight_grad = Self::conv1d_weight_backward(
+            input,
+            weight,
+            grad.clone(),
+            ConvOptions::new([1], [0], [1], channels),
+        );
+        let bias_grad = Tensor::<Self, 3>::from_primitive(TensorPrimitive::Float(grad))
+            .sum_dim(0)
+            .sum_dim(2)
+            .reshape([channels])
+            .into_primitive()
+            .tensor();
+        DepthwiseConv1dGradients {
+            input: input_grad,
+            weight: weight_grad,
+            bias: bias_grad,
+        }
+    }
+}
+
+pub(super) fn depthwise_conv1d<B: DepthwiseConv1dBackend>(
+    input: Tensor<B, 3>,
+    weight: Tensor<B, 3>,
+    bias: Tensor<B, 1>,
+) -> Tensor<B, 3> {
+    let output = B::depthwise_conv1d_inner(
+        input.into_primitive().tensor(),
+        weight.into_primitive().tensor(),
+        bias.into_primitive().tensor(),
+    );
+    Tensor::from_primitive(TensorPrimitive::Float(output))
+}
+
+impl DepthwiseConv1dBackend for burn_ndarray::NdArray {}
+
+#[derive(Clone, Debug)]
+struct DepthwiseConv1dState<B: DepthwiseConv1dBackend> {
+    input: FloatTensor<B>,
+    weight: FloatTensor<B>,
+}
+
+#[derive(Debug)]
+struct DepthwiseConv1dBackward;
+
+impl<B: DepthwiseConv1dBackend> Backward<B, 3> for DepthwiseConv1dBackward {
+    type State = DepthwiseConv1dState<B>;
+
+    fn backward(
+        self,
+        ops: Ops<Self::State, 3>,
+        grads: &mut Gradients,
+        _checkpointer: &mut Checkpointer,
+    ) {
+        let [node_input, node_weight, node_bias] = ops.parents;
+        let grad = grads.consume::<B>(&ops.node);
+        let output = B::depthwise_conv1d_backward(ops.state.input, ops.state.weight, grad);
+        for (node, grad) in [
+            (node_input, output.input),
+            (node_weight, output.weight),
+            (node_bias, output.bias),
+        ] {
+            if let Some(node) = node {
+                grads.register::<B>(node.id, grad);
+            }
+        }
+    }
+}
+
+impl<B: DepthwiseConv1dBackend, C: CheckpointStrategy> DepthwiseConv1dBackend for Autodiff<B, C> {
+    fn depthwise_conv1d_inner(
+        input: FloatTensor<Self>,
+        weight: FloatTensor<Self>,
+        bias: FloatTensor<Self>,
+    ) -> FloatTensor<Self> {
+        match DepthwiseConv1dBackward
+            .prepare::<C>([input.node.clone(), weight.node.clone(), bias.node.clone()])
+            .compute_bound()
+            .stateful()
+        {
+            OpsKind::Tracked(prep) => {
+                let output = B::depthwise_conv1d_inner(
+                    input.primitive.clone(),
+                    weight.primitive.clone(),
+                    bias.primitive,
+                );
+                let state = DepthwiseConv1dState {
+                    input: input.primitive,
+                    weight: weight.primitive,
+                };
+                prep.finish(state, output)
+            }
+            OpsKind::UnTracked(prep) => prep.finish(B::depthwise_conv1d_inner(
+                input.primitive,
+                weight.primitive,
+                bias.primitive,
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "metal", feature = "cuda"))]
+mod gpu {
+    use burn::tensor::Shape;
+    use burn_cubecl::cubecl::prelude::*;
+    use burn_cubecl::element::{BoolElement, IntElement};
+    use burn_cubecl::tensor::CubeTensor;
+    use burn_cubecl::{CubeBackend, CubeRuntime};
+
+    use super::{DepthwiseConv1dBackend, DepthwiseConv1dGradients};
+
+    const ELEMENTWISE_THREADS: u32 = 256;
+    const REDUCTION_THREADS: u32 = 32;
+
+    #[cube(launch)]
+    fn depthwise_conv1d_forward(
+        input: &Array<f32>,
+        weight: &Array<f32>,
+        bias: &Array<f32>,
+        output: &mut Array<f32>,
+        channels: u32,
+        input_len: u32,
+        output_len: u32,
+        #[comptime] kernel_size: usize,
+    ) {
+        let idx = ABSOLUTE_POS;
+        if idx < output.len() {
+            let output_len = output_len as usize;
+            let input_len = input_len as usize;
+            let channels = channels as usize;
+            let t = idx % output_len;
+            let channel_batch = idx / output_len;
+            let channel = channel_batch % channels;
+            let input_base = channel_batch * input_len + t;
+            let weight_base = channel * kernel_size;
+            let mut value = bias[channel];
+            for k in 0..kernel_size {
+                value += input[input_base + k] * weight[weight_base + k];
+            }
+            output[idx] = value;
+        }
+    }
+
+    #[cube(launch)]
+    fn depthwise_conv1d_backward_input(
+        weight: &Array<f32>,
+        grad: &Array<f32>,
+        grad_input: &mut Array<f32>,
+        channels: u32,
+        input_len: u32,
+        output_len: u32,
+        #[comptime] kernel_size: usize,
+    ) {
+        let idx = ABSOLUTE_POS;
+        if idx < grad_input.len() {
+            let input_len = input_len as usize;
+            let output_len = output_len as usize;
+            let channels = channels as usize;
+            let input_t = idx % input_len;
+            let channel_batch = idx / input_len;
+            let channel = channel_batch % channels;
+            let grad_base = channel_batch * output_len;
+            let weight_base = channel * kernel_size;
+            let mut value = 0.0f32;
+            for k in 0..kernel_size {
+                if input_t >= k {
+                    let t = input_t - k;
+                    if t < output_len {
+                        value += grad[grad_base + t] * weight[weight_base + k];
+                    }
+                }
+            }
+            grad_input[idx] = value;
+        }
+    }
+
+    #[cube(launch)]
+    fn depthwise_conv1d_backward_params(
+        input: &Array<f32>,
+        grad: &Array<f32>,
+        grad_weight: &mut Array<f32>,
+        grad_bias: &mut Array<f32>,
+        batch: u32,
+        channels: u32,
+        input_len: u32,
+        output_len: u32,
+        #[comptime] kernel_size: usize,
+    ) {
+        let param = CUBE_POS_X as usize;
+        let channel = param / kernel_size;
+        let k = param % kernel_size;
+        let lane = UNIT_POS_X as usize;
+        let batch = batch as usize;
+        let channels = channels as usize;
+        let input_len = input_len as usize;
+        let output_len = output_len as usize;
+        let sample_count = batch * output_len;
+        let mut weight_sum = 0.0f32;
+        let mut bias_sum = 0.0f32;
+        let mut sample = lane;
+        while sample < sample_count {
+            let batch_idx = sample / output_len;
+            let t = sample % output_len;
+            let grad_idx = (batch_idx * channels + channel) * output_len + t;
+            let grad_value = grad[grad_idx];
+            let input_idx = (batch_idx * channels + channel) * input_len + t + k;
+            weight_sum += grad_value * input[input_idx];
+            if k == 0 {
+                bias_sum += grad_value;
+            }
+            sample += REDUCTION_THREADS as usize;
+        }
+        let weight_sum = plane_sum(weight_sum);
+        let bias_sum = plane_sum(bias_sum);
+        if lane == 0 {
+            grad_weight[param] = weight_sum;
+            if k == 0 {
+                grad_bias[channel] = bias_sum;
+            }
+        }
+    }
+
+    fn contiguous<R: CubeRuntime>(tensor: CubeTensor<R>) -> CubeTensor<R> {
+        burn_cubecl::kernel::into_contiguous(tensor)
+    }
+
+    fn empty<R: CubeRuntime>(like: &CubeTensor<R>, shape: Shape) -> CubeTensor<R> {
+        burn_cubecl::ops::numeric::empty_device_contiguous_dtype(
+            like.client.clone(),
+            like.device.clone(),
+            shape,
+            like.dtype,
+        )
+    }
+
+    impl<R, I, BT> DepthwiseConv1dBackend for CubeBackend<R, f32, I, BT>
+    where
+        R: CubeRuntime,
+        I: IntElement,
+        BT: BoolElement,
+    {
+        fn depthwise_conv1d_inner(
+            input: CubeTensor<R>,
+            weight: CubeTensor<R>,
+            bias: CubeTensor<R>,
+        ) -> CubeTensor<R> {
+            let [batch, channels, input_len] = input.meta.shape.dims();
+            let [weight_channels, group_channels, kernel_size] = weight.meta.shape.dims();
+            assert_eq!(weight_channels, channels);
+            assert_eq!(group_channels, 1);
+            assert!(input_len >= kernel_size);
+            let output_len = input_len - kernel_size + 1;
+            let input = contiguous(input);
+            let weight = contiguous(weight);
+            let bias = contiguous(bias);
+            let output = empty(&input, Shape::new([batch, channels, output_len]));
+            let total = (batch * channels * output_len) as u32;
+            let client = input.client.clone();
+            depthwise_conv1d_forward::launch::<R>(
+                &client,
+                CubeCount::Static(total.div_ceil(ELEMENTWISE_THREADS), 1, 1),
+                CubeDim::new_1d(ELEMENTWISE_THREADS),
+                input.into_array_arg(),
+                weight.into_array_arg(),
+                bias.into_array_arg(),
+                output.clone().into_array_arg(),
+                channels as u32,
+                input_len as u32,
+                output_len as u32,
+                kernel_size,
+            );
+            output
+        }
+
+        fn depthwise_conv1d_backward(
+            input: CubeTensor<R>,
+            weight: CubeTensor<R>,
+            grad: CubeTensor<R>,
+        ) -> DepthwiseConv1dGradients<Self> {
+            let [batch, channels, input_len] = input.meta.shape.dims();
+            let [_, _, kernel_size] = weight.meta.shape.dims();
+            let [_, _, output_len] = grad.meta.shape.dims();
+            assert_eq!(output_len, input_len - kernel_size + 1);
+            let input = contiguous(input);
+            let weight = contiguous(weight);
+            let grad = contiguous(grad);
+            let grad_input = empty(&input, Shape::new([batch, channels, input_len]));
+            let grad_weight = empty(&weight, Shape::new([channels, 1, kernel_size]));
+            let grad_bias = empty(&weight, Shape::new([channels]));
+            let client = input.client.clone();
+
+            let input_total = (batch * channels * input_len) as u32;
+            depthwise_conv1d_backward_input::launch::<R>(
+                &client,
+                CubeCount::Static(input_total.div_ceil(ELEMENTWISE_THREADS), 1, 1),
+                CubeDim::new_1d(ELEMENTWISE_THREADS),
+                weight.into_array_arg(),
+                grad.clone().into_array_arg(),
+                grad_input.clone().into_array_arg(),
+                channels as u32,
+                input_len as u32,
+                output_len as u32,
+                kernel_size,
+            );
+            depthwise_conv1d_backward_params::launch::<R>(
+                &client,
+                CubeCount::Static((channels * kernel_size) as u32, 1, 1),
+                CubeDim::new_1d(REDUCTION_THREADS),
+                input.into_array_arg(),
+                grad.into_array_arg(),
+                grad_weight.clone().into_array_arg(),
+                grad_bias.clone().into_array_arg(),
+                batch as u32,
+                channels as u32,
+                input_len as u32,
+                output_len as u32,
+                kernel_size,
+            );
+
+            DepthwiseConv1dGradients {
+                input: grad_input,
+                weight: grad_weight,
+                bias: grad_bias,
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "metal"))]
+mod tests {
+    use burn::tensor::{Tensor, TensorData};
+    use burn_autodiff::Autodiff;
+    use burn_ndarray::NdArray;
+    use burn_wgpu::Wgpu;
+
+    use super::depthwise_conv1d;
+
+    fn values(len: usize, scale: f32) -> Vec<f32> {
+        (0..len).map(|i| (i as f32 * scale).sin() * 0.25).collect()
+    }
+
+    fn max_diff(lhs: TensorData, rhs: TensorData) -> f32 {
+        lhs.to_vec::<f32>()
+            .unwrap()
+            .into_iter()
+            .zip(rhs.to_vec::<f32>().unwrap())
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0, f32::max)
+    }
+
+    #[test]
+    fn fused_depthwise_conv1d_matches_ndarray_forward_and_backward() {
+        type Cpu = Autodiff<NdArray>;
+        type Gpu = Autodiff<Wgpu>;
+        let cpu = Default::default();
+        let gpu = Default::default();
+        let (batch, channels, input_len, kernel_size) = (2, 3, 7, 3);
+        let output_len = input_len - kernel_size + 1;
+        let input_data = values(batch * channels * input_len, 0.13);
+        let weight_data = values(channels * kernel_size, 0.19);
+        let bias_data = values(channels, 0.23);
+        let output_weights = values(batch * channels * output_len, 0.29);
+
+        macro_rules! run {
+            ($backend:ty, $device:expr) => {{
+                let input = Tensor::<$backend, 3>::from_data(
+                    TensorData::new(input_data.clone(), [batch, channels, input_len]),
+                    $device,
+                )
+                .require_grad();
+                let weight = Tensor::<$backend, 3>::from_data(
+                    TensorData::new(weight_data.clone(), [channels, 1, kernel_size]),
+                    $device,
+                )
+                .require_grad();
+                let bias = Tensor::<$backend, 1>::from_data(
+                    TensorData::new(bias_data.clone(), [channels]),
+                    $device,
+                )
+                .require_grad();
+                let output = depthwise_conv1d(input.clone(), weight.clone(), bias.clone());
+                let output_data = output.clone().inner().into_data();
+                let factors = Tensor::<$backend, 3>::from_data(
+                    TensorData::new(output_weights.clone(), [batch, channels, output_len]),
+                    $device,
+                );
+                let mut grads = (output * factors).sum().backward();
+                (
+                    output_data,
+                    input.grad_remove(&mut grads).unwrap().into_data(),
+                    weight.grad_remove(&mut grads).unwrap().into_data(),
+                    bias.grad_remove(&mut grads).unwrap().into_data(),
+                )
+            }};
+        }
+
+        let cpu = run!(Cpu, &cpu);
+        let gpu = run!(Gpu, &gpu);
+        assert!(max_diff(cpu.0, gpu.0) < 1e-5);
+        assert!(max_diff(cpu.1, gpu.1) < 1e-5);
+        assert!(max_diff(cpu.2, gpu.2) < 1e-4);
+        assert!(max_diff(cpu.3, gpu.3) < 1e-5);
+    }
+}

--- a/hermes-llm/src/burn_model/cube_tensor.rs
+++ b/hermes-llm/src/burn_model/cube_tensor.rs
@@ -1,0 +1,27 @@
+//! Shared allocation helpers for custom CubeCL operators.
+
+use burn::tensor::Shape;
+use burn_cubecl::CubeRuntime;
+use burn_cubecl::tensor::CubeTensor;
+
+pub(super) fn into_contiguous<R: CubeRuntime>(tensor: CubeTensor<R>) -> CubeTensor<R> {
+    burn_cubecl::kernel::into_contiguous(tensor)
+}
+
+pub(super) fn empty_like<R: CubeRuntime>(tensor: &CubeTensor<R>, shape: Shape) -> CubeTensor<R> {
+    burn_cubecl::ops::numeric::empty_device_contiguous_dtype(
+        tensor.client.clone(),
+        tensor.device.clone(),
+        shape,
+        tensor.dtype,
+    )
+}
+
+pub(super) fn zeros_like<R: CubeRuntime>(tensor: &CubeTensor<R>, shape: Shape) -> CubeTensor<R> {
+    burn_cubecl::ops::numeric::zeros_client(
+        tensor.client.clone(),
+        tensor.device.clone(),
+        shape,
+        tensor.dtype,
+    )
+}

--- a/hermes-llm/src/burn_model/mamba.rs
+++ b/hermes-llm/src/burn_model/mamba.rs
@@ -11,6 +11,7 @@ use burn_nn::{Linear, LinearConfig};
 
 use crate::mal::{ModelDef, SsmDef};
 
+use super::conv::depthwise_conv1d;
 use super::scan::{MambaBackend, selective_scan};
 
 /// Recurrent state for one Mamba layer.
@@ -138,7 +139,18 @@ impl<B: MambaBackend> MambaMixer<B> {
                 total - (self.conv_kernel - 1)..total,
             ]);
         }
-        let xs = silu(self.conv1d.forward(padded).swap_dims(1, 2));
+        let xs = silu(
+            depthwise_conv1d(
+                padded,
+                self.conv1d.weight.val(),
+                self.conv1d
+                    .bias
+                    .as_ref()
+                    .expect("Mamba depthwise convolution always has a bias")
+                    .val(),
+            )
+            .swap_dims(1, 2),
+        );
 
         // Input-dependent delta, B, C.
         let x_dbl = self.x_proj.forward(xs.clone());

--- a/hermes-llm/src/burn_model/mod.rs
+++ b/hermes-llm/src/burn_model/mod.rs
@@ -5,6 +5,8 @@ mod attention;
 pub mod backend;
 mod block;
 mod conv;
+#[cfg(any(feature = "metal", feature = "cuda"))]
+mod cube_tensor;
 mod ffn;
 mod mamba;
 mod norm;
@@ -21,6 +23,26 @@ pub use norm::Norm;
 pub use scan::MambaBackend;
 pub use transformer::Transformer;
 pub use weights::{load_safetensors, save_safetensors};
+
+#[cfg(all(test, feature = "metal"))]
+mod test_support {
+    use burn::tensor::TensorData;
+
+    pub(super) fn values(len: usize, scale: f32, offset: f32) -> Vec<f32> {
+        (0..len)
+            .map(|i| (i as f32 * scale).sin() * 0.25 + offset)
+            .collect()
+    }
+
+    pub(super) fn max_diff(lhs: TensorData, rhs: TensorData) -> f32 {
+        lhs.to_vec::<f32>()
+            .unwrap()
+            .into_iter()
+            .zip(rhs.to_vec::<f32>().unwrap())
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0, f32::max)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/hermes-llm/src/burn_model/mod.rs
+++ b/hermes-llm/src/burn_model/mod.rs
@@ -4,6 +4,7 @@
 mod attention;
 pub mod backend;
 mod block;
+mod conv;
 mod ffn;
 mod mamba;
 mod norm;

--- a/hermes-llm/src/burn_model/scan.rs
+++ b/hermes-llm/src/burn_model/scan.rs
@@ -10,6 +10,8 @@ use burn_autodiff::checkpoint::{base::Checkpointer, strategy::CheckpointStrategy
 use burn_autodiff::grads::Gradients;
 use burn_autodiff::ops::{Backward, Ops, OpsKind};
 
+use super::conv::DepthwiseConv1dBackend;
+
 #[derive(Clone, Debug)]
 #[doc(hidden)]
 pub struct ScanOutput<B: Backend> {
@@ -31,7 +33,7 @@ pub struct ScanGradients<B: Backend> {
 }
 
 /// Backend capability required by the Burn Mamba mixer.
-pub trait MambaBackend: Backend {
+pub trait MambaBackend: Backend + DepthwiseConv1dBackend {
     #[allow(clippy::too_many_arguments)]
     fn selective_scan_inner(
         delta: FloatTensor<Self>,

--- a/hermes-llm/src/burn_model/scan.rs
+++ b/hermes-llm/src/burn_model/scan.rs
@@ -426,6 +426,7 @@ mod gpu {
     use burn_cubecl::{CubeBackend, CubeRuntime};
 
     use super::{MambaBackend, ScanGradients, ScanOutput};
+    use crate::burn_model::cube_tensor::{empty_like, into_contiguous, zeros_like};
 
     const THREADS_PER_CUBE: u32 = 64;
 
@@ -589,28 +590,6 @@ mod gpu {
         }
     }
 
-    fn contiguous<R: CubeRuntime>(tensor: CubeTensor<R>) -> CubeTensor<R> {
-        burn_cubecl::kernel::into_contiguous(tensor)
-    }
-
-    fn empty<R: CubeRuntime>(like: &CubeTensor<R>, shape: Shape) -> CubeTensor<R> {
-        burn_cubecl::ops::numeric::empty_device_contiguous_dtype(
-            like.client.clone(),
-            like.device.clone(),
-            shape,
-            like.dtype,
-        )
-    }
-
-    fn zeros<R: CubeRuntime>(like: &CubeTensor<R>, shape: Shape) -> CubeTensor<R> {
-        burn_cubecl::ops::numeric::zeros_client(
-            like.client.clone(),
-            like.device.clone(),
-            shape,
-            like.dtype,
-        )
-    }
-
     impl<R, I, BT> MambaBackend for CubeBackend<R, f32, I, BT>
     where
         R: CubeRuntime,
@@ -629,17 +608,17 @@ mod gpu {
             save_states: bool,
         ) -> ScanOutput<Self> {
             let [batch, seq_len, channels] = xs.shape().dims();
-            let delta = contiguous(delta);
-            let xs = contiguous(xs);
-            let b_mat = contiguous(b_mat);
-            let c_mat = contiguous(c_mat);
-            let a = contiguous(a);
-            let d = contiguous(d);
-            let h = contiguous(h);
-            let y = empty(&xs, Shape::new([batch, seq_len, channels]));
-            let h_out = empty(&xs, Shape::new([batch, channels, state_dim]));
+            let delta = into_contiguous(delta);
+            let xs = into_contiguous(xs);
+            let b_mat = into_contiguous(b_mat);
+            let c_mat = into_contiguous(c_mat);
+            let a = into_contiguous(a);
+            let d = into_contiguous(d);
+            let h = into_contiguous(h);
+            let y = empty_like(&xs, Shape::new([batch, seq_len, channels]));
+            let h_out = empty_like(&xs, Shape::new([batch, channels, state_dim]));
             let states = if save_states {
-                empty(&xs, Shape::new([batch, seq_len, channels, state_dim]))
+                empty_like(&xs, Shape::new([batch, seq_len, channels, state_dim]))
             } else {
                 h_out.clone()
             };
@@ -685,22 +664,22 @@ mod gpu {
             state_dim: usize,
         ) -> ScanGradients<Self> {
             let [batch, seq_len, channels] = xs.shape().dims();
-            let delta = contiguous(delta);
-            let xs = contiguous(xs);
-            let b_mat = contiguous(b_mat);
-            let c_mat = contiguous(c_mat);
-            let a = contiguous(a);
-            let d = contiguous(d);
-            let h = contiguous(h);
-            let states = contiguous(states);
-            let grad_y = contiguous(grad_y);
-            let grad_delta = empty(&xs, Shape::new([batch, seq_len, channels]));
-            let grad_xs = empty(&xs, Shape::new([batch, seq_len, channels]));
-            let grad_b = zeros(&xs, Shape::new([batch, seq_len, state_dim]));
-            let grad_c = zeros(&xs, Shape::new([batch, seq_len, state_dim]));
-            let grad_a = zeros(&xs, Shape::new([channels, state_dim]));
-            let grad_d = zeros(&xs, Shape::new([channels]));
-            let grad_h = empty(&xs, Shape::new([batch, channels, state_dim]));
+            let delta = into_contiguous(delta);
+            let xs = into_contiguous(xs);
+            let b_mat = into_contiguous(b_mat);
+            let c_mat = into_contiguous(c_mat);
+            let a = into_contiguous(a);
+            let d = into_contiguous(d);
+            let h = into_contiguous(h);
+            let states = into_contiguous(states);
+            let grad_y = into_contiguous(grad_y);
+            let grad_delta = empty_like(&xs, Shape::new([batch, seq_len, channels]));
+            let grad_xs = empty_like(&xs, Shape::new([batch, seq_len, channels]));
+            let grad_b = zeros_like(&xs, Shape::new([batch, seq_len, state_dim]));
+            let grad_c = zeros_like(&xs, Shape::new([batch, seq_len, state_dim]));
+            let grad_a = zeros_like(&xs, Shape::new([channels, state_dim]));
+            let grad_d = zeros_like(&xs, Shape::new([channels]));
+            let grad_h = empty_like(&xs, Shape::new([batch, channels, state_dim]));
             let client = xs.client.clone();
 
             selective_scan_backward::launch::<R>(
@@ -753,21 +732,7 @@ mod tests {
     use burn_wgpu::Wgpu;
 
     use super::selective_scan;
-
-    fn values(len: usize, scale: f32, offset: f32) -> Vec<f32> {
-        (0..len)
-            .map(|i| (i as f32 * scale).sin() * 0.25 + offset)
-            .collect()
-    }
-
-    fn max_diff(lhs: TensorData, rhs: TensorData) -> f32 {
-        lhs.to_vec::<f32>()
-            .unwrap()
-            .into_iter()
-            .zip(rhs.to_vec::<f32>().unwrap())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0, f32::max)
-    }
+    use crate::burn_model::test_support::{max_diff, values};
 
     #[test]
     fn test_cubecl_selective_scan_matches_ndarray_reference() {

--- a/hermes-llm/src/burn_model/transformer.rs
+++ b/hermes-llm/src/burn_model/transformer.rs
@@ -241,9 +241,8 @@ impl<B: MambaBackend> Transformer<B> {
 
     /// Parameter IDs optimized by Muon during training.
     ///
-    /// This matches the original trainer's split: every 2D parameter inside a
-    /// transformer block uses Muon, while embeddings, the output head, norms,
-    /// biases, and convolution kernels remain on AdamW.
+    /// Every 2D parameter inside a transformer block uses Muon. Embeddings, the
+    /// output head, norms, biases, and convolution kernels remain on AdamW.
     pub fn muon_parameter_ids(&self) -> Vec<ParamId> {
         let mut visitor = MatrixParameterVisitor::default();
         for layer in &self.layers {

--- a/hermes-llm/src/lib.rs
+++ b/hermes-llm/src/lib.rs
@@ -10,9 +10,8 @@
 //! - **Tokenization**: HuggingFace `tokenizer.json` loading
 //! - **Export**: MAL → JSON model config
 //!
-//! Checkpoints are Burn-native safetensors with a single tensor-naming contract
-//! (`embedding.*`, `layers.{i}.attention.*`, `layers.{i}.feed_forward.*`,
-//! `final_norm.*`, `lm_head.*`) shared with `hermes-train`.
+//! Checkpoints are Burn-native safetensors written directly from the same
+//! [`Transformer`] module tree used by `hermes-train`, with no conversion layer.
 //!
 //! ## Quick Start
 //!

--- a/hermes-llm/src/main.rs
+++ b/hermes-llm/src/main.rs
@@ -17,15 +17,15 @@ struct Cli {
 enum Commands {
     /// Generate text from a trained model
     Generate {
-        /// Path to model checkpoint
+        /// Model weights path or remote URI
         #[arg(short, long)]
         checkpoint: String,
 
-        /// Path to model config
+        /// Model config path or remote URI
         #[arg(long)]
         config: String,
 
-        /// Path to tokenizer
+        /// Tokenizer path or remote URI
         #[arg(short, long)]
         tokenizer: String,
 

--- a/hermes-llm/src/remote.rs
+++ b/hermes-llm/src/remote.rs
@@ -82,8 +82,8 @@ mod imp {
             return Ok(dest);
         }
         tracing::info!("downloading {} …", uri);
-        // Atomic publish: write to a temp sibling then rename, so a concurrent
-        // or interrupted run never observes a partial cache file.
+        // Publish only after the complete object has been written and synced, so
+        // an interrupted run never exposes a partial cache file.
         let tmp = dest.with_extension("part");
         let size = download(uri, &tmp)?;
         std::fs::rename(&tmp, &dest)
@@ -146,22 +146,23 @@ pub use imp::resolve;
 /// The remote scheme of `uri` (`s3`, `gs`, `http`, `https`), or `None` for a
 /// local path or `file://`. Bare Windows drive letters (`C:\…`) are local.
 fn remote_scheme(uri: &str) -> Option<&'static str> {
-    let lower = uri.to_ascii_lowercase();
-    for scheme in ["s3://", "gs://", "gcs://", "http://", "https://"] {
-        if lower.starts_with(scheme) {
-            return Some(match scheme {
-                "s3://" => "s3",
-                "gs://" | "gcs://" => "gs",
-                "http://" => "http",
-                _ => "https",
-            });
-        }
-    }
-    None
+    [
+        ("s3://", "s3"),
+        ("gs://", "gs"),
+        ("gcs://", "gs"),
+        ("http://", "http"),
+        ("https://", "https"),
+    ]
+    .into_iter()
+    .find_map(|(prefix, scheme)| {
+        uri.get(..prefix.len())
+            .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
+            .then_some(scheme)
+    })
 }
 
-fn strip_file_scheme(uri: &str) -> String {
-    uri.strip_prefix("file://").unwrap_or(uri).to_string()
+fn strip_file_scheme(uri: &str) -> &str {
+    uri.strip_prefix("file://").unwrap_or(uri)
 }
 
 #[cfg(test)]

--- a/hermes-llm/src/remote.rs
+++ b/hermes-llm/src/remote.rs
@@ -30,8 +30,13 @@ mod imp {
 mod imp {
     use anyhow::{Context, Result};
     use std::collections::hash_map::DefaultHasher;
+    use std::fs::File;
     use std::hash::{Hash, Hasher};
+    use std::io::Write;
+    use std::ops::Range;
     use std::path::PathBuf;
+
+    pub(super) const DOWNLOAD_CHUNK_BYTES: u64 = 16 * 1024 * 1024;
 
     pub fn resolve(uri: &str) -> Result<PathBuf> {
         match super::remote_scheme(uri) {
@@ -77,24 +82,28 @@ mod imp {
             return Ok(dest);
         }
         tracing::info!("downloading {} …", uri);
-        let bytes = fetch(uri)?;
         // Atomic publish: write to a temp sibling then rename, so a concurrent
         // or interrupted run never observes a partial cache file.
         let tmp = dest.with_extension("part");
-        std::fs::write(&tmp, &bytes)
-            .with_context(|| format!("writing cache temp {}", tmp.display()))?;
+        let size = download(uri, &tmp)?;
         std::fs::rename(&tmp, &dest)
             .with_context(|| format!("publishing cache file {}", dest.display()))?;
         tracing::info!(
             "downloaded {} ({:.1} MiB) → {}",
             uri,
-            bytes.len() as f64 / (1024.0 * 1024.0),
+            size as f64 / (1024.0 * 1024.0),
             dest.display()
         );
         Ok(dest)
     }
 
-    fn fetch(uri: &str) -> Result<Vec<u8>> {
+    pub(super) fn ranges(size: u64) -> impl Iterator<Item = Range<u64>> {
+        (0..size)
+            .step_by(DOWNLOAD_CHUNK_BYTES as usize)
+            .map(move |start| start..(start + DOWNLOAD_CHUNK_BYTES).min(size))
+    }
+
+    fn download(uri: &str, dest: &std::path::Path) -> Result<u64> {
         use object_store::{ObjectStore, ObjectStoreExt};
 
         let url = url::Url::parse(uri).with_context(|| format!("parsing URI {uri}"))?;
@@ -108,14 +117,27 @@ mod imp {
             .enable_all()
             .build()
             .context("building download runtime")?;
-        let bytes = rt.block_on(async move {
-            let get = store
-                .get(&path)
+        let mut file = File::create(dest)
+            .with_context(|| format!("creating cache temp {}", dest.display()))?;
+        let size = rt.block_on(async move {
+            let size = store
+                .head(&path)
                 .await
-                .with_context(|| format!("GET {path}"))?;
-            get.bytes().await.context("reading object body")
+                .with_context(|| format!("HEAD {path}"))?
+                .size;
+            for range in ranges(size) {
+                let bytes = store
+                    .get_range(&path, range.clone())
+                    .await
+                    .with_context(|| format!("GET {path} bytes {}-{}", range.start, range.end))?;
+                file.write_all(&bytes)
+                    .with_context(|| format!("writing cache temp {}", dest.display()))?;
+            }
+            file.sync_all()
+                .with_context(|| format!("syncing cache temp {}", dest.display()))?;
+            anyhow::Ok(size)
         })?;
-        anyhow::Ok(bytes.to_vec())
+        Ok(size)
     }
 }
 
@@ -170,6 +192,23 @@ mod tests {
         assert_eq!(remote_scheme("https://h/k"), Some("https"));
         assert_eq!(remote_scheme("/local/path"), None);
         assert_eq!(remote_scheme("C:\\weights"), None);
+    }
+
+    #[cfg(feature = "remote")]
+    #[test]
+    fn download_ranges_cover_object_once() {
+        use super::imp::{DOWNLOAD_CHUNK_BYTES, ranges};
+
+        let size = DOWNLOAD_CHUNK_BYTES * 2 + 7;
+        let ranges = ranges(size).collect::<Vec<_>>();
+        assert_eq!(
+            ranges,
+            [
+                0..DOWNLOAD_CHUNK_BYTES,
+                DOWNLOAD_CHUNK_BYTES..DOWNLOAD_CHUNK_BYTES * 2,
+                DOWNLOAD_CHUNK_BYTES * 2..size,
+            ]
+        );
     }
 
     #[cfg(not(feature = "remote"))]

--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -43,7 +43,7 @@ The trainer uses Burn Autodiff with batched Muon updates for hidden 2D matrices
 and AdamW for embeddings, output weights, norms, biases, and convolution
 kernels. Muon uses a 20x learning rate; AdamW uses beta2 0.95; global gradient
 norm clipping covers both parameter sets. It supports cosine or
-warmup-stable-decay scheduling and fine-tuning from a Burn-native checkpoint.
+warmup-stable-decay scheduling and fine-tuning from Burn-native safetensors.
 On CUDA, Muon's Newton-Schulz iterations use BF16 while model parameters and
 optimizer state remain FP32.
 It atomically replaces the latest native checkpoint every 100 optimizer steps

--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -39,12 +39,13 @@ retaining the corpus in memory. Repeat `--data` to combine files. Samples never
 cross document boundaries. Set `--shuffle-buffer 0` only for ordered diagnostic
 runs.
 
-The trainer uses Burn Autodiff with Burn's Muon optimizer for hidden 2D matrices
+The trainer uses Burn Autodiff with batched Muon updates for hidden 2D matrices
 and AdamW for embeddings, output weights, norms, biases, and convolution
-kernels. This matches the original trainer's optimizer split, including Muon's
-20x learning rate, AdamW beta2 of 0.95, and global norm clipping. It supports
-cosine or warmup-stable-decay scheduling and fine-tuning from a Burn-native
-checkpoint.
+kernels. Muon uses a 20x learning rate; AdamW uses beta2 0.95; global gradient
+norm clipping covers both parameter sets. It supports cosine or
+warmup-stable-decay scheduling and fine-tuning from a Burn-native checkpoint.
+On CUDA, Muon's Newton-Schulz iterations use BF16 while model parameters and
+optimizer state remain FP32.
 It atomically replaces the latest native checkpoint every 100 optimizer steps
 by default; pass `--checkpoint-every 0` to save only at completion.
 On Mamba models, training and inference use fused CubeCL selective-scan kernels

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -7,12 +7,16 @@ use burn::module::{AutodiffModule, Module, ModuleVisitor, Param};
 use burn::tensor::backend::Backend as _;
 use burn::tensor::{Device, Int, Tensor, TensorData};
 use burn_autodiff::Autodiff;
-use burn_optim::{AdamWConfig, GradientsAccumulator, GradientsParams, MuonConfig, Optimizer};
+use burn_optim::{AdamWConfig, GradientsAccumulator, GradientsParams, Optimizer};
 use clap::{Parser, Subcommand, ValueEnum};
 use hermes_llm::{Backend, ModelDef, Tokenizer, Transformer, load_safetensors, save_safetensors};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
+
+mod muon;
+
+use muon::BatchedMuon;
 
 type TrainBackend = Autodiff<Backend>;
 
@@ -402,7 +406,7 @@ fn train(args: TrainArgs) -> Result<()> {
         !muon_parameter_ids.is_empty(),
         "model has no hidden matrix parameters for Muon"
     );
-    let mut muon_optimizer = MuonConfig::new().init();
+    let mut muon_optimizer = BatchedMuon::new(muon_parameter_ids.clone());
     let mut adamw_optimizer = AdamWConfig::new()
         .with_beta_1(0.9)
         .with_beta_2(0.95)
@@ -473,7 +477,7 @@ fn train(args: TrainArgs) -> Result<()> {
                         args.grad_clip,
                     )?;
                     let current = model.take().unwrap();
-                    let current = muon_optimizer.step(muon_lr, current, muon_grads);
+                    let current = muon_optimizer.step(muon_lr, current, muon_grads)?;
                     model = Some(adamw_optimizer.step(lr, current, adamw_grads));
                     step += 1;
                     let loss = loss_sum / args.grad_accum as f32;
@@ -569,7 +573,7 @@ mod tests {
         let muon_parameter_ids = model.muon_parameter_ids();
         assert!(!muon_parameter_ids.is_empty());
         assert!(muon_parameter_ids.len() < burn::module::list_param_ids(&model).len());
-        let mut muon_optimizer = MuonConfig::new().init();
+        let mut muon_optimizer = BatchedMuon::new(muon_parameter_ids.clone());
         let mut adamw_optimizer = AdamWConfig::new()
             .with_beta_2(0.95)
             .with_epsilon(1e-8)
@@ -602,7 +606,7 @@ mod tests {
             let norm =
                 gradient_norm_and_clip(&model, &mut muon_grads, &mut adamw_grads, 1.0).unwrap();
             assert!(norm.is_finite());
-            model = muon_optimizer.step(2e-2, model, muon_grads);
+            model = muon_optimizer.step(2e-2, model, muon_grads).unwrap();
             model = adamw_optimizer.step(1e-3, model, adamw_grads);
         }
         assert!(

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -279,6 +279,15 @@ impl ModuleVisitor<TrainBackend> for SquaredGradientNorm<'_> {
     }
 }
 
+fn squared_gradient_norm(
+    model: &Transformer<TrainBackend>,
+    grads: &GradientsParams,
+) -> Option<Tensor<Backend, 1>> {
+    let mut visitor = SquaredGradientNorm { grads, sum: None };
+    model.visit(&mut visitor);
+    visitor.sum
+}
+
 struct GradientScaler<'a> {
     grads: &'a mut GradientsParams,
     scale: f32,
@@ -294,23 +303,20 @@ impl ModuleVisitor<TrainBackend> for GradientScaler<'_> {
     }
 }
 
+fn scale_gradients(model: &Transformer<TrainBackend>, grads: &mut GradientsParams, scale: f32) {
+    model.visit(&mut GradientScaler { grads, scale });
+}
+
 fn gradient_norm_and_clip(
     model: &Transformer<TrainBackend>,
     muon_grads: &mut GradientsParams,
     adamw_grads: &mut GradientsParams,
     max_norm: f32,
 ) -> Result<f32> {
-    let mut muon_norm = SquaredGradientNorm {
-        grads: muon_grads,
-        sum: None,
-    };
-    model.visit(&mut muon_norm);
-    let mut adamw_norm = SquaredGradientNorm {
-        grads: adamw_grads,
-        sum: None,
-    };
-    model.visit(&mut adamw_norm);
-    let sum = match (muon_norm.sum, adamw_norm.sum) {
+    let sum = match (
+        squared_gradient_norm(model, muon_grads),
+        squared_gradient_norm(model, adamw_grads),
+    ) {
         (Some(muon), Some(adamw)) => muon + adamw,
         (Some(sum), None) | (None, Some(sum)) => sum,
         (None, None) => return Ok(0.0),
@@ -318,14 +324,8 @@ fn gradient_norm_and_clip(
     let norm = sum.sqrt().into_data().to_vec::<f32>()?[0];
     if max_norm > 0.0 && norm > max_norm {
         let scale = max_norm / norm;
-        model.visit(&mut GradientScaler {
-            grads: muon_grads,
-            scale,
-        });
-        model.visit(&mut GradientScaler {
-            grads: adamw_grads,
-            scale,
-        });
+        scale_gradients(model, muon_grads, scale);
+        scale_gradients(model, adamw_grads, scale);
     }
     Ok(norm)
 }

--- a/hermes-train/src/muon.rs
+++ b/hermes-train/src/muon.rs
@@ -15,11 +15,6 @@ const NS_COEFFICIENTS: (f64, f64, f64) = (3.4445, -4.775, 2.0315);
 const NS_STEPS: usize = 5;
 const EPSILON: f64 = 1e-7;
 
-struct GroupState {
-    ids: Vec<ParamId>,
-    velocity: Tensor<Backend, 3>,
-}
-
 /// Muon with Burn's update and hyperparameters, batched by matrix shape.
 ///
 /// Burn's generic optimizer visits every parameter separately. Transformer
@@ -29,14 +24,14 @@ struct GroupState {
 /// compute dtype, while parameters and momentum remain FP32.
 pub struct BatchedMuon {
     parameter_ids: Vec<ParamId>,
-    groups: BTreeMap<[usize; 2], GroupState>,
+    velocities: BTreeMap<[usize; 2], Tensor<Backend, 3>>,
 }
 
 impl BatchedMuon {
     pub fn new(parameter_ids: Vec<ParamId>) -> Self {
         Self {
             parameter_ids,
-            groups: BTreeMap::new(),
+            velocities: BTreeMap::new(),
         }
     }
 
@@ -61,21 +56,11 @@ impl BatchedMuon {
 
         let mut updates = GradientsParams::new();
         for (shape, batch) in batches {
-            let ids = batch.iter().map(|(id, _)| *id).collect::<Vec<_>>();
-            let gradients = batch
-                .into_iter()
-                .map(|(_, gradient)| gradient)
-                .collect::<Vec<_>>();
+            let (ids, gradients): (Vec<_>, Vec<_>) = batch.into_iter().unzip();
             let gradients = Tensor::stack::<3>(gradients, 0);
 
-            let velocity = match self.groups.remove(&shape) {
-                Some(state) => {
-                    ensure!(
-                        state.ids == ids,
-                        "Muon parameter order changed for shape {shape:?}"
-                    );
-                    gradients.clone() + state.velocity.mul_scalar(MOMENTUM)
-                }
+            let velocity = match self.velocities.remove(&shape) {
+                Some(velocity) => gradients.clone() + velocity.mul_scalar(MOMENTUM),
                 None => gradients.clone(),
             };
             let momentum_update = velocity.clone().mul_scalar(MOMENTUM) + gradients;
@@ -83,18 +68,18 @@ impl BatchedMuon {
             let adjusted_lr = lr * ((shape[0] as f64 / shape[1] as f64).max(1.0)).sqrt();
             let deltas = orthogonal.mul_scalar(adjusted_lr);
 
-            for (index, id) in ids.iter().enumerate() {
+            for (index, id) in ids.into_iter().enumerate() {
                 let delta = deltas
                     .clone()
                     .slice([index..index + 1, 0..shape[0], 0..shape[1]])
                     .reshape(shape);
-                updates.register::<Backend, 2>(*id, delta);
+                updates.register::<Backend, 2>(id, delta);
             }
-            self.groups.insert(shape, GroupState { ids, velocity });
+            self.velocities.insert(shape, velocity);
         }
 
         ensure!(
-            !self.groups.is_empty(),
+            !self.velocities.is_empty(),
             "Muon has no matrix groups to optimize"
         );
         let mut mapper = MuonUpdateMapper {

--- a/hermes-train/src/muon.rs
+++ b/hermes-train/src/muon.rs
@@ -1,0 +1,262 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result, ensure};
+use burn::module::{Module, ModuleMapper, Param, ParamId};
+#[cfg(feature = "cuda")]
+use burn::tensor::FloatDType;
+use burn::tensor::Tensor;
+use burn_optim::GradientsParams;
+use hermes_llm::Backend;
+
+use crate::TrainBackend;
+
+const MOMENTUM: f64 = 0.95;
+const NS_COEFFICIENTS: (f64, f64, f64) = (3.4445, -4.775, 2.0315);
+const NS_STEPS: usize = 5;
+const EPSILON: f64 = 1e-7;
+
+struct GroupState {
+    ids: Vec<ParamId>,
+    velocity: Tensor<Backend, 3>,
+}
+
+/// Muon with Burn's update and hyperparameters, batched by matrix shape.
+///
+/// Burn's generic optimizer visits every parameter separately. Transformer
+/// blocks repeat a small set of matrix shapes, so batching those matrices
+/// avoids thousands of tiny GPU launches without changing optimizer state or
+/// hyperparameters. CUDA runs Newton-Schulz in BF16, its intended stable
+/// compute dtype, while parameters and momentum remain FP32.
+pub struct BatchedMuon {
+    parameter_ids: Vec<ParamId>,
+    groups: BTreeMap<[usize; 2], GroupState>,
+}
+
+impl BatchedMuon {
+    pub fn new(parameter_ids: Vec<ParamId>) -> Self {
+        Self {
+            parameter_ids,
+            groups: BTreeMap::new(),
+        }
+    }
+
+    pub fn step<M: Module<TrainBackend>>(
+        &mut self,
+        lr: f64,
+        model: M,
+        mut grads: GradientsParams,
+    ) -> Result<M> {
+        let mut batches = BTreeMap::<[usize; 2], Vec<(ParamId, Tensor<Backend, 2>)>>::new();
+        for id in &self.parameter_ids {
+            let grad = grads
+                .remove::<Backend, 2>(*id)
+                .with_context(|| format!("Muon gradient is missing for parameter {id}"))?;
+            batches.entry(grad.dims()).or_default().push((*id, grad));
+        }
+        ensure!(
+            grads.is_empty(),
+            "Muon received {} unexpected gradients",
+            grads.len()
+        );
+
+        let mut updates = GradientsParams::new();
+        for (shape, batch) in batches {
+            let ids = batch.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+            let gradients = batch
+                .into_iter()
+                .map(|(_, gradient)| gradient)
+                .collect::<Vec<_>>();
+            let gradients = Tensor::stack::<3>(gradients, 0);
+
+            let velocity = match self.groups.remove(&shape) {
+                Some(state) => {
+                    ensure!(
+                        state.ids == ids,
+                        "Muon parameter order changed for shape {shape:?}"
+                    );
+                    gradients.clone() + state.velocity.mul_scalar(MOMENTUM)
+                }
+                None => gradients.clone(),
+            };
+            let momentum_update = velocity.clone().mul_scalar(MOMENTUM) + gradients;
+            let orthogonal = zeropower_via_newton_schulz(momentum_update);
+            let adjusted_lr = lr * ((shape[0] as f64 / shape[1] as f64).max(1.0)).sqrt();
+            let deltas = orthogonal.mul_scalar(adjusted_lr);
+
+            for (index, id) in ids.iter().enumerate() {
+                let delta = deltas
+                    .clone()
+                    .slice([index..index + 1, 0..shape[0], 0..shape[1]])
+                    .reshape(shape);
+                updates.register::<Backend, 2>(*id, delta);
+            }
+            self.groups.insert(shape, GroupState { ids, velocity });
+        }
+
+        ensure!(
+            !self.groups.is_empty(),
+            "Muon has no matrix groups to optimize"
+        );
+        let mut mapper = MuonUpdateMapper {
+            updates: &mut updates,
+        };
+        let model = model.map(&mut mapper);
+        ensure!(
+            updates.is_empty(),
+            "{} Muon updates did not match model parameters",
+            updates.len()
+        );
+        Ok(model)
+    }
+}
+
+fn zeropower_via_newton_schulz(gradient: Tensor<Backend, 3>) -> Tensor<Backend, 3> {
+    let [_, rows, columns] = gradient.dims();
+    let (mut x, transpose) = if rows > columns {
+        (gradient.swap_dims(1, 2), true)
+    } else {
+        (gradient, false)
+    };
+    x = to_compute_dtype(x);
+    let norm = x
+        .clone()
+        .powf_scalar(2.0)
+        .sum_dim(2)
+        .sum_dim(1)
+        .sqrt()
+        .clamp_min(EPSILON);
+    x = x / norm;
+
+    let (a, b, c) = NS_COEFFICIENTS;
+    for _ in 0..NS_STEPS {
+        let gram = x.clone().matmul(x.clone().swap_dims(1, 2));
+        let polynomial = gram.clone().mul_scalar(b) + gram.clone().matmul(gram).mul_scalar(c);
+        x = x.clone().mul_scalar(a) + polynomial.matmul(x);
+    }
+
+    x = from_compute_dtype(x);
+    if transpose { x.swap_dims(1, 2) } else { x }
+}
+
+#[cfg(feature = "cuda")]
+fn to_compute_dtype(tensor: Tensor<Backend, 3>) -> Tensor<Backend, 3> {
+    tensor.cast(FloatDType::BF16)
+}
+
+#[cfg(not(feature = "cuda"))]
+fn to_compute_dtype(tensor: Tensor<Backend, 3>) -> Tensor<Backend, 3> {
+    tensor
+}
+
+#[cfg(feature = "cuda")]
+fn from_compute_dtype(tensor: Tensor<Backend, 3>) -> Tensor<Backend, 3> {
+    tensor.cast(FloatDType::F32)
+}
+
+#[cfg(not(feature = "cuda"))]
+fn from_compute_dtype(tensor: Tensor<Backend, 3>) -> Tensor<Backend, 3> {
+    tensor
+}
+
+struct MuonUpdateMapper<'a> {
+    updates: &'a mut GradientsParams,
+}
+
+impl ModuleMapper<TrainBackend> for MuonUpdateMapper<'_> {
+    fn map_float<const D: usize>(
+        &mut self,
+        param: Param<Tensor<TrainBackend, D>>,
+    ) -> Param<Tensor<TrainBackend, D>> {
+        let (id, tensor, mapper) = param.consume();
+        let tensor = match self.updates.remove::<Backend, D>(id) {
+            Some(delta) => {
+                let requires_grad = tensor.is_require_grad();
+                let mut updated = Tensor::from_inner(tensor.inner() - delta);
+                if requires_grad {
+                    updated = updated.require_grad();
+                }
+                updated
+            }
+            None => tensor,
+        };
+        Param::from_mapped_value(id, tensor, mapper)
+    }
+}
+
+#[cfg(all(test, not(feature = "cuda")))]
+mod tests {
+    use burn::tensor::{TensorData, backend::Backend as _};
+    use burn_optim::{MuonConfig, Optimizer};
+
+    use super::*;
+
+    #[derive(Module, Debug)]
+    struct MatrixPair<B: burn::tensor::backend::Backend> {
+        first: Param<Tensor<B, 2>>,
+        second: Param<Tensor<B, 2>>,
+    }
+
+    impl<B: burn::tensor::backend::Backend> MatrixPair<B> {
+        fn loss(&self, input: Tensor<B, 2>) -> Tensor<B, 1> {
+            (input.clone().matmul(self.first.val()).square()
+                + input.matmul(self.second.val()).square())
+            .sum()
+        }
+    }
+
+    fn values(model: &MatrixPair<TrainBackend>) -> Vec<f32> {
+        [model.first.val(), model.second.val()]
+            .into_iter()
+            .flat_map(|tensor| tensor.inner().into_data().to_vec::<f32>().unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn batched_muon_matches_burn_for_repeated_shapes() {
+        let device = hermes_llm::default_device();
+        Backend::seed(&device, 17);
+        let matrix = |scale: f32| {
+            Param::from_tensor(
+                Tensor::<TrainBackend, 2>::from_data(
+                    TensorData::new(
+                        (0..24)
+                            .map(|i| (i as f32 * scale).sin())
+                            .collect::<Vec<_>>(),
+                        [4, 6],
+                    ),
+                    &device,
+                )
+                .require_grad(),
+            )
+        };
+        let mut actual = MatrixPair {
+            first: matrix(0.17),
+            second: matrix(0.23),
+        };
+        let mut expected = actual.clone();
+        let ids = vec![actual.first.id, actual.second.id];
+        let input = || {
+            Tensor::<TrainBackend, 2>::from_data(
+                TensorData::new((0..12).map(|i| i as f32 * 0.03).collect(), [3, 4]),
+                &device,
+            )
+        };
+
+        let mut batched = BatchedMuon::new(ids);
+        let mut burn = MuonConfig::new().init();
+        for _ in 0..2 {
+            let grads = GradientsParams::from_grads(actual.loss(input()).backward(), &actual);
+            let reference_grads =
+                GradientsParams::from_grads(expected.loss(input()).backward(), &expected);
+            actual = batched.step(2e-2, actual, grads).unwrap();
+            expected = burn.step(2e-2, expected, reference_grads);
+        }
+
+        let max_diff = values(&actual)
+            .into_iter()
+            .zip(values(&expected))
+            .map(|(actual, expected)| (actual - expected).abs())
+            .fold(0.0, f32::max);
+        assert!(max_diff < 2e-5, "Muon parameter max diff: {max_diff}");
+    }
+}


### PR DESCRIPTION
## Summary
- replace Burn grouped-convolution backward fallback with fused CubeCL depthwise Conv1d forward/backward kernels
- batch repeated-shape Muon matrices and run CUDA Newton-Schulz in BF16 while retaining FP32 parameters/state
- stream large GCS/S3/HTTP artifacts in bounded ranged chunks
- correct stale backend/training documentation

## Validation
- 16 hermes-llm Metal tests pass, including CubeCL scan and depthwise forward/backward parity
- 4 hermes-train tests pass, including two-step batched Muon equivalence with Burn
- clippy with -D warnings, rustfmt, and diff checks pass
- A100 CUDA 5-step smoke has finite matching loss/gradient norms
- steady batch-16 throughput improved from ~1.6k tok/s before depthwise fusion to ~11.0k tok/s; batch 28 reaches ~12.4k tok/s, 92.5% GPU activity, 226 W average and 314 W peak