### PR TITLE
Fix WASM build before publishing

### DIFF
--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod loader;
 mod types;
 
 pub use bmp::BmpIndex;
+#[cfg(feature = "native")]
 pub(crate) use types::DimRawData;
 pub use types::{SparseIndex, VectorIndex, VectorSearchResult};
 


### PR DESCRIPTION
Gate the native-only DimRawData re-export behind the native feature so the WASM build remains warning-free under RUSTFLAGS=-Dwarnings. This fixes the failed WASM job on the merged lifecycle PR and prevents publish.yml from bumping/tagging before an avoidable NPM build failure. Validated with the WASM feature configuration, warnings denied, formatting, Clippy, and repository hooks.