### PR TITLE
Fix segment commit and reorder lifecycle reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ For production indexes, BP reorder resources are controlled independently:
 hermes-server --data-dir /data \
   --optimizer-threads 16 \
   --optimizer-concurrent-passes 1 \
+  --optimizer-max-unconverged-passes 3 \
   --bp-memory-budget-mb 24576
 ```
 
@@ -117,9 +118,16 @@ hermes-server --data-dir /data \
   optimizer, merge-time reorder, and manual reorder. It is not a thread count;
   keep it small because each pass can use the shared pool and its own memory
   budget.
-- `--bp-memory-budget-mb` caps the forward index of one pass rather than total
-  process RSS. Worst-case reorder working memory is approximately concurrent
-  passes times this cap, plus readers, mmap pages, merge buffers, and indexing.
+- `--optimizer-max-unconverged-passes` is a hard eligibility bound for
+  optimizer follow-up on one budget-truncated replacement lineage (the default
+  `3` includes the initial partial pass). This prevents a segment that cannot
+  converge within its budget from keeping the optimizer BP pool busy forever.
+- `--bp-memory-budget-mb` bounds the main per-pass algorithmic working set:
+  document maps, the BP forward graph and degree arrays, and record-rewrite
+  grid/encode windows. Over-budget record passes fall back to block order and
+  graph dimensions are trimmed. It is not a total-process RSS cap: readers,
+  mmap/page-cache residency, output buffering, merge state, and indexing are
+  additional.
 
 Segment publication, replacement, reader retirement, orphan cleanup, failure
 backoff, and index deletion follow one ownership protocol. Missing files that
@@ -128,6 +136,11 @@ tight merge loop; start once with `--doctor` only when you intentionally want
 to remove those corrupt metadata entries. See
 [Segment lifecycle and recovery](docs/segment-lifecycle.md) and the full
 [server options](hermes-server/README.md#background-merge-and-reorder).
+
+Commit publication is cancellation-safe: after workers flush, an owned
+finalizer carries metadata publication, primary-key refresh, and worker resume
+to completion even if the client disconnects. A pre-publication storage error
+keeps that generation paused and retryable instead of mixing it with new input.
 
 Python client:
 

--- a/docs/budgeted-reorder.md
+++ b/docs/budgeted-reorder.md
@@ -29,7 +29,8 @@ converge to full-BP quality.
   fan-out). Hitting it ends the pass cleanly with `converged = false`.
 
 Per-segment metadata gains `bp_converged` (serde-default true for old
-metadata). What you cannot budget: each pass still rewrites the whole sparse
+metadata) and `bp_unconverged_passes` (serde-default zero). What you cannot
+budget away: each pass still rewrites the whole sparse
 blob (the 4-bit grid is row-major — any permutation rewrites every row), so
 partial reorder bounds CPU/memory, not per-pass IO. Passes go through the
 cold-IO writer, so at least they no longer evict the cache.
@@ -46,6 +47,13 @@ cold-IO writer, so at least they no longer evict the cache.
   Starting cooldown at completion is important because a full sparse rewrite
   can outlast the BP deadline; starting it at launch caused the replacement
   segment to be requeued immediately.
+- The optimizer deepens a replacement lineage only while its consecutive
+  budget-exhausted rewrite count is below
+  `--optimizer-max-unconverged-passes` (default 3, including its initial
+  partial pass). The counter follows replacement IDs, includes a partial
+  merge-time BP pass, and resets after convergence or a non-reordered merge.
+  `0` disables optimizer follow-up deepening; it does not disable explicitly
+  configured merge-time reorder.
 - Merge-time reorder uses its own `--merge-bp-budget-secs` deadline. A
   truncated output joins the same paced deepening ladder.
 
@@ -115,15 +123,16 @@ query pool:
 
 1. **Forward-index build** (was fully serial). Real doc ids are assigned in
    ascending vid order, so each BMP block owns a contiguous real-id range —
-   df counting is a rayon fold/reduce over blocks, and the CSR count/fill
-   phases write disjoint per-block slices (safe `split_at_mut` carving, no
-   locks). Also df counting aggregates per (block, dim) instead of per
-   posting, which speeds up the serial path too.
+   df counting uses one dense atomic vocabulary table shared by the bounded
+   pool, and the CSR count/fill phases write disjoint per-block slices (safe
+   `split_at_mut` carving, no locks). This avoids one vocabulary-sized hash map
+   per worker. Candidate discovery retains only a budgeted low-frequency set.
 2. **Graph bisection** (already parallel: `rayon::join` halves + parallel
    gain passes, wall-clock budgeted).
 3. **Permuted blob write** (was fully serial). Output blocks encode
-   independently; they are encoded in parallel in 4096-block windows and
-   written serially in blob order (the window bounds buffered bytes).
+   independently; they are encoded in parallel in memory-derived windows and
+   written serially in blob order. Grid spill and encoded-window budgets share
+   the remaining per-pass allowance after persistent document maps.
 
 Measured (300k docs / 14.4M postings, RamDirectory, aarch64, release):
 forward index 135 ms → 50 ms (2.7×); blob-encode phase ~3.3 s → ~1.0 s;
@@ -154,9 +163,19 @@ Thread width and operation concurrency are intentionally independent:
   across every index and every entry point: optimizer, merge-time, and manual.
   Concurrent passes share the CPU pool, but each may consume its own forward
   index budget and rewrite buffers.
-- `--bp-memory-budget-mb` is therefore a **per-pass** cap. A conservative
-  process estimate starts with `concurrent passes × memory budget`, then adds
-  indexing builders, merge structures, readers, and mmap/page-cache residency.
+- `--bp-memory-budget-mb` is therefore a **per-pass algorithmic working-set
+  bound**. It covers record maps, forward CSR, candidate/remap storage,
+  vocabulary degree arrays (including parallel recursion), and rewrite
+  grid/encode windows. It does not include source/output mmap pages, directory
+  implementation buffers, unrelated merge structures, or indexing. A
+  conservative process estimate starts with `concurrent passes × memory
+budget`, then adds those external consumers.
+
+When the dense vocabulary table itself cannot fit, the pass emits identity or
+block order and remains explicitly unconverged. Recursion parallelism is
+reduced to the number of vocabulary-sized degree arrays that fit. Memory
+pressure can therefore reduce reorder quality or parallelism, but cannot be
+misreported as convergence and trigger an unbounded immediate loop.
 
 The gate is acquired before expensive forward-index construction. Scheduler
 permits are nonblocking, indexes are visited with a rotating start point, fresh

--- a/docs/segment-lifecycle.md
+++ b/docs/segment-lifecycle.md
@@ -55,6 +55,15 @@ and no partial generation is published. A timeout leaves the writer paused on
 the same generation so a late worker cannot acknowledge the next commit by
 mistake; the caller retries commit.
 
+Once a prepared indexing commit starts, an owned finalizer—not the requesting
+RPC—holds its segment guards. It completes metadata publication, refreshes the
+primary-key view, and resumes workers in that order even if the request is
+canceled. Ingestion receives explicit backpressure until the finalizer ends.
+If publication fails before the atomic rename, the same prepared segments stay
+owned and workers remain paused for a lossless retry; a new indexing generation
+cannot be mixed into them. After the rename, optional cache-refresh failures
+are fail-closed and cannot turn a durable commit into an apparent abort.
+
 ## Cancellation and shutdown
 
 Tokio cannot cancel a `spawn_blocking` closure after it has started. Dropping or
@@ -101,6 +110,18 @@ Standalone optimizer failures use the same exponential delay per source,
 measured from pass completion; otherwise a pass longer than the scan interval
 would restart almost immediately. Deterministic reorder corruption enters the
 same process-lifetime quarantine as a corrupt merge source.
+
+Reorder copies distinguish absent optional files from failures: only a genuine
+`NotFound` for a file the source reader did not observe is skipped. Required
+files, permission/storage errors, short copies, and invalid optional formats
+fail the output. Before replacement publication, Hermes opens the complete
+output segment and verifies its document count; metadata is never switched to
+an output that only passed a shallow `.meta` check.
+
+Budget-truncated BP is a successful lifecycle transition, not a failure retry.
+Its replacement metadata carries `bp_unconverged_passes`; the optimizer admits
+only lineages below `--optimizer-max-unconverged-passes`. Thus both failure
+retries and successful deepening have explicit, finite scheduling bounds.
 
 ## Operator recovery
 

--- a/hermes-core/src/error.rs
+++ b/hermes-core/src/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
     #[error("Indexing queue full — apply backpressure")]
     QueueFull,
 
+    #[error("Commit is still finalizing or awaiting retry")]
+    CommitInProgress,
+
     #[error("Internal error: {0}")]
     Internal(String),
 

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -63,6 +63,11 @@ pub struct SegmentMetaInfo {
     /// Old metadata (field absent) deserializes as converged.
     #[serde(default = "default_true")]
     pub bp_converged: bool,
+    /// Number of consecutive budget-exhausted BP rewrites in this segment's
+    /// current reordered lineage. Carried across replacement IDs so the
+    /// optimizer can impose a hard follow-up bound instead of rewriting forever.
+    #[serde(default)]
+    pub bp_unconverged_passes: u32,
 }
 
 /// Per-field vector index metadata
@@ -130,6 +135,7 @@ impl IndexMetadata {
                 generation: 0,
                 reordered: false,
                 bp_converged: true,
+                bp_unconverged_passes: 0,
             },
         );
     }
@@ -144,7 +150,7 @@ impl IndexMetadata {
         reordered: bool,
         bp_converged: bool,
     ) {
-        self.segment_metas.insert(
+        self.add_segment_meta(
             segment_id,
             SegmentMetaInfo {
                 num_docs,
@@ -152,8 +158,16 @@ impl IndexMetadata {
                 generation,
                 reordered,
                 bp_converged,
+                bp_unconverged_passes: 0,
             },
         );
+    }
+
+    /// Insert fully constructed lifecycle metadata. Merge/reorder code uses
+    /// this to carry bounded BP lineage; ordinary callers use the safer
+    /// constructors above, which start a fresh lineage.
+    pub(crate) fn add_segment_meta(&mut self, segment_id: String, info: SegmentMetaInfo) {
+        self.segment_metas.insert(segment_id, info);
     }
 
     /// Remove a segment
@@ -609,6 +623,20 @@ mod tests {
         assert_eq!(loaded.segment_doc_count("seg1"), Some(100));
         assert_eq!(loaded.total_vectors, meta.total_vectors);
         assert!(loaded.vector_fields.contains_key(&0));
+    }
+
+    #[test]
+    fn old_metadata_defaults_the_bp_retry_counter() {
+        let mut meta = IndexMetadata::new(test_schema());
+        meta.add_segment("legacy".to_string(), 10);
+        let mut json = serde_json::to_value(&meta).unwrap();
+        json["segment_metas"]["legacy"]
+            .as_object_mut()
+            .unwrap()
+            .remove("bp_unconverged_passes");
+
+        let loaded: IndexMetadata = serde_json::from_value(json).unwrap();
+        assert_eq!(loaded.segment_metas["legacy"].bp_unconverged_passes, 0);
     }
 
     #[test]

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -37,7 +37,9 @@ pub use wasm_writer::IndexWriter as WasmIndexWriter;
 pub use writer::{IndexWriter, PreparedCommit};
 
 mod metadata;
-pub use metadata::{FieldVectorMeta, INDEX_META_FILENAME, IndexMetadata, VectorIndexState};
+pub use metadata::{
+    FieldVectorMeta, INDEX_META_FILENAME, IndexMetadata, SegmentMetaInfo, VectorIndexState,
+};
 
 #[cfg(feature = "native")]
 mod helpers;

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -949,6 +949,29 @@ async fn test_bmp_merge_large() {
     );
 }
 
+/// A schema-level sparse field may have no values in a particular segment.
+#[tokio::test]
+async fn test_bmp_reorder_accepts_segment_without_sparse_values() {
+    let (schema, title, _sparse) = bmp_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    let mut doc = Document::new();
+    doc.add_text(title, "text only");
+    writer.add_document(doc).unwrap();
+    writer.commit().await.unwrap();
+
+    // A sparse field in the schema does not imply that every segment owns a
+    // `.sparse` file. Reorder must preserve this valid optional-file case.
+    writer.reorder().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert_eq!(index.num_docs().await.unwrap(), 1);
+}
+
 /// BMP standalone reorder: build 1 segment, call writer.reorder(), verify all docs findable.
 ///
 /// Tests the record-level BP reorder path where individual ordinals are
@@ -1807,6 +1830,7 @@ async fn test_budgeted_reorder_marks_unconverged_and_stays_searchable() {
         !info.bp_converged,
         "zero-budget pass must be marked unconverged for the optimizer to deepen"
     );
+    assert_eq!(info.bp_unconverged_passes, 1);
 
     // All docs still searchable after the partial pass
     let index = Index::open(dir.clone(), config.clone()).await.unwrap();
@@ -1818,9 +1842,22 @@ async fn test_budgeted_reorder_marks_unconverged_and_stays_searchable() {
         assert_eq!(results.len(), 1, "dim {} lost after budgeted reorder", i);
     }
 
-    // Pass 2: full budget → warm-started pass converges
+    // Pass 2: another truncated rewrite inherits and increments the lineage
+    // counter even though replacement gives it a new segment ID.
     let new_seg_id = metadata.segment_ids()[0].clone();
     let sm = std::sync::Arc::clone(index.segment_manager());
+    let reordered = sm
+        .reorder_single_segment(&new_seg_id, None, budget)
+        .await
+        .unwrap();
+    assert!(reordered);
+    let metadata = crate::index::IndexMetadata::load(&dir).await.unwrap();
+    let info = metadata.segment_metas.values().next().unwrap();
+    assert!(!info.bp_converged);
+    assert_eq!(info.bp_unconverged_passes, 2);
+
+    // Pass 3: a completed full-depth pass clears the retry lineage.
+    let new_seg_id = metadata.segment_ids()[0].clone();
     let reordered = sm
         .reorder_single_segment(&new_seg_id, None, BpBudget::full())
         .await
@@ -1832,6 +1869,7 @@ async fn test_budgeted_reorder_marks_unconverged_and_stays_searchable() {
         info.bp_converged,
         "full-budget follow-up pass must converge"
     );
+    assert_eq!(info.bp_unconverged_passes, 0);
 }
 
 /// Small-segment reorder must still cluster: with a fixed min_doc_freq=128,
@@ -3071,7 +3109,7 @@ async fn bench_forward_index_build() {
 
     for round in 0..3 {
         let t = std::time::Instant::now();
-        let (fwd, _) = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget);
+        let (fwd, _) = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget).unwrap();
         println!(
             "record-level fwd build round {}: {:.1}ms ({} terms, {} postings)",
             round,
@@ -3094,7 +3132,7 @@ async fn bench_forward_index_build() {
 
     // Full-pipeline breakdown: BP itself, then the whole reorder (fwd build +
     // BP + permuted blob write + commit) — blob write ≈ total − fwd − BP.
-    let (fwd, _) = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget);
+    let (fwd, _) = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget).unwrap();
     let t = std::time::Instant::now();
     let (_perm, converged) = graph_bisection(&fwd, 64, 20, crate::segment::BpBudget::full());
     println!(
@@ -3182,7 +3220,8 @@ async fn test_bmp_block_posting_overflow_256() {
     // BP forward-index build over the oversized block must not read wild
     // slices (this is the exact prod crash path).
     let (fwd, _) =
-        crate::segment::build_forward_index_from_bmps(&[bmp], 2, 1_000_000, 2 * 1024 * 1024 * 1024);
+        crate::segment::build_forward_index_from_bmps(&[bmp], 2, 1_000_000, 2 * 1024 * 1024 * 1024)
+            .unwrap();
     // Needle dims have df=1 and are correctly filtered by min_doc_freq=2;
     // the 300 shared dims × 256 docs must all survive — reading them walks
     // every posting slice past the old u16 wrap point.

--- a/hermes-core/src/index/tests/primary_key.rs
+++ b/hermes-core/src/index/tests/primary_key.rs
@@ -3,6 +3,145 @@ use crate::dsl::{Document, Field, SchemaBuilder};
 use crate::error::Error;
 use crate::index::{IndexConfig, IndexWriter};
 
+#[derive(Clone)]
+struct BlockingMetadataDirectory {
+    inner: RamDirectory,
+    block_next_rename: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    fail_next_rename: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    panic_next_bloom_write: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    rename_started: std::sync::Arc<tokio::sync::Semaphore>,
+    allow_rename: std::sync::Arc<tokio::sync::Semaphore>,
+}
+
+impl Default for BlockingMetadataDirectory {
+    fn default() -> Self {
+        Self {
+            inner: RamDirectory::default(),
+            block_next_rename: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            fail_next_rename: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            panic_next_bloom_write: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            rename_started: std::sync::Arc::new(tokio::sync::Semaphore::new(0)),
+            allow_rename: std::sync::Arc::new(tokio::sync::Semaphore::new(0)),
+        }
+    }
+}
+
+impl BlockingMetadataDirectory {
+    fn block_next_metadata_rename(&self) {
+        self.block_next_rename
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    fn fail_next_metadata_rename(&self) {
+        self.fail_next_rename
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    fn panic_next_bloom_write(&self) {
+        self.panic_next_bloom_write
+            .store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    async fn wait_until_rename_started(&self) {
+        self.rename_started.acquire().await.unwrap().forget();
+    }
+
+    fn release_rename(&self) {
+        self.allow_rename.add_permits(1);
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::directories::Directory for BlockingMetadataDirectory {
+    async fn exists(&self, path: &std::path::Path) -> std::io::Result<bool> {
+        self.inner.exists(path).await
+    }
+
+    async fn file_size(&self, path: &std::path::Path) -> std::io::Result<u64> {
+        self.inner.file_size(path).await
+    }
+
+    async fn open_read(
+        &self,
+        path: &std::path::Path,
+    ) -> std::io::Result<crate::directories::FileHandle> {
+        self.inner.open_read(path).await
+    }
+
+    async fn read_range(
+        &self,
+        path: &std::path::Path,
+        range: std::ops::Range<u64>,
+    ) -> std::io::Result<crate::directories::OwnedBytes> {
+        self.inner.read_range(path, range).await
+    }
+
+    async fn list_files(
+        &self,
+        prefix: &std::path::Path,
+    ) -> std::io::Result<Vec<std::path::PathBuf>> {
+        self.inner.list_files(prefix).await
+    }
+
+    async fn open_lazy(
+        &self,
+        path: &std::path::Path,
+    ) -> std::io::Result<crate::directories::FileHandle> {
+        self.inner.open_lazy(path).await
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::directories::DirectoryWriter for BlockingMetadataDirectory {
+    async fn write(&self, path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
+        if path == std::path::Path::new(crate::index::primary_key::PK_BLOOM_FILE)
+            && self
+                .panic_next_bloom_write
+                .swap(false, std::sync::atomic::Ordering::AcqRel)
+        {
+            panic!("injected post-publication bloom-write panic");
+        }
+        self.inner.write(path, data).await
+    }
+
+    async fn delete(&self, path: &std::path::Path) -> std::io::Result<()> {
+        self.inner.delete(path).await
+    }
+
+    async fn rename(&self, from: &std::path::Path, to: &std::path::Path) -> std::io::Result<()> {
+        if to == std::path::Path::new(crate::index::INDEX_META_FILENAME)
+            && self
+                .fail_next_rename
+                .swap(false, std::sync::atomic::Ordering::AcqRel)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "injected metadata rename failure",
+            ));
+        }
+        if to == std::path::Path::new(crate::index::INDEX_META_FILENAME)
+            && self
+                .block_next_rename
+                .swap(false, std::sync::atomic::Ordering::AcqRel)
+        {
+            self.rename_started.add_permits(1);
+            self.allow_rename.acquire().await.unwrap().forget();
+        }
+        self.inner.rename(from, to).await
+    }
+
+    async fn sync(&self) -> std::io::Result<()> {
+        self.inner.sync().await
+    }
+
+    async fn streaming_writer(
+        &self,
+        path: &std::path::Path,
+    ) -> std::io::Result<Box<dyn crate::directories::StreamingWriter>> {
+        self.inner.streaming_writer(path).await
+    }
+}
+
 /// Helper: build a schema with a primary key text field + a regular text field.
 fn make_schema() -> (crate::dsl::Schema, Field, Field) {
     let mut builder = SchemaBuilder::default();
@@ -194,6 +333,122 @@ async fn test_dedup_abort_clears_uncommitted() {
         .add_document(make_doc(pk, title, "abort_key", "Retry"))
         .unwrap();
     writer.commit().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_cancelled_commit_finishes_publication_before_resuming_ingestion() {
+    let (schema, pk, title) = make_schema();
+    let dir = BlockingMetadataDirectory::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, IndexConfig::default())
+        .await
+        .unwrap();
+    writer.init_primary_key_dedup().await.unwrap();
+    writer
+        .add_document(make_doc(pk, title, "cancelled-commit", "original"))
+        .unwrap();
+
+    let writer = std::sync::Arc::new(tokio::sync::Mutex::new(writer));
+    dir.block_next_metadata_rename();
+    let request = {
+        let writer = std::sync::Arc::clone(&writer);
+        tokio::spawn(async move { writer.lock().await.commit().await })
+    };
+
+    dir.wait_until_rename_started().await;
+    request.abort();
+    assert!(request.await.unwrap_err().is_cancelled());
+
+    // The request no longer owns the writer, but the detached finalizer still
+    // owns publication and must keep ingestion unavailable until it resolves.
+    let error = writer
+        .lock()
+        .await
+        .add_document(make_doc(pk, title, "another", "too early"))
+        .unwrap_err();
+    assert!(matches!(error, Error::CommitInProgress));
+
+    dir.release_rename();
+    let writer_guard = writer.lock().await;
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        writer_guard.wait_for_commit_finalization(),
+    )
+    .await
+    .expect("owned commit finalizer did not finish");
+
+    let metadata = crate::index::IndexMetadata::load(&dir).await.unwrap();
+    assert_eq!(metadata.segment_metas.len(), 1);
+
+    // Most importantly, cancellation cannot clear this reservation before the
+    // newly published fast field enters committed PK state.
+    let duplicate = writer_guard
+        .add_document(make_doc(pk, title, "cancelled-commit", "duplicate"))
+        .unwrap_err();
+    assert!(matches!(duplicate, Error::DuplicatePrimaryKey(_)));
+
+    writer_guard
+        .add_document(make_doc(pk, title, "after-cancel", "accepted"))
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_failed_publication_stays_paused_and_retries_losslessly() {
+    let (schema, pk, title) = make_schema();
+    let dir = BlockingMetadataDirectory::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, IndexConfig::default())
+        .await
+        .unwrap();
+    writer.init_primary_key_dedup().await.unwrap();
+    writer
+        .add_document(make_doc(pk, title, "retry-me", "original"))
+        .unwrap();
+
+    dir.fail_next_metadata_rename();
+    assert!(matches!(writer.commit().await, Err(Error::Io(_))));
+
+    // The prepared generation remains intact and workers remain paused; new
+    // ingestion gets explicit backpressure instead of mixing generations.
+    assert!(matches!(
+        writer.add_document(make_doc(pk, title, "too-early", "blocked")),
+        Err(Error::CommitInProgress)
+    ));
+
+    assert!(writer.commit().await.unwrap());
+    let metadata = crate::index::IndexMetadata::load(&dir).await.unwrap();
+    assert_eq!(metadata.segment_metas.len(), 1);
+    assert!(matches!(
+        writer.add_document(make_doc(pk, title, "retry-me", "duplicate")),
+        Err(Error::DuplicatePrimaryKey(_))
+    ));
+    writer
+        .add_document(make_doc(pk, title, "after-retry", "accepted"))
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_post_publication_finalizer_panic_still_reports_committed() {
+    let (schema, pk, title) = make_schema();
+    let dir = BlockingMetadataDirectory::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, IndexConfig::default())
+        .await
+        .unwrap();
+    writer.init_primary_key_dedup().await.unwrap();
+    writer
+        .add_document(make_doc(pk, title, "durable-before-panic", "original"))
+        .unwrap();
+
+    dir.panic_next_bloom_write();
+    assert!(writer.commit().await.unwrap());
+
+    let metadata = crate::index::IndexMetadata::load(&dir).await.unwrap();
+    assert_eq!(metadata.segment_metas.len(), 1);
+    assert!(matches!(
+        writer.add_document(make_doc(pk, title, "durable-before-panic", "duplicate")),
+        Err(Error::DuplicatePrimaryKey(_))
+    ));
+    writer
+        .add_document(make_doc(pk, title, "after-panic", "accepted"))
+        .unwrap();
 }
 
 // ---------------------------------------------------------------------------

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -32,6 +32,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
+use futures::FutureExt;
 use rustc_hash::FxHashMap;
 
 use crate::directories::DirectoryWriter;
@@ -47,8 +48,10 @@ const PIPELINE_MAX_SIZE_IN_DOCS: usize = 10_000;
 
 /// Async IndexWriter for adding documents and committing segments.
 ///
-/// **Backpressure:** `add_document()` is sync, O(1). Returns `Error::QueueFull`
-/// when the shared queue is at capacity — caller must back off.
+/// **Backpressure:** `add_document()` is sync and O(1). It returns
+/// `Error::QueueFull` when the shared queue is full and
+/// `Error::CommitInProgress` while a generation is publishing or awaiting
+/// retry; callers must back off.
 ///
 /// **Two-phase commit:**
 /// - `prepare_commit()` → `PreparedCommit::commit()` or `PreparedCommit::abort()`
@@ -60,9 +63,9 @@ pub struct IndexWriter<D: DirectoryWriter + 'static> {
     pub(super) directory: Arc<D>,
     pub(super) schema: Arc<Schema>,
     pub(super) config: IndexConfig,
-    /// MPMC sender — `try_send(&self)` is thread-safe, no lock needed.
-    /// Replaced on each commit cycle (workers get new receiver via resume).
-    doc_sender: async_channel::Sender<Document>,
+    /// MPMC sender, replaced under a brief lock on each commit cycle (workers
+    /// get the corresponding new receiver via resume).
+    doc_sender: Arc<parking_lot::RwLock<async_channel::Sender<Document>>>,
     /// Worker OS thread handles — long-lived, survive across commits.
     workers: Vec<std::thread::JoinHandle<()>>,
     /// Shared worker state (immutable config + mutable segment output + sync)
@@ -71,9 +74,42 @@ pub struct IndexWriter<D: DirectoryWriter + 'static> {
     pub(super) segment_manager: Arc<crate::merge::SegmentManager<D>>,
     /// Segments flushed to disk but not yet registered in metadata. Each item
     /// owns an active-operation guard, so orphan sweeping cannot delete it.
-    flushed_segments: Vec<PreparedSegment<D>>,
+    flushed_segments: Arc<parking_lot::Mutex<Vec<PreparedSegment<D>>>>,
     /// Primary key dedup index (None if schema has no primary field)
-    primary_key_index: Option<super::primary_key::PrimaryKeyIndex>,
+    primary_key_index: Arc<parking_lot::RwLock<Option<super::primary_key::PrimaryKeyIndex>>>,
+    /// Tracks the owned finalizer spawned by `PreparedCommit::commit`. The
+    /// requesting future may disappear, but a second commit generation must
+    /// not start until this one has made publication and worker state agree.
+    commit_finalization: Arc<CommitFinalizationState>,
+}
+
+#[derive(Default)]
+struct CommitFinalizationState {
+    in_progress: AtomicBool,
+    idle: tokio::sync::Notify,
+}
+
+impl CommitFinalizationState {
+    fn begin(&self) -> bool {
+        self.in_progress
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    fn finish(&self) {
+        self.in_progress.store(false, Ordering::Release);
+        self.idle.notify_waiters();
+    }
+
+    async fn wait_until_idle(&self) {
+        while self.in_progress.load(Ordering::Acquire) {
+            let notified = self.idle.notified();
+            if !self.in_progress.load(Ordering::Acquire) {
+                break;
+            }
+            notified.await;
+        }
+    }
 }
 
 /// Shared state for worker threads.
@@ -331,12 +367,13 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             directory,
             schema,
             config,
-            doc_sender,
+            doc_sender: Arc::new(parking_lot::RwLock::new(doc_sender)),
             workers,
             worker_state,
             segment_manager,
-            flushed_segments: Vec::new(),
-            primary_key_index: None,
+            flushed_segments: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            primary_key_index: Arc::new(parking_lot::RwLock::new(None)),
+            commit_finalization: Arc::new(CommitFinalizationState::default()),
         }
     }
 
@@ -395,6 +432,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// No-op if schema has no primary field.
     pub async fn init_primary_key_dedup(&mut self) -> Result<()> {
         use super::primary_key::{PK_BLOOM_FILE, deserialize_pk_bloom};
+
+        self.commit_finalization.wait_until_idle().await;
 
         let field = match self.schema.primary_field() {
             Some(f) => f,
@@ -497,7 +536,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 self.persist_pk_bloom(&pk_index, &current_seg_ids).await;
             }
 
-            self.primary_key_index = Some(pk_index);
+            *self.primary_key_index.write() = Some(pk_index);
         } else {
             // No cache — full rebuild, offloaded to blocking thread.
             let pk_index = tokio::task::spawn_blocking(move || {
@@ -507,7 +546,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             .map_err(|e| Error::Internal(format!("spawn_blocking failed: {}", e)))?;
 
             self.persist_pk_bloom(&pk_index, &current_seg_ids).await;
-            self.primary_key_index = Some(pk_index);
+            *self.primary_key_index.write() = Some(pk_index);
         }
 
         Ok(())
@@ -533,32 +572,44 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         }
     }
 
-    /// Add a document to the indexing queue (sync, O(1), lock-free).
+    /// Add a document to the indexing queue (sync, O(1)).
     ///
     /// `Document` is moved into the channel (zero-copy). Workers compete to pull it.
-    /// Returns `Error::QueueFull` when the queue is at capacity — caller must back off.
+    /// Returns an explicit backpressure error when the queue is at capacity or
+    /// a prepared commit generation is not yet resolved.
     pub fn add_document(&self, doc: Document) -> Result<()> {
         if self.worker_state.shutdown.load(Ordering::Acquire) {
             return Err(Error::IndexClosed);
         }
-        if let Some(ref pk_index) = self.primary_key_index {
+        if self.commit_finalization.in_progress.load(Ordering::Acquire) {
+            return Err(Error::CommitInProgress);
+        }
+        let sender = self.doc_sender.read().clone();
+        // A publication error deliberately leaves the prepared generation and
+        // its workers paused for a lossless retry. Report this as backpressure
+        // instead of inserting/rolling back a PK key against a closed channel.
+        if sender.is_closed() {
+            return Err(Error::CommitInProgress);
+        }
+        let primary_key_index = self.primary_key_index.read();
+        if let Some(ref pk_index) = *primary_key_index {
             pk_index.check_and_insert(&doc)?;
         }
-        match self.doc_sender.try_send(doc) {
+        match sender.try_send(doc) {
             Ok(()) => Ok(()),
             Err(async_channel::TrySendError::Full(doc)) => {
                 // Roll back PK registration so the caller can retry later
-                if let Some(ref pk_index) = self.primary_key_index {
+                if let Some(ref pk_index) = *primary_key_index {
                     pk_index.rollback_uncommitted_key(&doc);
                 }
                 Err(Error::QueueFull)
             }
             Err(async_channel::TrySendError::Closed(doc)) => {
                 // Roll back PK registration for defense-in-depth
-                if let Some(ref pk_index) = self.primary_key_index {
+                if let Some(ref pk_index) = *primary_key_index {
                     pk_index.rollback_uncommitted_key(&doc);
                 }
-                Err(Error::Internal("Document channel closed".into()))
+                Err(Error::CommitInProgress)
             }
         }
     }
@@ -566,13 +617,13 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Add multiple documents to the indexing queue.
     ///
     /// Returns the number of documents successfully queued. Stops at the first
-    /// `QueueFull` and returns the count queued so far.
+    /// backpressure error and returns the count queued so far.
     pub fn add_documents(&self, documents: Vec<Document>) -> Result<usize> {
         let total = documents.len();
         for (i, doc) in documents.into_iter().enumerate() {
             match self.add_document(doc) {
                 Ok(()) => {}
-                Err(Error::QueueFull) => return Ok(i),
+                Err(Error::QueueFull | Error::CommitInProgress) => return Ok(i),
                 Err(e) => return Err(e),
             }
         }
@@ -839,6 +890,12 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         self.segment_manager.begin_shutdown();
         self.signal_worker_shutdown();
 
+        // A cancelled commit request leaves its owned finalizer running. Do not
+        // clear shared PK/prepared state while that task may still publish or
+        // refresh it. Worker shutdown is signalled first, so a successful
+        // finalizer cannot restart ingestion while deletion is waiting.
+        self.commit_finalization.wait_until_idle().await;
+
         let workers = std::mem::take(&mut self.workers);
         let panicked = tokio::task::spawn_blocking(move || {
             workers
@@ -855,9 +912,9 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
         // No commit is possible after shutdown. Dropping these RAII values
         // releases their lifecycle ownership before directory deletion.
-        self.flushed_segments.clear();
+        self.flushed_segments.lock().clear();
         self.worker_state.built_segments.lock().clear();
-        if let Some(pk_index) = &mut self.primary_key_index {
+        if let Some(pk_index) = self.primary_key_index.write().as_mut() {
             pk_index.clear_uncommitted();
         }
         Ok(())
@@ -871,6 +928,14 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Wait for all eligible merges to complete, including cascading merges.
     pub async fn wait_for_all_merges(&self) {
         self.segment_manager.wait_for_all_merges().await;
+    }
+
+    /// Wait until an owned commit finalizer has reconciled durable metadata,
+    /// primary-key state, and worker availability. Normally callers need not
+    /// use this: it exists for orderly shutdown and request supervisors that
+    /// want to observe completion after cancelling their original waiter.
+    pub async fn wait_for_commit_finalization(&self) {
+        self.commit_finalization.wait_until_idle().await;
     }
 
     /// Get the segment tracker for sharing with readers.
@@ -897,13 +962,16 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Workers are NOT destroyed — they flush their builders and wait for
     /// `resume_workers()` to give them a new channel.
     ///
-    /// `add_document` will return `Closed` error until commit/abort resumes workers.
+    /// `add_document` returns `CommitInProgress` until commit/abort resumes workers.
     pub async fn prepare_commit(&mut self) -> Result<PreparedCommit<'_, D>> {
         if self.worker_state.shutdown.load(Ordering::Acquire) {
             return Err(Error::IndexClosed);
         }
+        if self.commit_finalization.in_progress.load(Ordering::Acquire) {
+            return Err(Error::CommitInProgress);
+        }
         // 1. Close channel → workers drain remaining docs and flush builders
-        self.doc_sender.close();
+        self.doc_sender.read().close();
 
         // Wake any workers still waiting on resume_cvar from previous cycle.
         // They'll clone the stale receiver, enter recv_blocking, get Err
@@ -954,9 +1022,9 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             // longer exist in a worker builder, so successful sibling outputs
             // cannot be committed without violating commit's all-prior-docs
             // guarantee. Their RAII drops retain ownership through deletion.
-            self.flushed_segments.clear();
+            self.flushed_segments.lock().clear();
             self.worker_state.built_segments.lock().clear();
-            if let Some(pk_index) = &mut self.primary_key_index {
+            if let Some(pk_index) = self.primary_key_index.write().as_mut() {
                 pk_index.clear_uncommitted();
             }
             self.resume_workers();
@@ -967,12 +1035,11 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
         // 3. Collect built segments
         let built = std::mem::take(&mut *self.worker_state.built_segments.lock());
-        self.flushed_segments.extend(built);
+        self.flushed_segments.lock().extend(built);
 
         Ok(PreparedCommit {
             writer: self,
             is_resolved: false,
-            is_published: false,
         })
     }
 
@@ -1009,42 +1076,45 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Workers are already alive — just give them a new channel and wake them.
     /// If the tokio runtime has shut down (e.g., program exit), this is a no-op.
     fn resume_workers(&mut self) {
-        if self.worker_state.shutdown.load(Ordering::Acquire) {
+        Self::resume_workers_shared(&self.worker_state, &self.doc_sender);
+    }
+
+    fn resume_workers_shared(
+        worker_state: &Arc<WorkerState<D>>,
+        doc_sender: &Arc<parking_lot::RwLock<async_channel::Sender<Document>>>,
+    ) {
+        if worker_state.shutdown.load(Ordering::Acquire) {
             return;
         }
         if tokio::runtime::Handle::try_current().is_err() {
             // Runtime is gone — signal permanent shutdown so workers don't
             // hang forever on resume_cvar.
-            self.worker_state.shutdown.store(true, Ordering::Release);
-            self.worker_state.resume_cvar.notify_all();
+            worker_state.shutdown.store(true, Ordering::Release);
+            worker_state.resume_cvar.notify_all();
             return;
         }
 
         // Reset flush count for next cycle
-        self.worker_state.flush_count.store(0, Ordering::Release);
-        *self.worker_state.cycle_error.lock() = None;
-        self.worker_state
-            .cycle_failed
-            .store(false, Ordering::Release);
+        worker_state.flush_count.store(0, Ordering::Release);
+        *worker_state.cycle_error.lock() = None;
+        worker_state.cycle_failed.store(false, Ordering::Release);
 
         // Create new channel
         let (sender, receiver) = async_channel::bounded(PIPELINE_MAX_SIZE_IN_DOCS);
-        self.doc_sender = sender;
+        *doc_sender.write() = sender;
 
         // Set new receiver, bump epoch, and wake all workers
         {
-            let mut lock = self.worker_state.resume_receiver.lock();
+            let mut lock = worker_state.resume_receiver.lock();
             *lock = Some(receiver);
         }
-        self.worker_state
-            .resume_epoch
-            .fetch_add(1, Ordering::Release);
-        self.worker_state.resume_cvar.notify_all();
+        worker_state.resume_epoch.fetch_add(1, Ordering::Release);
+        worker_state.resume_cvar.notify_all();
     }
 
     fn signal_worker_shutdown(&self) {
         self.worker_state.shutdown.store(true, Ordering::Release);
-        self.doc_sender.close();
+        self.doc_sender.read().close();
         self.worker_state.resume_cvar.notify_all();
     }
 
@@ -1069,9 +1139,184 @@ impl<D: DirectoryWriter + 'static> Drop for IndexWriter<D> {
 pub struct PreparedCommit<'a, D: DirectoryWriter + 'static> {
     writer: &'a mut IndexWriter<D>,
     is_resolved: bool,
-    /// Metadata publication is the commit point. Post-publication cache work
-    /// may still fail or be cancelled, but must never be described as an abort.
-    is_published: bool,
+}
+
+/// Returns prepared segments to the writer if an owned commit finalizer fails
+/// or unwinds before it can establish that metadata owns them. Retrying commit
+/// is safe even when publication actually won the race: `SegmentManager::commit`
+/// is idempotent and the operation guards keep the files protected meanwhile.
+struct PreparedSegmentsGuard<D: DirectoryWriter + 'static> {
+    segments: Option<Vec<PreparedSegment<D>>>,
+    retry_slot: Arc<parking_lot::Mutex<Vec<PreparedSegment<D>>>>,
+}
+
+impl<D: DirectoryWriter + 'static> PreparedSegmentsGuard<D> {
+    fn metadata_entries(&self) -> Vec<(String, u32)> {
+        self.segments
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(PreparedSegment::metadata_entry)
+            .collect()
+    }
+
+    fn take_published(&mut self) -> Vec<PreparedSegment<D>> {
+        self.segments.take().unwrap_or_default()
+    }
+}
+
+impl<D: DirectoryWriter + 'static> Drop for PreparedSegmentsGuard<D> {
+    fn drop(&mut self) {
+        if let Some(segments) = self.segments.take() {
+            self.retry_slot.lock().extend(segments);
+        }
+    }
+}
+
+/// Couples completion of the owned commit task to writer availability. The
+/// default is deliberately fail-closed: a pre-publication error or panic keeps
+/// workers paused so the retained prepared generation can be retried. Only the
+/// normal published path arms resumption.
+struct CommitFinalizationGuard<D: DirectoryWriter + 'static> {
+    state: Arc<CommitFinalizationState>,
+    worker_state: Arc<WorkerState<D>>,
+    doc_sender: Arc<parking_lot::RwLock<async_channel::Sender<Document>>>,
+    resume_workers: bool,
+}
+
+impl<D: DirectoryWriter + 'static> CommitFinalizationGuard<D> {
+    fn resume_on_drop(&mut self) {
+        self.resume_workers = true;
+    }
+}
+
+impl<D: DirectoryWriter + 'static> Drop for CommitFinalizationGuard<D> {
+    fn drop(&mut self) {
+        if self.resume_workers {
+            IndexWriter::<D>::resume_workers_shared(&self.worker_state, &self.doc_sender);
+        }
+        self.state.finish();
+    }
+}
+
+/// Everything needed to finish one prepared generation is moved into this
+/// value before spawning. Its two guards therefore reconcile segment
+/// ownership and writer availability even if Tokio drops the task before its
+/// first poll.
+struct OwnedCommitFinalization<D: DirectoryWriter + 'static> {
+    directory: Arc<D>,
+    schema: Arc<Schema>,
+    segment_manager: Arc<crate::merge::SegmentManager<D>>,
+    primary_key_index: Arc<parking_lot::RwLock<Option<super::primary_key::PrimaryKeyIndex>>>,
+    prepared: PreparedSegmentsGuard<D>,
+    finalization: Option<CommitFinalizationGuard<D>>,
+    publication_observed: Arc<AtomicBool>,
+}
+
+async fn refresh_primary_key_after_commit<D: DirectoryWriter + 'static>(
+    directory: &Arc<D>,
+    schema: &Arc<Schema>,
+    segment_manager: &Arc<crate::merge::SegmentManager<D>>,
+    primary_key_index: &Arc<parking_lot::RwLock<Option<super::primary_key::PrimaryKeyIndex>>>,
+) -> Result<()> {
+    let existing_ids: std::collections::HashSet<String> = {
+        let guard = primary_key_index.read();
+        let Some(pk_index) = guard.as_ref() else {
+            return Ok(());
+        };
+        pk_index
+            .committed_segment_ids()
+            .map(ToOwned::to_owned)
+            .collect()
+    };
+
+    let snapshot = segment_manager.acquire_snapshot().await;
+    let load_futures: Vec<_> = snapshot
+        .segment_ids()
+        .iter()
+        .filter(|id| !existing_ids.contains(id.as_str()))
+        .map(|seg_id_str| {
+            let seg_id_str = seg_id_str.clone();
+            let dir = directory.as_ref();
+            let schema = Arc::clone(schema);
+            async move { load_pk_segment_data(dir, &seg_id_str, &schema).await }
+        })
+        .collect();
+    let new_data = futures::future::try_join_all(load_futures).await?;
+    let seg_ids: Vec<String> = snapshot.segment_ids().to_vec();
+
+    let bloom_file = {
+        let mut guard = primary_key_index.write();
+        let Some(pk_index) = guard.as_mut() else {
+            return Ok(());
+        };
+        pk_index.refresh_incremental(new_data, snapshot);
+        let bloom_bytes = pk_index.bloom_to_bytes();
+        super::primary_key::serialize_pk_bloom(&seg_ids, &bloom_bytes)
+    };
+
+    if let Err(error) = directory
+        .write(
+            std::path::Path::new(super::primary_key::PK_BLOOM_FILE),
+            &bloom_file,
+        )
+        .await
+    {
+        log::warn!("[primary_key] failed to persist bloom cache: {}", error);
+    }
+    Ok(())
+}
+
+async fn finalize_prepared_commit<D: DirectoryWriter + 'static>(
+    mut commit: OwnedCommitFinalization<D>,
+) -> Result<bool> {
+    let metadata_entries = commit.prepared.metadata_entries();
+
+    // This entire future is owned by a Tokio task. Cancelling the RPC only
+    // drops its JoinHandle; it cannot split durable metadata publication from
+    // PK reservations or worker resumption.
+    commit.segment_manager.commit(&metadata_entries).await?;
+    commit.publication_observed.store(true, Ordering::Release);
+
+    let mut published = commit.prepared.take_published();
+    for segment in &mut published {
+        segment.mark_published();
+    }
+    drop(published);
+    // Publication is irreversible. From here onward every exit path, including
+    // panic unwind, must make the writer available again while PK reservations
+    // remain fail-closed until refresh succeeds.
+    if let Some(finalization) = commit.finalization.as_mut() {
+        finalization.resume_on_drop();
+    } else {
+        log::error!("owned commit finalization guard was already released after publication");
+    }
+
+    // Metadata publication is the commit point. Cache refresh is fail-closed:
+    // retaining the generation's uncommitted keys may cause conservative
+    // duplicate rejections, but can never admit a duplicate or turn a durable
+    // commit into an API error.
+    if let Err(error) = refresh_primary_key_after_commit(
+        &commit.directory,
+        &commit.schema,
+        &commit.segment_manager,
+        &commit.primary_key_index,
+    )
+    .await
+    {
+        log::error!(
+            "[primary_key] committed metadata but failed to refresh dedup state; \
+             retaining reservations until a later successful commit: {}",
+            error,
+        );
+    }
+
+    // Merge scheduling is optional post-commit work and may briefly wait on
+    // manager state. Reconcile worker availability first so it cannot extend
+    // ingestion backpressure after metadata and PK state already agree.
+    drop(commit.finalization.take());
+    commit.segment_manager.maybe_merge().await;
+    Ok(true)
 }
 
 impl<'a, D: DirectoryWriter + 'static> PreparedCommit<'a, D> {
@@ -1079,7 +1324,7 @@ impl<'a, D: DirectoryWriter + 'static> PreparedCommit<'a, D> {
     ///
     /// Returns `true` if new segments were committed, `false` if nothing changed.
     pub async fn commit(mut self) -> Result<bool> {
-        let mut segments = std::mem::take(&mut self.writer.flushed_segments);
+        let segments = std::mem::take(&mut *self.writer.flushed_segments.lock());
 
         // Fast path: nothing to commit
         if segments.is_empty() {
@@ -1089,87 +1334,84 @@ impl<'a, D: DirectoryWriter + 'static> PreparedCommit<'a, D> {
             return Ok(false);
         }
 
-        let metadata_entries: Vec<(String, u32)> = segments
-            .iter()
-            .map(PreparedSegment::metadata_entry)
-            .collect();
-        if let Err(error) = self.writer.segment_manager.commit(&metadata_entries).await {
-            // Publication is transactional, so these guarded files remain a
-            // valid prepared commit. Preserve them and keep this generation
-            // paused for the caller's next commit/abort. Resuming here allowed
-            // a later worker generation to mix with the retained outputs; a
-            // failure in that generation then discarded documents from both.
-            self.writer.flushed_segments = segments;
+        if !self.writer.commit_finalization.begin() {
+            self.writer.flushed_segments.lock().extend(segments);
+            // Keep the prepared generation paused. Letting `Drop` auto-abort
+            // here would delete the retryable segments owned by another
+            // finalization state transition.
             self.is_resolved = true;
-            return Err(error);
+            return Err(Error::CommitInProgress);
         }
-        self.is_published = true;
 
-        // Metadata + tracker now own the IDs; releasing indexing ownership is
-        // the final transition from prepared to live.
-        for segment in &mut segments {
-            segment.mark_published();
-        }
-        drop(segments);
+        let publication_observed = Arc::new(AtomicBool::new(false));
+        let owned = OwnedCommitFinalization {
+            directory: Arc::clone(&self.writer.directory),
+            schema: Arc::clone(&self.writer.schema),
+            segment_manager: Arc::clone(&self.writer.segment_manager),
+            primary_key_index: Arc::clone(&self.writer.primary_key_index),
+            prepared: PreparedSegmentsGuard {
+                segments: Some(segments),
+                retry_slot: Arc::clone(&self.writer.flushed_segments),
+            },
+            finalization: Some(CommitFinalizationGuard {
+                state: Arc::clone(&self.writer.commit_finalization),
+                worker_state: Arc::clone(&self.writer.worker_state),
+                doc_sender: Arc::clone(&self.writer.doc_sender),
+                resume_workers: false,
+            }),
+            publication_observed: Arc::clone(&publication_observed),
+        };
 
-        // Refresh primary key index: only load fast fields for NEW segments.
-        let post_publish_result = async {
-            if let Some(ref mut pk_index) = self.writer.primary_key_index {
-                let snapshot = self.writer.segment_manager.acquire_snapshot().await;
-                let existing_ids: std::collections::HashSet<&str> =
-                    pk_index.committed_segment_ids().collect();
-
-                // Only load fast fields for segments not already held.
-                let load_futures: Vec<_> = snapshot
-                    .segment_ids()
-                    .iter()
-                    .filter(|id| !existing_ids.contains(id.as_str()))
-                    .map(|seg_id_str| {
-                        let seg_id_str = seg_id_str.clone();
-                        let dir = self.writer.directory.as_ref();
-                        let schema = Arc::clone(&self.writer.schema);
-                        async move { load_pk_segment_data(dir, &seg_id_str, &schema).await }
-                    })
-                    .collect();
-                let new_data = futures::future::try_join_all(load_futures).await?;
-
-                let seg_ids: Vec<String> = snapshot.segment_ids().to_vec();
-                pk_index.refresh_incremental(new_data, snapshot);
-
-                // Persist bloom cache (extract bytes to avoid borrow conflict).
-                let bloom_bytes = pk_index.bloom_to_bytes();
-                let data = super::primary_key::serialize_pk_bloom(&seg_ids, &bloom_bytes);
-                if let Err(e) = self
-                    .writer
-                    .directory
-                    .write(
-                        std::path::Path::new(super::primary_key::PK_BLOOM_FILE),
-                        &data,
-                    )
+        // From this point the owned value, not this cancel-sensitive guard,
+        // controls every segment and the paused worker generation. Resolve the
+        // local guard before spawning so even a runtime-spawn panic cannot
+        // auto-abort the retryable generation during unwind.
+        self.is_resolved = true;
+        let task_publication = Arc::clone(&publication_observed);
+        let task = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            tokio::spawn(async move {
+                match std::panic::AssertUnwindSafe(finalize_prepared_commit(owned))
+                    .catch_unwind()
                     .await
                 {
-                    log::warn!("[primary_key] failed to persist bloom cache: {}", e);
+                    Ok(result) => result,
+                    Err(_) if task_publication.load(Ordering::Acquire) => {
+                        log::error!(
+                            "owned commit finalizer panicked after metadata publication; \
+                             treating the durable generation as committed"
+                        );
+                        Ok(true)
+                    }
+                    Err(_) => Err(Error::Internal(
+                        "owned commit finalizer panicked before metadata publication".into(),
+                    )),
                 }
+            })
+        }))
+        .map_err(|_| Error::Internal("runtime rejected owned commit finalizer".into()))?;
+
+        match task.await {
+            Ok(result) => result,
+            Err(error) if publication_observed.load(Ordering::Acquire) => {
+                log::error!(
+                    "owned commit finalizer terminated after metadata publication: {}; \
+                     treating the durable generation as committed",
+                    error,
+                );
+                Ok(true)
             }
-
-            self.writer.segment_manager.maybe_merge().await;
-            Ok(())
+            Err(error) => Err(Error::Internal(format!(
+                "owned commit finalizer terminated unexpectedly: {error}"
+            ))),
         }
-        .await;
-
-        // Worker availability must not depend on optional post-publication
-        // cache refresh or merge scheduling.
-        self.is_resolved = true;
-        self.writer.resume_workers();
-        post_publish_result.map(|()| true)
     }
 
     /// Abort: discard prepared segments, delete their files asynchronously,
     /// and resume workers. Lifecycle ownership is held until deletion ends.
     pub fn abort(mut self) {
         self.is_resolved = true;
-        self.writer.flushed_segments.clear();
-        if let Some(ref mut pk_index) = self.writer.primary_key_index {
+        self.writer.flushed_segments.lock().clear();
+        if let Some(pk_index) = self.writer.primary_key_index.write().as_mut() {
             pk_index.clear_uncommitted();
         }
         self.writer.resume_workers();
@@ -1179,14 +1421,10 @@ impl<'a, D: DirectoryWriter + 'static> PreparedCommit<'a, D> {
 impl<D: DirectoryWriter + 'static> Drop for PreparedCommit<'_, D> {
     fn drop(&mut self) {
         if !self.is_resolved {
-            if self.is_published {
-                log::warn!("PreparedCommit dropped after metadata publication — resuming workers");
-            } else {
-                log::warn!("PreparedCommit dropped without commit/abort — auto-aborting");
-                self.writer.flushed_segments.clear();
-                if let Some(ref mut pk_index) = self.writer.primary_key_index {
-                    pk_index.clear_uncommitted();
-                }
+            log::warn!("PreparedCommit dropped without commit/abort — auto-aborting");
+            self.writer.flushed_segments.lock().clear();
+            if let Some(pk_index) = self.writer.primary_key_index.write().as_mut() {
+                pk_index.clear_uncommitted();
             }
             self.writer.resume_workers();
         }

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -51,7 +51,7 @@ use tokio::task::JoinHandle;
 
 use crate::directories::DirectoryWriter;
 use crate::error::{Error, Result};
-use crate::index::IndexMetadata;
+use crate::index::{IndexMetadata, SegmentMetaInfo};
 use crate::segment::{
     SegmentFiles, SegmentId, SegmentMeta, SegmentSnapshot, SegmentTracker, TrainedVectorStructures,
 };
@@ -1233,6 +1233,32 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         // The operation guard owns the output during validation. Publication
         // below replaces that ownership with metadata + tracker atomically.
         self.validate_completed_segment(&new_id, doc_count).await?;
+        let output_id = SegmentId::from_hex(&new_id).ok_or_else(|| {
+            Error::Corruption(format!("invalid replacement segment ID: {new_id}"))
+        })?;
+        let output_reader = SegmentReader::open(
+            self.directory.as_ref(),
+            output_id,
+            Arc::clone(&self.schema),
+            self.term_cache_blocks,
+        )
+        .await
+        .map_err(|error| match error {
+            // Preserve retryable storage failures as I/O. Structural failures
+            // are deterministic for this completed output and get explicit
+            // corruption context.
+            Error::Io(_) | Error::IndexClosed => error,
+            error => Error::Corruption(format!(
+                "replacement segment {new_id} failed full reader validation: {error}"
+            )),
+        })?;
+        if output_reader.num_docs() != doc_count {
+            return Err(Error::Corruption(format!(
+                "replacement segment {new_id} opened with {} docs, expected {doc_count}",
+                output_reader.num_docs(),
+            )));
+        }
+        drop(output_reader);
 
         let mut st = Arc::clone(&self.state).lock_owned().await;
         // Every source must still be live: callers hold operation ownership,
@@ -1258,18 +1284,32 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             .unwrap_or(0)
             .checked_add(1)
             .ok_or_else(|| Error::Corruption("merge generation exceeds u32::MAX".into()))?;
+        let parent_unconverged_passes = old_ids
+            .iter()
+            .filter_map(|id| st.metadata.segment_metas.get(id))
+            .map(|info| info.bp_unconverged_passes)
+            .max()
+            .unwrap_or(0);
+        let bp_unconverged_passes = if reordered && !bp_converged {
+            parent_unconverged_passes.saturating_add(1)
+        } else {
+            0
+        };
         let retired_ids = old_ids.to_vec();
         let mut next = st.metadata.clone();
         for id in old_ids {
             next.remove_segment(id);
         }
-        next.add_merged_segment(
+        next.add_segment_meta(
             new_id.clone(),
-            doc_count,
-            retired_ids.clone(),
-            parent_generation,
-            reordered,
-            bp_converged,
+            SegmentMetaInfo {
+                num_docs: doc_count,
+                ancestors: retired_ids.clone(),
+                generation: parent_generation,
+                reordered,
+                bp_converged,
+                bp_unconverged_passes,
+            },
         );
 
         let directory = Arc::clone(&self.directory);
@@ -1778,6 +1818,19 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     /// (`bp_converged == false`). A warm-started follow-up pass deepens the
     /// ordering; the optimizer revisits these at low priority.
     pub async fn unconverged_segments(&self) -> Vec<(String, u32)> {
+        self.unconverged_segments_below(u32::MAX)
+            .await
+            .into_iter()
+            .map(|(id, docs, _)| (id, docs))
+            .collect()
+    }
+
+    /// Unconverged segments still below a hard replacement-lineage work
+    /// bound. Includes the persisted attempt count for scheduler diagnostics.
+    pub async fn unconverged_segments_below(
+        &self,
+        max_unconverged_passes: u32,
+    ) -> Vec<(String, u32, u32)> {
         let quarantined = self.quarantined_segments.lock().clone();
         let paused = self.paused_reorder_segments();
         let st = self.state.lock().await;
@@ -1788,11 +1841,12 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             .filter(|(id, info)| {
                 info.reordered
                     && !info.bp_converged
+                    && info.bp_unconverged_passes < max_unconverged_passes
                     && !active_ids.contains(*id)
                     && !quarantined.contains(*id)
                     && !paused.contains(*id)
             })
-            .map(|(id, info)| (id.clone(), info.num_docs))
+            .map(|(id, info)| (id.clone(), info.num_docs, info.bp_unconverged_passes))
             .collect()
     }
 
@@ -2215,6 +2269,54 @@ mod tests {
         .await
         .expect("shutdown did not drain detached lifecycle transaction");
         assert!(completed.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn unconverged_scheduler_stops_at_the_lineage_limit() {
+        let manager = lifecycle_test_manager();
+        {
+            let mut state = manager.state.lock().await;
+            state.metadata.add_segment_meta(
+                "eligible".into(),
+                SegmentMetaInfo {
+                    num_docs: 10,
+                    ancestors: Vec::new(),
+                    generation: 1,
+                    reordered: true,
+                    bp_converged: false,
+                    bp_unconverged_passes: 2,
+                },
+            );
+            state.metadata.add_segment_meta(
+                "at-limit".into(),
+                SegmentMetaInfo {
+                    num_docs: 20,
+                    ancestors: Vec::new(),
+                    generation: 1,
+                    reordered: true,
+                    bp_converged: false,
+                    bp_unconverged_passes: 3,
+                },
+            );
+            state.metadata.add_segment_meta(
+                "converged".into(),
+                SegmentMetaInfo {
+                    num_docs: 30,
+                    ancestors: Vec::new(),
+                    generation: 1,
+                    reordered: true,
+                    bp_converged: true,
+                    bp_unconverged_passes: 0,
+                },
+            );
+            state.metadata.add_segment("fresh".into(), 40);
+        }
+
+        assert_eq!(
+            manager.unconverged_segments_below(3).await,
+            vec![("eligible".into(), 10, 2)]
+        );
+        assert!(manager.unconverged_segments_below(0).await.is_empty());
     }
 
     #[test]

--- a/hermes-core/src/segment/builder/dense.rs
+++ b/hermes-core/src/segment/builder/dense.rs
@@ -318,16 +318,19 @@ pub(super) fn build_vectors_streaming(
                     &builder.vectors,
                     &builder.doc_ids,
                 );
-                let blob = index.to_bytes().map_err(crate::Error::Io)?;
                 let blob_offset = current_offset;
-                writer.write_all(&blob)?;
-                current_offset += blob.len() as u64;
+                let mut output = &mut *writer;
+                let blob_len = index.write_to(&mut output).map_err(crate::Error::Io)? as u64;
+                current_offset = current_offset.checked_add(blob_len).ok_or_else(|| {
+                    crate::Error::Internal("binary IVF output offset exceeds u64".into())
+                })?;
                 toc.push(DenseVectorTocEntry {
                     field_id,
                     index_type: super::super::ann_build::BINARY_IVF_TYPE,
                     offset: blob_offset,
-                    size: blob.len() as u64,
+                    size: blob_len,
                 });
+                drop(index);
                 let pad = (8 - (current_offset % 8)) % 8;
                 if pad > 0 {
                     writer.write_all(&[0u8; 8][..pad as usize])?;
@@ -338,7 +341,7 @@ pub(super) fn build_vectors_streaming(
                     field_id,
                     num_vectors,
                     num_clusters,
-                    blob.len(),
+                    blob_len,
                 );
             }
         }

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -11,7 +11,32 @@
 
 #[cfg(feature = "native")]
 use rayon::prelude::*;
-use rustc_hash::FxHashMap;
+const TERM_DEGREE_VALUE_BYTES: usize = std::mem::size_of::<[u32; 2]>();
+const CANDIDATE_ENTRY_BYTES: usize = std::mem::size_of::<(usize, u32)>();
+
+fn term_degree_bytes(num_terms: usize) -> usize {
+    num_terms
+        .saturating_mul(TERM_DEGREE_VALUE_BYTES)
+        .saturating_add(num_terms.div_ceil(64).saturating_mul(8))
+}
+
+fn parallel_bisect_depth(
+    memory_budget_bytes: usize,
+    non_degree_bytes: usize,
+    num_terms: usize,
+) -> usize {
+    let per_node = term_degree_bytes(num_terms).max(1);
+    let affordable_nodes = memory_budget_bytes
+        .saturating_sub(non_degree_bytes)
+        .checked_div(per_node)
+        .unwrap_or(0)
+        .max(1);
+    #[cfg(feature = "native")]
+    let worker_limit = rayon::current_num_threads().max(1);
+    #[cfg(not(feature = "native"))]
+    let worker_limit = 1usize;
+    affordable_nodes.min(worker_limit).ilog2() as usize
+}
 
 /// Per-partition left/right term degrees with direct compact-term indexing.
 ///
@@ -73,6 +98,14 @@ pub(crate) struct ForwardIndex {
     /// by dropping dims below the u32 limit.
     offsets: Vec<u64>,
     pub num_terms: usize,
+    /// Maximum recursion depth at which both children may own a vocabulary-
+    /// sized degree array concurrently. Deeper partitions still use Rayon for
+    /// gain computation, but recurse serially to honor the memory budget.
+    parallel_bisect_depth: usize,
+    /// True when the configured memory limit forced graph signal to be
+    /// discarded. Callers must not report the resulting order as fully
+    /// converged: a later pass with a larger budget may still improve it.
+    budget_limited: bool,
 }
 
 /// Build CSR offsets (prefix sums) from per-entity counts. u64 output — the
@@ -107,6 +140,11 @@ impl ForwardIndex {
     pub fn total_postings(&self) -> u64 {
         self.offsets.last().copied().unwrap_or(0)
     }
+
+    #[inline]
+    pub fn budget_limited(&self) -> bool {
+        self.budget_limited
+    }
 }
 
 /// Build virtual→real and real→virtual vid maps from a BMP doc map.
@@ -118,11 +156,14 @@ impl ForwardIndex {
 ///
 /// Returns `(virtual_to_real, real_to_virtual)` where `virtual_to_real[vid]`
 /// is the dense real index or `u32::MAX` for padding.
-pub(crate) fn build_vid_maps(bmp: &crate::segment::reader::bmp::BmpIndex) -> (Vec<u32>, Vec<u32>) {
+pub(crate) fn build_vid_maps(
+    bmp: &crate::segment::reader::bmp::BmpIndex,
+) -> crate::Result<(Vec<u32>, Vec<u32>)> {
     let ids = bmp.doc_map_ids_slice();
     let num_virtual = bmp.num_virtual_docs as usize;
+    let expected_real = bmp.num_real_docs() as usize;
     let mut virtual_to_real = vec![u32::MAX; num_virtual];
-    let mut real_to_virtual = Vec::with_capacity(bmp.num_real_docs() as usize);
+    let mut real_to_virtual = Vec::with_capacity(expected_real);
     for (vid, (slot, chunk)) in virtual_to_real
         .iter_mut()
         .zip(ids.as_chunks::<4>().0)
@@ -130,18 +171,22 @@ pub(crate) fn build_vid_maps(bmp: &crate::segment::reader::bmp::BmpIndex) -> (Ve
     {
         let doc_id = u32::from_le_bytes(*chunk);
         if doc_id != u32::MAX {
+            if real_to_virtual.len() == expected_real {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP document map contains more than the footer's {expected_real} real slots"
+                )));
+            }
             *slot = real_to_virtual.len() as u32;
             real_to_virtual.push(vid as u32);
         }
     }
-    if real_to_virtual.len() != bmp.num_real_docs() as usize {
-        log::warn!(
-            "[reorder] BMP doc map has {} real slots but footer says num_real_docs={} — trusting the doc map",
+    if real_to_virtual.len() != expected_real {
+        return Err(crate::Error::Corruption(format!(
+            "BMP document map has {} real slots but footer declares {expected_real}",
             real_to_virtual.len(),
-            bmp.num_real_docs(),
-        );
+        )));
     }
-    (virtual_to_real, real_to_virtual)
+    Ok((virtual_to_real, real_to_virtual))
 }
 
 /// One (source, block) unit of forward-index construction. Because
@@ -188,21 +233,6 @@ fn build_block_jobs(
     jobs
 }
 
-/// Merge the smaller df map into the larger (rayon reduce combiner).
-#[cfg(feature = "native")]
-fn merge_df_maps(
-    mut a: FxHashMap<u32, usize>,
-    mut b: FxHashMap<u32, usize>,
-) -> FxHashMap<u32, usize> {
-    if a.len() < b.len() {
-        std::mem::swap(&mut a, &mut b);
-    }
-    for (k, v) in b {
-        *a.entry(k).or_insert(0) += v;
-    }
-    a
-}
-
 /// Build forward index from BmpIndex sources (single or multi-source).
 ///
 /// Documents are identified by dense *real* indices assigned sequentially
@@ -222,15 +252,18 @@ pub(crate) fn build_forward_index_from_bmps(
     min_doc_freq: usize,
     max_doc_freq: usize,
     memory_budget_bytes: usize,
-) -> (ForwardIndex, Vec<usize>) {
-    let vid_maps: Vec<(Vec<u32>, Vec<u32>)> = bmps.iter().map(|b| build_vid_maps(b)).collect();
-    build_forward_index_from_bmps_with_maps(
+) -> crate::Result<(ForwardIndex, Vec<usize>)> {
+    let vid_maps: Vec<(Vec<u32>, Vec<u32>)> = bmps
+        .iter()
+        .map(|bmp| build_vid_maps(bmp))
+        .collect::<crate::Result<_>>()?;
+    Ok(build_forward_index_from_bmps_with_maps(
         bmps,
         &vid_maps,
         min_doc_freq,
         max_doc_freq,
         memory_budget_bytes,
-    )
+    ))
 }
 
 /// Variant for reorder callers that already need the virtual/real maps during
@@ -253,6 +286,8 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
                 terms: Vec::new(),
                 offsets: Vec::new(),
                 num_terms: 0,
+                parallel_bisect_depth: 0,
+                budget_limited: false,
             },
             source_doc_counts,
         );
@@ -264,8 +299,40 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
     // parallel, writing disjoint slices.
     let jobs = build_block_jobs(bmps, vid_maps);
 
-    // Phase 1: count doc freq per dimension across all sources + assign compact IDs
-    let count_block_df = |job: &BlockJob, acc: &mut FxHashMap<u32, usize>| {
+    // Phase 1: count doc frequency in one dense atomic table. The previous
+    // Rayon fold built a vocabulary-sized hash map per worker before the
+    // budget check, multiplying peak memory by the CPU count.
+    let max_dims = bmps
+        .iter()
+        .map(|bmp| bmp.dims() as usize)
+        .max()
+        .unwrap_or(0);
+    let jobs_bytes = jobs
+        .len()
+        .saturating_mul(std::mem::size_of::<BlockJob>().saturating_add(40));
+    let frequency_bytes =
+        max_dims.saturating_mul(std::mem::size_of::<std::sync::atomic::AtomicU32>());
+    if frequency_bytes > memory_budget_bytes.saturating_sub(jobs_bytes) {
+        log::warn!(
+            "[reorder] memory budget {:.0} MB cannot hold the {:.0} MB dimension-frequency table; using identity order",
+            memory_budget_bytes as f64 / (1024.0 * 1024.0),
+            frequency_bytes as f64 / (1024.0 * 1024.0),
+        );
+        return (
+            ForwardIndex {
+                terms: Vec::new(),
+                offsets: Vec::new(),
+                num_terms: 0,
+                parallel_bisect_depth: 0,
+                budget_limited: true,
+            },
+            source_doc_counts,
+        );
+    }
+    let dim_df: Vec<std::sync::atomic::AtomicU32> = (0..max_dims)
+        .map(|_| std::sync::atomic::AtomicU32::new(0))
+        .collect();
+    let count_block_df = |job: &BlockJob| {
         let bmp = bmps[job.src as usize];
         let (v2r, _) = &vid_maps[job.src as usize];
         let block_size = bmp.bmp_block_size as usize;
@@ -277,48 +344,74 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
                     n += 1;
                 }
             }
-            if n > 0 {
-                *acc.entry(dim_id).or_insert(0) += n;
+            if n > 0
+                && let Some(count) = dim_df.get(dim_id as usize)
+            {
+                count.fetch_add(n as u32, std::sync::atomic::Ordering::Relaxed);
             }
         }
     };
     #[cfg(feature = "native")]
-    let dim_df: FxHashMap<u32, usize> = jobs
-        .par_iter()
-        .fold(FxHashMap::default, |mut acc, job| {
-            count_block_df(job, &mut acc);
-            acc
-        })
-        .reduce(FxHashMap::default, merge_df_maps);
+    jobs.par_iter().for_each(count_block_df);
     #[cfg(not(feature = "native"))]
-    let dim_df: FxHashMap<u32, usize> = {
-        let mut acc = FxHashMap::default();
-        for job in &jobs {
-            count_block_df(job, &mut acc);
-        }
-        acc
-    };
+    jobs.iter().for_each(count_block_df);
 
-    // Filter dims by [min_doc_freq, max_doc_freq] range
-    let mut eligible: Vec<(u32, usize)> = dim_df
+    // Retain the lowest-frequency candidates in a bounded heap while the
+    // frequency table is live. This makes candidate discovery itself obey the
+    // configured limit even for extremely large vocabularies.
+    let eligible_candidate_count = dim_df
         .iter()
-        .filter(|&(_, df)| *df >= min_doc_freq && *df <= max_doc_freq)
-        .map(|(&dim_id, &df)| (dim_id, df))
-        .collect();
+        .filter(|df| {
+            let df = df.load(std::sync::atomic::Ordering::Relaxed) as usize;
+            df >= min_doc_freq && df <= max_doc_freq
+        })
+        .count();
+    let candidate_capacity = memory_budget_bytes
+        .saturating_sub(jobs_bytes)
+        .saturating_sub(frequency_bytes)
+        .checked_div(std::mem::size_of::<(usize, u32)>())
+        .unwrap_or(0)
+        .min(eligible_candidate_count);
+    let mut candidate_heap = std::collections::BinaryHeap::with_capacity(candidate_capacity);
+    for (dim_id, df) in dim_df.iter().enumerate() {
+        let df = df.load(std::sync::atomic::Ordering::Relaxed) as usize;
+        if df < min_doc_freq || df > max_doc_freq {
+            continue;
+        }
+        let candidate = (df, dim_id as u32);
+        if candidate_heap.len() < candidate_capacity {
+            candidate_heap.push(candidate);
+        } else if candidate_capacity > 0 && candidate < *candidate_heap.peek().unwrap() {
+            candidate_heap.pop();
+            candidate_heap.push(candidate);
+        }
+    }
     drop(dim_df);
+    let mut eligible: Vec<(u32, usize)> = candidate_heap
+        .into_vec()
+        .into_iter()
+        .map(|(df, dim_id)| (dim_id, df))
+        .collect();
+    let mut budget_limited = eligible.len() < eligible_candidate_count;
 
     // Memory budget: estimate forward index + bisection scratch.
-    // Peak ≈ 4*total_postings (terms array) + 32*total_docs (u64 offsets,
-    //   counts, docs, gains, indices, new_left, new_right) + 8*num_terms
-    //   (degree arrays).
+    // Includes jobs/slice descriptors, dense remap, all per-document scratch,
+    // and at least one exact TermDegrees allocation.
     let total_postings_est = eligible
         .iter()
         .fold(0usize, |total, (_, df)| total.saturating_add(*df));
     let entity_scratch_bytes = total_docs.saturating_mul(32);
+    let remap_bytes = max_dims.saturating_mul(4);
+    let fixed_bytes = entity_scratch_bytes
+        .saturating_add(remap_bytes)
+        .saturating_add(jobs_bytes);
     let estimated_bytes = total_postings_est
         .saturating_mul(4)
-        .saturating_add(entity_scratch_bytes)
-        .saturating_add(eligible.len().saturating_mul(8));
+        .saturating_add(fixed_bytes)
+        // Candidate metadata coexists with the dense remap until construction
+        // starts; omitting it let a huge rare-term vocabulary exceed the cap.
+        .saturating_add(eligible.len().saturating_mul(CANDIDATE_ENTRY_BYTES))
+        .saturating_add(term_degree_bytes(eligible.len()));
 
     if estimated_bytes > memory_budget_bytes && !eligible.is_empty() {
         // Sort by df ascending — keep discriminative low-df dims first,
@@ -329,11 +422,14 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         // calculation charged the eight-byte degree slot for every candidate
         // before deciding how many to retain; a large rare-term vocabulary
         // could therefore make the target zero even when a useful subset fit.
-        let mut used_bytes = entity_scratch_bytes;
+        let mut used_bytes = fixed_bytes;
         let mut cum = 0usize;
         let mut keep_count = 0;
         for &(_, df) in &eligible {
-            let term_bytes = df.saturating_mul(4).saturating_add(8);
+            let term_bytes = df
+                .saturating_mul(4)
+                .saturating_add(TERM_DEGREE_VALUE_BYTES + 1)
+                .saturating_add(CANDIDATE_ENTRY_BYTES);
             if term_bytes > memory_budget_bytes.saturating_sub(used_bytes) {
                 break;
             }
@@ -344,6 +440,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
 
         let dropped = eligible.len() - keep_count;
         eligible.truncate(keep_count);
+        budget_limited |= dropped > 0;
 
         log::warn!(
             "[reorder] memory budget {:.0} MB: estimated {:.0} MB, dropped {} highest-df dims, keeping {} ({} postings)",
@@ -365,17 +462,24 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
                 terms: Vec::new(),
                 offsets: Vec::new(),
                 num_terms: 0,
+                parallel_bisect_depth: 0,
+                budget_limited,
             },
             source_doc_counts,
         );
     }
 
-    let mut term_remap: FxHashMap<u32, u32> = FxHashMap::default();
-    for &(dim_id, _) in &eligible {
-        let compact_id = term_remap.len() as u32;
-        term_remap.insert(dim_id, compact_id);
+    let mut term_remap = vec![u32::MAX; max_dims];
+    for (compact_id, &(dim_id, _)) in eligible.iter().enumerate() {
+        term_remap[dim_id as usize] = compact_id as u32;
     }
-    let num_active_terms = term_remap.len();
+    let num_active_terms = eligible.len();
+    let retained_postings = eligible
+        .iter()
+        .fold(0usize, |total, (_, df)| total.saturating_add(*df));
+    let non_degree_bytes = fixed_bytes.saturating_add(retained_postings.saturating_mul(4));
+    let parallel_bisect_depth =
+        parallel_bisect_depth(memory_budget_bytes, non_degree_bytes, num_active_terms);
     drop(eligible);
 
     // Phase 2: count terms per doc (filtered) — per-block disjoint slices
@@ -385,7 +489,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         let (v2r, _) = &vid_maps[job.src as usize];
         let block_size = bmp.bmp_block_size as usize;
         for (dim_id, postings) in bmp.iter_block_terms(job.block_id) {
-            if !term_remap.contains_key(&dim_id) {
+            if term_remap.get(dim_id as usize).copied().unwrap_or(u32::MAX) == u32::MAX {
                 continue;
             }
             for p in postings {
@@ -432,9 +536,10 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         let mut cursor = [0u32; 256];
         let base = offsets[global_real_start] as usize;
         for (dim_id, postings) in bmp.iter_block_terms(job.block_id) {
-            let Some(&compact) = term_remap.get(&dim_id) else {
+            let compact = term_remap.get(dim_id as usize).copied().unwrap_or(u32::MAX);
+            if compact == u32::MAX {
                 continue;
-            };
+            }
             for p in postings {
                 let vid = job.block_id as usize * block_size + p.local_slot as usize;
                 let real = v2r[vid];
@@ -475,6 +580,8 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
             terms,
             offsets,
             num_terms: num_active_terms,
+            parallel_bisect_depth,
+            budget_limited,
         },
         source_doc_counts,
     )
@@ -497,6 +604,8 @@ pub(crate) fn build_forward_index_from_blocks(
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
+            parallel_bisect_depth: 0,
+            budget_limited: false,
         };
     }
 
@@ -507,52 +616,103 @@ pub(crate) fn build_forward_index_from_blocks(
         .flat_map(|(src, bmp)| (0..bmp.num_blocks).map(move |b| (src as u32, b)))
         .collect();
 
-    // Phase 1: dim → number of blocks containing it (block-level df)
-    let count_block_bf = |&(src, block_id): &(u32, u32), acc: &mut FxHashMap<u32, usize>| {
+    // Phase 1: one bounded dense frequency table, shared by every worker.
+    let max_dims = bmps
+        .iter()
+        .map(|bmp| bmp.dims() as usize)
+        .max()
+        .unwrap_or(0);
+    let blocks_bytes = blocks
+        .len()
+        .saturating_mul(std::mem::size_of::<(u32, u32)>().saturating_add(32));
+    let frequency_bytes =
+        max_dims.saturating_mul(std::mem::size_of::<std::sync::atomic::AtomicU32>());
+    if frequency_bytes > memory_budget_bytes.saturating_sub(blocks_bytes) {
+        log::warn!(
+            "[reorder] block-level frequency table exceeds memory budget; using identity order"
+        );
+        return ForwardIndex {
+            terms: Vec::new(),
+            offsets: Vec::new(),
+            num_terms: 0,
+            parallel_bisect_depth: 0,
+            budget_limited: true,
+        };
+    }
+    let dim_bf: Vec<std::sync::atomic::AtomicU32> = (0..max_dims)
+        .map(|_| std::sync::atomic::AtomicU32::new(0))
+        .collect();
+    let count_block_bf = |&(src, block_id): &(u32, u32)| {
         for (dim_id, _) in bmps[src as usize].iter_block_terms(block_id) {
-            *acc.entry(dim_id).or_insert(0) += 1;
+            if let Some(count) = dim_bf.get(dim_id as usize) {
+                count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
         }
     };
     #[cfg(feature = "native")]
-    let dim_bf: FxHashMap<u32, usize> = blocks
-        .par_iter()
-        .fold(FxHashMap::default, |mut acc, b| {
-            count_block_bf(b, &mut acc);
-            acc
-        })
-        .reduce(FxHashMap::default, merge_df_maps);
+    blocks.par_iter().for_each(count_block_bf);
     #[cfg(not(feature = "native"))]
-    let dim_bf: FxHashMap<u32, usize> = {
-        let mut acc = FxHashMap::default();
-        for b in &blocks {
-            count_block_bf(b, &mut acc);
-        }
-        acc
-    };
+    blocks.iter().for_each(count_block_bf);
 
     let max_bf = (total_blocks as f64 * 0.9) as usize;
-    let mut eligible: Vec<(u32, usize)> = dim_bf
+    let eligible_candidate_count = dim_bf
         .iter()
-        .filter(|&(_, bf)| *bf >= 2 && *bf <= max_bf.max(2))
-        .map(|(&dim_id, &bf)| (dim_id, bf))
-        .collect();
+        .filter(|bf| {
+            let bf = bf.load(std::sync::atomic::Ordering::Relaxed) as usize;
+            bf >= 2 && bf <= max_bf.max(2)
+        })
+        .count();
+    let candidate_capacity = memory_budget_bytes
+        .saturating_sub(blocks_bytes)
+        .saturating_sub(frequency_bytes)
+        .checked_div(std::mem::size_of::<(usize, u32)>())
+        .unwrap_or(0)
+        .min(eligible_candidate_count);
+    let mut candidate_heap = std::collections::BinaryHeap::with_capacity(candidate_capacity);
+    for (dim_id, bf) in dim_bf.iter().enumerate() {
+        let bf = bf.load(std::sync::atomic::Ordering::Relaxed) as usize;
+        if bf < 2 || bf > max_bf.max(2) {
+            continue;
+        }
+        let candidate = (bf, dim_id as u32);
+        if candidate_heap.len() < candidate_capacity {
+            candidate_heap.push(candidate);
+        } else if candidate_capacity > 0 && candidate < *candidate_heap.peek().unwrap() {
+            candidate_heap.pop();
+            candidate_heap.push(candidate);
+        }
+    }
     drop(dim_bf);
+    let mut eligible: Vec<(u32, usize)> = candidate_heap
+        .into_vec()
+        .into_iter()
+        .map(|(bf, dim_id)| (dim_id, bf))
+        .collect();
+    let mut budget_limited = eligible.len() < eligible_candidate_count;
 
     let total_postings_est = eligible
         .iter()
         .fold(0usize, |total, (_, bf)| total.saturating_add(*bf));
     let entity_scratch_bytes = total_blocks.saturating_mul(32);
+    let remap_bytes = max_dims.saturating_mul(4);
+    let fixed_bytes = entity_scratch_bytes
+        .saturating_add(remap_bytes)
+        .saturating_add(blocks_bytes);
     let estimated_bytes = total_postings_est
         .saturating_mul(4)
-        .saturating_add(entity_scratch_bytes)
-        .saturating_add(eligible.len().saturating_mul(8));
+        .saturating_add(fixed_bytes)
+        .saturating_add(eligible.len().saturating_mul(CANDIDATE_ENTRY_BYTES))
+        .saturating_add(term_degree_bytes(eligible.len()));
     if estimated_bytes > memory_budget_bytes && !eligible.is_empty() {
         eligible.sort_by_key(|&(_, bf)| bf);
-        let mut used_bytes = entity_scratch_bytes;
+        let mut used_bytes = fixed_bytes;
         let mut cum = 0usize;
         let mut keep = 0;
         for &(_, bf) in &eligible {
-            let term_bytes = bf.saturating_mul(4).saturating_add(8);
+            let term_bytes = bf
+                .saturating_mul(4)
+                .saturating_add(TERM_DEGREE_VALUE_BYTES + 1)
+                .saturating_add(CANDIDATE_ENTRY_BYTES);
             if term_bytes > memory_budget_bytes.saturating_sub(used_bytes) {
                 break;
             }
@@ -560,9 +720,11 @@ pub(crate) fn build_forward_index_from_blocks(
             cum = cum.saturating_add(bf);
             keep += 1;
         }
+        let dropped = eligible.len() - keep;
+        budget_limited |= dropped > 0;
         log::warn!(
             "[reorder] block-level fwd index over budget — dropped {} highest-bf dims",
-            eligible.len() - keep,
+            dropped,
         );
         eligible.truncate(keep);
     }
@@ -572,15 +734,22 @@ pub(crate) fn build_forward_index_from_blocks(
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
+            parallel_bisect_depth: 0,
+            budget_limited,
         };
     }
 
-    let mut term_remap: FxHashMap<u32, u32> = FxHashMap::default();
-    for &(dim_id, _) in &eligible {
-        let compact = term_remap.len() as u32;
-        term_remap.insert(dim_id, compact);
+    let mut term_remap = vec![u32::MAX; max_dims];
+    for (compact, &(dim_id, _)) in eligible.iter().enumerate() {
+        term_remap[dim_id as usize] = compact as u32;
     }
-    let num_terms = term_remap.len();
+    let num_terms = eligible.len();
+    let retained_postings = eligible
+        .iter()
+        .fold(0usize, |total, (_, bf)| total.saturating_add(*bf));
+    let non_degree_bytes = fixed_bytes.saturating_add(retained_postings.saturating_mul(4));
+    let parallel_bisect_depth =
+        parallel_bisect_depth(memory_budget_bytes, non_degree_bytes, num_terms);
     drop(eligible);
 
     // Phase 2+3: counts and CSR fill — one entity per block, so each block
@@ -588,7 +757,13 @@ pub(crate) fn build_forward_index_from_blocks(
     let count_remapped = |&(src, block_id): &(u32, u32)| -> u32 {
         bmps[src as usize]
             .iter_block_terms(block_id)
-            .filter(|(dim_id, _)| term_remap.contains_key(dim_id))
+            .filter(|(dim_id, _)| {
+                term_remap
+                    .get(*dim_id as usize)
+                    .copied()
+                    .unwrap_or(u32::MAX)
+                    != u32::MAX
+            })
             .count() as u32
     };
     #[cfg(feature = "native")]
@@ -604,7 +779,8 @@ pub(crate) fn build_forward_index_from_blocks(
     let fill_block = |&(src, block_id): &(u32, u32), out: &mut [u32]| {
         let mut n = 0usize;
         for (dim_id, _) in bmps[src as usize].iter_block_terms(block_id) {
-            if let Some(&compact) = term_remap.get(&dim_id) {
+            let compact = term_remap.get(dim_id as usize).copied().unwrap_or(u32::MAX);
+            if compact != u32::MAX {
                 out[n] = compact;
                 n += 1;
             }
@@ -633,6 +809,8 @@ pub(crate) fn build_forward_index_from_blocks(
         terms,
         offsets,
         num_terms,
+        parallel_bisect_depth,
+        budget_limited,
     }
 }
 
@@ -681,7 +859,7 @@ pub(crate) fn graph_bisection(
 ) -> (Vec<u32>, bool) {
     let n = fwd.num_docs();
     if n == 0 {
-        return (Vec::new(), true);
+        return (Vec::new(), !fwd.budget_limited);
     }
 
     let effective_min_partition = budget
@@ -715,37 +893,31 @@ pub(crate) fn graph_bisection(
     });
     #[cfg(not(feature = "native"))]
     let deadline: Option<()> = None;
-    #[cfg(not(feature = "native"))]
-    let _ = deadline;
 
     let exhausted = std::sync::atomic::AtomicBool::new(false);
-    #[cfg(feature = "native")]
-    bisect(
-        &mut docs,
+    let context = BisectContext {
         fwd,
-        effective_min_partition,
+        min_partition_size: effective_min_partition,
         max_iters,
-        &log_table,
+        log_table: &log_table,
+        #[cfg(feature = "native")]
         deadline,
-        &exhausted,
-    );
+        #[cfg(not(feature = "native"))]
+        deadline,
+        exhausted: &exhausted,
+    };
+    #[cfg(feature = "native")]
+    bisect(&mut docs, fwd.parallel_bisect_depth, &context);
     #[cfg(not(feature = "native"))]
-    bisect(
-        &mut docs,
-        fwd,
-        effective_min_partition,
-        max_iters,
-        &log_table,
-        None,
-        &exhausted,
-    );
+    bisect(&mut docs, 0, &context);
 
-    let converged = !exhausted.load(std::sync::atomic::Ordering::Relaxed);
+    let converged = !fwd.budget_limited && !exhausted.load(std::sync::atomic::Ordering::Relaxed);
     if !converged {
         log::info!(
-            "BP graph_bisection: wall-clock budget {:?} exhausted at n={} — emitting partial (still valid) permutation",
-            budget.time_budget,
+            "BP graph_bisection: budget incomplete at n={} (time={:?}, memory_limited={}) — emitting partial (still valid) permutation",
             n,
+            budget.time_budget,
+            fwd.budget_limited,
         );
     }
     (docs, converged)
@@ -759,44 +931,51 @@ pub(crate) fn graph_bisection(
 /// Gain computation is parallelized via rayon for large partitions (n > 4096).
 /// Adaptive iteration count reduces work at top levels where coarse splits
 /// converge faster and dominate total runtime.
-fn bisect(
-    docs: &mut [u32],
-    fwd: &ForwardIndex,
+struct BisectContext<'a> {
+    fwd: &'a ForwardIndex,
     min_partition_size: usize,
     max_iters: usize,
-    log_table: &[f32],
-    #[cfg(feature = "native")] deadline: Option<std::time::Instant>,
-    #[cfg(not(feature = "native"))] deadline: Option<()>,
-    exhausted: &std::sync::atomic::AtomicBool,
-) {
+    log_table: &'a [f32],
+    #[cfg(feature = "native")]
+    deadline: Option<std::time::Instant>,
+    #[cfg(not(feature = "native"))]
+    deadline: Option<()>,
+    exhausted: &'a std::sync::atomic::AtomicBool,
+}
+
+fn bisect(docs: &mut [u32], parallel_depth: usize, context: &BisectContext<'_>) {
+    #[cfg(not(feature = "native"))]
+    let _ = parallel_depth;
     let n = docs.len();
-    if n <= min_partition_size {
+    if n <= context.min_partition_size {
         return;
     }
     // Anytime cutoff: leave this subtree in its current (valid) order.
-    if exhausted.load(std::sync::atomic::Ordering::Relaxed) {
+    if context.exhausted.load(std::sync::atomic::Ordering::Relaxed) {
         return;
     }
     #[cfg(feature = "native")]
-    if let Some(dl) = deadline
+    if let Some(dl) = context.deadline
         && std::time::Instant::now() >= dl
     {
-        exhausted.store(true, std::sync::atomic::Ordering::Relaxed);
+        context
+            .exhausted
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         return;
     }
     #[cfg(not(feature = "native"))]
-    let _ = deadline;
+    let _ = context.deadline;
 
     let mid = n / 2;
-    let nt = fwd.num_terms;
+    let nt = context.fwd.num_terms;
 
     // Adaptive iteration count: large partitions converge faster with
     // coarse splits, so fewer refinement passes suffice. The fine-grained
     // clustering is handled by deeper recursion levels with full iterations.
     let effective_iters = if n > 100_000 {
-        max_iters.min(12)
+        context.max_iters.min(12)
     } else {
-        max_iters
+        context.max_iters
     };
 
     // Compact term IDs permit direct indexing. Slots are initialized lazily so
@@ -805,7 +984,7 @@ fn bisect(
 
     for (i, &doc) in docs.iter().enumerate() {
         let side = usize::from(i >= mid);
-        for &term in fwd.doc_terms(doc as usize) {
+        for &term in context.fwd.doc_terms(doc as usize) {
             degrees.entry_mut(term as usize)[side] += 1;
         }
     }
@@ -819,15 +998,24 @@ fn bisect(
     for iter in 0..effective_iters {
         // Anytime cutoff between refinement passes: keep the current split.
         #[cfg(feature = "native")]
-        if let Some(dl) = deadline
+        if let Some(dl) = context.deadline
             && std::time::Instant::now() >= dl
         {
-            exhausted.store(true, std::sync::atomic::Ordering::Relaxed);
+            context
+                .exhausted
+                .store(true, std::sync::atomic::Ordering::Relaxed);
             break;
         }
         // Compute gain for each document (approx_1 from Dhulipala et al.)
         // Parallelized for large partitions where per-doc work dominates.
-        compute_gains(docs, fwd, mid, &degrees, log_table, &mut gains);
+        compute_gains(
+            docs,
+            context.fwd,
+            mid,
+            &degrees,
+            context.log_table,
+            &mut gains,
+        );
 
         // Partition: the `mid` LOWEST keys (strongest left affinity) go left
         indices.clear();
@@ -854,7 +1042,7 @@ fn bisect(
 
             if was_left != now_left {
                 swap_count += 1;
-                for &term in fwd.doc_terms(doc as usize) {
+                for &term in context.fwd.doc_terms(doc as usize) {
                     let degree = degrees.entry_mut(term as usize);
                     if was_left {
                         degree[0] -= 1;
@@ -900,50 +1088,22 @@ fn bisect(
 
     let (left, right) = docs.split_at_mut(mid);
     #[cfg(feature = "native")]
-    rayon::join(
-        || {
-            bisect(
-                left,
-                fwd,
-                min_partition_size,
-                max_iters,
-                log_table,
-                deadline,
-                exhausted,
-            )
-        },
-        || {
-            bisect(
-                right,
-                fwd,
-                min_partition_size,
-                max_iters,
-                log_table,
-                deadline,
-                exhausted,
-            )
-        },
-    );
+    if parallel_depth > 0 {
+        rayon::join(
+            || bisect(left, parallel_depth - 1, context),
+            || bisect(right, parallel_depth - 1, context),
+        );
+    } else {
+        // Gain computation inside each node remains parallel, so serializing
+        // recursion here bounds vocabulary-sized degree arrays without leaving
+        // the Rayon pool idle.
+        bisect(left, 0, context);
+        bisect(right, 0, context);
+    }
     #[cfg(not(feature = "native"))]
     {
-        bisect(
-            left,
-            fwd,
-            min_partition_size,
-            max_iters,
-            log_table,
-            deadline,
-            exhausted,
-        );
-        bisect(
-            right,
-            fwd,
-            min_partition_size,
-            max_iters,
-            log_table,
-            deadline,
-            exhausted,
-        );
+        bisect(left, 0, context);
+        bisect(right, 0, context);
     }
 }
 
@@ -1082,6 +1242,8 @@ mod tests {
             terms,
             offsets,
             num_terms,
+            parallel_bisect_depth: 0,
+            budget_limited: false,
         }
     }
 
@@ -1091,6 +1253,8 @@ mod tests {
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
+            parallel_bisect_depth: 0,
+            budget_limited: false,
         };
         let (perm, _) = graph_bisection(&fwd, 4, 20, BpBudget::full());
         assert!(perm.is_empty());
@@ -1222,6 +1386,19 @@ mod tests {
         let mut sorted = perm.clone();
         sorted.sort();
         assert_eq!(sorted, (0..64).collect::<Vec<u32>>());
+    }
+
+    #[test]
+    fn test_memory_limited_graph_never_reports_converged() {
+        let mut fwd = make_fwd(&[&[0], &[0], &[1], &[1]], 2);
+        fwd.budget_limited = true;
+
+        let (perm, converged) = graph_bisection(&fwd, 2, 20, BpBudget::full());
+
+        assert!(!converged);
+        let mut sorted = perm;
+        sorted.sort_unstable();
+        assert_eq!(sorted, vec![0, 1, 2, 3]);
     }
 
     #[test]

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -129,7 +129,7 @@ async fn write_flat_entry(
                     .read_bytes_range(base_offset + chunk_start..base_offset + chunk_end)
                     .await
                     .map_err(crate::Error::Io)?;
-                writer.write_all(bytes.as_slice())?;
+                super::block_in_place_if_multithread(|| writer.write_all(bytes.as_slice()))?;
             }
         }
     }
@@ -148,7 +148,7 @@ async fn write_flat_entry(
                     buf.extend_from_slice(&(offset + doc_id).to_le_bytes());
                     buf.extend_from_slice(&ordinal.to_le_bytes());
                 }
-                writer.write_all(&buf)?;
+                super::block_in_place_if_multithread(|| writer.write_all(&buf))?;
             }
         }
     }
@@ -245,17 +245,36 @@ impl SegmentMerger {
             let config = entry.dense_vector_config.as_ref();
 
             // ── ANN entry (written first, index_type != FLAT_TYPE) ───────
-            let ann_blob = if entry.field_type == FieldType::BinaryDenseVector {
-                self.try_build_binary_ivf(field, entry, segments, &doc_offs, fi.total_vectors)
+            if entry.field_type == FieldType::BinaryDenseVector {
+                if let Some(index) = self
+                    .try_build_binary_ivf(field, entry, segments, &doc_offs, fi.total_vectors)
                     .await?
-            } else {
-                self.try_build_ann(field, config, segments, &doc_offs, trained)
-                    .await?
-            };
-
-            if let Some((index_type, bytes)) = ann_blob {
+                {
+                    let data_offset = writer.offset();
+                    super::block_in_place_if_multithread(|| index.write_to(&mut writer))
+                        .map_err(crate::Error::Io)?;
+                    let data_size = writer.offset() - data_offset;
+                    toc.push(DenseVectorTocEntry {
+                        field_id: field.0,
+                        index_type: crate::segment::ann_build::BINARY_IVF_TYPE,
+                        offset: data_offset,
+                        size: data_size,
+                    });
+                    // Drop the in-memory index before streaming the Flat entry.
+                    drop(index);
+                    let pad = (8 - (writer.offset() % 8)) % 8;
+                    if pad > 0 {
+                        super::block_in_place_if_multithread(|| {
+                            writer.write_all(&[0u8; 8][..pad as usize])
+                        })?;
+                    }
+                }
+            } else if let Some((index_type, bytes)) = self
+                .try_build_ann(field, config, segments, &doc_offs, trained)
+                .await?
+            {
                 let data_offset = writer.offset();
-                writer.write_all(&bytes)?;
+                super::block_in_place_if_multithread(|| writer.write_all(&bytes))?;
                 let data_size = writer.offset() - data_offset;
                 toc.push(DenseVectorTocEntry {
                     field_id: field.0,
@@ -266,7 +285,9 @@ impl SegmentMerger {
                 // Pad to 8-byte boundary
                 let pad = (8 - (writer.offset() % 8)) % 8;
                 if pad > 0 {
-                    writer.write_all(&[0u8; 8][..pad as usize])?;
+                    super::block_in_place_if_multithread(|| {
+                        writer.write_all(&[0u8; 8][..pad as usize])
+                    })?;
                 }
                 // `bytes` dropped here — frees the ANN blob immediately
             }
@@ -293,7 +314,9 @@ impl SegmentMerger {
             // Pad to 8-byte boundary
             let pad = (8 - (writer.offset() % 8)) % 8;
             if pad > 0 {
-                writer.write_all(&[0u8; 8][..pad as usize])?;
+                super::block_in_place_if_multithread(|| {
+                    writer.write_all(&[0u8; 8][..pad as usize])
+                })?;
             }
         }
 
@@ -302,7 +325,7 @@ impl SegmentMerger {
         write_dense_toc_and_footer(&mut writer, toc_offset, &toc)?;
 
         let output_size = writer.offset() as usize;
-        writer.finish()?;
+        super::block_in_place_if_multithread(move || writer.finish())?;
         log::info!(
             "[merge_vectors] file written: {} ({} entries) in {:.1}s",
             super::format_bytes(output_size),
@@ -329,7 +352,7 @@ impl SegmentMerger {
         segments: &[SegmentReader],
         doc_offs: &[u32],
         total_vectors: usize,
-    ) -> Result<Option<(u8, Vec<u8>)>> {
+    ) -> Result<Option<crate::structures::BinaryIvfIndex>> {
         let Some(cfg) = entry.binary_dense_vector_config.as_ref() else {
             return Ok(None);
         };
@@ -340,7 +363,10 @@ impl SegmentMerger {
         }
 
         let byte_len = cfg.dim.div_ceil(8);
-        let mut codes: Vec<u8> = Vec::with_capacity(total_vectors * byte_len);
+        let code_capacity = total_vectors.checked_mul(byte_len).ok_or_else(|| {
+            crate::Error::Internal("binary IVF code capacity exceeds usize".into())
+        })?;
+        let mut codes: Vec<u8> = Vec::with_capacity(code_capacity);
         let mut labels: Vec<(u32, u16)> = Vec::with_capacity(total_vectors);
 
         const CODE_BATCH: usize = 65536;
@@ -359,7 +385,12 @@ impl SegmentMerger {
                 codes.extend_from_slice(bytes.as_slice());
                 for i in 0..batch_count {
                     let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
-                    labels.push((doc_id + offset, ordinal));
+                    let merged_doc_id = doc_id.checked_add(offset).ok_or_else(|| {
+                        crate::Error::Corruption(format!(
+                            "binary IVF doc-id offset overflow: {doc_id} + {offset}"
+                        ))
+                    })?;
+                    labels.push((merged_doc_id, ordinal));
                 }
             }
         }
@@ -368,18 +399,44 @@ impl SegmentMerger {
             return Ok(None);
         }
 
-        let num_clusters = cfg.optimal_num_clusters(labels.len());
+        if codes.len() != labels.len().saturating_mul(byte_len) {
+            return Err(crate::Error::Corruption(format!(
+                "binary IVF code/label mismatch: {} bytes for {} labels × {} bytes",
+                codes.len(),
+                labels.len(),
+                byte_len,
+            )));
+        }
+
+        let vector_count = labels.len();
+        let num_clusters = cfg.optimal_num_clusters(vector_count);
         let ivf_config = crate::structures::BinaryIvfConfig::new(cfg.dim, num_clusters);
-        let index = crate::structures::BinaryIvfIndex::build(ivf_config, &codes, &labels);
-        let bytes = index.to_bytes().map_err(crate::Error::Io)?;
+        let pool = self.background_pool.clone();
+        let index = tokio::task::spawn_blocking(move || {
+            let build = || crate::structures::BinaryIvfIndex::build(ivf_config, &codes, &labels);
+            let index = if let Some(pool) = pool {
+                pool.install(build)
+            } else {
+                build()
+            };
+            // The built clusters now own the only code copy needed by the
+            // serializer. Release the raw merge inputs before returning.
+            drop(codes);
+            drop(labels);
+            index
+        })
+        .await
+        .map_err(|error| {
+            crate::Error::Internal(format!("binary IVF build task failed: {error}"))
+        })?;
         log::debug!(
-            "[merge_vectors] field {}: binary IVF rebuilt ({} vectors, {} clusters, {} bytes)",
+            "[merge_vectors] field {}: binary IVF rebuilt ({} vectors, {} clusters, estimated {} bytes)",
             field.0,
-            labels.len(),
+            vector_count,
             num_clusters,
-            bytes.len(),
+            index.estimated_memory_bytes(),
         );
-        Ok(Some((crate::segment::ann_build::BINARY_IVF_TYPE, bytes)))
+        Ok(Some(index))
     }
 
     async fn try_build_ann(
@@ -540,7 +597,9 @@ impl SegmentMerger {
                     total_fed,
                     ann_start.elapsed().as_secs_f64()
                 );
-                let bytes = crate::segment::ann_build::serialize_ivf_rabitq(index, codebook)?;
+                let bytes = super::block_in_place_if_multithread(|| {
+                    crate::segment::ann_build::serialize_ivf_rabitq(index, codebook)
+                })?;
                 (crate::segment::ann_build::IVF_RABITQ_TYPE, bytes)
             }
             VectorIndexType::ScaNN => {
@@ -573,7 +632,9 @@ impl SegmentMerger {
                     total_fed,
                     ann_start.elapsed().as_secs_f64()
                 );
-                let bytes = crate::segment::ann_build::serialize_scann(index, codebook)?;
+                let bytes = super::block_in_place_if_multithread(|| {
+                    crate::segment::ann_build::serialize_scann(index, codebook)
+                })?;
                 (crate::segment::ann_build::SCANN_TYPE, bytes)
             }
         };

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -28,6 +28,27 @@ pub struct VectorsFileData {
     pub flat_vectors: FxHashMap<u32, LazyFlatVectorData>,
 }
 
+fn take_toc_bytes<'a>(
+    data: &'a [u8],
+    position: &mut usize,
+    length: usize,
+    description: &str,
+) -> Result<&'a [u8]> {
+    let end = position
+        .checked_add(length)
+        .ok_or_else(|| crate::Error::Corruption(format!("{description} range overflows usize")))?;
+    let bytes = data.get(*position..end).ok_or_else(|| {
+        crate::Error::Corruption(format!(
+            "truncated {description}: need bytes {}..{}, TOC has {}",
+            *position,
+            end,
+            data.len(),
+        ))
+    })?;
+    *position = end;
+    Ok(bytes)
+}
+
 use crate::segment::format::{
     DENSE_TOC_ENTRY_SIZE, DenseVectorTocEntry, FOOTER_SIZE, VECTORS_FOOTER_MAGIC, read_dense_toc,
 };
@@ -63,43 +84,92 @@ pub async fn load_vectors_file<D: Directory>(
     // Try to open vectors file (may not exist if no vectors were indexed)
     let handle = match dir.open_lazy(&files.vectors).await {
         Ok(h) => h,
-        Err(_) => return Ok(empty()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(empty()),
+        Err(error) => return Err(crate::Error::Io(error)),
     };
 
     let file_size = handle.len();
-    if file_size < FOOTER_SIZE {
+    if file_size == 0 {
         return Ok(empty());
     }
+    if file_size < 4 {
+        return Err(crate::Error::Corruption(format!(
+            "vector file is {file_size} bytes, shorter than a legacy header"
+        )));
+    }
 
-    // Try new format: read footer (last 16 bytes)
-    let footer_bytes = handle
-        .read_bytes_range(file_size - FOOTER_SIZE..file_size)
-        .await?;
-    let mut cursor = Cursor::new(footer_bytes.as_slice());
-    let toc_offset = cursor.read_u64::<LittleEndian>()?;
-    let num_fields = cursor.read_u32::<LittleEndian>()?;
-    let magic = cursor.read_u32::<LittleEndian>()?;
+    // Try new format when a complete footer is present; otherwise validate
+    // the legacy header instead of silently accepting a truncated file.
+    let footer = if file_size >= FOOTER_SIZE {
+        let footer_bytes = handle
+            .read_bytes_range(file_size - FOOTER_SIZE..file_size)
+            .await?;
+        let mut cursor = Cursor::new(footer_bytes.as_slice());
+        Some((
+            cursor.read_u64::<LittleEndian>()?,
+            cursor.read_u32::<LittleEndian>()?,
+            cursor.read_u32::<LittleEndian>()?,
+        ))
+    } else {
+        None
+    };
 
-    let entries: Vec<DenseVectorTocEntry> =
-        if magic == VECTORS_FOOTER_MAGIC && toc_offset < file_size - FOOTER_SIZE {
-            // New format: TOC at end
-            let toc_size = num_fields as u64 * DENSE_TOC_ENTRY_SIZE;
-            let toc_bytes = handle
-                .read_bytes_range(toc_offset..toc_offset + toc_size)
-                .await?;
-            read_dense_toc(toc_bytes.as_slice(), num_fields)?
-        } else {
-            // Legacy format: header at start (num_fields(4) + entries)
-            let header_bytes = handle.read_bytes_range(0..4).await?;
-            let mut cursor = Cursor::new(header_bytes.as_slice());
-            let num_fields = cursor.read_u32::<LittleEndian>()?;
-            if num_fields == 0 {
-                return Ok(empty());
-            }
-            let entries_size = num_fields as u64 * DENSE_TOC_ENTRY_SIZE;
-            let entries_bytes = handle.read_bytes_range(4..4 + entries_size).await?;
-            read_dense_toc(entries_bytes.as_slice(), num_fields)?
-        };
+    let (entries, data_start, data_end): (Vec<DenseVectorTocEntry>, u64, u64) = if let Some((
+        toc_offset,
+        num_fields,
+        _,
+    )) =
+        footer.filter(|(_, _, magic)| *magic == VECTORS_FOOTER_MAGIC)
+    {
+        // New format: TOC at end
+        let footer_start = file_size - FOOTER_SIZE;
+        let toc_size = u64::from(num_fields)
+            .checked_mul(DENSE_TOC_ENTRY_SIZE)
+            .ok_or_else(|| {
+                crate::Error::Corruption("dense-vector TOC size overflows u64".into())
+            })?;
+        let toc_end = toc_offset.checked_add(toc_size).ok_or_else(|| {
+            crate::Error::Corruption("dense-vector TOC range overflows u64".into())
+        })?;
+        if toc_offset > footer_start || toc_end > footer_start {
+            return Err(crate::Error::Corruption(format!(
+                "dense-vector TOC range {toc_offset}..{toc_end} exceeds footer start {footer_start}"
+            )));
+        }
+        let toc_bytes = handle.read_bytes_range(toc_offset..toc_end).await?;
+        (
+            read_dense_toc(toc_bytes.as_slice(), num_fields)?,
+            0,
+            toc_offset,
+        )
+    } else {
+        // Legacy format: header at start (num_fields(4) + entries)
+        let header_bytes = handle.read_bytes_range(0..4).await?;
+        let mut cursor = Cursor::new(header_bytes.as_slice());
+        let num_fields = cursor.read_u32::<LittleEndian>()?;
+        if num_fields == 0 {
+            return Ok(empty());
+        }
+        let entries_size = u64::from(num_fields)
+            .checked_mul(DENSE_TOC_ENTRY_SIZE)
+            .ok_or_else(|| {
+                crate::Error::Corruption("legacy dense-vector TOC size overflows u64".into())
+            })?;
+        let entries_end = 4u64.checked_add(entries_size).ok_or_else(|| {
+            crate::Error::Corruption("legacy dense-vector TOC range overflows u64".into())
+        })?;
+        if entries_end > file_size {
+            return Err(crate::Error::Corruption(format!(
+                "legacy dense-vector TOC ends at {entries_end}, beyond file size {file_size}"
+            )));
+        }
+        let entries_bytes = handle.read_bytes_range(4..entries_end).await?;
+        (
+            read_dense_toc(entries_bytes.as_slice(), num_fields)?,
+            entries_end,
+            file_size,
+        )
+    };
 
     if entries.is_empty() {
         return Ok(empty());
@@ -114,65 +184,65 @@ pub async fn load_vectors_file<D: Directory>(
         size: length,
     } in entries
     {
+        let end = offset
+            .checked_add(length)
+            .filter(|&end| offset >= data_start && end <= data_end)
+            .ok_or_else(|| {
+                crate::Error::Corruption(format!(
+                    "vector field {field_id} has invalid data range {offset}..{offset}+{length}; valid payload is {data_start}..{data_end}"
+                ))
+            })?;
         match index_type {
             ann_build::FLAT_TYPE => {
                 // Flat binary — load lazily (only doc_ids in memory, vectors via mmap)
-                let slice = handle.slice(offset..offset + length);
-                match LazyFlatVectorData::open(slice).await {
-                    Ok(lazy_flat) => {
-                        flat_vectors.insert(field_id, lazy_flat);
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to load lazy flat vectors for field {}: {}",
-                            field_id,
-                            e
-                        );
-                    }
+                let slice = handle.slice(offset..end);
+                let lazy_flat = LazyFlatVectorData::open(slice).await.map_err(|error| {
+                    crate::Error::Corruption(format!(
+                        "invalid flat vectors for field {field_id}: {error}"
+                    ))
+                })?;
+                if flat_vectors.insert(field_id, lazy_flat).is_some() {
+                    return Err(crate::Error::Corruption(format!(
+                        "duplicate flat-vector entry for field {field_id}"
+                    )));
                 }
             }
-            ann_build::SCANN_TYPE => {
-                // ScaNN (IVF-PQ) — lazy: OwnedBytes stored (zero-copy mmap ref),
-                // deserialized on first search. No heap copy during segment load.
-                let data = handle.read_bytes_range(offset..offset + length).await?;
-                indexes.insert(
-                    field_id,
-                    VectorIndex::ScaNN(Arc::new(super::types::LazyScaNN::new(data))),
-                );
-            }
-            ann_build::IVF_RABITQ_TYPE => {
-                // IVF-RaBitQ — lazy: OwnedBytes stored (zero-copy mmap ref),
-                // deserialized on first search. No heap copy during segment load.
-                let data = handle.read_bytes_range(offset..offset + length).await?;
-                indexes.insert(
-                    field_id,
-                    VectorIndex::IVF(Arc::new(super::types::LazyIVF::new(data))),
-                );
-            }
-            ann_build::BINARY_IVF_TYPE => {
-                // Binary IVF (Hamming) — lazy: OwnedBytes stored (zero-copy mmap ref),
-                // deserialized on first search. No heap copy during segment load.
-                let data = handle.read_bytes_range(offset..offset + length).await?;
-                indexes.insert(
-                    field_id,
-                    VectorIndex::BinaryIvf(Arc::new(super::types::LazyBinaryIvf::new(data))),
-                );
-            }
-            ann_build::RABITQ_TYPE => {
-                // RaBitQ — lazy: OwnedBytes stored (zero-copy mmap ref),
-                // deserialized on first search. No heap copy during segment load.
-                let data = handle.read_bytes_range(offset..offset + length).await?;
-                indexes.insert(
-                    field_id,
-                    VectorIndex::RaBitQ(Arc::new(super::types::LazyRaBitQ::new(data))),
-                );
+            ann_build::SCANN_TYPE
+            | ann_build::IVF_RABITQ_TYPE
+            | ann_build::BINARY_IVF_TYPE
+            | ann_build::RABITQ_TYPE => {
+                // ANN payloads stay lazy and zero-copy; only their validated
+                // byte range is retained until first search.
+                let data = handle.read_bytes_range(offset..end).await?;
+                let index = match index_type {
+                    ann_build::SCANN_TYPE => {
+                        VectorIndex::ScaNN(Arc::new(super::types::LazyScaNN::new(data)))
+                    }
+                    ann_build::IVF_RABITQ_TYPE => {
+                        VectorIndex::IVF(Arc::new(super::types::LazyIVF::new(data)))
+                    }
+                    ann_build::BINARY_IVF_TYPE => {
+                        VectorIndex::BinaryIvf(Arc::new(super::types::LazyBinaryIvf::new(data)))
+                    }
+                    ann_build::RABITQ_TYPE => {
+                        VectorIndex::RaBitQ(Arc::new(super::types::LazyRaBitQ::new(data)))
+                    }
+                    _ => {
+                        return Err(crate::Error::Corruption(format!(
+                            "unknown vector index type {index_type} for field {field_id}"
+                        )));
+                    }
+                };
+                if indexes.insert(field_id, index).is_some() {
+                    return Err(crate::Error::Corruption(format!(
+                        "multiple ANN entries for vector field {field_id}"
+                    )));
+                }
             }
             _ => {
-                log::warn!(
-                    "Unknown vector index type {} for field {}",
-                    index_type,
-                    field_id
-                );
+                return Err(crate::Error::Corruption(format!(
+                    "unknown vector index type {index_type} for field {field_id}"
+                )));
             }
         }
     }
@@ -201,7 +271,7 @@ pub async fn load_sparse_file<D: Directory>(
     schema: &Schema,
 ) -> Result<SparseFileData> {
     use crate::segment::format::{SPARSE_FOOTER_MAGIC, SPARSE_FOOTER_SIZE};
-    use crate::structures::SparseVectorConfig;
+    use crate::structures::{SparseSkipEntry, SparseVectorConfig};
 
     let empty = || SparseFileData {
         maxscore_indexes: FxHashMap::default(),
@@ -223,24 +293,29 @@ pub async fn load_sparse_file<D: Directory>(
     let handle = match dir.open_lazy(&files.sparse).await {
         Ok(h) => h,
         Err(e) => {
-            log::debug!("No sparse file found ({}): {:?}", files.sparse.display(), e);
-            return Ok(empty());
+            if e.kind() == std::io::ErrorKind::NotFound {
+                log::debug!("No sparse file found ({}): {:?}", files.sparse.display(), e);
+                return Ok(empty());
+            }
+            return Err(crate::Error::Io(e));
         }
     };
 
     let file_size = handle.len();
     if file_size < SPARSE_FOOTER_SIZE {
-        return Ok(empty());
+        return if file_size == 0 {
+            Ok(empty())
+        } else {
+            Err(crate::Error::Corruption(format!(
+                "sparse file is {file_size} bytes, shorter than its {SPARSE_FOOTER_SIZE}-byte footer"
+            )))
+        };
     }
 
     // Read footer (24 bytes): skip_offset(8) + toc_offset(8) + num_fields(4) + magic(4)
-    let footer_bytes = match handle
+    let footer_bytes = handle
         .read_bytes_range(file_size - SPARSE_FOOTER_SIZE..file_size)
-        .await
-    {
-        Ok(d) => d,
-        Err(_) => return Ok(empty()),
-    };
+        .await?;
     let fb = footer_bytes.as_slice();
 
     let skip_offset = u64::from_le_bytes(fb[0..8].try_into().unwrap());
@@ -255,6 +330,13 @@ pub async fn load_sparse_file<D: Directory>(
         )));
     }
 
+    let footer_start = file_size - SPARSE_FOOTER_SIZE;
+    if skip_offset > toc_offset || toc_offset > footer_start {
+        return Err(crate::Error::Corruption(format!(
+            "invalid sparse section offsets: skip={skip_offset}, toc={toc_offset}, footer={footer_start}"
+        )));
+    }
+
     log::debug!(
         "Loading sparse: size={} bytes, num_fields={}, skip_offset={}, toc_offset={}",
         file_size,
@@ -264,59 +346,93 @@ pub async fn load_sparse_file<D: Directory>(
     );
 
     if num_fields == 0 {
+        if skip_offset != footer_start || toc_offset != footer_start {
+            return Err(crate::Error::Corruption(format!(
+                "empty sparse TOC leaves unowned bytes before footer: skip={skip_offset}, toc={toc_offset}, footer={footer_start}"
+            )));
+        }
         return Ok(empty());
     }
 
     // Single tail read: skip section + TOC (skip_offset .. footer_start)
     // For mmap this is zero-copy. Block data at the front is never touched.
-    let tail_bytes = handle
-        .read_bytes_range(skip_offset..file_size - SPARSE_FOOTER_SIZE)
-        .await?;
+    let tail_bytes = handle.read_bytes_range(skip_offset..footer_start).await?;
     let tail = tail_bytes.as_slice();
 
     // skip section is at tail[0 .. toc_offset - skip_offset]
-    let skip_section_len = (toc_offset - skip_offset) as usize;
+    let skip_section_len = usize::try_from(toc_offset - skip_offset).map_err(|_| {
+        crate::Error::Corruption("sparse skip section does not fit in address space".into())
+    })?;
+    if skip_section_len % SparseSkipEntry::SIZE != 0 {
+        return Err(crate::Error::Corruption(format!(
+            "sparse skip section is {skip_section_len} bytes, not a multiple of {}",
+            SparseSkipEntry::SIZE,
+        )));
+    }
     let skip_section = tail_bytes.slice(0..skip_section_len);
     let toc_data = &tail[skip_section_len..];
+    let skip_entry_count = skip_section_len / SparseSkipEntry::SIZE;
 
     // Parse TOC: per-field header(13B) + per-dim entries(28B each)
     let mut pos = 0usize;
 
     for _ in 0..num_fields {
         // Field header: field_id(4) + quant(1) + num_dims(4) + total_vectors(4) = 13 bytes
-        let field_id = u32::from_le_bytes(toc_data[pos..pos + 4].try_into().unwrap());
-        let quantization = toc_data[pos + 4];
-        let ndims = u32::from_le_bytes(toc_data[pos + 5..pos + 9].try_into().unwrap()) as usize;
-        let total_vectors = u32::from_le_bytes(toc_data[pos + 9..pos + 13].try_into().unwrap());
-        pos += 13;
+        let header = take_toc_bytes(toc_data, &mut pos, 13, "sparse field header")?;
+        let field_id = u32::from_le_bytes(header[0..4].try_into().unwrap());
+        let quantization = header[4];
+        let ndims = u32::from_le_bytes(header[5..9].try_into().unwrap()) as usize;
+        let total_vectors = u32::from_le_bytes(header[9..13].try_into().unwrap());
+        let entries_len = ndims.checked_mul(28).ok_or_else(|| {
+            crate::Error::Corruption(format!(
+                "sparse field {field_id} dimension TOC size overflows usize"
+            ))
+        })?;
+        let entries = take_toc_bytes(toc_data, &mut pos, entries_len, "sparse dimension entries")?;
+
+        if maxscore_indexes.contains_key(&field_id) || bmp_indexes.contains_key(&field_id) {
+            return Err(crate::Error::Corruption(format!(
+                "duplicate sparse field {field_id} in TOC"
+            )));
+        }
 
         // Detect BMP format from the quant byte (bit 3 = format flag)
-        let is_bmp = SparseVectorConfig::from_byte(quantization)
-            .is_some_and(|c| c.format == crate::structures::SparseFormat::Bmp);
+        let stored_config = SparseVectorConfig::from_byte(quantization).ok_or_else(|| {
+            crate::Error::Corruption(format!(
+                "invalid sparse configuration byte {quantization:#04x} for field {field_id}"
+            ))
+        })?;
+        let is_bmp = stored_config.format == crate::structures::SparseFormat::Bmp;
 
-        if is_bmp && ndims >= 1 {
+        if is_bmp && ndims != 1 {
+            return Err(crate::Error::Corruption(format!(
+                "BMP field {field_id} has {ndims} TOC entries, expected one blob marker"
+            )));
+        }
+
+        if is_bmp {
             // BMP field: single sentinel entry with blob location
-            let d = &toc_data[pos..pos + 28];
+            let d = &entries[..28];
             let dim_id = u32::from_le_bytes(d[0..4].try_into().unwrap());
             let blob_offset = u64::from_le_bytes(d[4..12].try_into().unwrap());
             let blob_len_low = u32::from_le_bytes(d[12..16].try_into().unwrap());
             let blob_len_high = u32::from_le_bytes(d[16..20].try_into().unwrap());
-            pos += 28;
-
-            // Skip any additional dim entries (shouldn't have more, but be safe)
-            for _ in 1..ndims {
-                pos += 28;
-            }
 
             if dim_id != 0xFFFFFFFF {
-                log::warn!(
-                    "BMP field {} has unexpected dim_id {:#x} (expected sentinel)",
-                    field_id,
-                    dim_id
-                );
+                return Err(crate::Error::Corruption(format!(
+                    "BMP field {field_id} has dimension marker {dim_id:#x}, expected 0xffffffff"
+                )));
             }
 
             let blob_len = (blob_len_high as u64) << 32 | blob_len_low as u64;
+            let blob_end = blob_offset.checked_add(blob_len).ok_or_else(|| {
+                crate::Error::Corruption(format!("BMP field {field_id} blob range overflows u64"))
+            })?;
+            if blob_end > skip_offset {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP field {field_id} blob {blob_offset}..{blob_end} overlaps sparse metadata at {skip_offset}"
+                )));
+            }
 
             match BmpIndex::parse(
                 handle.clone(),
@@ -342,14 +458,31 @@ pub async fn load_sparse_file<D: Directory>(
         } else {
             // MaxScore field: standard per-dimension entries
             let mut dims = super::types::DimensionTable::with_capacity(ndims);
-            for _ in 0..ndims {
-                let d = &toc_data[pos..pos + 28];
+            for d in entries.chunks_exact(28) {
                 let dim_id = u32::from_le_bytes(d[0..4].try_into().unwrap());
                 let block_data_offset = u64::from_le_bytes(d[4..12].try_into().unwrap());
                 let skip_start = u32::from_le_bytes(d[12..16].try_into().unwrap());
                 let num_blocks = u32::from_le_bytes(d[16..20].try_into().unwrap());
                 let doc_count = u32::from_le_bytes(d[20..24].try_into().unwrap());
                 let max_weight = f32::from_le_bytes(d[24..28].try_into().unwrap());
+                let _skip_end = (skip_start as usize)
+                    .checked_add(num_blocks as usize)
+                    .filter(|&end| end <= skip_entry_count)
+                    .ok_or_else(|| {
+                        crate::Error::Corruption(format!(
+                            "sparse field {field_id} dimension {dim_id} references skip entries {skip_start}+{num_blocks}, but only {skip_entry_count} exist"
+                        ))
+                    })?;
+                if block_data_offset > skip_offset {
+                    return Err(crate::Error::Corruption(format!(
+                        "sparse field {field_id} dimension {dim_id} block offset {block_data_offset} exceeds data section {skip_offset}"
+                    )));
+                }
+                if doc_count > total_docs {
+                    return Err(crate::Error::Corruption(format!(
+                        "sparse field {field_id} dimension {dim_id} has {doc_count} docs, segment has {total_docs}"
+                    )));
+                }
                 dims.push(
                     dim_id,
                     block_data_offset,
@@ -358,9 +491,13 @@ pub async fn load_sparse_file<D: Directory>(
                     doc_count,
                     max_weight,
                 );
-                pos += 28;
             }
             dims.sort_by_dim_id();
+            if dims.dim_ids.windows(2).any(|pair| pair[0] == pair[1]) {
+                return Err(crate::Error::Corruption(format!(
+                    "sparse field {field_id} contains duplicate dimension IDs"
+                )));
+            }
 
             log::debug!(
                 "Loaded sparse index for field {}: num_dims={}, total_vectors={}, skip_bytes={}",
@@ -381,6 +518,13 @@ pub async fn load_sparse_file<D: Directory>(
                 ),
             );
         }
+    }
+
+    if pos != toc_data.len() {
+        return Err(crate::Error::Corruption(format!(
+            "sparse TOC has {} trailing bytes after {num_fields} fields",
+            toc_data.len() - pos,
+        )));
     }
 
     log::debug!(
@@ -410,7 +554,8 @@ pub async fn open_positions_file<D: Directory>(
     // Try to open positions file (may not exist if no positions were indexed)
     match dir.open_lazy(&files.positions).await {
         Ok(h) => Ok(Some(h)),
-        Err(_) => Ok(None),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(crate::Error::Io(error)),
     }
 }
 
@@ -434,10 +579,11 @@ pub async fn load_fast_fields_file<D: Directory>(
     // Try to open the .fast file (may not exist for old segments)
     let handle = match dir.open_read(&files.fast).await {
         Ok(h) => h,
-        Err(e) => {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             log::debug!("[fast-fields] .fast file not found ({}), skipping", e);
             return Ok(FxHashMap::default());
         }
+        Err(e) => return Err(crate::Error::Io(e)),
     };
 
     let file_data = handle.read_bytes().await?;
@@ -462,4 +608,71 @@ pub async fn load_fast_fields_file<D: Directory>(
     );
 
     Ok(readers)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::directories::{DirectoryWriter, RamDirectory};
+    use crate::dsl::SchemaBuilder;
+    use crate::segment::format::{DenseVectorTocEntry, write_dense_toc_and_footer};
+    use crate::structures::SparseVectorConfig;
+
+    use super::{SegmentFiles, load_sparse_file, load_vectors_file};
+
+    #[tokio::test]
+    async fn existing_truncated_sparse_file_is_corruption() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_sparse_vector_field_with_config(
+            "sparse",
+            true,
+            true,
+            SparseVectorConfig::default(),
+        );
+        let schema = schema.build();
+        let files = SegmentFiles::new(7);
+        let dir = RamDirectory::new();
+        dir.write(&files.sparse, &[1, 2, 3]).await.unwrap();
+
+        let result = load_sparse_file(&dir, &files, 1, &schema).await;
+        assert!(matches!(result, Err(crate::Error::Corruption(_))));
+    }
+
+    #[tokio::test]
+    async fn unknown_dense_vector_type_is_corruption() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_binary_dense_vector_field("binary", 8, true, true);
+        let schema = schema.build();
+        let files = SegmentFiles::new(8);
+        let dir = RamDirectory::new();
+
+        let mut bytes = vec![0];
+        write_dense_toc_and_footer(
+            &mut bytes,
+            1,
+            &[DenseVectorTocEntry {
+                field_id: 0,
+                index_type: u8::MAX,
+                offset: 0,
+                size: 1,
+            }],
+        )
+        .unwrap();
+        dir.write(&files.vectors, &bytes).await.unwrap();
+
+        let result = load_vectors_file(&dir, &files, &schema).await;
+        assert!(matches!(result, Err(crate::Error::Corruption(_))));
+    }
+
+    #[tokio::test]
+    async fn existing_truncated_dense_vector_file_is_corruption() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_binary_dense_vector_field("binary", 8, true, true);
+        let schema = schema.build();
+        let files = SegmentFiles::new(9);
+        let dir = RamDirectory::new();
+        dir.write(&files.vectors, &[1, 2, 3]).await.unwrap();
+
+        let result = load_vectors_file(&dir, &files, &schema).await;
+        assert!(matches!(result, Err(crate::Error::Corruption(_))));
+    }
 }

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -296,15 +296,27 @@ pub async fn reorder_segment<D: Directory + DirectoryWriter>(
 
     // Copy unchanged segment files
     let copy_start = std::time::Instant::now();
-    for (src, dst) in [
-        (&src_files.term_dict, &dst_files.term_dict),
-        (&src_files.postings, &dst_files.postings),
-        (&src_files.positions, &dst_files.positions),
-        (&src_files.store, &dst_files.store),
-        (&src_files.fast, &dst_files.fast),
-        (&src_files.vectors, &dst_files.vectors),
+    for (src, dst, required) in [
+        (&src_files.term_dict, &dst_files.term_dict, true),
+        (&src_files.postings, &dst_files.postings, true),
+        (
+            &src_files.positions,
+            &dst_files.positions,
+            reader.has_positions_file(),
+        ),
+        (&src_files.store, &dst_files.store, true),
+        (
+            &src_files.fast,
+            &dst_files.fast,
+            !reader.fast_fields().is_empty(),
+        ),
+        (
+            &src_files.vectors,
+            &dst_files.vectors,
+            !reader.vector_indexes().is_empty() || !reader.flat_vectors().is_empty(),
+        ),
     ] {
-        copy_segment_file(dir, src, dst).await?;
+        copy_segment_file(dir, src, dst, required).await?;
     }
     log::info!(
         "[reorder] copied files in {:.1}s",
@@ -338,34 +350,71 @@ pub async fn reorder_segment<D: Directory + DirectoryWriter>(
 
 /// Copy a segment file via streaming I/O (4 MB chunks).
 ///
-/// No-op if the source file does not exist.
+/// No-op if an optional source file does not exist. A file observed by the
+/// source reader is required: losing it during the copy is corruption, not an
+/// empty optional field.
 /// Empty files are still created (SegmentReader requires their existence).
 async fn copy_segment_file<D: Directory + DirectoryWriter>(
     dir: &D,
     src: &Path,
     dst: &Path,
+    required: bool,
 ) -> Result<()> {
     let handle = match dir.open_read(src).await {
         Ok(h) => h,
-        Err(_) => return Ok(()), // file doesn't exist
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound && !required => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(crate::Error::Corruption(format!(
+                "required reorder source file {src:?} disappeared before copy"
+            )));
+        }
+        Err(error) => return Err(crate::Error::Io(error)),
     };
-    let data = handle.read_bytes().await.map_err(crate::Error::Io)?;
-    let slice = data.as_slice();
-
     let mut writer = dir
         .streaming_writer_cold(dst)
         .await
         .map_err(crate::Error::Io)?;
     const CHUNK: usize = 4 * 1024 * 1024;
-    for (i, chunk) in slice.chunks(CHUNK).enumerate() {
-        writer.write_all(chunk).map_err(crate::Error::Io)?;
-        // Drop source pages behind the copy cursor — a whole-file copy must
-        // not fault the entire source into the page cache and leave it
-        // resident (see docs/cold-io.md).
-        #[cfg(feature = "native")]
-        data.madvise_range(i * CHUNK..i * CHUNK + chunk.len(), libc::MADV_DONTNEED);
+    let source_len = handle.len();
+    let mut offset = 0u64;
+    while offset < source_len {
+        let end = (offset + CHUNK as u64).min(source_len);
+        let data = handle
+            .read_bytes_range(offset..end)
+            .await
+            .map_err(crate::Error::Io)?;
+        writer = tokio::task::spawn_blocking(move || {
+            writer.write_all(data.as_slice())?;
+            // Drop source pages behind the copy cursor — a whole-file copy
+            // must not leave the complete source resident in page cache.
+            #[cfg(feature = "native")]
+            data.madvise_range(0..data.len(), libc::MADV_DONTNEED);
+            Ok::<_, std::io::Error>(writer)
+        })
+        .await
+        .map_err(|error| {
+            crate::Error::Internal(format!("reorder copy worker failed for {src:?}: {error}"))
+        })?
+        .map_err(crate::Error::Io)?;
+        offset = end;
     }
-    writer.finish().map_err(crate::Error::Io)?;
+    if writer.bytes_written() != source_len {
+        return Err(crate::Error::Corruption(format!(
+            "short reorder copy from {:?} to {:?}: wrote {} of {} bytes",
+            src,
+            dst,
+            writer.bytes_written(),
+            source_len,
+        )));
+    }
+    tokio::task::spawn_blocking(move || writer.finish())
+        .await
+        .map_err(|error| {
+            crate::Error::Internal(format!(
+                "reorder copy finalizer failed for {dst:?}: {error}"
+            ))
+        })?
+        .map_err(crate::Error::Io)?;
 
     Ok(())
 }
@@ -411,6 +460,13 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
             && reader.bmp_indexes().get(&field.0).is_some()
     });
 
+    // Sparse files are legitimately absent when the schema has sparse fields
+    // but this segment contains no sparse values. Do not turn that valid
+    // optional-file case into a required-copy corruption error.
+    if reader.sparse_indexes().is_empty() && reader.bmp_indexes().is_empty() {
+        return Ok(true);
+    }
+
     if !has_bmp_data {
         // No BMP field wants reordering — just copy the sparse file as-is
         log::info!(
@@ -418,7 +474,7 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
             reader.meta().id,
         );
         let src_files = SegmentFiles::new(reader.meta().id);
-        copy_segment_file(dir, &src_files.sparse, &dst_files.sparse).await?;
+        copy_segment_file(dir, &src_files.sparse, &dst_files.sparse, true).await?;
         return Ok(true);
     }
 
@@ -653,7 +709,10 @@ fn reorder_bmp_field_blockwise(
             };
             graph_bisection(&fwd, sb, 20, block_budget)
         } else {
-            ((0..num_blocks_total as u32).collect(), true)
+            (
+                (0..num_blocks_total as u32).collect(),
+                num_blocks_total <= sb || !fwd.budget_limited(),
+            )
         }
     };
     let (perm, converged) = if let Some(ref pool) = rayon_pool {
@@ -1114,6 +1173,51 @@ pub(crate) fn reorder_bmp_field(
         );
     }
 
+    // Record-level BP needs both directions of every document map before it
+    // can even start building the forward graph. Reserve that non-negotiable
+    // peak up front; previously these vectors were allocated outside the
+    // advertised budget. Fall back to a valid blockwise rewrite when the
+    // record representation itself cannot fit, but keep the result marked
+    // unconverged so a larger-budget/manual pass may still deepen it later.
+    let record_map_bytes = sources.iter().fold(0usize, |total, (bmp, _)| {
+        total
+            .saturating_add((bmp.num_virtual_docs as usize).saturating_mul(4))
+            .saturating_add((bmp.num_real_docs() as usize).saturating_mul(4))
+    });
+    let record_rewrite_fixed_bytes = sources.iter().fold(0usize, |total, (bmp, _)| {
+        total
+            // retained real→virtual map + output permutation
+            .saturating_add((bmp.num_real_docs() as usize).saturating_mul(8))
+            // output block-offset table
+            .saturating_add((bmp.num_blocks as usize).saturating_mul(8))
+    });
+    let record_fixed_peak = record_map_bytes.max(record_rewrite_fixed_bytes);
+    const MIN_RECORD_WORKSPACE: usize = 16 * 1024 * 1024;
+    if record_fixed_peak > memory_budget.saturating_sub(MIN_RECORD_WORKSPACE) {
+        log::warn!(
+            "[reorder_bmp] field {}: record maps need {:.0} MB of the {:.0} MB total budget; falling back to blockwise order",
+            field_id,
+            record_fixed_peak as f64 / (1024.0 * 1024.0),
+            memory_budget as f64 / (1024.0 * 1024.0),
+        );
+        let (writer, field_tocs, _) = reorder_bmp_field_blockwise(
+            sources,
+            field_id,
+            quantization,
+            dims,
+            effective_block_size,
+            grid_bits,
+            max_weight_scale,
+            total_vectors,
+            memory_budget,
+            bp_budget,
+            writer,
+            field_tocs,
+            rayon_pool,
+        )?;
+        return Ok((writer, field_tocs, false));
+    }
+
     let source_pages =
         crate::segment::reader::bmp::BmpScanPageGuard::new(sources.iter().map(|(bmp, _)| bmp));
 
@@ -1124,8 +1228,10 @@ pub(crate) fn reorder_bmp_field(
     // Build padding-aware maps once. Forward-index construction needs both
     // directions; output encoding reuses real→virtual instead of rescanning
     // every source document map.
-    let mut vid_maps: Vec<(Vec<u32>, Vec<u32>)> =
-        bmp_refs.iter().map(|bmp| build_vid_maps(bmp)).collect();
+    let mut vid_maps: Vec<(Vec<u32>, Vec<u32>)> = bmp_refs
+        .iter()
+        .map(|bmp| build_vid_maps(bmp))
+        .collect::<Result<_>>()?;
     // Prefix sums of real doc counts: source s owns global real ids
     // real_base[s]..real_base[s+1].
     let mut real_base = Vec::with_capacity(vid_maps.len() + 1);
@@ -1165,6 +1271,13 @@ pub(crate) fn reorder_bmp_field(
     let zero_budget = bp_budget.time_budget.is_some_and(|d| d.is_zero());
 
     let (perm, converged) = if zero_budget {
+        // No forward graph will consume virtual→real. Release it before
+        // allocating the identity permutation; otherwise the zero-budget path
+        // briefly holds both full map directions plus the permutation and can
+        // exceed the same budget check that protects normal passes.
+        for (virtual_to_real, _) in &mut vid_maps {
+            *virtual_to_real = Vec::new();
+        }
         log::info!(
             "[reorder_bmp] field {}: zero time budget — identity re-block, forward index skipped",
             field_id,
@@ -1180,13 +1293,14 @@ pub(crate) fn reorder_bmp_field(
         let min_doc_freq = (num_real_docs / 5000).clamp(2, 128);
 
         // Forward-index build is parallel too — keep it on the bounded pool.
+        let forward_budget = memory_budget.saturating_sub(record_map_bytes);
         let build_forward = || {
             build_forward_index_from_bmps_with_maps(
                 &bmp_refs,
                 &vid_maps,
                 min_doc_freq,
                 max_doc_freq.max(1),
-                memory_budget,
+                forward_budget,
             )
         };
         let (fwd, _source_doc_counts) = if let Some(ref pool) = rayon_pool {
@@ -1232,7 +1346,10 @@ pub(crate) fn reorder_bmp_field(
             );
             (perm, converged)
         } else {
-            ((0..num_real_docs as u32).collect(), true)
+            (
+                (0..num_real_docs as u32).collect(),
+                num_real_docs <= effective_block_size || !fwd.budget_limited(),
+            )
         }
     };
 
@@ -1267,11 +1384,32 @@ pub(crate) fn reorder_bmp_field(
     let mut total_postings: u64 = 0;
     let mut cumulative_bytes: u64 = 0;
 
+    // Grid entries and parallel encoded blocks coexist with the retained
+    // real→virtual map and permutation. Divide the actual remaining pass
+    // budget between them instead of adding fixed 512+256 MB allocations on
+    // top of `--bp-memory-budget-mb`.
+    let persistent_rewrite_bytes = perm
+        .capacity()
+        .saturating_mul(std::mem::size_of::<u32>())
+        .saturating_add(real_to_virtual.iter().fold(0usize, |total, map| {
+            total.saturating_add(map.capacity().saturating_mul(std::mem::size_of::<u32>()))
+        }))
+        .saturating_add(
+            block_data_starts
+                .capacity()
+                .saturating_mul(std::mem::size_of::<u64>()),
+        );
+    let rewrite_workspace = memory_budget.saturating_sub(persistent_rewrite_bytes);
+    let grid_entries_budget =
+        (rewrite_workspace.saturating_mul(2) / 3).clamp(1024 * 1024, 512 * 1024 * 1024);
+    let encode_window_budget = rewrite_workspace
+        .saturating_sub(grid_entries_budget)
+        .clamp(1024 * 1024, 256 * 1024 * 1024);
+
     // Grid entries with external merge sort: accumulate in memory up to budget,
     // spill sorted runs to temp files when exceeded. 12 bytes per entry in memory.
-    const GRID_ENTRIES_BUDGET: usize = 512 * 1024 * 1024; // 512 MB
     const GRID_ENTRY_MEM_SIZE: usize = std::mem::size_of::<(u32, u32, u8)>(); // 12 bytes
-    let max_entries_in_memory = GRID_ENTRIES_BUDGET / GRID_ENTRY_MEM_SIZE;
+    let max_entries_in_memory = grid_entries_budget / GRID_ENTRY_MEM_SIZE;
 
     let total_source_terms = bmp_refs.iter().fold(0usize, |total, bmp| {
         total.saturating_add(bmp.total_terms() as usize)
@@ -1297,7 +1435,10 @@ pub(crate) fn reorder_bmp_field(
         let slots_count = new_vid_end - new_vid_start;
 
         // Group records by (source, source block), scatter matching slots
-        let mut slot_map = [u8::MAX; 256];
+        // All 256 u8 values are valid slots when bmp_block_size=256. The old
+        // u8::MAX "unmapped" sentinel therefore dropped a posting whenever
+        // source slot 255 mapped to output slot 255.
+        let mut slot_map = [u16::MAX; 256];
         let mut block_mappings: rustc_hash::FxHashMap<(usize, usize), Vec<(u8, u8)>> =
             rustc_hash::FxHashMap::default();
         for new_local_slot in 0..slots_count {
@@ -1317,23 +1458,23 @@ pub(crate) fn reorder_bmp_field(
             rustc_hash::FxHashMap::default();
         for (&(src, old_block), mappings) in &block_mappings {
             for &(old_s, new_s) in mappings {
-                slot_map[old_s as usize] = new_s;
+                slot_map[old_s as usize] = u16::from(new_s);
             }
 
             for (dim_id, postings) in sources[src].0.iter_block_terms(old_block as u32) {
                 for p in postings {
                     let new_slot = slot_map[p.local_slot as usize];
-                    if new_slot != u8::MAX {
+                    if new_slot != u16::MAX {
                         dim_postings
                             .entry(dim_id)
                             .or_default()
-                            .push((new_slot, p.impact));
+                            .push((new_slot as u8, p.impact));
                     }
                 }
             }
 
             for &(old_s, _) in mappings {
-                slot_map[old_s as usize] = u8::MAX;
+                slot_map[old_s as usize] = u16::MAX;
             }
         }
 
@@ -1383,7 +1524,6 @@ pub(crate) fn reorder_bmp_field(
 
     // Encode blocks in parallel per bounded window (blob order is fixed, so
     // the write itself stays serial; the window caps buffered bytes).
-    const ENCODE_WINDOW_BUDGET: usize = 256 * 1024 * 1024;
     let source_block_bytes = bmp_refs
         .iter()
         .map(|bmp| bmp.block_data_slice().len())
@@ -1412,7 +1552,7 @@ pub(crate) fn reorder_bmp_field(
         .max(1);
     let max_parallel_window = parallel_width.saturating_mul(2);
     let encode_window =
-        (ENCODE_WINDOW_BUDGET / estimated_bytes_per_block).clamp(1, max_parallel_window);
+        (encode_window_budget / estimated_bytes_per_block).clamp(1, max_parallel_window);
     let mut encoded: Vec<Result<EncodedBlock>> = Vec::new();
     for window_start in (0..new_num_blocks).step_by(encode_window) {
         let window_end = (window_start + encode_window).min(new_num_blocks);
@@ -1639,6 +1779,47 @@ pub(crate) fn reorder_bmp_field(
 
 #[cfg(test)]
 mod grid_run_prefix_tests {
+    use crate::directories::{Directory, DirectoryWriter};
+
+    #[tokio::test]
+    async fn segment_copy_distinguishes_optional_and_required_missing_files() {
+        let dir = crate::directories::RamDirectory::new();
+        let missing = std::path::Path::new("missing");
+        let output = std::path::Path::new("output");
+
+        super::copy_segment_file(&dir, missing, output, false)
+            .await
+            .unwrap();
+        assert!(!dir.exists(output).await.unwrap());
+
+        let error = super::copy_segment_file(&dir, missing, output, true)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, crate::Error::Corruption(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn segment_copy_preserves_all_bytes() {
+        let dir = crate::directories::RamDirectory::new();
+        let source = std::path::Path::new("source");
+        let output = std::path::Path::new("output");
+        let data = vec![0x5a; 4 * 1024 * 1024 + 17];
+        dir.write(source, &data).await.unwrap();
+
+        super::copy_segment_file(&dir, source, output, true)
+            .await
+            .unwrap();
+
+        let copied = dir
+            .open_read(output)
+            .await
+            .unwrap()
+            .read_bytes()
+            .await
+            .unwrap();
+        assert_eq!(copied.as_slice(), data);
+    }
+
     /// Regression: run prefixes were `pid_field` — identical for every pass
     /// in a container (PID 1) reordering the same field id, so concurrent
     /// passes clobbered and deleted each other's spill files (prod ENOENT).

--- a/hermes-core/src/structures/vector/index/binary_ivf.rs
+++ b/hermes-core/src/structures/vector/index/binary_ivf.rs
@@ -91,7 +91,10 @@ impl BinaryIvfIndex {
         debug_assert_eq!(codes.len(), n * byte_len);
 
         // Can't have more clusters than vectors
-        config.num_clusters = config.num_clusters.clamp(1, n.max(1));
+        config.num_clusters = config
+            .num_clusters
+            .clamp(1, n.max(1))
+            .min(u32::MAX as usize);
         let k = config.num_clusters;
 
         let centroids = train_k_majority(&config, codes, n);
@@ -106,7 +109,7 @@ impl BinaryIvfIndex {
         // Phase 1: nearest-centroid assignment — embarrassingly parallel,
         // dominates build time at O(n × k) Hamming comparisons.
         #[cfg(feature = "native")]
-        let assignments: Vec<usize> = {
+        let assignments: Vec<u32> = {
             use rayon::prelude::*;
             (0..n)
                 .into_par_iter()
@@ -114,25 +117,40 @@ impl BinaryIvfIndex {
                     || vec![0f32; index.config.num_clusters],
                     |scores, i| {
                         index.nearest_centroid(&codes[i * byte_len..(i + 1) * byte_len], scores)
+                            as u32
                     },
                 )
                 .collect()
         };
         #[cfg(not(feature = "native"))]
-        let assignments: Vec<usize> = {
+        let assignments: Vec<u32> = {
             let mut scores = vec![0f32; index.config.num_clusters];
             (0..n)
                 .map(|i| {
                     index.nearest_centroid(&codes[i * byte_len..(i + 1) * byte_len], &mut scores)
+                        as u32
                 })
                 .collect()
         };
+
+        // Reserve exact cluster payload sizes before copying. Geometric Vec
+        // growth otherwise keeps substantial over-capacity for large clusters
+        // while the complete input code buffer is still resident.
+        let mut cluster_sizes = vec![0usize; k];
+        for &assignment in &assignments {
+            cluster_sizes[assignment as usize] += 1;
+        }
+        for (cluster, count) in index.clusters.iter_mut().zip(cluster_sizes) {
+            cluster.doc_ids.reserve_exact(count);
+            cluster.ordinals.reserve_exact(count);
+            cluster.codes.reserve_exact(count.saturating_mul(byte_len));
+        }
 
         // Phase 2: sequential append into SoA cluster storage
         for i in 0..n {
             let code = &codes[i * byte_len..(i + 1) * byte_len];
             let (doc_id, ordinal) = doc_id_ordinals[i];
-            let c = &mut index.clusters[assignments[i]];
+            let c = &mut index.clusters[assignments[i] as usize];
             c.doc_ids.push(doc_id);
             c.ordinals.push(ordinal);
             c.codes.extend_from_slice(code);
@@ -270,6 +288,13 @@ impl BinaryIvfIndex {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
     }
 
+    /// Serialize directly into an output stream without materializing a second
+    /// complete ANN blob in memory.
+    pub fn write_to<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<usize> {
+        bincode::serde::encode_into_std_write(self, writer, bincode::config::standard())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    }
+
     /// Deserialize from bytes.
     pub fn from_bytes(data: &[u8]) -> std::io::Result<Self> {
         bincode::serde::decode_from_slice(data, bincode::config::standard())
@@ -300,9 +325,8 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
     let mut rng = rand::rngs::StdRng::seed_from_u64(config.seed);
 
     // Bound training cost: iterate over a sample, assign everything later
-    let mut sample: Vec<usize> = (0..n).collect();
-    sample.shuffle(&mut rng);
-    sample.truncate(config.max_train_samples.max(k));
+    let sample_len = config.max_train_samples.max(k).min(n);
+    let sample = rand::seq::index::sample(&mut rng, n, sample_len).into_vec();
     let n = sample.len();
     let vec_at = |i: usize| -> &[u8] {
         let vi = sample[i];
@@ -508,6 +532,10 @@ mod tests {
 
         let index = BinaryIvfIndex::build(BinaryIvfConfig::new(dim, 4), &codes, &labels);
         let bytes = index.to_bytes().unwrap();
+        let mut streamed = Vec::new();
+        let written = index.write_to(&mut streamed).unwrap();
+        assert_eq!(written, streamed.len());
+        assert_eq!(streamed, bytes);
         let back = BinaryIvfIndex::from_bytes(&bytes).unwrap();
         assert_eq!(back.len(), index.len());
 

--- a/hermes-server/README.md
+++ b/hermes-server/README.md
@@ -49,8 +49,9 @@ These are deliberately separate controls:
 | `--optimizer-time-budget-secs`           |     `600` | Wall-clock budget for an optimizer pass on a large segment.                                                                              |
 | `--optimizer-partial-min-partition-docs` |    `4096` | Initial depth floor for large segments.                                                                                                  |
 | `--optimizer-unconverged-cooldown-secs`  |     `600` | Delay after a rewrite finishes before another deepening pass.                                                                            |
+| `--optimizer-max-unconverged-passes`     |       `3` | Optimizer follow-up eligibility limit per truncated lineage, including the initial partial pass. `0` disables follow-up deepening.       |
 | `--merge-bp-budget-secs`                 |     `600` | Wall-clock budget for BP performed inside a merge; `0` means unbudgeted.                                                                 |
-| `--bp-memory-budget-mb`                  |   `24576` | Per-pass forward-index cap, not a reservation and not a total RSS limit.                                                                 |
+| `--bp-memory-budget-mb`                  |   `24576` | Per-pass algorithmic working-set bound; not a reservation or a total-process RSS limit.                                                  |
 
 An active BP pass is CPU-bound and is expected to occupy up to
 `--optimizer-threads` cores. Concurrent passes share that same pool, so raising
@@ -59,12 +60,15 @@ it does not create another pool per pass or per index. For predictable service
 latency, start with one pass and a CPU width that leaves capacity for query and
 indexing work.
 
-The forward index is roughly `4 bytes/posting + 32 bytes/document` before
-format-specific rewrite buffers. At the process level, budget for up to
-`concurrent-passes * bp-memory-budget`, plus indexing builders, merge state,
-mmap/page-cache residency, and open readers. The memory limit drops
-highest-frequency dimensions from BP when necessary; it does not truncate or
-drop stored postings.
+The dominant graph representation is roughly `4 bytes/posting + 32
+bytes/document`. The limit also accounts for record maps, vocabulary-sized
+degree arrays, and record-rewrite grid/encode windows. If the record
+representation cannot fit, Hermes performs a valid blockwise rewrite and marks
+it unconverged; if only the graph is too large, it retains a bounded set of
+low-frequency dimensions. Stored postings are never truncated. At the process
+level, still budget for up to `concurrent-passes * bp-memory-budget`, plus
+indexing builders, merge state, mmap/page-cache residency, output buffering,
+and open readers.
 
 Merge failures use exponential retry backoff (30 seconds through 30 minutes).
 A deterministic missing/corrupt source is quarantined for the process lifetime
@@ -81,8 +85,12 @@ and removes entries that cannot be opened. Normal startup/writer-open cleanup
 only deletes true unowned files and cannot delete metadata-live, actively
 written, or reader-retained segments. Standalone reorder failures are also
 backed off per source from pass completion, so a pass that outlasts the scan
-interval cannot restart continuously. Details and invariants are in
-[Segment lifecycle and recovery](../docs/segment-lifecycle.md).
+interval cannot restart continuously. Successful but budget-truncated outputs
+carry a retry count across replacement IDs and stop being optimizer candidates
+at `--optimizer-max-unconverged-passes`, so a lineage that never converges
+cannot consume the optimizer pool forever. Explicitly configured merge-time BP
+still runs when that lineage later participates in a real merge. Details and
+invariants are in [Segment lifecycle and recovery](../docs/segment-lifecycle.md).
 
 ## gRPC API
 

--- a/hermes-server/src/error.rs
+++ b/hermes-server/src/error.rs
@@ -23,7 +23,9 @@ pub fn hermes_error_to_status(e: hermes_core::Error) -> Status {
         hermes_core::Error::DuplicatePrimaryKey(_) => Status::already_exists(e.to_string()),
 
         // Backpressure
-        hermes_core::Error::QueueFull => Status::resource_exhausted(e.to_string()),
+        hermes_core::Error::QueueFull | hermes_core::Error::CommitInProgress => {
+            Status::resource_exhausted(e.to_string())
+        }
 
         // Precondition failures
         hermes_core::Error::IndexClosed => Status::failed_precondition(e.to_string()),

--- a/hermes-server/src/index_service.rs
+++ b/hermes-server/src/index_service.rs
@@ -57,9 +57,9 @@ impl IndexServiceImpl {
                         error: format!("Duplicate primary key: {}", key),
                     });
                 }
-                Err(hermes_core::Error::QueueFull) => {
+                Err(hermes_core::Error::QueueFull | hermes_core::Error::CommitInProgress) => {
                     warn!(
-                        "QueueFull during stream batch: indexed {}/{} docs before backpressure",
+                        "Indexing backpressure during stream batch: indexed {}/{} docs",
                         count, total_docs
                     );
                     break;
@@ -142,15 +142,18 @@ impl IndexService for IndexServiceImpl {
                             error: format!("Duplicate primary key: {}", key),
                         });
                     }
-                    Err(hermes_core::Error::QueueFull) => {
+                    Err(hermes_core::Error::QueueFull | hermes_core::Error::CommitInProgress) => {
                         let skipped = total_docs - i;
                         warn!(
-                            "QueueFull during batch_index: index={}, indexed {}/{} docs, {} skipped",
+                            "Indexing backpressure during batch_index: index={}, indexed {}/{} docs, {} skipped",
                             req.index_name, indexed_count, total_docs, skipped
                         );
                         doc_errors.push(DocumentError {
                             index: i as u32,
-                            error: format!("Queue full — {} remaining documents skipped", skipped),
+                            error: format!(
+                                "Indexing backpressure — {} remaining documents skipped",
+                                skipped
+                            ),
                         });
                         break;
                     }

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -96,16 +96,21 @@ struct Args {
     #[arg(long, default_value = "600")]
     optimizer_unconverged_cooldown_secs: u64,
 
+    /// Maximum consecutive budget-exhausted rewrites that remain eligible for
+    /// optimizer follow-up, including the initial partial pass. 0 disables
+    /// follow-up deepening.
+    #[arg(long, default_value = "3")]
+    optimizer_max_unconverged_passes: u32,
+
     /// Wall-clock budget in seconds for merge-time BP reorder (0 = unbudgeted).
     /// A truncated pass still produces a valid, better-ordered segment; it is
     /// marked unconverged and the background optimizer deepens it later.
     #[arg(long, default_value = "600")]
     merge_bp_budget_secs: u64,
 
-    /// Memory budget (MB) for the BP forward index during reorder passes
-    /// (merge-time and background). A cap, not an allocation — usage is
-    /// proportional to the segment being reordered. Over-budget passes drop
-    /// highest-df dims from BP's input with a loud warning.
+    /// Memory budget (MB) for the main BP/rewrite working set of one pass
+    /// (merge-time and background). A cap, not an allocation. Over-budget
+    /// record passes fall back to blockwise order and/or drop graph dimensions.
     #[arg(long, default_value = "24576")]
     bp_memory_budget_mb: usize,
 
@@ -259,6 +264,7 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
             time_budget: Duration::from_secs(args.optimizer_time_budget_secs),
             partial_min_partition_docs: args.optimizer_partial_min_partition_docs,
             unconverged_cooldown: Duration::from_secs(args.optimizer_unconverged_cooldown_secs),
+            max_unconverged_passes: args.optimizer_max_unconverged_passes,
         },
     );
 
@@ -271,8 +277,11 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
     info!("Reload interval: {} ms", args.reload_interval_ms);
     if args.optimizer_threads > 0 {
         info!(
-            "Optimizer: {} shared BP threads, {} concurrent pass(es), {}s scan interval",
-            args.optimizer_threads, concurrent_reorder_passes, args.optimizer_scan_interval_secs,
+            "Optimizer: {} shared BP threads, {} concurrent pass(es), {}s scan interval, {}-pass unconverged follow-up threshold",
+            args.optimizer_threads,
+            concurrent_reorder_passes,
+            args.optimizer_scan_interval_secs,
+            args.optimizer_max_unconverged_passes,
         );
     }
 

--- a/hermes-server/src/optimizer.rs
+++ b/hermes-server/src/optimizer.rs
@@ -40,6 +40,11 @@ pub struct OptimizerConfig {
     /// pass hit its wall-clock budget (`bp_converged == false`). Each
     /// follow-up warm-starts from the previous order and deepens.
     pub unconverged_cooldown: Duration,
+    /// Optimizer follow-up threshold for budget-exhausted rewrites in one
+    /// replacement lineage. Without it, a segment that can never beat
+    /// `time_budget` is rewritten forever by the optimizer, continually
+    /// consuming all BP workers and disk I/O.
+    pub max_unconverged_passes: u32,
 }
 
 /// Global gate for expensive full-depth deepening passes.
@@ -106,10 +111,11 @@ pub fn spawn_optimizer(
     }
 
     info!(
-        "Starting background optimizer: {} shared BP threads, {} concurrent pass(es), {:.0}s scan interval",
+        "Starting background optimizer: {} shared BP threads, {} concurrent pass(es), {:.0}s scan interval, {}-pass unconverged follow-up threshold",
         config.threads,
         config.concurrent_passes,
         config.scan_interval.as_secs_f64(),
+        config.max_unconverged_passes,
     );
 
     let semaphore = Arc::new(Semaphore::new(config.concurrent_passes.max(1)));
@@ -229,13 +235,19 @@ async fn scan_and_optimize(
         // budget-truncated segment per cooldown window (each follow-up is a
         // full segment rewrite; it warm-starts from the previous order and
         // deepens toward block-granularity).
-        let mut unconverged = segment_manager.unconverged_segments().await;
+        let mut unconverged = segment_manager
+            .unconverged_segments_below(config.max_unconverged_passes)
+            .await;
         unconverged.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-        if let Some((id, docs)) = unconverged.into_iter().next() {
+        if let Some((id, docs, attempts)) = unconverged.into_iter().next() {
             // Put deepening first so an endless stream of fresh flushes cannot
             // consume every slot. The cooldown gate is acquired only after a
             // scheduler slot exists; merely discovering a candidate must not
             // start its cooldown.
+            debug!(
+                "[optimizer] segment {} has used {}/{} unconverged pass(es)",
+                id, attempts, config.max_unconverged_passes,
+            );
             candidates.insert(0, (id, docs, true));
         }
 


### PR DESCRIPTION
## Summary

- Make indexing commit finalization cancellation- and panic-safe while preserving retryable pre-publication state.
- Harden segment reader/reorder validation and publication, including corrupt inputs, empty sparse segments, and 256-block mappings.
- Bound optimizer follow-ups, BP memory and parallelism, and binary-IVF build/merge memory.
- Add lifecycle regressions, update operator documentation, and validate with 741 core tests, 3 server tests, doctests, and strict Clippy.