### PR TITLE
Harden search performance and segment lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,21 @@ For production indexes, BP reorder resources are controlled independently:
 
 ```bash
 hermes-server --data-dir /data \
+  --search-threads 12 \
+  --max-concurrent-searches 6 \
   --optimizer-threads 16 \
   --optimizer-concurrent-passes 1 \
   --optimizer-max-unconverged-passes 3 \
   --bp-memory-budget-mb 24576
 ```
 
+- `--search-threads` bounds the process-wide CPU pool shared by nested search
+  work across every index; it defaults to one quarter of detected CPUs.
+- `--max-concurrent-searches` bounds simultaneous search pipelines and rejects
+  overload promptly instead of queueing an unbounded number of decoded RPCs.
+  Result windows, fusion/reranker work, query-tree expansion, vector payloads,
+  stored-field hydration, and response bytes also have explicit server-side
+  budgets; see [Search resource controls](hermes-server/README.md#search-resource-controls).
 - `--optimizer-threads` is the width of one process-wide Rayon pool shared by
   every index and BP path. An active pass intentionally keeps that pool busy;
   lower this value when search or indexing needs more CPU. `0` disables the

--- a/hermes-core/src/compression/mod.rs
+++ b/hermes-core/src/compression/mod.rs
@@ -17,5 +17,5 @@ mod zstd;
 
 pub use self::zstd::{
     CompressionDict, CompressionLevel, compress, compress_with_dict, decompress,
-    decompress_with_dict,
+    decompress_limited, decompress_with_dict, decompress_with_dict_limited,
 };

--- a/hermes-core/src/compression/zstd.rs
+++ b/hermes-core/src/compression/zstd.rs
@@ -6,6 +6,10 @@
 //! - Larger block sizes to improve compression efficiency
 
 use std::io;
+use std::io::Read;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_DICTIONARY_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Compression level (1-22 for zstd)
 #[derive(Debug, Clone, Copy)]
@@ -34,6 +38,10 @@ impl Default for CompressionLevel {
 #[derive(Clone)]
 pub struct CompressionDict {
     raw_dict: crate::directories::OwnedBytes,
+    /// Stable across clones and never derived from an allocator address. The
+    /// thread-local codec caches can outlive a dictionary, so raw pointers are
+    /// vulnerable to allocator ABA reuse.
+    cache_id: u64,
 }
 
 impl CompressionDict {
@@ -45,6 +53,7 @@ impl CompressionDict {
         let raw_dict = zstd::dict::from_samples(samples, dict_size).map_err(io::Error::other)?;
         Ok(Self {
             raw_dict: crate::directories::OwnedBytes::new(raw_dict),
+            cache_id: NEXT_DICTIONARY_ID.fetch_add(1, Ordering::Relaxed),
         })
     }
 
@@ -52,12 +61,16 @@ impl CompressionDict {
     pub fn from_bytes(bytes: Vec<u8>) -> Self {
         Self {
             raw_dict: crate::directories::OwnedBytes::new(bytes),
+            cache_id: NEXT_DICTIONARY_ID.fetch_add(1, Ordering::Relaxed),
         }
     }
 
     /// Create dictionary from OwnedBytes (zero-copy for mmap)
     pub fn from_owned_bytes(bytes: crate::directories::OwnedBytes) -> Self {
-        Self { raw_dict: bytes }
+        Self {
+            raw_dict: bytes,
+            cache_id: NEXT_DICTIONARY_ID.fetch_add(1, Ordering::Relaxed),
+        }
     }
 
     /// Get raw dictionary bytes (for saving)
@@ -73,6 +86,11 @@ impl CompressionDict {
     /// Check if dictionary is empty
     pub fn is_empty(&self) -> bool {
         self.raw_dict.is_empty()
+    }
+
+    #[inline]
+    fn cache_id(&self) -> u64 {
+        self.cache_id
     }
 }
 
@@ -109,10 +127,10 @@ pub fn compress_with_dict(
     dict: &CompressionDict,
 ) -> io::Result<Vec<u8>> {
     thread_local! {
-        static DICT_CMP: std::cell::RefCell<Option<(usize, i32, zstd::bulk::Compressor<'static>)>> =
+        static DICT_CMP: std::cell::RefCell<Option<(u64, i32, zstd::bulk::Compressor<'static>)>> =
             const { std::cell::RefCell::new(None) };
     }
-    let dict_key = dict.as_bytes().as_ptr() as usize;
+    let dict_key = dict.cache_id();
 
     DICT_CMP.with(|cell| {
         let mut slot = cell.borrow_mut();
@@ -152,6 +170,24 @@ pub fn decompress(data: &[u8]) -> io::Result<Vec<u8>> {
     })
 }
 
+/// Decompress while rejecting output larger than `max_output` bytes.
+///
+/// Index files are trusted only after validation. Using an explicit bound at
+/// compressed block boundaries prevents a tiny corrupt frame from expanding
+/// until the process runs out of memory.
+pub fn decompress_limited(data: &[u8], max_output: usize) -> io::Result<Vec<u8>> {
+    thread_local! {
+        static DECOMPRESSOR: std::cell::RefCell<zstd::bulk::Decompressor<'static>> =
+            std::cell::RefCell::new(zstd::bulk::Decompressor::new().unwrap());
+    }
+    DECOMPRESSOR.with(|dc| {
+        dc.borrow_mut().decompress(data, max_output).or_else(|_| {
+            let decoder = zstd::Decoder::new(data)?;
+            read_limited(decoder, max_output)
+        })
+    })
+}
+
 /// Decompress data using Zstd with a trained dictionary
 ///
 /// Caches the dictionary decompressor in a thread-local, keyed by the
@@ -161,11 +197,11 @@ pub fn decompress(data: &[u8]) -> io::Result<Vec<u8>> {
 /// a different dictionary is encountered (e.g., switching between segments).
 pub fn decompress_with_dict(data: &[u8], dict: &CompressionDict) -> io::Result<Vec<u8>> {
     thread_local! {
-        static DICT_DC: std::cell::RefCell<Option<(usize, zstd::bulk::Decompressor<'static>)>> =
+        static DICT_DC: std::cell::RefCell<Option<(u64, zstd::bulk::Decompressor<'static>)>> =
             const { std::cell::RefCell::new(None) };
     }
     // Use the raw dict slice pointer as a stable identity key.
-    let dict_key = dict.as_bytes().as_ptr() as usize;
+    let dict_key = dict.cache_id();
 
     DICT_DC.with(|cell| {
         let mut slot = cell.borrow_mut();
@@ -186,6 +222,52 @@ pub fn decompress_with_dict(data: &[u8], dict: &CompressionDict) -> io::Result<V
                 Ok(output)
             })
     })
+}
+
+/// Dictionary variant of [`decompress_limited`].
+pub fn decompress_with_dict_limited(
+    data: &[u8],
+    dict: &CompressionDict,
+    max_output: usize,
+) -> io::Result<Vec<u8>> {
+    thread_local! {
+        static DICT_DC: std::cell::RefCell<Option<(u64, zstd::bulk::Decompressor<'static>)>> =
+            const { std::cell::RefCell::new(None) };
+    }
+    let dict_key = dict.cache_id();
+
+    DICT_DC.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        if slot.as_ref().is_none_or(|(key, _)| *key != dict_key) {
+            let dc = zstd::bulk::Decompressor::with_dictionary(dict.as_bytes())
+                .map_err(io::Error::other)?;
+            *slot = Some((dict_key, dc));
+        }
+        slot.as_mut()
+            .unwrap()
+            .1
+            .decompress(data, max_output)
+            .or_else(|_| {
+                let decoder = zstd::Decoder::with_dictionary(data, dict.as_bytes())?;
+                read_limited(decoder, max_output)
+            })
+    })
+}
+
+fn read_limited(mut reader: impl Read, max_output: usize) -> io::Result<Vec<u8>> {
+    let read_limit = u64::try_from(max_output)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1);
+    let initial_capacity = max_output.min(DECOMPRESS_CAPACITY);
+    let mut output = Vec::with_capacity(initial_capacity);
+    reader.by_ref().take(read_limit).read_to_end(&mut output)?;
+    if output.len() > max_output {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "decompressed data exceeds configured limit",
+        ));
+    }
+    Ok(output)
 }
 
 #[cfg(test)]
@@ -216,6 +298,33 @@ mod tests {
             let compressed = compress(&data, CompressionLevel(level)).unwrap();
             let decompressed = decompress(&compressed).unwrap();
             assert_eq!(data.as_slice(), decompressed.as_slice());
+        }
+    }
+
+    #[test]
+    fn test_limited_decompression_rejects_oversized_output() {
+        let data = vec![7u8; 4096];
+        let compressed = compress(&data, CompressionLevel::default()).unwrap();
+        assert!(decompress_limited(&compressed, 1024).is_err());
+        assert_eq!(decompress_limited(&compressed, data.len()).unwrap(), data);
+    }
+
+    #[test]
+    fn test_dictionary_cache_identity_is_stable_and_unique() {
+        let first = CompressionDict::from_bytes(b"first dictionary material".repeat(16));
+        let first_clone = first.clone();
+        let second = CompressionDict::from_bytes(b"second dictionary material".repeat(16));
+        assert_eq!(first.cache_id(), first_clone.cache_id());
+        assert_ne!(first.cache_id(), second.cache_id());
+
+        let payload = b"dictionary cache switches must rebuild their codec state".repeat(64);
+        for dict in [&first, &second, &first_clone] {
+            let compressed =
+                compress_with_dict(&payload, CompressionLevel::default(), dict).unwrap();
+            assert_eq!(
+                decompress_with_dict_limited(&compressed, dict, payload.len()).unwrap(),
+                payload
+            );
         }
     }
 }

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -23,6 +23,12 @@ pub const INDEX_META_FILENAME: &str = "metadata.json";
 /// Temp file for atomic writes (write here, then rename to INDEX_META_FILENAME)
 const INDEX_META_TMP_FILENAME: &str = "metadata.json.tmp";
 
+/// Index-level centroids/codebooks are deliberately bounded before they are
+/// read or decoded. Besides limiting ordinary corruption damage, the matching
+/// bincode limit prevents a tiny forged collection length from requesting an
+/// effectively unbounded allocation.
+pub(crate) const MAX_TRAINED_ARTIFACT_BYTES: usize = 512 * 1024 * 1024;
+
 /// State of vector index for a field
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum VectorIndexState {
@@ -101,7 +107,12 @@ pub struct IndexMetadata {
     /// Per-field vector index metadata
     #[serde(default)]
     pub vector_fields: HashMap<u32, FieldVectorMeta>,
-    /// Total vectors across all segments (updated on commit)
+    /// Aggregate vector count recorded by all built vector fields.
+    ///
+    /// The per-field `VectorIndexState::Built::vector_count` values are the
+    /// source of truth. This cached aggregate is refreshed whenever a field is
+    /// marked built, rather than being overwritten with whichever field was
+    /// trained last.
     #[serde(default)]
     pub total_vectors: usize,
 }
@@ -227,7 +238,24 @@ impl IndexMetadata {
             };
             field.centroids_file = Some(centroids_file);
             field.codebook_file = codebook_file;
+            self.refresh_total_vectors();
         }
+    }
+
+    /// Refresh the cached aggregate from the authoritative per-field states.
+    ///
+    /// Saturation keeps this infallible metadata helper safe even if it is
+    /// called after loading externally modified metadata with impossible
+    /// counts.
+    pub(crate) fn refresh_total_vectors(&mut self) {
+        self.total_vectors = self
+            .vector_fields
+            .values()
+            .filter_map(|field| match field.state {
+                VectorIndexState::Built { vector_count, .. } => Some(vector_count),
+                VectorIndexState::Flat => None,
+            })
+            .fold(0usize, usize::saturating_add);
     }
 
     /// Check if field should be built based on threshold
@@ -315,23 +343,64 @@ impl IndexMetadata {
         Ok(())
     }
 
-    /// Load trained structures from a vector_fields map.
-    /// Accepts a pre-cloned map so callers can release locks before disk I/O.
+    /// Compatibility loader for callers that only have the persisted field
+    /// map. Invalid/incomplete state is logged and returns `None` rather than a
+    /// partial set.
+    ///
+    /// Index open/build paths use the fallible, schema-aware
+    /// [`Self::try_load_trained_from_fields`] method below.
     pub async fn load_trained_from_fields<D: crate::directories::Directory>(
         vector_fields: &HashMap<u32, FieldVectorMeta>,
         dir: &D,
     ) -> Option<crate::segment::TrainedVectorStructures> {
+        match Self::load_trained_from_fields_impl(vector_fields, None, dir).await {
+            Ok(trained) => trained,
+            Err(error) => {
+                log::error!("[trained] refusing incomplete/corrupt artifact set: {error}");
+                None
+            }
+        }
+    }
+
+    /// Fallible schema-aware loader used for lifecycle publication.
+    pub(crate) async fn try_load_trained_from_fields<D: crate::directories::Directory>(
+        vector_fields: &HashMap<u32, FieldVectorMeta>,
+        schema: &Schema,
+        dir: &D,
+    ) -> Result<Option<crate::segment::TrainedVectorStructures>> {
+        Self::load_trained_from_fields_impl(vector_fields, Some(schema), dir).await
+    }
+
+    /// Load and validate the complete trained-artifact set described by a
+    /// `vector_fields` snapshot.
+    ///
+    /// This is intentionally all-or-nothing. A `Built` field is a durable
+    /// promise that every artifact required by its configured index exists and
+    /// is compatible with the schema. Returning a partial map would let some
+    /// segment builders publish ANN data while another field was silently
+    /// unusable, and would make the same index behave differently after a
+    /// restart.
+    async fn load_trained_from_fields_impl<D: crate::directories::Directory>(
+        vector_fields: &HashMap<u32, FieldVectorMeta>,
+        schema: Option<&Schema>,
+        dir: &D,
+    ) -> Result<Option<crate::segment::TrainedVectorStructures>> {
         use std::sync::Arc;
 
         let mut centroids = rustc_hash::FxHashMap::default();
         let mut codebooks = rustc_hash::FxHashMap::default();
+        let mut built_fields: Vec<_> = vector_fields
+            .iter()
+            .filter(|(_, meta)| matches!(meta.state, VectorIndexState::Built { .. }))
+            .collect();
+        built_fields.sort_unstable_by_key(|(field_id, _)| **field_id);
 
         log::debug!(
             "[trained] loading trained structures, vector_fields={:?}",
             vector_fields.keys().collect::<Vec<_>>()
         );
 
-        for (field_id, field_meta) in vector_fields {
+        for (field_id, field_meta) in built_fields {
             log::debug!(
                 "[trained] field {} state={:?} centroids_file={:?} codebook_file={:?}",
                 field_id,
@@ -339,131 +408,235 @@ impl IndexMetadata {
                 field_meta.centroids_file,
                 field_meta.codebook_file,
             );
-            if !matches!(field_meta.state, VectorIndexState::Built { .. }) {
-                log::debug!("[trained] field {} skipped (not Built)", field_id);
-                continue;
+            if field_meta.field_id != *field_id {
+                return Err(Error::Corruption(format!(
+                    "trained vector metadata key {field_id} contains field_id {}",
+                    field_meta.field_id
+                )));
             }
 
-            // Load centroids
-            match &field_meta.centroids_file {
-                None => {
-                    log::warn!(
-                        "[trained] field {} is Built but has no centroids_file",
-                        field_id
-                    );
+            let schema_config = match schema {
+                None => None,
+                Some(schema) => {
+                    let entry = schema
+                        .get_field_entry(crate::dsl::Field(*field_id))
+                        .ok_or_else(|| {
+                            Error::Corruption(format!(
+                                "trained vector metadata references missing field {field_id}"
+                            ))
+                        })?;
+                    if entry.field_type != crate::dsl::FieldType::DenseVector {
+                        return Err(Error::Corruption(format!(
+                            "trained vector metadata field {field_id} has non-dense schema type {:?}",
+                            entry.field_type
+                        )));
+                    }
+                    let config = entry.dense_vector_config.as_ref().ok_or_else(|| {
+                        Error::Corruption(format!(
+                            "trained vector metadata field {field_id} has no dense-vector configuration"
+                        ))
+                    })?;
+                    if field_meta.index_type != config.index_type {
+                        return Err(Error::Corruption(format!(
+                            "trained vector metadata field {field_id} uses {:?}, schema requires {:?}",
+                            field_meta.index_type, config.index_type
+                        )));
+                    }
+                    Some(config)
                 }
-                Some(file) => match dir.open_read(Path::new(file)).await {
-                    Err(e) => {
-                        log::warn!(
-                            "[trained] field {} failed to open centroids file '{}': {}",
-                            field_id,
-                            file,
-                            e
-                        );
-                    }
-                    Ok(slice) => match slice.read_bytes().await {
-                        Err(e) => {
-                            log::warn!(
-                                "[trained] field {} failed to read centroids file '{}': {}",
-                                field_id,
-                                file,
-                                e
-                            );
-                        }
-                        Ok(bytes) => {
-                            match bincode::serde::decode_from_slice::<
-                                crate::structures::CoarseCentroids,
-                                _,
-                            >(
-                                bytes.as_slice(), bincode::config::standard()
-                            )
-                            .map(|(v, _)| v)
-                            {
-                                Err(e) => {
-                                    log::warn!(
-                                        "[trained] field {} failed to deserialize centroids from '{}': {}",
-                                        field_id,
-                                        file,
-                                        e
-                                    );
-                                }
-                                Ok(c) => {
-                                    log::debug!(
-                                        "[trained] field {} loaded centroids ({} clusters)",
-                                        field_id,
-                                        c.num_clusters
-                                    );
-                                    centroids.insert(*field_id, Arc::new(c));
-                                }
-                            }
-                        }
-                    },
-                },
+            };
+            if !matches!(
+                field_meta.index_type,
+                VectorIndexType::IvfRaBitQ | VectorIndexType::ScaNN
+            ) {
+                return Err(Error::Corruption(format!(
+                    "field {field_id} is Built for {:?}, which has no index-level trained artifacts",
+                    field_meta.index_type
+                )));
             }
 
-            // Load codebook (for ScaNN)
-            match &field_meta.codebook_file {
-                None => {} // optional, not all index types use codebooks
-                Some(file) => match dir.open_read(Path::new(file)).await {
-                    Err(e) => {
-                        log::warn!(
-                            "[trained] field {} failed to open codebook file '{}': {}",
-                            field_id,
-                            file,
-                            e
-                        );
-                    }
-                    Ok(slice) => match slice.read_bytes().await {
-                        Err(e) => {
-                            log::warn!(
-                                "[trained] field {} failed to read codebook file '{}': {}",
-                                field_id,
-                                file,
-                                e
-                            );
-                        }
-                        Ok(bytes) => {
-                            match bincode::serde::decode_from_slice::<
-                                crate::structures::PQCodebook,
-                                _,
-                            >(
-                                bytes.as_slice(), bincode::config::standard()
-                            )
-                            .map(|(v, _)| v)
-                            {
-                                Err(e) => {
-                                    log::warn!(
-                                        "[trained] field {} failed to deserialize codebook from '{}': {}",
-                                        field_id,
-                                        file,
-                                        e
-                                    );
-                                }
-                                Ok(c) => {
-                                    log::debug!("[trained] field {} loaded codebook", field_id);
-                                    codebooks.insert(*field_id, Arc::new(c));
-                                }
-                            }
-                        }
-                    },
-                },
+            let expected_clusters = match field_meta.state {
+                VectorIndexState::Built { num_clusters, .. } if num_clusters > 0 => num_clusters,
+                VectorIndexState::Built { .. } => {
+                    return Err(Error::Corruption(format!(
+                        "trained vector metadata field {field_id} has zero clusters"
+                    )));
+                }
+                VectorIndexState::Flat => unreachable!("built_fields contains only Built entries"),
+            };
+
+            let centroids_file = field_meta.centroids_file.as_deref().ok_or_else(|| {
+                Error::Corruption(format!(
+                    "trained vector metadata field {field_id} is Built but has no centroids_file"
+                ))
+            })?;
+            let c: crate::structures::CoarseCentroids =
+                load_trained_artifact(dir, *field_id, "centroids", centroids_file).await?;
+            let expected_dim = schema_config.map_or(c.dim, |config| config.dim);
+            let actual_clusters = c.num_clusters as usize;
+            let expected_values = actual_clusters.checked_mul(expected_dim).ok_or_else(|| {
+                Error::Corruption(format!(
+                    "trained centroid dimensions overflow for field {field_id}"
+                ))
+            })?;
+            if actual_clusters == 0
+                || actual_clusters > expected_clusters
+                || c.dim == 0
+                || c.dim != expected_dim
+                || c.centroids.len() != expected_values
+                || c.centroids.iter().any(|value| !value.is_finite())
+            {
+                return Err(Error::Corruption(format!(
+                    "trained centroids for field {field_id} do not match metadata/schema: \
+                     clusters={} (metadata maximum {expected_clusters}), dim={} (expected {}), \
+                     values={} (expected {expected_values})",
+                    c.num_clusters,
+                    c.dim,
+                    expected_dim,
+                    c.centroids.len(),
+                )));
             }
+            if actual_clusters < expected_clusters {
+                // Older writers persisted the requested cluster count even
+                // though the trainer clamps it to the available sample. This
+                // shape is safe and self-describing in the artifact; accepting
+                // it keeps pre-fix indexes openable. New writers persist the
+                // actual count, so no new mismatch is produced.
+                log::warn!(
+                    "[trained] field {} legacy cluster-count clamp: metadata={}, artifact={}",
+                    field_id,
+                    expected_clusters,
+                    actual_clusters,
+                );
+            }
+            log::debug!(
+                "[trained] field {} loaded centroids ({} clusters)",
+                field_id,
+                c.num_clusters
+            );
+
+            if field_meta.index_type == VectorIndexType::ScaNN {
+                let codebook_file = field_meta.codebook_file.as_deref().ok_or_else(|| {
+                    Error::Corruption(format!(
+                        "trained vector metadata field {field_id} is ScaNN Built but has no codebook_file"
+                    ))
+                })?;
+                let codebook: crate::structures::PQCodebook =
+                    load_trained_artifact(dir, *field_id, "codebook", codebook_file).await?;
+                codebook.validate().map_err(|error| {
+                    Error::Corruption(format!(
+                        "invalid trained codebook for field {field_id}: {error}"
+                    ))
+                })?;
+                if codebook.config.dim != expected_dim {
+                    return Err(Error::Corruption(format!(
+                        "trained codebook for field {field_id} has dimension {}, expected {}",
+                        codebook.config.dim, expected_dim
+                    )));
+                }
+                log::debug!("[trained] field {} loaded codebook", field_id);
+                codebooks.insert(*field_id, Arc::new(codebook));
+            }
+            centroids.insert(*field_id, Arc::new(c));
         }
 
         if centroids.is_empty() {
-            None
+            Ok(None)
         } else {
-            Some(crate::segment::TrainedVectorStructures {
+            Ok(Some(crate::segment::TrainedVectorStructures {
                 centroids,
                 codebooks,
-            })
+            }))
         }
     }
+}
+
+fn validate_trained_artifact_path(field_id: u32, kind: &str, filename: &str) -> Result<()> {
+    use std::path::Component;
+
+    let path = Path::new(filename);
+    if filename.is_empty()
+        || path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+    {
+        return Err(Error::Corruption(format!(
+            "trained {kind} path for field {field_id} is not a safe relative path: '{filename}'"
+        )));
+    }
+    Ok(())
+}
+
+async fn load_trained_artifact<T, D>(
+    dir: &D,
+    field_id: u32,
+    kind: &str,
+    filename: &str,
+) -> Result<T>
+where
+    T: serde::de::DeserializeOwned,
+    D: crate::directories::Directory,
+{
+    validate_trained_artifact_path(field_id, kind, filename)?;
+    let path = Path::new(filename);
+    let file_size = dir.file_size(path).await.map_err(|error| {
+        Error::Corruption(format!(
+            "failed to stat trained {kind} '{filename}' for field {field_id}: {error}"
+        ))
+    })?;
+    validate_trained_artifact_size(field_id, kind, filename, file_size)?;
+    let slice = dir.open_read(path).await.map_err(|error| {
+        Error::Corruption(format!(
+            "failed to open trained {kind} '{filename}' for field {field_id}: {error}"
+        ))
+    })?;
+    validate_trained_artifact_size(field_id, kind, filename, slice.len())?;
+    let bytes = slice.read_bytes().await.map_err(|error| {
+        Error::Corruption(format!(
+            "failed to read trained {kind} '{filename}' for field {field_id}: {error}"
+        ))
+    })?;
+    let (artifact, consumed) = bincode::serde::decode_from_slice::<T, _>(
+        bytes.as_slice(),
+        bincode::config::standard().with_limit::<MAX_TRAINED_ARTIFACT_BYTES>(),
+    )
+    .map_err(|error| {
+        Error::Corruption(format!(
+            "failed to deserialize trained {kind} '{filename}' for field {field_id}: {error}"
+        ))
+    })?;
+    if consumed != bytes.len() {
+        return Err(Error::Corruption(format!(
+            "trained {kind} '{filename}' for field {field_id} has {} trailing bytes",
+            bytes.len() - consumed
+        )));
+    }
+    Ok(artifact)
+}
+
+fn validate_trained_artifact_size(
+    field_id: u32,
+    kind: &str,
+    filename: &str,
+    file_size: u64,
+) -> Result<()> {
+    if file_size > MAX_TRAINED_ARTIFACT_BYTES as u64 {
+        return Err(Error::Corruption(format!(
+            "trained {kind} '{filename}' for field {field_id} is {file_size} bytes, \
+             exceeding the {MAX_TRAINED_ARTIFACT_BYTES}-byte safety limit"
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::directories::DirectoryWriter;
 
     #[derive(Clone, Default)]
     struct SyncFailDirectory(crate::directories::RamDirectory);
@@ -529,6 +702,36 @@ mod tests {
         Schema::default()
     }
 
+    fn dense_schema(index_type: VectorIndexType) -> (Schema, crate::dsl::Field) {
+        let mut builder = crate::dsl::SchemaBuilder::default();
+        let config = match index_type {
+            VectorIndexType::IvfRaBitQ => crate::dsl::DenseVectorConfig::with_ivf(2, Some(1), 1),
+            VectorIndexType::ScaNN => crate::dsl::DenseVectorConfig::with_scann(2, Some(1), 1),
+            other => panic!("unsupported trained test index type: {other:?}"),
+        };
+        let field = builder.add_dense_vector_field_with_config("embedding", true, true, config);
+        (builder.build(), field)
+    }
+
+    fn test_centroids() -> crate::structures::CoarseCentroids {
+        crate::structures::CoarseCentroids {
+            num_clusters: 1,
+            dim: 2,
+            centroids: vec![0.25, 0.75],
+            version: 7,
+            soar_config: None,
+        }
+    }
+
+    async fn write_bincode(
+        directory: &crate::directories::RamDirectory,
+        filename: &str,
+        value: &impl serde::Serialize,
+    ) {
+        let bytes = bincode::serde::encode_to_vec(value, bincode::config::standard()).unwrap();
+        directory.write(Path::new(filename), &bytes).await.unwrap();
+    }
+
     #[test]
     fn test_metadata_init() {
         let mut meta = IndexMetadata::new(test_schema());
@@ -551,6 +754,184 @@ mod tests {
 
         let loaded = IndexMetadata::load(&directory).await.unwrap();
         assert_eq!(loaded.segment_doc_count("committed"), Some(7));
+    }
+
+    #[tokio::test]
+    async fn trained_artifacts_load_only_when_the_complete_built_set_is_valid() {
+        let mut builder = crate::dsl::SchemaBuilder::default();
+        let config = crate::dsl::DenseVectorConfig::with_ivf(2, Some(1), 1);
+        let first = builder.add_dense_vector_field_with_config(
+            "first_embedding",
+            true,
+            true,
+            config.clone(),
+        );
+        let second =
+            builder.add_dense_vector_field_with_config("second_embedding", true, true, config);
+        let schema = builder.build();
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(schema.clone());
+        metadata.init_field(first.0, VectorIndexType::IvfRaBitQ);
+        metadata.init_field(second.0, VectorIndexType::IvfRaBitQ);
+        metadata.mark_field_built(first.0, 10, 1, "field_0_centroids.bin".into(), None);
+        metadata.mark_field_built(second.0, 10, 1, "field_1_centroids.bin".into(), None);
+        write_bincode(&directory, "field_0_centroids.bin", &test_centroids()).await;
+
+        let error = IndexMetadata::try_load_trained_from_fields(
+            &metadata.vector_fields,
+            &schema,
+            &directory,
+        )
+        .await
+        .err()
+        .expect("missing artifact must fail the complete load")
+        .to_string();
+        assert!(error.contains("field_1_centroids.bin"), "{error}");
+        assert!(error.contains("field 1"), "{error}");
+        assert!(
+            IndexMetadata::load_trained_from_fields(&metadata.vector_fields, &directory)
+                .await
+                .is_none(),
+            "the compatibility API must also fail closed instead of returning the valid subset"
+        );
+    }
+
+    #[tokio::test]
+    async fn index_open_fails_closed_when_built_artifact_is_missing() {
+        let (schema, field) = dense_schema(VectorIndexType::IvfRaBitQ);
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(schema);
+        metadata.init_field(field.0, VectorIndexType::IvfRaBitQ);
+        metadata.mark_field_built(field.0, 10, 1, "missing_centroids.bin".into(), None);
+        metadata.save(&directory).await.unwrap();
+
+        let error = match crate::index::Index::open(directory, crate::index::IndexConfig::default())
+            .await
+        {
+            Ok(_) => panic!("Index::open accepted a Built field with no artifact"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("missing_centroids.bin"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn scann_built_state_requires_a_codebook() {
+        let (schema, field) = dense_schema(VectorIndexType::ScaNN);
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(schema.clone());
+        metadata.init_field(field.0, VectorIndexType::ScaNN);
+        metadata.mark_field_built(field.0, 10, 1, "field_0_centroids.bin".into(), None);
+        write_bincode(&directory, "field_0_centroids.bin", &test_centroids()).await;
+
+        let error = IndexMetadata::try_load_trained_from_fields(
+            &metadata.vector_fields,
+            &schema,
+            &directory,
+        )
+        .await
+        .err()
+        .expect("ScaNN Built state without a codebook must fail")
+        .to_string();
+        assert!(error.contains("has no codebook_file"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn legacy_requested_cluster_count_accepts_a_clamped_artifact() {
+        let mut builder = crate::dsl::SchemaBuilder::default();
+        let field = builder.add_dense_vector_field_with_config(
+            "embedding",
+            true,
+            true,
+            crate::dsl::DenseVectorConfig::with_ivf(2, Some(4), 1),
+        );
+        let schema = builder.build();
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(schema.clone());
+        metadata.init_field(field.0, VectorIndexType::IvfRaBitQ);
+        metadata.mark_field_built(field.0, 1, 4, "field_0_centroids.bin".into(), None);
+        write_bincode(&directory, "field_0_centroids.bin", &test_centroids()).await;
+
+        let trained = IndexMetadata::try_load_trained_from_fields(
+            &metadata.vector_fields,
+            &schema,
+            &directory,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(trained.centroids[&field.0].num_clusters, 1);
+    }
+
+    #[tokio::test]
+    async fn trained_artifact_loader_rejects_trailing_data() {
+        let (schema, field) = dense_schema(VectorIndexType::IvfRaBitQ);
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(schema.clone());
+        metadata.init_field(field.0, VectorIndexType::IvfRaBitQ);
+        metadata.mark_field_built(field.0, 10, 1, "field_0_centroids.bin".into(), None);
+        let mut bytes =
+            bincode::serde::encode_to_vec(test_centroids(), bincode::config::standard()).unwrap();
+        bytes.extend_from_slice(&[0xaa, 0xbb]);
+        directory
+            .write(Path::new("field_0_centroids.bin"), &bytes)
+            .await
+            .unwrap();
+
+        let error = IndexMetadata::try_load_trained_from_fields(
+            &metadata.vector_fields,
+            &schema,
+            &directory,
+        )
+        .await
+        .err()
+        .expect("trailing artifact bytes must fail validation")
+        .to_string();
+        assert!(error.contains("trailing bytes"), "{error}");
+    }
+
+    #[test]
+    fn trained_artifact_size_limit_rejects_before_reading() {
+        let error = validate_trained_artifact_size(
+            3,
+            "centroids",
+            "field_3_centroids.bin",
+            MAX_TRAINED_ARTIFACT_BYTES as u64 + 1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("exceeding"), "{error}");
+        assert!(error.contains("field 3"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn trained_artifact_decode_limit_rejects_forged_collection_length() {
+        let (schema, field) = dense_schema(VectorIndexType::IvfRaBitQ);
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(schema.clone());
+        metadata.init_field(field.0, VectorIndexType::IvfRaBitQ);
+        metadata.mark_field_built(field.0, 10, 1, "field_0_centroids.bin".into(), None);
+
+        // CoarseCentroids begins with num_clusters=1, dim=2, then the Vec
+        // length. Bincode's standard varint marker 253 introduces a u64; this
+        // tiny payload claims an impossible f32 vector and must hit the decode
+        // limit before any large allocation is attempted.
+        let mut bytes = vec![1, 2, 253];
+        bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+        directory
+            .write(Path::new("field_0_centroids.bin"), &bytes)
+            .await
+            .unwrap();
+
+        let error = IndexMetadata::try_load_trained_from_fields(
+            &metadata.vector_fields,
+            &schema,
+            &directory,
+        )
+        .await
+        .err()
+        .expect("forged collection length must fail the bounded decoder")
+        .to_string();
+        assert!(error.contains("failed to deserialize"), "{error}");
     }
 
     #[test]
@@ -589,6 +970,31 @@ mod tests {
             field.centroids_file.as_deref(),
             Some("field_0_centroids.bin")
         );
+    }
+
+    #[test]
+    fn total_vectors_is_aggregate_of_built_field_counts() {
+        let mut meta = IndexMetadata::new(test_schema());
+        meta.init_field(7, VectorIndexType::IvfRaBitQ);
+        meta.init_field(3, VectorIndexType::ScaNN);
+
+        // Build in reverse field-id order to ensure the result is not tied to
+        // HashMap or training iteration order.
+        meta.mark_field_built(7, 400, 20, "field_7_centroids.bin".to_string(), None);
+        assert_eq!(meta.total_vectors, 400);
+        meta.mark_field_built(
+            3,
+            250,
+            15,
+            "field_3_centroids.bin".to_string(),
+            Some("field_3_codebook.bin".to_string()),
+        );
+        assert_eq!(meta.total_vectors, 650);
+
+        // Rebuilding a field replaces its contribution; it does not add a
+        // duplicate training snapshot.
+        meta.mark_field_built(7, 425, 20, "field_7_centroids.bin".to_string(), None);
+        assert_eq!(meta.total_vectors, 675);
     }
 
     #[test]

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -11,8 +11,12 @@
 use crate::dsl::Schema;
 #[cfg(feature = "native")]
 use crate::error::Result;
+#[cfg(feature = "sync")]
+use std::collections::HashMap;
 #[cfg(feature = "native")]
 use std::sync::Arc;
+#[cfg(feature = "sync")]
+use std::sync::{OnceLock, Weak};
 
 mod searcher;
 pub use searcher::Searcher;
@@ -55,7 +59,11 @@ pub const SLICE_CACHE_FILENAME: &str = "index.slicecache";
 /// Index configuration
 #[derive(Debug, Clone)]
 pub struct IndexConfig {
-    /// Number of threads for CPU-intensive tasks (search parallelism)
+    /// Number of threads shared by CPU-intensive search work.
+    ///
+    /// Indexes in the same process that request the same width reuse one Rayon
+    /// pool. A value of zero is invalid and is rejected by `Index::create` and
+    /// `Index::open`.
     pub num_threads: usize,
     /// Number of parallel segment builders (documents distributed round-robin)
     pub num_indexing_threads: usize,
@@ -108,20 +116,62 @@ pub struct IndexConfig {
     pub background_reorder_pool: Option<Arc<rayon::ThreadPool>>,
 }
 
+/// Search pools are shared process-wide by width. This avoids multiplying OS
+/// threads by the number of open indexes while still allowing applications to
+/// deliberately isolate indexes that need different CPU budgets.
+#[cfg(feature = "sync")]
+static SEARCH_CPU_POOLS: OnceLock<parking_lot::Mutex<HashMap<usize, Weak<rayon::ThreadPool>>>> =
+    OnceLock::new();
+
+#[cfg(feature = "sync")]
+fn shared_search_pool(num_threads: usize) -> Result<Arc<rayon::ThreadPool>> {
+    if num_threads == 0 {
+        return Err(crate::Error::Internal(
+            "IndexConfig.num_threads must be greater than zero".into(),
+        ));
+    }
+
+    let mut pools = SEARCH_CPU_POOLS
+        .get_or_init(|| parking_lot::Mutex::new(HashMap::new()))
+        .lock();
+    if let Some(pool) = pools.get(&num_threads).and_then(Weak::upgrade) {
+        return Ok(pool);
+    }
+
+    // Build while holding the registry lock. Index construction is cold-path
+    // work, and serialization here prevents two concurrent opens from creating
+    // duplicate pools for the same width.
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .thread_name(move |idx| format!("hermes-search-{}-{}", num_threads, idx))
+            .build()
+            .map_err(|error| {
+                crate::Error::Internal(format!(
+                    "failed to create {num_threads}-thread search pool: {error}"
+                ))
+            })?,
+    );
+    pools.retain(|_, pool| pool.strong_count() > 0);
+    pools.insert(num_threads, Arc::downgrade(&pool));
+    log::info!("[search] process-wide CPU pool: {} thread(s)", num_threads);
+    Ok(pool)
+}
+
 impl Default for IndexConfig {
     fn default() -> Self {
-        #[cfg(feature = "native")]
-        let indexing_threads = crate::default_indexing_threads();
-        #[cfg(not(feature = "native"))]
-        let indexing_threads = 1;
-
         #[cfg(feature = "native")]
         let compression_threads = crate::default_compression_threads();
         #[cfg(not(feature = "native"))]
         let compression_threads = 1;
 
+        #[cfg(feature = "native")]
+        let search_threads = crate::default_search_threads();
+        #[cfg(not(feature = "native"))]
+        let search_threads = 1;
+
         Self {
-            num_threads: indexing_threads,
+            num_threads: search_threads,
             num_indexing_threads: 1, // Increase to 2+ for production to avoid stalls during segment build
             num_compression_threads: compression_threads,
             term_cache_blocks: 256,
@@ -171,6 +221,8 @@ pub struct Index<D: crate::directories::DirectoryWriter + 'static> {
     directory: Arc<D>,
     schema: Arc<Schema>,
     config: IndexConfig,
+    /// Cache and CPU policy used by every searcher reload.
+    search_resources: searcher::SearcherResources,
     /// Segment manager - owns segments, tracker, metadata, and trained structures
     segment_manager: Arc<crate::merge::SegmentManager<D>>,
     /// Cached reader (created lazily, reused across calls)
@@ -181,6 +233,11 @@ pub struct Index<D: crate::directories::DirectoryWriter + 'static> {
 impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
     /// Create a new index in the directory
     pub async fn create(directory: D, schema: Schema, config: IndexConfig) -> Result<Self> {
+        let search_resources = searcher::SearcherResources::new(
+            config.term_cache_blocks,
+            config.store_cache_blocks,
+            config.num_threads,
+        )?;
         let directory = Arc::new(directory);
         let schema = Arc::new(schema);
         // Directory-layer metrics (cold writes, lazy reads) carry the index label
@@ -208,6 +265,7 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
             directory,
             schema,
             config,
+            search_resources,
             segment_manager,
             cached_reader: tokio::sync::OnceCell::new(),
         })
@@ -215,6 +273,11 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
 
     /// Open an existing index from a directory
     pub async fn open(directory: D, config: IndexConfig) -> Result<Self> {
+        let search_resources = searcher::SearcherResources::new(
+            config.term_cache_blocks,
+            config.store_cache_blocks,
+            config.num_threads,
+        )?;
         let directory = Arc::new(directory);
 
         // Load metadata (includes schema)
@@ -238,12 +301,13 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
         ));
 
         // Load trained structures into SegmentManager's ArcSwap
-        segment_manager.load_and_publish_trained().await;
+        segment_manager.try_load_and_publish_trained().await?;
 
         Ok(Self {
             directory,
             schema,
             config,
+            search_resources,
             segment_manager,
             cached_reader: tokio::sync::OnceCell::new(),
         })
@@ -276,11 +340,11 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
     pub async fn reader(&self) -> Result<&IndexReader<D>> {
         self.cached_reader
             .get_or_try_init(|| async {
-                IndexReader::from_segment_manager(
+                IndexReader::from_segment_manager_with_resources(
                     Arc::clone(&self.schema),
                     Arc::clone(&self.segment_manager),
-                    self.config.term_cache_blocks,
                     self.config.reload_interval_ms,
+                    self.search_resources.clone(),
                 )
                 .await
             })

--- a/hermes-core/src/index/reader.rs
+++ b/hermes-core/src/index/reader.rs
@@ -14,6 +14,7 @@ use crate::dsl::Schema;
 use crate::error::Result;
 
 use super::Searcher;
+use super::searcher::SearcherResources;
 
 /// IndexReader - manages Searcher with reload policy
 ///
@@ -43,8 +44,8 @@ pub struct IndexReader<D: DirectoryWriter + 'static> {
     segment_manager: Arc<crate::merge::SegmentManager<D>>,
     /// Current searcher + segment IDs (ArcSwap for wait-free reads)
     state: ArcSwap<SearcherState<D>>,
-    /// Term cache blocks
-    term_cache_blocks: usize,
+    /// Cache and CPU policy preserved across every searcher reload.
+    resources: SearcherResources,
     /// Last reload check time
     last_reload_check: RwLock<std::time::Instant>,
     /// Reload check interval (default 1 second)
@@ -64,10 +65,50 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
         term_cache_blocks: usize,
         reload_interval_ms: u64,
     ) -> Result<Self> {
+        Self::from_segment_manager_with_cache_blocks(
+            schema,
+            segment_manager,
+            term_cache_blocks,
+            term_cache_blocks,
+            reload_interval_ms,
+        )
+        .await
+    }
+
+    /// Create an IndexReader with independent term and document-store caches.
+    pub async fn from_segment_manager_with_cache_blocks(
+        schema: Arc<Schema>,
+        segment_manager: Arc<crate::merge::SegmentManager<D>>,
+        term_cache_blocks: usize,
+        store_cache_blocks: usize,
+        reload_interval_ms: u64,
+    ) -> Result<Self> {
+        let resources = SearcherResources::new(
+            term_cache_blocks,
+            store_cache_blocks,
+            crate::default_search_threads(),
+        )?;
+        Self::from_segment_manager_with_resources(
+            schema,
+            segment_manager,
+            reload_interval_ms,
+            resources,
+        )
+        .await
+    }
+
+    /// Internal constructor used by `Index` to preserve its configured cache
+    /// and search CPU policy across reader reloads.
+    pub(crate) async fn from_segment_manager_with_resources(
+        schema: Arc<Schema>,
+        segment_manager: Arc<crate::merge::SegmentManager<D>>,
+        reload_interval_ms: u64,
+        resources: SearcherResources,
+    ) -> Result<Self> {
         // Get initial segment IDs
         let initial_segment_ids = segment_manager.get_segment_ids().await;
 
-        let reader = Self::create_reader(&schema, &segment_manager, term_cache_blocks).await?;
+        let reader = Self::create_reader(&schema, &segment_manager, resources.clone()).await?;
 
         Ok(Self {
             schema,
@@ -76,7 +117,7 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
                 searcher: Arc::new(reader),
                 segment_ids: initial_segment_ids,
             }),
-            term_cache_blocks,
+            resources,
             last_reload_check: RwLock::new(std::time::Instant::now()),
             reload_check_interval: std::time::Duration::from_millis(reload_interval_ms),
             reloading: AtomicBool::new(false),
@@ -89,7 +130,7 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
     async fn create_reader(
         schema: &Arc<Schema>,
         segment_manager: &Arc<crate::merge::SegmentManager<D>>,
-        term_cache_blocks: usize,
+        resources: SearcherResources,
     ) -> Result<Searcher<D>> {
         // Read trained centroids from ArcSwap (lock-free)
         let trained = segment_manager.trained();
@@ -106,7 +147,7 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
             Arc::clone(schema),
             snapshot,
             trained_centroids,
-            term_cache_blocks,
+            resources,
         )
         .await
     }
@@ -231,7 +272,7 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
             Arc::clone(&self.schema),
             snapshot,
             trained_centroids,
-            self.term_cache_blocks,
+            self.resources.clone(),
             &existing_segments,
         )
         .await?;

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -16,6 +16,43 @@ use crate::segment::{SegmentId, SegmentReader};
 use crate::segment::{SegmentSnapshot, SegmentTracker};
 use crate::structures::CoarseCentroids;
 
+/// Immutable resources that must stay identical across `IndexReader` reloads.
+/// The search pool exists only when synchronous scoring is compiled in; native
+/// async-only builds retain the cache policy without spawning unused threads.
+#[cfg(feature = "native")]
+#[derive(Clone)]
+pub(crate) struct SearcherResources {
+    pub(crate) term_cache_blocks: usize,
+    pub(crate) store_cache_blocks: usize,
+    #[cfg(feature = "sync")]
+    pub(crate) search_pool: Arc<rayon::ThreadPool>,
+}
+
+#[cfg(feature = "native")]
+impl SearcherResources {
+    pub(crate) fn new(
+        term_cache_blocks: usize,
+        store_cache_blocks: usize,
+        num_threads: usize,
+    ) -> Result<Self> {
+        if num_threads == 0 {
+            return Err(crate::Error::Internal(
+                "IndexConfig.num_threads must be greater than zero".into(),
+            ));
+        }
+
+        #[cfg(feature = "sync")]
+        let search_pool = super::shared_search_pool(num_threads)?;
+
+        Ok(Self {
+            term_cache_blocks,
+            store_cache_blocks,
+            #[cfg(feature = "sync")]
+            search_pool,
+        })
+    }
+}
+
 /// Searcher - provides search over loaded segments
 ///
 /// For wasm/read-only use, create via `Searcher::open()`.
@@ -42,6 +79,9 @@ pub struct Searcher<D: Directory + 'static> {
     segment_map: FxHashMap<u128, usize>,
     /// Total document count across all segments
     total_docs: u32,
+    /// Bounded process-wide-by-width pool for the complete nested search tree.
+    #[cfg(feature = "sync")]
+    search_pool: Arc<rayon::ThreadPool>,
 }
 
 impl<D: Directory + 'static> Searcher<D> {
@@ -55,12 +95,31 @@ impl<D: Directory + 'static> Searcher<D> {
         segment_ids: &[String],
         term_cache_blocks: usize,
     ) -> Result<Self> {
+        Self::open_with_cache_blocks(
+            directory,
+            schema,
+            segment_ids,
+            term_cache_blocks,
+            term_cache_blocks,
+        )
+        .await
+    }
+
+    /// Create a read-only searcher with independent cache capacities.
+    pub async fn open_with_cache_blocks(
+        directory: Arc<D>,
+        schema: Arc<Schema>,
+        segment_ids: &[String],
+        term_cache_blocks: usize,
+        store_cache_blocks: usize,
+    ) -> Result<Self> {
         Self::create(
             directory,
             schema,
             segment_ids,
             FxHashMap::default(),
             term_cache_blocks,
+            store_cache_blocks,
         )
         .await
     }
@@ -72,14 +131,15 @@ impl<D: Directory + 'static> Searcher<D> {
         schema: Arc<Schema>,
         snapshot: SegmentSnapshot,
         trained_centroids: FxHashMap<u32, Arc<CoarseCentroids>>,
-        term_cache_blocks: usize,
+        resources: SearcherResources,
     ) -> Result<Self> {
         let (segments, default_fields, global_stats, segment_map, total_docs) = Self::load_common(
             &directory,
             &schema,
             snapshot.segment_ids(),
             &trained_centroids,
-            term_cache_blocks,
+            resources.term_cache_blocks,
+            resources.store_cache_blocks,
             &[],
         )
         .await?;
@@ -95,6 +155,8 @@ impl<D: Directory + 'static> Searcher<D> {
             global_stats,
             segment_map,
             total_docs,
+            #[cfg(feature = "sync")]
+            search_pool: resources.search_pool,
         })
     }
 
@@ -107,7 +169,7 @@ impl<D: Directory + 'static> Searcher<D> {
         schema: Arc<Schema>,
         snapshot: SegmentSnapshot,
         trained_centroids: FxHashMap<u32, Arc<CoarseCentroids>>,
-        term_cache_blocks: usize,
+        resources: SearcherResources,
         existing_segments: &[Arc<SegmentReader>],
     ) -> Result<Self> {
         let (segments, default_fields, global_stats, segment_map, total_docs) = Self::load_common(
@@ -115,7 +177,8 @@ impl<D: Directory + 'static> Searcher<D> {
             &schema,
             snapshot.segment_ids(),
             &trained_centroids,
-            term_cache_blocks,
+            resources.term_cache_blocks,
+            resources.store_cache_blocks,
             existing_segments,
         )
         .await?;
@@ -131,6 +194,8 @@ impl<D: Directory + 'static> Searcher<D> {
             global_stats,
             segment_map,
             total_docs,
+            #[cfg(feature = "sync")]
+            search_pool: resources.search_pool,
         })
     }
 
@@ -141,6 +206,7 @@ impl<D: Directory + 'static> Searcher<D> {
         segment_ids: &[String],
         trained_centroids: FxHashMap<u32, Arc<CoarseCentroids>>,
         term_cache_blocks: usize,
+        store_cache_blocks: usize,
     ) -> Result<Self> {
         let (segments, default_fields, global_stats, segment_map, total_docs) = Self::load_common(
             &directory,
@@ -148,6 +214,7 @@ impl<D: Directory + 'static> Searcher<D> {
             segment_ids,
             &trained_centroids,
             term_cache_blocks,
+            store_cache_blocks,
             &[],
         )
         .await?;
@@ -157,6 +224,9 @@ impl<D: Directory + 'static> Searcher<D> {
             let tracker = Arc::new(SegmentTracker::new());
             SegmentSnapshot::new(tracker, segment_ids.to_vec())
         };
+
+        #[cfg(feature = "sync")]
+        let search_pool = super::shared_search_pool(crate::default_search_threads())?;
 
         let _ = directory; // suppress unused warning on wasm
         Ok(Self {
@@ -171,6 +241,8 @@ impl<D: Directory + 'static> Searcher<D> {
             global_stats,
             segment_map,
             total_docs,
+            #[cfg(feature = "sync")]
+            search_pool,
         })
     }
 
@@ -181,6 +253,7 @@ impl<D: Directory + 'static> Searcher<D> {
         segment_ids: &[String],
         trained_centroids: &FxHashMap<u32, Arc<CoarseCentroids>>,
         term_cache_blocks: usize,
+        store_cache_blocks: usize,
         existing_segments: &[Arc<SegmentReader>],
     ) -> Result<(
         Vec<Arc<SegmentReader>>,
@@ -195,6 +268,7 @@ impl<D: Directory + 'static> Searcher<D> {
             segment_ids,
             trained_centroids,
             term_cache_blocks,
+            store_cache_blocks,
             existing_segments,
         )
         .await?;
@@ -219,6 +293,7 @@ impl<D: Directory + 'static> Searcher<D> {
         segment_ids: &[String],
         trained_centroids: &FxHashMap<u32, Arc<CoarseCentroids>>,
         term_cache_blocks: usize,
+        store_cache_blocks: usize,
         existing_segments: &[Arc<SegmentReader>],
     ) -> Result<Vec<Arc<SegmentReader>>> {
         // Build lookup from existing segment readers for reuse
@@ -260,7 +335,16 @@ impl<D: Directory + 'static> Searcher<D> {
                 let dir = Arc::clone(directory);
                 let sch = Arc::clone(schema);
                 let sid = *segment_id;
-                async move { SegmentReader::open(dir.as_ref(), sid, sch, term_cache_blocks).await }
+                async move {
+                    SegmentReader::open_with_cache_blocks(
+                        dir.as_ref(),
+                        sid,
+                        sch,
+                        term_cache_blocks,
+                        store_cache_blocks,
+                    )
+                    .await
+                }
             })
             .collect();
 
@@ -395,6 +479,19 @@ impl<D: Directory + 'static> Searcher<D> {
         &self.segment_map
     }
 
+    /// Run a bounded piece of CPU work inside this index's shared search pool.
+    /// Async-only/WASM builds execute inline because Rayon is not available.
+    pub(crate) fn install_search_cpu<R: Send>(&self, operation: impl FnOnce() -> R + Send) -> R {
+        #[cfg(feature = "sync")]
+        {
+            self.search_pool.install(operation)
+        }
+        #[cfg(not(feature = "sync"))]
+        {
+            operation()
+        }
+    }
+
     /// Get number of segments
     pub fn num_segments(&self) -> usize {
         self.segments.len()
@@ -470,7 +567,7 @@ impl<D: Directory + 'static> Searcher<D> {
         offset: usize,
         collect_positions: bool,
     ) -> Result<(Vec<crate::query::SearchResult>, u32)> {
-        let fetch_limit = offset + limit;
+        let fetch_limit = checked_search_window(limit, offset)?;
 
         // Use rayon + block_in_place for CPU-bound scoring (sync feature required).
         // Offloads the scoring loop from tokio workers so search doesn't starve
@@ -485,50 +582,44 @@ impl<D: Directory + 'static> Searcher<D> {
             return self.search_internal_parallel(query, fetch_limit, offset, collect_positions);
         }
 
-        // No segments, no sync feature, or current_thread runtime: use async path
-        let futures: Vec<_> = self
-            .segments
-            .iter()
-            .map(|segment| {
-                let sid = segment.meta().id;
-                async move {
-                    let (mut results, segment_seen) = if collect_positions {
-                        crate::query::search_segment_with_positions_and_count(
-                            segment.as_ref(),
-                            query,
-                            fetch_limit,
-                        )
+        // No segments, no sync feature, or current_thread runtime: use an
+        // explicitly bounded async stream. Starting every segment at once can
+        // retain `segments × top_k` results while the slowest I/O completes.
+        const MAX_ASYNC_SEGMENT_SEARCHES: usize = 8;
+        use futures::StreamExt;
+        use futures::TryStreamExt;
+        let searches = futures::stream::iter(self.segments.iter().cloned().map(|segment| {
+            let sid = segment.meta().id;
+            async move {
+                let (mut results, segment_seen) = if collect_positions {
+                    crate::query::search_segment_with_positions_and_count(
+                        segment.as_ref(),
+                        query,
+                        fetch_limit,
+                    )
+                    .await?
+                } else {
+                    crate::query::search_segment_with_count(segment.as_ref(), query, fetch_limit)
                         .await?
-                    } else {
-                        crate::query::search_segment_with_count(
-                            segment.as_ref(),
-                            query,
-                            fetch_limit,
-                        )
-                        .await?
-                    };
-                    // Stamp segment_id on each result
-                    for r in &mut results {
-                        r.segment_id = sid;
-                    }
-                    Ok::<_, crate::error::Error>((results, segment_seen))
+                };
+                // Stamp segment_id on each result
+                for r in &mut results {
+                    r.segment_id = sid;
                 }
-            })
-            .collect();
-
-        let batches = futures::future::try_join_all(futures).await?;
-        let mut total_seen: u32 = 0;
-
-        let mut sorted_batches: Vec<Vec<crate::query::SearchResult>> =
-            Vec::with_capacity(batches.len());
-        for (batch, segment_seen) in batches {
-            total_seen = total_seen.saturating_add(segment_seen);
-            if !batch.is_empty() {
-                sorted_batches.push(batch);
+                Ok::<_, crate::error::Error>((results, segment_seen))
             }
+        }))
+        .buffer_unordered(MAX_ASYNC_SEGMENT_SEARCHES);
+        futures::pin_mut!(searches);
+
+        let mut total_seen: u32 = 0;
+        let mut merged = Vec::new();
+        while let Some((batch, segment_seen)) = searches.try_next().await? {
+            total_seen = total_seen.saturating_add(segment_seen);
+            merged = merge_two_ranked(merged, batch, fetch_limit);
         }
 
-        let results = merge_segment_results(sorted_batches, fetch_limit, offset);
+        let results = apply_result_offset(merged, fetch_limit, offset);
         Ok((results, total_seen))
     }
 
@@ -563,7 +654,7 @@ impl<D: Directory + 'static> Searcher<D> {
     ) -> Result<(Vec<crate::query::SearchResult>, u32)> {
         use rayon::prelude::*;
 
-        let batches: Vec<Result<(Vec<crate::query::SearchResult>, u32)>> = {
+        let (merged, total_seen) = self.search_pool.install(|| {
             self.segments
                 .par_iter()
                 .map(|segment| {
@@ -584,23 +675,20 @@ impl<D: Directory + 'static> Searcher<D> {
                     for r in &mut results {
                         r.segment_id = sid;
                     }
-                    Ok((results, segment_seen))
+                    Ok::<_, crate::Error>((results, segment_seen))
                 })
-                .collect()
-        };
+                .try_reduce(
+                    || (Vec::new(), 0u32),
+                    |(left, left_seen), (right, right_seen)| {
+                        Ok((
+                            merge_two_ranked(left, right, fetch_limit),
+                            left_seen.saturating_add(right_seen),
+                        ))
+                    },
+                )
+        })?;
 
-        let mut total_seen: u32 = 0;
-        let mut sorted_batches: Vec<Vec<crate::query::SearchResult>> =
-            Vec::with_capacity(batches.len());
-        for result in batches {
-            let (batch, segment_seen) = result?;
-            total_seen = total_seen.saturating_add(segment_seen);
-            if !batch.is_empty() {
-                sorted_batches.push(batch);
-            }
-        }
-
-        let results = merge_segment_results(sorted_batches, fetch_limit, offset);
+        let results = apply_result_offset(merged, fetch_limit, offset);
         Ok((results, total_seen))
     }
 
@@ -616,37 +704,35 @@ impl<D: Directory + 'static> Searcher<D> {
     ) -> Result<(Vec<crate::query::SearchResult>, u32)> {
         use rayon::prelude::*;
 
-        let fetch_limit = offset + limit;
+        let fetch_limit = checked_search_window(limit, offset)?;
 
-        let batches: Vec<Result<(Vec<crate::query::SearchResult>, u32)>> = self
-            .segments
-            .par_iter()
-            .map(|segment| {
-                let sid = segment.meta().id;
-                let (mut results, segment_seen) = crate::query::search_segment_with_count_sync(
-                    segment.as_ref(),
-                    query,
-                    fetch_limit,
-                )?;
-                for r in &mut results {
-                    r.segment_id = sid;
-                }
-                Ok((results, segment_seen))
-            })
-            .collect();
+        let (merged, total_seen) = self.search_pool.install(|| {
+            self.segments
+                .par_iter()
+                .map(|segment| {
+                    let sid = segment.meta().id;
+                    let (mut results, segment_seen) = crate::query::search_segment_with_count_sync(
+                        segment.as_ref(),
+                        query,
+                        fetch_limit,
+                    )?;
+                    for r in &mut results {
+                        r.segment_id = sid;
+                    }
+                    Ok::<_, crate::Error>((results, segment_seen))
+                })
+                .try_reduce(
+                    || (Vec::new(), 0u32),
+                    |(left, left_seen), (right, right_seen)| {
+                        Ok((
+                            merge_two_ranked(left, right, fetch_limit),
+                            left_seen.saturating_add(right_seen),
+                        ))
+                    },
+                )
+        })?;
 
-        let mut total_seen: u32 = 0;
-        let mut sorted_batches: Vec<Vec<crate::query::SearchResult>> =
-            Vec::with_capacity(batches.len());
-        for result in batches {
-            let (batch, segment_seen) = result?;
-            total_seen = total_seen.saturating_add(segment_seen);
-            if !batch.is_empty() {
-                sorted_batches.push(batch);
-            }
-        }
-
-        let results = merge_segment_results(sorted_batches, fetch_limit, offset);
+        let results = apply_result_offset(merged, fetch_limit, offset);
         Ok((results, total_seen))
     }
 
@@ -677,6 +763,66 @@ impl<D: Directory + 'static> Searcher<D> {
         method: crate::query::FusionMethod,
         combiner: crate::query::MultiValueCombiner,
     ) -> Result<Vec<crate::query::SearchResult>> {
+        let (results, _) = self
+            .search_fused_with_count(queries, fetch_limit, limit, method, combiner)
+            .await?;
+        Ok(results)
+    }
+
+    /// Fusion variant that also returns the aggregate number of documents
+    /// scored by all sub-queries. This lets request-facing callers use the
+    /// parallel fusion path without rerunning sub-queries for observability.
+    pub async fn search_fused_with_count(
+        &self,
+        queries: &[(&dyn crate::query::Query, f32)],
+        fetch_limit: usize,
+        limit: usize,
+        method: crate::query::FusionMethod,
+        combiner: crate::query::MultiValueCombiner,
+    ) -> Result<(Vec<crate::query::SearchResult>, u32)> {
+        if queries.is_empty() {
+            return Err(crate::Error::Query(
+                "fusion requires at least one sub-query".to_string(),
+            ));
+        }
+        if queries.len() > crate::query::MAX_FUSION_SUB_QUERIES {
+            return Err(crate::Error::Query(format!(
+                "fusion supports at most {} sub-queries, got {}",
+                crate::query::MAX_FUSION_SUB_QUERIES,
+                queries.len()
+            )));
+        }
+        if fetch_limit == 0 {
+            return Err(crate::Error::Query(
+                "fusion fetch_limit must be greater than zero".to_string(),
+            ));
+        }
+        let candidate_slots = fetch_limit
+            .checked_mul(queries.len())
+            .ok_or_else(|| crate::Error::Query("fusion candidate budget overflow".to_string()))?;
+        if candidate_slots > crate::query::MAX_FUSION_CANDIDATE_SLOTS {
+            return Err(crate::Error::Query(format!(
+                "fusion candidate budget must not exceed {}, got {candidate_slots}",
+                crate::query::MAX_FUSION_CANDIDATE_SLOTS
+            )));
+        }
+        for (index, &(_, weight)) in queries.iter().enumerate() {
+            if !weight.is_finite() || weight < 0.0 {
+                return Err(crate::Error::Query(format!(
+                    "fusion query weight at index {index} must be finite and non-negative, \
+                     got {weight}"
+                )));
+            }
+        }
+        if let crate::query::FusionMethod::Rrf { k } = method
+            && (!k.is_finite() || k < 0.0)
+        {
+            return Err(crate::Error::Query(format!(
+                "fusion RRF k must be finite and non-negative, got {k}"
+            )));
+        }
+        combiner.validate().map_err(crate::Error::Query)?;
+
         // Sub-queries are independent — fan them out on rayon under a single
         // block_in_place (each also par_iters its segments; rayon
         // work-stealing composes the two levels). Sequential fallback for
@@ -687,31 +833,59 @@ impl<D: Directory + 'static> Searcher<D> {
                 == tokio::runtime::RuntimeFlavor::MultiThread
         {
             use rayon::prelude::*;
-            let lists: Vec<Result<(Vec<crate::query::SearchResult>, f32)>> =
+            let lists: Vec<Result<(Vec<crate::query::SearchResult>, f32, u32)>> =
                 tokio::task::block_in_place(|| {
-                    queries
-                        .par_iter()
-                        .map(|&(query, weight)| {
-                            let (results, _) =
-                                self.search_internal_sync(query, fetch_limit, 0, true)?;
-                            Ok((results, weight))
-                        })
-                        .collect()
+                    self.search_pool.install(|| {
+                        queries
+                            .par_iter()
+                            .map(|&(query, weight)| {
+                                let (results, seen) =
+                                    self.search_internal_sync(query, fetch_limit, 0, true)?;
+                                Ok((results, weight, seen))
+                            })
+                            .collect()
+                    })
                 });
             let lists = lists.into_iter().collect::<Result<Vec<_>>>()?;
-            return Ok(crate::query::fuse_ranked_lists_chunked(
-                lists, method, combiner, limit,
-            ));
+            let mut total_seen = 0u32;
+            let ranked_lists = lists
+                .into_iter()
+                .map(|(results, weight, seen)| {
+                    total_seen = total_seen.saturating_add(seen);
+                    (results, weight)
+                })
+                .collect();
+            let fused =
+                crate::query::try_fuse_ranked_lists_chunked(ranked_lists, method, combiner, limit)
+                    .map_err(crate::Error::Query)?;
+            return Ok((fused, total_seen));
         }
 
-        let mut lists = Vec::with_capacity(queries.len());
+        // Async/current-thread fallback retains bounded I/O concurrency and
+        // preserves input list order for deterministic rank ties.
+        const MAX_ASYNC_FUSION_SEARCHES: usize = 4;
+        use futures::{StreamExt, TryStreamExt};
+        let mut pending = Vec::with_capacity(queries.len());
         for &(query, weight) in queries {
-            let (results, _) = self.search_with_positions(query, fetch_limit).await?;
-            lists.push((results, weight));
+            pending.push(async move {
+                let (results, seen) = self.search_with_positions(query, fetch_limit).await?;
+                Ok::<_, crate::Error>((results, weight, seen))
+            });
         }
-        Ok(crate::query::fuse_ranked_lists_chunked(
-            lists, method, combiner, limit,
-        ))
+        let searches = futures::stream::iter(pending).buffered(MAX_ASYNC_FUSION_SEARCHES);
+        let lists: Vec<_> = searches.try_collect().await?;
+        let mut total_seen = 0u32;
+        let ranked_lists = lists
+            .into_iter()
+            .map(|(results, weight, seen)| {
+                total_seen = total_seen.saturating_add(seen);
+                (results, weight)
+            })
+            .collect();
+        let fused =
+            crate::query::try_fuse_ranked_lists_chunked(ranked_lists, method, combiner, limit)
+                .map_err(crate::Error::Query)?;
+        Ok((fused, total_seen))
     }
 
     /// Two-stage search: L1 retrieval + L2 dense vector reranking
@@ -821,74 +995,52 @@ impl<D: Directory + 'static> Searcher<D> {
     }
 }
 
-/// K-way merge of pre-sorted segment result batches.
-///
-/// Each batch is sorted by score descending. Uses a max-heap of
-/// (score, batch_idx, position) to merge in O(N log K).
-fn merge_segment_results(
-    sorted_batches: Vec<Vec<crate::query::SearchResult>>,
+/// Merge two canonically sorted batches while moving (not cloning) hits.
+/// Reductions use this eagerly, so retained cross-segment results stay O(k)
+/// instead of O(number_of_segments × k).
+fn merge_two_ranked(
+    left: Vec<crate::query::SearchResult>,
+    right: Vec<crate::query::SearchResult>,
+    limit: usize,
+) -> Vec<crate::query::SearchResult> {
+    let mut left = left.into_iter().peekable();
+    let mut right = right.into_iter().peekable();
+    let mut merged = Vec::with_capacity(limit.min(left.len().saturating_add(right.len())));
+
+    while merged.len() < limit {
+        let take_left = match (left.peek(), right.peek()) {
+            (Some(left), Some(right)) => {
+                !crate::query::compare_search_results_desc(left, right).is_gt()
+            }
+            (Some(_), None) => true,
+            (None, Some(_)) => false,
+            (None, None) => break,
+        };
+        if take_left {
+            merged.push(left.next().expect("peeked left result"));
+        } else {
+            merged.push(right.next().expect("peeked right result"));
+        }
+    }
+    merged
+}
+
+fn apply_result_offset(
+    results: Vec<crate::query::SearchResult>,
     fetch_limit: usize,
     offset: usize,
 ) -> Vec<crate::query::SearchResult> {
-    use std::cmp::Ordering;
-
-    struct MergeEntry {
-        score: f32,
-        batch_idx: usize,
-        pos: usize,
-    }
-    impl PartialEq for MergeEntry {
-        fn eq(&self, other: &Self) -> bool {
-            self.score == other.score
-        }
-    }
-    impl Eq for MergeEntry {}
-    impl PartialOrd for MergeEntry {
-        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-            Some(self.cmp(other))
-        }
-    }
-    impl Ord for MergeEntry {
-        fn cmp(&self, other: &Self) -> Ordering {
-            self.score
-                .partial_cmp(&other.score)
-                .unwrap_or(Ordering::Equal)
-        }
-    }
-
-    let mut heap = std::collections::BinaryHeap::with_capacity(sorted_batches.len());
-    for (i, batch) in sorted_batches.iter().enumerate() {
-        if !batch.is_empty() {
-            heap.push(MergeEntry {
-                score: batch[0].score,
-                batch_idx: i,
-                pos: 0,
-            });
-        }
-    }
-
-    let mut results = Vec::with_capacity(fetch_limit.min(64));
-    let mut emitted = 0usize;
-    while let Some(entry) = heap.pop() {
-        if emitted >= fetch_limit {
-            break;
-        }
-        let batch = &sorted_batches[entry.batch_idx];
-        if emitted >= offset {
-            results.push(batch[entry.pos].clone());
-        }
-        emitted += 1;
-        let next_pos = entry.pos + 1;
-        if next_pos < batch.len() {
-            heap.push(MergeEntry {
-                score: batch[next_pos].score,
-                batch_idx: entry.batch_idx,
-                pos: next_pos,
-            });
-        }
-    }
-
     results
+        .into_iter()
+        .skip(offset)
+        .take(fetch_limit.saturating_sub(offset))
+        .collect()
+}
+
+fn checked_search_window(limit: usize, offset: usize) -> Result<usize> {
+    offset
+        .checked_add(limit)
+        .ok_or_else(|| crate::Error::Query("search offset + limit overflow".into()))
 }
 
 /// Get current process RSS in MB (best-effort, returns 0.0 on failure)
@@ -949,5 +1101,52 @@ fn process_rss_mb() -> f64 {
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         0.0
+    }
+}
+
+#[cfg(test)]
+mod search_window_tests {
+    use super::{apply_result_offset, checked_search_window, merge_two_ranked};
+    use crate::query::SearchResult;
+
+    fn result(segment_id: u128, doc_id: u32, score: f32) -> SearchResult {
+        SearchResult {
+            doc_id,
+            score,
+            segment_id,
+            positions: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn search_window_is_checked() {
+        assert_eq!(checked_search_window(7, 5).unwrap(), 12);
+        assert!(checked_search_window(1, usize::MAX).is_err());
+    }
+
+    #[test]
+    fn bounded_merge_preserves_canonical_order_and_ties() {
+        let left = vec![result(2, 9, 10.0), result(2, 3, 7.0)];
+        let right = vec![result(1, 8, 10.0), result(1, 2, 7.0)];
+
+        let merged = merge_two_ranked(left, right, 3);
+        let keys: Vec<_> = merged
+            .iter()
+            .map(|result| (result.score, result.segment_id, result.doc_id))
+            .collect();
+        assert_eq!(keys, vec![(10.0, 1, 8), (10.0, 2, 9), (7.0, 1, 2)]);
+    }
+
+    #[test]
+    fn result_offset_returns_only_the_requested_window() {
+        let results = (0..8)
+            .map(|doc_id| result(1, doc_id, 8.0 - doc_id as f32))
+            .collect();
+
+        let page = apply_result_offset(results, 5, 2);
+        assert_eq!(
+            page.iter().map(|result| result.doc_id).collect::<Vec<_>>(),
+            vec![2, 3, 4]
+        );
     }
 }

--- a/hermes-core/src/index/tests/basic.rs
+++ b/hermes-core/src/index/tests/basic.rs
@@ -1,6 +1,7 @@
 use crate::directories::RamDirectory;
-use crate::dsl::{Document, SchemaBuilder};
+use crate::dsl::{Document, PositionMode, SchemaBuilder};
 use crate::index::{Index, IndexConfig, IndexWriter};
+use crate::query::{BooleanQuery, BoostQuery, PhraseQuery, Query, ScorerOptions, TermQuery};
 
 #[tokio::test]
 async fn test_index_create_and_search() {
@@ -198,6 +199,95 @@ async fn test_match_query() {
         !doc.field_values().is_empty(),
         "Doc should have field values"
     );
+}
+
+#[tokio::test]
+async fn boolean_and_boost_search_preserve_requested_positions_and_scores() {
+    let mut schema_builder = SchemaBuilder::default();
+    let title = schema_builder.add_text_field("title", true, true);
+    schema_builder.set_positions(title, PositionMode::Full);
+    let schema = schema_builder.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    let mut rust_doc = Document::new();
+    rust_doc.add_text(title, "rust");
+    writer.add_document(rust_doc).unwrap();
+    let mut search_doc = Document::new();
+    search_doc.add_text(title, "search");
+    writer.add_document(search_doc).unwrap();
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let boosted = BoostQuery::new(TermQuery::text(title, "rust"), 10.0);
+    let query = BooleanQuery::new()
+        .should(boosted.clone())
+        .should(TermQuery::text(title, "search"));
+
+    let (without_positions, _) = searcher.search_with_count(&query, 2).await.unwrap();
+    assert!(
+        without_positions
+            .iter()
+            .all(|result| result.positions.is_empty())
+    );
+    assert_eq!(without_positions[0].doc_id, 0);
+    assert!(without_positions[0].score > without_positions[1].score);
+
+    let (with_positions, _) = searcher.search_with_positions(&query, 2).await.unwrap();
+    assert!(
+        with_positions
+            .iter()
+            .all(|result| !result.positions.is_empty())
+    );
+    assert_eq!(with_positions[0].doc_id, 0);
+    let position_score: f32 = with_positions[0]
+        .positions
+        .iter()
+        .flat_map(|(_, positions)| positions)
+        .map(|position| position.score)
+        .sum();
+    assert!((position_score - with_positions[0].score).abs() < 1e-5);
+}
+
+#[tokio::test]
+async fn single_term_phrase_propagates_position_collection_options() {
+    let mut schema_builder = SchemaBuilder::default();
+    let title = schema_builder.add_text_field("title", true, true);
+    schema_builder.set_positions(title, PositionMode::Full);
+    let schema = schema_builder.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    let mut doc = Document::new();
+    doc.add_text(title, "rust");
+    writer.add_document(doc).unwrap();
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let segment = &searcher.segment_readers()[0];
+    let query = PhraseQuery::new(title, vec![b"rust".to_vec()]);
+
+    let scorer = query
+        .scorer_with_options(segment, 1, ScorerOptions::default())
+        .await
+        .unwrap();
+    assert!(scorer.matched_positions().is_none());
+
+    let scorer = query
+        .scorer_with_options(segment, 1, ScorerOptions::with_positions())
+        .await
+        .unwrap();
+    assert!(scorer.matched_positions().is_some());
 }
 
 #[tokio::test]

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -7,3 +7,19 @@ mod primary_key;
 mod range;
 mod search;
 mod vector;
+
+#[cfg(feature = "sync")]
+#[test]
+fn search_cpu_pool_is_bounded_and_reused_by_width() {
+    let first = super::shared_search_pool(1).unwrap();
+    let second = super::shared_search_pool(1).unwrap();
+
+    assert!(std::sync::Arc::ptr_eq(&first, &second));
+    assert_eq!(first.install(rayon::current_num_threads), 1);
+}
+
+#[cfg(feature = "native")]
+#[test]
+fn zero_search_threads_is_rejected() {
+    assert!(super::searcher::SearcherResources::new(1, 1, 0).is_err());
+}

--- a/hermes-core/src/index/tests/vector.rs
+++ b/hermes-core/src/index/tests/vector.rs
@@ -124,6 +124,117 @@ async fn test_vector_index_threshold_switch() {
     assert!(writer.segment_manager.trained().is_some());
 }
 
+#[tokio::test]
+async fn rebuild_rejects_segments_bound_to_the_current_artifact_generation() {
+    use crate::dsl::DenseVectorConfig;
+
+    let mut schema_builder = SchemaBuilder::default();
+    let embedding = schema_builder.add_dense_vector_field_with_config(
+        "embedding",
+        true,
+        true,
+        DenseVectorConfig::with_ivf(4, Some(1), 1),
+    );
+    let schema = schema_builder.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    // Segments committed before training remain flat and provide the sample.
+    for i in 0..4 {
+        let mut doc = Document::new();
+        doc.add_dense_vector(embedding, vec![i as f32; 4]);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    writer.build_vector_index().await.unwrap();
+    let old_version = writer.segment_manager.trained().unwrap().centroids[&embedding.0].version;
+
+    // Once trained, a newly committed segment embeds that exact centroid
+    // generation in its IVF data.
+    let mut doc = Document::new();
+    doc.add_dense_vector(embedding, vec![10.0; 4]);
+    writer.add_document(doc).unwrap();
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert!(
+        index
+            .segment_readers()
+            .await
+            .unwrap()
+            .iter()
+            .any(|segment| matches!(
+                segment.vector_indexes().get(&embedding.0),
+                Some(crate::segment::VectorIndex::IVF(_))
+            ))
+    );
+    drop(index);
+
+    let error = writer
+        .rebuild_vector_index()
+        .await
+        .expect_err("retraining must reject an existing IVF generation")
+        .to_string();
+    assert!(
+        error.contains("already contains an IVF/ScaNN index"),
+        "{error}"
+    );
+    assert!(
+        writer
+            .segment_manager
+            .read_metadata(|metadata| metadata.is_field_built(embedding.0))
+            .await
+    );
+    assert_eq!(
+        writer.segment_manager.trained().unwrap().centroids[&embedding.0].version,
+        old_version,
+        "a rejected rebuild must leave the published generation untouched"
+    );
+
+    // Simulate metadata left Flat by a crash-interrupted rebuild from an older
+    // Hermes release. The ordinary build entry point must inspect the segment
+    // generation too; trusting metadata alone would silently replace artifacts
+    // still required by the committed IVF segment.
+    writer
+        .segment_manager
+        .update_metadata(|metadata| {
+            let field = metadata.vector_fields.get_mut(&embedding.0).unwrap();
+            field.state = crate::index::VectorIndexState::Flat;
+            field.centroids_file = None;
+            field.codebook_file = None;
+            metadata.refresh_total_vectors();
+        })
+        .await
+        .unwrap();
+    let error = writer
+        .build_vector_index()
+        .await
+        .expect_err("ordinary training must reject a stale Flat metadata state")
+        .to_string();
+    assert!(
+        error.contains("already contains an IVF/ScaNN index"),
+        "{error}"
+    );
+    assert!(
+        !writer
+            .segment_manager
+            .read_metadata(|metadata| metadata.is_field_built(embedding.0))
+            .await,
+        "a rejected recovery build must not mutate metadata"
+    );
+    assert_eq!(
+        writer.segment_manager.trained().unwrap().centroids[&embedding.0].version,
+        old_version,
+        "a rejected recovery build must not replace the published generation"
+    );
+}
+
 /// Sparse vector needle-in-haystack: one document with unique dimensions.
 #[tokio::test]
 async fn test_needle_sparse_vector() {
@@ -893,6 +1004,24 @@ async fn search_fused_hybrid_union_impl() {
         )
         .await
         .unwrap();
+    let (counted_fused, total_seen) = searcher
+        .search_fused_with_count(
+            &[(&text_query, 1.0), (&dense_query, 1.0)],
+            10,
+            10,
+            FusionMethod::default(),
+            crate::query::MultiValueCombiner::Max,
+        )
+        .await
+        .unwrap();
+    assert!(total_seen > 0);
+    assert_eq!(
+        fused.iter().map(|result| result.doc_id).collect::<Vec<_>>(),
+        counted_fused
+            .iter()
+            .map(|result| result.doc_id)
+            .collect::<Vec<_>>()
+    );
 
     // Union semantics: text-only, dense-only, and both-match docs all present
     assert!(fused.len() >= 3, "expected at least 3 fused results");

--- a/hermes-core/src/index/vector_builder.rs
+++ b/hermes-core/src/index/vector_builder.rs
@@ -4,6 +4,7 @@
 //! Call `build_vector_index()` explicitly when ready.
 //! ANN indexes are built naturally during subsequent merges.
 
+use std::io::Write;
 use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
@@ -14,6 +15,102 @@ use crate::error::{Error, Result};
 use crate::segment::{SegmentId, SegmentReader};
 
 use super::IndexWriter;
+
+/// Maximum supported IVF centroid count. Query-side `nprobe` and serialized
+/// cluster identifiers use the same practical bound.
+const MAX_IVF_CLUSTERS: usize = 4096;
+
+struct TrainedFieldUpdate {
+    field_id: u32,
+    index_type: VectorIndexType,
+    vector_count: usize,
+    num_clusters: usize,
+    centroids_file: String,
+    codebook_file: Option<String>,
+}
+
+/// Write adapter that rejects an artifact before its serialized form exceeds
+/// the same bound enforced by the loader. Encoding directly through this
+/// adapter avoids materializing a second, potentially hundreds-of-megabytes
+/// copy of the trained structure.
+struct SizeLimitedWriter<'a, W: Write + ?Sized> {
+    inner: &'a mut W,
+    written: usize,
+    limit: usize,
+}
+
+impl<'a, W: Write + ?Sized> SizeLimitedWriter<'a, W> {
+    fn new(inner: &'a mut W, limit: usize) -> Self {
+        Self {
+            inner,
+            written: 0,
+            limit,
+        }
+    }
+}
+
+impl<W: Write + ?Sized> Write for SizeLimitedWriter<'_, W> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        let next_size = self
+            .written
+            .checked_add(buffer.len())
+            .ok_or_else(|| std::io::Error::other("trained artifact size overflow"))?;
+        if next_size > self.limit {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "trained artifact exceeds the {}-byte safety limit",
+                    self.limit
+                ),
+            ));
+        }
+        let written = self.inner.write(buffer)?;
+        self.written += written;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn validate_explicit_ivf_num_clusters(config: &DenseVectorConfig) -> Result<()> {
+    match config.num_clusters {
+        Some(0) => Err(Error::Schema(
+            "dense vector num_clusters must be at least 1".to_string(),
+        )),
+        Some(value) if value > MAX_IVF_CLUSTERS => Err(Error::Schema(format!(
+            "dense vector num_clusters must not exceed {MAX_IVF_CLUSTERS}, got {value}"
+        ))),
+        _ => Ok(()),
+    }
+}
+
+/// Validate the configured centroid count and cap it to the training sample.
+///
+/// Corpus size drives the automatic heuristic, but training cannot produce
+/// more distinct centroids than the number of sampled vectors. Keeping this
+/// decision here avoids relying on a panic-prone, implicit clamp inside the
+/// trainer and gives callers a schema error for invalid explicit values.
+fn effective_ivf_num_clusters(
+    config: &DenseVectorConfig,
+    corpus_count: usize,
+    sample_count: usize,
+) -> Result<usize> {
+    if sample_count == 0 {
+        return Err(Error::Schema(
+            "cannot train an IVF vector index without sample vectors".to_string(),
+        ));
+    }
+
+    validate_explicit_ivf_num_clusters(config)?;
+    let requested = match config.num_clusters {
+        Some(value) => value,
+        None => config.optimal_num_clusters(corpus_count),
+    };
+
+    Ok(requested.min(sample_count))
+}
 
 impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Train vector index from accumulated Flat vectors (manual, not auto-triggered).
@@ -32,11 +129,30 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             return Ok(());
         }
 
+        let artifact_update = self.segment_manager.begin_vector_artifact_update().await?;
+        self.build_vector_index_locked(&dense_fields, &artifact_update)
+            .await
+    }
+
+    /// Build while the SegmentManager's artifact-update gate is held.
+    async fn build_vector_index_locked(
+        &self,
+        dense_fields: &[(Field, DenseVectorConfig)],
+        artifact_update: &crate::merge::VectorArtifactUpdateGuard,
+    ) -> Result<()> {
         // Check which fields need building (skip already built)
-        let fields_to_build = self.get_fields_to_build(&dense_fields).await;
+        let fields_to_build = self.get_fields_to_build(dense_fields).await;
         if fields_to_build.is_empty() {
             log::info!("All vector fields already built, skipping training");
             return Ok(());
+        }
+
+        // Reject malformed explicit settings before opening segments or
+        // allocating the bounded training samples.
+        for (_, config) in &fields_to_build {
+            if config.uses_ivf() {
+                validate_explicit_ivf_num_clusters(config)?;
+            }
         }
 
         // Acquire snapshot — segments won't be deleted while we read them
@@ -47,17 +163,44 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         }
 
         // Collect vectors for training
-        let all_vectors = self
+        let (all_vectors, total_vectors) = self
             .collect_vectors_for_training(segment_ids, &fields_to_build)
             .await?;
 
-        // Train centroids/codebooks for each field
+        // Train every requested field before changing metadata. If any field
+        // fails, all durable field states remain Flat and the successfully
+        // written files are merely unreferenced retry targets.
+        let mut updates = Vec::with_capacity(fields_to_build.len());
         for (field, config) in &fields_to_build {
-            self.train_field_index(*field, config, &all_vectors).await?;
+            if let Some(update) = self
+                .train_field_index(*field, config, &all_vectors, &total_vectors)
+                .await?
+            {
+                updates.push(update);
+            }
         }
 
-        // Publish to ArcSwap — merges and new segment builds will use these
-        self.segment_manager.load_and_publish_trained().await;
+        if updates.is_empty() {
+            log::info!("No vectors available for trained vector-index fields");
+            return Ok(());
+        }
+
+        // Durable metadata and the complete validated ArcSwap set advance in a
+        // single cancellation-safe SegmentManager transaction.
+        self.segment_manager
+            .update_vector_metadata_and_publish(artifact_update, |meta| {
+                for update in &updates {
+                    meta.init_field(update.field_id, update.index_type);
+                    meta.mark_field_built(
+                        update.field_id,
+                        update.vector_count,
+                        update.num_clusters,
+                        update.centroids_file.clone(),
+                        update.codebook_file.clone(),
+                    );
+                }
+            })
+            .await?;
 
         log::info!("Vector index training complete, ANN will be built during merges");
 
@@ -66,51 +209,88 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
     /// Rebuild vector index by retraining centroids/codebooks.
     ///
-    /// Resets Built state to Flat, clears trained structures, then trains fresh.
+    /// Rebuilding a global artifact generation is only safe while every
+    /// committed segment is still flat. IVF/ScaNN segments embed the artifact
+    /// versions they were built with and cannot be interpreted by freshly
+    /// trained centroids/codebooks.
     pub async fn rebuild_vector_index(&self) -> Result<()> {
         let dense_fields = self.get_dense_vector_fields();
         if dense_fields.is_empty() {
             return Ok(());
         }
-        let dense_fields: Vec<Field> = dense_fields.into_iter().map(|(f, _)| f).collect();
 
-        // Reset fields to Flat and collect files to delete
-        let dense_field_ids: Vec<u32> = dense_fields.iter().map(|f| f.0).collect();
-        let mut files_to_delete = Vec::new();
+        // Raise the producer gate and drain operations that may already have
+        // captured the previous trained generation. New producers continue in
+        // flat mode until this guard drops.
+        let artifact_update = self.segment_manager.begin_vector_artifact_update().await?;
+        let snapshot = self.segment_manager.acquire_snapshot().await;
+        let field_ids: Vec<u32> = dense_fields.iter().map(|(field, _)| field.0).collect();
+        self.reject_rebuild_with_ann_segments(snapshot.segment_ids(), &field_ids)
+            .await?;
+
+        // Reset metadata and the ArcSwap set together. Old fixed-name artifact
+        // files are left in place until the atomic writer replaces them; this
+        // avoids a cancellation window and does not accumulate generations.
         self.segment_manager
-            .update_metadata(|meta| {
-                for field_id in &dense_field_ids {
+            .update_vector_metadata_and_publish(&artifact_update, |meta| {
+                for field_id in &field_ids {
                     if let Some(field_meta) = meta.vector_fields.get_mut(field_id) {
                         field_meta.state = super::VectorIndexState::Flat;
-                        if let Some(ref f) = field_meta.centroids_file {
-                            files_to_delete.push(f.clone());
-                        }
-                        if let Some(ref f) = field_meta.codebook_file {
-                            files_to_delete.push(f.clone());
-                        }
                         field_meta.centroids_file = None;
                         field_meta.codebook_file = None;
                     }
                 }
+                meta.refresh_total_vectors();
             })
             .await?;
 
-        // Delete old files
-        for file in files_to_delete {
-            let _ = self.directory.delete(std::path::Path::new(&file)).await;
-        }
-
-        // Clear ArcSwap so workers produce flat segments during retraining
-        self.segment_manager.clear_trained();
-
         log::info!("Reset vector index state to Flat, triggering rebuild...");
 
-        self.build_vector_index().await
+        self.build_vector_index_locked(&dense_fields, &artifact_update)
+            .await
     }
 
     // ========================================================================
     // Helper methods
     // ========================================================================
+
+    async fn reject_rebuild_with_ann_segments(
+        &self,
+        segment_ids: &[String],
+        field_ids: &[u32],
+    ) -> Result<()> {
+        for id_str in segment_ids {
+            let segment_id = SegmentId::from_hex(id_str)
+                .ok_or_else(|| Error::Corruption(format!("Invalid segment ID: {id_str}")))?;
+            let reader = SegmentReader::open_with_cache_blocks(
+                self.directory.as_ref(),
+                segment_id,
+                Arc::clone(&self.schema),
+                self.config.term_cache_blocks,
+                self.config.store_cache_blocks,
+            )
+            .await?;
+            Self::reject_ann_in_reader(&reader, id_str, field_ids)?;
+        }
+        Ok(())
+    }
+
+    fn reject_ann_in_reader(reader: &SegmentReader, id_str: &str, field_ids: &[u32]) -> Result<()> {
+        for &field_id in field_ids {
+            if matches!(
+                reader.vector_indexes().get(&field_id),
+                Some(crate::segment::VectorIndex::IVF(_))
+                    | Some(crate::segment::VectorIndex::ScaNN(_))
+            ) {
+                return Err(Error::Schema(format!(
+                    "cannot retrain vector artifacts for field {field_id}: segment {id_str} \
+                     already contains an IVF/ScaNN index built with the current generation; \
+                     rebuild requires all committed segments for the field to be flat"
+                )));
+            }
+        }
+        Ok(())
+    }
 
     /// Get all dense vector fields that need ANN indexes
     fn get_dense_vector_fields(&self) -> Vec<(Field, DenseVectorConfig)> {
@@ -121,7 +301,11 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     entry
                         .dense_vector_config
                         .as_ref()
-                        .filter(|c| !c.is_flat())
+                        // Only IVF-backed indexes require a global training
+                        // artifact. Standalone RaBitQ trains per segment; including
+                        // it here repeatedly sampled up to 100k vectors and then
+                        // returned without producing metadata.
+                        .filter(|c| c.uses_ivf())
                         .map(|c| (field, c.clone()))
                 } else {
                     None
@@ -161,28 +345,40 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         &self,
         segment_ids: &[String],
         fields_to_build: &[(Field, DenseVectorConfig)],
-    ) -> Result<FxHashMap<u32, Vec<Vec<f32>>>> {
+    ) -> Result<(FxHashMap<u32, Vec<Vec<f32>>>, FxHashMap<u32, usize>)> {
         /// Maximum vectors per field for training. K-means converges well with ~100K samples.
         const MAX_TRAINING_VECTORS: usize = 100_000;
 
         let mut all_vectors: FxHashMap<u32, Vec<Vec<f32>>> = FxHashMap::default();
+        let mut total_vectors: FxHashMap<u32, usize> = FxHashMap::default();
         let mut total_skipped = 0usize;
+        let field_ids: Vec<u32> = fields_to_build.iter().map(|(field, _)| field.0).collect();
 
         for id_str in segment_ids {
             let segment_id = SegmentId::from_hex(id_str)
                 .ok_or_else(|| Error::Corruption(format!("Invalid segment ID: {}", id_str)))?;
-            let reader = SegmentReader::open(
+            let reader = SegmentReader::open_with_cache_blocks(
                 self.directory.as_ref(),
                 segment_id,
                 Arc::clone(&self.schema),
                 self.config.term_cache_blocks,
+                self.config.store_cache_blocks,
             )
             .await?;
+
+            // `build_vector_index` is also effectively a retrain whenever
+            // metadata says Flat. A crash-interrupted rebuild from an older
+            // Hermes version can leave that state beside committed ANN
+            // segments, so validate generation safety during the same segment
+            // scan that collects the samples.
+            Self::reject_ann_in_reader(&reader, id_str, &field_ids)?;
 
             for (field_id, lazy_flat) in reader.flat_vectors() {
                 if !fields_to_build.iter().any(|(f, _)| f.0 == *field_id) {
                     continue;
                 }
+                let total = total_vectors.entry(*field_id).or_default();
+                *total = total.saturating_add(lazy_flat.num_vectors);
                 let entry = all_vectors.entry(*field_id).or_default();
                 let remaining = MAX_TRAINING_VECTORS.saturating_sub(entry.len());
 
@@ -226,7 +422,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                                 quant,
                                 floats,
                                 &mut f32_buf,
-                            );
+                            )
+                            .map_err(crate::Error::Io)?;
                             for i in 0..chunk.len() {
                                 entry.push(f32_buf[i * dim..(i + 1) * dim].to_vec());
                             }
@@ -254,7 +451,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             );
         }
 
-        Ok(all_vectors)
+        Ok((all_vectors, total_vectors))
     }
 
     /// Train index for a single field
@@ -263,21 +460,36 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         field: Field,
         config: &DenseVectorConfig,
         all_vectors: &FxHashMap<u32, Vec<Vec<f32>>>,
-    ) -> Result<()> {
+        total_vectors: &FxHashMap<u32, usize>,
+    ) -> Result<Option<TrainedFieldUpdate>> {
         let field_id = field.0;
         let vectors = match all_vectors.get(&field_id) {
             Some(v) if !v.is_empty() => v,
-            _ => return Ok(()),
+            _ => return Ok(None),
         };
 
         let dim = config.dim;
-        let num_vectors = vectors.len();
-        let num_clusters = config.optimal_num_clusters(num_vectors);
+        let sample_count = vectors.len();
+        let corpus_count = total_vectors
+            .get(&field_id)
+            .copied()
+            .unwrap_or(sample_count);
+        // RaBitQ is trained independently per segment and does not need an
+        // index-level centroid artifact.
+        if !matches!(
+            config.index_type,
+            VectorIndexType::IvfRaBitQ | VectorIndexType::ScaNN
+        ) {
+            return Ok(None);
+        }
+
+        let num_clusters = effective_ivf_num_clusters(config, corpus_count, sample_count)?;
 
         log::info!(
-            "Training vector index for field {} with {} vectors, {} clusters (dim={})",
+            "Training vector index for field {} with {} sampled / {} total vectors, {} clusters (dim={})",
             field_id,
-            num_vectors,
+            sample_count,
+            corpus_count,
             num_clusters,
             dim,
         );
@@ -285,7 +497,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let centroids_filename = format!("field_{}_centroids.bin", field_id);
         let mut codebook_filename: Option<String> = None;
 
-        match config.index_type {
+        let actual_num_clusters = match config.index_type {
             VectorIndexType::IvfRaBitQ => {
                 self.train_ivf_rabitq(
                     field_id,
@@ -295,7 +507,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     vectors,
                     &centroids_filename,
                 )
-                .await?;
+                .await?
             }
             VectorIndexType::ScaNN => {
                 codebook_filename = Some(format!("field_{}_codebook.bin", field_id));
@@ -308,30 +520,19 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     &centroids_filename,
                     codebook_filename.as_ref().unwrap(),
                 )
-                .await?;
+                .await?
             }
-            _ => {
-                // RaBitQ or Flat - no pre-training needed
-                return Ok(());
-            }
-        }
+            _ => unreachable!("non-IVF vector index returned above"),
+        };
 
-        // Update metadata to mark this field as built
-        self.segment_manager
-            .update_metadata(|meta| {
-                meta.init_field(field_id, config.index_type);
-                meta.total_vectors = num_vectors;
-                meta.mark_field_built(
-                    field_id,
-                    num_vectors,
-                    num_clusters,
-                    centroids_filename.clone(),
-                    codebook_filename.clone(),
-                );
-            })
-            .await?;
-
-        Ok(())
+        Ok(Some(TrainedFieldUpdate {
+            field_id,
+            index_type: config.index_type,
+            vector_count: corpus_count,
+            num_clusters: actual_num_clusters,
+            centroids_file: centroids_filename,
+            codebook_file: codebook_filename,
+        }))
     }
 
     /// Serialize a trained structure to bincode and save to an index-level file.
@@ -340,11 +541,37 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         artifact: &impl serde::Serialize,
         filename: &str,
     ) -> Result<()> {
-        let bytes = bincode::serde::encode_to_vec(artifact, bincode::config::standard())
-            .map_err(|e| Error::Serialization(e.to_string()))?;
-        self.directory
-            .write(std::path::Path::new(filename), &bytes)
-            .await?;
+        let temp_filename = format!("{filename}.tmp");
+        let temp_path = std::path::Path::new(&temp_filename);
+        let final_path = std::path::Path::new(filename);
+        let mut writer = self.directory.streaming_writer(temp_path).await?;
+        let encode_result = {
+            let mut limited = SizeLimitedWriter::new(
+                writer.as_mut(),
+                super::metadata::MAX_TRAINED_ARTIFACT_BYTES,
+            );
+            bincode::serde::encode_into_std_write(
+                artifact,
+                &mut limited,
+                bincode::config::standard(),
+            )
+        };
+        if let Err(error) = encode_result {
+            drop(writer);
+            let _ = self.directory.delete(temp_path).await;
+            return Err(Error::Serialization(format!(
+                "failed to serialize trained artifact '{filename}': {error}"
+            )));
+        }
+        if let Err(error) = writer.finish() {
+            let _ = self.directory.delete(temp_path).await;
+            return Err(Error::Io(error));
+        }
+        if let Err(error) = self.directory.rename(temp_path, final_path).await {
+            let _ = self.directory.delete(temp_path).await;
+            return Err(Error::Io(error));
+        }
+        self.directory.sync().await?;
         Ok(())
     }
 
@@ -357,7 +584,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         soar: Option<crate::structures::SoarConfig>,
         vectors: &[Vec<f32>],
         centroids_filename: &str,
-    ) -> Result<()> {
+    ) -> Result<usize> {
         let mut coarse_config = crate::structures::CoarseConfig::new(dim, num_clusters);
         if let Some(soar) = soar {
             coarse_config = coarse_config.with_soar(soar);
@@ -372,7 +599,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             centroids.num_clusters,
             centroids.soar_config.is_some()
         );
-        Ok(())
+        Ok(centroids.num_clusters as usize)
     }
 
     /// Train ScaNN (IVF-PQ) centroids and codebook
@@ -386,7 +613,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         vectors: &[Vec<f32>],
         centroids_filename: &str,
         codebook_filename: &str,
-    ) -> Result<()> {
+    ) -> Result<usize> {
         let mut coarse_config = crate::structures::CoarseConfig::new(dim, num_clusters);
         if let Some(soar) = soar {
             coarse_config = coarse_config.with_soar(soar);
@@ -405,6 +632,70 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             field_id,
             centroids.num_clusters
         );
-        Ok(())
+        Ok(centroids.num_clusters as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ivf_config(num_clusters: Option<usize>) -> DenseVectorConfig {
+        DenseVectorConfig::with_ivf(8, num_clusters, 4)
+    }
+
+    #[test]
+    fn effective_clusters_follow_corpus_heuristic_but_fit_sample() {
+        let config = ivf_config(None);
+
+        assert_eq!(
+            effective_ivf_num_clusters(&config, 1_000_000, 73).unwrap(),
+            73
+        );
+        assert_eq!(
+            effective_ivf_num_clusters(&config, 10_000, 1_000).unwrap(),
+            100
+        );
+    }
+
+    #[test]
+    fn effective_clusters_clamp_explicit_value_to_sample() {
+        let config = ivf_config(Some(256));
+        assert_eq!(
+            effective_ivf_num_clusters(&config, 1_000_000, 17).unwrap(),
+            17
+        );
+    }
+
+    #[test]
+    fn effective_clusters_reject_invalid_explicit_bounds() {
+        let zero = effective_ivf_num_clusters(&ivf_config(Some(0)), 10_000, 100)
+            .unwrap_err()
+            .to_string();
+        assert!(zero.contains("at least 1"));
+
+        let too_many =
+            effective_ivf_num_clusters(&ivf_config(Some(MAX_IVF_CLUSTERS + 1)), 10_000, 100)
+                .unwrap_err()
+                .to_string();
+        assert!(too_many.contains("must not exceed 4096"));
+    }
+
+    #[test]
+    fn effective_clusters_reject_empty_training_sample() {
+        let error = effective_ivf_num_clusters(&ivf_config(None), 10_000, 0)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("without sample vectors"));
+    }
+
+    #[test]
+    fn artifact_writer_enforces_limit_without_writing_past_it() {
+        let mut output = Vec::new();
+        let mut writer = SizeLimitedWriter::new(&mut output, 3);
+        writer.write_all(&[1, 2]).unwrap();
+        let error = writer.write_all(&[3, 4]).unwrap_err().to_string();
+        assert!(error.contains("3-byte safety limit"), "{error}");
+        assert_eq!(output, vec![1, 2]);
     }
 }

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -294,7 +294,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 swept
             );
         }
-        segment_manager.load_and_publish_trained().await;
+        segment_manager.try_load_and_publish_trained().await?;
 
         Ok(Self::new_with_parts(
             directory,
@@ -806,7 +806,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 return;
             }
         };
-        let trained = state.segment_manager.trained();
+        let trained = state.segment_manager.trained_for_segment_build();
         let doc_count = builder.num_docs();
         let build_start = std::time::Instant::now();
 

--- a/hermes-core/src/lib.rs
+++ b/hermes-core/src/lib.rs
@@ -99,6 +99,12 @@ pub fn default_indexing_threads() -> usize {
     (num_cpus::get() / 4).max(1)
 }
 
+/// Default width of the process-wide search CPU pool (cpu / 4, minimum 1).
+#[cfg(feature = "native")]
+pub fn default_search_threads() -> usize {
+    (num_cpus::get() / 4).max(1)
+}
+
 /// Default number of compression threads (cpu / 4, minimum 1).
 /// Centralized so all configs share one definition.
 #[cfg(feature = "native")]

--- a/hermes-core/src/merge/mod.rs
+++ b/hermes-core/src/merge/mod.rs
@@ -10,7 +10,7 @@ mod segment_manager;
 #[cfg(feature = "native")]
 pub use segment_manager::SegmentManager;
 #[cfg(feature = "native")]
-pub(crate) use segment_manager::SegmentOperationGuard;
+pub(crate) use segment_manager::{SegmentOperationGuard, VectorArtifactUpdateGuard};
 
 /// Information about a segment for merge decisions
 #[derive(Debug, Clone)]

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -33,6 +33,7 @@
 //!
 //! Independent bookkeeping (never held with `state`):
 //!   trained                — arc_swap::ArcSwapOption, lock-free
+//!   vector_artifact_update — atomic producer gate, held across manual training
 //!   merge_handles          — parking_lot::Mutex, synchronous short hold
 //!   lifecycle_handles      — parking_lot::Mutex, synchronous short hold
 //!   merge/reorder permits  — tokio semaphores shared by configuration
@@ -71,6 +72,8 @@ use super::{MergePolicy, SegmentInfo};
 /// new output only and live from before the first write through commit/abort.
 struct ActiveOperationState {
     segment_ids: HashSet<String>,
+    operation_tokens: HashSet<u64>,
+    next_operation_token: u64,
     accepting: bool,
 }
 
@@ -85,6 +88,8 @@ impl ActiveSegmentOperations {
         Self {
             inner: parking_lot::Mutex::new(ActiveOperationState {
                 segment_ids: HashSet::new(),
+                operation_tokens: HashSet::new(),
+                next_operation_token: 0,
                 accepting: true,
             }),
             idle: Notify::new(),
@@ -116,18 +121,31 @@ impl ActiveSegmentOperations {
             segment_ids.len(),
             inner.segment_ids.len() + segment_ids.len()
         );
+        let operation_token = inner.next_operation_token;
+        let next_operation_token = operation_token.checked_add(1)?;
         for id in &segment_ids {
             inner.segment_ids.insert(id.clone());
         }
+        inner.next_operation_token = next_operation_token;
+        inner.operation_tokens.insert(operation_token);
         Some(SegmentOperationGuard {
             active_operations: Arc::clone(self),
             segment_ids,
+            operation_token,
         })
     }
 
     /// Snapshot of all IDs owned by active operations.
     fn snapshot(&self) -> HashSet<String> {
         self.inner.lock().segment_ids.clone()
+    }
+
+    /// Exact operation identities active at one instant. Unlike segment IDs,
+    /// tokens cannot be reused by a later retry, so an artifact-update barrier
+    /// can drain only pre-gate producers without being starved by new flat
+    /// producers.
+    fn operation_tokens_snapshot(&self) -> HashSet<u64> {
+        self.inner.lock().operation_tokens.clone()
     }
 
     /// Atomically prevent new lifecycle work from starting. Existing guards
@@ -158,6 +176,16 @@ impl ActiveSegmentOperations {
         }
     }
 
+    async fn wait_until_operations_finish(&self, operations: &HashSet<u64>) {
+        while !operations.is_empty() {
+            let notified = self.idle.notified();
+            if self.inner.lock().operation_tokens.is_disjoint(operations) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
     /// Resolve when shutdown starts, without missing a notification between
     /// checking the state and registering the waiter.
     async fn wait_for_shutdown(&self) {
@@ -177,6 +205,7 @@ impl ActiveSegmentOperations {
 pub(crate) struct SegmentOperationGuard {
     active_operations: Arc<ActiveSegmentOperations>,
     segment_ids: Vec<String>,
+    operation_token: u64,
 }
 
 impl Drop for SegmentOperationGuard {
@@ -185,10 +214,36 @@ impl Drop for SegmentOperationGuard {
         for id in &self.segment_ids {
             inner.segment_ids.remove(id);
         }
+        inner.operation_tokens.remove(&self.operation_token);
+        // Token barriers need notification on every completion, not only the
+        // transition to complete global idleness.
+        self.active_operations.idle.notify_waiters();
         if inner.segment_ids.is_empty() {
-            self.active_operations.idle.notify_waiters();
+            debug_assert!(inner.operation_tokens.is_empty());
         }
     }
+}
+
+/// Exclusive gate for an index-level trained-vector artifact update.
+///
+/// Segment producers consult this gate before capturing the current trained
+/// structures. Once the gate is raised, new producers deliberately emit flat
+/// vector data; waiting for already-active producers to drain then guarantees
+/// that no segment using the previous generation can appear after a rebuild
+/// safety check.
+struct VectorArtifactUpdateLease {
+    updating: Arc<AtomicBool>,
+}
+
+impl Drop for VectorArtifactUpdateLease {
+    fn drop(&mut self) {
+        self.updating.store(false, Ordering::Release);
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct VectorArtifactUpdateGuard {
+    _lease: Arc<VectorArtifactUpdateLease>,
 }
 
 /// Merge-time/manual BP pools are shared by every index in this process.
@@ -367,7 +422,14 @@ pub struct SegmentManager<D: DirectoryWriter + 'static> {
     lifecycle_handles: Arc<parking_lot::Mutex<Vec<JoinHandle<()>>>>,
 
     /// Trained vector structures — lock-free reads via ArcSwap.
-    trained: ArcSwapOption<TrainedVectorStructures>,
+    /// Wrapped in `Arc` so cancellation-safe metadata transactions can publish
+    /// the matching in-memory generation after their durable commit point.
+    trained: Arc<ArcSwapOption<TrainedVectorStructures>>,
+
+    /// Raised while index-level trained artifacts and their metadata are being
+    /// replaced. Search readers keep using the last valid generation, while
+    /// segment producers fall back to flat output until publication completes.
+    vector_artifact_update: Arc<AtomicBool>,
 
     /// Reference counting for safe segment deletion (sync Mutex for Drop).
     tracker: Arc<SegmentTracker>,
@@ -496,7 +558,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             merge_handles: parking_lot::Mutex::new(Vec::new()),
             global_merge_wakeup_pending: AtomicBool::new(false),
             lifecycle_handles,
-            trained: ArcSwapOption::new(None),
+            trained: Arc::new(ArcSwapOption::new(None)),
+            vector_artifact_update: Arc::new(AtomicBool::new(false)),
             tracker,
             delete_fn,
             directory,
@@ -863,25 +926,121 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         self.trained.load_full()
     }
 
+    /// Capture trained structures for a segment producer.
+    ///
+    /// The second gate check closes the race where an update begins after the
+    /// first check but before the ArcSwap load. Producers have lifecycle guards
+    /// before calling this method, so an updater that raised the gate waits for
+    /// any producer that successfully captured the previous generation.
+    pub(crate) fn trained_for_segment_build(&self) -> Option<Arc<TrainedVectorStructures>> {
+        if self.vector_artifact_update.load(Ordering::Acquire) {
+            return None;
+        }
+        let trained = self.trained.load_full();
+        if self.vector_artifact_update.load(Ordering::Acquire) {
+            None
+        } else {
+            trained
+        }
+    }
+
+    /// Start an exclusive trained-artifact update and drain producers that may
+    /// already hold the previous generation.
+    ///
+    /// New segment operations may continue while this waits, but they observe
+    /// the gate through `trained_for_segment_build` and therefore emit flat
+    /// vector data. The guard is cancellation-safe: dropping the requesting
+    /// future reopens ANN production without leaving the manager wedged.
+    pub(crate) async fn begin_vector_artifact_update(&self) -> Result<VectorArtifactUpdateGuard> {
+        self.vector_artifact_update
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| {
+                Error::Internal("a trained-vector artifact update is already in progress".into())
+            })?;
+        let guard = VectorArtifactUpdateGuard {
+            _lease: Arc::new(VectorArtifactUpdateLease {
+                updating: Arc::clone(&self.vector_artifact_update),
+            }),
+        };
+        let preexisting = self.active_operations.operation_tokens_snapshot();
+        self.active_operations
+            .wait_until_operations_finish(&preexisting)
+            .await;
+        Ok(guard)
+    }
+
+    /// Compatibility entry point: load the complete trained set or clear the
+    /// published generation and log the validation failure.
+    pub async fn load_and_publish_trained(&self) {
+        if let Err(error) = self.try_load_and_publish_trained().await {
+            self.trained.store(None);
+            log::error!("[trained] refusing to publish trained artifacts: {error}");
+        }
+    }
+
     /// Load trained structures from disk and publish to ArcSwap.
     /// Copies metadata under lock, releases lock, then does disk I/O.
-    pub async fn load_and_publish_trained(&self) {
+    pub(crate) async fn try_load_and_publish_trained(&self) -> Result<()> {
         // Copy vector_fields under lock (cheap clone of HashMap<u32, FieldMeta>)
         let vector_fields = {
             let st = self.state.lock().await;
             st.metadata.vector_fields.clone()
         };
         // Disk I/O happens WITHOUT holding the state lock
-        let trained =
-            IndexMetadata::load_trained_from_fields(&vector_fields, self.directory.as_ref()).await;
-        if let Some(t) = trained {
-            self.trained.store(Some(Arc::new(t)));
-        }
+        let trained = IndexMetadata::try_load_trained_from_fields(
+            &vector_fields,
+            self.schema.as_ref(),
+            self.directory.as_ref(),
+        )
+        .await?
+        .map(Arc::new);
+        // Publish exactly the validated snapshot, including None. Retaining a
+        // previous map when metadata has no Built fields would let new segments
+        // depend on artifacts no longer referenced durably.
+        self.trained.store(trained);
+        Ok(())
     }
 
-    /// Clear trained structures (sets ArcSwap to None)
-    pub(crate) fn clear_trained(&self) {
-        self.trained.store(None);
+    /// Persist vector metadata and publish its fully validated artifact set as
+    /// one cancellation-safe lifecycle transaction.
+    ///
+    /// Validation happens before the durable metadata commit. Once the rename
+    /// commits, both in-memory metadata and ArcSwap publication are completed by
+    /// the tracked transaction even if the requesting RPC is cancelled.
+    pub(crate) async fn update_vector_metadata_and_publish<F>(
+        self: &Arc<Self>,
+        artifact_update: &VectorArtifactUpdateGuard,
+        update: F,
+    ) -> Result<()>
+    where
+        F: FnOnce(&mut IndexMetadata),
+    {
+        let mut st = Arc::clone(&self.state).lock_owned().await;
+        let mut next = st.metadata.clone();
+        update(&mut next);
+
+        let next_trained = IndexMetadata::try_load_trained_from_fields(
+            &next.vector_fields,
+            self.schema.as_ref(),
+            self.directory.as_ref(),
+        )
+        .await?
+        .map(Arc::new);
+
+        let directory = Arc::clone(&self.directory);
+        let trained = Arc::clone(&self.trained);
+        // Keep the producer gate raised if the requesting future is cancelled
+        // after the metadata transaction has been detached. The last guard
+        // clone drops only after durable metadata and ArcSwap state agree.
+        let artifact_update = artifact_update.clone();
+        self.run_lifecycle_transaction(async move {
+            let _artifact_update = artifact_update;
+            next.save(directory.as_ref()).await?;
+            st.metadata = next;
+            trained.store(next_trained);
+            Ok(())
+        })
+        .await
     }
 
     /// Read metadata with a closure (no persist)
@@ -1127,7 +1286,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             let mut reevaluate = false;
             let mut retry_delay = None;
 
-            let trained_snap = sm.trained();
+            let trained_snap = sm.trained_for_segment_build();
             let granularity = sm.merge_granularity(&ids).await;
             let result = Self::do_merge(
                 sm.directory.as_ref(),
@@ -1696,7 +1855,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             };
             let mut output_cleanup = self.output_cleanup_guard(output_id);
 
-            let trained_snap = self.trained();
+            let trained_snap = self.trained_for_segment_build();
             let granularity = self.merge_granularity(&batch).await;
             let merge_result = Self::do_merge(
                 self.directory.as_ref(),
@@ -2210,6 +2369,59 @@ mod tests {
         assert!(snap.contains("x"));
         assert!(snap.contains("y"));
         assert!(!snap.contains("z"));
+    }
+
+    #[tokio::test]
+    async fn operation_barrier_ignores_producers_started_after_snapshot() {
+        let active = Arc::new(ActiveSegmentOperations::new());
+        let before_gate = active.try_register(vec!["old".into()]).unwrap();
+        let barrier = active.operation_tokens_snapshot();
+        let after_gate = active.try_register(vec!["new-flat".into()]).unwrap();
+
+        let waiter = {
+            let active = Arc::clone(&active);
+            tokio::spawn(async move { active.wait_until_operations_finish(&barrier).await })
+        };
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(before_gate);
+        tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("pre-gate operation barrier was starved by a post-gate producer")
+            .unwrap();
+        assert!(active.snapshot().contains("new-flat"));
+        drop(after_gate);
+    }
+
+    #[tokio::test]
+    async fn artifact_update_gate_preserves_search_generation_but_forces_flat_producers() {
+        let manager = lifecycle_test_manager();
+        manager
+            .trained
+            .store(Some(Arc::new(TrainedVectorStructures {
+                centroids: rustc_hash::FxHashMap::default(),
+                codebooks: rustc_hash::FxHashMap::default(),
+            })));
+
+        let guard = manager.begin_vector_artifact_update().await.unwrap();
+        assert!(
+            manager.trained().is_some(),
+            "search readers keep the last fully validated generation"
+        );
+        assert!(
+            manager.trained_for_segment_build().is_none(),
+            "new segment producers must stay flat during an artifact update"
+        );
+
+        let detached_transaction_guard = guard.clone();
+        drop(guard);
+        assert!(
+            manager.trained_for_segment_build().is_none(),
+            "a detached lifecycle transaction must retain the producer gate after request cancellation"
+        );
+        drop(detached_transaction_guard);
+        assert!(manager.trained_for_segment_build().is_some());
     }
 
     #[tokio::test]

--- a/hermes-core/src/observe.rs
+++ b/hermes-core/src/observe.rs
@@ -168,6 +168,7 @@ mod imp {
     }
 
     #[inline(always)]
+    #[allow(clippy::too_many_arguments)]
     pub fn bmp_query(_: &str, _: &str, _: f64, _: usize, _: usize, _: usize, _: usize, _: usize) {}
     #[inline(always)]
     pub fn maxscore_query(_: &str, _: &str, _: f64, _: usize) {}

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -167,8 +167,8 @@ thread_local! {
 ///
 /// `heap_factor` controls approximate retrieval (BMP alpha parameter):
 /// - **1.0**: exact/safe retrieval (default)
-/// - **0.8**: prune when `UB * 0.8 <= threshold` → ~20% more aggressive
-/// - **0.6**: prune when `UB * 0.6 <= threshold` → ~40% more aggressive
+/// - **0.8**: prune when `UB * 0.8 < threshold` → ~20% more aggressive
+/// - **0.6**: prune when `UB * 0.6 < threshold` → ~40% more aggressive
 ///
 /// `max_superblocks` (LSP/0 gamma cap): hard limit on superblock visits.
 /// - **0**: unlimited (default, existing behavior)
@@ -240,7 +240,7 @@ fn execute_bmp_inner(
     }
 
     // Alpha parameter for approximate retrieval:
-    // UB * alpha <= threshold → prune when UB < threshold / alpha
+    // UB * alpha < threshold → prune when UB < threshold / alpha
     // alpha < 1.0 means more aggressive pruning (approximate but faster)
     let alpha = heap_factor.clamp(0.01, 1.0);
     let scale = index.max_weight_scale / 255.0;
@@ -270,6 +270,17 @@ fn execute_bmp_inner(
 
     if query_info.is_empty() {
         return Ok(Vec::new());
+    }
+
+    // Block masks and the two-phase scorer use one u64 bit per query term.
+    // SparseVectorQuery enforces this already; reject oversized direct calls
+    // rather than silently producing an incomplete mask.
+    if query_info.len() > crate::query::MAX_QUERY_TERMS {
+        return Err(crate::Error::Query(format!(
+            "BMP query has {} resolved dimensions; maximum is {}",
+            query_info.len(),
+            crate::query::MAX_QUERY_TERMS
+        )));
     }
 
     // Sort by dim_id for binary search within blocks (blocks store dim_id directly).
@@ -324,7 +335,7 @@ fn execute_bmp_inner(
 
     // ── Two-phase lazy block scoring setup ────────────────────────────
     // For queries with >5 dims, score only the top-3 heaviest dims first (phase1).
-    // If max_partial_score + remaining_block_ub <= threshold, skip phase2.
+    // If max_partial_score + remaining_block_ub < threshold, skip phase2.
     // For ≤5 dims: full scoring directly (zero overhead).
     const PHASE1_DIMS: usize = 3;
     const MIN_DIMS_FOR_TWO_PHASE: usize = 6;
@@ -352,16 +363,11 @@ fn execute_bmp_inner(
         Vec::new()
     };
 
-    // Over-fetch for multi-ordinal: each real doc may occupy multiple collector
-    // slots (one per ordinal). Inflate collector so combine_ordinal_results has
-    // enough unique docs after grouping. Cap at 10× to avoid degenerate cases
-    // (e.g., 200 ordinals/doc). For single-ordinal, collector_k == k (no overhead).
-    let ordinals_per_doc = if index.num_real_docs() > 0 {
-        (index.num_virtual_docs as f32 / index.num_real_docs() as f32).ceil() as usize
-    } else {
-        1
-    };
-    let collector_k = k.saturating_mul(ordinals_per_doc).min(k.saturating_mul(10));
+    // The planner has already applied the configured ordinal over-fetch factor
+    // to `k`.  Do not derive another factor from num_virtual_docs: that ratio
+    // includes block-alignment padding and used to multiply the heap depth a
+    // second time (usually turning the default 2x into 4x).
+    let collector_k = k;
 
     let t_start = std::time::Instant::now();
 
@@ -475,7 +481,7 @@ fn execute_bmp_inner(
         // Pre-compute suffix-max of ACTUAL UBs for safe early termination.
         // Because coverage-biased ordering is non-monotonic in UB, we can't `break`
         // on a single low-UB SB. Instead we `break` when the max UB of ALL remaining
-        // SBs <= threshold — guaranteed correct.
+        // SBs < threshold — guaranteed correct while retaining canonical ties.
         compute_suffix_max_ubs(
             &scratch.sb_ubs,
             &scratch.sb_order,
@@ -494,16 +500,16 @@ fn execute_bmp_inner(
                 break;
             }
 
-            // Safe early termination: max UB of ALL remaining SBs <= threshold
+            // Safe early termination: max UB of ALL remaining SBs < threshold
             if collector.len() >= collector_k
-                && scratch.sb_suffix_max[idx] * alpha <= collector.threshold()
+                && scratch.sb_suffix_max[idx] * alpha < collector.threshold()
             {
                 break;
             }
 
             // Individual SB skip (continue, not break — ordering is non-monotonic in UB)
             let sb_ub = scratch.sb_ubs[sb_id as usize];
-            if collector.len() >= collector_k && sb_ub * alpha <= collector.threshold() {
+            if collector.len() >= collector_k && sb_ub * alpha < collector.threshold() {
                 continue;
             }
 
@@ -566,7 +572,7 @@ fn execute_bmp_inner(
 
             // Level 3: page-level prefetch of the surviving blocks' data.
             // Mirrors the scoring loop's skip conditions (UB-descending order,
-            // break on ub*alpha <= threshold, skip zero-mask blocks) to find
+            // break on ub*alpha < threshold, skip zero-mask blocks) to find
             // the byte span that will actually be read, then issues a single
             // MADV_WILLNEED so cold pages are clustered into sequential reads
             // instead of one major fault per block (memory-bound hosts).
@@ -581,7 +587,7 @@ fn execute_bmp_inner(
                     if li >= count {
                         break;
                     }
-                    if heap_full && scratch.local_block_ubs[li] * alpha <= thr {
+                    if heap_full && scratch.local_block_ubs[li] * alpha < thr {
                         break;
                     }
                     if scratch.local_block_masks[li] == 0 {
@@ -774,7 +780,7 @@ fn score_block_bsearch_int(
 ///
 /// **Two-phase lazy scoring**: When `phase1_mask != u64::MAX` and `phase1_local_ubs`
 /// is `Some`, scores only phase1 dims first. If the best possible score from phase1 +
-/// remaining block UB <= threshold, skips phase2 dims entirely (~40-60% of scoring work).
+/// remaining block UB < threshold, skips phase2 dims entirely (~40-60% of scoring work).
 ///
 /// Integer scoring: accumulates u16×u8 products into u32, then dequantizes to f32
 /// for collector comparison.
@@ -799,7 +805,6 @@ fn score_superblock_blocks(
     phase1_local_ubs: Option<&[f32]>,
 ) {
     let block_size = index.bmp_block_size as usize;
-    let num_vdocs_total = index.num_virtual_docs as usize;
     let two_phase = phase1_mask != u64::MAX && phase1_local_ubs.is_some();
 
     // Level 2: Pre-warm first few blocks' data (eliminates cold-start for first block).
@@ -818,34 +823,12 @@ fn score_superblock_blocks(
         }
 
         let ub = local_ubs[local_idx as usize];
-        // Block early termination: UB * alpha <= threshold (BMP alpha parameter)
-        if collector.len() >= k && ub * alpha <= collector.threshold() {
+        // Block early termination: UB * alpha < threshold (BMP alpha parameter)
+        if collector.len() >= k && ub * alpha < collector.threshold() {
             break;
         }
 
         let block_id = (block_start + local_idx as usize) as u32;
-
-        // Lazy per-block predicate bitmask: only evaluated for blocks that survive
-        // UB pruning. For each slot, check the predicate.
-        // If all words are 0, skip the entire block (no scoring needed).
-        // Cost: block_size predicate evaluations per block.
-        let pred_mask: [u64; 4] = if let Some(pred) = predicate {
-            let base = block_id as usize * block_size;
-            let end = (base + block_size).min(num_vdocs_total);
-            let mut mask = [0u64; 4];
-            for slot in 0..(end - base) {
-                let doc_id = index.doc_id_for_virtual((base + slot) as u32);
-                if doc_id != u32::MAX && pred(doc_id) {
-                    mask[slot / 64] |= 1u64 << (slot % 64);
-                }
-            }
-            if mask == [0u64; 4] {
-                continue; // skip scoring entirely — no matching docs
-            }
-            mask
-        } else {
-            [u64::MAX; 4]
-        };
 
         // Level 3: Two-deep data prefetch (N+1 and N+2 block data).
         // block_data_starts offsets are warm from superblock-level prefetch,
@@ -884,12 +867,12 @@ fn score_superblock_blocks(
                 );
 
                 // Check if phase2 can be skipped:
-                // max_partial_score + remaining_ub <= threshold?
+                // max_partial_score + remaining_ub < threshold?
                 // remaining_ub = full_block_ub - phase1_block_ub
                 let max_partial = max_touched_acc(acc, &touched) as f32 * dequant;
                 let phase1_ub = phase1_local_ubs.unwrap()[local_idx as usize];
                 let remaining_ub = (ub - phase1_ub).max(0.0);
-                if (max_partial + remaining_ub) * alpha <= collector.threshold() {
+                if (max_partial + remaining_ub) * alpha < collector.threshold() {
                     // Skip phase2 — zero touched slots and continue
                     zero_touched_acc(acc, &touched);
                     *blocks_scored += 1;
@@ -926,26 +909,18 @@ fn score_superblock_blocks(
             }
         }
 
-        // Collect results + lazy zeroing.
-        // Split into collect (touched & pred_mask) and reject (touched & !pred_mask).
-        // When no predicate, pred_mask = [u64::MAX; 4] so reject is all zeros.
+        // Collect results + lazy zeroing. Apply an ordinary predicate only to
+        // slots that scoring actually touched. Sparse queries commonly touch a
+        // small fraction of a block, so evaluating every slot before scoring
+        // was needlessly expensive for broad/non-bitset predicates.
         //
         // Resolve virtual → real (doc_id, ordinal) inline and insert with real
         // doc_id. The combine_ordinal_results layer handles multi-ordinal grouping.
         let base = block_id as usize * block_size;
         let num_vdocs = index.num_virtual_docs as usize;
 
-        for word in 0..4 {
-            // Zero rejected slots (touched but filtered out by predicate)
-            let mut reject = touched[word] & !pred_mask[word];
-            while reject != 0 {
-                let bit = reject.trailing_zeros() as usize;
-                reject &= reject - 1;
-                acc[word * 64 + bit] = 0;
-            }
-
-            // Collect matching slots
-            let mut scan = touched[word] & pred_mask[word];
+        for (word, &touched_word) in touched.iter().enumerate() {
+            let mut scan = touched_word;
             while scan != 0 {
                 let bit = scan.trailing_zeros() as usize;
                 scan &= scan - 1;
@@ -969,9 +944,14 @@ fn score_superblock_blocks(
                 if doc_id == u32::MAX {
                     continue;
                 }
+                if let Some(pred) = predicate
+                    && !pred(doc_id)
+                {
+                    continue;
+                }
 
                 let score = score_u32 as f32 * dequant;
-                if collector.would_enter(score) {
+                if collector.would_enter_candidate(doc_id, score, ordinal) {
                     collector.insert_with_ordinal(doc_id, score, ordinal);
                 }
             }
@@ -1025,7 +1005,7 @@ fn sort_sb_desc_into(values: &[f32], out: &mut Vec<u32>) {
 ///
 /// `suffix_max[i]` = max UB among all SBs at positions `i..order.len()`.
 /// This enables safe early termination with non-monotonic ordering:
-/// if `suffix_max[i] * alpha <= threshold`, ALL remaining SBs can be skipped.
+/// if `suffix_max[i] * alpha < threshold`, ALL remaining SBs can be skipped.
 ///
 /// O(num_superblocks) pre-computation, then O(1) check per SB in the loop.
 fn compute_suffix_max_ubs(sb_ubs: &[f32], order: &[u32], out: &mut [f32]) {

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -115,7 +115,7 @@ fn build_should_scorer<'a>(scorers: Vec<Box<dyn Scorer + 'a>>) -> Box<dyn Scorer
 // ── Planner macro ────────────────────────────────────────────────────────
 //
 // Unified planner for both async and sync paths.  Parameterised on:
-//   $scorer_fn      – scorer | scorer_sync
+//   $scorer_fn      – scorer_with_options | scorer_sync_with_options
 //   $get_postings_fn – get_postings | get_postings_sync
 //   $execute_fn     – execute | execute_sync
 //   $($aw)*         – .await  (present for async, absent for sync)
@@ -127,7 +127,7 @@ fn build_should_scorer<'a>(scorers: Vec<Box<dyn Scorer + 'a>>) -> Box<dyn Scorer
 //   4. Standard BooleanScorer fallback
 macro_rules! boolean_plan {
     ($must:expr, $should:expr, $must_not:expr, $global_stats:expr,
-     $reader:expr, $limit:expr,
+     $reader:expr, $limit:expr, $scorer_options:expr,
      $scorer_fn:ident, $get_postings_fn:ident, $execute_fn:ident
      $(, $aw:tt)*) => {{
         let must: &[Arc<dyn Query>] = &$must;
@@ -136,6 +136,7 @@ macro_rules! boolean_plan {
         let global_stats: Option<&Arc<GlobalStats>> = $global_stats;
         let reader: &SegmentReader = $reader;
         let limit: usize = $limit;
+        let scorer_options: super::ScorerOptions = $scorer_options;
 
         // Cap SHOULD clauses to MAX_QUERY_TERMS, but only count queries that need
         // posting-list cursors. Fast-field predicates (O(1) per doc) are exempt.
@@ -182,17 +183,18 @@ macro_rules! boolean_plan {
         // ── 1. Single-clause optimisation ────────────────────────────────
         if must_not.is_empty() {
             if must.len() == 1 && should.is_empty() {
-                return must[0].$scorer_fn(reader, limit) $(.  $aw)* ;
+                return must[0].$scorer_fn(reader, limit, scorer_options) $(.  $aw)* ;
             }
             if should.len() == 1 && must.is_empty() {
-                return should[0].$scorer_fn(reader, limit) $(. $aw)* ;
+                return should[0].$scorer_fn(reader, limit, scorer_options) $(. $aw)* ;
             }
         }
 
         // ── 2. Pure OR → MaxScore optimisations ──────────────────────────
         if must.is_empty() && must_not.is_empty() && should.len() >= 2 {
             // 2a. Text MaxScore (single-field, all term queries)
-            if let Some((mut infos, text_field, avg_field_len, num_docs)) =
+            if !scorer_options.collect_positions
+                && let Some((mut infos, text_field, avg_field_len, num_docs)) =
                 prepare_text_maxscore(should, reader, global_stats)
             {
                 let mut posting_lists = Vec::with_capacity(infos.len());
@@ -232,7 +234,9 @@ macro_rules! boolean_plan {
             }
 
             // 2c. Per-field text MaxScore (multi-field term grouping)
-            if let Some(grouping) = prepare_per_field_grouping(should, reader, limit, global_stats)
+            if !scorer_options.collect_positions
+                && let Some(grouping) =
+                    prepare_per_field_grouping(should, reader, limit, global_stats)
             {
                 let mut scorers: Vec<Box<dyn Scorer + '_>> = Vec::new();
                 // Query-local cross-group threshold seeding (see finish_text_maxscore)
@@ -261,14 +265,18 @@ macro_rules! boolean_plan {
                     }
                 }
                 for &idx in &grouping.fallback_indices {
-                    scorers.push(should[idx].$scorer_fn(reader, limit) $(. $aw)* ?);
+                    scorers.push(should[idx].$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
                 }
                 return Ok(build_should_scorer(scorers));
             }
         }
 
         // ── 3. Filter push-down (MUST + SHOULD) ─────────────────────────
-        if !should.is_empty() && !must.is_empty() && limit < usize::MAX / 4 {
+        if !scorer_options.collect_positions
+            && !should.is_empty()
+            && !must.is_empty()
+            && limit < usize::MAX / 4
+        {
             // Pre-check: is SHOULD all-sparse? This determines whether we can
             // use bitset fallback for MUST clauses that lack fast-field predicates.
             // For sparse SHOULD, the predicate is pushed into BMP/MaxScore traversal
@@ -294,11 +302,11 @@ macro_rules! boolean_plan {
                         predicates.push(Box::new(move |doc_id| bitset.contains(doc_id)));
                     } else {
                         log::debug!("BooleanQuery planner 3a: MUST clause → verifier scorer ({})", q);
-                        must_verifiers.push(q.$scorer_fn(reader, limit) $(. $aw)* ?);
+                        must_verifiers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
                     }
                 } else {
                     log::debug!("BooleanQuery planner 3a: MUST clause → verifier scorer ({})", q);
-                    must_verifiers.push(q.$scorer_fn(reader, limit) $(. $aw)* ?);
+                    must_verifiers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
                 }
             }
             // Compile MUST_NOT → negated predicates vs verifier scorers
@@ -313,10 +321,10 @@ macro_rules! boolean_plan {
                         log::debug!("BooleanQuery planner 3a: MUST_NOT clause → bitset predicate ({})", q);
                         predicates.push(Box::new(move |doc_id| !bitset.contains(doc_id)));
                     } else {
-                        must_not_verifiers.push(q.$scorer_fn(reader, limit) $(. $aw)* ?);
+                        must_not_verifiers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
                     }
                 } else {
-                    must_not_verifiers.push(q.$scorer_fn(reader, limit) $(. $aw)* ?);
+                    must_not_verifiers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
                 }
             }
 
@@ -394,7 +402,7 @@ macro_rules! boolean_plan {
                 || !must_not_verifiers.is_empty();
             let should_limit = if has_filters { limit * 4 } else { limit };
             let should_scorer = if should.len() == 1 {
-                should[0].$scorer_fn(reader, should_limit) $(. $aw)* ?
+                should[0].$scorer_fn(reader, should_limit, scorer_options) $(. $aw)* ?
             } else {
                 let sub = BooleanQuery {
                     must: Vec::new(),
@@ -402,7 +410,7 @@ macro_rules! boolean_plan {
                     must_not: Vec::new(),
                     global_stats: global_stats.cloned(),
                 };
-                sub.$scorer_fn(reader, should_limit) $(. $aw)* ?
+                sub.$scorer_fn(reader, should_limit, scorer_options) $(. $aw)* ?
             };
 
             let use_predicated =
@@ -440,15 +448,15 @@ macro_rules! boolean_plan {
         // ── 4. Standard BooleanScorer fallback ───────────────────────────
         let mut must_scorers = Vec::with_capacity(must.len());
         for q in must {
-            must_scorers.push(q.$scorer_fn(reader, limit) $(. $aw)* ?);
+            must_scorers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
         }
         let mut should_scorers = Vec::with_capacity(should.len());
         for q in should {
-            should_scorers.push(q.$scorer_fn(reader, limit) $(. $aw)* ?);
+            should_scorers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
         }
         let mut must_not_scorers = Vec::with_capacity(must_not.len());
         for q in must_not {
-            must_not_scorers.push(q.$scorer_fn(reader, limit) $(. $aw)* ?);
+            must_not_scorers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
         }
         let mut scorer = BooleanScorer {
             must: must_scorers,
@@ -463,6 +471,15 @@ macro_rules! boolean_plan {
 
 impl Query for BooleanQuery {
     fn scorer<'a>(&self, reader: &'a SegmentReader, limit: usize) -> ScorerFuture<'a> {
+        self.scorer_with_options(reader, limit, super::ScorerOptions::with_positions())
+    }
+
+    fn scorer_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: super::ScorerOptions,
+    ) -> ScorerFuture<'a> {
         let must = self.must.clone();
         let should = self.should.clone();
         let must_not = self.must_not.clone();
@@ -475,7 +492,8 @@ impl Query for BooleanQuery {
                 global_stats.as_ref(),
                 reader,
                 limit,
-                scorer,
+                options,
+                scorer_with_options,
                 get_postings,
                 execute,
                 await
@@ -489,6 +507,16 @@ impl Query for BooleanQuery {
         reader: &'a SegmentReader,
         limit: usize,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        self.scorer_sync_with_options(reader, limit, super::ScorerOptions::with_positions())
+    }
+
+    #[cfg(feature = "sync")]
+    fn scorer_sync_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: super::ScorerOptions,
+    ) -> crate::Result<Box<dyn Scorer + 'a>> {
         boolean_plan!(
             self.must,
             self.should,
@@ -496,7 +524,8 @@ impl Query for BooleanQuery {
             self.global_stats.as_ref(),
             reader,
             limit,
-            scorer_sync,
+            options,
+            scorer_sync_with_options,
             get_postings_sync,
             execute_sync
         )

--- a/hermes-core/src/query/boost.rs
+++ b/hermes-core/src/query/boost.rs
@@ -39,10 +39,24 @@ impl BoostQuery {
 
 impl Query for BoostQuery {
     fn scorer<'a>(&self, reader: &'a SegmentReader, limit: usize) -> ScorerFuture<'a> {
+        self.scorer_with_options(reader, limit, super::ScorerOptions::with_positions())
+    }
+
+    fn scorer_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: super::ScorerOptions,
+    ) -> ScorerFuture<'a> {
         let inner = self.inner.clone();
         let boost = self.boost;
         Box::pin(async move {
-            let inner_scorer = inner.scorer(reader, limit).await?;
+            if !boost.is_finite() {
+                return Err(crate::Error::Query(
+                    "boost must be a finite number".to_string(),
+                ));
+            }
+            let inner_scorer = inner.scorer_with_options(reader, limit, options).await?;
             Ok(Box::new(BoostScorer {
                 inner: inner_scorer,
                 boost,
@@ -56,7 +70,24 @@ impl Query for BoostQuery {
         reader: &'a SegmentReader,
         limit: usize,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
-        let inner_scorer = self.inner.scorer_sync(reader, limit)?;
+        self.scorer_sync_with_options(reader, limit, super::ScorerOptions::with_positions())
+    }
+
+    #[cfg(feature = "sync")]
+    fn scorer_sync_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: super::ScorerOptions,
+    ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        if !self.boost.is_finite() {
+            return Err(crate::Error::Query(
+                "boost must be a finite number".to_string(),
+            ));
+        }
+        let inner_scorer = self
+            .inner
+            .scorer_sync_with_options(reader, limit, options)?;
         Ok(Box::new(BoostScorer {
             inner: inner_scorer,
             boost: self.boost,
@@ -69,15 +100,21 @@ impl Query for BoostQuery {
     }
 
     fn is_filter(&self) -> bool {
-        self.inner.is_filter()
+        self.boost == 1.0 && self.inner.is_filter()
     }
 
     fn as_doc_predicate<'a>(&self, reader: &'a SegmentReader) -> Option<super::DocPredicate<'a>> {
-        self.inner.as_doc_predicate(reader)
+        (self.boost == 1.0)
+            .then(|| self.inner.as_doc_predicate(reader))
+            .flatten()
     }
 
     fn decompose(&self) -> super::QueryDecomposition {
-        self.inner.decompose()
+        if self.boost == 1.0 {
+            self.inner.decompose()
+        } else {
+            super::QueryDecomposition::Opaque
+        }
     }
 }
 
@@ -107,5 +144,15 @@ impl super::docset::DocSet for BoostScorer<'_> {
 impl Scorer for BoostScorer<'_> {
     fn score(&self) -> Score {
         self.inner.score() * self.boost
+    }
+
+    fn matched_positions(&self) -> Option<super::MatchedPositions> {
+        let mut positions = self.inner.matched_positions()?;
+        for (_, scored_positions) in &mut positions {
+            for position in scored_positions {
+                position.score *= self.boost;
+            }
+        }
+        Some(positions)
     }
 }

--- a/hermes-core/src/query/collector.rs
+++ b/hermes-core/src/query/collector.rs
@@ -105,6 +105,14 @@ fn is_zero_u128(v: &u128) -> bool {
     *v == 0
 }
 
+/// Canonical result order used by search, reranking, fusion, and pagination.
+pub(crate) fn compare_search_results_desc(a: &SearchResult, b: &SearchResult) -> Ordering {
+    b.score
+        .total_cmp(&a.score)
+        .then_with(|| a.segment_id.cmp(&b.segment_id))
+        .then_with(|| a.doc_id.cmp(&b.doc_id))
+}
+
 /// Matched field info with ordinals (for multi-valued fields)
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct MatchedField {
@@ -176,7 +184,9 @@ pub struct SearchResponse {
 
 impl PartialEq for SearchResult {
     fn eq(&self, other: &Self) -> bool {
-        self.segment_id == other.segment_id && self.doc_id == other.doc_id
+        self.score.to_bits() == other.score.to_bits()
+            && self.segment_id == other.segment_id
+            && self.doc_id == other.doc_id
     }
 }
 
@@ -192,8 +202,7 @@ impl Ord for SearchResult {
     fn cmp(&self, other: &Self) -> Ordering {
         other
             .score
-            .partial_cmp(&self.score)
-            .unwrap_or(Ordering::Equal)
+            .total_cmp(&self.score)
             .then_with(|| self.segment_id.cmp(&other.segment_id))
             .then_with(|| self.doc_id.cmp(&other.doc_id))
     }
@@ -207,6 +216,20 @@ pub trait Collector {
     /// Called for each matching document
     /// positions: Vec of (field_id, scored_positions)
     fn collect(&mut self, doc_id: DocId, score: Score, positions: &[(u32, Vec<ScoredPosition>)]);
+
+    /// Whether this score can enter the collector's retained result set.
+    ///
+    /// The scorer still calls `collect` when this returns false so counters and
+    /// other side effects remain exact; it only skips materializing positions.
+    fn would_collect(&self, _doc_id: DocId, _score: Score) -> bool {
+        true
+    }
+
+    /// Collect already-owned positions. Position-aware collectors can override
+    /// this to move the nested vectors instead of cloning them.
+    fn collect_owned(&mut self, doc_id: DocId, score: Score, positions: super::MatchedPositions) {
+        self.collect(doc_id, score, &positions);
+    }
 
     /// Whether this collector needs position information
     fn needs_positions(&self) -> bool {
@@ -223,10 +246,16 @@ pub struct TopKCollector {
     total_seen: u32,
 }
 
+// Avoid trusting a caller-controlled `k` as an up-front allocation size. The
+// heap still grows to the number of results actually retained, but malformed
+// or overly broad requests cannot reserve gigabytes once per segment before
+// any document has been scored.
+const MAX_INITIAL_TOP_K_CAPACITY: usize = 8 * 1024;
+
 impl TopKCollector {
     pub fn new(k: usize) -> Self {
         Self {
-            heap: BinaryHeap::with_capacity(k + 1),
+            heap: BinaryHeap::with_capacity(k.min(MAX_INITIAL_TOP_K_CAPACITY)),
             k,
             collect_positions: false,
             total_seen: 0,
@@ -236,7 +265,7 @@ impl TopKCollector {
     /// Create a collector that also collects positions
     pub fn with_positions(k: usize) -> Self {
         Self {
-            heap: BinaryHeap::with_capacity(k + 1),
+            heap: BinaryHeap::with_capacity(k.min(MAX_INITIAL_TOP_K_CAPACITY)),
             k,
             collect_positions: true,
             total_seen: 0,
@@ -250,12 +279,7 @@ impl TopKCollector {
 
     pub fn into_sorted_results(self) -> Vec<SearchResult> {
         let mut results: Vec<_> = self.heap.into_vec();
-        results.sort_unstable_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| a.doc_id.cmp(&b.doc_id))
-        });
+        results.sort_unstable_by(compare_search_results_desc);
         results
     }
 
@@ -273,9 +297,7 @@ impl Collector for TopKCollector {
         // Only clone positions when the document will actually be kept in the heap.
         // This avoids deep-cloning Vec<ScoredPosition> for documents that are
         // immediately discarded (the common case for large result sets).
-        let dominated =
-            self.heap.len() >= self.k && self.heap.peek().is_some_and(|min| score <= min.score);
-        if dominated {
+        if !self.would_collect(doc_id, score) {
             return;
         }
 
@@ -293,6 +315,37 @@ impl Collector for TopKCollector {
             score,
             segment_id: 0,
             positions,
+        });
+    }
+
+    fn would_collect(&self, doc_id: DocId, score: Score) -> bool {
+        self.k > 0
+            && (self.heap.len() < self.k
+                || self.heap.peek().is_some_and(|min| {
+                    score.total_cmp(&min.score).is_gt()
+                        || (score.total_cmp(&min.score).is_eq() && doc_id < min.doc_id)
+                }))
+    }
+
+    fn collect_owned(&mut self, doc_id: DocId, score: Score, positions: super::MatchedPositions) {
+        self.total_seen = self.total_seen.saturating_add(1);
+
+        if !self.would_collect(doc_id, score) {
+            return;
+        }
+
+        if self.heap.len() >= self.k {
+            self.heap.pop();
+        }
+        self.heap.push(SearchResult {
+            doc_id,
+            score,
+            segment_id: 0,
+            positions: if self.collect_positions {
+                positions
+            } else {
+                Vec::new()
+            },
         });
     }
 
@@ -336,8 +389,9 @@ pub async fn search_segment_with_count(
     query: &dyn Query,
     limit: usize,
 ) -> Result<(Vec<SearchResult>, u32)> {
-    let mut collector = TopKCollector::new(limit);
-    collect_segment_with_limit(reader, query, &mut collector, limit).await?;
+    let segment_limit = limit.min(reader.num_docs() as usize);
+    let mut collector = TopKCollector::new(segment_limit);
+    collect_segment_with_limit(reader, query, &mut collector, segment_limit).await?;
     Ok(collector.into_results_with_count())
 }
 
@@ -347,9 +401,35 @@ pub async fn search_segment_with_positions_and_count(
     query: &dyn Query,
     limit: usize,
 ) -> Result<(Vec<SearchResult>, u32)> {
-    let mut collector = TopKCollector::with_positions(limit);
-    collect_segment_with_limit(reader, query, &mut collector, limit).await?;
+    let segment_limit = limit.min(reader.num_docs() as usize);
+    let mut collector = TopKCollector::with_positions(segment_limit);
+    collect_segment_with_limit(reader, query, &mut collector, segment_limit).await?;
     Ok(collector.into_results_with_count())
+}
+
+/// Return positions for the next collector that can retain them. All but the
+/// final consumer receive a clone; the final consumer takes the original
+/// allocation. Tuple collectors use this to avoid a deep clone when only one
+/// child actually needs positions (the common top-k + count case).
+fn positions_for_next_collector(
+    positions: &mut Option<super::MatchedPositions>,
+    remaining_consumers: &mut usize,
+) -> super::MatchedPositions {
+    assert!(
+        *remaining_consumers > 0,
+        "position consumer count underflow"
+    );
+    *remaining_consumers -= 1;
+    if *remaining_consumers == 0 {
+        positions
+            .take()
+            .expect("owned positions must remain for the final collector")
+    } else {
+        positions
+            .as_ref()
+            .cloned()
+            .expect("owned positions must remain while collectors are pending")
+    }
 }
 
 // Implement Collector for tuple of 2 collectors
@@ -360,6 +440,37 @@ impl<A: Collector, B: Collector> Collector for (&mut A, &mut B) {
     }
     fn needs_positions(&self) -> bool {
         self.0.needs_positions() || self.1.needs_positions()
+    }
+    fn would_collect(&self, doc_id: DocId, score: Score) -> bool {
+        (self.0.needs_positions() && self.0.would_collect(doc_id, score))
+            || (self.1.needs_positions() && self.1.would_collect(doc_id, score))
+    }
+    fn collect_owned(&mut self, doc_id: DocId, score: Score, positions: super::MatchedPositions) {
+        let wants = [
+            self.0.needs_positions() && self.0.would_collect(doc_id, score),
+            self.1.needs_positions() && self.1.would_collect(doc_id, score),
+        ];
+        let mut remaining = wants.iter().filter(|&&want| want).count();
+        let mut positions = Some(positions);
+
+        if wants[0] {
+            self.0.collect_owned(
+                doc_id,
+                score,
+                positions_for_next_collector(&mut positions, &mut remaining),
+            );
+        } else {
+            self.0.collect(doc_id, score, &[]);
+        }
+        if wants[1] {
+            self.1.collect_owned(
+                doc_id,
+                score,
+                positions_for_next_collector(&mut positions, &mut remaining),
+            );
+        } else {
+            self.1.collect(doc_id, score, &[]);
+        }
     }
 }
 
@@ -372,6 +483,48 @@ impl<A: Collector, B: Collector, C: Collector> Collector for (&mut A, &mut B, &m
     }
     fn needs_positions(&self) -> bool {
         self.0.needs_positions() || self.1.needs_positions() || self.2.needs_positions()
+    }
+    fn would_collect(&self, doc_id: DocId, score: Score) -> bool {
+        (self.0.needs_positions() && self.0.would_collect(doc_id, score))
+            || (self.1.needs_positions() && self.1.would_collect(doc_id, score))
+            || (self.2.needs_positions() && self.2.would_collect(doc_id, score))
+    }
+    fn collect_owned(&mut self, doc_id: DocId, score: Score, positions: super::MatchedPositions) {
+        let wants = [
+            self.0.needs_positions() && self.0.would_collect(doc_id, score),
+            self.1.needs_positions() && self.1.would_collect(doc_id, score),
+            self.2.needs_positions() && self.2.would_collect(doc_id, score),
+        ];
+        let mut remaining = wants.iter().filter(|&&want| want).count();
+        let mut positions = Some(positions);
+
+        if wants[0] {
+            self.0.collect_owned(
+                doc_id,
+                score,
+                positions_for_next_collector(&mut positions, &mut remaining),
+            );
+        } else {
+            self.0.collect(doc_id, score, &[]);
+        }
+        if wants[1] {
+            self.1.collect_owned(
+                doc_id,
+                score,
+                positions_for_next_collector(&mut positions, &mut remaining),
+            );
+        } else {
+            self.1.collect(doc_id, score, &[]);
+        }
+        if wants[2] {
+            self.2.collect_owned(
+                doc_id,
+                score,
+                positions_for_next_collector(&mut positions, &mut remaining),
+            );
+        } else {
+            self.2.collect(doc_id, score, &[]);
+        }
     }
 }
 
@@ -415,7 +568,10 @@ pub async fn collect_segment_with_limit<C: Collector>(
     collector: &mut C,
     limit: usize,
 ) -> Result<()> {
-    let mut scorer = query.scorer(reader, limit).await?;
+    let options = super::ScorerOptions {
+        collect_positions: collector.needs_positions(),
+    };
+    let mut scorer = query.scorer_with_options(reader, limit, options).await?;
     drive_scorer(scorer.as_mut(), collector);
     Ok(())
 }
@@ -425,11 +581,12 @@ fn drive_scorer<C: Collector>(scorer: &mut dyn super::Scorer, collector: &mut C)
     let needs_positions = collector.needs_positions();
     let mut doc = scorer.doc();
     while doc != TERMINATED {
-        if needs_positions {
+        let score = scorer.score();
+        if needs_positions && collector.would_collect(doc, score) {
             let positions = scorer.matched_positions().unwrap_or_default();
-            collector.collect(doc, scorer.score(), &positions);
+            collector.collect_owned(doc, score, positions);
         } else {
-            collector.collect(doc, scorer.score(), &[]);
+            collector.collect(doc, score, &[]);
         }
         doc = scorer.advance();
     }
@@ -444,8 +601,9 @@ pub fn search_segment_with_count_sync(
     query: &dyn Query,
     limit: usize,
 ) -> Result<(Vec<SearchResult>, u32)> {
-    let mut collector = TopKCollector::new(limit);
-    collect_segment_with_limit_sync(reader, query, &mut collector, limit)?;
+    let segment_limit = limit.min(reader.num_docs() as usize);
+    let mut collector = TopKCollector::new(segment_limit);
+    collect_segment_with_limit_sync(reader, query, &mut collector, segment_limit)?;
     Ok(collector.into_results_with_count())
 }
 
@@ -456,8 +614,9 @@ pub fn search_segment_with_positions_and_count_sync(
     query: &dyn Query,
     limit: usize,
 ) -> Result<(Vec<SearchResult>, u32)> {
-    let mut collector = TopKCollector::with_positions(limit);
-    collect_segment_with_limit_sync(reader, query, &mut collector, limit)?;
+    let segment_limit = limit.min(reader.num_docs() as usize);
+    let mut collector = TopKCollector::with_positions(segment_limit);
+    collect_segment_with_limit_sync(reader, query, &mut collector, segment_limit)?;
     Ok(collector.into_results_with_count())
 }
 
@@ -469,7 +628,10 @@ pub fn collect_segment_with_limit_sync<C: Collector>(
     collector: &mut C,
     limit: usize,
 ) -> Result<()> {
-    let mut scorer = query.scorer_sync(reader, limit)?;
+    let options = super::ScorerOptions {
+        collect_positions: collector.needs_positions(),
+    };
+    let mut scorer = query.scorer_sync_with_options(reader, limit, options)?;
     drive_scorer(scorer.as_mut(), collector);
     Ok(())
 }
@@ -477,6 +639,81 @@ pub fn collect_segment_with_limit_sync<C: Collector>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+
+    #[derive(Default)]
+    struct OwnedPositionCollector {
+        owned_calls: usize,
+        borrowed_calls: usize,
+        positions: super::super::MatchedPositions,
+    }
+
+    impl Collector for OwnedPositionCollector {
+        fn collect(
+            &mut self,
+            _doc_id: DocId,
+            _score: Score,
+            positions: &[(u32, Vec<ScoredPosition>)],
+        ) {
+            self.borrowed_calls += 1;
+            self.positions = positions.to_vec();
+        }
+
+        fn collect_owned(
+            &mut self,
+            _doc_id: DocId,
+            _score: Score,
+            positions: super::super::MatchedPositions,
+        ) {
+            self.owned_calls += 1;
+            self.positions = positions;
+        }
+
+        fn needs_positions(&self) -> bool {
+            true
+        }
+    }
+
+    struct PositionCountingScorer {
+        index: usize,
+        position_calls: Arc<AtomicUsize>,
+    }
+
+    impl super::super::DocSet for PositionCountingScorer {
+        fn doc(&self) -> DocId {
+            if self.index < 3 {
+                self.index as DocId
+            } else {
+                TERMINATED
+            }
+        }
+
+        fn advance(&mut self) -> DocId {
+            self.index += 1;
+            self.doc()
+        }
+
+        fn seek(&mut self, target: DocId) -> DocId {
+            self.index = target.min(3) as usize;
+            self.doc()
+        }
+
+        fn size_hint(&self) -> u32 {
+            3u32.saturating_sub(self.index as u32)
+        }
+    }
+
+    impl super::super::Scorer for PositionCountingScorer {
+        fn score(&self) -> Score {
+            [10.0, 1.0, 2.0][self.index]
+        }
+
+        fn matched_positions(&self) -> Option<super::super::MatchedPositions> {
+            self.position_calls.fetch_add(1, AtomicOrdering::Relaxed);
+            Some(vec![(7, vec![ScoredPosition::new(self.index as u32, 1.0)])])
+        }
+    }
 
     #[test]
     fn test_top_k_collector() {
@@ -494,6 +731,72 @@ mod tests {
         assert_eq!(results[0].doc_id, 3); // score 4.0
         assert_eq!(results[1].doc_id, 1); // score 3.0
         assert_eq!(results[2].doc_id, 2); // score 2.0
+    }
+
+    #[test]
+    fn top_k_zero_retains_no_results() {
+        let mut collector = TopKCollector::new(0);
+        collector.collect(1, 1.0, &[]);
+
+        assert!(collector.into_sorted_results().is_empty());
+    }
+
+    #[test]
+    fn huge_top_k_does_not_trigger_a_huge_initial_allocation() {
+        let collector = TopKCollector::new(usize::MAX);
+
+        assert!(collector.heap.capacity() <= MAX_INITIAL_TOP_K_CAPACITY);
+    }
+
+    #[test]
+    fn positions_are_only_materialized_for_competitive_hits() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut scorer = PositionCountingScorer {
+            index: 0,
+            position_calls: Arc::clone(&calls),
+        };
+        let mut collector = TopKCollector::with_positions(1);
+
+        drive_scorer(&mut scorer, &mut collector);
+
+        assert_eq!(calls.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(collector.total_seen(), 3);
+        let results = collector.into_sorted_results();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].doc_id, 0);
+        assert_eq!(results[0].positions[0].0, 7);
+    }
+
+    #[test]
+    fn tuple_moves_owned_positions_to_single_position_collector() {
+        let mut positions = OwnedPositionCollector::default();
+        let mut count = CountCollector::new();
+        let input = vec![(7, vec![ScoredPosition::new(3, 1.0)])];
+        let input_ptr = input[0].1.as_ptr();
+
+        (&mut positions, &mut count).collect_owned(11, 2.0, input);
+
+        assert_eq!(positions.owned_calls, 1);
+        assert_eq!(positions.borrowed_calls, 0);
+        assert_eq!(positions.positions[0].1.as_ptr(), input_ptr);
+        assert_eq!(count.count(), 1);
+    }
+
+    #[test]
+    fn tuple_clones_for_all_but_final_position_collector() {
+        let mut first = OwnedPositionCollector::default();
+        let mut second = OwnedPositionCollector::default();
+        let mut count = CountCollector::new();
+        let input = vec![(7, vec![ScoredPosition::new(3, 1.0)])];
+        let input_ptr = input[0].1.as_ptr();
+
+        (&mut first, &mut count, &mut second).collect_owned(11, 2.0, input);
+
+        assert_eq!((first.owned_calls, first.borrowed_calls), (1, 0));
+        assert_eq!((second.owned_calls, second.borrowed_calls), (1, 0));
+        assert_ne!(first.positions[0].1.as_ptr(), input_ptr);
+        assert_eq!(second.positions[0].1.as_ptr(), input_ptr);
+        assert_eq!(count.count(), 1);
     }
 
     #[test]

--- a/hermes-core/src/query/fusion.rs
+++ b/hermes-core/src/query/fusion.rs
@@ -21,10 +21,16 @@
 use rustc_hash::FxHashMap;
 
 use super::vector::MultiValueCombiner;
-use super::{ScoredPosition, SearchResult};
+use super::{ScoredPosition, SearchResult, compare_search_results_desc};
 
 /// Default RRF rank constant (from Cormack et al., the standard choice).
 pub const DEFAULT_RRF_K: f32 = 60.0;
+/// Maximum independently executed lists accepted by the Searcher fusion API.
+pub const MAX_FUSION_SUB_QUERIES: usize = 16;
+/// Maximum aggregate list slots retained before fusion.
+pub const MAX_FUSION_CANDIDATE_SLOTS: usize = 200_000;
+/// Maximum per-ordinal chunk contributions materialized during fusion.
+pub const MAX_FUSION_CHUNK_SLOTS: usize = 500_000;
 
 /// Method for fusing multiple ranked result lists.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -74,7 +80,14 @@ pub fn fuse_ranked_lists(
     method: FusionMethod,
     limit: usize,
 ) -> Vec<SearchResult> {
-    let capacity = lists.iter().map(|(l, _)| l.len()).sum();
+    // Avoid reserving an attacker-controlled sum up front. The map can grow
+    // naturally if a trusted embedded caller intentionally fuses more.
+    const MAX_INITIAL_FUSION_CAPACITY: usize = 200_000;
+    let capacity = lists
+        .iter()
+        .map(|(list, _)| list.len())
+        .fold(0usize, usize::saturating_add)
+        .min(MAX_INITIAL_FUSION_CAPACITY);
     let mut fused: FxHashMap<(u128, u32), SearchResult> =
         FxHashMap::with_capacity_and_hasher(capacity, Default::default());
 
@@ -118,14 +131,10 @@ pub fn fuse_ranked_lists(
 
     let mut results: Vec<SearchResult> = fused.into_values().collect();
     if results.len() > limit {
-        results.select_nth_unstable_by(limit, |a, b| b.score.total_cmp(&a.score));
+        results.select_nth_unstable_by(limit, compare_search_results_desc);
         results.truncate(limit);
     }
-    results.sort_unstable_by(|a, b| {
-        b.score
-            .total_cmp(&a.score)
-            .then_with(|| a.doc_id.cmp(&b.doc_id))
-    });
+    results.sort_unstable_by(compare_search_results_desc);
     results
 }
 
@@ -238,15 +247,78 @@ pub fn fuse_ranked_lists_chunked(
         .collect();
 
     if results.len() > limit {
-        results.select_nth_unstable_by(limit, |a, b| b.score.total_cmp(&a.score));
+        results.select_nth_unstable_by(limit, compare_search_results_desc);
         results.truncate(limit);
     }
-    results.sort_unstable_by(|a, b| {
-        b.score
-            .total_cmp(&a.score)
-            .then_with(|| a.doc_id.cmp(&b.doc_id))
-    });
+    results.sort_unstable_by(compare_search_results_desc);
     results
+}
+
+/// Validated, bounded entry point for chunk-level fusion used by Searcher and
+/// the server. The legacy pure helper remains available for trusted embedded
+/// callers, while request-facing paths must account for ordinal expansion
+/// before allocating fusion maps.
+pub fn try_fuse_ranked_lists_chunked(
+    lists: Vec<(Vec<SearchResult>, f32)>,
+    method: FusionMethod,
+    combiner: MultiValueCombiner,
+    limit: usize,
+) -> Result<Vec<SearchResult>, String> {
+    if lists.is_empty() {
+        return Err("fusion requires at least one ranked list".to_string());
+    }
+    if lists.len() > MAX_FUSION_SUB_QUERIES {
+        return Err(format!(
+            "fusion supports at most {MAX_FUSION_SUB_QUERIES} ranked lists"
+        ));
+    }
+    if let FusionMethod::Rrf { k } = method
+        && (!k.is_finite() || k < 0.0)
+    {
+        return Err(format!(
+            "fusion RRF k must be finite and non-negative, got {k}"
+        ));
+    }
+    combiner.validate()?;
+
+    let mut candidates = 0usize;
+    let mut chunks = 0usize;
+    for (list_index, (list, weight)) in lists.iter().enumerate() {
+        if !weight.is_finite() || *weight < 0.0 {
+            return Err(format!(
+                "fusion list weight at index {list_index} must be finite and non-negative, \
+                 got {weight}"
+            ));
+        }
+        candidates = candidates
+            .checked_add(list.len())
+            .ok_or_else(|| "fusion candidate count overflow".to_string())?;
+        if candidates > MAX_FUSION_CANDIDATE_SLOTS {
+            return Err(format!(
+                "fusion contains more than {MAX_FUSION_CANDIDATE_SLOTS} candidate slots"
+            ));
+        }
+        for result in list {
+            let position_count = result
+                .positions
+                .iter()
+                .try_fold(0usize, |count, (_, positions)| {
+                    count.checked_add(positions.len())
+                })
+                .ok_or_else(|| "fusion chunk count overflow".to_string())?;
+            // Results without positions contribute one pseudo-chunk.
+            chunks = chunks
+                .checked_add(position_count.max(1))
+                .ok_or_else(|| "fusion chunk count overflow".to_string())?;
+            if chunks > MAX_FUSION_CHUNK_SLOTS {
+                return Err(format!(
+                    "fusion expands to more than {MAX_FUSION_CHUNK_SLOTS} ordinal chunks"
+                ));
+            }
+        }
+    }
+
+    Ok(fuse_ranked_lists_chunked(lists, method, combiner, limit))
 }
 
 #[cfg(test)]
@@ -424,6 +496,28 @@ mod tests {
         assert_eq!(fused[0].doc_id, 1);
         assert!((fused[0].score - 2.0 / 61.0).abs() < 1e-6);
         assert_eq!(fused.len(), 2);
+    }
+
+    #[test]
+    fn test_validated_chunked_fusion_rejects_invalid_parameters() {
+        assert!(
+            try_fuse_ranked_lists_chunked(
+                vec![(vec![result(1, 1.0)], -1.0)],
+                FusionMethod::default(),
+                MultiValueCombiner::Max,
+                10,
+            )
+            .is_err()
+        );
+        assert!(
+            try_fuse_ranked_lists_chunked(
+                vec![(vec![result(1, 1.0)], 1.0)],
+                FusionMethod::Rrf { k: f32::NAN },
+                MultiValueCombiner::Max,
+                10,
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/hermes-core/src/query/phrase.rs
+++ b/hermes-core/src/query/phrase.rs
@@ -121,35 +121,52 @@ fn build_phrase_scorer<'a>(
 // ── Shared early-return checks for phrase scorer ─────────────────────────
 //
 // Handles: empty terms, single-term delegation, no-positions fallback.
-// Parameterised on $scorer_fn + $($aw)* for async/sync.
+// Parameterised on the option-aware scorer function plus async/sync awaiting.
 macro_rules! phrase_early_returns {
     ($field:expr, $terms:expr, $reader:expr, $limit:expr,
-     $scorer_fn:ident $(, $aw:tt)*) => {
+     $scorer_fn:ident, $options:expr $(, $aw:tt)*) => {
         if $terms.is_empty() {
             return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
         }
         if $terms.len() == 1 {
             let tq = super::TermQuery::new($field, $terms[0].clone());
-            return tq.$scorer_fn($reader, $limit) $(. $aw)* ;
+            return tq.$scorer_fn($reader, $limit, $options) $(. $aw)* ;
         }
         if !$reader.has_positions($field) {
             let mut bq = super::BooleanQuery::new();
             for t in $terms.iter() {
                 bq = bq.must(super::TermQuery::new($field, t.clone()));
             }
-            return bq.$scorer_fn($reader, $limit) $(. $aw)* ;
+            return bq.$scorer_fn($reader, $limit, $options) $(. $aw)* ;
         }
     };
 }
 
 impl Query for PhraseQuery {
     fn scorer<'a>(&self, reader: &'a SegmentReader, limit: usize) -> ScorerFuture<'a> {
+        self.scorer_with_options(reader, limit, super::ScorerOptions::with_positions())
+    }
+
+    fn scorer_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: super::ScorerOptions,
+    ) -> ScorerFuture<'a> {
         let field = self.field;
         let terms = self.terms.clone();
         let slop = self.slop;
 
         Box::pin(async move {
-            phrase_early_returns!(field, terms, reader, limit, scorer, await);
+            phrase_early_returns!(
+                field,
+                terms,
+                reader,
+                limit,
+                scorer_with_options,
+                options,
+                await
+            );
 
             // Fetch postings + positions in parallel per term via futures::join!
             let mut term_data = Vec::with_capacity(terms.len());
@@ -174,7 +191,24 @@ impl Query for PhraseQuery {
         reader: &'a SegmentReader,
         limit: usize,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
-        phrase_early_returns!(self.field, self.terms, reader, limit, scorer_sync);
+        self.scorer_sync_with_options(reader, limit, super::ScorerOptions::with_positions())
+    }
+
+    #[cfg(feature = "sync")]
+    fn scorer_sync_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: super::ScorerOptions,
+    ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        phrase_early_returns!(
+            self.field,
+            self.terms,
+            reader,
+            limit,
+            scorer_sync_with_options,
+            options
+        );
 
         // Parallel fetch across all terms via rayon
         use rayon::prelude::*;

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -137,7 +137,9 @@ pub(super) fn prepare_per_field_grouping(
     }
 
     let num_groups = field_groups.len() + non_term_indices.len();
-    let per_field_limit = limit * num_groups;
+    let per_field_limit = limit
+        .saturating_mul(num_groups)
+        .min(reader.num_docs() as usize);
     let num_docs = reader.num_docs() as f32;
 
     let mut multi_term_groups = Vec::new();
@@ -166,6 +168,21 @@ pub(super) fn prepare_per_field_grouping(
 
 // ── Sparse MaxScore helpers ──────────────────────────────────────────────
 
+const MAX_SPARSE_EXECUTOR_RESULTS: usize = 200_000;
+
+pub(super) fn bounded_sparse_executor_limit(limit: usize, over_fetch_factor: f32) -> usize {
+    let factor = if over_fetch_factor.is_finite() && over_fetch_factor >= 1.0 {
+        over_fetch_factor as f64
+    } else {
+        1.0
+    };
+    let derived = (limit as f64 * factor).ceil();
+    if !derived.is_finite() || derived >= usize::MAX as f64 {
+        return MAX_SPARSE_EXECUTOR_RESULTS;
+    }
+    (derived as usize).min(MAX_SPARSE_EXECUTOR_RESULTS)
+}
+
 /// Build a sparse MaxScoreExecutor from decomposed sparse infos.
 ///
 /// Returns the executor + representative info (for combiner/field), or None
@@ -186,7 +203,11 @@ pub(crate) fn build_sparse_maxscore_executor<'a>(
     if query_terms.is_empty() {
         return None;
     }
-    let executor_limit = (limit as f32 * infos[0].over_fetch_factor).ceil() as usize;
+    // Sparse postings contain one entry per stored ordinal, so the raw heap
+    // may legitimately need to exceed the real document count before ordinal
+    // scores can be combined back into documents.
+    let executor_limit = bounded_sparse_executor_limit(limit, infos[0].over_fetch_factor)
+        .min(si.total_vectors as usize);
     let mut executor =
         MaxScoreExecutor::sparse(si, query_terms, executor_limit, infos[0].heap_factor)
             .with_metric_labels(
@@ -218,7 +239,8 @@ pub(crate) fn build_sparse_bmp_results(
     if query_terms.is_empty() {
         return None;
     }
-    let executor_limit = (limit as f32 * infos[0].over_fetch_factor).ceil() as usize;
+    let executor_limit = bounded_sparse_executor_limit(limit, infos[0].over_fetch_factor)
+        .min(bmp.num_virtual_docs as usize);
     let max_sb = infos[0].max_superblocks;
     let field_label = reader.schema().get_field_name(field).unwrap_or("?");
     match super::bmp::execute_bmp(
@@ -257,7 +279,8 @@ pub(crate) fn build_sparse_bmp_results_filtered(
     if query_terms.is_empty() {
         return None;
     }
-    let executor_limit = (limit as f32 * infos[0].over_fetch_factor).ceil() as usize;
+    let executor_limit = bounded_sparse_executor_limit(limit, infos[0].over_fetch_factor)
+        .min(bmp.num_virtual_docs as usize);
     let max_sb = infos[0].max_superblocks;
     let field_label = reader.schema().get_field_name(field).unwrap_or("?");
     match super::bmp::execute_bmp_filtered(

--- a/hermes-core/src/query/prefix.rs
+++ b/hermes-core/src/query/prefix.rs
@@ -1,6 +1,6 @@
 //! Prefix query — matches all documents containing any term that starts with a
 //! given prefix. Materializes the union of matching posting lists into a sorted
-//! doc ID set, giving O(log N) seek via `SortedVecDocSet`. Score is always 1.0
+//! doc ID set bounded by the segment's document count. Score is always 1.0
 //! (filter-style, like `RangeQuery`).
 
 use std::sync::Arc;
@@ -58,7 +58,7 @@ impl Query for PrefixQuery {
             if postings.is_empty() {
                 return Ok(Box::new(EmptyScorer) as Box<dyn Scorer>);
             }
-            let docs = materialize_union(&postings);
+            let docs = materialize_union(&postings, reader.num_docs());
             if docs.is_empty() {
                 return Ok(Box::new(EmptyScorer) as Box<dyn Scorer>);
             }
@@ -76,7 +76,7 @@ impl Query for PrefixQuery {
         if postings.is_empty() {
             return Ok(Box::new(EmptyScorer) as Box<dyn Scorer>);
         }
-        let docs = materialize_union(&postings);
+        let docs = materialize_union(&postings, reader.num_docs());
         if docs.is_empty() {
             return Ok(Box::new(EmptyScorer) as Box<dyn Scorer>);
         }
@@ -88,7 +88,10 @@ impl Query for PrefixQuery {
         let prefix = self.prefix.clone();
         Box::pin(async move {
             let postings = reader.get_prefix_postings(field, &prefix).await?;
-            Ok(postings.iter().map(|p| p.doc_count()).sum())
+            Ok(postings
+                .iter()
+                .fold(0u32, |sum, posting| sum.saturating_add(posting.doc_count()))
+                .min(reader.num_docs()))
         })
     }
 
@@ -166,11 +169,37 @@ impl Scorer for PrefixScorer {
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
-/// Iterate all posting lists, collect doc IDs, sort, and deduplicate.
-fn materialize_union(postings: &[BlockPostingList]) -> Vec<u32> {
-    let total: usize = postings.iter().map(|p| p.doc_count() as usize).sum();
-    let mut docs = Vec::with_capacity(total);
+/// Materialize a posting union using the smaller of two bounded scratch forms.
+/// Narrow prefixes append/sort doc IDs; broad, overlapping prefixes use a
+/// segment-sized bitset so duplicate postings cannot multiply memory.
+fn materialize_union(postings: &[BlockPostingList], num_docs: u32) -> Vec<u32> {
+    let posting_count = postings.iter().fold(0usize, |sum, posting| {
+        sum.saturating_add(posting.doc_count() as usize)
+    });
+    let posting_bytes = posting_count.saturating_mul(std::mem::size_of::<u32>());
+    let bitset_bytes = (num_docs as usize)
+        .div_ceil(64)
+        .saturating_mul(std::mem::size_of::<u64>());
 
+    if posting_bytes <= bitset_bytes {
+        let mut docs = Vec::with_capacity(posting_count);
+        for posting in postings {
+            let mut iter = posting.iterator();
+            loop {
+                let d = iter.doc();
+                if d == TERMINATED {
+                    break;
+                }
+                docs.push(d);
+                iter.advance();
+            }
+        }
+        docs.sort_unstable();
+        docs.dedup();
+        return docs;
+    }
+
+    let mut bitset = super::DocBitset::new(num_docs);
     for posting in postings {
         let mut iter = posting.iterator();
         loop {
@@ -178,13 +207,20 @@ fn materialize_union(postings: &[BlockPostingList]) -> Vec<u32> {
             if d == TERMINATED {
                 break;
             }
-            docs.push(d);
+            bitset.set(d);
             iter.advance();
         }
     }
 
-    docs.sort_unstable();
-    docs.dedup();
+    let mut docs = Vec::with_capacity(bitset.count() as usize);
+    for (word_idx, &word) in bitset.bits.iter().enumerate() {
+        let mut remaining = word;
+        while remaining != 0 {
+            let bit = remaining.trailing_zeros() as usize;
+            docs.push((word_idx * 64 + bit) as u32);
+            remaining &= remaining - 1;
+        }
+    }
     docs
 }
 
@@ -194,8 +230,32 @@ mod tests {
 
     #[test]
     fn test_materialize_union_empty() {
-        let docs = materialize_union(&[]);
+        let docs = materialize_union(&[], 0);
         assert!(docs.is_empty());
+    }
+
+    #[test]
+    fn test_materialize_union_deduplicates() {
+        let mut left = crate::structures::PostingList::new();
+        left.push(1, 1);
+        left.push(5, 1);
+        left.push(9, 1);
+        let mut right = crate::structures::PostingList::new();
+        right.push(2, 1);
+        right.push(5, 1);
+        right.push(10, 1);
+        let postings = vec![
+            BlockPostingList::from_posting_list(&left).unwrap(),
+            BlockPostingList::from_posting_list(&right).unwrap(),
+        ];
+
+        assert_eq!(materialize_union(&postings, 11), vec![1, 2, 5, 9, 10]);
+        // A huge segment with a narrow prefix takes the posting-vector path;
+        // it must not allocate a num_docs-sized bitset.
+        assert_eq!(
+            materialize_union(&postings[..1], 1_000_000_000),
+            vec![1, 5, 9]
+        );
     }
 
     #[test]

--- a/hermes-core/src/query/reranker.rs
+++ b/hermes-core/src/query/reranker.rs
@@ -3,15 +3,176 @@
 //! Optimized for throughput:
 //! - Candidates grouped by segment for batched I/O
 //! - Flat indexes sorted for sequential mmap access (OS readahead)
-//! - Single SIMD batch-score call per segment (not per candidate)
-//! - Reusable buffers across segments (no per-candidate heap allocation)
+//! - Bounded SIMD batches (not per-candidate scoring or unbounded raw buffers)
+//! - Reusable per-segment scratch buffers
 //! - unit_norm fast path: skip per-vector norm when vectors are pre-normalized
 
-use rustc_hash::FxHashMap;
+use futures::{StreamExt, TryStreamExt};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
 use crate::dsl::Field;
 
-use super::{MultiValueCombiner, ScoredPosition, SearchResult};
+use super::{MultiValueCombiner, ScoredPosition, SearchResult, compare_search_results_desc};
+
+/// Maximum stored vectors expanded from the document candidate set by one L2
+/// rerank request. Candidate documents are bounded separately by the server;
+/// this closes the multi-value/ordinal multiplier.
+const MAX_L2_RERANK_VECTORS: usize = 500_000;
+const MAX_L2_RERANK_VECTOR_BYTES: usize = 512 * 1024 * 1024;
+const RERANK_SCORE_BATCH: usize = 4_096;
+const MAX_RERANK_RAW_BATCH_BYTES: usize = 8 * 1024 * 1024;
+const MAX_CONCURRENT_RERANK_SEGMENTS: usize = 8;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RerankerKind {
+    Dense,
+    Binary,
+}
+
+fn validate_reranker_config<D: crate::directories::Directory + 'static>(
+    searcher: &crate::index::Searcher<D>,
+    config: &RerankerConfig,
+) -> crate::error::Result<RerankerKind> {
+    if !config.rrf_k.is_finite() || config.rrf_k < 0.0 {
+        return Err(crate::Error::Query(format!(
+            "reranker rrf_k must be finite and non-negative, got {}",
+            config.rrf_k
+        )));
+    }
+    config.combiner.validate().map_err(crate::Error::Query)?;
+    if config.vector.is_empty() == config.binary_vector.is_empty() {
+        return Err(crate::Error::Query(
+            "reranker must provide exactly one of vector or binary_vector".to_string(),
+        ));
+    }
+
+    let entry = searcher
+        .schema()
+        .get_field_entry(config.field)
+        .ok_or_else(|| crate::Error::FieldNotFound(config.field.0.to_string()))?;
+    if !config.binary_vector.is_empty() {
+        if entry.field_type != crate::dsl::FieldType::BinaryDenseVector {
+            return Err(crate::Error::InvalidFieldType {
+                expected: "binary_dense_vector".to_string(),
+                got: format!("{:?}", entry.field_type),
+            });
+        }
+        let field_config = entry.binary_dense_vector_config.as_ref().ok_or_else(|| {
+            crate::Error::Schema(format!(
+                "binary dense vector field '{}' has no configuration",
+                entry.name
+            ))
+        })?;
+        if field_config.dim == 0 || !field_config.dim.is_multiple_of(8) {
+            return Err(crate::Error::Schema(format!(
+                "binary dense vector field '{}' has invalid dimension {}",
+                entry.name, field_config.dim
+            )));
+        }
+        if config.binary_vector.len() != field_config.byte_len() {
+            return Err(crate::Error::Query(format!(
+                "reranker binary vector byte length {} does not match field '{}' byte length {}",
+                config.binary_vector.len(),
+                entry.name,
+                field_config.byte_len()
+            )));
+        }
+        if config.matryoshka_dims.is_some() {
+            return Err(crate::Error::Query(
+                "reranker matryoshka_dims is not supported for binary vectors".to_string(),
+            ));
+        }
+        return Ok(RerankerKind::Binary);
+    }
+
+    if entry.field_type != crate::dsl::FieldType::DenseVector {
+        return Err(crate::Error::InvalidFieldType {
+            expected: "dense_vector".to_string(),
+            got: format!("{:?}", entry.field_type),
+        });
+    }
+    let field_config = entry.dense_vector_config.as_ref().ok_or_else(|| {
+        crate::Error::Schema(format!(
+            "dense vector field '{}' has no configuration",
+            entry.name
+        ))
+    })?;
+    if config.vector.len() != field_config.dim {
+        return Err(crate::Error::Query(format!(
+            "reranker vector dimension {} does not match field '{}' dimension {}",
+            config.vector.len(),
+            entry.name,
+            field_config.dim
+        )));
+    }
+    if let Some((index, value)) = config
+        .vector
+        .iter()
+        .enumerate()
+        .find(|(_, value)| !value.is_finite())
+    {
+        return Err(crate::Error::Query(format!(
+            "reranker vector contains non-finite value {value} at index {index}"
+        )));
+    }
+    if config.unit_norm != field_config.unit_norm {
+        return Err(crate::Error::Query(format!(
+            "reranker unit_norm={} does not match field '{}' unit_norm={}",
+            config.unit_norm, entry.name, field_config.unit_norm
+        )));
+    }
+    if let Some(dims) = config.matryoshka_dims
+        && (dims == 0 || dims > field_config.dim)
+    {
+        return Err(crate::Error::Query(format!(
+            "reranker matryoshka_dims must be in 1..={}, got {dims}",
+            field_config.dim
+        )));
+    }
+    Ok(RerankerKind::Dense)
+}
+
+fn reserve_rerank_vectors(
+    vector_budget: &AtomicUsize,
+    byte_budget: &AtomicUsize,
+    count: usize,
+    vector_byte_size: usize,
+) -> crate::error::Result<()> {
+    let bytes = count.checked_mul(vector_byte_size).ok_or_else(|| {
+        crate::Error::Query("reranker stored-vector byte budget overflow".to_string())
+    })?;
+    byte_budget
+        .fetch_update(AtomicOrdering::Relaxed, AtomicOrdering::Relaxed, |used| {
+            used.checked_add(bytes)
+                .filter(|&next| next <= MAX_L2_RERANK_VECTOR_BYTES)
+        })
+        .map_err(|used| {
+            crate::Error::Query(format!(
+                "reranker reads more than {MAX_L2_RERANK_VECTOR_BYTES} stored vector bytes \
+                 (already reserved {used}, next document needs {bytes})"
+            ))
+        })?;
+
+    vector_budget
+        .fetch_update(AtomicOrdering::Relaxed, AtomicOrdering::Relaxed, |used| {
+            used.checked_add(count)
+                .filter(|&next| next <= MAX_L2_RERANK_VECTORS)
+        })
+        .map(|_| ())
+        .map_err(|used| {
+            crate::Error::Query(format!(
+                "reranker expands to more than {MAX_L2_RERANK_VECTORS} stored vectors \
+                 (already reserved {used}, next document has {count})"
+            ))
+        })
+}
+
+#[inline]
+fn rerank_batch_len(vector_byte_size: usize) -> usize {
+    RERANK_SCORE_BATCH.min((MAX_RERANK_RAW_BATCH_BYTES / vector_byte_size.max(1)).max(1))
+}
 
 /// Precomputed query data for dense reranking (computed once, reused across segments).
 struct PrecompQuery<'a> {
@@ -30,32 +191,49 @@ fn score_batch_precomp(
     dim: usize,
     scores: &mut [f32],
     unit_norm: bool,
-) {
+) -> crate::error::Result<()> {
     let query = pq.query;
     let inv_norm_q = pq.inv_norm_q;
     let query_f16 = pq.query_f16;
     use crate::dsl::DenseVectorQuantization;
     use crate::structures::simd;
+    let element_size = quant.element_size();
+    let required_bytes = scores
+        .len()
+        .checked_mul(dim)
+        .and_then(|elements| elements.checked_mul(element_size))
+        .ok_or_else(|| {
+            crate::Error::Corruption("dense reranker batch size overflow".to_string())
+        })?;
+    if raw.len() < required_bytes {
+        return Err(crate::Error::Corruption(format!(
+            "dense reranker batch is truncated: need {required_bytes} bytes, got {}",
+            raw.len()
+        )));
+    }
+    if matches!(
+        quant,
+        DenseVectorQuantization::F32 | DenseVectorQuantization::F16
+    ) && required_bytes > 0
+        && !(raw.as_ptr() as usize).is_multiple_of(element_size)
+    {
+        return Err(crate::Error::Corruption(format!(
+            "dense reranker {:?} data is not {}-byte aligned",
+            quant, element_size
+        )));
+    }
     match (quant, unit_norm) {
         (DenseVectorQuantization::F32, false) => {
             let num_floats = scores.len() * dim;
             // Safety: Vec<u8> from the global allocator is guaranteed to be at least
             // 8-byte aligned on 64-bit platforms (aligned to max_align_t). Assert at
             // runtime to guard against custom allocators with weaker guarantees.
-            assert!(
-                (raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()),
-                "f32 vector data not 4-byte aligned"
-            );
             let vectors: &[f32] =
                 unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const f32, num_floats) };
             simd::batch_cosine_scores_precomp(query, vectors, dim, scores, inv_norm_q);
         }
         (DenseVectorQuantization::F32, true) => {
             let num_floats = scores.len() * dim;
-            assert!(
-                (raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()),
-                "f32 vector data not 4-byte aligned"
-            );
             let vectors: &[f32] =
                 unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const f32, num_floats) };
             simd::batch_dot_scores_precomp(query, vectors, dim, scores, inv_norm_q);
@@ -73,9 +251,13 @@ fn score_batch_precomp(
             simd::batch_dot_scores_u8_precomp(query, raw, dim, scores, inv_norm_q);
         }
         (DenseVectorQuantization::Binary, _) => {
-            unreachable!("Binary quantization should not reach score_batch_precomp");
+            return Err(crate::Error::InvalidFieldType {
+                expected: "non-binary dense vector".to_string(),
+                got: "binary dense vector".to_string(),
+            });
         }
     }
+    Ok(())
 }
 
 /// Configuration for L2 dense/binary vector reranking
@@ -174,16 +356,15 @@ fn apply_rrf(
             + super::fusion::rrf_contribution(k, l2_idx + 1);
     }
 
-    scored.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
+    scored.sort_unstable_by(compare_search_results_desc);
     scored.truncate(final_limit);
 }
 
 /// Rerank L1 candidates by exact dense vector distance.
 ///
 /// Groups candidates by segment for batched I/O, sorts flat indexes for
-/// sequential mmap access, and scores all vectors in a single SIMD batch
-/// per segment. Reuses buffers across segments to avoid per-candidate
-/// heap allocation.
+/// sequential mmap access, and scores vectors in bounded SIMD batches.
+/// Scratch memory remains independent of the candidate count.
 ///
 /// When `unit_norm` is set in the config, scoring uses dot-product only
 /// (skips per-vector norm computation — ~40% less work).
@@ -193,13 +374,16 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
     config: &RerankerConfig,
     final_limit: usize,
 ) -> crate::error::Result<Vec<SearchResult>> {
-    // Dispatch: binary vector → Hamming, f32 vector → cosine/dot
-    if !config.binary_vector.is_empty() {
-        return rerank_binary(searcher, candidates, config, final_limit).await;
+    // Validate before empty-result early returns so malformed requests do not
+    // succeed or fail depending on whether the first-stage query found hits.
+    let kind = validate_reranker_config(searcher, config)?;
+    if final_limit == 0 || candidates.is_empty() {
+        return Ok(Vec::new());
     }
 
-    if config.vector.is_empty() || candidates.is_empty() {
-        return Ok(Vec::new());
+    // Dispatch: binary vector → Hamming, f32 vector → cosine/dot.
+    if kind == RerankerKind::Binary {
+        return rerank_binary(searcher, candidates, config, final_limit).await;
     }
 
     let t0 = std::time::Instant::now();
@@ -237,15 +421,16 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
     }
 
     // ── Phase 2: Per-segment batched resolve + read + score (concurrent) ──
-    // Each segment runs independently: resolve flat indexes, read vectors,
-    // and score — all overlapping I/O across segments via join_all.
+    // Bound the fan-out so many immutable segments cannot each retain a raw
+    // scoring buffer and candidate scratch at the same time.
     let query_ref = pq.query;
     let inv_norm_q_val = pq.inv_norm_q;
     let query_f16_ref = pq.query_f16;
+    let vector_budget = Arc::new(AtomicUsize::new(0));
+    let byte_budget = Arc::new(AtomicUsize::new(0));
 
-    let segment_futs: Vec<_> = segment_groups
-        .into_iter()
-        .map(|(si, candidate_indices)| {
+    let segment_futs = futures::stream::iter(segment_groups.into_iter().map(
+        |(si, candidate_indices)| {
             #[allow(clippy::redundant_locals)]
             let segments = &segments;
             #[allow(clippy::redundant_locals)]
@@ -256,6 +441,8 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
             let query_f16_ref = query_f16_ref;
             #[allow(clippy::redundant_locals)]
             let config = config;
+            let vector_budget = Arc::clone(&vector_budget);
+            let byte_budget = Arc::clone(&byte_budget);
             async move {
                 let mut scores: Vec<(usize, u32, f32)> = Vec::new();
                 let mut vectors = 0usize;
@@ -269,7 +456,15 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
                     ));
                 };
                 if lazy_flat.dim != query_dim {
-                    return Ok((scores, vectors, candidate_indices.len() as u32));
+                    return Err(crate::Error::Corruption(format!(
+                        "dense reranker field {field_id} stores dimension {}, expected {query_dim}",
+                        lazy_flat.dim
+                    )));
+                }
+                if lazy_flat.quantization == crate::dsl::DenseVectorQuantization::Binary {
+                    return Err(crate::Error::Corruption(format!(
+                        "dense reranker field {field_id} unexpectedly uses binary storage"
+                    )));
                 }
 
                 let vbs = lazy_flat.vector_byte_size();
@@ -284,6 +479,7 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
                         seg_skipped += 1;
                         continue;
                     }
+                    reserve_rerank_vectors(&vector_budget, &byte_budget, count, vbs)?;
                     for j in 0..count {
                         let (_, ordinal) = lazy_flat.get_doc_id(start + j);
                         resolved.push((ci, start + j, ordinal as u32));
@@ -297,43 +493,17 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
                 let n = resolved.len();
                 vectors = n;
 
-                // Sort by flat_idx for sequential mmap access
+                // Sort by flat_idx for sequential mmap access. Prefetch only
+                // each bounded scoring chunk below; advising the entire
+                // candidate set at once can flood the page cache.
                 resolved.sort_unstable_by_key(|&(_, flat_idx, _)| flat_idx);
 
-                let first_idx = resolved[0].1;
-                let last_idx = resolved[n - 1].1;
-                let span = last_idx - first_idx + 1;
-
-                let mut raw_buf: Vec<u8> = vec![0u8; n * vbs];
-
-                if span <= n * 4 {
-                    let range_bytes = lazy_flat
-                        .read_vectors_batch(first_idx, span)
-                        .await
-                        .map_err(crate::error::Error::Io)?;
-                    let rb = range_bytes.as_slice();
-                    for (buf_idx, &(_, flat_idx, _)) in resolved.iter().enumerate() {
-                        let rel = flat_idx - first_idx;
-                        let src = &rb[rel * vbs..(rel + 1) * vbs];
-                        raw_buf[buf_idx * vbs..(buf_idx + 1) * vbs].copy_from_slice(src);
-                    }
-                } else {
-                    // Scattered reads: batch-prefetch candidate pages so
-                    // page-ins overlap instead of one major fault per vector
-                    // (same treatment as the ANN rerank path).
-                    #[cfg(feature = "native")]
-                    lazy_flat.prefetch_vectors(resolved.iter().map(|&(_, flat_idx, _)| flat_idx));
-
-                    for (buf_idx, &(_, flat_idx, _)) in resolved.iter().enumerate() {
-                        lazy_flat
-                            .read_vector_raw_into(
-                                flat_idx,
-                                &mut raw_buf[buf_idx * vbs..(buf_idx + 1) * vbs],
-                            )
-                            .await
-                            .map_err(crate::error::Error::Io)?;
-                    }
-                }
+                let batch_len = rerank_batch_len(vbs);
+                let max_batch = batch_len.min(n);
+                let max_raw_len = max_batch.checked_mul(vbs).ok_or_else(|| {
+                    crate::Error::Query("dense reranker buffer size overflow".into())
+                })?;
+                let mut raw_buf = vec![0u8; max_raw_len];
 
                 // Reconstruct PrecompQuery from captured components
                 let pq = PrecompQuery {
@@ -342,12 +512,10 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
                     query_f16: query_f16_ref,
                 };
 
-                let mut scores_buf: Vec<f32> = vec![0.0; n];
-
                 // Matryoshka pre-filter
                 if let Some(mdims) = config.matryoshka_dims
                     && mdims < query_dim
-                    && n > final_limit * 2
+                    && n > final_limit.saturating_mul(2)
                 {
                     let trunc_dim = mdims;
                     let trunc_pq = PrecompQuery {
@@ -367,108 +535,170 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
                         query_f16: &query_f16_ref[..trunc_dim],
                     };
                     let trunc_vbs = trunc_dim * quant.element_size();
-                    for i in 0..n {
-                        let vec_start = i * vbs;
-                        score_batch_precomp(
-                            &trunc_pq,
-                            &raw_buf[vec_start..vec_start + trunc_vbs],
-                            quant,
-                            trunc_dim,
-                            &mut scores_buf[i..i + 1],
-                            config.unit_norm,
+                    let mut scores_buf = vec![0.0f32; n];
+                    for (chunk_idx, chunk) in resolved.chunks(batch_len).enumerate() {
+                        // Pack only the Matryoshka prefix for this batch. The
+                        // previous full-vector reads pulled every unused tail
+                        // into the page cache and then reread surviving vectors.
+                        let raw_len = chunk.len().checked_mul(trunc_vbs).ok_or_else(|| {
+                            crate::Error::Query("dense reranker buffer size overflow".into())
+                        })?;
+                        let raw = &mut raw_buf[..raw_len];
+                        for (buf_idx, &(_, flat_idx, _)) in chunk.iter().enumerate() {
+                            lazy_flat
+                                .read_vector_prefix_raw_into(
+                                    flat_idx,
+                                    trunc_vbs,
+                                    &mut raw[buf_idx * trunc_vbs..(buf_idx + 1) * trunc_vbs],
+                                )
+                                .await
+                                .map_err(crate::error::Error::Io)?;
+                        }
+                        let score_base = chunk_idx * batch_len;
+                        searcher.install_search_cpu(|| {
+                            score_batch_precomp(
+                                &trunc_pq,
+                                raw,
+                                quant,
+                                trunc_dim,
+                                &mut scores_buf[score_base..score_base + chunk.len()],
+                                config.unit_norm,
+                            )
+                        })?;
+                    }
+
+                    // Rank approximate *documents*, using every stored value
+                    // and the configured combiner. Selecting individual
+                    // vectors here can discard the other values needed by
+                    // Avg/Sum/LSE and can choose the wrong Max document.
+                    let mut approximate_ordinals: FxHashMap<usize, Vec<(u32, f32)>> =
+                        FxHashMap::default();
+                    for (resolved_index, &(ci, _, ordinal)) in resolved.iter().enumerate() {
+                        approximate_ordinals
+                            .entry(ci)
+                            .or_default()
+                            .push((ordinal, scores_buf[resolved_index]));
+                    }
+                    let mut ranked: Vec<(usize, f32)> = approximate_ordinals
+                        .into_iter()
+                        .map(|(ci, ordinals)| (ci, config.combiner.combine(&ordinals)))
+                        .collect();
+                    searcher.install_search_cpu(|| {
+                        ranked.sort_unstable_by(|a, b| {
+                            b.1.total_cmp(&a.1)
+                                .then_with(|| candidates[a.0].doc_id.cmp(&candidates[b.0].doc_id))
+                        });
+                    });
+                    let approximate_docs = ranked.len();
+                    let survivor_doc_limit = final_limit.saturating_mul(2).min(approximate_docs);
+                    let survivor_docs: FxHashSet<usize> = ranked
+                        .into_iter()
+                        .take(survivor_doc_limit)
+                        .map(|(ci, _)| ci)
+                        .collect();
+                    // Full-score every value belonging to each surviving doc;
+                    // the final combiner must never see a truncated value set.
+                    let mut survivor_entries: Vec<_> = resolved
+                        .iter()
+                        .copied()
+                        .filter(|(ci, _, _)| survivor_docs.contains(ci))
+                        .collect();
+                    survivor_entries.sort_unstable_by_key(|&(_, flat_idx, _)| flat_idx);
+                    let mut full_scores = vec![0.0f32; max_batch.min(survivor_entries.len())];
+                    scores.reserve(survivor_entries.len());
+                    for chunk in survivor_entries.chunks(batch_len) {
+                        #[cfg(feature = "native")]
+                        lazy_flat.prefetch_vectors(
+                            chunk.iter().map(|&(_, flat_idx, _)| flat_idx),
                         );
-                    }
-
-                    let per_doc_cap: usize = match &config.combiner {
-                        super::MultiValueCombiner::Max => 1,
-                        super::MultiValueCombiner::WeightedTopK { k, .. } => *k,
-                        _ => usize::MAX,
-                    };
-
-                    let mut ranked: Vec<(usize, f32)> =
-                        (0..n).map(|i| (i, scores_buf[i])).collect();
-                    ranked.sort_unstable_by(|a, b| b.1.total_cmp(&a.1));
-
-                    let mut survivors: Vec<(usize, f32)> =
-                        Vec::with_capacity(n.min(final_limit * 4));
-                    let mut doc_vector_counts: FxHashMap<usize, usize> = FxHashMap::default();
-                    let mut unique_docs = 0usize;
-
-                    for &(orig_idx, score) in &ranked {
-                        let ci = resolved[orig_idx].0;
-                        let count = doc_vector_counts.entry(ci).or_insert(0);
-
-                        if *count >= per_doc_cap {
-                            continue;
+                        let raw_len = chunk.len().checked_mul(vbs).ok_or_else(|| {
+                            crate::Error::Query("dense reranker buffer size overflow".into())
+                        })?;
+                        let raw = &mut raw_buf[..raw_len];
+                        for (buf_idx, &(_, flat_idx, _)) in chunk.iter().enumerate() {
+                            lazy_flat
+                                .read_vector_raw_into(
+                                    flat_idx,
+                                    &mut raw[buf_idx * vbs..(buf_idx + 1) * vbs],
+                                )
+                                .await
+                                .map_err(crate::error::Error::Io)?;
                         }
-                        if *count == 0 {
-                            unique_docs += 1;
-                        }
-                        *count += 1;
-                        survivors.push((orig_idx, score));
-
-                        if unique_docs >= final_limit && survivors.len() >= final_limit * 2 {
-                            break;
+                        searcher.install_search_cpu(|| {
+                            score_batch_precomp(
+                                &pq,
+                                raw,
+                                quant,
+                                query_dim,
+                                &mut full_scores[..chunk.len()],
+                                config.unit_norm,
+                            )
+                        })?;
+                        for (buf_idx, &(ci, _, ordinal)) in chunk.iter().enumerate() {
+                            scores.push((ci, ordinal, full_scores[buf_idx]));
                         }
                     }
 
-                    scores.reserve(survivors.len());
-                    for &(orig_idx, _) in &survivors {
-                        let vec_start = orig_idx * vbs;
-                        let mut score = 0.0f32;
-                        score_batch_precomp(
-                            &pq,
-                            &raw_buf[vec_start..vec_start + vbs],
-                            quant,
-                            query_dim,
-                            std::slice::from_mut(&mut score),
-                            config.unit_norm,
-                        );
-                        let (ci, _, ordinal) = resolved[orig_idx];
-                        scores.push((ci, ordinal, score));
-                    }
-
-                    let filtered = n - survivors.len();
+                    let survivor_vectors = survivor_entries.len();
                     log::debug!(
-                        "[reranker] matryoshka pre-filter: {}/{} dims, {}/{} vectors survived from {} unique docs (filtered {}, per_doc_cap={})",
+                        "[reranker] matryoshka pre-filter: {}/{} dims, {}/{} docs and {}/{} vectors survived",
                         trunc_dim,
                         query_dim,
-                        survivors.len(),
+                        survivor_docs.len(),
+                        approximate_docs,
+                        survivor_vectors,
                         n,
-                        unique_docs,
-                        filtered,
-                        per_doc_cap
                     );
                 } else {
-                    score_batch_precomp(
-                        &pq,
-                        &raw_buf[..n * vbs],
-                        quant,
-                        query_dim,
-                        &mut scores_buf[..n],
-                        config.unit_norm,
-                    );
-
+                    let mut scores_buf = vec![0.0f32; max_batch];
                     scores.reserve(n);
-                    for (buf_idx, &(ci, _, ordinal)) in resolved.iter().enumerate() {
-                        scores.push((ci, ordinal, scores_buf[buf_idx]));
+                    for chunk in resolved.chunks(batch_len) {
+                        #[cfg(feature = "native")]
+                        lazy_flat.prefetch_vectors(
+                            chunk.iter().map(|&(_, flat_idx, _)| flat_idx),
+                        );
+                        let raw_len = chunk.len().checked_mul(vbs).ok_or_else(|| {
+                            crate::Error::Query("dense reranker buffer size overflow".into())
+                        })?;
+                        let raw = &mut raw_buf[..raw_len];
+                        for (buf_idx, &(_, flat_idx, _)) in chunk.iter().enumerate() {
+                            lazy_flat
+                                .read_vector_raw_into(
+                                    flat_idx,
+                                    &mut raw[buf_idx * vbs..(buf_idx + 1) * vbs],
+                                )
+                                .await
+                                .map_err(crate::error::Error::Io)?;
+                        }
+                        searcher.install_search_cpu(|| {
+                            score_batch_precomp(
+                                &pq,
+                                raw,
+                                quant,
+                                query_dim,
+                                &mut scores_buf[..chunk.len()],
+                                config.unit_norm,
+                            )
+                        })?;
+                        for (buf_idx, &(ci, _, ordinal)) in chunk.iter().enumerate() {
+                            scores.push((ci, ordinal, scores_buf[buf_idx]));
+                        }
                     }
                 }
 
                 Ok((scores, vectors, seg_skipped))
             }
-        })
-        .collect();
-
-    let results = futures::future::join_all(segment_futs).await;
+        },
+    ))
+    .buffer_unordered(MAX_CONCURRENT_RERANK_SEGMENTS);
+    futures::pin_mut!(segment_futs);
 
     let mut all_scores: Vec<(usize, u32, f32)> = Vec::new();
     let mut total_vectors = 0usize;
-    for result in results {
-        let (scores, vectors, seg_skipped) = result?;
+    while let Some((scores, vectors, seg_skipped)) = segment_futs.try_next().await? {
         all_scores.extend(scores);
-        total_vectors += vectors;
-        skipped += seg_skipped;
+        total_vectors = total_vectors.saturating_add(vectors);
+        skipped = skipped.saturating_add(seg_skipped);
     }
 
     let read_score_elapsed = t0.elapsed();
@@ -517,7 +747,7 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
         });
     }
 
-    scored.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
+    scored.sort_unstable_by(compare_search_results_desc);
 
     if config.rrf_k > 0.0 {
         apply_rrf(candidates, &mut scored, config.rrf_k, final_limit);
@@ -570,23 +800,35 @@ async fn rerank_binary<D: crate::directories::Directory + 'static>(
         }
     }
 
-    // Concurrent per-segment scoring (same pattern as dense reranker)
-    let segment_futs: Vec<_> = segment_groups
-        .into_iter()
-        .map(|(seg_idx, cand_indices)| {
+    // Bounded concurrent per-segment scoring (same pattern as dense reranker).
+    let vector_budget = Arc::new(AtomicUsize::new(0));
+    let byte_budget = Arc::new(AtomicUsize::new(0));
+    let segment_futs = futures::stream::iter(segment_groups.into_iter().map(
+        |(seg_idx, cand_indices)| {
             #[allow(clippy::redundant_locals)]
             let segments = &segments;
             #[allow(clippy::redundant_locals)]
             let candidates = candidates;
+            let vector_budget = Arc::clone(&vector_budget);
+            let byte_budget = Arc::clone(&byte_budget);
             async move {
                 let mut scores: Vec<(usize, u32, f32)> = Vec::new();
 
                 let Some(lazy_flat) = segments[seg_idx].flat_vectors().get(&field_id) else {
                     return Ok::<_, crate::error::Error>(scores);
                 };
+                if lazy_flat.quantization != crate::dsl::DenseVectorQuantization::Binary
+                    || !lazy_flat.dim.is_multiple_of(8)
+                {
+                    return Err(crate::Error::Corruption(format!(
+                        "binary reranker field {field_id} has invalid flat-vector metadata"
+                    )));
+                }
                 let vbs = lazy_flat.vector_byte_size();
                 if vbs != byte_len {
-                    return Ok(scores);
+                    return Err(crate::Error::Corruption(format!(
+                        "binary reranker field {field_id} stores {vbs} bytes/vector, expected {byte_len}"
+                    )));
                 }
 
                 // Resolve flat indexes
@@ -594,6 +836,7 @@ async fn rerank_binary<D: crate::directories::Directory + 'static>(
                 for &ci in &cand_indices {
                     let doc_id = candidates[ci].doc_id;
                     let (start, count) = lazy_flat.flat_indexes_for_doc_range(doc_id);
+                    reserve_rerank_vectors(&vector_budget, &byte_budget, count, vbs)?;
                     for j in 0..count {
                         resolved.push((ci, start + j));
                     }
@@ -605,62 +848,56 @@ async fn rerank_binary<D: crate::directories::Directory + 'static>(
                 resolved.sort_unstable_by_key(|&(_, flat_idx)| flat_idx);
 
                 let n = resolved.len();
-                let first_idx = resolved[0].1;
-                let last_idx = resolved[n - 1].1;
-                let span = last_idx - first_idx + 1;
+                let batch_len = rerank_batch_len(vbs);
+                let max_batch = batch_len.min(n);
+                let max_raw_len = max_batch.checked_mul(vbs).ok_or_else(|| {
+                    crate::Error::Query("binary reranker buffer size overflow".into())
+                })?;
+                let mut raw_buf = vec![0u8; max_raw_len];
+                let mut scores_buf = vec![0f32; max_batch];
+                scores.reserve(n);
 
-                let mut raw_buf = vec![0u8; n * vbs];
-
-                if span <= n * 4 {
-                    let range_bytes = lazy_flat
-                        .read_vectors_batch(first_idx, span)
-                        .await
-                        .map_err(crate::error::Error::Io)?;
-                    let rb = range_bytes.as_slice();
-                    for (buf_idx, &(_, flat_idx)) in resolved.iter().enumerate() {
-                        let rel = flat_idx - first_idx;
-                        raw_buf[buf_idx * vbs..(buf_idx + 1) * vbs]
-                            .copy_from_slice(&rb[rel * vbs..(rel + 1) * vbs]);
-                    }
-                } else {
-                    for (buf_idx, &(_, flat_idx)) in resolved.iter().enumerate() {
+                for chunk in resolved.chunks(batch_len) {
+                    let raw_len = chunk.len().checked_mul(vbs).ok_or_else(|| {
+                        crate::Error::Query("binary reranker buffer size overflow".into())
+                    })?;
+                    let raw = &mut raw_buf[..raw_len];
+                    for (buf_idx, &(_, flat_idx)) in chunk.iter().enumerate() {
                         lazy_flat
                             .read_vector_raw_into(
                                 flat_idx,
-                                &mut raw_buf[buf_idx * vbs..(buf_idx + 1) * vbs],
+                                &mut raw[buf_idx * vbs..(buf_idx + 1) * vbs],
                             )
                             .await
                             .map_err(crate::error::Error::Io)?;
                     }
-                }
+                    searcher.install_search_cpu(|| {
+                        crate::structures::simd::batch_hamming_scores(
+                            query,
+                            raw,
+                            byte_len,
+                            lazy_flat.dim,
+                            &mut scores_buf[..chunk.len()],
+                        );
+                    });
 
-                // Batch Hamming scoring
-                let dim_bits = lazy_flat.dim;
-                let mut scores_buf = vec![0f32; n];
-                crate::structures::simd::batch_hamming_scores(
-                    query,
-                    &raw_buf,
-                    byte_len,
-                    dim_bits,
-                    &mut scores_buf,
-                );
-
-                for (buf_idx, &(ci, flat_idx)) in resolved.iter().enumerate() {
-                    let (_, ordinal) = lazy_flat.get_doc_id(flat_idx);
-                    scores.push((ci, ordinal as u32, scores_buf[buf_idx]));
+                    for (buf_idx, &(ci, flat_idx)) in chunk.iter().enumerate() {
+                        let (_, ordinal) = lazy_flat.get_doc_id(flat_idx);
+                        scores.push((ci, ordinal as u32, scores_buf[buf_idx]));
+                    }
                 }
 
                 Ok(scores)
             }
-        })
-        .collect();
-
-    let results = futures::future::join_all(segment_futs).await;
+        },
+    ))
+    .buffer_unordered(MAX_CONCURRENT_RERANK_SEGMENTS);
+    futures::pin_mut!(segment_futs);
 
     // Combine ordinal scores per candidate and apply combiner
     let mut cand_ordinal_scores: FxHashMap<usize, Vec<(u32, f32)>> = FxHashMap::default();
-    for result in results {
-        for (ci, ordinal, score) in result? {
+    while let Some(scores) = segment_futs.try_next().await? {
+        for (ci, ordinal, score) in scores {
             cand_ordinal_scores
                 .entry(ci)
                 .or_default()
@@ -684,7 +921,7 @@ async fn rerank_binary<D: crate::directories::Directory + 'static>(
         });
     }
 
-    scored.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
+    scored.sort_unstable_by(compare_search_results_desc);
 
     if config.rrf_k > 0.0 {
         apply_rrf(candidates, &mut scored, config.rrf_k, final_limit);
@@ -721,6 +958,33 @@ mod tests {
             matryoshka_dims: None,
             rrf_k: 0.0,
         }
+    }
+
+    #[test]
+    fn rerank_batches_are_bounded_by_bytes() {
+        assert_eq!(rerank_batch_len(1), RERANK_SCORE_BATCH);
+        assert_eq!(
+            rerank_batch_len(MAX_RERANK_RAW_BATCH_BYTES),
+            1,
+            "one very wide vector must still make progress"
+        );
+        assert!(
+            rerank_batch_len(4_096) * 4_096 <= MAX_RERANK_RAW_BATCH_BYTES,
+            "normal batches must stay within the raw scratch budget"
+        );
+    }
+
+    #[test]
+    fn rerank_budget_bounds_count_and_bytes() {
+        let vectors = AtomicUsize::new(0);
+        let bytes = AtomicUsize::new(0);
+        reserve_rerank_vectors(&vectors, &bytes, 2, 32).unwrap();
+        assert_eq!(vectors.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(bytes.load(AtomicOrdering::Relaxed), 64);
+
+        let vectors = AtomicUsize::new(0);
+        let bytes = AtomicUsize::new(0);
+        assert!(reserve_rerank_vectors(&vectors, &bytes, 2, MAX_L2_RERANK_VECTOR_BYTES).is_err());
     }
 
     #[test]

--- a/hermes-core/src/query/scoring.rs
+++ b/hermes-core/src/query/scoring.rs
@@ -23,7 +23,9 @@ pub struct HeapEntry {
 
 impl PartialEq for HeapEntry {
     fn eq(&self, other: &Self) -> bool {
-        self.score == other.score && self.doc_id == other.doc_id
+        self.score.to_bits() == other.score.to_bits()
+            && self.doc_id == other.doc_id
+            && self.ordinal == other.ordinal
     }
 }
 
@@ -36,7 +38,8 @@ impl Ord for HeapEntry {
         other
             .score
             .total_cmp(&self.score)
-            .then(self.doc_id.cmp(&other.doc_id))
+            .then_with(|| self.doc_id.cmp(&other.doc_id))
+            .then_with(|| self.ordinal.cmp(&other.ordinal))
     }
 }
 
@@ -106,23 +109,23 @@ impl ScoreCollector {
     /// Caller must ensure each doc_id is inserted only once.
     #[inline]
     pub fn insert_with_ordinal(&mut self, doc_id: DocId, score: f32, ordinal: u16) -> bool {
+        if self.k == 0 {
+            return false;
+        }
+        let entry = HeapEntry {
+            doc_id,
+            score,
+            ordinal,
+        };
         if self.heap.len() < self.k {
-            self.heap.push(HeapEntry {
-                doc_id,
-                score,
-                ordinal,
-            });
+            self.heap.push(entry);
             // Only recompute threshold when heap just became full
             if self.heap.len() == self.k {
                 self.update_threshold();
             }
             true
-        } else if score > self.cached_threshold {
-            self.heap.push(HeapEntry {
-                doc_id,
-                score,
-                ordinal,
-            });
+        } else if self.heap.peek().is_some_and(|worst| entry < *worst) {
+            self.heap.push(entry);
             self.heap.pop(); // Remove lowest
             self.update_threshold();
             true
@@ -135,6 +138,21 @@ impl ScoreCollector {
     #[inline]
     pub fn would_enter(&self, score: f32) -> bool {
         self.heap.len() < self.k || score > self.cached_threshold
+    }
+
+    /// Check whether this fully identified candidate ranks ahead of the current
+    /// worst retained entry, including deterministic tie breaks.
+    #[inline]
+    pub fn would_enter_candidate(&self, doc_id: DocId, score: f32, ordinal: u16) -> bool {
+        if self.k == 0 {
+            return false;
+        }
+        let entry = HeapEntry {
+            doc_id,
+            score,
+            ordinal,
+        };
+        self.heap.len() < self.k || self.heap.peek().is_some_and(|worst| entry < *worst)
     }
 
     /// Get number of documents collected so far
@@ -179,7 +197,11 @@ impl ScoreCollector {
             .collect();
 
         // Sort by score descending, then doc_id ascending
-        results.sort_unstable_by(|a, b| b.1.total_cmp(&a.1).then(a.0.cmp(&b.0)));
+        results.sort_unstable_by(|a, b| {
+            b.1.total_cmp(&a.1)
+                .then_with(|| a.0.cmp(&b.0))
+                .then_with(|| a.2.cmp(&b.2))
+        });
 
         results
     }
@@ -783,7 +805,7 @@ macro_rules! bms_execute_loop {
                     mask &= mask - 1;
                 }
 
-                if present_upper + non_essential_upper <= adjusted_threshold {
+                if present_upper + non_essential_upper < adjusted_threshold {
                     let mut mask = at_min_mask;
                     while mask != 0 {
                         let i = mask.trailing_zeros() as usize;
@@ -806,7 +828,7 @@ macro_rules! bms_execute_loop {
                     mask &= mask - 1;
                 }
 
-                if block_max_sum + non_essential_upper <= adjusted_threshold {
+                if block_max_sum + non_essential_upper < adjusted_threshold {
                     let mut mask = at_min_mask;
                     while mask != 0 {
                         let i = mask.trailing_zeros() as usize;
@@ -853,7 +875,7 @@ macro_rules! bms_execute_loop {
 
             let essential_total: f32 = ordinal_scores.iter().map(|(_, s)| *s).sum();
             if $self.collector.len() >= $self.collector.k
-                && essential_total + non_essential_upper <= adjusted_threshold
+                && essential_total + non_essential_upper < adjusted_threshold
             {
                 docs_skipped += 1;
                 continue;
@@ -863,7 +885,7 @@ macro_rules! bms_execute_loop {
             let mut running_total = essential_total;
             for i in (0..partition).rev() {
                 if $self.collector.len() >= $self.collector.k
-                    && running_total + $self.prefix_sums[i] <= adjusted_threshold
+                    && running_total + $self.prefix_sums[i] < adjusted_threshold
                 {
                     break;
                 }
@@ -965,6 +987,18 @@ impl<'a> MaxScoreExecutor<'a> {
     /// Cursors are sorted by max_score ascending (non-essential first) and
     /// prefix sums are computed for the MaxScore partitioning.
     pub(crate) fn new(mut cursors: Vec<TermCursor<'a>>, k: usize, heap_factor: f32) -> Self {
+        // The execution loop tracks cursors at the current document in a u64.
+        // Query construction normally enforces this bound, but keep this
+        // boundary defensive for direct/internal executor users as well.
+        if cursors.len() > super::MAX_QUERY_TERMS {
+            cursors.sort_unstable_by(|a, b| b.max_score.total_cmp(&a.max_score));
+            cursors.truncate(super::MAX_QUERY_TERMS);
+            log::warn!(
+                "MaxScore cursor count exceeded {}; retaining the strongest cursors",
+                super::MAX_QUERY_TERMS
+            );
+        }
+
         // Enable lazy ordinal decode — ordinals are only decoded when a doc
         // actually reaches the scoring phase (saves ~100ns per skipped block).
         for c in &mut cursors {
@@ -1061,7 +1095,9 @@ impl<'a> MaxScoreExecutor<'a> {
         // non-essential → more aggressive pruning (approximate retrieval).
         // Use multiplication by reciprocal (cheaper than division).
         let threshold = self.collector.threshold() * self.inv_heap_factor;
-        self.prefix_sums.partition_point(|&sum| sum <= threshold)
+        // Keep an equal-score candidate essential: it can still displace the
+        // current worst hit through the deterministic doc/ordinal tie-break.
+        self.prefix_sums.partition_point(|&sum| sum < threshold)
     }
 
     /// Attach a per-doc predicate filter to this executor.

--- a/hermes-core/src/query/term.rs
+++ b/hermes-core/src/query/term.rs
@@ -103,7 +103,7 @@ fn compute_term_idf(
 //   $($aw)*          – .await  (present for async, absent for sync)
 macro_rules! term_plan {
     ($field:expr, $term:expr, $global_stats:expr, $reader:expr,
-     $get_postings_fn:ident, $get_positions_fn:ident
+     $load_positions:expr, $get_postings_fn:ident, $get_positions_fn:ident
      $(, $aw:tt)*) => {{
         let field: Field = $field;
         let term: &[u8] = $term;
@@ -127,8 +127,11 @@ macro_rules! term_plan {
                 let (idf, avg_field_len) =
                     compute_term_idf(&posting_list, field, reader, global_stats, term);
 
-                let positions = reader.$get_positions_fn(field, term)
-                    $(. $aw)* .ok().flatten();
+                let positions = if $load_positions {
+                    reader.$get_positions_fn(field, term) $(. $aw)* ?
+                } else {
+                    None
+                };
 
                 let mut scorer = TermScorer::new(posting_list, idf, avg_field_len, 1.0);
                 if let Some(pos) = positions {
@@ -149,16 +152,27 @@ macro_rules! term_plan {
 }
 
 impl Query for TermQuery {
-    fn scorer<'a>(&self, reader: &'a SegmentReader, _limit: usize) -> ScorerFuture<'a> {
+    fn scorer<'a>(&self, reader: &'a SegmentReader, limit: usize) -> ScorerFuture<'a> {
+        self.scorer_with_options(reader, limit, super::ScorerOptions::with_positions())
+    }
+
+    fn scorer_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        _limit: usize,
+        options: super::ScorerOptions,
+    ) -> ScorerFuture<'a> {
         let field = self.field;
         let term = self.term.clone();
         let global_stats = self.global_stats.clone();
+        let load_positions = options.collect_positions;
         Box::pin(async move {
             term_plan!(
                 field,
                 &term,
                 global_stats.as_ref(),
                 reader,
+                load_positions,
                 get_postings,
                 get_positions,
                 await
@@ -181,13 +195,24 @@ impl Query for TermQuery {
     fn scorer_sync<'a>(
         &self,
         reader: &'a SegmentReader,
+        limit: usize,
+    ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        self.scorer_sync_with_options(reader, limit, super::ScorerOptions::with_positions())
+    }
+
+    #[cfg(feature = "sync")]
+    fn scorer_sync_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
         _limit: usize,
+        options: super::ScorerOptions,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
         term_plan!(
             self.field,
             &self.term,
             self.global_stats.as_ref(),
             reader,
+            options.collect_positions,
             get_postings_sync,
             get_positions_sync
         )

--- a/hermes-core/src/query/traits.rs
+++ b/hermes-core/src/query/traits.rs
@@ -29,6 +29,25 @@ pub type ScorerFuture<'a> = Pin<Box<dyn Future<Output = Result<Box<dyn Scorer + 
 #[cfg(target_arch = "wasm32")]
 pub type ScorerFuture<'a> = Pin<Box<dyn Future<Output = Result<Box<dyn Scorer + 'a>>> + 'a>>;
 
+/// Options that affect scorer construction rather than scoring semantics.
+///
+/// Position postings can be much larger than the top-k result itself. Keeping
+/// this explicit lets ID/score-only collectors avoid loading them while query
+/// types that need positions for matching (for example phrases) remain free to
+/// load their own internal data.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScorerOptions {
+    pub collect_positions: bool,
+}
+
+impl ScorerOptions {
+    pub const fn with_positions() -> Self {
+        Self {
+            collect_positions: true,
+        }
+    }
+}
+
 /// Future type for count estimation
 #[cfg(not(target_arch = "wasm32"))]
 pub type CountFuture<'a> = Pin<Box<dyn Future<Output = Result<u32>> + Send + 'a>>;
@@ -204,6 +223,19 @@ macro_rules! define_query_traits {
                 limit: usize,
             ) -> ScorerFuture<'a>;
 
+            /// Create a scorer with collector-specific construction options.
+            /// Query implementations that can avoid optional position data
+            /// should override this; the default preserves existing behavior.
+            fn scorer_with_options<'a>(
+                &self,
+                reader: &'a SegmentReader,
+                limit: usize,
+                options: ScorerOptions,
+            ) -> ScorerFuture<'a> {
+                let _ = options;
+                self.scorer(reader, limit)
+            }
+
             /// Estimated number of matching documents in a segment (async)
             fn count_estimate<'a>(&self, reader: &'a SegmentReader) -> CountFuture<'a>;
 
@@ -221,6 +253,18 @@ macro_rules! define_query_traits {
                 Err(crate::error::Error::Query(
                     "sync scorer not supported for this query type".into(),
                 ))
+            }
+
+            /// Synchronous counterpart to [`Query::scorer_with_options`].
+            #[cfg(feature = "sync")]
+            fn scorer_sync_with_options<'a>(
+                &self,
+                reader: &'a SegmentReader,
+                limit: usize,
+                options: ScorerOptions,
+            ) -> Result<Box<dyn Scorer + 'a>> {
+                let _ = options;
+                self.scorer_sync(reader, limit)
             }
 
             /// Decompose this query for MaxScore optimization.
@@ -299,6 +343,15 @@ impl Query for Box<dyn Query> {
         (**self).count_estimate(reader)
     }
 
+    fn scorer_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: ScorerOptions,
+    ) -> ScorerFuture<'a> {
+        (**self).scorer_with_options(reader, limit, options)
+    }
+
     fn decompose(&self) -> QueryDecomposition {
         (**self).decompose()
     }
@@ -326,6 +379,16 @@ impl Query for Box<dyn Query> {
         limit: usize,
     ) -> Result<Box<dyn Scorer + 'a>> {
         (**self).scorer_sync(reader, limit)
+    }
+
+    #[cfg(feature = "sync")]
+    fn scorer_sync_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: ScorerOptions,
+    ) -> Result<Box<dyn Scorer + 'a>> {
+        (**self).scorer_sync_with_options(reader, limit, options)
     }
 }
 

--- a/hermes-core/src/query/vector/combiner.rs
+++ b/hermes-core/src/query/vector/combiner.rs
@@ -35,6 +35,27 @@ impl Default for MultiValueCombiner {
 }
 
 impl MultiValueCombiner {
+    pub(crate) fn validate(self) -> Result<(), String> {
+        match self {
+            Self::LogSumExp { temperature } if !temperature.is_finite() || temperature <= 0.0 => {
+                Err(format!(
+                    "LogSumExp temperature must be finite and greater than zero, got {temperature}"
+                ))
+            }
+            Self::WeightedTopK { k: 0, .. } => {
+                Err("WeightedTopK k must be greater than zero".to_string())
+            }
+            Self::WeightedTopK { decay, .. }
+                if !decay.is_finite() || !(0.0..=1.0).contains(&decay) =>
+            {
+                Err(format!(
+                    "WeightedTopK decay must be finite and in [0, 1], got {decay}"
+                ))
+            }
+            _ => Ok(()),
+        }
+    }
+
     /// Create LogSumExp combiner with default temperature (1.5)
     pub fn log_sum_exp() -> Self {
         Self::LogSumExp { temperature: 1.5 }

--- a/hermes-core/src/query/vector/dense.rs
+++ b/hermes-core/src/query/vector/dense.rs
@@ -7,6 +7,19 @@ use super::VectorResultScorer;
 use super::combiner::MultiValueCombiner;
 use crate::query::traits::{CountFuture, Query, Scorer, ScorerFuture};
 
+/// Maximum number of IVF clusters a single dense query may probe.
+///
+/// Automatic IVF construction caps the cluster count at 4096. Keeping the
+/// query override within the same bound prevents malformed requests from
+/// turning into unbounded work while still permitting a full-cluster scan.
+pub const MAX_DENSE_NPROBE: usize = 4096;
+
+/// Maximum exact-rerank candidate multiplier accepted by dense search.
+///
+/// Normal deployments use 2-5x. 32x leaves ample room for recall tuning while
+/// bounding the heap and raw-vector buffers derived from the requested top-k.
+pub const MAX_DENSE_RERANK_FACTOR: f32 = 32.0;
+
 /// Dense vector query for similarity search
 #[derive(Debug, Clone)]
 pub struct DenseVectorQuery {
@@ -48,12 +61,18 @@ impl DenseVectorQuery {
     }
 
     /// Set the number of clusters to probe (for IVF indexes)
+    ///
+    /// Values are validated when the query is executed. See
+    /// [`MAX_DENSE_NPROBE`].
     pub fn with_nprobe(mut self, nprobe: usize) -> Self {
         self.nprobe = nprobe;
         self
     }
 
     /// Set the re-ranking factor (e.g. 3.0 = fetch 3x candidates for reranking)
+    ///
+    /// Values are validated when the query is executed. See
+    /// [`MAX_DENSE_RERANK_FACTOR`].
     pub fn with_rerank_factor(mut self, factor: f32) -> Self {
         self.rerank_factor = factor;
         self

--- a/hermes-core/src/query/vector/mod.rs
+++ b/hermes-core/src/query/vector/mod.rs
@@ -7,7 +7,7 @@ mod sparse;
 
 pub use binary_dense::BinaryDenseVectorQuery;
 pub use combiner::MultiValueCombiner;
-pub use dense::DenseVectorQuery;
+pub use dense::{DenseVectorQuery, MAX_DENSE_NPROBE, MAX_DENSE_RERANK_FACTOR};
 pub use sparse::{SparseTermQuery, SparseVectorQuery};
 
 use crate::segment::VectorSearchResult;

--- a/hermes-core/src/query/vector/sparse.rs
+++ b/hermes-core/src/query/vector/sparse.rs
@@ -86,6 +86,43 @@ impl SparseVectorQuery {
         self.pruned.as_deref().unwrap_or(&self.vector)
     }
 
+    fn validate(&self, reader: &SegmentReader) -> crate::Result<()> {
+        let entry = reader
+            .schema()
+            .get_field_entry(self.field)
+            .ok_or_else(|| crate::Error::FieldNotFound(self.field.0.to_string()))?;
+        if entry.field_type != crate::dsl::FieldType::SparseVector {
+            return Err(crate::Error::InvalidFieldType {
+                expected: "sparse_vector".to_string(),
+                got: format!("{:?}", entry.field_type),
+            });
+        }
+        if self.vector.iter().any(|(_, weight)| !weight.is_finite()) {
+            return Err(crate::Error::Query(
+                "sparse query contains a non-finite weight".to_string(),
+            ));
+        }
+        if self.pruned_dims().len() > crate::query::MAX_QUERY_TERMS {
+            return Err(crate::Error::Query(format!(
+                "sparse query contains more than {} effective dimensions",
+                crate::query::MAX_QUERY_TERMS
+            )));
+        }
+        if !self.heap_factor.is_finite() || !(0.0..=1.0).contains(&self.heap_factor) {
+            return Err(crate::Error::Query(format!(
+                "sparse heap_factor must be finite and in [0, 1], got {}",
+                self.heap_factor
+            )));
+        }
+        if !self.over_fetch_factor.is_finite() || self.over_fetch_factor < 1.0 {
+            return Err(crate::Error::Query(format!(
+                "sparse over_fetch_factor must be finite and at least 1, got {}",
+                self.over_fetch_factor
+            )));
+        }
+        self.combiner.validate().map_err(crate::Error::Query)
+    }
+
     /// Set the multi-value score combiner
     pub fn with_combiner(mut self, combiner: MultiValueCombiner) -> Self {
         self.combiner = combiner;
@@ -122,7 +159,9 @@ impl SparseVectorQuery {
 
     /// Set maximum number of query dimensions (top-k by weight)
     pub fn with_max_query_dims(mut self, max_dims: usize) -> Self {
-        self.max_query_dims = Some(max_dims);
+        // MaxScore and BMP use a u64 query-term mask in their hot paths.  Keep
+        // this invariant here even when an SDL or RPC override asks for more.
+        self.max_query_dims = Some(max_dims.min(crate::query::MAX_QUERY_TERMS));
         self.pruned = Some(self.compute_pruned_vector());
         self
     }
@@ -179,10 +218,14 @@ impl SparseVectorQuery {
         }
         let after_pruning = v.len();
 
-        // Step 3: max_query_dims — absolute cap on dimensions
-        if let Some(max_dims) = self.max_query_dims
-            && v.len() > max_dims
-        {
+        // Step 3: max_query_dims — absolute cap on dimensions.  The hard
+        // MAX_QUERY_TERMS bound is a correctness requirement, not merely a
+        // tuning default: both sparse executors represent query terms in u64.
+        let max_dims = self
+            .max_query_dims
+            .unwrap_or(crate::query::MAX_QUERY_TERMS)
+            .min(crate::query::MAX_QUERY_TERMS);
+        if v.len() > max_dims {
             if !sorted_by_weight {
                 v.sort_unstable_by(|a, b| {
                     b.1.abs()
@@ -394,9 +437,11 @@ impl SparseVectorQuery {
 
 impl Query for SparseVectorQuery {
     fn scorer<'a>(&self, reader: &'a SegmentReader, limit: usize) -> ScorerFuture<'a> {
+        let validation = self.validate(reader);
         let infos = self.sparse_infos();
 
         Box::pin(async move {
+            validation?;
             if infos.is_empty() {
                 return Ok(Box::new(crate::query::EmptyScorer) as Box<dyn Scorer>);
             }
@@ -436,6 +481,7 @@ impl Query for SparseVectorQuery {
         reader: &'a SegmentReader,
         limit: usize,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        self.validate(reader)?;
         let infos = self.sparse_infos();
         if infos.is_empty() {
             return Ok(Box::new(crate::query::EmptyScorer) as Box<dyn Scorer + 'a>);
@@ -540,6 +586,37 @@ impl SparseTermQuery {
         self
     }
 
+    fn validate(&self, reader: &SegmentReader) -> crate::Result<()> {
+        let entry = reader
+            .schema()
+            .get_field_entry(self.field)
+            .ok_or_else(|| crate::Error::FieldNotFound(self.field.0.to_string()))?;
+        if entry.field_type != crate::dsl::FieldType::SparseVector {
+            return Err(crate::Error::InvalidFieldType {
+                expected: "sparse_vector".to_string(),
+                got: format!("{:?}", entry.field_type),
+            });
+        }
+        if !self.weight.is_finite() {
+            return Err(crate::Error::Query(
+                "sparse term query weight must be finite".to_string(),
+            ));
+        }
+        if !self.heap_factor.is_finite() || !(0.0..=1.0).contains(&self.heap_factor) {
+            return Err(crate::Error::Query(format!(
+                "sparse heap_factor must be finite and in [0, 1], got {}",
+                self.heap_factor
+            )));
+        }
+        if !self.over_fetch_factor.is_finite() || self.over_fetch_factor < 1.0 {
+            return Err(crate::Error::Query(format!(
+                "sparse over_fetch_factor must be finite and at least 1, got {}",
+                self.over_fetch_factor
+            )));
+        }
+        self.combiner.validate().map_err(crate::Error::Query)
+    }
+
     /// BMP fallback: execute BMP for this single dimension and wrap in a TopK scorer.
     fn bmp_fallback_scorer<'a>(
         &self,
@@ -547,12 +624,15 @@ impl SparseTermQuery {
         limit: usize,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
         if let Some(bmp) = reader.bmp_index(self.field) {
+            let executor_limit =
+                crate::query::planner::bounded_sparse_executor_limit(limit, self.over_fetch_factor)
+                    .min(bmp.num_virtual_docs as usize);
             let results = crate::query::bmp::execute_bmp(
                 bmp,
                 reader.schema().index_label(),
                 reader.schema().get_field_name(self.field).unwrap_or("?"),
                 &[(self.dim_id, self.weight)],
-                limit,
+                executor_limit,
                 self.heap_factor,
                 0,
             )?;
@@ -602,6 +682,7 @@ impl Query for SparseTermQuery {
     fn scorer<'a>(&self, reader: &'a SegmentReader, limit: usize) -> ScorerFuture<'a> {
         let query = self.clone();
         Box::pin(async move {
+            query.validate(reader)?;
             let mut scorer = match query.make_scorer(reader)? {
                 Some(s) => s,
                 None => return query.bmp_fallback_scorer(reader, limit),
@@ -617,6 +698,7 @@ impl Query for SparseTermQuery {
         reader: &'a SegmentReader,
         limit: usize,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        self.validate(reader)?;
         let mut scorer = match self.make_scorer(reader)? {
             Some(s) => s,
             None => return self.bmp_fallback_scorer(reader, limit),
@@ -727,5 +809,15 @@ mod tests {
             SparseVectorQuery::from_indices_weights(Field(0), vec![1, 5, 10], vec![0.5, 0.3, 0.2]);
 
         assert_eq!(query.vector, vec![(1, 0.5), (5, 0.3), (10, 0.2)]);
+    }
+
+    #[test]
+    fn max_query_dims_cannot_exceed_executor_mask_width() {
+        let vector: Vec<(u32, f32)> = (0..100).map(|dim| (dim, dim as f32 + 1.0)).collect();
+        let query = SparseVectorQuery::new(Field(0), vector).with_max_query_dims(usize::MAX);
+
+        assert_eq!(query.pruned_dims().len(), crate::query::MAX_QUERY_TERMS);
+        // Pruning retains the dimensions with the largest absolute weights.
+        assert!(query.pruned_dims().iter().all(|(dim, _)| *dim >= 36));
     }
 }

--- a/hermes-core/src/segment/builder/dense.rs
+++ b/hermes-core/src/segment/builder/dense.rs
@@ -12,7 +12,7 @@ use rustc_hash::FxHashMap;
 use crate::Result;
 #[cfg(feature = "native")]
 use crate::dsl::VectorIndexType;
-use crate::dsl::{DenseVectorQuantization, Field, Schema};
+use crate::dsl::{DenseVectorQuantization, Field, FieldType, Schema};
 use crate::segment::format::{DenseVectorTocEntry, write_dense_toc_and_footer};
 use crate::segment::vector_data::FlatVectorData;
 
@@ -125,38 +125,98 @@ pub(super) fn build_vectors_streaming(
     // Resolve quantization config per field from schema
     let quants: Vec<DenseVectorQuantization> = fields
         .iter()
-        .map(|(field_id, _)| {
-            schema
-                .get_field_entry(Field(*field_id))
-                .and_then(|e| e.dense_vector_config.as_ref())
-                .map(|c| c.quantization)
-                .unwrap_or(DenseVectorQuantization::F32)
+        .map(|(field_id, builder)| {
+            let entry = schema.get_field_entry(Field(*field_id)).ok_or_else(|| {
+                crate::Error::Schema(format!(
+                    "dense vector builder references unknown field {field_id}"
+                ))
+            })?;
+            let config = entry
+                .dense_vector_config
+                .as_ref()
+                .filter(|_| entry.field_type == FieldType::DenseVector)
+                .ok_or_else(|| {
+                    crate::Error::Schema(format!(
+                        "dense vector builder field {field_id} does not match its schema type"
+                    ))
+                })?;
+            if builder.dim != config.dim {
+                return Err(crate::Error::Schema(format!(
+                    "dense vector builder field {field_id} has dimension {}, schema expects {}",
+                    builder.dim, config.dim
+                )));
+            }
+            Ok(config.quantization)
         })
-        .collect();
+        .collect::<Result<_>>()?;
+
+    for (field_id, builder) in &binary_fields {
+        let entry = schema.get_field_entry(Field(*field_id)).ok_or_else(|| {
+            crate::Error::Schema(format!(
+                "binary vector builder references unknown field {field_id}"
+            ))
+        })?;
+        let config = entry
+            .binary_dense_vector_config
+            .as_ref()
+            .filter(|_| entry.field_type == FieldType::BinaryDenseVector)
+            .ok_or_else(|| {
+                crate::Error::Schema(format!(
+                    "binary vector builder field {field_id} does not match its schema type"
+                ))
+            })?;
+        if builder.dim_bits != config.dim {
+            return Err(crate::Error::Schema(format!(
+                "binary vector builder field {field_id} has dimension {}, schema expects {}",
+                builder.dim_bits, config.dim
+            )));
+        }
+    }
 
     // Compute sizes using deterministic formula (no serialization needed)
     let mut field_sizes: Vec<usize> = Vec::with_capacity(fields.len());
     for (i, (_field_id, builder)) in fields.iter().enumerate() {
-        field_sizes.push(FlatVectorData::serialized_binary_size(
+        field_sizes.push(FlatVectorData::validate_dense_input(
             builder.dim,
-            builder.len(),
+            &builder.vectors,
+            &builder.doc_ids,
             quants[i],
-        ));
+        )?);
     }
+    let binary_field_sizes: Vec<usize> = binary_fields
+        .iter()
+        .map(|(_, builder)| {
+            FlatVectorData::validate_binary_input(
+                builder.dim_bits,
+                &builder.vectors,
+                &builder.doc_ids,
+            )
+        })
+        .collect::<std::io::Result<_>>()?;
 
     // Data-first format: stream field data, then write TOC + footer at end.
     // Data starts at file offset 0 → mmap page-aligned, no alignment copies.
-    let mut toc: Vec<DenseVectorTocEntry> = Vec::with_capacity(fields.len() * 2);
+    let toc_capacity = fields
+        .len()
+        .checked_add(binary_fields.len())
+        .and_then(|field_count| field_count.checked_mul(2))
+        .ok_or_else(|| {
+            crate::Error::Internal("dense-vector TOC capacity overflows usize".into())
+        })?;
+    let mut toc: Vec<DenseVectorTocEntry> = Vec::with_capacity(toc_capacity);
     let mut current_offset = 0u64;
 
     // Pre-build ANN indexes across fields (native only — requires trained structures).
     #[cfg(feature = "native")]
     let ann_blobs: Vec<(u32, u8, Vec<u8>)> = if let Some(trained) = trained {
-        let ann_blob_fn =
-            |(field_id, builder): &(u32, DenseVectorBuilder)| -> Option<(u32, u8, Vec<u8>)> {
-                let config = schema
+        let ann_blob_fn = |(field_id, builder): &(u32, DenseVectorBuilder)|
+         -> Result<Option<(u32, u8, Vec<u8>)>> {
+                let Some(config) = schema
                     .get_field_entry(Field(*field_id))
-                    .and_then(|e| e.dense_vector_config.as_ref())?;
+                    .and_then(|e| e.dense_vector_config.as_ref())
+                else {
+                    return Ok(None);
+                };
 
                 let dim = builder.dim;
                 let blob = match config.index_type {
@@ -187,31 +247,26 @@ pub(super) fn build_vectors_streaming(
                         super::super::ann_build::serialize_scann(index, codebook)
                             .map(|b| (super::super::ann_build::SCANN_TYPE, b))
                     }
-                    _ => return None,
+                    _ => return Ok(None),
                 };
-                match blob {
-                    Ok((index_type, bytes)) => {
-                        log::info!(
-                            "[segment_build] built ANN(type={}) for field {} ({} vectors, {} bytes)",
-                            index_type,
-                            field_id,
-                            builder.doc_ids.len(),
-                            bytes.len()
-                        );
-                        Some((*field_id, index_type, bytes))
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "[segment_build] ANN serialize failed for field {}: {}",
-                            field_id,
-                            e
-                        );
-                        None
-                    }
-                }
+                let (index_type, bytes) = blob?;
+                log::info!(
+                    "[segment_build] built ANN(type={}) for field {} ({} vectors, {} bytes)",
+                    index_type,
+                    field_id,
+                    builder.doc_ids.len(),
+                    bytes.len()
+                );
+                Ok(Some((*field_id, index_type, bytes)))
             };
 
-        fields.par_iter().filter_map(ann_blob_fn).collect()
+        fields
+            .par_iter()
+            .map(ann_blob_fn)
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
+            .collect()
     } else {
         Vec::new()
     };
@@ -233,18 +288,24 @@ pub(super) fn build_vectors_streaming(
             writer,
         )
         .map_err(crate::Error::Io)?;
-        current_offset += field_sizes[i] as u64;
+        let field_size = u64::try_from(field_sizes[i])
+            .map_err(|_| crate::Error::Internal("flat vector size exceeds u64".into()))?;
+        current_offset = current_offset
+            .checked_add(field_size)
+            .ok_or_else(|| crate::Error::Internal("vector output offset exceeds u64".into()))?;
         toc.push(DenseVectorTocEntry {
             field_id: _field_id,
             index_type: super::super::ann_build::FLAT_TYPE,
             offset: data_offset,
-            size: field_sizes[i] as u64,
+            size: field_size,
         });
         // Pad to 8-byte boundary so next field's mmap slice is aligned
         let pad = (8 - (current_offset % 8)) % 8;
         if pad > 0 {
             writer.write_all(&[0u8; 8][..pad as usize])?;
-            current_offset += pad;
+            current_offset = current_offset.checked_add(pad).ok_or_else(|| {
+                crate::Error::Internal("vector output padding exceeds u64".into())
+            })?;
         }
         // builder dropped here, freeing vector memory before next field
     }
@@ -252,9 +313,12 @@ pub(super) fn build_vectors_streaming(
     // Write ANN blob entries after flat entries
     for (field_id, index_type, blob) in ann_blobs {
         let data_offset = current_offset;
-        let blob_len = blob.len() as u64;
+        let blob_len = u64::try_from(blob.len())
+            .map_err(|_| crate::Error::Internal("ANN blob size exceeds u64".into()))?;
         writer.write_all(&blob)?;
-        current_offset += blob_len;
+        current_offset = current_offset
+            .checked_add(blob_len)
+            .ok_or_else(|| crate::Error::Internal("vector output offset exceeds u64".into()))?;
         toc.push(DenseVectorTocEntry {
             field_id,
             index_type,
@@ -264,18 +328,16 @@ pub(super) fn build_vectors_streaming(
         let pad = (8 - (current_offset % 8)) % 8;
         if pad > 0 {
             writer.write_all(&[0u8; 8][..pad as usize])?;
-            current_offset += pad;
+            current_offset = current_offset.checked_add(pad).ok_or_else(|| {
+                crate::Error::Internal("vector output padding exceeds u64".into())
+            })?;
         }
     }
 
     // Stream binary dense vector fields (packed bits, Hamming distance)
-    for (field_id, builder) in binary_fields.into_iter() {
+    for ((field_id, builder), data_size) in binary_fields.into_iter().zip(binary_field_sizes) {
         let data_offset = current_offset;
-        let byte_len = builder.byte_len;
         let num_vectors = builder.len();
-        let data_size = crate::segment::format::FLAT_BINARY_HEADER_SIZE
-            + num_vectors * byte_len
-            + num_vectors * crate::segment::format::DOC_ID_ENTRY_SIZE;
 
         FlatVectorData::serialize_binary_from_bits_streaming(
             builder.dim_bits,
@@ -285,18 +347,24 @@ pub(super) fn build_vectors_streaming(
         )
         .map_err(crate::Error::Io)?;
 
-        current_offset += data_size as u64;
+        let data_size = u64::try_from(data_size)
+            .map_err(|_| crate::Error::Internal("binary flat vector size exceeds u64".into()))?;
+        current_offset = current_offset
+            .checked_add(data_size)
+            .ok_or_else(|| crate::Error::Internal("vector output offset exceeds u64".into()))?;
         toc.push(DenseVectorTocEntry {
             field_id,
             index_type: super::super::ann_build::FLAT_TYPE,
             offset: data_offset,
-            size: data_size as u64,
+            size: data_size,
         });
 
         let pad = (8 - (current_offset % 8)) % 8;
         if pad > 0 {
             writer.write_all(&[0u8; 8][..pad as usize])?;
-            current_offset += pad;
+            current_offset = current_offset.checked_add(pad).ok_or_else(|| {
+                crate::Error::Internal("vector output padding exceeds u64".into())
+            })?;
         }
 
         // Binary IVF index (native only): built at commit when configured
@@ -317,10 +385,14 @@ pub(super) fn build_vectors_streaming(
                     ivf_config,
                     &builder.vectors,
                     &builder.doc_ids,
-                );
+                )
+                .map_err(crate::Error::Io)?;
                 let blob_offset = current_offset;
                 let mut output = &mut *writer;
-                let blob_len = index.write_to(&mut output).map_err(crate::Error::Io)? as u64;
+                let blob_len = u64::try_from(
+                    index.write_to(&mut output).map_err(crate::Error::Io)?,
+                )
+                .map_err(|_| crate::Error::Internal("binary IVF blob size exceeds u64".into()))?;
                 current_offset = current_offset.checked_add(blob_len).ok_or_else(|| {
                     crate::Error::Internal("binary IVF output offset exceeds u64".into())
                 })?;
@@ -334,7 +406,9 @@ pub(super) fn build_vectors_streaming(
                 let pad = (8 - (current_offset % 8)) % 8;
                 if pad > 0 {
                     writer.write_all(&[0u8; 8][..pad as usize])?;
-                    current_offset += pad;
+                    current_offset = current_offset.checked_add(pad).ok_or_else(|| {
+                        crate::Error::Internal("vector output padding exceeds u64".into())
+                    })?;
                 }
                 log::debug!(
                     "[build_vectors] field {}: binary IVF built ({} vectors, {} clusters, {} bytes)",

--- a/hermes-core/src/segment/builder/mod.rs
+++ b/hermes-core/src/segment/builder/mod.rs
@@ -344,6 +344,16 @@ impl SegmentBuilder {
         ordinal
     }
 
+    fn next_vector_ordinal(&mut self, field_id: u32) -> Result<u16> {
+        let ordinal = self.next_element_ordinal(field_id);
+        u16::try_from(ordinal).map_err(|_| {
+            crate::Error::Document(format!(
+                "field {field_id} has more than {} vector values in one document",
+                u16::MAX as usize + 1
+            ))
+        })
+    }
+
     pub fn num_docs(&self) -> u32 {
         self.next_doc_id
     }
@@ -566,18 +576,18 @@ impl SegmentBuilder {
                 (FieldType::DenseVector, FieldValue::DenseVector(vec))
                     if entry.indexed || entry.stored =>
                 {
-                    let ordinal = self.next_element_ordinal(field.0);
-                    self.index_dense_vector_field(*field, doc_id, ordinal as u16, vec)?;
+                    let ordinal = self.next_vector_ordinal(field.0)?;
+                    self.index_dense_vector_field(*field, doc_id, ordinal, vec)?;
                 }
                 (FieldType::BinaryDenseVector, FieldValue::BinaryDenseVector(bytes))
                     if entry.indexed || entry.stored =>
                 {
-                    let ordinal = self.next_element_ordinal(field.0);
-                    self.index_binary_dense_vector_field(*field, doc_id, ordinal as u16, bytes)?;
+                    let ordinal = self.next_vector_ordinal(field.0)?;
+                    self.index_binary_dense_vector_field(*field, doc_id, ordinal, bytes)?;
                 }
                 (FieldType::SparseVector, FieldValue::SparseVector(entries)) => {
-                    let ordinal = self.next_element_ordinal(field.0);
-                    self.index_sparse_vector_field(*field, doc_id, ordinal as u16, entries)?;
+                    let ordinal = self.next_vector_ordinal(field.0)?;
+                    self.index_sparse_vector_field(*field, doc_id, ordinal, entries)?;
                 }
                 _ => {}
             }
@@ -835,6 +845,15 @@ impl SegmentBuilder {
                 expected_dim, dim
             )));
         }
+        if let Some((index, value)) = vector
+            .iter()
+            .enumerate()
+            .find(|(_, value)| !value.is_finite())
+        {
+            return Err(crate::Error::Document(format!(
+                "dense vector contains non-finite value {value} at index {index}"
+            )));
+        }
 
         let builder = self
             .dense_vectors
@@ -874,6 +893,11 @@ impl SegmentBuilder {
             })?;
 
         let expected_byte_len = dim_bits.div_ceil(8);
+        if dim_bits == 0 || !dim_bits.is_multiple_of(8) {
+            return Err(crate::Error::Schema(format!(
+                "Binary vector dimension must be a positive multiple of 8, got {dim_bits}"
+            )));
+        }
         if bytes.len() != expected_byte_len {
             return Err(crate::Error::Schema(format!(
                 "Binary vector byte length mismatch: expected {} (dim={}), got {}",
@@ -910,6 +934,15 @@ impl SegmentBuilder {
         ordinal: u16,
         entries: &[(u32, f32)],
     ) -> Result<()> {
+        if let Some((index, (_, weight))) = entries
+            .iter()
+            .enumerate()
+            .find(|(_, (_, weight))| !weight.is_finite())
+        {
+            return Err(crate::Error::Document(format!(
+                "sparse vector contains non-finite weight {weight} at index {index}"
+            )));
+        }
         let (weight_threshold, doc_mass, min_terms) = self
             .schema
             .get_field_entry(field)

--- a/hermes-core/src/segment/builder/sparse.rs
+++ b/hermes-core/src/segment/builder/sparse.rs
@@ -17,7 +17,7 @@ use crate::Result;
 use crate::dsl::{Field, Schema};
 use crate::segment::format::{SparseDimTocEntry, SparseFieldToc, write_sparse_toc_and_footer};
 use crate::structures::{
-    BlockSparsePostingList, SparseFormat, SparseSkipEntry, WeightQuantization, optimal_partition,
+    BlockSparsePostingList, SparseFormat, SparseSkipEntry, WeightQuantization,
 };
 
 use crate::DocId;
@@ -155,10 +155,12 @@ pub(super) fn build_sparse_streaming(
                 }
             }
             SparseFormat::MaxScore => {
+                let block_size = sparse_config.map(|c| c.block_size).unwrap_or(128);
                 build_maxscore_field(
                     builder,
                     field_id,
                     quantization,
+                    block_size,
                     pruning_fraction,
                     weight_threshold,
                     min_terms,
@@ -197,6 +199,7 @@ fn build_maxscore_field(
     builder: &mut SparseVectorBuilder,
     field_id: u32,
     quantization: WeightQuantization,
+    block_size: usize,
     pruning_fraction: Option<f32>,
     weight_threshold: f32,
     min_terms: usize,
@@ -243,12 +246,14 @@ fn build_maxscore_field(
             postings.sort_unstable_by_key(|(doc_id, ordinal, _)| (*doc_id, *ordinal));
         }
 
-        let weights: Vec<f32> = postings.iter().map(|(_, _, w)| w.abs()).collect();
-        let partition = optimal_partition(&weights);
-        let block_list = BlockSparsePostingList::from_postings_with_partition(
+        // Honor the field's configured block size. The old unconstrained
+        // block-error DP always preferred the smallest (16-entry) blocks,
+        // multiplying skip metadata and decode overhead while effectively
+        // ignoring this setting.
+        let block_list = BlockSparsePostingList::from_postings_with_block_size(
             &postings,
             quantization,
-            &partition,
+            block_size,
         )
         .map_err(crate::Error::Io)?;
 

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -71,19 +71,22 @@ async fn feed_segment(
             .await
             .map_err(crate::Error::Io)?;
         let raw = batch_bytes.as_slice();
-        let batch_floats = batch_count * dim;
+        let batch_floats = batch_count.checked_mul(dim).ok_or_else(|| {
+            crate::Error::Corruption("dense merge batch size overflows usize".into())
+        })?;
 
         // For f32: reinterpret mmap bytes directly (zero-copy).
         // For f16/u8: dequantize into buffer.
         let vectors: &[f32] = if needs_dequant {
             f32_buf.resize(batch_floats, 0.0);
-            dequantize_raw(raw, quant, batch_floats, &mut f32_buf);
+            dequantize_raw(raw, quant, batch_floats, &mut f32_buf).map_err(crate::Error::Io)?;
             &f32_buf
         } else {
-            assert!(
-                (raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()),
-                "f32 vector data not 4-byte aligned"
-            );
+            if !(raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()) {
+                return Err(crate::Error::Corruption(
+                    "f32 flat vector data is not 4-byte aligned".into(),
+                ));
+            }
             // Safety: mmap-backed vector data is page-aligned. Assertion above
             // guards against unexpected misalignment.
             unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const f32, batch_floats) }
@@ -124,11 +127,28 @@ async fn write_flat_entry(
             let base_offset = lazy_flat.vectors_byte_offset();
             let handle = lazy_flat.handle();
             for chunk_start in (0..total_bytes).step_by(FLAT_VECTOR_CHUNK as usize) {
-                let chunk_end = (chunk_start + FLAT_VECTOR_CHUNK).min(total_bytes);
+                let chunk_end = chunk_start
+                    .saturating_add(FLAT_VECTOR_CHUNK)
+                    .min(total_bytes);
+                let range_start = base_offset.checked_add(chunk_start).ok_or_else(|| {
+                    crate::Error::Corruption("flat vector source offset exceeds u64".into())
+                })?;
+                let range_end = base_offset.checked_add(chunk_end).ok_or_else(|| {
+                    crate::Error::Corruption("flat vector source range exceeds u64".into())
+                })?;
                 let bytes = handle
-                    .read_bytes_range(base_offset + chunk_start..base_offset + chunk_end)
+                    .read_bytes_range(range_start..range_end)
                     .await
                     .map_err(crate::Error::Io)?;
+                let expected_len = usize::try_from(chunk_end - chunk_start).map_err(|_| {
+                    crate::Error::Corruption("flat vector merge chunk exceeds usize".into())
+                })?;
+                if bytes.len() != expected_len {
+                    return Err(crate::Error::Corruption(format!(
+                        "flat vector merge read returned {} bytes, expected {expected_len}",
+                        bytes.len()
+                    )));
+                }
                 super::block_in_place_if_multithread(|| writer.write_all(bytes.as_slice()))?;
             }
         }
@@ -200,10 +220,16 @@ impl SegmentMerger {
                 continue;
             }
 
-            let total_vectors: usize = segments
+            let total_vectors = segments
                 .iter()
                 .filter_map(|s| s.flat_vectors().get(&field.0).map(|f| f.num_vectors))
-                .sum();
+                .try_fold(0usize, |total, count| total.checked_add(count))
+                .ok_or_else(|| {
+                    crate::Error::Corruption(format!(
+                        "flat vector count overflows usize for field {}",
+                        field.0
+                    ))
+                })?;
             if total_vectors == 0 {
                 continue;
             }
@@ -418,17 +444,16 @@ impl SegmentMerger {
                 pool.install(build)
             } else {
                 build()
-            };
+            }?;
             // The built clusters now own the only code copy needed by the
             // serializer. Release the raw merge inputs before returning.
             drop(codes);
             drop(labels);
-            index
+            Ok::<_, std::io::Error>(index)
         })
         .await
-        .map_err(|error| {
-            crate::Error::Internal(format!("binary IVF build task failed: {error}"))
-        })?;
+        .map_err(|error| crate::Error::Internal(format!("binary IVF build task failed: {error}")))?
+        .map_err(crate::Error::Io)?;
         log::debug!(
             "[merge_vectors] field {}: binary IVF rebuilt ({} vectors, {} clusters, estimated {} bytes)",
             field.0,

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -12,7 +12,9 @@ use super::bmp::BmpIndex;
 use super::{SparseIndex, VectorIndex};
 use crate::Result;
 use crate::directories::{Directory, FileHandle};
-use crate::dsl::Schema;
+use crate::dsl::{
+    BinaryIndexType, DenseVectorQuantization, Field, FieldType, Schema, VectorIndexType,
+};
 
 /// Result of loading the `.sparse` file — may contain MaxScore and/or BMP indexes.
 pub struct SparseFileData {
@@ -26,6 +28,151 @@ pub struct VectorsFileData {
     pub indexes: FxHashMap<u32, VectorIndex>,
     /// Lazy flat vectors per field — doc_ids in memory, vectors via mmap for reranking/merge
     pub flat_vectors: FxHashMap<u32, LazyFlatVectorData>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_sparse_dimension_skip_entries(
+    skip_section: &[u8],
+    skip_start: usize,
+    num_blocks: usize,
+    block_data_offset: u64,
+    data_end: u64,
+    total_docs: u32,
+    global_max_weight: f32,
+    field_id: u32,
+    dim_id: u32,
+) -> Result<std::ops::Range<u64>> {
+    if num_blocks == 0 {
+        return Err(crate::Error::Corruption(format!(
+            "sparse field {field_id} dimension {dim_id} has no blocks"
+        )));
+    }
+    if !global_max_weight.is_finite() || global_max_weight < 0.0 {
+        return Err(crate::Error::Corruption(format!(
+            "sparse field {field_id} dimension {dim_id} has invalid global max weight {global_max_weight}"
+        )));
+    }
+
+    let mut previous_end = 0u64;
+    let mut previous_first_doc = 0u32;
+    let mut previous_last_doc = 0u32;
+    let mut range_start = None;
+    let mut range_end = 0u64;
+    for block_index in 0..num_blocks {
+        let entry =
+            crate::structures::SparseSkipEntry::read_at(skip_section, skip_start + block_index);
+        if entry.length == 0 {
+            return Err(crate::Error::Corruption(format!(
+                "sparse field {field_id} dimension {dim_id} block {block_index} is empty"
+            )));
+        }
+        if entry.first_doc > entry.last_doc || entry.last_doc >= total_docs {
+            return Err(crate::Error::Corruption(format!(
+                "sparse field {field_id} dimension {dim_id} block {block_index} has invalid document range {}..={} for {total_docs} documents",
+                entry.first_doc, entry.last_doc
+            )));
+        }
+        if !entry.max_weight.is_finite()
+            || entry.max_weight < 0.0
+            || entry.max_weight > global_max_weight
+        {
+            return Err(crate::Error::Corruption(format!(
+                "sparse field {field_id} dimension {dim_id} block {block_index} has invalid max weight {} (global {global_max_weight})",
+                entry.max_weight
+            )));
+        }
+
+        let relative_end = entry
+            .offset
+            .checked_add(u64::from(entry.length))
+            .ok_or_else(|| {
+                crate::Error::Corruption(format!(
+                    "sparse field {field_id} dimension {dim_id} block {block_index} range overflows u64"
+                ))
+            })?;
+        let absolute_start = block_data_offset
+            .checked_add(entry.offset)
+            .ok_or_else(|| {
+                crate::Error::Corruption(format!(
+                    "sparse field {field_id} dimension {dim_id} block {block_index} file start overflows u64"
+                ))
+            })?;
+        let absolute_end = block_data_offset
+            .checked_add(relative_end)
+            .ok_or_else(|| {
+                crate::Error::Corruption(format!(
+                    "sparse field {field_id} dimension {dim_id} block {block_index} file range overflows u64"
+                ))
+            })?;
+        if absolute_end > data_end || entry.offset < previous_end {
+            return Err(crate::Error::Corruption(format!(
+                "sparse field {field_id} dimension {dim_id} block {block_index} has overlapping or out-of-bounds byte range"
+            )));
+        }
+        if block_index > 0
+            && (entry.first_doc < previous_first_doc || entry.last_doc < previous_last_doc)
+        {
+            return Err(crate::Error::Corruption(format!(
+                "sparse field {field_id} dimension {dim_id} block {block_index} document ranges are not monotonic"
+            )));
+        }
+        previous_end = relative_end;
+        previous_first_doc = entry.first_doc;
+        previous_last_doc = entry.last_doc;
+        range_start.get_or_insert(absolute_start);
+        range_end = absolute_end;
+    }
+    Ok(range_start.expect("num_blocks was validated above")..range_end)
+}
+
+fn validate_ann_schema(schema: &Schema, field_id: u32, index_type: u8) -> Result<()> {
+    use crate::segment::ann_build;
+
+    let field = schema.get_field_entry(Field(field_id)).ok_or_else(|| {
+        crate::Error::Corruption(format!(
+            "ANN vectors reference unknown schema field {field_id}"
+        ))
+    })?;
+
+    let matches_schema = match index_type {
+        ann_build::RABITQ_TYPE => {
+            field.field_type == FieldType::DenseVector
+                && field
+                    .dense_vector_config
+                    .as_ref()
+                    .is_some_and(|config| config.index_type == VectorIndexType::RaBitQ)
+        }
+        ann_build::IVF_RABITQ_TYPE => {
+            field.field_type == FieldType::DenseVector
+                && field
+                    .dense_vector_config
+                    .as_ref()
+                    .is_some_and(|config| config.index_type == VectorIndexType::IvfRaBitQ)
+        }
+        ann_build::SCANN_TYPE => {
+            field.field_type == FieldType::DenseVector
+                && field
+                    .dense_vector_config
+                    .as_ref()
+                    .is_some_and(|config| config.index_type == VectorIndexType::ScaNN)
+        }
+        ann_build::BINARY_IVF_TYPE => {
+            field.field_type == FieldType::BinaryDenseVector
+                && field
+                    .binary_dense_vector_config
+                    .as_ref()
+                    .is_some_and(|config| config.index_type == BinaryIndexType::Ivf)
+        }
+        _ => false,
+    };
+
+    if !matches_schema {
+        return Err(crate::Error::Corruption(format!(
+            "ANN vector type {index_type} for field {field_id} does not match schema field '{}' ({:?})",
+            field.name, field.field_type
+        )));
+    }
+    Ok(())
 }
 
 fn take_toc_bytes<'a>(
@@ -53,6 +200,73 @@ use crate::segment::format::{
     DENSE_TOC_ENTRY_SIZE, DenseVectorTocEntry, FOOTER_SIZE, VECTORS_FOOTER_MAGIC, read_dense_toc,
 };
 
+fn is_ann_vector_type(index_type: u8) -> bool {
+    use crate::segment::ann_build;
+
+    matches!(
+        index_type,
+        ann_build::SCANN_TYPE
+            | ann_build::IVF_RABITQ_TYPE
+            | ann_build::BINARY_IVF_TYPE
+            | ann_build::RABITQ_TYPE
+    )
+}
+
+fn checked_vector_payload_end(
+    entry: &DenseVectorTocEntry,
+    data_start: u64,
+    data_end: u64,
+) -> Result<u64> {
+    entry
+        .offset
+        .checked_add(entry.size)
+        .filter(|&end| entry.offset >= data_start && end <= data_end)
+        .ok_or_else(|| {
+            crate::Error::Corruption(format!(
+                "vector field {} has invalid data range {}..{}+{}; valid payload is {data_start}..{data_end}",
+                entry.field_id, entry.offset, entry.offset, entry.size
+            ))
+        })
+}
+
+fn validate_vector_toc_ranges(
+    entries: &[DenseVectorTocEntry],
+    data_start: u64,
+    data_end: u64,
+) -> Result<()> {
+    let mut ranges = Vec::with_capacity(entries.len());
+    for entry in entries {
+        if is_ann_vector_type(entry.index_type) && entry.size == 0 {
+            return Err(crate::Error::Corruption(format!(
+                "ANN vectors for field {} have an empty payload",
+                entry.field_id
+            )));
+        }
+        let end = checked_vector_payload_end(entry, data_start, data_end)?;
+        ranges.push((entry.offset, end, entry.field_id, entry.index_type));
+    }
+
+    ranges.sort_unstable();
+    for pair in ranges.windows(2) {
+        let previous = pair[0];
+        let current = pair[1];
+        if current.0 < previous.1 {
+            return Err(crate::Error::Corruption(format!(
+                "vector TOC payloads overlap: field {} type {} uses {}..{}, field {} type {} uses {}..{}",
+                previous.2,
+                previous.3,
+                previous.0,
+                previous.1,
+                current.2,
+                current.3,
+                current.0,
+                current.1
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Load dense vector indexes from unified .vectors file
 ///
 /// File format (data-first, TOC at end):
@@ -65,6 +279,7 @@ pub async fn load_vectors_file<D: Directory>(
     dir: &D,
     files: &SegmentFiles,
     schema: &Schema,
+    total_docs: u32,
 ) -> Result<VectorsFileData> {
     let mut indexes = FxHashMap::default();
     let mut flat_vectors = FxHashMap::default();
@@ -174,6 +389,7 @@ pub async fn load_vectors_file<D: Directory>(
     if entries.is_empty() {
         return Ok(empty());
     }
+    validate_vector_toc_ranges(&entries, data_start, data_end)?;
 
     // Load each entry — a field can have both Flat (lazy) and ANN (in-memory)
     use crate::segment::ann_build;
@@ -184,23 +400,61 @@ pub async fn load_vectors_file<D: Directory>(
         size: length,
     } in entries
     {
-        let end = offset
-            .checked_add(length)
-            .filter(|&end| offset >= data_start && end <= data_end)
-            .ok_or_else(|| {
-                crate::Error::Corruption(format!(
-                    "vector field {field_id} has invalid data range {offset}..{offset}+{length}; valid payload is {data_start}..{data_end}"
-                ))
-            })?;
+        // The complete TOC was bounds/overlap checked before any payload read.
+        let end = offset + length;
         match index_type {
             ann_build::FLAT_TYPE => {
                 // Flat binary — load lazily (only doc_ids in memory, vectors via mmap)
-                let slice = handle.slice(offset..end);
-                let lazy_flat = LazyFlatVectorData::open(slice).await.map_err(|error| {
+                let field = schema.get_field_entry(Field(field_id)).ok_or_else(|| {
                     crate::Error::Corruption(format!(
-                        "invalid flat vectors for field {field_id}: {error}"
+                        "flat vectors reference unknown schema field {field_id}"
                     ))
                 })?;
+                let slice = handle.slice(offset..end);
+                let lazy_flat = LazyFlatVectorData::open_with_doc_limit(slice, Some(total_docs))
+                    .await
+                    .map_err(|error| {
+                        crate::Error::Corruption(format!(
+                            "invalid flat vectors for field {field_id}: {error}"
+                        ))
+                    })?;
+                match lazy_flat.quantization {
+                    DenseVectorQuantization::Binary => {
+                        let config = field
+                            .binary_dense_vector_config
+                            .as_ref()
+                            .filter(|_| field.field_type == FieldType::BinaryDenseVector)
+                            .ok_or_else(|| {
+                                crate::Error::Corruption(format!(
+                                    "binary flat vectors for field {field_id} do not match its schema type"
+                                ))
+                            })?;
+                        if lazy_flat.dim != config.dim {
+                            return Err(crate::Error::Corruption(format!(
+                                "binary flat vectors for field {field_id} have dimension {}, schema expects {}",
+                                lazy_flat.dim, config.dim
+                            )));
+                        }
+                    }
+                    stored_quantization => {
+                        let config = field
+                            .dense_vector_config
+                            .as_ref()
+                            .filter(|_| field.field_type == FieldType::DenseVector)
+                            .ok_or_else(|| {
+                                crate::Error::Corruption(format!(
+                                    "flat vectors for field {field_id} do not match its schema type"
+                                ))
+                            })?;
+                        if lazy_flat.dim != config.dim || stored_quantization != config.quantization
+                        {
+                            return Err(crate::Error::Corruption(format!(
+                                "flat vectors for field {field_id} have dimension {} and {:?} storage, schema expects {} and {:?}",
+                                lazy_flat.dim, stored_quantization, config.dim, config.quantization
+                            )));
+                        }
+                    }
+                }
                 if flat_vectors.insert(field_id, lazy_flat).is_some() {
                     return Err(crate::Error::Corruption(format!(
                         "duplicate flat-vector entry for field {field_id}"
@@ -211,6 +465,7 @@ pub async fn load_vectors_file<D: Directory>(
             | ann_build::IVF_RABITQ_TYPE
             | ann_build::BINARY_IVF_TYPE
             | ann_build::RABITQ_TYPE => {
+                validate_ann_schema(schema, field_id, index_type)?;
                 // ANN payloads stay lazy and zero-copy; only their validated
                 // byte range is retained until first search.
                 let data = handle.read_bytes_range(offset..end).await?;
@@ -244,6 +499,20 @@ pub async fn load_vectors_file<D: Directory>(
                     "unknown vector index type {index_type} for field {field_id}"
                 )));
             }
+        }
+    }
+
+    // Every ANN implementation relies on the exact flat payload for reranking,
+    // multi-value expansion, merge streaming, and corruption checks. Flat-only
+    // fields remain valid while a segment is below its ANN build threshold, but
+    // an ANN-only field would silently change query semantics.
+    let mut ann_fields: Vec<u32> = indexes.keys().copied().collect();
+    ann_fields.sort_unstable();
+    for field_id in ann_fields {
+        if !flat_vectors.contains_key(&field_id) {
+            return Err(crate::Error::Corruption(format!(
+                "ANN vectors for field {field_id} are missing matching flat vector storage"
+            )));
         }
     }
 
@@ -375,6 +644,8 @@ pub async fn load_sparse_file<D: Directory>(
 
     // Parse TOC: per-field header(13B) + per-dim entries(28B each)
     let mut pos = 0usize;
+    let mut payload_ranges: Vec<(u64, u64, u32, u32)> = Vec::new();
+    let mut skip_ranges: Vec<(usize, usize, u32, u32)> = Vec::new();
 
     for _ in 0..num_fields {
         // Field header: field_id(4) + quant(1) + num_dims(4) + total_vectors(4) = 13 bytes
@@ -433,6 +704,7 @@ pub async fn load_sparse_file<D: Directory>(
                     "BMP field {field_id} blob {blob_offset}..{blob_end} overlaps sparse metadata at {skip_offset}"
                 )));
             }
+            payload_ranges.push((blob_offset, blob_end, field_id, dim_id));
 
             match BmpIndex::parse(
                 handle.clone(),
@@ -465,7 +737,7 @@ pub async fn load_sparse_file<D: Directory>(
                 let num_blocks = u32::from_le_bytes(d[16..20].try_into().unwrap());
                 let doc_count = u32::from_le_bytes(d[20..24].try_into().unwrap());
                 let max_weight = f32::from_le_bytes(d[24..28].try_into().unwrap());
-                let _skip_end = (skip_start as usize)
+                let skip_end = (skip_start as usize)
                     .checked_add(num_blocks as usize)
                     .filter(|&end| end <= skip_entry_count)
                     .ok_or_else(|| {
@@ -473,6 +745,7 @@ pub async fn load_sparse_file<D: Directory>(
                             "sparse field {field_id} dimension {dim_id} references skip entries {skip_start}+{num_blocks}, but only {skip_entry_count} exist"
                         ))
                     })?;
+                skip_ranges.push((skip_start as usize, skip_end, field_id, dim_id));
                 if block_data_offset > skip_offset {
                     return Err(crate::Error::Corruption(format!(
                         "sparse field {field_id} dimension {dim_id} block offset {block_data_offset} exceeds data section {skip_offset}"
@@ -483,6 +756,23 @@ pub async fn load_sparse_file<D: Directory>(
                         "sparse field {field_id} dimension {dim_id} has {doc_count} docs, segment has {total_docs}"
                     )));
                 }
+                if doc_count == 0 {
+                    return Err(crate::Error::Corruption(format!(
+                        "sparse field {field_id} dimension {dim_id} has blocks but no documents"
+                    )));
+                }
+                let payload_range = validate_sparse_dimension_skip_entries(
+                    skip_section.as_slice(),
+                    skip_start as usize,
+                    num_blocks as usize,
+                    block_data_offset,
+                    skip_offset,
+                    total_docs,
+                    max_weight,
+                    field_id,
+                    dim_id,
+                )?;
+                payload_ranges.push((payload_range.start, payload_range.end, field_id, dim_id));
                 dims.push(
                     dim_id,
                     block_data_offset,
@@ -518,6 +808,36 @@ pub async fn load_sparse_file<D: Directory>(
                 ),
             );
         }
+    }
+
+    payload_ranges.sort_unstable_by_key(|range| (range.0, range.1, range.2, range.3));
+    for pair in payload_ranges.windows(2) {
+        let (left_start, left_end, left_field, left_dim) = pair[0];
+        let (right_start, right_end, right_field, right_dim) = pair[1];
+        if right_start < left_end {
+            return Err(crate::Error::Corruption(format!(
+                "sparse payloads overlap: field {left_field} dimension {left_dim} uses \
+                 {left_start}..{left_end}, field {right_field} dimension {right_dim} uses \
+                 {right_start}..{right_end}"
+            )));
+        }
+    }
+    skip_ranges.sort_unstable_by_key(|range| (range.0, range.1, range.2, range.3));
+    let mut owned_skip_entries = 0usize;
+    for &(start, end, field_id, dim_id) in &skip_ranges {
+        if start != owned_skip_entries {
+            return Err(crate::Error::Corruption(format!(
+                "sparse skip-entry ownership has a gap or overlap before field {field_id} \
+                 dimension {dim_id}: expected start {owned_skip_entries}, got {start}"
+            )));
+        }
+        owned_skip_entries = end;
+    }
+    if owned_skip_entries != skip_entry_count {
+        return Err(crate::Error::Corruption(format!(
+            "sparse skip section contains {} unowned entries",
+            skip_entry_count - owned_skip_entries
+        )));
     }
 
     if pos != toc_data.len() {
@@ -613,11 +933,62 @@ pub async fn load_fast_fields_file<D: Directory>(
 #[cfg(test)]
 mod tests {
     use crate::directories::{DirectoryWriter, RamDirectory};
-    use crate::dsl::SchemaBuilder;
+    use crate::dsl::{DenseVectorQuantization, SchemaBuilder};
     use crate::segment::format::{DenseVectorTocEntry, write_dense_toc_and_footer};
-    use crate::structures::SparseVectorConfig;
+    use crate::segment::{FlatVectorData, ann_build};
+    use crate::structures::{SparseSkipEntry, SparseVectorConfig};
 
-    use super::{SegmentFiles, load_sparse_file, load_vectors_file};
+    use super::{
+        SegmentFiles, load_sparse_file, load_vectors_file, validate_sparse_dimension_skip_entries,
+    };
+
+    fn encoded_skip_entries(entries: &[SparseSkipEntry]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(entries.len() * SparseSkipEntry::SIZE);
+        for entry in entries {
+            entry.write_to_vec(&mut bytes);
+        }
+        bytes
+    }
+
+    fn vectors_file_with_toc(mut payload: Vec<u8>, entries: &[DenseVectorTocEntry]) -> Vec<u8> {
+        let toc_offset = payload.len() as u64;
+        write_dense_toc_and_footer(&mut payload, toc_offset, entries).unwrap();
+        payload
+    }
+
+    fn vectors_file_with_payloads(payloads: Vec<(u32, u8, Vec<u8>)>) -> Vec<u8> {
+        let mut file = Vec::new();
+        let mut entries = Vec::with_capacity(payloads.len());
+        for (field_id, index_type, payload) in payloads {
+            let offset = file.len() as u64;
+            let size = payload.len() as u64;
+            file.extend_from_slice(&payload);
+            entries.push(DenseVectorTocEntry {
+                field_id,
+                index_type,
+                offset,
+                size,
+            });
+        }
+        vectors_file_with_toc(file, &entries)
+    }
+
+    fn vectors_file_with_flat_payload(payload: Vec<u8>) -> Vec<u8> {
+        vectors_file_with_payloads(vec![(0, ann_build::FLAT_TYPE, payload)])
+    }
+
+    fn one_dense_flat_payload() -> Vec<u8> {
+        let mut payload = Vec::new();
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            2,
+            &[1.0, 2.0],
+            &[(0, 0)],
+            DenseVectorQuantization::F32,
+            &mut payload,
+        )
+        .unwrap();
+        payload
+    }
 
     #[tokio::test]
     async fn existing_truncated_sparse_file_is_corruption() {
@@ -659,7 +1030,7 @@ mod tests {
         .unwrap();
         dir.write(&files.vectors, &bytes).await.unwrap();
 
-        let result = load_vectors_file(&dir, &files, &schema).await;
+        let result = load_vectors_file(&dir, &files, &schema, 1).await;
         assert!(matches!(result, Err(crate::Error::Corruption(_))));
     }
 
@@ -672,7 +1043,276 @@ mod tests {
         let dir = RamDirectory::new();
         dir.write(&files.vectors, &[1, 2, 3]).await.unwrap();
 
-        let result = load_vectors_file(&dir, &files, &schema).await;
+        let result = load_vectors_file(&dir, &files, &schema, 1).await;
         assert!(matches!(result, Err(crate::Error::Corruption(_))));
+    }
+
+    #[tokio::test]
+    async fn flat_vectors_must_match_schema_storage() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_dense_vector_field("dense", 2, true, true);
+        let schema = schema.build();
+        let files = SegmentFiles::new(10);
+        let dir = RamDirectory::new();
+
+        let mut payload = Vec::new();
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            2,
+            &[1.0, 2.0],
+            &[(0, 0)],
+            DenseVectorQuantization::F16,
+            &mut payload,
+        )
+        .unwrap();
+        dir.write(&files.vectors, &vectors_file_with_flat_payload(payload))
+            .await
+            .unwrap();
+
+        let result = load_vectors_file(&dir, &files, &schema, 1).await;
+        assert!(matches!(result, Err(crate::Error::Corruption(_))));
+    }
+
+    #[tokio::test]
+    async fn flat_vector_doc_ids_must_fit_segment_metadata() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_dense_vector_field("dense", 2, true, true);
+        let schema = schema.build();
+        let files = SegmentFiles::new(11);
+        let dir = RamDirectory::new();
+
+        let mut payload = Vec::new();
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            2,
+            &[1.0, 2.0],
+            &[(1, 0)],
+            DenseVectorQuantization::F32,
+            &mut payload,
+        )
+        .unwrap();
+        dir.write(&files.vectors, &vectors_file_with_flat_payload(payload))
+            .await
+            .unwrap();
+
+        let result = load_vectors_file(&dir, &files, &schema, 1).await;
+        assert!(matches!(result, Err(crate::Error::Corruption(_))));
+    }
+
+    #[tokio::test]
+    async fn ann_vectors_require_same_field_flat_storage() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_dense_vector_field("dense_0", 2, true, true);
+        schema.add_dense_vector_field("dense_1", 2, true, true);
+        let schema = schema.build();
+        let files = SegmentFiles::new(12);
+        let dir = RamDirectory::new();
+
+        let mut flat = Vec::new();
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            2,
+            &[1.0, 2.0],
+            &[(0, 0)],
+            DenseVectorQuantization::F32,
+            &mut flat,
+        )
+        .unwrap();
+        let bytes = vectors_file_with_payloads(vec![
+            (0, ann_build::FLAT_TYPE, flat),
+            (1, ann_build::RABITQ_TYPE, vec![0]),
+        ]);
+        dir.write(&files.vectors, &bytes).await.unwrap();
+
+        let result = load_vectors_file(&dir, &files, &schema, 1).await;
+        let Err(crate::Error::Corruption(message)) = result else {
+            panic!("ANN storage without a same-field flat payload must be rejected");
+        };
+        assert!(message.contains("field 1"));
+        assert!(message.contains("missing matching flat"));
+    }
+
+    #[tokio::test]
+    async fn ann_vector_type_must_match_schema_index_type() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_dense_vector_field("dense", 2, true, true);
+        let schema = schema.build();
+        let files = SegmentFiles::new(13);
+        let dir = RamDirectory::new();
+
+        let mut flat = Vec::new();
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            2,
+            &[1.0, 2.0],
+            &[(0, 0)],
+            DenseVectorQuantization::F32,
+            &mut flat,
+        )
+        .unwrap();
+        let bytes = vectors_file_with_payloads(vec![
+            (0, ann_build::FLAT_TYPE, flat),
+            // `add_dense_vector_field` configures RaBitQ, not ScaNN.
+            (0, ann_build::SCANN_TYPE, vec![0]),
+        ]);
+        dir.write(&files.vectors, &bytes).await.unwrap();
+
+        let result = load_vectors_file(&dir, &files, &schema, 1).await;
+        let Err(crate::Error::Corruption(message)) = result else {
+            panic!("ANN storage that disagrees with the schema must be rejected");
+        };
+        assert!(message.contains("does not match schema"));
+    }
+
+    #[tokio::test]
+    async fn flat_only_vectors_are_valid_below_ann_build_threshold() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_dense_vector_field("dense", 2, true, true);
+        let schema = schema.build();
+        let files = SegmentFiles::new(14);
+        let dir = RamDirectory::new();
+
+        let mut flat = Vec::new();
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            2,
+            &[1.0, 2.0],
+            &[(0, 0)],
+            DenseVectorQuantization::F32,
+            &mut flat,
+        )
+        .unwrap();
+        dir.write(&files.vectors, &vectors_file_with_flat_payload(flat))
+            .await
+            .unwrap();
+
+        let loaded = load_vectors_file(&dir, &files, &schema, 1)
+            .await
+            .expect("flat-only pre-threshold segment must remain readable");
+        assert!(loaded.indexes.is_empty());
+        assert!(loaded.flat_vectors.contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn ann_vector_payload_must_not_be_empty() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_dense_vector_field("dense", 2, true, true);
+        let schema = schema.build();
+        let files = SegmentFiles::new(15);
+        let dir = RamDirectory::new();
+
+        let bytes = vectors_file_with_payloads(vec![
+            (0, ann_build::FLAT_TYPE, one_dense_flat_payload()),
+            (0, ann_build::RABITQ_TYPE, Vec::new()),
+        ]);
+        dir.write(&files.vectors, &bytes).await.unwrap();
+
+        let result = load_vectors_file(&dir, &files, &schema, 1).await;
+        let Err(crate::Error::Corruption(message)) = result else {
+            panic!("an empty ANN payload must be rejected");
+        };
+        assert!(message.contains("empty payload"));
+    }
+
+    #[tokio::test]
+    async fn vector_toc_rejects_overlapping_and_aliased_payloads() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_dense_vector_field("dense", 2, true, true);
+        let schema = schema.build();
+        let flat = one_dense_flat_payload();
+        let flat_len = flat.len() as u64;
+
+        // Exercise both exact aliasing and a one-byte partial overlap.
+        for (segment_id, ann_offset, ann_size) in [(16, 0, flat_len), (17, flat_len - 1, 2)] {
+            let files = SegmentFiles::new(segment_id);
+            let dir = RamDirectory::new();
+            let mut payload = flat.clone();
+            let required_len = (ann_offset + ann_size) as usize;
+            payload.resize(payload.len().max(required_len), 0);
+            let entries = [
+                DenseVectorTocEntry {
+                    field_id: 0,
+                    index_type: ann_build::FLAT_TYPE,
+                    offset: 0,
+                    size: flat_len,
+                },
+                DenseVectorTocEntry {
+                    field_id: 0,
+                    index_type: ann_build::RABITQ_TYPE,
+                    offset: ann_offset,
+                    size: ann_size,
+                },
+            ];
+            let bytes = vectors_file_with_toc(payload, &entries);
+            dir.write(&files.vectors, &bytes).await.unwrap();
+
+            let result = load_vectors_file(&dir, &files, &schema, 1).await;
+            let Err(crate::Error::Corruption(message)) = result else {
+                panic!("overlapping vector payloads must be rejected");
+            };
+            assert!(message.contains("overlap"));
+        }
+    }
+
+    #[tokio::test]
+    async fn vector_toc_allows_unreferenced_padding_gaps() {
+        let mut schema = SchemaBuilder::default();
+        schema.add_dense_vector_field("dense_0", 2, true, true);
+        schema.add_dense_vector_field("dense_1", 2, true, true);
+        let schema = schema.build();
+        let files = SegmentFiles::new(18);
+        let dir = RamDirectory::new();
+
+        let first = one_dense_flat_payload();
+        let second = one_dense_flat_payload();
+        let first_size = first.len() as u64;
+        let padding = 8 - first.len() % 8;
+        let second_offset = first_size + padding as u64;
+        let second_size = second.len() as u64;
+        let mut payload = first;
+        payload.resize(payload.len() + padding, 0);
+        payload.extend_from_slice(&second);
+        let entries = [
+            DenseVectorTocEntry {
+                field_id: 0,
+                index_type: ann_build::FLAT_TYPE,
+                offset: 0,
+                size: first_size,
+            },
+            DenseVectorTocEntry {
+                field_id: 1,
+                index_type: ann_build::FLAT_TYPE,
+                offset: second_offset,
+                size: second_size,
+            },
+        ];
+        let bytes = vectors_file_with_toc(payload, &entries);
+        dir.write(&files.vectors, &bytes).await.unwrap();
+
+        let loaded = load_vectors_file(&dir, &files, &schema, 1)
+            .await
+            .expect("padding between disjoint vector payloads must be allowed");
+        assert_eq!(loaded.flat_vectors.len(), 2);
+    }
+
+    #[test]
+    fn sparse_skip_metadata_rejects_unsafe_ranges_and_pruning_bounds() {
+        let valid = [
+            SparseSkipEntry::new(0, 4, 0, 8, 2.0),
+            SparseSkipEntry::new(4, 9, 8, 12, 3.0),
+        ];
+        let valid_bytes = encoded_skip_entries(&valid);
+        validate_sparse_dimension_skip_entries(&valid_bytes, 0, valid.len(), 10, 30, 10, 3.0, 0, 7)
+            .unwrap();
+
+        let overlapping = encoded_skip_entries(&[
+            SparseSkipEntry::new(0, 4, 0, 8, 2.0),
+            SparseSkipEntry::new(5, 9, 7, 4, 2.0),
+        ]);
+        assert!(
+            validate_sparse_dimension_skip_entries(&overlapping, 0, 2, 10, 30, 10, 2.0, 0, 7,)
+                .is_err()
+        );
+
+        let unsafe_bound = encoded_skip_entries(&[SparseSkipEntry::new(0, 9, 0, 8, 4.0)]);
+        assert!(
+            validate_sparse_dimension_skip_entries(&unsafe_bound, 0, 1, 10, 30, 10, 3.0, 0, 7,)
+                .is_err()
+        );
     }
 }

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -9,6 +9,20 @@ pub use bmp::BmpIndex;
 pub(crate) use types::DimRawData;
 pub use types::{SparseIndex, VectorIndex, VectorSearchResult};
 
+/// Bound vocabulary and posting expansion before a prefix query starts loading
+/// posting payloads. These are per-segment limits; callers should use exact-term
+/// or a more selective prefix when they are exceeded.
+const MAX_PREFIX_TERMS: usize = 1_024;
+const MAX_PREFIX_POSTINGS: u64 = 5_000_000;
+/// Bound ANN result/resolution vectors per segment. Exact vector bytes are
+/// scored in smaller batches below, so peak rerank scratch stays predictable.
+const MAX_DENSE_CANDIDATES_PER_SEGMENT: usize = 200_000;
+const MAX_ANN_ORDINAL_OVERFETCH: usize = 32;
+/// Preferred vector count; wide vectors reduce it to stay under the byte cap.
+const DENSE_SCORE_BATCH: usize = 4_096;
+const BINARY_SCORE_BATCH: usize = 8_192;
+const MAX_VECTOR_SCORE_BATCH_BYTES: usize = 8 * 1024 * 1024;
+
 /// Memory statistics for a single segment
 #[derive(Debug, Clone, Default)]
 pub struct SegmentMemoryStats {
@@ -44,6 +58,8 @@ impl SegmentMemoryStats {
     }
 }
 
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
 use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
@@ -51,6 +67,7 @@ use rustc_hash::FxHashMap;
 use super::vector_data::LazyFlatVectorData;
 use crate::directories::{Directory, FileHandle};
 use crate::dsl::{DenseVectorQuantization, Document, Field, Schema};
+use crate::query::{MAX_DENSE_NPROBE, MAX_DENSE_RERANK_FACTOR};
 use crate::structures::{
     AsyncSSTableReader, BlockPostingList, CoarseCentroids, IVFPQIndex, IVFRaBitQIndex, PQCodebook,
     RaBitQIndex, SSTableStats, TermInfo,
@@ -95,8 +112,8 @@ pub(crate) fn combine_ordinal_results(
             .collect();
         results.sort_unstable_by(|a, b| {
             b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
+                .total_cmp(&a.score)
+                .then_with(|| a.doc_id.cmp(&b.doc_id))
         });
         results.truncate(limit);
         return results;
@@ -120,11 +137,407 @@ pub(crate) fn combine_ordinal_results(
         .collect();
     results.sort_unstable_by(|a, b| {
         b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .total_cmp(&a.score)
+            .then_with(|| a.doc_id.cmp(&b.doc_id))
     });
     results.truncate(limit);
     results
+}
+
+/// Heap entry used by exact flat-vector search after all values belonging to
+/// one document have been combined. Keeping the heap at document granularity
+/// prevents several strong values from one document from crowding other
+/// documents out of the raw vector top-k.
+struct HeapVectorResult(VectorSearchResult);
+
+impl PartialEq for HeapVectorResult {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.score.to_bits() == other.0.score.to_bits() && self.0.doc_id == other.0.doc_id
+    }
+}
+
+impl Eq for HeapVectorResult {}
+
+impl Ord for HeapVectorResult {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // BinaryHeap top is the worst retained document: lower score, then
+        // larger doc ID for deterministic equal-score eviction.
+        other
+            .0
+            .score
+            .total_cmp(&self.0.score)
+            .then_with(|| self.0.doc_id.cmp(&other.0.doc_id))
+    }
+}
+
+impl PartialOrd for HeapVectorResult {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Incrementally combine a flat vector stream sorted by `(doc_id, ordinal)`
+/// and retain only the best `limit` documents. Scratch is O(values in the
+/// current document + retained output), independent of the segment size.
+struct FlatDocumentCollector {
+    heap: BinaryHeap<HeapVectorResult>,
+    limit: usize,
+    combiner: crate::query::MultiValueCombiner,
+    current_doc: Option<DocId>,
+    current_ordinals: Vec<(u32, f32)>,
+}
+
+impl FlatDocumentCollector {
+    fn new(limit: usize, combiner: crate::query::MultiValueCombiner) -> Self {
+        Self {
+            heap: BinaryHeap::with_capacity(limit.min(8 * 1024)),
+            limit,
+            combiner,
+            current_doc: None,
+            current_ordinals: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, doc_id: DocId, ordinal: u16, score: f32) {
+        if self.current_doc.is_some_and(|current| current != doc_id) {
+            self.finish_current();
+        }
+        self.current_doc = Some(doc_id);
+        self.current_ordinals.push((ordinal as u32, score));
+    }
+
+    fn finish_current(&mut self) {
+        let Some(doc_id) = self.current_doc.take() else {
+            return;
+        };
+        let score = self.combiner.combine(&self.current_ordinals);
+        let should_retain = self.heap.len() < self.limit
+            || self.heap.peek().is_some_and(|worst| {
+                HeapVectorResult(VectorSearchResult::new(doc_id, score, Vec::new()))
+                    .cmp(worst)
+                    .is_lt()
+            });
+
+        if !should_retain {
+            // The overwhelmingly common path once the heap is full. Reuse
+            // the ordinal scratch instead of allocating a fresh Vec for
+            // every rejected document in a flat scan.
+            self.current_ordinals.clear();
+            return;
+        }
+
+        let ordinals = std::mem::take(&mut self.current_ordinals);
+        let entry = HeapVectorResult(VectorSearchResult::new(doc_id, score, ordinals));
+        if self.heap.len() < self.limit {
+            self.heap.push(entry);
+        } else if let Some(mut worst) = self.heap.peek_mut() {
+            // Recycle the evicted result's allocation as the next document's
+            // scratch. PeekMut restores heap order when it is dropped.
+            let mut evicted = std::mem::replace(&mut worst.0, entry.0);
+            evicted.ordinals.clear();
+            self.current_ordinals = evicted.ordinals;
+        }
+    }
+
+    fn into_results(mut self) -> Vec<VectorSearchResult> {
+        self.finish_current();
+        let mut results: Vec<_> = self.heap.into_iter().map(|entry| entry.0).collect();
+        results.sort_unstable_by(|a, b| {
+            b.score
+                .total_cmp(&a.score)
+                .then_with(|| a.doc_id.cmp(&b.doc_id))
+        });
+        results
+    }
+}
+
+/// Collect a stream already grouped by document (the layout produced by flat
+/// storage expansion) without rebuilding a hash table for every candidate.
+fn combine_grouped_ordinal_results(
+    raw: impl IntoIterator<Item = RawVectorCandidate>,
+    combiner: crate::query::MultiValueCombiner,
+    limit: usize,
+) -> Vec<VectorSearchResult> {
+    let mut collector = FlatDocumentCollector::new(limit, combiner);
+    for (doc_id, ordinal, score) in raw {
+        collector.push(doc_id, ordinal, score);
+    }
+    collector.into_results()
+}
+
+#[derive(Clone, Copy)]
+struct DenseSearchParams {
+    dim: usize,
+    nprobe: usize,
+    unit_norm: bool,
+}
+
+/// Compute the ANN candidate count without relying on saturating float casts.
+fn checked_dense_fetch_k(k: usize, rerank_factor: f32) -> Result<usize> {
+    if !rerank_factor.is_finite() || !(1.0..=MAX_DENSE_RERANK_FACTOR).contains(&rerank_factor) {
+        return Err(Error::Query(format!(
+            "dense rerank_factor must be finite and in [1, {MAX_DENSE_RERANK_FACTOR}], got {rerank_factor}"
+        )));
+    }
+
+    let fetch = (k as f64) * (rerank_factor as f64);
+    if !fetch.is_finite()
+        || fetch > usize::MAX as f64
+        || fetch > MAX_DENSE_CANDIDATES_PER_SEGMENT as f64
+    {
+        return Err(Error::Query(format!(
+            "dense candidate count exceeds the per-segment maximum of \
+             {MAX_DENSE_CANDIDATES_PER_SEGMENT}: k={k}, rerank_factor={rerank_factor}"
+        )));
+    }
+    Ok(fetch.ceil() as usize)
+}
+
+fn ann_ordinal_fetch_k(fetch_k: usize, num_vectors: usize, num_docs: usize) -> usize {
+    if num_vectors == 0 || num_docs == 0 {
+        return 0;
+    }
+    let average_values_per_doc = num_vectors
+        .div_ceil(num_docs)
+        .clamp(1, MAX_ANN_ORDINAL_OVERFETCH);
+    fetch_k
+        .saturating_mul(average_values_per_doc)
+        .min(MAX_DENSE_CANDIDATES_PER_SEGMENT)
+        .min(num_vectors)
+}
+
+/// Search vector-level ANN progressively until it yields enough distinct
+/// documents, or until the probed candidate population / safety cap is
+/// exhausted. A fixed average-values overfetch is insufficient for skewed
+/// fields where one document owns most of the best vectors.
+fn progressive_ann_search<F>(
+    target_docs: usize,
+    initial_fetch: usize,
+    max_vectors: usize,
+    mut search: F,
+) -> Result<Vec<RawVectorCandidate>>
+where
+    F: FnMut(usize) -> Vec<RawVectorCandidate>,
+{
+    let max_fetch = max_vectors.min(MAX_DENSE_CANDIDATES_PER_SEGMENT);
+    if target_docs == 0 || max_fetch == 0 {
+        return Ok(Vec::new());
+    }
+
+    let target_docs = target_docs.min(max_fetch);
+    let mut fetch = initial_fetch.max(target_docs).min(max_fetch);
+    loop {
+        let results = search(fetch);
+        let mut docs = rustc_hash::FxHashSet::with_capacity_and_hasher(
+            target_docs.min(results.len()),
+            Default::default(),
+        );
+        for &(doc_id, _, _) in &results {
+            docs.insert(doc_id);
+            if docs.len() >= target_docs {
+                return Ok(results);
+            }
+        }
+        if results.len() < fetch || fetch == max_vectors {
+            return Ok(results);
+        }
+        if fetch == max_fetch {
+            return Err(Error::Query(format!(
+                "ANN search reached the per-segment candidate limit of \
+                 {MAX_DENSE_CANDIDATES_PER_SEGMENT} with only {} of {target_docs} requested \
+                 documents; reduce k or the number of vector values per document",
+                docs.len()
+            )));
+        }
+
+        let next_fetch = fetch.saturating_mul(2).min(max_fetch);
+        if next_fetch == fetch {
+            return Ok(results);
+        }
+        fetch = next_fetch;
+    }
+}
+
+#[inline]
+fn bounded_vector_score_batch(vector_byte_size: usize, preferred: usize) -> usize {
+    preferred.min((MAX_VECTOR_SCORE_BATCH_BYTES / vector_byte_size.max(1)).max(1))
+}
+
+fn checked_file_range(
+    offset: u64,
+    length: u64,
+    file_length: u64,
+    description: &str,
+) -> Result<std::ops::Range<u64>> {
+    let end = offset
+        .checked_add(length)
+        .ok_or_else(|| Error::Corruption(format!("{description} byte range overflows u64")))?;
+    if end > file_length {
+        return Err(Error::Corruption(format!(
+            "{description} byte range {offset}..{end} exceeds file length {file_length}"
+        )));
+    }
+    Ok(offset..end)
+}
+
+type RawVectorCandidate = (u32, u16, f32);
+type ResolvedVectorCandidate = (usize, usize); // (result index, flat-vector index)
+
+/// ANN operates on individual vectors, but document combiners require every
+/// stored value for a candidate document. Expand the deduplicated ANN document
+/// union before exact reranking, with a hard per-segment vector budget.
+fn expand_ann_candidate_documents(
+    ann_results: &[RawVectorCandidate],
+    flat: &LazyFlatVectorData,
+) -> Result<(Vec<RawVectorCandidate>, Vec<ResolvedVectorCandidate>)> {
+    let mut candidate_docs: Vec<DocId> = ann_results.iter().map(|candidate| candidate.0).collect();
+    candidate_docs.sort_unstable();
+    candidate_docs.dedup();
+
+    let mut expanded = Vec::new();
+    let mut resolved = Vec::new();
+    for doc_id in candidate_docs {
+        let (start, count) = flat.flat_indexes_for_doc_range(doc_id);
+        if count == 0 {
+            return Err(Error::Corruption(format!(
+                "ANN candidate document {doc_id} is missing from flat vector storage"
+            )));
+        }
+        let next_len = expanded
+            .len()
+            .checked_add(count)
+            .ok_or_else(|| Error::Query("ANN candidate vector expansion overflow".to_string()))?;
+        if next_len > MAX_DENSE_CANDIDATES_PER_SEGMENT {
+            return Err(Error::Query(format!(
+                "ANN candidate documents expand to more than \
+                 {MAX_DENSE_CANDIDATES_PER_SEGMENT} vectors in one segment"
+            )));
+        }
+        expanded.reserve(count);
+        resolved.reserve(count);
+        let end = start
+            .checked_add(count)
+            .ok_or_else(|| Error::Corruption("flat vector range overflow".to_string()))?;
+        for flat_index in start..end {
+            let (stored_doc_id, ordinal) = flat.get_doc_id(flat_index);
+            if stored_doc_id != doc_id {
+                return Err(Error::Corruption(format!(
+                    "flat vector doc map is not contiguous for document {doc_id}"
+                )));
+            }
+            let result_index = expanded.len();
+            expanded.push((doc_id, ordinal, 0.0));
+            resolved.push((result_index, flat_index));
+        }
+    }
+    Ok((expanded, resolved))
+}
+
+async fn exact_score_binary_candidate_documents(
+    ann_results: &[RawVectorCandidate],
+    flat: &LazyFlatVectorData,
+    query: &[u8],
+    dim_bits: usize,
+) -> Result<Vec<RawVectorCandidate>> {
+    let (mut expanded, resolved) = expand_ann_candidate_documents(ann_results, flat)?;
+    let vector_byte_size = flat.vector_byte_size();
+    let batch_len = bounded_vector_score_batch(vector_byte_size, BINARY_SCORE_BATCH);
+    let raw_capacity = batch_len
+        .checked_mul(vector_byte_size)
+        .ok_or_else(|| Error::Query("binary candidate buffer size overflow".to_string()))?;
+    let mut raw = vec![0u8; raw_capacity];
+    let mut scores = vec![0.0f32; batch_len];
+
+    for chunk in resolved.chunks(batch_len) {
+        #[cfg(feature = "native")]
+        flat.prefetch_vectors(chunk.iter().map(|&(_, flat_index)| flat_index));
+        let raw_len = chunk
+            .len()
+            .checked_mul(vector_byte_size)
+            .ok_or_else(|| Error::Query("binary candidate buffer size overflow".to_string()))?;
+        let raw = &mut raw[..raw_len];
+        for (buffer_index, &(_, flat_index)) in chunk.iter().enumerate() {
+            flat.read_vector_raw_into(
+                flat_index,
+                &mut raw[buffer_index * vector_byte_size..(buffer_index + 1) * vector_byte_size],
+            )
+            .await
+            .map_err(Error::Io)?;
+        }
+        crate::structures::simd::batch_hamming_scores(
+            query,
+            raw,
+            vector_byte_size,
+            dim_bits,
+            &mut scores[..chunk.len()],
+        );
+        for (buffer_index, &(result_index, _)) in chunk.iter().enumerate() {
+            expanded[result_index].2 = scores[buffer_index];
+        }
+    }
+    Ok(expanded)
+}
+
+#[cfg(feature = "sync")]
+fn exact_score_binary_candidate_documents_sync(
+    ann_results: &[RawVectorCandidate],
+    flat: &LazyFlatVectorData,
+    query: &[u8],
+    dim_bits: usize,
+) -> Result<Vec<RawVectorCandidate>> {
+    let (mut expanded, resolved) = expand_ann_candidate_documents(ann_results, flat)?;
+    let vector_byte_size = flat.vector_byte_size();
+    let batch_len = bounded_vector_score_batch(vector_byte_size, BINARY_SCORE_BATCH);
+    let raw_capacity = batch_len
+        .checked_mul(vector_byte_size)
+        .ok_or_else(|| Error::Query("binary candidate buffer size overflow".to_string()))?;
+    let mut raw = vec![0u8; raw_capacity];
+    let mut scores = vec![0.0f32; batch_len];
+
+    for chunk in resolved.chunks(batch_len) {
+        let raw_len = chunk
+            .len()
+            .checked_mul(vector_byte_size)
+            .ok_or_else(|| Error::Query("binary candidate buffer size overflow".to_string()))?;
+        let raw = &mut raw[..raw_len];
+        for (buffer_index, &(_, flat_index)) in chunk.iter().enumerate() {
+            flat.read_vector_raw_into_sync(
+                flat_index,
+                &mut raw[buffer_index * vector_byte_size..(buffer_index + 1) * vector_byte_size],
+            )
+            .map_err(Error::Io)?;
+        }
+        crate::structures::simd::batch_hamming_scores(
+            query,
+            raw,
+            vector_byte_size,
+            dim_bits,
+            &mut scores[..chunk.len()],
+        );
+        for (buffer_index, &(result_index, _)) in chunk.iter().enumerate() {
+            expanded[result_index].2 = scores[buffer_index];
+        }
+    }
+    Ok(expanded)
+}
+
+fn validate_coarse_centroids(centroids: &CoarseCentroids, dim: usize) -> Result<()> {
+    let expected = (centroids.num_clusters as usize)
+        .checked_mul(dim)
+        .ok_or_else(|| Error::Corruption("coarse centroid size overflow".into()))?;
+    if centroids.num_clusters == 0
+        || centroids.dim != dim
+        || centroids.centroids.len() != expected
+        || centroids.centroids.iter().any(|value| !value.is_finite())
+    {
+        return Err(Error::Corruption(format!(
+            "invalid coarse centroids: clusters={}, dim={}, values={} (expected dim={dim}, values={expected})",
+            centroids.num_clusters,
+            centroids.dim,
+            centroids.centroids.len()
+        )));
+    }
+    Ok(())
 }
 
 /// Async segment reader with lazy loading
@@ -171,6 +584,21 @@ impl SegmentReader {
         schema: Arc<Schema>,
         cache_blocks: usize,
     ) -> Result<Self> {
+        Self::open_with_cache_blocks(dir, segment_id, schema, cache_blocks, cache_blocks).await
+    }
+
+    /// Open a segment with independent term-dictionary and document-store caches.
+    ///
+    /// [`Self::open`] keeps the historical single-capacity API for standalone
+    /// callers. Native indexes use this method so `IndexConfig::store_cache_blocks`
+    /// is not silently replaced by the (usually much larger) term cache capacity.
+    pub async fn open_with_cache_blocks<D: Directory>(
+        dir: &D,
+        segment_id: SegmentId,
+        schema: Arc<Schema>,
+        term_cache_blocks: usize,
+        store_cache_blocks: usize,
+    ) -> Result<Self> {
         let files = SegmentFiles::new(segment_id.0);
 
         // Read metadata (small, always loaded)
@@ -181,17 +609,17 @@ impl SegmentReader {
 
         // Open term dictionary with lazy loading (fetches ranges on demand)
         let term_dict_handle = dir.open_lazy(&files.term_dict).await?;
-        let term_dict = AsyncSSTableReader::open(term_dict_handle, cache_blocks).await?;
+        let term_dict = AsyncSSTableReader::open(term_dict_handle, term_cache_blocks).await?;
 
         // Get postings file handle (lazy - fetches ranges on demand)
         let postings_handle = dir.open_lazy(&files.postings).await?;
 
         // Open store with lazy loading
         let store_handle = dir.open_lazy(&files.store).await?;
-        let store = AsyncStoreReader::open(store_handle, cache_blocks).await?;
+        let store = AsyncStoreReader::open(store_handle, store_cache_blocks).await?;
 
         // Load dense vector indexes from unified .vectors file
-        let vectors_data = loader::load_vectors_file(dir, &files, &schema).await?;
+        let vectors_data = loader::load_vectors_file(dir, &files, &schema, meta.num_docs).await?;
         let vector_indexes = vectors_data.indexes;
         let flat_vectors = vectors_data.flat_vectors;
 
@@ -409,11 +837,11 @@ impl SegmentReader {
     pub fn memory_stats(&self) -> SegmentMemoryStats {
         let term_dict_stats = self.term_dict.stats();
 
-        // Term dict cache: num_blocks * avg_block_size (estimate 4KB per cached block)
-        let term_dict_cache_bytes = self.term_dict.cached_blocks() * 4096;
-
-        // Store cache: similar estimate
-        let store_cache_bytes = self.store.cached_blocks() * 4096;
+        // Report actual decompressed heap retention. Both caches use variable
+        // boundary blocks, so multiplying a block count by a guessed size can
+        // materially under-report resident memory.
+        let term_dict_cache_bytes = self.term_dict.cached_bytes();
+        let store_cache_bytes = self.store.cached_bytes();
 
         // Sparse index: SoA dim table + OwnedBytes skip section + BMP grids
         let sparse_index_bytes: usize = self
@@ -502,16 +930,13 @@ impl SegmentReader {
             Error::Corruption("TermInfo has neither inline nor external data".to_string())
         })?;
 
-        let start = posting_offset;
-        let end = start + posting_len;
-
-        if end > self.postings_handle.len() {
-            return Err(Error::Corruption(
-                "Posting offset out of bounds".to_string(),
-            ));
-        }
-
-        let posting_bytes = self.postings_handle.read_bytes_range(start..end).await?;
+        let range = checked_file_range(
+            posting_offset,
+            posting_len,
+            self.postings_handle.len(),
+            "posting",
+        )?;
+        let posting_bytes = self.postings_handle.read_bytes_range(range).await?;
         let block_list = BlockPostingList::deserialize_zero_copy(posting_bytes)?;
 
         Ok(Some(block_list))
@@ -523,12 +948,32 @@ impl SegmentReader {
         field: Field,
         prefix: &[u8],
     ) -> Result<Vec<BlockPostingList>> {
+        if prefix.is_empty() {
+            return Err(Error::Query("prefix must not be empty".into()));
+        }
         // Build composite key prefix: field_id ++ prefix
         let mut key_prefix = Vec::with_capacity(4 + prefix.len());
         key_prefix.extend_from_slice(&field.0.to_le_bytes());
         key_prefix.extend_from_slice(prefix);
 
-        let entries = self.term_dict.prefix_scan(&key_prefix).await?;
+        let (entries, truncated) = self
+            .term_dict
+            .prefix_scan_limited(&key_prefix, MAX_PREFIX_TERMS)
+            .await?;
+        if truncated {
+            return Err(Error::Query(format!(
+                "prefix expands to more than {MAX_PREFIX_TERMS} terms"
+            )));
+        }
+        let posting_count: u64 = entries
+            .iter()
+            .map(|(_, term_info)| term_info.doc_freq() as u64)
+            .sum();
+        if posting_count > MAX_PREFIX_POSTINGS {
+            return Err(Error::Query(format!(
+                "prefix expands to {posting_count} postings (maximum {MAX_PREFIX_POSTINGS})"
+            )));
+        }
         let mut results = Vec::with_capacity(entries.len());
 
         for (_key, term_info) in entries {
@@ -539,12 +984,13 @@ impl SegmentReader {
                 }
                 results.push(BlockPostingList::from_posting_list(&posting_list)?);
             } else if let Some((posting_offset, posting_len)) = term_info.external_info() {
-                let start = posting_offset;
-                let end = start + posting_len;
-                if end > self.postings_handle.len() {
-                    continue;
-                }
-                let posting_bytes = self.postings_handle.read_bytes_range(start..end).await?;
+                let range = checked_file_range(
+                    posting_offset,
+                    posting_len,
+                    self.postings_handle.len(),
+                    "prefix posting",
+                )?;
+                let posting_bytes = self.postings_handle.read_bytes_range(range).await?;
                 results.push(BlockPostingList::deserialize_zero_copy(posting_bytes)?);
             }
         }
@@ -713,9 +1159,8 @@ impl SegmentReader {
 
     /// Read raw posting bytes at offset
     pub async fn read_postings(&self, offset: u64, len: u64) -> Result<Vec<u8>> {
-        let start = offset;
-        let end = start + len;
-        let bytes = self.postings_handle.read_bytes_range(start..end).await?;
+        let range = checked_file_range(offset, len, self.postings_handle.len(), "posting")?;
+        let bytes = self.postings_handle.read_bytes_range(range).await?;
         Ok(bytes.to_vec())
     }
 
@@ -725,15 +1170,126 @@ impl SegmentReader {
             Some(h) => h,
             None => return Ok(None),
         };
-        let start = offset;
-        let end = start + len;
-        let bytes = handle.read_bytes_range(start..end).await?;
+        let range = checked_file_range(offset, len, handle.len(), "position")?;
+        let bytes = handle.read_bytes_range(range).await?;
         Ok(Some(bytes.to_vec()))
     }
 
     /// Check if this segment has a positions file
     pub fn has_positions_file(&self) -> bool {
         self.positions_handle.is_some()
+    }
+
+    /// Validate all caller-controlled dense-search inputs before touching ANN
+    /// structures or entering SIMD code. This is deliberately repeated at the
+    /// segment boundary so non-server users receive the same safety guarantees.
+    fn validate_dense_search_request(
+        &self,
+        field: Field,
+        query: &[f32],
+        nprobe: usize,
+        rerank_factor: f32,
+        combiner: crate::query::MultiValueCombiner,
+    ) -> Result<DenseSearchParams> {
+        let entry = self
+            .schema
+            .get_field_entry(field)
+            .ok_or_else(|| Error::FieldNotFound(field.0.to_string()))?;
+        if entry.field_type != crate::dsl::FieldType::DenseVector {
+            return Err(Error::InvalidFieldType {
+                expected: "dense_vector".to_string(),
+                got: format!("{:?}", entry.field_type),
+            });
+        }
+        let config = entry.dense_vector_config.as_ref().ok_or_else(|| {
+            Error::Schema(format!(
+                "dense vector field '{}' has no dense vector configuration",
+                entry.name
+            ))
+        })?;
+
+        if query.is_empty() {
+            return Err(Error::Query(format!(
+                "dense query vector for field '{}' must not be empty",
+                entry.name
+            )));
+        }
+        if query.len() != config.dim {
+            return Err(Error::Query(format!(
+                "dense query vector dimension {} does not match field '{}' dimension {}",
+                query.len(),
+                entry.name,
+                config.dim
+            )));
+        }
+        if let Some((index, value)) = query
+            .iter()
+            .enumerate()
+            .find(|(_, value)| !value.is_finite())
+        {
+            return Err(Error::Query(format!(
+                "dense query vector for field '{}' contains non-finite value {value} at index {index}",
+                entry.name
+            )));
+        }
+
+        // A zero query override means "use the schema". Legacy schemas may
+        // contain zero for flat fields, so retain 32 as a final ANN fallback.
+        let nprobe = match (nprobe, config.nprobe) {
+            (0, 0) => 32,
+            (0, schema_nprobe) => schema_nprobe,
+            (query_nprobe, _) => query_nprobe,
+        };
+        if nprobe > MAX_DENSE_NPROBE {
+            return Err(Error::Query(format!(
+                "dense nprobe must be at most {MAX_DENSE_NPROBE}, got {nprobe}"
+            )));
+        }
+
+        // Validate the factor here even for empty segments. Otherwise malformed
+        // requests would succeed or fail depending on segment contents.
+        checked_dense_fetch_k(0, rerank_factor)?;
+        combiner.validate().map_err(Error::Query)?;
+
+        Ok(DenseSearchParams {
+            dim: config.dim,
+            nprobe,
+            unit_norm: config.unit_norm,
+        })
+    }
+
+    fn validate_binary_search_request(&self, field: Field, query: &[u8]) -> Result<usize> {
+        let entry = self
+            .schema
+            .get_field_entry(field)
+            .ok_or_else(|| Error::FieldNotFound(field.0.to_string()))?;
+        if entry.field_type != crate::dsl::FieldType::BinaryDenseVector {
+            return Err(Error::InvalidFieldType {
+                expected: "binary_dense_vector".to_string(),
+                got: format!("{:?}", entry.field_type),
+            });
+        }
+        let config = entry.binary_dense_vector_config.as_ref().ok_or_else(|| {
+            Error::Schema(format!(
+                "binary dense vector field '{}' has no configuration",
+                entry.name
+            ))
+        })?;
+        if config.dim == 0 || !config.dim.is_multiple_of(8) {
+            return Err(Error::Schema(format!(
+                "binary dense vector field '{}' has invalid dimension {}",
+                entry.name, config.dim
+            )));
+        }
+        if query.len() != config.byte_len() {
+            return Err(Error::Query(format!(
+                "binary query byte length {} does not match field '{}' byte length {}",
+                query.len(),
+                entry.name,
+                config.byte_len()
+            )));
+        }
+        Ok(config.dim)
     }
 
     /// Batch cosine scoring on raw quantized bytes.
@@ -748,26 +1304,66 @@ impl SegmentReader {
         dim: usize,
         scores: &mut [f32],
         unit_norm: bool,
-    ) {
+    ) -> Result<()> {
         use crate::dsl::DenseVectorQuantization;
         use crate::structures::simd;
+
+        if query.len() != dim {
+            return Err(Error::Query(format!(
+                "dense SIMD query dimension {} does not match vector dimension {dim}",
+                query.len()
+            )));
+        }
+        let element_size = match quant {
+            DenseVectorQuantization::F32 => std::mem::size_of::<f32>(),
+            DenseVectorQuantization::F16 => std::mem::size_of::<u16>(),
+            DenseVectorQuantization::UInt8 => 1,
+            DenseVectorQuantization::Binary => {
+                return Err(Error::InvalidFieldType {
+                    expected: "non-binary dense vector".to_string(),
+                    got: "binary dense vector".to_string(),
+                });
+            }
+        };
+        let required_bytes = scores
+            .len()
+            .checked_mul(dim)
+            .and_then(|elements| elements.checked_mul(element_size))
+            .ok_or_else(|| Error::Corruption("dense vector batch byte length overflow".into()))?;
+        if raw.len() < required_bytes {
+            return Err(Error::Corruption(format!(
+                "dense vector batch is truncated: need {required_bytes} bytes, got {}",
+                raw.len()
+            )));
+        }
+        if quant == DenseVectorQuantization::F16
+            && required_bytes > 0
+            && !(raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>())
+        {
+            return Err(Error::Corruption(
+                "f16 vector data is not 2-byte aligned".to_string(),
+            ));
+        }
+
         match (quant, unit_norm) {
             (DenseVectorQuantization::F32, false) => {
                 let num_floats = scores.len() * dim;
-                debug_assert!(
-                    (raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()),
-                    "f32 vector data not 4-byte aligned — vectors file may use legacy format"
-                );
+                if !(raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()) {
+                    return Err(Error::Corruption(
+                        "f32 vector data is not 4-byte aligned".to_string(),
+                    ));
+                }
                 let vectors: &[f32] =
                     unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const f32, num_floats) };
                 simd::batch_cosine_scores(query, vectors, dim, scores);
             }
             (DenseVectorQuantization::F32, true) => {
                 let num_floats = scores.len() * dim;
-                debug_assert!(
-                    (raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()),
-                    "f32 vector data not 4-byte aligned"
-                );
+                if !(raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()) {
+                    return Err(Error::Corruption(
+                        "f32 vector data is not 4-byte aligned".to_string(),
+                    ));
+                }
                 let vectors: &[f32] =
                     unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const f32, num_floats) };
                 simd::batch_dot_scores(query, vectors, dim, scores);
@@ -784,11 +1380,9 @@ impl SegmentReader {
             (DenseVectorQuantization::UInt8, true) => {
                 simd::batch_dot_scores_u8(query, raw, dim, scores);
             }
-            (DenseVectorQuantization::Binary, _) => {
-                // Binary vectors use search_binary_dense_vector(), not search_dense_vector()
-                unreachable!("Binary quantization should not reach score_quantized_batch");
-            }
+            (DenseVectorQuantization::Binary, _) => unreachable!("validated above"),
         }
+        Ok(())
     }
 
     /// Search dense vectors using RaBitQ
@@ -805,28 +1399,43 @@ impl SegmentReader {
         rerank_factor: f32,
         combiner: crate::query::MultiValueCombiner,
     ) -> Result<Vec<VectorSearchResult>> {
+        let params =
+            self.validate_dense_search_request(field, query, nprobe, rerank_factor, combiner)?;
+        let fetch_k = checked_dense_fetch_k(k, rerank_factor)?;
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+
         let ann_index = self.vector_indexes.get(&field.0);
         let lazy_flat = self.flat_vectors.get(&field.0);
+        let ann_fetch_k = lazy_flat.map_or(fetch_k, |flat| {
+            ann_ordinal_fetch_k(fetch_k, flat.num_vectors, flat.num_docs_with_vectors())
+        });
 
         // No vectors at all for this field
         if ann_index.is_none() && lazy_flat.is_none() {
             return Ok(Vec::new());
         }
 
-        // Check if vectors are pre-normalized (skip per-vector norm in scoring)
-        let unit_norm = self
-            .schema
-            .get_field_entry(field)
-            .and_then(|e| e.dense_vector_config.as_ref())
-            .is_some_and(|c| c.unit_norm);
+        if ann_index.is_some() && lazy_flat.is_none() {
+            return Err(Error::Corruption(format!(
+                "dense ANN field {} is missing flat vector storage",
+                field.0
+            )));
+        }
 
-        /// Batch size for brute-force scoring (4096 vectors × 768 dims × 4 bytes ≈ 12MB)
-        const BRUTE_FORCE_BATCH: usize = 4096;
-
-        let fetch_k = (k as f32 * rerank_factor.max(1.0)).ceil() as usize;
+        if let Some(flat) = lazy_flat
+            && flat.dim != params.dim
+        {
+            return Err(Error::Corruption(format!(
+                "dense vector field {} has schema dimension {} but flat storage dimension {}",
+                field.0, params.dim, flat.dim
+            )));
+        }
 
         // Results are (doc_id, ordinal, score) where score = similarity (higher = better)
         let t0 = std::time::Instant::now();
+        let mut flat_results = None;
         let mut results: Vec<(u32, u16, f32)> = if let Some(index) = ann_index {
             // ANN search (RaBitQ, IVF, ScaNN)
             match index {
@@ -834,11 +1443,27 @@ impl SegmentReader {
                     let rabitq = lazy.get().ok_or_else(|| {
                         Error::Schema("RaBitQ index deserialization failed".to_string())
                     })?;
-                    rabitq
-                        .search(query, fetch_k)
-                        .into_iter()
-                        .map(|(doc_id, ordinal, dist)| (doc_id, ordinal, 1.0 / (1.0 + dist)))
-                        .collect()
+                    if rabitq.codebook.config.dim != params.dim {
+                        return Err(Error::Corruption(format!(
+                            "RaBitQ index dimension {} does not match schema dimension {}",
+                            rabitq.codebook.config.dim, params.dim
+                        )));
+                    }
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    progressive_ann_search(
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        ann_fetch_k,
+                        rabitq.len().min(flat.num_vectors),
+                        |candidate_k| {
+                            rabitq
+                                .search(query, candidate_k)
+                                .into_iter()
+                                .map(|(doc_id, ordinal, dist)| {
+                                    (doc_id, ordinal, 1.0 / (1.0 + dist))
+                                })
+                                .collect()
+                        },
+                    )?
                 }
                 VectorIndex::IVF(lazy) => {
                     let (index, codebook) = lazy.get().ok_or_else(|| {
@@ -850,12 +1475,43 @@ impl SegmentReader {
                             field.0
                         ))
                     })?;
-                    let effective_nprobe = if nprobe > 0 { nprobe } else { 32 };
-                    index
-                        .search(centroids, codebook, query, fetch_k, Some(effective_nprobe))
-                        .into_iter()
-                        .map(|(doc_id, ordinal, dist)| (doc_id, ordinal, 1.0 / (1.0 + dist)))
-                        .collect()
+                    validate_coarse_centroids(centroids, params.dim)?;
+                    if index.config.dim != params.dim
+                        || codebook.config.dim != params.dim
+                        || index.centroids_version != centroids.version
+                        || index.codebook_version != codebook.version
+                        || index
+                            .clusters
+                            .iter()
+                            .any(|(cluster_id, _)| cluster_id >= centroids.num_clusters)
+                    {
+                        return Err(Error::Corruption(format!(
+                            "IVF index/codebook/centroid metadata does not match schema dimension {}",
+                            params.dim
+                        )));
+                    }
+                    let effective_nprobe = params.nprobe.min(centroids.num_clusters as usize);
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    progressive_ann_search(
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        ann_fetch_k,
+                        index.len().min(flat.num_vectors),
+                        |candidate_k| {
+                            index
+                                .search(
+                                    centroids,
+                                    codebook,
+                                    query,
+                                    candidate_k,
+                                    Some(effective_nprobe),
+                                )
+                                .into_iter()
+                                .map(|(doc_id, ordinal, dist)| {
+                                    (doc_id, ordinal, 1.0 / (1.0 + dist))
+                                })
+                                .collect()
+                        },
+                    )?
                 }
                 VectorIndex::ScaNN(lazy) => {
                     let (index, codebook) = lazy.get().ok_or_else(|| {
@@ -867,12 +1523,43 @@ impl SegmentReader {
                             field.0
                         ))
                     })?;
-                    let effective_nprobe = if nprobe > 0 { nprobe } else { 32 };
-                    index
-                        .search(centroids, codebook, query, fetch_k, Some(effective_nprobe))
-                        .into_iter()
-                        .map(|(doc_id, ordinal, dist)| (doc_id, ordinal, 1.0 / (1.0 + dist)))
-                        .collect()
+                    validate_coarse_centroids(centroids, params.dim)?;
+                    if index.config.dim != params.dim
+                        || codebook.config.dim != params.dim
+                        || index.centroids_version != centroids.version
+                        || index.codebook_version != codebook.version
+                        || index
+                            .clusters
+                            .iter()
+                            .any(|(cluster_id, _)| cluster_id >= centroids.num_clusters)
+                    {
+                        return Err(Error::Corruption(format!(
+                            "ScaNN index/codebook/centroid metadata does not match schema dimension {}",
+                            params.dim
+                        )));
+                    }
+                    let effective_nprobe = params.nprobe.min(centroids.num_clusters as usize);
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    progressive_ann_search(
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        ann_fetch_k,
+                        index.len().min(flat.num_vectors),
+                        |candidate_k| {
+                            index
+                                .search(
+                                    centroids,
+                                    codebook,
+                                    query,
+                                    candidate_k,
+                                    Some(effective_nprobe),
+                                )
+                                .into_iter()
+                                .map(|(doc_id, ordinal, dist)| {
+                                    (doc_id, ordinal, 1.0 / (1.0 + dist))
+                                })
+                                .collect()
+                        },
+                    )?
                 }
                 VectorIndex::BinaryIvf(_) => {
                     // Binary IVF serves Hamming queries only (BinaryDenseVectorQuery)
@@ -880,8 +1567,9 @@ impl SegmentReader {
                 }
             }
         } else if let Some(lazy_flat) = lazy_flat {
-            // Batched brute-force from lazy flat vectors (native-precision SIMD scoring)
-            // Uses a top-k heap to avoid collecting and sorting all N candidates.
+            // Batched brute-force from lazy flat vectors (native-precision SIMD scoring).
+            // Combine every value of a document before document-level top-k;
+            // vector-level top-k loses documents on multi-valued fields.
             log::debug!(
                 "[search_dense] field {}: brute-force on {} vectors (dim={}, quant={:?})",
                 field.0,
@@ -892,11 +1580,13 @@ impl SegmentReader {
             let dim = lazy_flat.dim;
             let n = lazy_flat.num_vectors;
             let quant = lazy_flat.quantization;
-            let mut collector = crate::query::ScoreCollector::new(fetch_k);
-            let mut scores = vec![0f32; BRUTE_FORCE_BATCH];
+            let batch_len =
+                bounded_vector_score_batch(lazy_flat.vector_byte_size(), DENSE_SCORE_BATCH);
+            let mut collector = FlatDocumentCollector::new(fetch_k.min(n), combiner);
+            let mut scores = vec![0f32; batch_len];
 
-            for batch_start in (0..n).step_by(BRUTE_FORCE_BATCH) {
-                let batch_count = BRUTE_FORCE_BATCH.min(n - batch_start);
+            for batch_start in (0..n).step_by(batch_len) {
+                let batch_count = batch_len.min(n - batch_start);
                 let batch_bytes = lazy_flat
                     .read_vectors_batch(batch_start, batch_count)
                     .await
@@ -909,20 +1599,17 @@ impl SegmentReader {
                     quant,
                     dim,
                     &mut scores[..batch_count],
-                    unit_norm,
-                );
+                    params.unit_norm,
+                )?;
 
                 for (i, &score) in scores.iter().enumerate().take(batch_count) {
                     let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
-                    collector.insert_with_ordinal(doc_id, score, ordinal);
+                    collector.push(doc_id, ordinal, score);
                 }
             }
 
-            collector
-                .into_sorted_results()
-                .into_iter()
-                .map(|(doc_id, score, ordinal)| (doc_id, ordinal, score))
-                .collect()
+            flat_results = Some(collector.into_results());
+            Vec::new()
         } else {
             return Ok(Vec::new());
         };
@@ -940,15 +1627,19 @@ impl SegmentReader {
                 self.schema.get_field_name(field).unwrap_or("?"),
                 kind,
                 l1_elapsed.as_secs_f64(),
-                results.len(),
+                flat_results.as_ref().map_or(results.len(), Vec::len),
             );
         }
         log::debug!(
             "[search_dense] field {}: L1 returned {} candidates in {:.1}ms",
             field.0,
-            results.len(),
+            flat_results.as_ref().map_or(results.len(), Vec::len),
             l1_elapsed.as_secs_f64() * 1000.0
         );
+
+        if let Some(results) = flat_results {
+            return Ok(results);
+        }
 
         // Rerank ANN candidates using raw vectors from lazy flat (binary search lookup)
         // Uses native-precision SIMD scoring on quantized bytes — no dequantization overhead.
@@ -961,53 +1652,68 @@ impl SegmentReader {
             let quant = lazy_flat.quantization;
             let vbs = lazy_flat.vector_byte_size();
 
-            // Resolve flat indexes for each candidate via binary search
-            let mut resolved: Vec<(usize, usize)> = Vec::new(); // (result_idx, flat_idx)
-            for (ri, c) in results.iter().enumerate() {
-                let (start, entries) = lazy_flat.flat_indexes_for_doc(c.0);
-                for (j, &(_, ord)) in entries.iter().enumerate() {
-                    if ord == c.1 {
-                        resolved.push((ri, start + j));
-                        break;
-                    }
-                }
-            }
+            // Deduplicate ANN hits by document, then exact-score every value
+            // of each candidate document so the configured combiner sees a
+            // complete value set.
+            let (expanded, mut resolved) = expand_ann_candidate_documents(&results, lazy_flat)?;
+            results = expanded;
 
             let t_resolve = t_rerank.elapsed();
             if !resolved.is_empty() {
                 // Sort by flat_idx for sequential mmap access (better page locality)
                 resolved.sort_unstable_by_key(|&(_, flat_idx)| flat_idx);
 
-                // Under memory pressure the candidate pages are likely evicted;
-                // batch-prefetch them so page-ins overlap instead of serializing
-                // as one major fault per vector. (MADV_RANDOM for this region is
-                // set once at segment open.)
-                #[cfg(feature = "native")]
-                lazy_flat.prefetch_vectors(resolved.iter().map(|&(_, flat_idx)| flat_idx));
+                // Read and score bounded chunks. A legal high-recall request
+                // can resolve hundreds of thousands of candidates; allocating
+                // all raw vectors at once used to require gigabytes per segment.
+                let batch_len = bounded_vector_score_batch(vbs, DENSE_SCORE_BATCH);
+                let max_batch = batch_len.min(resolved.len());
+                let max_raw_len = max_batch
+                    .checked_mul(vbs)
+                    .ok_or_else(|| Error::Query("dense rerank buffer size overflow".into()))?;
+                let mut raw_buf = vec![0u8; max_raw_len];
+                let mut scores = vec![0f32; max_batch];
+                let mut read_elapsed = std::time::Duration::ZERO;
+                let mut score_elapsed = std::time::Duration::ZERO;
 
-                // Batch-read raw quantized bytes into contiguous buffer
-                let t_read = std::time::Instant::now();
-                let mut raw_buf = vec![0u8; resolved.len() * vbs];
-                for (buf_idx, &(_, flat_idx)) in resolved.iter().enumerate() {
-                    let _ = lazy_flat
-                        .read_vector_raw_into(
-                            flat_idx,
-                            &mut raw_buf[buf_idx * vbs..(buf_idx + 1) * vbs],
-                        )
-                        .await;
-                }
+                for chunk in resolved.chunks(batch_len) {
+                    // Advise only the bounded chunk about to be consumed. A
+                    // whole-candidate MADV_WILLNEED can evict the rest of the
+                    // working set long before those pages are read.
+                    #[cfg(feature = "native")]
+                    lazy_flat.prefetch_vectors(chunk.iter().map(|&(_, flat_idx)| flat_idx));
+                    let raw_len = chunk
+                        .len()
+                        .checked_mul(vbs)
+                        .ok_or_else(|| Error::Query("dense rerank buffer size overflow".into()))?;
+                    let raw = &mut raw_buf[..raw_len];
 
-                let read_elapsed = t_read.elapsed();
+                    let t_read = std::time::Instant::now();
+                    for (buf_idx, &(_, flat_idx)) in chunk.iter().enumerate() {
+                        lazy_flat
+                            .read_vector_raw_into(
+                                flat_idx,
+                                &mut raw[buf_idx * vbs..(buf_idx + 1) * vbs],
+                            )
+                            .await
+                            .map_err(crate::Error::Io)?;
+                    }
+                    read_elapsed += t_read.elapsed();
 
-                // Native-precision batch SIMD cosine scoring
-                let t_score = std::time::Instant::now();
-                let mut scores = vec![0f32; resolved.len()];
-                Self::score_quantized_batch(query, &raw_buf, quant, dim, &mut scores, unit_norm);
-                let score_elapsed = t_score.elapsed();
+                    let t_score = std::time::Instant::now();
+                    Self::score_quantized_batch(
+                        query,
+                        raw,
+                        quant,
+                        dim,
+                        &mut scores[..chunk.len()],
+                        params.unit_norm,
+                    )?;
+                    score_elapsed += t_score.elapsed();
 
-                // Write scores back to results
-                for (buf_idx, &(ri, _)) in resolved.iter().enumerate() {
-                    results[ri].2 = scores[buf_idx];
+                    for (buf_idx, &(ri, _)) in chunk.iter().enumerate() {
+                        results[ri].2 = scores[buf_idx];
+                    }
                 }
 
                 crate::observe::dense_rerank(
@@ -1031,11 +1737,6 @@ impl SegmentReader {
                 );
             }
 
-            if results.len() > fetch_k {
-                results.select_nth_unstable_by(fetch_k, |a, b| b.2.total_cmp(&a.2));
-                results.truncate(fetch_k);
-            }
-            results.sort_unstable_by(|a, b| b.2.total_cmp(&a.2));
             log::debug!(
                 "[search_dense] field {}: rerank total={:.1}ms",
                 field.0,
@@ -1043,7 +1744,7 @@ impl SegmentReader {
             );
         }
 
-        Ok(combine_ordinal_results(results, combiner, k))
+        Ok(combine_grouped_ordinal_results(results, combiner, k))
     }
 
     /// Query-time nprobe for a binary field from its schema config (None = index default).
@@ -1065,14 +1766,50 @@ impl SegmentReader {
         k: usize,
         combiner: crate::query::MultiValueCombiner,
     ) -> Result<Vec<VectorSearchResult>> {
+        let schema_dim = self.validate_binary_search_request(field, query)?;
+        combiner.validate().map_err(Error::Query)?;
+        if k == 0 {
+            return Ok(Vec::new());
+        }
         let t0 = crate::observe::Timer::start();
-        // Binary IVF index: probe nprobe nearest Hamming clusters (exact
-        // distances within probed clusters — no rerank needed).
+        // Binary IVF finds candidate documents. Expand each candidate to all
+        // of its stored values and exact-score them before applying the
+        // document combiner.
         if let Some(VectorIndex::BinaryIvf(lazy)) = self.vector_indexes.get(&field.0)
             && let Some(ivf) = lazy.get()
         {
+            if ivf.config.dim_bits != schema_dim {
+                return Err(Error::Corruption(format!(
+                    "binary IVF field {} has schema dimension {} but index dimension {}",
+                    field.0, schema_dim, ivf.config.dim_bits
+                )));
+            }
+            let flat = self.flat_vectors.get(&field.0).ok_or_else(|| {
+                Error::Corruption(format!(
+                    "binary IVF field {} is missing flat vector storage",
+                    field.0
+                ))
+            })?;
+            if flat.dim != schema_dim
+                || flat.quantization != crate::dsl::DenseVectorQuantization::Binary
+            {
+                return Err(Error::Corruption(format!(
+                    "binary IVF field {} has inconsistent flat vector metadata",
+                    field.0
+                )));
+            }
             let nprobe = self.binary_ivf_nprobe(field);
-            let results = ivf.search(query, k, nprobe);
+            let initial_fetch =
+                ann_ordinal_fetch_k(k, flat.num_vectors, flat.num_docs_with_vectors());
+            let ann_results = progressive_ann_search(
+                k.min(flat.num_docs_with_vectors()),
+                initial_fetch,
+                ivf.len().min(flat.num_vectors),
+                |candidate_k| ivf.search(query, candidate_k, nprobe),
+            )?;
+            let results =
+                exact_score_binary_candidate_documents(&ann_results, flat, query, schema_dim)
+                    .await?;
             crate::observe::dense_l1(
                 self.schema.index_label(),
                 self.schema.get_field_name(field).unwrap_or("?"),
@@ -1080,7 +1817,7 @@ impl SegmentReader {
                 t0.secs(),
                 results.len(),
             );
-            return Ok(combine_ordinal_results(results, combiner, k));
+            return Ok(combine_grouped_ordinal_results(results, combiner, k));
         }
 
         let lazy_flat = match self.flat_vectors.get(&field.0) {
@@ -1088,11 +1825,16 @@ impl SegmentReader {
             None => return Ok(Vec::new()),
         };
 
-        const BRUTE_FORCE_BATCH: usize = 8192; // Binary vectors are tiny, use larger batches
-
         let dim_bits = lazy_flat.dim;
         let byte_len = lazy_flat.vector_byte_size();
         let n = lazy_flat.num_vectors;
+
+        if dim_bits != schema_dim {
+            return Err(Error::Corruption(format!(
+                "binary vector field {} has schema dimension {} but flat storage dimension {}",
+                field.0, schema_dim, dim_bits
+            )));
+        }
 
         if byte_len != query.len() {
             return Err(Error::Schema(format!(
@@ -1102,11 +1844,12 @@ impl SegmentReader {
             )));
         }
 
-        let mut collector = crate::query::ScoreCollector::new(k);
-        let mut scores = vec![0f32; BRUTE_FORCE_BATCH];
+        let batch_len = bounded_vector_score_batch(byte_len, BINARY_SCORE_BATCH);
+        let mut collector = FlatDocumentCollector::new(k, combiner);
+        let mut scores = vec![0f32; batch_len];
 
-        for batch_start in (0..n).step_by(BRUTE_FORCE_BATCH) {
-            let batch_count = BRUTE_FORCE_BATCH.min(n - batch_start);
+        for batch_start in (0..n).step_by(batch_len) {
+            let batch_count = batch_len.min(n - batch_start);
             let batch_bytes = lazy_flat
                 .read_vectors_batch(batch_start, batch_count)
                 .await
@@ -1121,20 +1864,13 @@ impl SegmentReader {
                 &mut scores[..batch_count],
             );
 
-            let threshold = collector.threshold();
             for (i, &score) in scores.iter().enumerate().take(batch_count) {
-                if score > threshold {
-                    let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
-                    collector.insert_with_ordinal(doc_id, score, ordinal);
-                }
+                let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
+                collector.push(doc_id, ordinal, score);
             }
         }
 
-        let results: Vec<(u32, u16, f32)> = collector
-            .into_sorted_results()
-            .into_iter()
-            .map(|(doc_id, score, ordinal)| (doc_id, ordinal, score))
-            .collect();
+        let results = collector.into_results();
 
         crate::observe::dense_l1(
             self.schema.index_label(),
@@ -1143,7 +1879,7 @@ impl SegmentReader {
             t0.secs(),
             results.len(),
         );
-        Ok(combine_ordinal_results(results, combiner, k))
+        Ok(results)
     }
 
     /// Check if this segment has dense vectors for the given field
@@ -1228,8 +1964,11 @@ impl SegmentReader {
             None => return Ok(None),
         };
 
-        // Read the position data
-        let slice = handle.slice(offset..offset + length);
+        // Read the position data only after validating untrusted offsets from
+        // the term dictionary. Direct `offset + length` can wrap in release
+        // builds and alias an unrelated range.
+        let range = checked_file_range(offset, length, handle.len(), "position list")?;
+        let slice = handle.slice(range);
         let data = slice.read_bytes().await?;
 
         // Deserialize
@@ -1280,16 +2019,13 @@ impl SegmentReader {
             Error::Corruption("TermInfo has neither inline nor external data".to_string())
         })?;
 
-        let start = posting_offset;
-        let end = start + posting_len;
-
-        if end > self.postings_handle.len() {
-            return Err(Error::Corruption(
-                "Posting offset out of bounds".to_string(),
-            ));
-        }
-
-        let posting_bytes = self.postings_handle.read_bytes_range_sync(start..end)?;
+        let range = checked_file_range(
+            posting_offset,
+            posting_len,
+            self.postings_handle.len(),
+            "posting",
+        )?;
+        let posting_bytes = self.postings_handle.read_bytes_range_sync(range)?;
         let block_list = BlockPostingList::deserialize_zero_copy(posting_bytes)?;
 
         Ok(Some(block_list))
@@ -1301,11 +2037,30 @@ impl SegmentReader {
         field: Field,
         prefix: &[u8],
     ) -> Result<Vec<BlockPostingList>> {
+        if prefix.is_empty() {
+            return Err(Error::Query("prefix must not be empty".into()));
+        }
         let mut key_prefix = Vec::with_capacity(4 + prefix.len());
         key_prefix.extend_from_slice(&field.0.to_le_bytes());
         key_prefix.extend_from_slice(prefix);
 
-        let entries = self.term_dict.prefix_scan_sync(&key_prefix)?;
+        let (entries, truncated) = self
+            .term_dict
+            .prefix_scan_limited_sync(&key_prefix, MAX_PREFIX_TERMS)?;
+        if truncated {
+            return Err(Error::Query(format!(
+                "prefix expands to more than {MAX_PREFIX_TERMS} terms"
+            )));
+        }
+        let posting_count: u64 = entries
+            .iter()
+            .map(|(_, term_info)| term_info.doc_freq() as u64)
+            .sum();
+        if posting_count > MAX_PREFIX_POSTINGS {
+            return Err(Error::Query(format!(
+                "prefix expands to {posting_count} postings (maximum {MAX_PREFIX_POSTINGS})"
+            )));
+        }
         let mut results = Vec::with_capacity(entries.len());
 
         for (_key, term_info) in entries {
@@ -1316,12 +2071,13 @@ impl SegmentReader {
                 }
                 results.push(BlockPostingList::from_posting_list(&posting_list)?);
             } else if let Some((posting_offset, posting_len)) = term_info.external_info() {
-                let start = posting_offset;
-                let end = start + posting_len;
-                if end > self.postings_handle.len() {
-                    continue;
-                }
-                let posting_bytes = self.postings_handle.read_bytes_range_sync(start..end)?;
+                let range = checked_file_range(
+                    posting_offset,
+                    posting_len,
+                    self.postings_handle.len(),
+                    "prefix posting",
+                )?;
+                let posting_bytes = self.postings_handle.read_bytes_range_sync(range)?;
                 results.push(BlockPostingList::deserialize_zero_copy(posting_bytes)?);
             }
         }
@@ -1356,7 +2112,8 @@ impl SegmentReader {
             None => return Ok(None),
         };
 
-        let slice = handle.slice(offset..offset + length);
+        let range = checked_file_range(offset, length, handle.len(), "position list")?;
+        let slice = handle.slice(range);
         let data = slice.read_bytes_sync()?;
 
         let pos_list = crate::structures::PositionPostingList::deserialize(data.as_slice())?;
@@ -1374,21 +2131,38 @@ impl SegmentReader {
         rerank_factor: f32,
         combiner: crate::query::MultiValueCombiner,
     ) -> Result<Vec<VectorSearchResult>> {
+        let params =
+            self.validate_dense_search_request(field, query, nprobe, rerank_factor, combiner)?;
+        let fetch_k = checked_dense_fetch_k(k, rerank_factor)?;
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+
         let ann_index = self.vector_indexes.get(&field.0);
         let lazy_flat = self.flat_vectors.get(&field.0);
+        let ann_fetch_k = lazy_flat.map_or(fetch_k, |flat| {
+            ann_ordinal_fetch_k(fetch_k, flat.num_vectors, flat.num_docs_with_vectors())
+        });
 
         if ann_index.is_none() && lazy_flat.is_none() {
             return Ok(Vec::new());
         }
 
-        let unit_norm = self
-            .schema
-            .get_field_entry(field)
-            .and_then(|e| e.dense_vector_config.as_ref())
-            .is_some_and(|c| c.unit_norm);
+        if ann_index.is_some() && lazy_flat.is_none() {
+            return Err(Error::Corruption(format!(
+                "dense ANN field {} is missing flat vector storage",
+                field.0
+            )));
+        }
 
-        const BRUTE_FORCE_BATCH: usize = 4096;
-        let fetch_k = (k as f32 * rerank_factor.max(1.0)).ceil() as usize;
+        if let Some(flat) = lazy_flat
+            && flat.dim != params.dim
+        {
+            return Err(Error::Corruption(format!(
+                "dense vector field {} has schema dimension {} but flat storage dimension {}",
+                field.0, params.dim, flat.dim
+            )));
+        }
 
         let mut results: Vec<(u32, u16, f32)> = if let Some(index) = ann_index {
             // ANN search (already sync)
@@ -1397,11 +2171,27 @@ impl SegmentReader {
                     let rabitq = lazy.get().ok_or_else(|| {
                         Error::Schema("RaBitQ index deserialization failed".to_string())
                     })?;
-                    rabitq
-                        .search(query, fetch_k)
-                        .into_iter()
-                        .map(|(doc_id, ordinal, dist)| (doc_id, ordinal, 1.0 / (1.0 + dist)))
-                        .collect()
+                    if rabitq.codebook.config.dim != params.dim {
+                        return Err(Error::Corruption(format!(
+                            "RaBitQ index dimension {} does not match schema dimension {}",
+                            rabitq.codebook.config.dim, params.dim
+                        )));
+                    }
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    progressive_ann_search(
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        ann_fetch_k,
+                        rabitq.len().min(flat.num_vectors),
+                        |candidate_k| {
+                            rabitq
+                                .search(query, candidate_k)
+                                .into_iter()
+                                .map(|(doc_id, ordinal, dist)| {
+                                    (doc_id, ordinal, 1.0 / (1.0 + dist))
+                                })
+                                .collect()
+                        },
+                    )?
                 }
                 VectorIndex::IVF(lazy) => {
                     let (index, codebook) = lazy.get().ok_or_else(|| {
@@ -1413,12 +2203,43 @@ impl SegmentReader {
                             field.0
                         ))
                     })?;
-                    let effective_nprobe = if nprobe > 0 { nprobe } else { 32 };
-                    index
-                        .search(centroids, codebook, query, fetch_k, Some(effective_nprobe))
-                        .into_iter()
-                        .map(|(doc_id, ordinal, dist)| (doc_id, ordinal, 1.0 / (1.0 + dist)))
-                        .collect()
+                    validate_coarse_centroids(centroids, params.dim)?;
+                    if index.config.dim != params.dim
+                        || codebook.config.dim != params.dim
+                        || index.centroids_version != centroids.version
+                        || index.codebook_version != codebook.version
+                        || index
+                            .clusters
+                            .iter()
+                            .any(|(cluster_id, _)| cluster_id >= centroids.num_clusters)
+                    {
+                        return Err(Error::Corruption(format!(
+                            "IVF index/codebook/centroid metadata does not match schema dimension {}",
+                            params.dim
+                        )));
+                    }
+                    let effective_nprobe = params.nprobe.min(centroids.num_clusters as usize);
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    progressive_ann_search(
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        ann_fetch_k,
+                        index.len().min(flat.num_vectors),
+                        |candidate_k| {
+                            index
+                                .search(
+                                    centroids,
+                                    codebook,
+                                    query,
+                                    candidate_k,
+                                    Some(effective_nprobe),
+                                )
+                                .into_iter()
+                                .map(|(doc_id, ordinal, dist)| {
+                                    (doc_id, ordinal, 1.0 / (1.0 + dist))
+                                })
+                                .collect()
+                        },
+                    )?
                 }
                 VectorIndex::ScaNN(lazy) => {
                     let (index, codebook) = lazy.get().ok_or_else(|| {
@@ -1430,12 +2251,43 @@ impl SegmentReader {
                             field.0
                         ))
                     })?;
-                    let effective_nprobe = if nprobe > 0 { nprobe } else { 32 };
-                    index
-                        .search(centroids, codebook, query, fetch_k, Some(effective_nprobe))
-                        .into_iter()
-                        .map(|(doc_id, ordinal, dist)| (doc_id, ordinal, 1.0 / (1.0 + dist)))
-                        .collect()
+                    validate_coarse_centroids(centroids, params.dim)?;
+                    if index.config.dim != params.dim
+                        || codebook.config.dim != params.dim
+                        || index.centroids_version != centroids.version
+                        || index.codebook_version != codebook.version
+                        || index
+                            .clusters
+                            .iter()
+                            .any(|(cluster_id, _)| cluster_id >= centroids.num_clusters)
+                    {
+                        return Err(Error::Corruption(format!(
+                            "ScaNN index/codebook/centroid metadata does not match schema dimension {}",
+                            params.dim
+                        )));
+                    }
+                    let effective_nprobe = params.nprobe.min(centroids.num_clusters as usize);
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    progressive_ann_search(
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        ann_fetch_k,
+                        index.len().min(flat.num_vectors),
+                        |candidate_k| {
+                            index
+                                .search(
+                                    centroids,
+                                    codebook,
+                                    query,
+                                    candidate_k,
+                                    Some(effective_nprobe),
+                                )
+                                .into_iter()
+                                .map(|(doc_id, ordinal, dist)| {
+                                    (doc_id, ordinal, 1.0 / (1.0 + dist))
+                                })
+                                .collect()
+                        },
+                    )?
                 }
                 VectorIndex::BinaryIvf(_) => {
                     // Binary IVF serves Hamming queries only (BinaryDenseVectorQuery)
@@ -1447,11 +2299,13 @@ impl SegmentReader {
             let dim = lazy_flat.dim;
             let n = lazy_flat.num_vectors;
             let quant = lazy_flat.quantization;
-            let mut collector = crate::query::ScoreCollector::new(fetch_k);
-            let mut scores = vec![0f32; BRUTE_FORCE_BATCH];
+            let batch_len =
+                bounded_vector_score_batch(lazy_flat.vector_byte_size(), DENSE_SCORE_BATCH);
+            let mut collector = FlatDocumentCollector::new(fetch_k.min(n), combiner);
+            let mut scores = vec![0f32; batch_len];
 
-            for batch_start in (0..n).step_by(BRUTE_FORCE_BATCH) {
-                let batch_count = BRUTE_FORCE_BATCH.min(n - batch_start);
+            for batch_start in (0..n).step_by(batch_len) {
+                let batch_count = batch_len.min(n - batch_start);
                 let batch_bytes = lazy_flat
                     .read_vectors_batch_sync(batch_start, batch_count)
                     .map_err(crate::Error::Io)?;
@@ -1463,20 +2317,16 @@ impl SegmentReader {
                     quant,
                     dim,
                     &mut scores[..batch_count],
-                    unit_norm,
-                );
+                    params.unit_norm,
+                )?;
 
                 for (i, &score) in scores.iter().enumerate().take(batch_count) {
                     let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
-                    collector.insert_with_ordinal(doc_id, score, ordinal);
+                    collector.push(doc_id, ordinal, score);
                 }
             }
 
-            collector
-                .into_sorted_results()
-                .into_iter()
-                .map(|(doc_id, score, ordinal)| (doc_id, ordinal, score))
-                .collect()
+            return Ok(collector.into_results());
         } else {
             return Ok(Vec::new());
         };
@@ -1490,43 +2340,51 @@ impl SegmentReader {
             let quant = lazy_flat.quantization;
             let vbs = lazy_flat.vector_byte_size();
 
-            let mut resolved: Vec<(usize, usize)> = Vec::new();
-            for (ri, c) in results.iter().enumerate() {
-                let (start, entries) = lazy_flat.flat_indexes_for_doc(c.0);
-                for (j, &(_, ord)) in entries.iter().enumerate() {
-                    if ord == c.1 {
-                        resolved.push((ri, start + j));
-                        break;
-                    }
-                }
-            }
+            let (expanded, mut resolved) = expand_ann_candidate_documents(&results, lazy_flat)?;
+            results = expanded;
 
             if !resolved.is_empty() {
                 resolved.sort_unstable_by_key(|&(_, flat_idx)| flat_idx);
-                let mut raw_buf = vec![0u8; resolved.len() * vbs];
-                for (buf_idx, &(_, flat_idx)) in resolved.iter().enumerate() {
-                    let _ = lazy_flat.read_vector_raw_into_sync(
-                        flat_idx,
-                        &mut raw_buf[buf_idx * vbs..(buf_idx + 1) * vbs],
-                    );
-                }
+                let batch_len = bounded_vector_score_batch(vbs, DENSE_SCORE_BATCH);
+                let max_batch = batch_len.min(resolved.len());
+                let max_raw_len = max_batch
+                    .checked_mul(vbs)
+                    .ok_or_else(|| Error::Query("dense rerank buffer size overflow".into()))?;
+                let mut raw_buf = vec![0u8; max_raw_len];
+                let mut scores = vec![0f32; max_batch];
 
-                let mut scores = vec![0f32; resolved.len()];
-                Self::score_quantized_batch(query, &raw_buf, quant, dim, &mut scores, unit_norm);
+                for chunk in resolved.chunks(batch_len) {
+                    let raw_len = chunk
+                        .len()
+                        .checked_mul(vbs)
+                        .ok_or_else(|| Error::Query("dense rerank buffer size overflow".into()))?;
+                    let raw = &mut raw_buf[..raw_len];
+                    for (buf_idx, &(_, flat_idx)) in chunk.iter().enumerate() {
+                        lazy_flat
+                            .read_vector_raw_into_sync(
+                                flat_idx,
+                                &mut raw[buf_idx * vbs..(buf_idx + 1) * vbs],
+                            )
+                            .map_err(crate::Error::Io)?;
+                    }
 
-                for (buf_idx, &(ri, _)) in resolved.iter().enumerate() {
-                    results[ri].2 = scores[buf_idx];
+                    Self::score_quantized_batch(
+                        query,
+                        raw,
+                        quant,
+                        dim,
+                        &mut scores[..chunk.len()],
+                        params.unit_norm,
+                    )?;
+
+                    for (buf_idx, &(ri, _)) in chunk.iter().enumerate() {
+                        results[ri].2 = scores[buf_idx];
+                    }
                 }
             }
-
-            if results.len() > fetch_k {
-                results.select_nth_unstable_by(fetch_k, |a, b| b.2.total_cmp(&a.2));
-                results.truncate(fetch_k);
-            }
-            results.sort_unstable_by(|a, b| b.2.total_cmp(&a.2));
         }
 
-        Ok(combine_ordinal_results(results, combiner, k))
+        Ok(combine_grouped_ordinal_results(results, combiner, k))
     }
 
     /// Synchronous binary dense vector search (mmap/RAM only).
@@ -1541,14 +2399,47 @@ impl SegmentReader {
         k: usize,
         combiner: crate::query::MultiValueCombiner,
     ) -> Result<Vec<VectorSearchResult>> {
+        let schema_dim = self.validate_binary_search_request(field, query)?;
+        combiner.validate().map_err(Error::Query)?;
+        if k == 0 {
+            return Ok(Vec::new());
+        }
         let t0 = crate::observe::Timer::start();
-        // Binary IVF index: probe nprobe nearest Hamming clusters (exact
-        // distances within probed clusters — no rerank needed).
+        // Binary IVF candidate union followed by complete document scoring.
         if let Some(VectorIndex::BinaryIvf(lazy)) = self.vector_indexes.get(&field.0)
             && let Some(ivf) = lazy.get()
         {
+            if ivf.config.dim_bits != schema_dim {
+                return Err(Error::Corruption(format!(
+                    "binary IVF field {} has schema dimension {} but index dimension {}",
+                    field.0, schema_dim, ivf.config.dim_bits
+                )));
+            }
+            let flat = self.flat_vectors.get(&field.0).ok_or_else(|| {
+                Error::Corruption(format!(
+                    "binary IVF field {} is missing flat vector storage",
+                    field.0
+                ))
+            })?;
+            if flat.dim != schema_dim
+                || flat.quantization != crate::dsl::DenseVectorQuantization::Binary
+            {
+                return Err(Error::Corruption(format!(
+                    "binary IVF field {} has inconsistent flat vector metadata",
+                    field.0
+                )));
+            }
             let nprobe = self.binary_ivf_nprobe(field);
-            let results = ivf.search(query, k, nprobe);
+            let initial_fetch =
+                ann_ordinal_fetch_k(k, flat.num_vectors, flat.num_docs_with_vectors());
+            let ann_results = progressive_ann_search(
+                k.min(flat.num_docs_with_vectors()),
+                initial_fetch,
+                ivf.len().min(flat.num_vectors),
+                |candidate_k| ivf.search(query, candidate_k, nprobe),
+            )?;
+            let results =
+                exact_score_binary_candidate_documents_sync(&ann_results, flat, query, schema_dim)?;
             crate::observe::dense_l1(
                 self.schema.index_label(),
                 self.schema.get_field_name(field).unwrap_or("?"),
@@ -1556,7 +2447,7 @@ impl SegmentReader {
                 t0.secs(),
                 results.len(),
             );
-            return Ok(combine_ordinal_results(results, combiner, k));
+            return Ok(combine_grouped_ordinal_results(results, combiner, k));
         }
 
         let lazy_flat = match self.flat_vectors.get(&field.0) {
@@ -1564,11 +2455,16 @@ impl SegmentReader {
             None => return Ok(Vec::new()),
         };
 
-        const BRUTE_FORCE_BATCH: usize = 8192; // Binary vectors are tiny, use larger batches
-
         let dim_bits = lazy_flat.dim;
         let byte_len = lazy_flat.vector_byte_size();
         let n = lazy_flat.num_vectors;
+
+        if dim_bits != schema_dim {
+            return Err(Error::Corruption(format!(
+                "binary vector field {} has schema dimension {} but flat storage dimension {}",
+                field.0, schema_dim, dim_bits
+            )));
+        }
 
         if byte_len != query.len() {
             return Err(Error::Schema(format!(
@@ -1578,11 +2474,12 @@ impl SegmentReader {
             )));
         }
 
-        let mut collector = crate::query::ScoreCollector::new(k);
-        let mut scores = vec![0f32; BRUTE_FORCE_BATCH];
+        let batch_len = bounded_vector_score_batch(byte_len, BINARY_SCORE_BATCH);
+        let mut collector = FlatDocumentCollector::new(k, combiner);
+        let mut scores = vec![0f32; batch_len];
 
-        for batch_start in (0..n).step_by(BRUTE_FORCE_BATCH) {
-            let batch_count = BRUTE_FORCE_BATCH.min(n - batch_start);
+        for batch_start in (0..n).step_by(batch_len) {
+            let batch_count = batch_len.min(n - batch_start);
             let batch_bytes = lazy_flat
                 .read_vectors_batch_sync(batch_start, batch_count)
                 .map_err(crate::Error::Io)?;
@@ -1596,20 +2493,13 @@ impl SegmentReader {
                 &mut scores[..batch_count],
             );
 
-            let threshold = collector.threshold();
             for (i, &score) in scores.iter().enumerate().take(batch_count) {
-                if score > threshold {
-                    let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
-                    collector.insert_with_ordinal(doc_id, score, ordinal);
-                }
+                let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
+                collector.push(doc_id, ordinal, score);
             }
         }
 
-        let results: Vec<(u32, u16, f32)> = collector
-            .into_sorted_results()
-            .into_iter()
-            .map(|(doc_id, score, ordinal)| (doc_id, ordinal, score))
-            .collect();
+        let results = collector.into_results();
 
         crate::observe::dense_l1(
             self.schema.index_label(),
@@ -1618,6 +2508,130 @@ impl SegmentReader {
             t0.secs(),
             results.len(),
         );
-        Ok(combine_ordinal_results(results, combiner, k))
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod dense_search_safety_tests {
+    use super::*;
+
+    #[test]
+    fn dense_fetch_count_rejects_non_finite_and_unbounded_factors() {
+        for factor in [
+            f32::NAN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            0.0,
+            0.5,
+            MAX_DENSE_RERANK_FACTOR + 1.0,
+        ] {
+            assert!(
+                checked_dense_fetch_k(10, factor).is_err(),
+                "factor={factor}"
+            );
+        }
+    }
+
+    #[test]
+    fn flat_document_collector_does_not_let_one_multivalue_doc_crowd_out_others() {
+        let mut collector = FlatDocumentCollector::new(2, crate::query::MultiValueCombiner::Max);
+        collector.push(1, 0, 1.0);
+        collector.push(1, 1, 0.9);
+        collector.push(2, 0, 0.8);
+
+        let results = collector.into_results();
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.doc_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(results[0].ordinals.len(), 2);
+    }
+
+    #[test]
+    fn flat_document_collector_evicts_by_score_then_doc_id() {
+        let mut collector = FlatDocumentCollector::new(2, crate::query::MultiValueCombiner::Max);
+        collector.push(1, 0, 0.5);
+        collector.push(3, 0, 0.8);
+        collector.push(2, 0, 0.9);
+        let results = collector.into_results();
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.doc_id)
+                .collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+
+        let mut tied = FlatDocumentCollector::new(1, crate::query::MultiValueCombiner::Max);
+        tied.push(2, 0, 1.0);
+        tied.push(1, 0, 1.0);
+        let results = tied.into_results();
+        assert_eq!(results[0].doc_id, 1);
+    }
+
+    #[test]
+    fn dense_fetch_count_rounds_up_and_detects_overflow() {
+        assert_eq!(checked_dense_fetch_k(3, 1.5).unwrap(), 5);
+        assert_eq!(checked_dense_fetch_k(50_000, 3.0).unwrap(), 150_000);
+        assert!(checked_dense_fetch_k(50_000, 32.0).is_err());
+        assert!(checked_dense_fetch_k(usize::MAX, 2.0).is_err());
+    }
+
+    #[test]
+    fn ann_fetch_depth_accounts_for_multivalue_density_and_stays_bounded() {
+        assert_eq!(ann_ordinal_fetch_k(100, 1_000, 100), 1_000);
+        assert_eq!(
+            ann_ordinal_fetch_k(100_000, usize::MAX, 1),
+            MAX_DENSE_CANDIDATES_PER_SEGMENT
+        );
+        assert_eq!(ann_ordinal_fetch_k(100, 0, 10), 0);
+    }
+
+    #[test]
+    fn ann_search_deepens_until_skewed_results_contain_enough_documents() {
+        let ranked = [
+            (1, 0, 1.0),
+            (1, 1, 0.99),
+            (1, 2, 0.98),
+            (1, 3, 0.97),
+            (1, 4, 0.96),
+            (1, 5, 0.95),
+            (2, 0, 0.9),
+            (3, 0, 0.8),
+        ];
+        let mut fetches = Vec::new();
+        let results = progressive_ann_search(2, 2, ranked.len(), |fetch| {
+            fetches.push(fetch);
+            ranked.iter().copied().take(fetch).collect()
+        })
+        .unwrap();
+
+        assert_eq!(fetches, vec![2, 4, 8]);
+        assert!(results.iter().any(|&(doc_id, _, _)| doc_id == 2));
+    }
+
+    #[test]
+    fn ann_search_stops_when_probed_population_is_exhausted() {
+        let ranked = [(1, 0, 1.0), (1, 1, 0.9)];
+        let mut calls = 0;
+        let results = progressive_ann_search(3, 4, 100, |fetch| {
+            calls += 1;
+            ranked.iter().copied().take(fetch).collect()
+        })
+        .unwrap();
+
+        assert_eq!(calls, 1);
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn file_ranges_reject_overflow_and_truncation() {
+        assert_eq!(checked_file_range(4, 3, 7, "test").unwrap(), 4..7);
+        assert!(checked_file_range(u64::MAX, 1, u64::MAX, "test").is_err());
+        assert!(checked_file_range(5, 3, 7, "test").is_err());
     }
 }

--- a/hermes-core/src/segment/reader/types.rs
+++ b/hermes-core/src/segment/reader/types.rs
@@ -88,15 +88,13 @@ impl LazyRaBitQ {
 
     pub fn get(&self) -> Option<&Arc<RaBitQIndex>> {
         self.resolved
-            .get_or_init(
-                || match serde_json::from_slice::<RaBitQIndex>(self.raw.as_slice()) {
-                    Ok(idx) => Some(Arc::new(idx)),
-                    Err(e) => {
-                        log::warn!("[lazy_rabitq] deserialization failed: {}", e);
-                        None
-                    }
-                },
-            )
+            .get_or_init(|| match RaBitQIndex::from_bytes(self.raw.as_slice()) {
+                Ok(idx) => Some(Arc::new(idx)),
+                Err(e) => {
+                    log::warn!("[lazy_rabitq] deserialization failed: {}", e);
+                    None
+                }
+            })
             .as_ref()
     }
 
@@ -342,6 +340,25 @@ pub struct SparseIndex {
     pub total_vectors: u32,
 }
 
+fn checked_sparse_block_range(
+    base: u64,
+    entry: SparseSkipEntry,
+    file_len: u64,
+) -> crate::Result<std::ops::Range<u64>> {
+    let start = base.checked_add(entry.offset).ok_or_else(|| {
+        crate::Error::Corruption("sparse block start offset overflows u64".into())
+    })?;
+    let end = start
+        .checked_add(u64::from(entry.length))
+        .ok_or_else(|| crate::Error::Corruption("sparse block end offset overflows u64".into()))?;
+    if end > file_len {
+        return Err(crate::Error::Corruption(format!(
+            "sparse block range {start}..{end} exceeds file length {file_len}"
+        )));
+    }
+    Ok(start..end)
+}
+
 impl SparseIndex {
     /// Pin the skip section (priority 2: every posting traversal reads it).
     #[cfg(feature = "native")]
@@ -410,10 +427,10 @@ impl SparseIndex {
     async fn load_block_at(&self, dim_idx: usize, block_idx: usize) -> crate::Result<SparseBlock> {
         let entry = self.read_skip_entry(self.dims.skip_starts[dim_idx] as usize + block_idx);
         let base = self.dims.block_offsets[dim_idx];
-        let abs_offset = base + entry.offset;
+        let range = checked_sparse_block_range(base, entry, self.handle.len())?;
         let data = self
             .handle
-            .read_bytes_range(abs_offset..abs_offset + entry.length as u64)
+            .read_bytes_range(range)
             .await
             .map_err(crate::Error::Io)?;
 
@@ -502,19 +519,24 @@ impl SparseIndex {
         if block_start >= total_blocks || block_count == 0 {
             return Ok(Vec::new());
         }
-        let end = (block_start + block_count).min(total_blocks);
+        let end = block_start.saturating_add(block_count).min(total_blocks);
         let base = self.dims.block_offsets[idx];
 
         // Compute the byte range covering all blocks [block_start..end)
         let first_entry = self.read_skip_entry(skip_start + block_start);
         let last_entry = self.read_skip_entry(skip_start + end - 1);
-        let range_start = base + first_entry.offset;
-        let range_end = base + last_entry.offset + last_entry.length as u64;
+        let first_range = checked_sparse_block_range(base, first_entry, self.handle.len())?;
+        let last_range = checked_sparse_block_range(base, last_entry, self.handle.len())?;
+        if last_range.end < first_range.start {
+            return Err(crate::Error::Corruption(
+                "sparse block offsets are not monotonic".into(),
+            ));
+        }
 
         // Single coalesced mmap read
         let range_data = self
             .handle
-            .read_bytes_range(range_start..range_end)
+            .read_bytes_range(first_range.start..last_range.end)
             .await
             .map_err(crate::Error::Io)?;
 
@@ -522,9 +544,22 @@ impl SparseIndex {
         let mut blocks = Vec::with_capacity(end - block_start);
         for bi in block_start..end {
             let entry = self.read_skip_entry(skip_start + bi);
-            let rel_offset = entry.offset - first_entry.offset;
-            let block_bytes = range_data
-                .slice(rel_offset as usize..(rel_offset as usize + entry.length as usize));
+            let rel_offset = entry
+                .offset
+                .checked_sub(first_entry.offset)
+                .ok_or_else(|| {
+                    crate::Error::Corruption("sparse block offsets are not monotonic".into())
+                })?;
+            let rel_start = usize::try_from(rel_offset).map_err(|_| {
+                crate::Error::Corruption("sparse relative block offset exceeds usize".into())
+            })?;
+            let rel_end = rel_start
+                .checked_add(entry.length as usize)
+                .filter(|&end| end <= range_data.len())
+                .ok_or_else(|| {
+                    crate::Error::Corruption("sparse block exceeds coalesced range".into())
+                })?;
+            let block_bytes = range_data.slice(rel_start..rel_end);
             blocks.push(SparseBlock::from_owned_bytes(block_bytes).map_err(|e| {
                 crate::Error::Corruption(format!(
                     "dim_id={} block={}/{} skip_entry(offset={},length={}) base={}: {e}",
@@ -562,15 +597,18 @@ impl SparseIndex {
         block_data_offset: u64,
         block_idx: usize,
     ) -> crate::Result<Option<SparseBlock>> {
-        if skip_start + block_idx >= self.skip_entry_count() {
+        let Some(entry_idx) = skip_start.checked_add(block_idx) else {
+            return Ok(None);
+        };
+        if entry_idx >= self.skip_entry_count() {
             return Ok(None);
         }
-        let entry = self.read_skip_entry(skip_start + block_idx);
+        let entry = self.read_skip_entry(entry_idx);
         let base = block_data_offset;
-        let abs_offset = base + entry.offset;
+        let range = checked_sparse_block_range(base, entry, self.handle.len())?;
         let data = self
             .handle
-            .read_bytes_range(abs_offset..abs_offset + entry.length as u64)
+            .read_bytes_range(range)
             .await
             .map_err(crate::Error::Io)?;
         Ok(Some(SparseBlock::from_owned_bytes(data).map_err(|e| {
@@ -652,15 +690,18 @@ impl SparseIndex {
         block_data_offset: u64,
         block_idx: usize,
     ) -> crate::Result<Option<SparseBlock>> {
-        if skip_start + block_idx >= self.skip_entry_count() {
+        let Some(entry_idx) = skip_start.checked_add(block_idx) else {
+            return Ok(None);
+        };
+        if entry_idx >= self.skip_entry_count() {
             return Ok(None);
         }
-        let entry = self.read_skip_entry(skip_start + block_idx);
+        let entry = self.read_skip_entry(entry_idx);
         let base = block_data_offset;
-        let abs_offset = base + entry.offset;
+        let range = checked_sparse_block_range(base, entry, self.handle.len())?;
         let data = self
             .handle
-            .read_bytes_range_sync(abs_offset..abs_offset + entry.length as u64)
+            .read_bytes_range_sync(range)
             .map_err(crate::Error::Io)?;
         Ok(Some(SparseBlock::from_owned_bytes(data).map_err(|e| {
             crate::Error::Corruption(format!(
@@ -689,25 +730,43 @@ impl SparseIndex {
         if block_start >= total_blocks || block_count == 0 {
             return Ok(Vec::new());
         }
-        let end = (block_start + block_count).min(total_blocks);
+        let end = block_start.saturating_add(block_count).min(total_blocks);
         let base = self.dims.block_offsets[idx];
 
         let first_entry = self.read_skip_entry(skip_start + block_start);
         let last_entry = self.read_skip_entry(skip_start + end - 1);
-        let range_start = base + first_entry.offset;
-        let range_end = base + last_entry.offset + last_entry.length as u64;
+        let first_range = checked_sparse_block_range(base, first_entry, self.handle.len())?;
+        let last_range = checked_sparse_block_range(base, last_entry, self.handle.len())?;
+        if last_range.end < first_range.start {
+            return Err(crate::Error::Corruption(
+                "sparse block offsets are not monotonic".into(),
+            ));
+        }
 
         let range_data = self
             .handle
-            .read_bytes_range_sync(range_start..range_end)
+            .read_bytes_range_sync(first_range.start..last_range.end)
             .map_err(crate::Error::Io)?;
 
         let mut blocks = Vec::with_capacity(end - block_start);
         for bi in block_start..end {
             let entry = self.read_skip_entry(skip_start + bi);
-            let rel_offset = entry.offset - first_entry.offset;
-            let block_bytes = range_data
-                .slice(rel_offset as usize..(rel_offset as usize + entry.length as usize));
+            let rel_offset = entry
+                .offset
+                .checked_sub(first_entry.offset)
+                .ok_or_else(|| {
+                    crate::Error::Corruption("sparse block offsets are not monotonic".into())
+                })?;
+            let rel_start = usize::try_from(rel_offset).map_err(|_| {
+                crate::Error::Corruption("sparse relative block offset exceeds usize".into())
+            })?;
+            let rel_end = rel_start
+                .checked_add(entry.length as usize)
+                .filter(|&end| end <= range_data.len())
+                .ok_or_else(|| {
+                    crate::Error::Corruption("sparse block exceeds coalesced range".into())
+                })?;
+            let block_bytes = range_data.slice(rel_start..rel_end);
             blocks.push(SparseBlock::from_owned_bytes(block_bytes).map_err(|e| {
                 crate::Error::Corruption(format!(
                     "sync dim_id={} block={}/{} skip_entry(offset={},length={}) base={}: {e}",

--- a/hermes-core/src/segment/store.rs
+++ b/hermes-core/src/segment/store.rs
@@ -34,6 +34,12 @@ pub const STORE_BLOCK_SIZE: usize = 16 * 1024;
 /// Default dictionary size (4KB is a good balance)
 pub const DEFAULT_DICT_SIZE: usize = 4 * 1024;
 
+/// Hard safety bounds for individual on-disk store objects. Writers normally
+/// emit ~16 KiB blocks and 4 KiB dictionaries; these generous limits preserve
+/// large legacy documents while bounding corrupt compressed frames.
+const MAX_STORE_BLOCK_BYTES: usize = 64 * 1024 * 1024;
+const MAX_STORE_DICTIONARY_BYTES: u64 = 16 * 1024 * 1024;
+
 /// Default compression level for document store
 #[cfg(feature = "native")]
 const DEFAULT_COMPRESSION_LEVEL: CompressionLevel = CompressionLevel(3);
@@ -49,7 +55,12 @@ fn write_store_index_and_footer(
     num_docs: u32,
     has_dict: bool,
 ) -> io::Result<()> {
-    writer.write_u32::<LittleEndian>(index.len() as u32)?;
+    writer.write_u32::<LittleEndian>(u32::try_from(index.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "too many document store blocks",
+        )
+    })?)?;
     for entry in index {
         writer.write_u32::<LittleEndian>(entry.first_doc_id)?;
         writer.write_u64::<LittleEndian>(entry.offset)?;
@@ -111,15 +122,22 @@ pub fn serialize_document_into(
         .filter(|(field, value)| is_stored(field, value))
         .count();
 
-    buf.write_u16::<LittleEndian>(stored_count as u16)?;
+    buf.write_u16::<LittleEndian>(
+        u16::try_from(stored_count)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "too many stored fields"))?,
+    )?;
 
     for (field, value) in doc.field_values().iter().filter(|(f, v)| is_stored(f, v)) {
-        buf.write_u16::<LittleEndian>(field.0 as u16)?;
+        buf.write_u16::<LittleEndian>(u16::try_from(field.0).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "stored field id exceeds u16")
+        })?)?;
         match value {
             FieldValue::Text(s) => {
                 buf.push(0);
                 let bytes = s.as_bytes();
-                buf.write_u32::<LittleEndian>(bytes.len() as u32)?;
+                buf.write_u32::<LittleEndian>(u32::try_from(bytes.len()).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "stored text is too large")
+                })?)?;
                 buf.extend_from_slice(bytes);
             }
             FieldValue::U64(v) => {
@@ -136,12 +154,22 @@ pub fn serialize_document_into(
             }
             FieldValue::Bytes(b) => {
                 buf.push(4);
-                buf.write_u32::<LittleEndian>(b.len() as u32)?;
+                buf.write_u32::<LittleEndian>(u32::try_from(b.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "stored byte field is too large",
+                    )
+                })?)?;
                 buf.extend_from_slice(b);
             }
             FieldValue::SparseVector(entries) => {
                 buf.push(5);
-                buf.write_u32::<LittleEndian>(entries.len() as u32)?;
+                buf.write_u32::<LittleEndian>(u32::try_from(entries.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "stored sparse vector is too large",
+                    )
+                })?)?;
                 for (idx, val) in entries {
                     buf.write_u32::<LittleEndian>(*idx)?;
                     buf.write_f32::<LittleEndian>(*val)?;
@@ -149,7 +177,12 @@ pub fn serialize_document_into(
             }
             FieldValue::DenseVector(values) => {
                 buf.push(6);
-                buf.write_u32::<LittleEndian>(values.len() as u32)?;
+                buf.write_u32::<LittleEndian>(u32::try_from(values.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "stored dense vector is too large",
+                    )
+                })?)?;
                 // Write raw f32 bytes directly
                 let byte_slice = unsafe {
                     std::slice::from_raw_parts(values.as_ptr() as *const u8, values.len() * 4)
@@ -160,12 +193,19 @@ pub fn serialize_document_into(
                 buf.push(7);
                 let json_bytes = serde_json::to_vec(v)
                     .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-                buf.write_u32::<LittleEndian>(json_bytes.len() as u32)?;
+                buf.write_u32::<LittleEndian>(u32::try_from(json_bytes.len()).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "stored JSON is too large")
+                })?)?;
                 buf.extend_from_slice(&json_bytes);
             }
             FieldValue::BinaryDenseVector(b) => {
                 buf.push(8);
-                buf.write_u32::<LittleEndian>(b.len() as u32)?;
+                buf.write_u32::<LittleEndian>(u32::try_from(b.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "stored binary dense vector is too large",
+                    )
+                })?)?;
                 buf.extend_from_slice(b);
             }
         }
@@ -266,8 +306,17 @@ impl<'a> EagerParallelStoreWriter<'a> {
 
     pub fn store(&mut self, doc: &Document, schema: &Schema) -> io::Result<DocId> {
         serialize_document_into(doc, schema, &mut self.serialize_buf)?;
+        if self.serialize_buf.len() > MAX_STORE_BLOCK_BYTES.saturating_sub(4) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "serialized document exceeds store block limit",
+            ));
+        }
         let doc_id = self.next_doc_id;
-        self.next_doc_id += 1;
+        self.next_doc_id = self
+            .next_doc_id
+            .checked_add(1)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "document id overflow"))?;
         self.block_buffer
             .write_u32::<LittleEndian>(self.serialize_buf.len() as u32)?;
         self.block_buffer.extend_from_slice(&self.serialize_buf);
@@ -279,8 +328,17 @@ impl<'a> EagerParallelStoreWriter<'a> {
 
     /// Store pre-serialized document bytes directly (avoids deserialize+reserialize roundtrip).
     pub fn store_raw(&mut self, doc_bytes: &[u8]) -> io::Result<DocId> {
+        if doc_bytes.len() > MAX_STORE_BLOCK_BYTES.saturating_sub(4) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "serialized document exceeds store block limit",
+            ));
+        }
         let doc_id = self.next_doc_id;
-        self.next_doc_id += 1;
+        self.next_doc_id = self
+            .next_doc_id
+            .checked_add(1)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "document id overflow"))?;
 
         self.block_buffer
             .write_u32::<LittleEndian>(doc_bytes.len() as u32)?;
@@ -375,12 +433,19 @@ impl<'a> EagerParallelStoreWriter<'a> {
             index.push(StoreBlockIndex {
                 first_doc_id: block.first_doc_id,
                 offset: current_offset,
-                length: block.compressed.len() as u32,
+                length: u32::try_from(block.compressed.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "compressed store block too large",
+                    )
+                })?,
                 num_docs: block.num_docs,
             });
 
             self.writer.write_all(&block.compressed)?;
-            current_offset += block.compressed.len() as u64;
+            current_offset = current_offset
+                .checked_add(block.compressed.len() as u64)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "store size overflow"))?;
         }
 
         let data_end_offset = current_offset;
@@ -447,20 +512,51 @@ struct CachedBlock {
 
 impl CachedBlock {
     fn build(data: Vec<u8>, num_docs: u32) -> io::Result<Self> {
-        let mut offsets = Vec::with_capacity(num_docs as usize);
+        if num_docs as usize > data.len() / 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "store block document count exceeds block length",
+            ));
+        }
+        let mut offsets = Vec::new();
+        offsets.try_reserve_exact(num_docs as usize).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "store block has too many documents",
+            )
+        })?;
         let mut pos = 0usize;
         for _ in 0..num_docs {
-            if pos + 4 > data.len() {
+            let length_end = pos.checked_add(4).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "store block offset overflow")
+            })?;
+            if length_end > data.len() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated block while building offset table",
                 ));
             }
-            offsets.push(pos as u32);
+            offsets.push(u32::try_from(pos).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "store block offset exceeds u32")
+            })?);
             let doc_len =
                 u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]])
                     as usize;
-            pos += 4 + doc_len;
+            pos = length_end.checked_add(doc_len).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "store document length overflow")
+            })?;
+            if pos > data.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "store document is truncated",
+                ));
+            }
+        }
+        if pos != data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "store block contains trailing data",
+            ));
         }
         Ok(Self { data, offsets })
     }
@@ -475,7 +571,10 @@ impl CachedBlock {
             ));
         }
         let start = self.offsets[idx] as usize;
-        if start + 4 > self.data.len() {
+        let data_start = start.checked_add(4).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "store document offset overflow")
+        })?;
+        if data_start > self.data.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "truncated doc length",
@@ -487,21 +586,29 @@ impl CachedBlock {
             self.data[start + 2],
             self.data[start + 3],
         ]) as usize;
-        let data_start = start + 4;
-        if data_start + doc_len > self.data.len() {
+        let data_end = data_start.checked_add(doc_len).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "store document length overflow")
+        })?;
+        if data_end > self.data.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "doc data overflow",
             ));
         }
-        Ok(&self.data[data_start..data_start + doc_len])
+        Ok(&self.data[data_start..data_end])
+    }
+
+    #[inline]
+    fn retained_bytes(&self) -> usize {
+        self.data.capacity() + self.offsets.capacity() * std::mem::size_of::<u32>()
     }
 }
 
-/// LRU block cache — O(1) lookup/insert, amortized O(n) promotion.
+/// Bounded block cache with a contention-free read path.
 ///
-/// On `get()`, promotes accessed entry to MRU position.
-/// For typical cache sizes (16-64 blocks), the linear promote scan is negligible.
+/// Normal reads use [`StoreBlockCache::peek`] under a shared lock and do not
+/// promote hits, so normal eviction order is insertion order. `get()` promotes
+/// only on the exclusive race-resolution path.
 struct StoreBlockCache {
     blocks: FxHashMap<DocId, Arc<CachedBlock>>,
     lru_order: std::collections::VecDeque<DocId>,
@@ -529,6 +636,9 @@ impl StoreBlockCache {
     }
 
     fn insert(&mut self, first_doc_id: DocId, block: Arc<CachedBlock>) {
+        if self.max_blocks == 0 {
+            return;
+        }
         if self.blocks.contains_key(&first_doc_id) {
             self.promote(first_doc_id);
             return;
@@ -590,31 +700,101 @@ impl AsyncStoreReader {
             ));
         }
 
+        let index_end = file_len - 32;
+        if data_end_offset > index_end {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "store data section extends past its footer",
+            ));
+        }
+
         // Load dictionary if present, and compute index_start in one pass
-        let (dict, index_start) = if has_dict && dict_offset > 0 {
+        let (dict, index_start) = if has_dict {
+            if dict_offset < data_end_offset || dict_offset >= index_end {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "store dictionary offset is out of bounds",
+                ));
+            }
             let dict_start = dict_offset;
+            let dict_header_end = dict_start.checked_add(4).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "store dictionary range overflow",
+                )
+            })?;
+            if dict_header_end > index_end {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "store dictionary length is truncated",
+                ));
+            }
             let dict_len_bytes = file_handle
-                .read_bytes_range(dict_start..dict_start + 4)
+                .read_bytes_range(dict_start..dict_header_end)
                 .await?;
             let dict_len = (&dict_len_bytes[..]).read_u32::<LittleEndian>()? as u64;
+            if dict_len > MAX_STORE_DICTIONARY_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "store dictionary exceeds safety limit",
+                ));
+            }
+            let dict_end = dict_header_end.checked_add(dict_len).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "store dictionary range overflow",
+                )
+            })?;
+            if dict_end > index_end {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "store dictionary is truncated",
+                ));
+            }
             let dict_bytes = file_handle
-                .read_bytes_range(dict_start + 4..dict_start + 4 + dict_len)
+                .read_bytes_range(dict_header_end..dict_end)
                 .await?;
-            let idx_start = dict_start + 4 + dict_len;
             (
                 Some(CompressionDict::from_owned_bytes(dict_bytes)),
-                idx_start,
+                dict_end,
             )
         } else {
+            if dict_offset != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "store without a dictionary has a dictionary offset",
+                ));
+            }
             (None, data_end_offset)
         };
-        let index_end = file_len - 32;
+
+        if index_start > index_end {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "store index offset is out of bounds",
+            ));
+        }
 
         let index_bytes = file_handle.read_bytes_range(index_start..index_end).await?;
         let mut reader = index_bytes.as_slice();
 
         let num_blocks = reader.read_u32::<LittleEndian>()? as usize;
-        let mut index = Vec::with_capacity(num_blocks);
+        let required_index_bytes = num_blocks.checked_mul(20).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "store index size overflow")
+        })?;
+        if reader.len() != required_index_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "store index length is inconsistent",
+            ));
+        }
+        let mut index = Vec::new();
+        index
+            .try_reserve_exact(num_blocks)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "too many store blocks"))?;
+
+        let mut expected_doc = 0u32;
+        let mut expected_offset = 0u64;
 
         for _ in 0..num_blocks {
             let first_doc_id = reader.read_u32::<LittleEndian>()?;
@@ -622,12 +802,37 @@ impl AsyncStoreReader {
             let length = reader.read_u32::<LittleEndian>()?;
             let num_docs_in_block = reader.read_u32::<LittleEndian>()?;
 
+            let end = offset.checked_add(length as u64).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "store block range overflow")
+            })?;
+            if first_doc_id != expected_doc
+                || num_docs_in_block == 0
+                || offset != expected_offset
+                || end > data_end_offset
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "store block index is inconsistent",
+                ));
+            }
+            expected_doc = expected_doc.checked_add(num_docs_in_block).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "store document count overflow")
+            })?;
+            expected_offset = end;
+
             index.push(StoreBlockIndex {
                 first_doc_id,
                 offset,
                 length,
                 num_docs: num_docs_in_block,
             });
+        }
+
+        if expected_doc != num_docs || expected_offset != data_end_offset {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "store footer totals do not match its block index",
+            ));
         }
 
         // Create lazy slice for data portion only
@@ -650,6 +855,16 @@ impl AsyncStoreReader {
     /// Number of blocks currently in the cache
     pub fn cached_blocks(&self) -> usize {
         self.cache.read().blocks.len()
+    }
+
+    /// Heap bytes retained by decompressed blocks and their document offsets.
+    pub fn cached_bytes(&self) -> usize {
+        self.cache
+            .read()
+            .blocks
+            .values()
+            .map(|block| block.retained_bytes())
+            .sum()
     }
 
     /// Get a document by doc_id (async - may load block)
@@ -720,7 +935,7 @@ impl AsyncStoreReader {
                 return Ok(block);
             }
         }
-        // Slow path: write lock for LRU promotion or insert
+        // Resolve a race where another reader inserted after our shared probe.
         {
             if let Some(block) = self.cache.write().get(entry.first_doc_id) {
                 return Ok(block);
@@ -729,14 +944,20 @@ impl AsyncStoreReader {
 
         // Load from FileSlice
         let start = entry.offset;
-        let end = start + entry.length as u64;
+        let end = start.checked_add(entry.length as u64).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "store block range overflow")
+        })?;
         let compressed = self.data_slice.read_bytes_range(start..end).await?;
 
         // Use dictionary decompression if available
         let decompressed = if let Some(ref dict) = self.dict {
-            crate::compression::decompress_with_dict(compressed.as_slice(), dict)?
+            crate::compression::decompress_with_dict_limited(
+                compressed.as_slice(),
+                dict,
+                MAX_STORE_BLOCK_BYTES,
+            )?
         } else {
-            crate::compression::decompress(compressed.as_slice())?
+            crate::compression::decompress_limited(compressed.as_slice(), MAX_STORE_BLOCK_BYTES)?
         };
 
         // Build offset table for O(1) doc lookup within the block
@@ -796,12 +1017,12 @@ fn deserialize_document_inner(
             0 => {
                 // Text
                 let len = reader.read_u32::<LittleEndian>()? as usize;
+                let bytes = take_document_bytes(&mut reader, len, "text field")?;
                 if wanted {
-                    let s = std::str::from_utf8(&reader[..len])
+                    let s = std::str::from_utf8(bytes)
                         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
                     doc.add_text(Field(field_id as u32), s);
                 }
-                reader = &reader[len..];
             }
             1 => {
                 // U64
@@ -827,85 +1048,68 @@ fn deserialize_document_inner(
             4 => {
                 // Bytes
                 let len = reader.read_u32::<LittleEndian>()? as usize;
+                let bytes = take_document_bytes(&mut reader, len, "byte field")?;
                 if wanted {
-                    doc.add_bytes(Field(field_id as u32), reader[..len].to_vec());
+                    doc.add_bytes(Field(field_id as u32), bytes.to_vec());
                 }
-                reader = &reader[len..];
             }
             5 => {
                 // SparseVector
                 let count = reader.read_u32::<LittleEndian>()? as usize;
+                let byte_len = count.checked_mul(8).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "sparse vector size overflow")
+                })?;
+                let bytes = take_document_bytes(&mut reader, byte_len, "sparse vector")?;
                 if wanted {
-                    let mut entries = Vec::with_capacity(count);
+                    let mut entries = Vec::new();
+                    entries.try_reserve_exact(count).map_err(|_| {
+                        io::Error::new(io::ErrorKind::InvalidData, "sparse vector is too large")
+                    })?;
+                    let mut vector_reader = bytes;
                     for _ in 0..count {
-                        let idx = reader.read_u32::<LittleEndian>()?;
-                        let val = reader.read_f32::<LittleEndian>()?;
+                        let idx = vector_reader.read_u32::<LittleEndian>()?;
+                        let val = vector_reader.read_f32::<LittleEndian>()?;
                         entries.push((idx, val));
                     }
                     doc.add_sparse_vector(Field(field_id as u32), entries);
-                } else {
-                    let skip = count * 8;
-                    if skip > reader.len() {
-                        return Err(io::Error::new(
-                            io::ErrorKind::UnexpectedEof,
-                            "sparse vector skip overflow",
-                        ));
-                    }
-                    reader = &reader[skip..];
                 }
             }
             6 => {
                 // DenseVector
                 let count = reader.read_u32::<LittleEndian>()? as usize;
-                let byte_len = count * 4;
-                if byte_len > reader.len() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        "dense vector truncated",
-                    ));
-                }
+                let byte_len = count.checked_mul(4).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "dense vector size overflow")
+                })?;
+                let bytes = take_document_bytes(&mut reader, byte_len, "dense vector")?;
                 if wanted {
                     let mut values = vec![0.0f32; count];
                     unsafe {
                         std::ptr::copy_nonoverlapping(
-                            reader.as_ptr(),
+                            bytes.as_ptr(),
                             values.as_mut_ptr() as *mut u8,
                             byte_len,
                         );
                     }
                     doc.add_dense_vector(Field(field_id as u32), values);
                 }
-                reader = &reader[byte_len..];
             }
             7 => {
                 // Json
                 let len = reader.read_u32::<LittleEndian>()? as usize;
-                if len > reader.len() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        "json field truncated",
-                    ));
-                }
+                let bytes = take_document_bytes(&mut reader, len, "JSON field")?;
                 if wanted {
-                    let v: serde_json::Value = serde_json::from_slice(&reader[..len])
+                    let v: serde_json::Value = serde_json::from_slice(bytes)
                         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
                     doc.add_json(Field(field_id as u32), v);
                 }
-                reader = &reader[len..];
             }
             8 => {
                 // BinaryDenseVector
                 let len = reader.read_u32::<LittleEndian>()? as usize;
-                if len > reader.len() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        "binary dense vector truncated",
-                    ));
-                }
+                let bytes = take_document_bytes(&mut reader, len, "binary dense vector")?;
                 if wanted {
-                    doc.add_binary_dense_vector(Field(field_id as u32), reader[..len].to_vec());
+                    doc.add_binary_dense_vector(Field(field_id as u32), bytes.to_vec());
                 }
-                reader = &reader[len..];
             }
             _ => {
                 return Err(io::Error::new(
@@ -917,6 +1121,18 @@ fn deserialize_document_inner(
     }
 
     Ok(doc)
+}
+
+fn take_document_bytes<'a>(reader: &mut &'a [u8], len: usize, field: &str) -> io::Result<&'a [u8]> {
+    if len > reader.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            format!("{field} is truncated"),
+        ));
+    }
+    let (value, remaining) = reader.split_at(len);
+    *reader = remaining;
+    Ok(value)
 }
 
 /// Raw block info for store merging (without decompression)
@@ -967,7 +1183,15 @@ impl<'a, W: Write> StoreMerger<'a, W> {
         for block in blocks {
             // Read raw compressed block data
             let start = block.offset;
-            let end = start + block.length as u64;
+            let end = start.checked_add(block.length as u64).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "store block range overflow")
+            })?;
+            if end > data_slice.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "store block range is out of bounds",
+                ));
+            }
             let compressed_data = data_slice.read_bytes_range(start..end).await?;
 
             // Write to output
@@ -981,8 +1205,16 @@ impl<'a, W: Write> StoreMerger<'a, W> {
                 num_docs: block.num_docs,
             });
 
-            self.current_offset += block.length as u64;
-            self.next_doc_id += block.num_docs;
+            self.current_offset = self
+                .current_offset
+                .checked_add(block.length as u64)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "store size overflow"))?;
+            self.next_doc_id = self
+                .next_doc_id
+                .checked_add(block.num_docs)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "store document count overflow")
+                })?;
         }
 
         Ok(())
@@ -1001,14 +1233,29 @@ impl<'a, W: Write> StoreMerger<'a, W> {
 
         for block in blocks {
             let start = block.offset;
-            let end = start + block.length as u64;
+            let end = start.checked_add(block.length as u64).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "store block range overflow")
+            })?;
+            if end > data_slice.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "store block range is out of bounds",
+                ));
+            }
             let compressed = data_slice.read_bytes_range(start..end).await?;
 
             // Decompress with source dict (or without if no dict)
             let decompressed = if let Some(d) = dict {
-                crate::compression::decompress_with_dict(compressed.as_slice(), d)?
+                crate::compression::decompress_with_dict_limited(
+                    compressed.as_slice(),
+                    d,
+                    MAX_STORE_BLOCK_BYTES,
+                )?
             } else {
-                crate::compression::decompress(compressed.as_slice())?
+                crate::compression::decompress_limited(
+                    compressed.as_slice(),
+                    MAX_STORE_BLOCK_BYTES,
+                )?
             };
 
             // Recompress without dictionary
@@ -1022,12 +1269,25 @@ impl<'a, W: Write> StoreMerger<'a, W> {
             self.index.push(StoreBlockIndex {
                 first_doc_id: self.next_doc_id,
                 offset: self.current_offset,
-                length: recompressed.len() as u32,
+                length: u32::try_from(recompressed.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "compressed store block too large",
+                    )
+                })?,
                 num_docs: block.num_docs,
             });
 
-            self.current_offset += recompressed.len() as u64;
-            self.next_doc_id += block.num_docs;
+            self.current_offset = self
+                .current_offset
+                .checked_add(recompressed.len() as u64)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "store size overflow"))?;
+            self.next_doc_id = self
+                .next_doc_id
+                .checked_add(block.num_docs)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "store document count overflow")
+                })?;
         }
 
         Ok(())
@@ -1086,5 +1346,26 @@ impl AsyncStoreReader {
     /// Get block index for iteration
     pub(crate) fn block_index(&self) -> &[StoreBlockIndex] {
         &self.index
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_block_rejects_truncated_and_trailing_documents() {
+        assert!(CachedBlock::build(vec![8, 0, 0, 0, 1], 1).is_err());
+        assert!(CachedBlock::build(vec![0, 0, 0, 0, 1], 1).is_err());
+    }
+
+    #[test]
+    fn document_deserializer_rejects_length_prefixed_slice_overrun() {
+        let schema = Schema::builder().build();
+        let truncated_text = [1, 0, 0, 0, 0, 5, 0, 0, 0, b'x'];
+        assert!(deserialize_document(&truncated_text, &schema).is_err());
+
+        let truncated_sparse = [1, 0, 0, 0, 5, 2, 0, 0, 0, 1, 0, 0, 0];
+        assert!(deserialize_document(&truncated_sparse, &schema).is_err());
     }
 }

--- a/hermes-core/src/segment/vector_data.rs
+++ b/hermes-core/src/segment/vector_data.rs
@@ -21,38 +21,84 @@ pub fn dequantize_raw(
     quant: DenseVectorQuantization,
     num_floats: usize,
     out: &mut [f32],
-) {
-    debug_assert!(out.len() >= num_floats);
+) -> io::Result<()> {
+    if out.len() < num_floats {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "dequantization output is too short: need {num_floats} floats, got {}",
+                out.len()
+            ),
+        ));
+    }
+
+    let element_size = match quant {
+        DenseVectorQuantization::F32 => size_of::<f32>(),
+        DenseVectorQuantization::F16 => size_of::<u16>(),
+        DenseVectorQuantization::UInt8 => size_of::<u8>(),
+        DenseVectorQuantization::Binary => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "binary vectors cannot be dequantized to f32",
+            ));
+        }
+    };
+    let expected_bytes = num_floats.checked_mul(element_size).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "dequantization byte length overflows usize",
+        )
+    })?;
+    if raw.len() != expected_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "dequantization input length mismatch: need {expected_bytes} bytes, got {}",
+                raw.len()
+            ),
+        ));
+    }
+
     match quant {
         DenseVectorQuantization::F32 => {
-            debug_assert!(
-                (raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()),
-                "f32 vector data not 4-byte aligned"
-            );
+            if expected_bytes > 0
+                && !(raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>())
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "f32 vector data is not 4-byte aligned",
+                ));
+            }
             out[..num_floats].copy_from_slice(unsafe {
+                // Safety: the exact byte length and f32 alignment were checked above.
                 std::slice::from_raw_parts(raw.as_ptr() as *const f32, num_floats)
             });
         }
         DenseVectorQuantization::F16 => {
-            debug_assert!(
-                (raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>()),
-                "f16 vector data not 2-byte aligned"
-            );
-            let f16_slice =
-                unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const u16, num_floats) };
+            if expected_bytes > 0
+                && !(raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>())
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "f16 vector data is not 2-byte aligned",
+                ));
+            }
+            let f16_slice = unsafe {
+                // Safety: the exact byte length and u16 alignment were checked above.
+                std::slice::from_raw_parts(raw.as_ptr() as *const u16, num_floats)
+            };
             for (i, &h) in f16_slice.iter().enumerate() {
                 out[i] = f16_to_f32(h);
             }
         }
         DenseVectorQuantization::UInt8 => {
-            for (i, &b) in raw.iter().enumerate().take(num_floats) {
+            for (i, &b) in raw.iter().enumerate() {
                 out[i] = u8_to_f32(b);
             }
         }
-        DenseVectorQuantization::Binary => {
-            unreachable!("Binary vectors use raw bytes, not f32 dequantization");
-        }
+        DenseVectorQuantization::Binary => unreachable!("validated above"),
     }
+    Ok(())
 }
 
 /// Flat vector binary format helpers for writing.
@@ -70,6 +116,124 @@ pub fn dequantize_raw(
 pub struct FlatVectorData;
 
 impl FlatVectorData {
+    fn validate_shape(
+        dim: usize,
+        num_vectors: usize,
+        quant: DenseVectorQuantization,
+    ) -> io::Result<usize> {
+        if dim == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flat vector dimension must be greater than zero",
+            ));
+        }
+        if quant == DenseVectorQuantization::Binary && !dim.is_multiple_of(8) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("binary flat vector dimension must be a multiple of 8, got {dim}"),
+            ));
+        }
+        u32::try_from(dim).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("flat vector dimension {dim} exceeds u32::MAX"),
+            )
+        })?;
+        u32::try_from(num_vectors).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("flat vector count {num_vectors} exceeds u32::MAX"),
+            )
+        })?;
+
+        match quant {
+            DenseVectorQuantization::Binary => dim.checked_add(7).map(|bits| bits / 8),
+            _ => dim.checked_mul(quant.element_size()),
+        }
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flat vector byte size overflows usize",
+            )
+        })
+    }
+
+    fn validate_doc_ids(doc_ids: &[(u32, u16)]) -> io::Result<()> {
+        if let Some(pair) = doc_ids.windows(2).find(|pair| pair[0] >= pair[1]) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "flat vector doc map must be strictly sorted by (doc_id, ordinal), found {:?} before {:?}",
+                    pair[0], pair[1]
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Validate a dense writer input completely before any bytes are emitted.
+    /// Returns the exact serialized size on success.
+    pub(crate) fn validate_dense_input(
+        dim: usize,
+        flat_vectors: &[f32],
+        doc_ids: &[(u32, u16)],
+        quant: DenseVectorQuantization,
+    ) -> io::Result<usize> {
+        if quant == DenseVectorQuantization::Binary {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "binary quantization must use serialize_binary_from_bits_streaming",
+            ));
+        }
+        let num_vectors = doc_ids.len();
+        let expected_floats = num_vectors.checked_mul(dim).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flat f32 vector count overflows usize",
+            )
+        })?;
+        if flat_vectors.len() != expected_floats {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "flat vector input has {} floats, expected {num_vectors} x {dim} = {expected_floats}",
+                    flat_vectors.len()
+                ),
+            ));
+        }
+        Self::validate_doc_ids(doc_ids)?;
+        Self::serialized_binary_size(dim, num_vectors, quant)
+    }
+
+    /// Validate a packed-binary writer input completely before any bytes are
+    /// emitted. Returns the exact serialized size on success.
+    pub(crate) fn validate_binary_input(
+        dim_bits: usize,
+        packed_vectors: &[u8],
+        doc_ids: &[(u32, u16)],
+    ) -> io::Result<usize> {
+        let num_vectors = doc_ids.len();
+        let byte_len =
+            Self::validate_shape(dim_bits, num_vectors, DenseVectorQuantization::Binary)?;
+        let expected_bytes = num_vectors.checked_mul(byte_len).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "packed binary vector size overflows usize",
+            )
+        })?;
+        if packed_vectors.len() != expected_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "packed binary input has {} bytes, expected {num_vectors} x {byte_len} = {expected_bytes}",
+                    packed_vectors.len()
+                ),
+            ));
+        }
+        Self::validate_doc_ids(doc_ids)?;
+        Self::serialized_binary_size(dim_bits, num_vectors, DenseVectorQuantization::Binary)
+    }
+
     /// Write the binary header to a writer.
     pub fn write_binary_header(
         dim: usize,
@@ -77,9 +241,19 @@ impl FlatVectorData {
         quant: DenseVectorQuantization,
         writer: &mut dyn std::io::Write,
     ) -> std::io::Result<()> {
+        Self::validate_shape(dim, num_vectors, quant)?;
+        let dim = u32::try_from(dim).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flat vector dimension exceeds u32",
+            )
+        })?;
+        let num_vectors = u32::try_from(num_vectors).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "flat vector count exceeds u32")
+        })?;
         writer.write_all(&FLAT_BINARY_MAGIC.to_le_bytes())?;
-        writer.write_all(&(dim as u32).to_le_bytes())?;
-        writer.write_all(&(num_vectors as u32).to_le_bytes())?;
+        writer.write_all(&dim.to_le_bytes())?;
+        writer.write_all(&num_vectors.to_le_bytes())?;
         writer.write_all(&[quant.tag(), 0, 0, 0])?; // quant_type + 3 bytes padding
         Ok(())
     }
@@ -89,12 +263,29 @@ impl FlatVectorData {
         dim: usize,
         num_vectors: usize,
         quant: DenseVectorQuantization,
-    ) -> usize {
-        let bytes_per_vector = match quant {
-            DenseVectorQuantization::Binary => dim.div_ceil(8),
-            _ => dim * quant.element_size(),
-        };
-        FLAT_BINARY_HEADER_SIZE + num_vectors * bytes_per_vector + num_vectors * DOC_ID_ENTRY_SIZE
+    ) -> io::Result<usize> {
+        let bytes_per_vector = Self::validate_shape(dim, num_vectors, quant)?;
+        let vector_bytes = num_vectors.checked_mul(bytes_per_vector).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flat vector payload size overflows usize",
+            )
+        })?;
+        let doc_id_bytes = num_vectors.checked_mul(DOC_ID_ENTRY_SIZE).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flat vector doc-map size overflows usize",
+            )
+        })?;
+        FLAT_BINARY_HEADER_SIZE
+            .checked_add(vector_bytes)
+            .and_then(|size| size.checked_add(doc_id_bytes))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "flat vector serialized size overflows usize",
+                )
+            })
     }
 
     /// Stream from flat f32 storage to a writer, quantizing on write.
@@ -108,6 +299,7 @@ impl FlatVectorData {
         quant: DenseVectorQuantization,
         writer: &mut dyn std::io::Write,
     ) -> std::io::Result<()> {
+        Self::validate_dense_input(dim, flat_vectors, doc_ids, quant)?;
         let num_vectors = doc_ids.len();
         Self::write_binary_header(dim, num_vectors, quant, writer)?;
 
@@ -137,10 +329,7 @@ impl FlatVectorData {
                     writer.write_all(&buf)?;
                 }
             }
-            DenseVectorQuantization::Binary => {
-                // Binary vectors use serialize_binary_from_bits_streaming(), not this path
-                unreachable!("Binary quantization should use serialize_binary_from_bits_streaming");
-            }
+            DenseVectorQuantization::Binary => unreachable!("validated above"),
         }
 
         for &(doc_id, ordinal) in doc_ids {
@@ -161,9 +350,8 @@ impl FlatVectorData {
         doc_ids: &[(u32, u16)],
         writer: &mut dyn std::io::Write,
     ) -> std::io::Result<()> {
+        Self::validate_binary_input(dim_bits, packed_vectors, doc_ids)?;
         let num_vectors = doc_ids.len();
-        let byte_len = dim_bits.div_ceil(8);
-        debug_assert_eq!(packed_vectors.len(), num_vectors * byte_len);
 
         Self::write_binary_header(
             dim_bits,
@@ -209,6 +397,8 @@ pub struct LazyFlatVectorData {
     pub dim: usize,
     /// Total number of vectors
     pub num_vectors: usize,
+    /// Number of distinct document IDs represented in the flat vector map.
+    num_docs_with_vectors: usize,
     /// Storage quantization type
     pub quantization: DenseVectorQuantization,
     /// Zero-copy doc_id index: packed [u32_le doc_id + u16_le ordinal] × num_vectors
@@ -219,6 +409,8 @@ pub struct LazyFlatVectorData {
     vectors_offset: u64,
     /// Bytes per vector in storage (cached: Binary = ceil(dim/8), else dim * element_size)
     vbs: usize,
+    /// Exact byte length of the raw vector region, validated when opening.
+    vectors_byte_len: u64,
 }
 
 impl LazyFlatVectorData {
@@ -227,10 +419,45 @@ impl LazyFlatVectorData {
     /// Reads header (16 bytes) + doc_ids (~6 bytes/vector) into memory.
     /// Vector data stays lazy on disk.
     pub async fn open(handle: FileHandle) -> io::Result<Self> {
+        Self::open_with_doc_limit(handle, None).await
+    }
+
+    /// Open flat vectors while also validating every referenced document ID.
+    ///
+    /// Segment readers pass their durable `num_docs` here. Keeping the public
+    /// `open` entry point is useful for standalone flat payloads and tests that
+    /// do not have segment metadata available.
+    pub(crate) async fn open_with_doc_limit(
+        handle: FileHandle,
+        total_docs: Option<u32>,
+    ) -> io::Result<Self> {
+        let header_len = u64::try_from(FLAT_BINARY_HEADER_SIZE).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector header size does not fit in u64",
+            )
+        })?;
+        if handle.len() < header_len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "flat vector payload is {} bytes, shorter than its {FLAT_BINARY_HEADER_SIZE}-byte header",
+                    handle.len()
+                ),
+            ));
+        }
+
         // Read header: magic(4) + dim(4) + num_vectors(4) + quant_type(1) + pad(3) = 16 bytes
-        let header = handle
-            .read_bytes_range(0..FLAT_BINARY_HEADER_SIZE as u64)
-            .await?;
+        let header = handle.read_bytes_range(0..header_len).await?;
+        if header.len() != FLAT_BINARY_HEADER_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "flat vector header read returned {} bytes, expected {FLAT_BINARY_HEADER_SIZE}",
+                    header.len()
+                ),
+            ));
+        }
         let hdr = header.as_slice();
 
         let magic = u32::from_le_bytes([hdr[0], hdr[1], hdr[2], hdr[3]]);
@@ -249,29 +476,224 @@ impl LazyFlatVectorData {
                 format!("Unknown quantization tag: {}", hdr[12]),
             )
         })?;
-        // Read doc_ids section as zero-copy OwnedBytes (6 bytes per vector)
-        let vbs = if quantization == DenseVectorQuantization::Binary {
-            dim.div_ceil(8)
-        } else {
-            dim * quantization.element_size()
-        };
-        let vectors_byte_len = num_vectors * vbs;
-        let doc_ids_start = (FLAT_BINARY_HEADER_SIZE + vectors_byte_len) as u64;
-        let doc_ids_byte_len = (num_vectors * DOC_ID_ENTRY_SIZE) as u64;
+        if hdr[13..] != [0, 0, 0] {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector header has non-zero reserved bytes",
+            ));
+        }
 
-        let doc_ids_bytes = handle
-            .read_bytes_range(doc_ids_start..doc_ids_start + doc_ids_byte_len)
-            .await?;
+        // Read doc_ids section as zero-copy OwnedBytes (6 bytes per vector)
+        let vbs =
+            FlatVectorData::validate_shape(dim, num_vectors, quantization).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid flat vector shape: {error}"),
+                )
+            })?;
+        let vectors_byte_len_usize = num_vectors.checked_mul(vbs).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector payload size overflows usize",
+            )
+        })?;
+        let doc_ids_byte_len_usize =
+            num_vectors.checked_mul(DOC_ID_ENTRY_SIZE).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "flat vector doc-map size overflows usize",
+                )
+            })?;
+        let expected_len_usize = FLAT_BINARY_HEADER_SIZE
+            .checked_add(vectors_byte_len_usize)
+            .and_then(|size| size.checked_add(doc_ids_byte_len_usize))
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "flat vector serialized size overflows usize",
+                )
+            })?;
+        let expected_len = u64::try_from(expected_len_usize).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector serialized size does not fit in u64",
+            )
+        })?;
+        if handle.len() != expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "flat vector payload has {} bytes, expected exactly {expected_len}",
+                    handle.len()
+                ),
+            ));
+        }
+
+        let vectors_byte_len = u64::try_from(vectors_byte_len_usize).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector payload size does not fit in u64",
+            )
+        })?;
+        let doc_ids_byte_len = u64::try_from(doc_ids_byte_len_usize).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector doc-map size does not fit in u64",
+            )
+        })?;
+        let doc_ids_start = header_len.checked_add(vectors_byte_len).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector doc-map offset overflows u64",
+            )
+        })?;
+        let doc_ids_end = doc_ids_start.checked_add(doc_ids_byte_len).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector doc-map range overflows u64",
+            )
+        })?;
+
+        let doc_ids_bytes = handle.read_bytes_range(doc_ids_start..doc_ids_end).await?;
+        if doc_ids_bytes.len() != doc_ids_byte_len_usize {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "flat vector doc-map read returned {} bytes, expected {doc_ids_byte_len_usize}",
+                    doc_ids_bytes.len()
+                ),
+            ));
+        }
+
+        let mut previous = None;
+        let mut num_docs_with_vectors = 0usize;
+        for entry in doc_ids_bytes.as_slice().chunks_exact(DOC_ID_ENTRY_SIZE) {
+            let doc_id = u32::from_le_bytes([entry[0], entry[1], entry[2], entry[3]]);
+            let ordinal = u16::from_le_bytes([entry[4], entry[5]]);
+            let current = (doc_id, ordinal);
+            if let Some(previous) = previous
+                && previous >= current
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "flat vector doc map must be strictly sorted by (doc_id, ordinal), found {previous:?} before {current:?}"
+                    ),
+                ));
+            }
+            if let Some(limit) = total_docs
+                && doc_id >= limit
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "flat vector doc map references document {doc_id}, but segment contains only {} documents",
+                        limit
+                    ),
+                ));
+            }
+            if previous.is_none_or(|(previous_doc_id, _)| previous_doc_id != doc_id) {
+                num_docs_with_vectors = num_docs_with_vectors.checked_add(1).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "flat vector distinct-document count overflows usize",
+                    )
+                })?;
+            }
+            previous = Some(current);
+        }
 
         Ok(Self {
             dim,
             num_vectors,
+            num_docs_with_vectors,
             quantization,
             doc_ids_bytes,
             handle,
-            vectors_offset: FLAT_BINARY_HEADER_SIZE as u64,
+            vectors_offset: header_len,
             vbs,
+            vectors_byte_len,
         })
+    }
+
+    fn checked_vector_range(
+        &self,
+        start_idx: usize,
+        count: usize,
+    ) -> io::Result<(std::ops::Range<u64>, usize)> {
+        let end_idx = start_idx.checked_add(count).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flat vector index range overflows usize",
+            )
+        })?;
+        if end_idx > self.num_vectors {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "flat vector range {start_idx}..{end_idx} exceeds {} vectors",
+                    self.num_vectors
+                ),
+            ));
+        }
+
+        let relative_offset = start_idx.checked_mul(self.vbs).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector byte offset overflows usize",
+            )
+        })?;
+        let byte_len = count.checked_mul(self.vbs).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flat vector byte length overflows usize",
+            )
+        })?;
+        let relative_offset = u64::try_from(relative_offset).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector byte offset does not fit in u64",
+            )
+        })?;
+        let byte_len_u64 = u64::try_from(byte_len).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "flat vector byte length does not fit in u64",
+            )
+        })?;
+        let start = self
+            .vectors_offset
+            .checked_add(relative_offset)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "flat vector byte offset overflows u64",
+                )
+            })?;
+        let end = start.checked_add(byte_len_u64).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "flat vector byte range overflows u64",
+            )
+        })?;
+        let vectors_end = self
+            .vectors_offset
+            .checked_add(self.vectors_byte_len)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "flat vector payload boundary overflows u64",
+                )
+            })?;
+        if end > vectors_end || end > self.handle.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "flat vector byte range {start}..{end} exceeds payload boundary {vectors_end}"
+                ),
+            ));
+        }
+        Ok((start..end, byte_len))
     }
 
     /// Pin the doc-id map (priority 3: every rerank / top-k resolution
@@ -300,11 +722,11 @@ impl LazyFlatVectorData {
     /// No-op for non-mmap (RAM, HTTP) backing.
     #[cfg(feature = "native")]
     pub fn advise_random_access(&self) {
-        let data_len = (self.num_vectors * self.vbs) as u64;
-        self.handle.madvise_range(
-            self.vectors_offset..self.vectors_offset + data_len,
-            libc::MADV_RANDOM,
-        );
+        let Some(vectors_end) = self.vectors_offset.checked_add(self.vectors_byte_len) else {
+            return;
+        };
+        self.handle
+            .madvise_range(self.vectors_offset..vectors_end, libc::MADV_RANDOM);
     }
 
     /// Prefetch the pages backing a sorted set of vector indexes (`MADV_WILLNEED`).
@@ -317,22 +739,24 @@ impl LazyFlatVectorData {
     pub fn prefetch_vectors(&self, sorted_flat_indexes: impl IntoIterator<Item = usize>) {
         /// Gap (in bytes) below which two candidate ranges are merged into one advice call.
         const COALESCE_GAP: u64 = 64 * 1024;
-        let vbs = self.vbs as u64;
-        let mut iter = sorted_flat_indexes.into_iter();
-        let Some(first) = iter.next() else {
+        let mut ranges = sorted_flat_indexes.into_iter().filter_map(|idx| {
+            self.checked_vector_range(idx, 1)
+                .ok()
+                .map(|(range, _)| range)
+        });
+        let Some(first) = ranges.next() else {
             return;
         };
-        let mut run_start = self.vectors_offset + first as u64 * vbs;
-        let mut run_end = run_start + vbs;
-        for idx in iter {
-            let start = self.vectors_offset + idx as u64 * vbs;
-            if start <= run_end + COALESCE_GAP {
-                run_end = start + vbs;
+        let mut run_start = first.start;
+        let mut run_end = first.end;
+        for range in ranges {
+            if range.start <= run_end.saturating_add(COALESCE_GAP) {
+                run_end = run_end.max(range.end);
             } else {
                 self.handle
                     .madvise_range(run_start..run_end, libc::MADV_WILLNEED);
-                run_start = start;
-                run_end = start + vbs;
+                run_start = range.start;
+                run_end = range.end;
             }
         }
         self.handle
@@ -344,17 +768,18 @@ impl LazyFlatVectorData {
     /// `out` must have length >= `self.dim`. Returns `Ok(())` on success.
     /// Used for ANN training and doc() hydration where f32 is needed.
     pub async fn read_vector_into(&self, idx: usize, out: &mut [f32]) -> io::Result<()> {
-        debug_assert!(out.len() >= self.dim);
-        let vbs = self.vector_byte_size();
-        let byte_offset = self.vectors_offset + (idx * vbs) as u64;
-        let bytes = self
-            .handle
-            .read_bytes_range(byte_offset..byte_offset + vbs as u64)
-            .await?;
-        let raw = bytes.as_slice();
-
-        dequantize_raw(raw, self.quantization, self.dim, out);
-        Ok(())
+        if out.len() < self.dim {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "flat vector output is too short: need {} floats, got {}",
+                    self.dim,
+                    out.len()
+                ),
+            ));
+        }
+        let bytes = self.read_vectors_batch(idx, 1).await?;
+        dequantize_raw(bytes.as_slice(), self.quantization, self.dim, out)
     }
 
     /// Read a single vector by index, dequantized to f32 (allocates a new Vec<f32>).
@@ -369,14 +794,72 @@ impl LazyFlatVectorData {
     /// `out` must have length >= `self.vector_byte_size()`.
     /// Used for native-precision reranking where raw quantized bytes are scored directly.
     pub async fn read_vector_raw_into(&self, idx: usize, out: &mut [u8]) -> io::Result<()> {
+        self.read_vector_prefix_raw_into(idx, self.vector_byte_size(), out)
+            .await
+    }
+
+    /// Read a prefix of one vector's raw bytes into a caller-provided buffer.
+    ///
+    /// This is used by Matryoshka scoring to avoid reading the unused tail of
+    /// a vector. Unlike the old full-vector boundary, all caller-controlled
+    /// sizes and offset arithmetic are checked in release builds.
+    pub async fn read_vector_prefix_raw_into(
+        &self,
+        idx: usize,
+        prefix_byte_len: usize,
+        out: &mut [u8],
+    ) -> io::Result<()> {
         let vbs = self.vector_byte_size();
-        debug_assert!(out.len() >= vbs);
-        let byte_offset = self.vectors_offset + (idx * vbs) as u64;
+        if prefix_byte_len > vbs {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "vector prefix is {prefix_byte_len} bytes, but a vector has only {vbs} bytes"
+                ),
+            ));
+        }
+        if out.len() < prefix_byte_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "vector prefix output is too short: need {prefix_byte_len} bytes, got {}",
+                    out.len()
+                ),
+            ));
+        }
+        let (full_range, _) = self.checked_vector_range(idx, 1)?;
+        if prefix_byte_len == 0 {
+            return Ok(());
+        }
+        let prefix_byte_len_u64 = u64::try_from(prefix_byte_len).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "vector prefix length does not fit in u64",
+            )
+        })?;
+        let byte_end = full_range
+            .start
+            .checked_add(prefix_byte_len_u64)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "vector byte range overflows u64",
+                )
+            })?;
         let bytes = self
             .handle
-            .read_bytes_range(byte_offset..byte_offset + vbs as u64)
+            .read_bytes_range(full_range.start..byte_end)
             .await?;
-        out[..vbs].copy_from_slice(bytes.as_slice());
+        if bytes.len() != prefix_byte_len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "vector prefix read returned {} bytes, expected {prefix_byte_len}",
+                    bytes.len()
+                ),
+            ));
+        }
+        out[..prefix_byte_len].copy_from_slice(bytes.as_slice());
         Ok(())
     }
 
@@ -390,24 +873,34 @@ impl LazyFlatVectorData {
         start_idx: usize,
         count: usize,
     ) -> io::Result<OwnedBytes> {
-        debug_assert!(start_idx + count <= self.num_vectors);
-        let vbs = self.vector_byte_size();
-        let byte_offset = self.vectors_offset + (start_idx * vbs) as u64;
-        let byte_len = (count * vbs) as u64;
-        self.handle
-            .read_bytes_range(byte_offset..byte_offset + byte_len)
-            .await
+        let (range, expected_len) = self.checked_vector_range(start_idx, count)?;
+        let bytes = self.handle.read_bytes_range(range).await?;
+        if bytes.len() != expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "flat vector batch read returned {} bytes, expected {expected_len}",
+                    bytes.len()
+                ),
+            ));
+        }
+        Ok(bytes)
     }
 
     /// Synchronous read of a single vector's raw bytes.
     #[cfg(feature = "sync")]
     pub fn read_vector_raw_into_sync(&self, idx: usize, out: &mut [u8]) -> io::Result<()> {
         let vbs = self.vector_byte_size();
-        debug_assert!(out.len() >= vbs);
-        let byte_offset = self.vectors_offset + (idx * vbs) as u64;
-        let bytes = self
-            .handle
-            .read_bytes_range_sync(byte_offset..byte_offset + vbs as u64)?;
+        if out.len() < vbs {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "flat vector output is too short: need {vbs} bytes, got {}",
+                    out.len()
+                ),
+            ));
+        }
+        let bytes = self.read_vectors_batch_sync(idx, 1)?;
         out[..vbs].copy_from_slice(bytes.as_slice());
         Ok(())
     }
@@ -419,12 +912,18 @@ impl LazyFlatVectorData {
         start_idx: usize,
         count: usize,
     ) -> io::Result<OwnedBytes> {
-        debug_assert!(start_idx + count <= self.num_vectors);
-        let vbs = self.vector_byte_size();
-        let byte_offset = self.vectors_offset + (start_idx * vbs) as u64;
-        let byte_len = (count * vbs) as u64;
-        self.handle
-            .read_bytes_range_sync(byte_offset..byte_offset + byte_len)
+        let (range, expected_len) = self.checked_vector_range(start_idx, count)?;
+        let bytes = self.handle.read_bytes_range_sync(range)?;
+        if bytes.len() != expected_len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "flat vector batch read returned {} bytes, expected {expected_len}",
+                    bytes.len()
+                ),
+            ));
+        }
+        Ok(bytes)
     }
 
     /// Find flat index range for a given doc_id (non-allocating).
@@ -516,9 +1015,15 @@ impl LazyFlatVectorData {
         self.vbs
     }
 
+    /// Number of distinct documents that have at least one vector in this field.
+    #[inline]
+    pub fn num_docs_with_vectors(&self) -> usize {
+        self.num_docs_with_vectors
+    }
+
     /// Total byte length of raw vector data (for chunked merger streaming).
     pub fn vector_bytes_len(&self) -> u64 {
-        (self.num_vectors as u64) * (self.vector_byte_size() as u64)
+        self.vectors_byte_len
     }
 
     /// Byte offset where vector data starts (for direct handle access in merger).
@@ -554,9 +1059,52 @@ impl IVFRaBitQIndexData {
     }
 
     pub fn from_bytes(data: &[u8]) -> std::io::Result<Self> {
-        bincode::serde::decode_from_slice(data, bincode::config::standard())
-            .map(|(v, _)| v)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        let value: Self = crate::structures::vector::decode_ann_bincode_exact(data, "IVF-RaBitQ")?;
+        value
+            .codebook
+            .validate()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        if value.index.config.default_nprobe == 0
+            || value.index.config.dim != value.codebook.config.dim
+            || value.index.codebook_version != value.codebook.version
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "IVF-RaBitQ index/codebook metadata mismatch",
+            ));
+        }
+        let mut total_vectors = 0usize;
+        for (_, cluster) in value.index.clusters.iter() {
+            if cluster.doc_ids.len() != cluster.ordinals.len()
+                || cluster.doc_ids.len() != cluster.codes.len()
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "IVF-RaBitQ cluster column lengths differ",
+                ));
+            }
+            total_vectors = total_vectors
+                .checked_add(cluster.codes.len())
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "IVF-RaBitQ vector count overflow",
+                    )
+                })?;
+            for code in &cluster.codes {
+                value
+                    .codebook
+                    .validate_vector(code)
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            }
+        }
+        if total_vectors != value.index.clusters.total_vectors {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "IVF-RaBitQ total vector count is inconsistent",
+            ));
+        }
+        Ok(value)
     }
 }
 
@@ -577,8 +1125,491 @@ impl ScaNNIndexData {
     }
 
     pub fn from_bytes(data: &[u8]) -> std::io::Result<Self> {
-        bincode::serde::decode_from_slice(data, bincode::config::standard())
-            .map(|(v, _)| v)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        let value: Self = crate::structures::vector::decode_ann_bincode_exact(data, "ScaNN")?;
+        value
+            .codebook
+            .validate()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        if value.index.config.default_nprobe == 0
+            || value.index.config.dim != value.codebook.config.dim
+            || value.index.codebook_version != value.codebook.version
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "ScaNN index/codebook metadata mismatch",
+            ));
+        }
+        let expected_codes = value.codebook.config.num_subspaces;
+        let num_centroids = value.codebook.config.num_centroids;
+        let mut total_vectors = 0usize;
+        for (_, cluster) in value.index.clusters.iter() {
+            if cluster.doc_ids.len() != cluster.ordinals.len()
+                || cluster.doc_ids.len() != cluster.codes.len()
+                || cluster.codes.iter().any(|code| {
+                    code.codes.len() != expected_codes
+                        || !code.norm.is_finite()
+                        || code.norm < 0.0
+                        || code
+                            .codes
+                            .iter()
+                            .any(|&centroid| centroid as usize >= num_centroids)
+                })
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "ScaNN cluster columns or PQ code lengths are invalid",
+                ));
+            }
+            total_vectors = total_vectors
+                .checked_add(cluster.codes.len())
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "ScaNN vector count overflow",
+                    )
+                })?;
+        }
+        if total_vectors != value.index.clusters.total_vectors {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "ScaNN total vector count is inconsistent",
+            ));
+        }
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dequantize_raw_accepts_valid_storage_formats() {
+        let f32_values = [1.25f32, -2.5];
+        let f32_bytes = unsafe {
+            // Safety: viewing an initialized f32 array as bytes is always valid.
+            std::slice::from_raw_parts(
+                f32_values.as_ptr().cast::<u8>(),
+                std::mem::size_of_val(&f32_values),
+            )
+        };
+        let mut out = [0.0; 2];
+        dequantize_raw(f32_bytes, DenseVectorQuantization::F32, 2, &mut out).unwrap();
+        assert_eq!(out, f32_values);
+
+        let f16_values = [0x3c00u16, 0xc000u16]; // 1.0, -2.0
+        let f16_bytes = unsafe {
+            // Safety: viewing an initialized u16 array as bytes is always valid.
+            std::slice::from_raw_parts(
+                f16_values.as_ptr().cast::<u8>(),
+                std::mem::size_of_val(&f16_values),
+            )
+        };
+        dequantize_raw(f16_bytes, DenseVectorQuantization::F16, 2, &mut out).unwrap();
+        assert_eq!(out, [1.0, -2.0]);
+
+        dequantize_raw(&[0, u8::MAX], DenseVectorQuantization::UInt8, 2, &mut out).unwrap();
+        assert_eq!(out, [u8_to_f32(0), u8_to_f32(u8::MAX)]);
+    }
+
+    #[test]
+    fn dequantize_raw_rejects_invalid_lengths_and_binary_storage() {
+        let mut out = [0.0; 2];
+        assert_eq!(
+            dequantize_raw(&[0; 7], DenseVectorQuantization::F32, 2, &mut out)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            dequantize_raw(&[0; 8], DenseVectorQuantization::F32, 2, &mut out[..1])
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        assert_eq!(
+            dequantize_raw(&[], DenseVectorQuantization::Binary, 0, &mut [])
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn dequantize_raw_rejects_misaligned_typed_storage() {
+        let storage = [0u8; 9];
+        let offset = if (storage.as_ptr() as usize).is_multiple_of(4) {
+            1
+        } else {
+            0
+        };
+        let raw = &storage[offset..offset + 8];
+        assert!(!(raw.as_ptr() as usize).is_multiple_of(4));
+
+        let mut out = [0.0; 2];
+        assert_eq!(
+            dequantize_raw(raw, DenseVectorQuantization::F32, 2, &mut out)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn flat_vector_writers_reject_inconsistent_shapes_and_doc_maps() {
+        let mut encoded = Vec::new();
+        assert!(
+            FlatVectorData::serialize_binary_from_flat_streaming(
+                0,
+                &[],
+                &[],
+                DenseVectorQuantization::F32,
+                &mut encoded,
+            )
+            .is_err()
+        );
+        assert!(encoded.is_empty());
+
+        assert!(
+            FlatVectorData::serialize_binary_from_flat_streaming(
+                2,
+                &[1.0],
+                &[(0, 0)],
+                DenseVectorQuantization::F32,
+                &mut encoded,
+            )
+            .is_err()
+        );
+        assert!(encoded.is_empty());
+
+        assert!(
+            FlatVectorData::serialize_binary_from_flat_streaming(
+                1,
+                &[1.0],
+                &[(0, 0)],
+                DenseVectorQuantization::Binary,
+                &mut encoded,
+            )
+            .is_err()
+        );
+        assert!(encoded.is_empty());
+
+        assert!(
+            FlatVectorData::serialize_binary_from_flat_streaming(
+                1,
+                &[1.0, 2.0],
+                &[(1, 0), (0, 0)],
+                DenseVectorQuantization::F32,
+                &mut encoded,
+            )
+            .is_err()
+        );
+        assert!(encoded.is_empty());
+
+        assert!(
+            FlatVectorData::serialize_binary_from_flat_streaming(
+                1,
+                &[1.0, 2.0],
+                &[(0, 0), (0, 0)],
+                DenseVectorQuantization::F32,
+                &mut encoded,
+            )
+            .is_err()
+        );
+        assert!(encoded.is_empty());
+
+        assert!(
+            FlatVectorData::serialize_binary_from_bits_streaming(7, &[0], &[(0, 0)], &mut encoded,)
+                .is_err()
+        );
+        assert!(encoded.is_empty());
+
+        assert!(
+            FlatVectorData::serialize_binary_from_bits_streaming(8, &[], &[(0, 0)], &mut encoded,)
+                .is_err()
+        );
+        assert!(encoded.is_empty());
+
+        let vectors = [1.0f32, 2.0, 3.0, 4.0];
+        let doc_ids = [(0, 0), (1, 0)];
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            2,
+            &vectors,
+            &doc_ids,
+            DenseVectorQuantization::F32,
+            &mut encoded,
+        )
+        .unwrap();
+        assert_eq!(
+            encoded.len(),
+            FlatVectorData::serialized_binary_size(2, 2, DenseVectorQuantization::F32).unwrap()
+        );
+    }
+
+    fn encoded_two_vector_payload() -> Vec<u8> {
+        let mut encoded = Vec::new();
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            2,
+            &[1.0, 2.0, 3.0, 4.0],
+            &[(0, 0), (1, 0)],
+            DenseVectorQuantization::F32,
+            &mut encoded,
+        )
+        .unwrap();
+        encoded
+    }
+
+    #[tokio::test]
+    async fn flat_vector_open_rejects_corrupt_layout_and_doc_map() {
+        let valid = encoded_two_vector_payload();
+
+        let mut multi_value = Vec::new();
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            1,
+            &[1.0, 2.0, 3.0],
+            &[(0, 0), (0, 1), (2, 0)],
+            DenseVectorQuantization::F32,
+            &mut multi_value,
+        )
+        .unwrap();
+        let multi_value = LazyFlatVectorData::open_with_doc_limit(
+            FileHandle::from_bytes(OwnedBytes::new(multi_value)),
+            Some(3),
+        )
+        .await
+        .unwrap();
+        assert_eq!(multi_value.num_docs_with_vectors(), 2);
+
+        let mut trailing = valid.clone();
+        trailing.push(0);
+        assert!(
+            LazyFlatVectorData::open(FileHandle::from_bytes(OwnedBytes::new(trailing)))
+                .await
+                .is_err()
+        );
+
+        let mut truncated = valid.clone();
+        truncated.pop();
+        assert!(
+            LazyFlatVectorData::open(FileHandle::from_bytes(OwnedBytes::new(truncated)))
+                .await
+                .is_err()
+        );
+
+        let mut reserved = valid.clone();
+        reserved[13] = 1;
+        assert!(
+            LazyFlatVectorData::open(FileHandle::from_bytes(OwnedBytes::new(reserved)))
+                .await
+                .is_err()
+        );
+
+        let doc_map_start = FLAT_BINARY_HEADER_SIZE + 2 * 2 * size_of::<f32>();
+        let mut unsorted = valid.clone();
+        let (first, second) = unsorted[doc_map_start..doc_map_start + 2 * DOC_ID_ENTRY_SIZE]
+            .split_at_mut(DOC_ID_ENTRY_SIZE);
+        first.swap_with_slice(second);
+        assert!(
+            LazyFlatVectorData::open(FileHandle::from_bytes(OwnedBytes::new(unsorted)))
+                .await
+                .is_err()
+        );
+
+        let mut duplicate = valid.clone();
+        duplicate.copy_within(
+            doc_map_start..doc_map_start + DOC_ID_ENTRY_SIZE,
+            doc_map_start + DOC_ID_ENTRY_SIZE,
+        );
+        assert!(
+            LazyFlatVectorData::open(FileHandle::from_bytes(OwnedBytes::new(duplicate)))
+                .await
+                .is_err()
+        );
+
+        assert!(
+            LazyFlatVectorData::open_with_doc_limit(
+                FileHandle::from_bytes(OwnedBytes::new(valid)),
+                Some(1),
+            )
+            .await
+            .is_err()
+        );
+
+        let mut invalid_binary = Vec::new();
+        FlatVectorData::serialize_binary_from_bits_streaming(
+            8,
+            &[0],
+            &[(0, 0)],
+            &mut invalid_binary,
+        )
+        .unwrap();
+        invalid_binary[4..8].copy_from_slice(&7u32.to_le_bytes());
+        assert!(
+            LazyFlatVectorData::open(FileHandle::from_bytes(OwnedBytes::new(invalid_binary)))
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn flat_vector_batch_and_dequantized_reads_are_checked() {
+        let flat = LazyFlatVectorData::open(FileHandle::from_bytes(OwnedBytes::new(
+            encoded_two_vector_payload(),
+        )))
+        .await
+        .unwrap();
+
+        assert_eq!(flat.read_vectors_batch(0, 2).await.unwrap().len(), 16);
+        assert_eq!(flat.read_vectors_batch(2, 0).await.unwrap().len(), 0);
+        assert!(flat.read_vectors_batch(1, 2).await.is_err());
+        assert!(flat.read_vectors_batch(usize::MAX, 1).await.is_err());
+        assert!(flat.read_vectors_batch(0, usize::MAX).await.is_err());
+
+        let mut values = [0.0; 2];
+        flat.read_vector_into(1, &mut values).await.unwrap();
+        assert_eq!(values, [3.0, 4.0]);
+        assert!(flat.read_vector_into(2, &mut values).await.is_err());
+        assert!(flat.read_vector_into(0, &mut values[..1]).await.is_err());
+
+        #[cfg(feature = "sync")]
+        {
+            assert_eq!(flat.read_vectors_batch_sync(0, 2).unwrap().len(), 16);
+            assert!(flat.read_vectors_batch_sync(1, 2).is_err());
+            assert!(flat.read_vectors_batch_sync(usize::MAX, 1).is_err());
+            let mut too_short = [0; 7];
+            assert!(flat.read_vector_raw_into_sync(0, &mut too_short).is_err());
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn flat_vector_reads_reject_short_lazy_range_results() {
+        let payload = std::sync::Arc::new(encoded_two_vector_payload());
+        let payload_len = payload.len() as u64;
+        let read_payload = std::sync::Arc::clone(&payload);
+        let read_fn: crate::directories::RangeReadFn = std::sync::Arc::new(move |range| {
+            let payload = std::sync::Arc::clone(&read_payload);
+            Box::pin(async move {
+                let start = usize::try_from(range.start).unwrap();
+                let mut end = usize::try_from(range.end).unwrap();
+                // Header and doc-map reads are exact, allowing open to finish.
+                // Raw vector reads deliberately violate the range-read contract.
+                if range.start == FLAT_BINARY_HEADER_SIZE as u64 {
+                    end -= 1;
+                }
+                Ok(OwnedBytes::new(payload[start..end].to_vec()))
+            })
+        });
+        let flat = LazyFlatVectorData::open(FileHandle::lazy(payload_len, read_fn))
+            .await
+            .unwrap();
+
+        let error = flat.read_vectors_batch(0, 1).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+        let mut raw = [0; 8];
+        let error = flat.read_vector_raw_into(0, &mut raw).await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn ann_bincode_decoders_reject_trailing_and_invalid_semantics() {
+        let rabitq_codebook =
+            crate::structures::RaBitQCodebook::new(crate::structures::RaBitQConfig::new(8));
+        let rabitq = IVFRaBitQIndexData {
+            index: crate::structures::IVFRaBitQIndex::new(
+                crate::structures::IVFRaBitQConfig::new(8),
+                1,
+                rabitq_codebook.version,
+            ),
+            codebook: rabitq_codebook,
+        };
+        let mut rabitq_bytes = rabitq.to_bytes().unwrap();
+        assert!(IVFRaBitQIndexData::from_bytes(&rabitq_bytes).is_ok());
+        let mut invalid_rabitq = rabitq.clone();
+        invalid_rabitq.index.config.default_nprobe = 0;
+        assert!(IVFRaBitQIndexData::from_bytes(&invalid_rabitq.to_bytes().unwrap()).is_err());
+        invalid_rabitq.index.config.default_nprobe = 1;
+        invalid_rabitq.codebook.config.query_bits = 0;
+        assert!(IVFRaBitQIndexData::from_bytes(&invalid_rabitq.to_bytes().unwrap()).is_err());
+        rabitq_bytes.push(0);
+        assert!(IVFRaBitQIndexData::from_bytes(&rabitq_bytes).is_err());
+
+        let pq_config = crate::structures::PQConfig::new(2);
+        let pq_codebook = crate::structures::PQCodebook {
+            centroids: vec![
+                0.0;
+                pq_config.num_subspaces
+                    * pq_config.num_centroids
+                    * pq_config.dims_per_block
+            ],
+            rotation_matrix: None,
+            centroid_norms: None,
+            version: 2,
+            config: pq_config,
+        };
+        let scann = ScaNNIndexData {
+            index: crate::structures::IVFPQIndex::new(
+                crate::structures::IVFPQConfig::new(2),
+                1,
+                pq_codebook.version,
+            ),
+            codebook: pq_codebook,
+        };
+        let mut scann_bytes = scann.to_bytes().unwrap();
+        assert!(ScaNNIndexData::from_bytes(&scann_bytes).is_ok());
+        let mut invalid_scann = scann.clone();
+        invalid_scann.index.config.default_nprobe = 0;
+        assert!(ScaNNIndexData::from_bytes(&invalid_scann.to_bytes().unwrap()).is_err());
+        invalid_scann.index.config.default_nprobe = 1;
+        invalid_scann.codebook.config.aniso_eta = f32::NAN;
+        assert!(ScaNNIndexData::from_bytes(&invalid_scann.to_bytes().unwrap()).is_err());
+        scann_bytes.push(0);
+        assert!(ScaNNIndexData::from_bytes(&scann_bytes).is_err());
+    }
+
+    #[tokio::test]
+    async fn vector_prefix_reads_are_checked_and_do_not_fetch_the_tail() {
+        let vectors = [1.0f32, 2.0, 3.0, 4.0];
+        let doc_ids = [(0, 0), (1, 0)];
+        let mut encoded = Vec::new();
+        FlatVectorData::serialize_binary_from_flat_streaming(
+            2,
+            &vectors,
+            &doc_ids,
+            DenseVectorQuantization::F32,
+            &mut encoded,
+        )
+        .unwrap();
+        let flat = LazyFlatVectorData::open(FileHandle::from_bytes(OwnedBytes::new(encoded)))
+            .await
+            .unwrap();
+
+        let mut prefix = [0xa5; 8];
+        flat.read_vector_prefix_raw_into(1, 4, &mut prefix)
+            .await
+            .unwrap();
+        assert_eq!(&prefix[..4], &3.0f32.to_ne_bytes());
+        assert_eq!(&prefix[4..], &[0xa5; 4]);
+
+        let mut full = [0; 8];
+        flat.read_vector_raw_into(1, &mut full).await.unwrap();
+        assert_eq!(&full[..4], &3.0f32.to_ne_bytes());
+        assert_eq!(&full[4..], &4.0f32.to_ne_bytes());
+
+        assert!(
+            flat.read_vector_prefix_raw_into(2, 4, &mut prefix)
+                .await
+                .is_err()
+        );
+        assert!(
+            flat.read_vector_prefix_raw_into(0, 9, &mut prefix)
+                .await
+                .is_err()
+        );
+        assert!(
+            flat.read_vector_prefix_raw_into(0, 4, &mut prefix[..3])
+                .await
+                .is_err()
+        );
     }
 }

--- a/hermes-core/src/structures/fast_field/codec.rs
+++ b/hermes-core/src/structures/fast_field/codec.rs
@@ -42,6 +42,149 @@ impl CodecType {
 /// Block size for BlockwiseLinear codec (matching Tantivy).
 pub const BLOCKWISE_LINEAR_BLOCK_SIZE: usize = 512;
 
+/// Validate an auto-codec payload before exposing it through the infallible
+/// hot-path readers below. This keeps every bounds check out of per-document
+/// access while ensuring corrupt segment metadata cannot trigger slice panics.
+pub fn validate_auto(data: &[u8], expected_values: usize) -> io::Result<()> {
+    let (&codec_id, rest) = data.split_first().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::UnexpectedEof, "fast field codec is missing")
+    })?;
+
+    let packed_len = |count: usize, bpv: u8| -> io::Result<usize> {
+        if bpv > 64 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "fast field bit width exceeds 64",
+            ));
+        }
+        count
+            .checked_mul(bpv as usize)
+            .and_then(|bits| bits.checked_add(7))
+            .map(|bits| bits / 8)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "fast field size overflow"))
+    };
+
+    match CodecType::from_u8(codec_id) {
+        Some(CodecType::Constant) => {
+            if rest.len() != 8 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid constant fast field length",
+                ));
+            }
+        }
+        Some(CodecType::Bitpacked) => {
+            if rest.len() < 9 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "bitpacked fast field header is truncated",
+                ));
+            }
+            let expected_len = 9usize
+                .checked_add(packed_len(expected_values, rest[8])?)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "fast field size overflow")
+                })?;
+            if rest.len() != expected_len {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "bitpacked fast field length is inconsistent",
+                ));
+            }
+        }
+        Some(CodecType::Linear) => {
+            if rest.len() < 29 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "linear fast field header is truncated",
+                ));
+            }
+            let count = u32::from_le_bytes(rest[16..20].try_into().unwrap()) as usize;
+            if count != expected_values || count < 2 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "linear fast field value count is inconsistent",
+                ));
+            }
+            let expected_len = 29usize
+                .checked_add(packed_len(count, rest[28])?)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "fast field size overflow")
+                })?;
+            if rest.len() != expected_len {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "linear fast field length is inconsistent",
+                ));
+            }
+        }
+        Some(CodecType::BlockwiseLinear) => {
+            if rest.len() < 8 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "blockwise fast field header is truncated",
+                ));
+            }
+            let count = u32::from_le_bytes(rest[0..4].try_into().unwrap()) as usize;
+            let num_blocks = u32::from_le_bytes(rest[4..8].try_into().unwrap()) as usize;
+            if count != expected_values || num_blocks != count.div_ceil(BLOCKWISE_LINEAR_BLOCK_SIZE)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "blockwise fast field counts are inconsistent",
+                ));
+            }
+
+            let mut pos = 8usize;
+            for block_idx in 0..num_blocks {
+                let header_end = pos.checked_add(29).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "fast field offset overflow")
+                })?;
+                if header_end > rest.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "blockwise fast field block header is truncated",
+                    ));
+                }
+                let bpv = rest[pos + 24];
+                let declared =
+                    u32::from_le_bytes(rest[pos + 25..header_end].try_into().unwrap()) as usize;
+                let block_start = block_idx * BLOCKWISE_LINEAR_BLOCK_SIZE;
+                let block_count = (count - block_start).min(BLOCKWISE_LINEAR_BLOCK_SIZE);
+                let expected = packed_len(block_count, bpv)?;
+                if declared != expected {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "blockwise fast field packed length is inconsistent",
+                    ));
+                }
+                pos = header_end.checked_add(declared).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "fast field offset overflow")
+                })?;
+                if pos > rest.len() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "blockwise fast field data is truncated",
+                    ));
+                }
+            }
+            if pos != rest.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "blockwise fast field contains trailing data",
+                ));
+            }
+        }
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unknown fast field codec",
+            ));
+        }
+    }
+    Ok(())
+}
+
 // ── Estimator trait ──────────────────────────────────────────────────────
 
 /// Estimates serialized size for a given codec.
@@ -168,7 +311,7 @@ pub fn bitpacked_read(data: &[u8], index: usize) -> u64 {
         return min_value;
     }
     let packed = &data[9..];
-    bitpack_read(packed, bpv, index) + min_value
+    bitpack_read(packed, bpv, index).wrapping_add(min_value)
 }
 
 // ── Linear codec ─────────────────────────────────────────────────────────
@@ -588,7 +731,7 @@ pub fn bitpacked_read_batch(data: &[u8], start_index: usize, out: &mut [u64]) {
         8 => {
             for (i, v) in out.iter_mut().enumerate() {
                 let idx = start_index + i;
-                *v = packed[idx] as u64 + min_value;
+                *v = (packed[idx] as u64).wrapping_add(min_value);
             }
         }
         16 => {
@@ -596,7 +739,7 @@ pub fn bitpacked_read_batch(data: &[u8], start_index: usize, out: &mut [u64]) {
                 let idx = start_index + i;
                 let byte_off = idx * 2;
                 let raw = u16::from_le_bytes([packed[byte_off], packed[byte_off + 1]]);
-                *v = raw as u64 + min_value;
+                *v = (raw as u64).wrapping_add(min_value);
             }
         }
         32 => {
@@ -604,7 +747,7 @@ pub fn bitpacked_read_batch(data: &[u8], start_index: usize, out: &mut [u64]) {
                 let idx = start_index + i;
                 let byte_off = idx * 4;
                 let raw = u32::from_le_bytes(packed[byte_off..byte_off + 4].try_into().unwrap());
-                *v = raw as u64 + min_value;
+                *v = (raw as u64).wrapping_add(min_value);
             }
         }
         64 => {
@@ -618,7 +761,7 @@ pub fn bitpacked_read_batch(data: &[u8], start_index: usize, out: &mut [u64]) {
         // Arbitrary bpv — tight scalar loop using u64 fast-path read
         _ => {
             for (i, v) in out.iter_mut().enumerate() {
-                *v = super::bitpack_read(packed, bpv, start_index + i) + min_value;
+                *v = super::bitpack_read(packed, bpv, start_index + i).wrapping_add(min_value);
             }
         }
     }
@@ -737,6 +880,23 @@ mod tests {
         let mut buf = Vec::new();
         serialize_auto(&values, &mut buf).unwrap();
         assert!(buf.len() <= 10);
+    }
+
+    #[test]
+    fn test_validate_rejects_truncated_and_inconsistent_payloads() {
+        assert!(validate_auto(&[], 1).is_err());
+        assert!(validate_auto(&[CodecType::Constant as u8], 1).is_err());
+
+        let mut bitpacked = vec![CodecType::Bitpacked as u8];
+        bitpacked.extend_from_slice(&0u64.to_le_bytes());
+        bitpacked.push(65);
+        assert!(validate_auto(&bitpacked, 1).is_err());
+
+        let mut valid = Vec::new();
+        serialize_auto(&[1, 2, 3, 4], &mut valid).unwrap();
+        assert!(validate_auto(&valid, 4).is_ok());
+        valid.pop();
+        assert!(validate_auto(&valid, 4).is_err());
     }
 
     #[test]

--- a/hermes-core/src/structures/fast_field/mod.rs
+++ b/hermes-core/src/structures/fast_field/mod.rs
@@ -310,6 +310,12 @@ impl FastFieldTocEntry {
         let column_type = FastFieldColumnType::from_u8(ct)
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "bad column type"))?;
         let flags = r.read_u8()?;
+        if flags & !1 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unknown fast field flags",
+            ));
+        }
         let multi = (flags & 1) != 0;
         let data_offset = r.read_u64::<LittleEndian>()?;
         let data_len = r.read_u64::<LittleEndian>()?;
@@ -732,8 +738,21 @@ impl FastFieldReader {
     /// For text-ordinal columns, dictionary scanning and global dict merging are
     /// deferred to first access — no mmap pages are touched for dict data here.
     pub fn open(file_data: &OwnedBytes, toc: &FastFieldTocEntry) -> io::Result<Self> {
-        let region_start = toc.data_offset as usize;
-        let region_end = region_start + toc.data_len as usize;
+        let region_start = usize::try_from(toc.data_offset).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "fast field data offset exceeds address space",
+            )
+        })?;
+        let region_len = usize::try_from(toc.data_len).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "fast field data length exceeds address space",
+            )
+        })?;
+        let region_end = region_start.checked_add(region_len).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "fast field data range overflow")
+        })?;
 
         if region_end > file_data.len() {
             return Err(io::Error::new(
@@ -746,7 +765,7 @@ impl FastFieldReader {
 
         // Read num_blocks
         let mut pos = region_start;
-        if pos + 4 > region_end {
+        if pos.checked_add(4).is_none_or(|end| end > region_end) {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
                 "fast field: missing num_blocks",
@@ -756,35 +775,67 @@ impl FastFieldReader {
         pos += 4;
 
         // Read block index
-        let idx_size = num_blocks as usize * BLOCK_INDEX_ENTRY_SIZE;
-        if pos + idx_size > region_end {
+        let idx_size = (num_blocks as usize)
+            .checked_mul(BLOCK_INDEX_ENTRY_SIZE)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "fast field block index overflow",
+                )
+            })?;
+        let index_end = pos.checked_add(idx_size).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "fast field block index overflow",
+            )
+        })?;
+        if index_end > region_end {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
                 "fast field: block index truncated",
             ));
         }
-        let mut block_entries = Vec::with_capacity(num_blocks as usize);
+        let mut block_entries = Vec::new();
+        block_entries
+            .try_reserve_exact(num_blocks as usize)
+            .map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "too many fast field blocks")
+            })?;
         {
-            let mut cursor = std::io::Cursor::new(&raw[pos..pos + idx_size]);
+            let mut cursor = std::io::Cursor::new(&raw[pos..index_end]);
             for _ in 0..num_blocks {
                 block_entries.push(BlockIndexEntry::read_from(&mut cursor)?);
             }
         }
-        pos += idx_size;
+        pos = index_end;
 
         let empty = OwnedBytes::new(Vec::new());
 
         // Parse each block's data + dict slices
-        let mut blocks = Vec::with_capacity(num_blocks as usize);
+        let mut blocks = Vec::new();
+        blocks.try_reserve_exact(num_blocks as usize).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "too many fast field blocks")
+        })?;
         let mut cumulative = 0u32;
 
         for entry in &block_entries {
             let data_start = pos;
-            let data_end = data_start + entry.data_len as usize;
+            let data_end = data_start
+                .checked_add(entry.data_len as usize)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "fast field block range overflow",
+                    )
+                })?;
             let dict_start = data_end;
-            let dict_end = dict_start + entry.dict_len as usize;
+            let dict_end = dict_start
+                .checked_add(entry.dict_len as usize)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "fast field dict range overflow")
+                })?;
 
-            if dict_end > file_data.len() {
+            if dict_end > region_end {
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,
                     "fast field: block data/dict truncated",
@@ -795,27 +846,74 @@ impl FastFieldReader {
             let (block_data, offset_data, value_data) = if toc.multi {
                 let block_raw = &raw[data_start..data_end];
                 if block_raw.len() < 4 {
-                    (empty.clone(), empty.clone(), empty.clone())
-                } else {
-                    let offset_col_len =
-                        u32::from_le_bytes(block_raw[0..4].try_into().unwrap()) as usize;
-                    let o_start = data_start + 4;
-                    let o_end = o_start + offset_col_len;
-                    let v_start = o_end;
-                    let v_end = data_end;
-                    (
-                        file_data.slice(data_start..data_end),
-                        file_data.slice(o_start..o_end),
-                        file_data.slice(v_start..v_end),
-                    )
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "fast field multi-value header is truncated",
+                    ));
                 }
-            } else {
+                let offset_col_len =
+                    u32::from_le_bytes(block_raw[0..4].try_into().unwrap()) as usize;
+                let o_start = data_start + 4;
+                let o_end = o_start.checked_add(offset_col_len).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "fast field offset column range overflow",
+                    )
+                })?;
+                if o_end > data_end {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "fast field offset column is truncated",
+                    ));
+                }
+                let v_start = o_end;
+                let v_end = data_end;
+                let offset_data = file_data.slice(o_start..o_end);
+                let value_data = file_data.slice(v_start..v_end);
+                let offset_count = (entry.num_docs as usize).checked_add(1).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "fast field doc count overflow")
+                })?;
+                codec::validate_auto(offset_data.as_slice(), offset_count)?;
+
+                let mut previous = 0u64;
+                for index in 0..offset_count {
+                    let offset = codec::auto_read(offset_data.as_slice(), index);
+                    if offset > u32::MAX as u64 || (index == 0 && offset != 0) || offset < previous
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "fast field value offsets are invalid",
+                        ));
+                    }
+                    previous = offset;
+                }
+                codec::validate_auto(value_data.as_slice(), previous as usize)?;
+
                 (
                     file_data.slice(data_start..data_end),
-                    empty.clone(),
-                    empty.clone(),
+                    offset_data,
+                    value_data,
                 )
+            } else {
+                let block_data = file_data.slice(data_start..data_end);
+                codec::validate_auto(block_data.as_slice(), entry.num_docs as usize)?;
+                (block_data, empty.clone(), empty.clone())
             };
+
+            if toc.column_type == FastFieldColumnType::TextOrdinal {
+                if entry.dict_count == 0 && entry.dict_len != 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "empty fast field dictionary has data",
+                    ));
+                }
+                validate_text_dict_bytes(&raw[dict_start..dict_end], entry.dict_count)?;
+            } else if entry.dict_count != 0 || entry.dict_len != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "numeric fast field contains a text dictionary",
+                ));
+            }
 
             // Create lazy block dict — no scanning, just stores the data slice + count
             let dict = if entry.dict_count > 0 {
@@ -843,8 +941,23 @@ impl FastFieldReader {
                 raw_dict,
             });
 
-            cumulative += entry.num_docs;
+            cumulative = cumulative.checked_add(entry.num_docs).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "fast field doc count overflow")
+            })?;
             pos = dict_end;
+        }
+
+        if pos != region_end || cumulative != toc.num_docs {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "fast field block totals are inconsistent with the TOC",
+            ));
+        }
+        if toc.num_docs > 0 && blocks.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "non-empty fast field has no blocks",
+            ));
         }
 
         Ok(Self {
@@ -1250,7 +1363,7 @@ pub struct TextDictReader {
 impl TextDictReader {
     /// Create a lazy text dictionary from pre-sliced data.
     /// No scanning is performed — offsets are built on first `get()`/`ordinal()` call.
-    pub fn new_lazy(data: OwnedBytes, count: u32) -> Self {
+    fn new_lazy(data: OwnedBytes, count: u32) -> Self {
         Self {
             data,
             count,
@@ -1266,9 +1379,15 @@ impl TextDictReader {
         }
         // Scan to find end position (need to know the slice range)
         let dict_slice = file_data.as_slice();
+        if dict_start > dict_slice.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "text dict offset out of bounds",
+            ));
+        }
         let mut pos = dict_start;
         for _ in 0..count {
-            if pos + 4 > dict_slice.len() {
+            if pos.checked_add(4).is_none_or(|end| end > dict_slice.len()) {
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,
                     "text dict truncated",
@@ -1276,12 +1395,17 @@ impl TextDictReader {
             }
             let len = u32::from_le_bytes(dict_slice[pos..pos + 4].try_into().unwrap()) as usize;
             pos += 4;
-            if pos + len > dict_slice.len() {
+            if pos
+                .checked_add(len)
+                .is_none_or(|end| end > dict_slice.len())
+            {
                 return Err(io::Error::new(
                     io::ErrorKind::UnexpectedEof,
                     "text dict entry truncated",
                 ));
             }
+            std::str::from_utf8(&dict_slice[pos..pos + len])
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
             pos += len;
         }
         let data = file_data.slice(dict_start..pos);
@@ -1290,6 +1414,7 @@ impl TextDictReader {
 
     /// Open from raw dict bytes (already length-prefixed entries).
     pub fn open_from_raw(raw_dict: &OwnedBytes, count: u32) -> io::Result<Self> {
+        validate_text_dict_bytes(raw_dict.as_slice(), count)?;
         Ok(Self::new_lazy(raw_dict.clone(), count))
     }
 
@@ -1323,7 +1448,7 @@ impl TextDictReader {
         let offsets = self.ensure_offsets();
         let &(off, len) = offsets.get(ordinal as usize)?;
         let slice = &self.data.as_slice()[off as usize..off as usize + len as usize];
-        Some(unsafe { std::str::from_utf8_unchecked(slice) })
+        std::str::from_utf8(slice).ok()
     }
 
     /// Binary search for a string → ordinal.
@@ -1332,8 +1457,7 @@ impl TextDictReader {
         offsets
             .binary_search_by(|&(off, len)| {
                 let slice = &self.data.as_slice()[off as usize..off as usize + len as usize];
-                let entry = unsafe { std::str::from_utf8_unchecked(slice) };
-                entry.cmp(text)
+                std::str::from_utf8(slice).unwrap_or("").cmp(text)
             })
             .ok()
             .map(|i| i as u64)
@@ -1354,9 +1478,63 @@ impl TextDictReader {
         let offsets = self.ensure_offsets();
         offsets.iter().map(|&(off, len)| {
             let slice = &self.data.as_slice()[off as usize..off as usize + len as usize];
-            unsafe { std::str::from_utf8_unchecked(slice) }
+            std::str::from_utf8(slice).unwrap_or("")
         })
     }
+}
+
+fn validate_text_dict_bytes(data: &[u8], count: u32) -> io::Result<()> {
+    let minimum = (count as usize).checked_mul(4).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "text dictionary size overflow")
+    })?;
+    if minimum > data.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "text dictionary entry table is truncated",
+        ));
+    }
+
+    let mut pos = 0usize;
+    let mut previous: Option<&str> = None;
+    for _ in 0..count {
+        let len_end = pos.checked_add(4).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "text dictionary offset overflow",
+            )
+        })?;
+        let len = u32::from_le_bytes(data[pos..len_end].try_into().unwrap()) as usize;
+        pos = len_end;
+        let end = pos.checked_add(len).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "text dictionary offset overflow",
+            )
+        })?;
+        if end > data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "text dictionary entry is truncated",
+            ));
+        }
+        let value = std::str::from_utf8(&data[pos..end])
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        if previous.is_some_and(|previous| previous >= value) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "text dictionary entries are not strictly increasing",
+            ));
+        }
+        previous = Some(value);
+        pos = end;
+    }
+    if pos != data.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "text dictionary contains trailing data",
+        ));
+    }
+    Ok(())
 }
 
 // ── File-level write/read ─────────────────────────────────────────────────
@@ -1406,16 +1584,31 @@ pub fn read_fast_field_toc(
     toc_offset: u64,
     num_columns: u32,
 ) -> io::Result<Vec<FastFieldTocEntry>> {
-    let start = toc_offset as usize;
-    let expected = num_columns as usize * FAST_FIELD_TOC_ENTRY_SIZE;
-    if start + expected > file_data.len() {
+    let start = usize::try_from(toc_offset).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "fast field TOC offset exceeds address space",
+        )
+    })?;
+    let expected = (num_columns as usize)
+        .checked_mul(FAST_FIELD_TOC_ENTRY_SIZE)
+        .ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "fast field TOC size overflow")
+        })?;
+    let end = start.checked_add(expected).ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidData, "fast field TOC range overflow")
+    })?;
+    if end > file_data.len() {
         return Err(io::Error::new(
             io::ErrorKind::UnexpectedEof,
             "fast field TOC out of bounds",
         ));
     }
-    let mut cursor = std::io::Cursor::new(&file_data[start..start + expected]);
-    let mut entries = Vec::with_capacity(num_columns as usize);
+    let mut cursor = std::io::Cursor::new(&file_data[start..end]);
+    let mut entries = Vec::new();
+    entries
+        .try_reserve_exact(num_columns as usize)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "too many fast field columns"))?;
     for _ in 0..num_columns {
         entries.push(FastFieldTocEntry::read_from(&mut cursor)?);
     }

--- a/hermes-core/src/structures/postings/sparse/block.rs
+++ b/hermes-core/src/structures/postings/sparse/block.rs
@@ -209,7 +209,7 @@ impl SparseBlock {
             out.resize(count, 0u16);
         } else {
             // SIMD-accelerated unpack (bits is always 8, 16, or 32)
-            let mut temp = [0u32; BLOCK_SIZE];
+            let mut temp = [0u32; MAX_BLOCK_SIZE];
             simd::unpack_rounded(
                 &self.ordinals_data,
                 simd::RoundedBitWidth::from_u8(self.header.ordinal_bits),
@@ -527,8 +527,8 @@ impl BlockSparsePostingList {
             });
         }
 
-        let block_size = block_size.max(16); // minimum 16 for sanity
-        let mut blocks = Vec::new();
+        let block_size = block_size.clamp(16, MAX_BLOCK_SIZE);
+        let mut blocks = Vec::with_capacity(postings.len().div_ceil(block_size));
         for chunk in postings.chunks(block_size) {
             blocks.push(SparseBlock::from_postings(chunk, weight_quant)?);
         }
@@ -1107,6 +1107,46 @@ mod tests {
         assert_eq!(block.decode_ordinals(), vec![0, 0, 1, 0]);
         let weights = block.decode_weights();
         assert!((weights[0] - 1.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_max_size_block_ordinal_decode() {
+        let postings: Vec<(DocId, u16, f32)> = (0..MAX_BLOCK_SIZE)
+            .map(|i| (i as DocId, i as u16, i as f32 + 1.0))
+            .collect();
+        let list = BlockSparsePostingList::from_postings_with_block_size(
+            &postings,
+            WeightQuantization::Float32,
+            MAX_BLOCK_SIZE,
+        )
+        .unwrap();
+
+        assert_eq!(list.num_blocks(), 1);
+        assert_eq!(list.blocks[0].decode_ordinals().len(), MAX_BLOCK_SIZE);
+        assert_eq!(list.blocks[0].decode_ordinals()[255], 255);
+    }
+
+    #[test]
+    fn test_configurable_block_size_is_honored() {
+        let postings: Vec<(DocId, u16, f32)> = (0..300).map(|i| (i, 0, i as f32 + 1.0)).collect();
+
+        let small = BlockSparsePostingList::from_postings_with_block_size(
+            &postings,
+            WeightQuantization::Float32,
+            64,
+        )
+        .unwrap();
+        let large = BlockSparsePostingList::from_postings_with_block_size(
+            &postings,
+            WeightQuantization::Float32,
+            256,
+        )
+        .unwrap();
+
+        assert_eq!(small.num_blocks(), 5);
+        assert_eq!(small.blocks[0].header.count, 64);
+        assert_eq!(large.num_blocks(), 2);
+        assert_eq!(large.blocks[0].header.count, 256);
     }
 
     #[test]

--- a/hermes-core/src/structures/simd.rs
+++ b/hermes-core/src/structures/simd.rs
@@ -1672,6 +1672,12 @@ unsafe fn dequantize_uint8_sse(
 /// Compute dot product of two f32 arrays with SIMD acceleration
 #[inline]
 pub fn dot_product_f32(a: &[f32], b: &[f32], count: usize) -> f32 {
+    assert!(
+        count <= a.len() && count <= b.len(),
+        "dot_product_f32 count {count} exceeds input lengths ({}, {})",
+        a.len(),
+        b.len()
+    );
     #[cfg(target_arch = "aarch64")]
     {
         if neon::is_available() {
@@ -2164,8 +2170,15 @@ pub fn fast_inv_sqrt(x: f32) -> f32 {
 #[inline]
 pub fn batch_cosine_scores(query: &[f32], vectors: &[f32], dim: usize, scores: &mut [f32]) {
     let n = scores.len();
-    debug_assert!(vectors.len() >= n * dim);
-    debug_assert_eq!(query.len(), dim);
+    let required = n
+        .checked_mul(dim)
+        .expect("batch cosine vector length overflow");
+    assert_eq!(query.len(), dim, "batch cosine query dimension mismatch");
+    assert!(
+        vectors.len() >= required,
+        "batch cosine vectors are truncated: need {required}, got {}",
+        vectors.len()
+    );
 
     if dim == 0 || n == 0 {
         return;
@@ -2934,6 +2947,26 @@ fn dot_product_u8_quant(query: &[f32], vec_u8: &[u8], dim: usize) -> f32 {
 #[inline]
 pub fn batch_cosine_scores_f16(query: &[f32], vectors_raw: &[u8], dim: usize, scores: &mut [f32]) {
     let n = scores.len();
+    let vec_bytes = dim.checked_mul(2).expect("f16 vector size overflow");
+    let required = n
+        .checked_mul(vec_bytes)
+        .expect("f16 batch byte length overflow");
+    assert_eq!(
+        query.len(),
+        dim,
+        "f16 batch cosine query dimension mismatch"
+    );
+    assert!(
+        vectors_raw.len() >= required,
+        "f16 batch cosine vectors are truncated: need {required} bytes, got {}",
+        vectors_raw.len()
+    );
+    if required > 0 {
+        assert!(
+            (vectors_raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>()),
+            "f16 batch cosine vectors are not 2-byte aligned"
+        );
+    }
     if dim == 0 || n == 0 {
         return;
     }
@@ -2950,16 +2983,6 @@ pub fn batch_cosine_scores_f16(query: &[f32], vectors_raw: &[u8], dim: usize, sc
 
     // Quantize query to f16 once (O(dim)), reused for all N vector scorings
     let query_f16: Vec<u16> = query.iter().map(|&v| f32_to_f16(v)).collect();
-
-    let vec_bytes = dim * 2;
-    debug_assert!(vectors_raw.len() >= n * vec_bytes);
-
-    // Vectors file uses data-first layout with 8-byte padding between fields,
-    // so mmap slices are always 2-byte aligned for u16 access.
-    debug_assert!(
-        (vectors_raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>()),
-        "f16 vector data not 2-byte aligned"
-    );
 
     for i in 0..n {
         let raw = &vectors_raw[i * vec_bytes..(i + 1) * vec_bytes];
@@ -2982,6 +3005,13 @@ pub fn batch_cosine_scores_f16(query: &[f32], vectors_raw: &[u8], dim: usize, sc
 #[inline]
 pub fn batch_cosine_scores_u8(query: &[f32], vectors_raw: &[u8], dim: usize, scores: &mut [f32]) {
     let n = scores.len();
+    let required = n.checked_mul(dim).expect("u8 batch byte length overflow");
+    assert_eq!(query.len(), dim, "u8 batch cosine query dimension mismatch");
+    assert!(
+        vectors_raw.len() >= required,
+        "u8 batch cosine vectors are truncated: need {required} bytes, got {}",
+        vectors_raw.len()
+    );
     if dim == 0 || n == 0 {
         return;
     }
@@ -2994,8 +3024,6 @@ pub fn batch_cosine_scores_u8(query: &[f32], vectors_raw: &[u8], dim: usize, sco
         return;
     }
     let inv_norm_q = fast_inv_sqrt(norm_q_sq);
-
-    debug_assert!(vectors_raw.len() >= n * dim);
 
     for i in 0..n {
         let u8_slice = &vectors_raw[i * dim..(i + 1) * dim];
@@ -3020,8 +3048,15 @@ pub fn batch_cosine_scores_u8(query: &[f32], vectors_raw: &[u8], dim: usize, sco
 #[inline]
 pub fn batch_dot_scores(query: &[f32], vectors: &[f32], dim: usize, scores: &mut [f32]) {
     let n = scores.len();
-    debug_assert!(vectors.len() >= n * dim);
-    debug_assert_eq!(query.len(), dim);
+    let required = n
+        .checked_mul(dim)
+        .expect("batch dot vector length overflow");
+    assert_eq!(query.len(), dim, "batch dot query dimension mismatch");
+    assert!(
+        vectors.len() >= required,
+        "batch dot vectors are truncated: need {required}, got {}",
+        vectors.len()
+    );
 
     if dim == 0 || n == 0 {
         return;
@@ -3050,6 +3085,22 @@ pub fn batch_dot_scores(query: &[f32], vectors: &[f32], dim: usize, scores: &mut
 #[inline]
 pub fn batch_dot_scores_f16(query: &[f32], vectors_raw: &[u8], dim: usize, scores: &mut [f32]) {
     let n = scores.len();
+    let vec_bytes = dim.checked_mul(2).expect("f16 vector size overflow");
+    let required = n
+        .checked_mul(vec_bytes)
+        .expect("f16 batch byte length overflow");
+    assert_eq!(query.len(), dim, "f16 batch dot query dimension mismatch");
+    assert!(
+        vectors_raw.len() >= required,
+        "f16 batch dot vectors are truncated: need {required} bytes, got {}",
+        vectors_raw.len()
+    );
+    if required > 0 {
+        assert!(
+            (vectors_raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>()),
+            "f16 batch dot vectors are not 2-byte aligned"
+        );
+    }
     if dim == 0 || n == 0 {
         return;
     }
@@ -3064,13 +3115,6 @@ pub fn batch_dot_scores_f16(query: &[f32], vectors_raw: &[u8], dim: usize, score
     let inv_norm_q = fast_inv_sqrt(norm_q_sq);
 
     let query_f16: Vec<u16> = query.iter().map(|&v| f32_to_f16(v)).collect();
-    let vec_bytes = dim * 2;
-    debug_assert!(vectors_raw.len() >= n * vec_bytes);
-    debug_assert!(
-        (vectors_raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>()),
-        "f16 vector data not 2-byte aligned"
-    );
-
     for i in 0..n {
         let raw = &vectors_raw[i * vec_bytes..(i + 1) * vec_bytes];
         let f16_slice = unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const u16, dim) };
@@ -3086,6 +3130,13 @@ pub fn batch_dot_scores_f16(query: &[f32], vectors_raw: &[u8], dim: usize, score
 #[inline]
 pub fn batch_dot_scores_u8(query: &[f32], vectors_raw: &[u8], dim: usize, scores: &mut [f32]) {
     let n = scores.len();
+    let required = n.checked_mul(dim).expect("u8 batch byte length overflow");
+    assert_eq!(query.len(), dim, "u8 batch dot query dimension mismatch");
+    assert!(
+        vectors_raw.len() >= required,
+        "u8 batch dot vectors are truncated: need {required} bytes, got {}",
+        vectors_raw.len()
+    );
     if dim == 0 || n == 0 {
         return;
     }
@@ -3098,8 +3149,6 @@ pub fn batch_dot_scores_u8(query: &[f32], vectors_raw: &[u8], dim: usize, scores
         return;
     }
     let inv_norm_q = fast_inv_sqrt(norm_q_sq);
-
-    debug_assert!(vectors_raw.len() >= n * dim);
 
     for i in 0..n {
         let u8_slice = &vectors_raw[i * dim..(i + 1) * dim];
@@ -3122,7 +3171,19 @@ pub fn batch_cosine_scores_precomp(
     inv_norm_q: f32,
 ) {
     let n = scores.len();
-    debug_assert!(vectors.len() >= n * dim);
+    let required = n
+        .checked_mul(dim)
+        .expect("precomputed cosine vector length overflow");
+    assert_eq!(
+        query.len(),
+        dim,
+        "precomputed cosine query dimension mismatch"
+    );
+    assert!(
+        vectors.len() >= required,
+        "precomputed cosine vectors are truncated: need {required}, got {}",
+        vectors.len()
+    );
     for i in 0..n {
         let vec = &vectors[i * dim..(i + 1) * dim];
         let (dot, norm_v_sq) = fused_dot_norm(query, vec, dim);
@@ -3144,8 +3205,26 @@ pub fn batch_cosine_scores_f16_precomp(
     inv_norm_q: f32,
 ) {
     let n = scores.len();
-    let vec_bytes = dim * 2;
-    debug_assert!(vectors_raw.len() >= n * vec_bytes);
+    let vec_bytes = dim.checked_mul(2).expect("f16 vector size overflow");
+    let required = n
+        .checked_mul(vec_bytes)
+        .expect("precomputed f16 cosine batch byte length overflow");
+    assert_eq!(
+        query_f16.len(),
+        dim,
+        "precomputed f16 cosine query dimension mismatch"
+    );
+    assert!(
+        vectors_raw.len() >= required,
+        "precomputed f16 cosine vectors are truncated: need {required} bytes, got {}",
+        vectors_raw.len()
+    );
+    if required > 0 {
+        assert!(
+            (vectors_raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>()),
+            "precomputed f16 cosine vectors are not 2-byte aligned"
+        );
+    }
     for i in 0..n {
         let raw = &vectors_raw[i * vec_bytes..(i + 1) * vec_bytes];
         let f16_slice = unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const u16, dim) };
@@ -3168,7 +3247,19 @@ pub fn batch_cosine_scores_u8_precomp(
     inv_norm_q: f32,
 ) {
     let n = scores.len();
-    debug_assert!(vectors_raw.len() >= n * dim);
+    let required = n
+        .checked_mul(dim)
+        .expect("precomputed u8 cosine batch byte length overflow");
+    assert_eq!(
+        query.len(),
+        dim,
+        "precomputed u8 cosine query dimension mismatch"
+    );
+    assert!(
+        vectors_raw.len() >= required,
+        "precomputed u8 cosine vectors are truncated: need {required} bytes, got {}",
+        vectors_raw.len()
+    );
     for i in 0..n {
         let u8_slice = &vectors_raw[i * dim..(i + 1) * dim];
         let (dot, norm_v_sq) = fused_dot_norm_u8(query, u8_slice, dim);
@@ -3190,7 +3281,15 @@ pub fn batch_dot_scores_precomp(
     inv_norm_q: f32,
 ) {
     let n = scores.len();
-    debug_assert!(vectors.len() >= n * dim);
+    let required = n
+        .checked_mul(dim)
+        .expect("precomputed dot vector length overflow");
+    assert_eq!(query.len(), dim, "precomputed dot query dimension mismatch");
+    assert!(
+        vectors.len() >= required,
+        "precomputed dot vectors are truncated: need {required}, got {}",
+        vectors.len()
+    );
     for i in 0..n {
         let vec = &vectors[i * dim..(i + 1) * dim];
         scores[i] = dot_product_f32(query, vec, dim) * inv_norm_q;
@@ -3207,8 +3306,26 @@ pub fn batch_dot_scores_f16_precomp(
     inv_norm_q: f32,
 ) {
     let n = scores.len();
-    let vec_bytes = dim * 2;
-    debug_assert!(vectors_raw.len() >= n * vec_bytes);
+    let vec_bytes = dim.checked_mul(2).expect("f16 vector size overflow");
+    let required = n
+        .checked_mul(vec_bytes)
+        .expect("precomputed f16 dot batch byte length overflow");
+    assert_eq!(
+        query_f16.len(),
+        dim,
+        "precomputed f16 dot query dimension mismatch"
+    );
+    assert!(
+        vectors_raw.len() >= required,
+        "precomputed f16 dot vectors are truncated: need {required} bytes, got {}",
+        vectors_raw.len()
+    );
+    if required > 0 {
+        assert!(
+            (vectors_raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>()),
+            "precomputed f16 dot vectors are not 2-byte aligned"
+        );
+    }
     for i in 0..n {
         let raw = &vectors_raw[i * vec_bytes..(i + 1) * vec_bytes];
         let f16_slice = unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const u16, dim) };
@@ -3226,7 +3343,19 @@ pub fn batch_dot_scores_u8_precomp(
     inv_norm_q: f32,
 ) {
     let n = scores.len();
-    debug_assert!(vectors_raw.len() >= n * dim);
+    let required = n
+        .checked_mul(dim)
+        .expect("precomputed u8 dot batch byte length overflow");
+    assert_eq!(
+        query.len(),
+        dim,
+        "precomputed u8 dot query dimension mismatch"
+    );
+    assert!(
+        vectors_raw.len() >= required,
+        "precomputed u8 dot vectors are truncated: need {required} bytes, got {}",
+        vectors_raw.len()
+    );
     for i in 0..n {
         let u8_slice = &vectors_raw[i * dim..(i + 1) * dim];
         scores[i] = dot_product_u8_quant(query, u8_slice, dim) * inv_norm_q;
@@ -3239,7 +3368,7 @@ pub fn batch_dot_scores_u8_precomp(
 /// Returns 0.0 if either vector has zero norm.
 #[inline]
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    debug_assert_eq!(a.len(), b.len());
+    assert_eq!(a.len(), b.len(), "cosine vector dimension mismatch");
     let count = a.len();
 
     if count == 0 {
@@ -3268,7 +3397,7 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 /// Uses NEON intrinsics on aarch64, POPCNT on x86_64, scalar fallback otherwise.
 #[inline]
 pub fn hamming_distance(a: &[u8], b: &[u8]) -> u32 {
-    debug_assert_eq!(a.len(), b.len());
+    assert_eq!(a.len(), b.len(), "Hamming vector byte length mismatch");
 
     #[cfg(target_arch = "aarch64")]
     unsafe {
@@ -3325,8 +3454,15 @@ pub fn batch_hamming_scores(
     scores: &mut [f32],
 ) {
     let n = scores.len();
-    debug_assert_eq!(query.len(), byte_len);
-    debug_assert!(db.len() >= n * byte_len);
+    let required = n
+        .checked_mul(byte_len)
+        .expect("Hamming batch byte length overflow");
+    assert_eq!(query.len(), byte_len, "Hamming query byte length mismatch");
+    assert!(
+        db.len() >= required,
+        "Hamming batch is truncated: need {required} bytes, got {}",
+        db.len()
+    );
 
     if byte_len == 0 || n == 0 || dim_bits == 0 {
         return;
@@ -3344,6 +3480,60 @@ pub fn batch_hamming_scores(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn vector_simd_boundaries_reject_dimension_mismatches() {
+        let vectors = vec![1.0f32; 6];
+        let raw_f16 = vec![0u8; 12];
+        let raw_u8 = vec![0u8; 6];
+        let mut scores = vec![0.0f32; 2];
+
+        for invalid_query in [vec![1.0, 2.0], vec![1.0, 2.0, 3.0, 4.0]] {
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    batch_cosine_scores(&invalid_query, &vectors, 3, &mut scores)
+                }))
+                .is_err()
+            );
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    batch_dot_scores_f16(&invalid_query, &raw_f16, 3, &mut scores)
+                }))
+                .is_err()
+            );
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    batch_cosine_scores_u8(&invalid_query, &raw_u8, 3, &mut scores)
+                }))
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn vector_simd_boundaries_reject_truncated_storage() {
+        let query = [1.0f32, 2.0, 3.0];
+        let mut scores = [0.0f32; 2];
+
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                batch_dot_scores(&query, &[0.0; 5], 3, &mut scores)
+            }))
+            .is_err()
+        );
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                batch_cosine_scores_f16(&query, &[0u8; 11], 3, &mut scores)
+            }))
+            .is_err()
+        );
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                dot_product_f32(&query, &query, 4)
+            }))
+            .is_err()
+        );
+    }
 
     #[test]
     fn test_unpack_8bit() {

--- a/hermes-core/src/structures/sstable.rs
+++ b/hermes-core/src/structures/sstable.rs
@@ -46,6 +46,12 @@ pub const BLOOM_BITS_PER_KEY: usize = 10;
 /// Bloom filter hash count (optimal for 10 bits/key)
 pub const BLOOM_HASH_COUNT: usize = 7;
 
+const MAX_SSTABLE_BLOCK_BYTES: usize = 64 * 1024 * 1024;
+const MAX_SSTABLE_DICTIONARY_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Results and truncation flag returned by a budgeted prefix scan.
+pub type PrefixScanResult<V> = (Vec<(Vec<u8>, V)>, bool);
+
 // ============================================================================
 // Bloom Filter Implementation
 // ============================================================================
@@ -115,7 +121,7 @@ impl BloomBits {
 impl BloomFilter {
     /// Create a new bloom filter sized for expected number of keys
     pub fn new(expected_keys: usize, bits_per_key: usize) -> Self {
-        let num_bits = (expected_keys * bits_per_key).max(64);
+        let num_bits = expected_keys.saturating_mul(bits_per_key).max(64);
         let num_words = num_bits.div_ceil(64);
         Self {
             bits: BloomBits::Vec(vec![0u64; num_words]),
@@ -138,7 +144,9 @@ impl BloomFilter {
         let num_hashes = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
         let num_words = u32::from_le_bytes([data[8], data[9], data[10], data[11]]) as usize;
 
-        if data.len() < 12 + num_words * 8 {
+        validate_bloom_header(data.len(), num_bits, num_hashes, num_words)?;
+        let expected_len = 12 + num_words * 8;
+        if data.len() != expected_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Bloom filter data truncated",
@@ -171,7 +179,9 @@ impl BloomFilter {
         let num_hashes = u32::from_le_bytes([d[4], d[5], d[6], d[7]]) as usize;
         let num_words = u32::from_le_bytes([d[8], d[9], d[10], d[11]]) as usize;
 
-        if d.len() < 12 + num_words * 8 {
+        validate_bloom_header(d.len(), num_bits, num_hashes, num_words)?;
+        let expected_len = 12 + num_words * 8;
+        if d.len() != expected_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Bloom filter data truncated",
@@ -269,6 +279,39 @@ impl BloomFilter {
     }
 }
 
+fn validate_bloom_header(
+    data_len: usize,
+    num_bits: usize,
+    num_hashes: usize,
+    num_words: usize,
+) -> io::Result<()> {
+    if num_bits == 0 || num_hashes == 0 || num_hashes > 32 || num_words == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid bloom filter parameters",
+        ));
+    }
+    let word_bytes = num_words
+        .checked_mul(8)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "bloom filter size overflow"))?;
+    let expected_len = 12usize
+        .checked_add(word_bytes)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "bloom filter size overflow"))?;
+    let capacity_bits = num_words
+        .checked_mul(64)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "bloom filter size overflow"))?;
+    if expected_len > data_len
+        || num_bits > capacity_bits
+        || num_bits <= capacity_bits.saturating_sub(64)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "inconsistent bloom filter dimensions",
+        ));
+    }
+    Ok(())
+}
+
 /// Compute bloom filter hash pair for a key (standalone, no BloomFilter needed).
 /// Uses the same FNV-1a double-hashing as BloomFilter::hash_pair (single pass).
 #[inline]
@@ -309,7 +352,15 @@ impl SSTableValue for Vec<u8> {
     }
 
     fn deserialize<R: Read>(reader: &mut R) -> io::Result<Self> {
-        let len = read_vint(reader)? as usize;
+        let len = usize::try_from(read_vint(reader)?).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "SSTable value length too large")
+        })?;
+        if len > MAX_SSTABLE_BLOCK_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SSTable value exceeds block safety limit",
+            ));
+        }
         let mut data = vec![0u8; len];
         reader.read_exact(&mut data)?;
         Ok(data)
@@ -340,7 +391,12 @@ impl SSTableValue for SparseDimInfo {
 
     fn deserialize<R: Read>(reader: &mut R) -> io::Result<Self> {
         let offset = read_vint(reader)?;
-        let length = read_vint(reader)? as u32;
+        let length = u32::try_from(read_vint(reader)?).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "sparse posting length exceeds u32",
+            )
+        })?;
         Ok(Self { offset, length })
     }
 }
@@ -412,7 +468,10 @@ impl TermInfo {
     /// Try to create an inline TermInfo from posting data
     /// Returns None if posting list is too large to inline
     pub fn try_inline(doc_ids: &[u32], term_freqs: &[u32]) -> Option<Self> {
-        if doc_ids.len() > MAX_INLINE_POSTINGS || doc_ids.is_empty() {
+        if doc_ids.len() > MAX_INLINE_POSTINGS
+            || doc_ids.is_empty()
+            || doc_ids.len() != term_freqs.len()
+        {
             return None;
         }
 
@@ -421,7 +480,7 @@ impl TermInfo {
         let mut prev_doc_id = 0u32;
 
         for (i, &doc_id) in doc_ids.iter().enumerate() {
-            let delta = doc_id - prev_doc_id;
+            let delta = doc_id.checked_sub(prev_doc_id)?;
             if write_vint(&mut cursor, delta as u64).is_err() {
                 return None;
             }
@@ -455,8 +514,12 @@ impl TermInfo {
         let mut cursor = std::io::Cursor::new(&mut data[..]);
         let mut prev_doc_id = 0u32;
 
+        let mut actual_count = 0usize;
         for (doc_id, tf) in iter {
-            let delta = doc_id - prev_doc_id;
+            if actual_count >= count {
+                return None;
+            }
+            let delta = doc_id.checked_sub(prev_doc_id)?;
             if write_vint(&mut cursor, delta as u64).is_err() {
                 return None;
             }
@@ -464,6 +527,11 @@ impl TermInfo {
                 return None;
             }
             prev_doc_id = doc_id;
+            actual_count += 1;
+        }
+
+        if actual_count != count {
+            return None;
         }
 
         let data_len = cursor.position() as u8;
@@ -521,6 +589,12 @@ impl TermInfo {
                 data,
                 data_len,
             } => {
+                if *doc_freq == 0
+                    || *doc_freq as usize > MAX_INLINE_POSTINGS
+                    || *data_len as usize > data.len()
+                {
+                    return None;
+                }
                 let mut doc_ids = Vec::with_capacity(*doc_freq as usize);
                 let mut term_freqs = Vec::with_capacity(*doc_freq as usize);
                 let mut reader = &data[..*data_len as usize];
@@ -529,7 +603,7 @@ impl TermInfo {
                 for _ in 0..*doc_freq {
                     let delta = read_vint(&mut reader).ok()? as u32;
                     let tf = read_vint(&mut reader).ok()? as u32;
-                    let doc_id = prev_doc_id + delta;
+                    let doc_id = prev_doc_id.checked_add(delta)?;
                     doc_ids.push(doc_id);
                     term_freqs.push(tf);
                     prev_doc_id = doc_id;
@@ -550,6 +624,15 @@ impl SSTableValue for TermInfo {
                 data,
                 data_len,
             } => {
+                if *doc_freq == 0
+                    || *doc_freq as usize > MAX_INLINE_POSTINGS
+                    || *data_len as usize > data.len()
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "invalid inline TermInfo",
+                    ));
+                }
                 // Tag byte 0xFF = inline marker
                 writer.write_u8(0xFF)?;
                 writer.write_u8(*doc_freq)?;
@@ -590,6 +673,12 @@ impl SSTableValue for TermInfo {
             // Inline
             let doc_freq = reader.read_u8()?;
             let data_len = reader.read_u8()?;
+            if doc_freq == 0 || doc_freq as usize > MAX_INLINE_POSTINGS || data_len as usize > 16 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid inline TermInfo lengths",
+                ));
+            }
             let mut data = [0u8; 16];
             reader.read_exact(&mut data[..data_len as usize])?;
             Ok(TermInfo::Inline {
@@ -988,12 +1077,11 @@ pub struct AsyncSSTableReader<V: SSTableValue> {
     _phantom: std::marker::PhantomData<V>,
 }
 
-/// LRU block cache — O(1) lookup/insert, amortized O(n) promotion.
+/// Bounded block cache with a contention-free read path.
 ///
-/// On `get()`, promotes the accessed entry to MRU position.
-/// On eviction, removes the LRU entry (front of VecDeque).
-/// For typical cache sizes (16-64 blocks), the linear scan in
-/// `promote()` is negligible compared to I/O savings.
+/// Normal reads use [`BlockCache::peek`] under a shared lock and deliberately
+/// do not promote hits, so normal eviction order is insertion order. `get()`
+/// still promotes entries for exclusive warm-up and race-resolution paths.
 struct BlockCache {
     blocks: FxHashMap<u64, Arc<[u8]>>,
     lru_order: std::collections::VecDeque<u64>,
@@ -1024,6 +1112,9 @@ impl BlockCache {
     }
 
     fn insert(&mut self, offset: u64, block: Arc<[u8]>) {
+        if self.max_blocks == 0 {
+            return;
+        }
         if self.blocks.contains_key(&offset) {
             self.promote(offset);
             return;
@@ -1083,16 +1174,46 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
             ));
         }
 
+        let footer_start = file_len - 37;
+        if data_end_offset > footer_start {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SSTable data section extends past its footer",
+            ));
+        }
+        if bloom_offset != 0 && (bloom_offset < data_end_offset || bloom_offset >= footer_start) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SSTable bloom filter offset is out of bounds",
+            ));
+        }
+        if dict_offset != 0
+            && (dict_offset < data_end_offset
+                || dict_offset >= footer_start
+                || (bloom_offset != 0 && dict_offset <= bloom_offset))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SSTable dictionary offset is out of bounds",
+            ));
+        }
+
         // Read index section
         let index_start = data_end_offset;
-        let index_end = file_len - 37;
+        let index_end = if bloom_offset != 0 {
+            bloom_offset
+        } else if dict_offset != 0 {
+            dict_offset
+        } else {
+            footer_start
+        };
         let index_bytes = file_handle.read_bytes_range(index_start..index_end).await?;
 
         // Parse block index (length-prefixed FST or mmap index)
         let mut idx_reader = index_bytes.as_slice();
         let index_len = idx_reader.read_u32::<LittleEndian>()? as usize;
 
-        if index_len > idx_reader.len() {
+        if index_len != idx_reader.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Index data truncated",
@@ -1110,12 +1231,46 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
         #[cfg(not(feature = "fst-index"))]
         let block_index = BlockIndex::Mmap(MmapBlockIndex::load(index_data)?);
 
+        let mut expected_offset = 0u64;
+        for addr in block_index.all_addrs() {
+            let end = addr.offset.checked_add(addr.length as u64).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "SSTable block range overflow")
+            })?;
+            if addr.length == 0 || addr.offset != expected_offset || end > data_end_offset {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "SSTable block addresses are inconsistent",
+                ));
+            }
+            expected_offset = end;
+        }
+        if expected_offset != data_end_offset {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SSTable block addresses do not cover the data section",
+            ));
+        }
+
         // Load bloom filter if present
         let bloom_filter = if bloom_offset > 0 {
             let bloom_start = bloom_offset;
+            let bloom_end = if dict_offset != 0 {
+                dict_offset
+            } else {
+                footer_start
+            };
             // Read bloom filter size first (12 bytes header)
+            let bloom_header_end = bloom_start.checked_add(12).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "bloom filter range overflow")
+            })?;
+            if bloom_header_end > bloom_end {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "bloom filter header is truncated",
+                ));
+            }
             let bloom_header = file_handle
-                .read_bytes_range(bloom_start..bloom_start + 12)
+                .read_bytes_range(bloom_start..bloom_header_end)
                 .await?;
             let num_words = u32::from_le_bytes([
                 bloom_header[8],
@@ -1123,10 +1278,20 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
                 bloom_header[10],
                 bloom_header[11],
             ]) as u64;
-            let bloom_size = 12 + num_words * 8;
-            let bloom_data = file_handle
-                .read_bytes_range(bloom_start..bloom_start + bloom_size)
-                .await?;
+            let bloom_size = num_words
+                .checked_mul(8)
+                .and_then(|bytes| bytes.checked_add(12))
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "bloom filter size overflow")
+                })?;
+            let actual_bloom_size = bloom_end - bloom_start;
+            if bloom_size != actual_bloom_size {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "bloom filter length is inconsistent",
+                ));
+            }
+            let bloom_data = file_handle.read_bytes_range(bloom_start..bloom_end).await?;
             Some(BloomFilter::from_owned_bytes(bloom_data)?)
         } else {
             None
@@ -1136,8 +1301,17 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
         let dictionary = if dict_offset > 0 {
             let dict_start = dict_offset;
             // Read dictionary size first
+            let dict_header_end = dict_start.checked_add(4).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "dictionary range overflow")
+            })?;
+            if dict_header_end > footer_start {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "dictionary header is truncated",
+                ));
+            }
             let dict_len_bytes = file_handle
-                .read_bytes_range(dict_start..dict_start + 4)
+                .read_bytes_range(dict_start..dict_header_end)
                 .await?;
             let dict_len = u32::from_le_bytes([
                 dict_len_bytes[0],
@@ -1145,8 +1319,23 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
                 dict_len_bytes[2],
                 dict_len_bytes[3],
             ]) as u64;
+            if dict_len > MAX_SSTABLE_DICTIONARY_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "SSTable dictionary exceeds safety limit",
+                ));
+            }
+            let dict_end = dict_header_end.checked_add(dict_len).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "dictionary range overflow")
+            })?;
+            if dict_end != footer_start {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "SSTable dictionary length is inconsistent",
+                ));
+            }
             let dict_data = file_handle
-                .read_bytes_range(dict_start + 4..dict_start + 4 + dict_len)
+                .read_bytes_range(dict_header_end..dict_end)
                 .await?;
             Some(CompressionDict::from_owned_bytes(dict_data))
         } else {
@@ -1193,6 +1382,20 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
     /// Number of blocks currently in the cache
     pub fn cached_blocks(&self) -> usize {
         self.cache.read().blocks.len()
+    }
+
+    /// Heap bytes retained by decompressed cached blocks.
+    ///
+    /// This deliberately reports the actual block lengths instead of assuming
+    /// the configured writer block size: compression dictionaries and boundary
+    /// blocks make the retained size variable.
+    pub fn cached_bytes(&self) -> usize {
+        self.cache
+            .read()
+            .blocks
+            .values()
+            .map(|block| block.len())
+            .sum()
     }
 
     /// Look up a key (async - may need to load block)
@@ -1310,7 +1513,10 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
         let mut max_end: u64 = 0;
         for i in 0..num_blocks {
             if let Some(addr) = self.block_index.get_addr(i) {
-                max_end = max_end.max(addr.offset + addr.length as u64);
+                let end = addr.offset.checked_add(addr.length as u64).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "SSTable block range overflow")
+                })?;
+                max_end = max_end.max(end);
             }
         }
 
@@ -1326,12 +1532,27 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
             if cache.get(addr.offset).is_some() {
                 continue;
             }
-            let compressed =
-                &buf[addr.offset as usize..(addr.offset + addr.length as u64) as usize];
+            let start = usize::try_from(addr.offset).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "SSTable block offset too large")
+            })?;
+            let end = addr
+                .offset
+                .checked_add(addr.length as u64)
+                .and_then(|end| usize::try_from(end).ok())
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "SSTable block range overflow")
+                })?;
+            let compressed = buf.get(start..end).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::UnexpectedEof, "SSTable block is truncated")
+            })?;
             let decompressed = if let Some(ref dict) = self.dictionary {
-                crate::compression::decompress_with_dict(compressed, dict)?
+                crate::compression::decompress_with_dict_limited(
+                    compressed,
+                    dict,
+                    MAX_SSTABLE_BLOCK_BYTES,
+                )?
             } else {
-                crate::compression::decompress(compressed)?
+                crate::compression::decompress_limited(compressed, MAX_SSTABLE_BLOCK_BYTES)?
             };
             cache.insert(addr.offset, Arc::from(decompressed));
         }
@@ -1366,14 +1587,18 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
 
         // Decompress with dictionary if available
         let decompressed = if let Some(ref dict) = self.dictionary {
-            crate::compression::decompress_with_dict(compressed.as_slice(), dict)?
+            crate::compression::decompress_with_dict_limited(
+                compressed.as_slice(),
+                dict,
+                MAX_SSTABLE_BLOCK_BYTES,
+            )?
         } else {
-            crate::compression::decompress(compressed.as_slice())?
+            crate::compression::decompress_limited(compressed.as_slice(), MAX_SSTABLE_BLOCK_BYTES)?
         };
 
         let block: Arc<[u8]> = Arc::from(decompressed);
 
-        // Insert into cache (write lock, promotes LRU)
+        // Insert into cache under the write lock.
         {
             let mut cache = self.cache.write();
             cache.insert(addr.offset, Arc::clone(&block));
@@ -1402,14 +1627,18 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
 
         // Decompress with dictionary if available
         let decompressed = if let Some(ref dict) = self.dictionary {
-            crate::compression::decompress_with_dict(compressed.as_slice(), dict)?
+            crate::compression::decompress_with_dict_limited(
+                compressed.as_slice(),
+                dict,
+                MAX_SSTABLE_BLOCK_BYTES,
+            )?
         } else {
-            crate::compression::decompress(compressed.as_slice())?
+            crate::compression::decompress_limited(compressed.as_slice(), MAX_SSTABLE_BLOCK_BYTES)?
         };
 
         let block: Arc<[u8]> = Arc::from(decompressed);
 
-        // Insert into cache (write lock, promotes LRU)
+        // Insert into cache under the write lock.
         {
             let mut cache = self.cache.write();
             cache.insert(addr.offset, Arc::clone(&block));
@@ -1527,13 +1756,24 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
     /// forward collecting matching entries. Early-terminates once keys
     /// exceed the prefix range (keys are sorted).
     pub async fn prefix_scan(&self, prefix: &[u8]) -> io::Result<Vec<(Vec<u8>, V)>> {
+        let (results, _) = self.prefix_scan_limited(prefix, usize::MAX).await?;
+        Ok(results)
+    }
+
+    /// Prefix scan with an explicit result budget. The boolean indicates that
+    /// at least one additional matching entry existed beyond the budget.
+    pub async fn prefix_scan_limited(
+        &self,
+        prefix: &[u8],
+        max_results: usize,
+    ) -> io::Result<PrefixScanResult<V>> {
         if self.block_index.is_empty() || prefix.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), false));
         }
 
         let start_block = match self.block_index.locate(prefix) {
             Some(idx) => idx,
-            None => return Ok(Vec::new()),
+            None => return Ok((Vec::new(), false)),
         };
 
         let mut results = Vec::new();
@@ -1560,27 +1800,41 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
                 let value = V::deserialize(&mut reader)?;
 
                 if current_key.starts_with(prefix) {
+                    if results.len() >= max_results {
+                        return Ok((results, true));
+                    }
                     results.push((current_key.clone(), value));
                 } else if current_key.as_slice() > prefix {
                     // Keys are sorted — past the prefix range, done
-                    return Ok(results);
+                    return Ok((results, false));
                 }
             }
         }
 
-        Ok(results)
+        Ok((results, false))
     }
 
     /// Synchronous prefix scan — requires Inline (mmap/RAM) file handles.
     #[cfg(feature = "sync")]
     pub fn prefix_scan_sync(&self, prefix: &[u8]) -> io::Result<Vec<(Vec<u8>, V)>> {
+        let (results, _) = self.prefix_scan_limited_sync(prefix, usize::MAX)?;
+        Ok(results)
+    }
+
+    /// Synchronous prefix scan with an explicit result budget.
+    #[cfg(feature = "sync")]
+    pub fn prefix_scan_limited_sync(
+        &self,
+        prefix: &[u8],
+        max_results: usize,
+    ) -> io::Result<PrefixScanResult<V>> {
         if self.block_index.is_empty() || prefix.is_empty() {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), false));
         }
 
         let start_block = match self.block_index.locate(prefix) {
             Some(idx) => idx,
-            None => return Ok(Vec::new()),
+            None => return Ok((Vec::new(), false)),
         };
 
         let mut results = Vec::new();
@@ -1607,14 +1861,17 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
                 let value = V::deserialize(&mut reader)?;
 
                 if current_key.starts_with(prefix) {
+                    if results.len() >= max_results {
+                        return Ok((results, true));
+                    }
                     results.push((current_key.clone(), value));
                 } else if current_key.as_slice() > prefix {
-                    return Ok(results);
+                    return Ok((results, false));
                 }
             }
         }
 
-        Ok(results)
+        Ok((results, false))
     }
 }
 

--- a/hermes-core/src/structures/sstable_index.rs
+++ b/hermes-core/src/structures/sstable_index.rs
@@ -71,7 +71,9 @@ impl BlockAddrStore {
             deltas.push(delta);
             max_delta = max_delta.max(delta);
             max_length = max_length.max(addr.length);
-            prev_end = addr.offset + addr.length as u64;
+            prev_end = addr.offset.checked_add(addr.length as u64).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "block address overflow")
+            })?;
         }
 
         // Compute bit widths
@@ -88,7 +90,9 @@ impl BlockAddrStore {
 
         // Calculate packed size
         let bits_per_entry = offset_bits as usize + length_bits as usize;
-        let total_bits = bits_per_entry * addrs.len();
+        let total_bits = bits_per_entry.checked_mul(addrs.len()).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "block address table too large")
+        })?;
         let packed_bytes = total_bits.div_ceil(8);
 
         let mut buf = Vec::with_capacity(6 + packed_bytes);
@@ -121,23 +125,57 @@ impl BlockAddrStore {
         let offset_bits = reader.read_u8()?;
         let length_bits = reader.read_u8()?;
 
+        if offset_bits > 64 || length_bits > 32 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid block address bit width",
+            ));
+        }
+        if num_blocks > 0 && (offset_bits == 0 || length_bits == 0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "non-empty block address table has a zero bit width",
+            ));
+        }
+
+        let bits_per_entry = offset_bits as usize + length_bits as usize;
+        let total_bits = bits_per_entry
+            .checked_mul(num_blocks as usize)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "block address table overflow")
+            })?;
+        let packed_len = total_bits.checked_add(7).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "block address table overflow")
+        })? / 8;
+        if packed_len > data.len() - 6 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "block address table truncated",
+            ));
+        }
+
         // Eagerly decode all block addresses once at load time
-        let packed_data = &data.as_slice()[6..];
+        let packed_data = &data.as_slice()[6..6 + packed_len];
         let mut bit_reader = BitReader::new(packed_data);
-        let mut addrs = Vec::with_capacity(num_blocks as usize);
+        let mut addrs = Vec::new();
+        addrs.try_reserve_exact(num_blocks as usize).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "block address table too large")
+        })?;
         let mut current_offset: u64 = 0;
 
         for _ in 0..num_blocks {
-            if let (Ok(delta), Ok(length)) =
-                (bit_reader.read(offset_bits), bit_reader.read(length_bits))
-            {
-                current_offset += delta;
-                addrs.push(BlockAddr {
-                    offset: current_offset,
-                    length: length as u32,
-                });
-                current_offset += length;
-            }
+            let delta = bit_reader.read(offset_bits)?;
+            let length = bit_reader.read(length_bits)?;
+            let offset = current_offset.checked_add(delta).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "block address offset overflow")
+            })?;
+            let length = u32::try_from(length).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "block length exceeds u32")
+            })?;
+            current_offset = offset.checked_add(length as u64).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "block address end overflow")
+            })?;
+            addrs.push(BlockAddr { offset, length });
         }
 
         Ok(Self {
@@ -221,19 +259,41 @@ impl FstBlockIndex {
 
         let fst_len = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
 
-        if data.len() < 4 + fst_len {
+        let fst_end = 4usize.checked_add(fst_len).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "FstBlockIndex length overflow")
+        })?;
+        if data.len() < fst_end {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "FstBlockIndex FST data truncated",
             ));
         }
 
-        let fst_data = data.slice(4..4 + fst_len);
-        let addr_data = data.slice(4 + fst_len..data.len());
+        let fst_data = data.slice(4..fst_end);
+        let addr_data = data.slice(fst_end..data.len());
 
         let fst =
             fst::Map::new(fst_data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let block_addrs = BlockAddrStore::load(addr_data)?;
+
+        if fst.len() != block_addrs.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "FST key count does not match block address count",
+            ));
+        }
+        use fst::Streamer;
+        let mut entries = fst.stream();
+        let mut expected_ordinal = 0u64;
+        while let Some((_key, ordinal)) = entries.next() {
+            if ordinal != expected_ordinal {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "FST block ordinals are not contiguous",
+                ));
+            }
+            expected_ordinal += 1;
+        }
 
         Ok(Self { fst, block_addrs })
     }
@@ -374,7 +434,7 @@ impl MmapBlockIndex {
 
     /// Load from raw bytes
     pub fn load(data: OwnedBytes) -> io::Result<Self> {
-        if data.len() < 4 {
+        if data.len() < 16 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "MmapBlockIndex data too short",
@@ -388,11 +448,29 @@ impl MmapBlockIndex {
         let remaining = data.slice(addr_data_start..data.len());
         let block_addrs = BlockAddrStore::load(remaining.clone())?;
 
+        if block_addrs.len() != num_blocks as usize {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "block address count does not match key count",
+            ));
+        }
+
         // Calculate where keys start
         let bits_per_entry = block_addrs.offset_bits as usize + block_addrs.length_bits as usize;
-        let total_bits = bits_per_entry * num_blocks as usize;
-        let addr_packed_size = total_bits.div_ceil(8);
-        let keys_offset = addr_data_start + 6 + addr_packed_size; // 6 = header of BlockAddrStore
+        let total_bits = bits_per_entry
+            .checked_mul(num_blocks as usize)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "block index size overflow")
+            })?;
+        let addr_packed_size = total_bits.checked_add(7).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "block index size overflow")
+        })? / 8;
+        let keys_offset = addr_data_start
+            .checked_add(6)
+            .and_then(|v| v.checked_add(addr_packed_size))
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "block index offset overflow")
+            })?; // 6 = header of BlockAddrStore
 
         // Read footer (last 6 bytes: restart_count u32 + restart_interval u16)
         if data.len() < keys_offset + 6 {
@@ -411,11 +489,100 @@ impl MmapBlockIndex {
         let restart_interval =
             u16::from_le_bytes([data[footer_start + 4], data[footer_start + 5]]) as usize;
 
+        if restart_interval == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "block index restart interval is zero",
+            ));
+        }
+
+        let expected_restart_count = (num_blocks as usize).div_ceil(restart_interval);
+        if restart_count != expected_restart_count {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "block index restart count is inconsistent",
+            ));
+        }
+
         // Restart offsets array: restart_count × 4 bytes, just before footer
-        let restart_array_offset = footer_start - restart_count * 4;
+        let restart_bytes = restart_count.checked_mul(4).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "restart table size overflow")
+        })?;
+        let restart_array_offset = footer_start.checked_sub(restart_bytes).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "restart table out of bounds")
+        })?;
+        if restart_array_offset < keys_offset {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "restart table overlaps block keys",
+            ));
+        }
 
         // Keys section spans from keys_offset to restart_array_offset
         let keys_end = restart_array_offset;
+
+        // Validate the complete prefix-compressed key stream and all restart
+        // offsets once so the hot lookup path can remain allocation-light and
+        // infallible without trusting corrupt on-disk lengths.
+        let keys_data = &data.as_slice()[keys_offset..keys_end];
+        let mut reader = keys_data;
+        let mut current_key = Vec::new();
+        let mut previous_key: Option<Vec<u8>> = None;
+        for ordinal in 0..num_blocks as usize {
+            let entry_offset = keys_data.len() - reader.len();
+            if ordinal % restart_interval == 0 {
+                let restart_idx = ordinal / restart_interval;
+                let pos = restart_array_offset + restart_idx * 4;
+                let recorded =
+                    u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]])
+                        as usize;
+                if recorded != entry_offset {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "block index restart offset is inconsistent",
+                    ));
+                }
+            }
+
+            let prefix_len = usize::try_from(read_vint(&mut reader)?).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "block key prefix is too large")
+            })?;
+            let suffix_len = usize::try_from(read_vint(&mut reader)?).map_err(|_| {
+                io::Error::new(io::ErrorKind::InvalidData, "block key suffix is too large")
+            })?;
+            if ordinal % restart_interval == 0 && prefix_len != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "block index restart key uses a prefix",
+                ));
+            }
+            if prefix_len > current_key.len() || suffix_len > reader.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "block index key is truncated",
+                ));
+            }
+            current_key.truncate(prefix_len);
+            current_key.extend_from_slice(&reader[..suffix_len]);
+            reader = &reader[suffix_len..];
+
+            if previous_key
+                .as_ref()
+                .is_some_and(|previous| previous.as_slice() >= current_key.as_slice())
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "block index keys are not strictly increasing",
+                ));
+            }
+            previous_key = Some(current_key.clone());
+        }
+        if !reader.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "block index contains trailing key data",
+            ));
+        }
 
         Ok(Self {
             data,
@@ -815,6 +982,27 @@ mod tests {
         let store = BlockAddrStore::load(OwnedBytes::new(bytes)).unwrap();
         assert_eq!(store.len(), 0);
         assert!(store.get(0).is_none());
+    }
+
+    #[test]
+    fn test_block_addr_store_rejects_truncated_packed_data() {
+        let bytes = vec![1, 0, 0, 0, 1, 1];
+        assert!(BlockAddrStore::load(OwnedBytes::new(bytes)).is_err());
+    }
+
+    #[test]
+    fn test_mmap_index_rejects_restart_table_underflow() {
+        let entries = vec![(
+            b"key".to_vec(),
+            BlockAddr {
+                offset: 0,
+                length: 1,
+            },
+        )];
+        let mut bytes = MmapBlockIndex::build(&entries).unwrap();
+        let footer = bytes.len() - 6;
+        bytes[footer..footer + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(MmapBlockIndex::load(OwnedBytes::new(bytes)).is_err());
     }
 
     #[test]

--- a/hermes-core/src/structures/vector/index/binary_ivf.rs
+++ b/hermes-core/src/structures/vector/index/binary_ivf.rs
@@ -13,8 +13,27 @@
 
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::io;
 
 use crate::structures::simd::batch_hamming_scores;
+
+fn argmax_score_lowest_index(scores: &[f32]) -> usize {
+    scores
+        .iter()
+        .enumerate()
+        .max_by(|(left_index, left), (right_index, right)| {
+            left.total_cmp(right)
+                // `max_by` keeps the greater element; reverse the index
+                // comparison so equal scores consistently prefer the lowest
+                // cluster ID, matching query-time centroid ordering.
+                .then_with(|| right_index.cmp(left_index))
+        })
+        .map(|(index, _)| index)
+        .unwrap_or(0)
+}
+
+const MAX_BINARY_IVF_CLUSTERS: usize = 4_096;
+const BINARY_IVF_SCORE_BATCH: usize = 8_192;
 
 fn default_max_train_samples() -> usize {
     100_000
@@ -55,6 +74,28 @@ impl BinaryIvfConfig {
     pub fn byte_len(&self) -> usize {
         self.dim_bits.div_ceil(8)
     }
+
+    fn validate(&self) -> Result<(), String> {
+        if self.dim_bits == 0 || !self.dim_bits.is_multiple_of(8) {
+            return Err(format!(
+                "binary IVF dimension must be a positive multiple of 8, got {}",
+                self.dim_bits
+            ));
+        }
+        if !(1..=MAX_BINARY_IVF_CLUSTERS).contains(&self.num_clusters) {
+            return Err(format!(
+                "binary IVF cluster count must be in 1..={MAX_BINARY_IVF_CLUSTERS}, got {}",
+                self.num_clusters
+            ));
+        }
+        self.num_clusters
+            .checked_mul(self.byte_len())
+            .ok_or_else(|| "binary IVF centroid size overflow".to_string())?;
+        self.num_clusters
+            .checked_mul(self.dim_bits)
+            .ok_or_else(|| "binary IVF training scratch size overflow".to_string())?;
+        Ok(())
+    }
 }
 
 /// One cluster: SoA layout with contiguous packed codes for SIMD scanning.
@@ -77,6 +118,41 @@ pub struct BinaryIvfIndex {
 }
 
 impl BinaryIvfIndex {
+    fn validate(&self) -> Result<(), String> {
+        let config = &self.config;
+        config.validate()?;
+        let byte_len = config.byte_len();
+        let expected_centroids = config
+            .num_clusters
+            .checked_mul(byte_len)
+            .ok_or_else(|| "binary IVF centroid size overflow".to_string())?;
+        if self.centroids.len() != expected_centroids || self.clusters.len() != config.num_clusters
+        {
+            return Err("binary IVF centroid/cluster columns are inconsistent".to_string());
+        }
+
+        let mut total = 0usize;
+        for cluster in &self.clusters {
+            let count = cluster.doc_ids.len();
+            let expected_codes = count
+                .checked_mul(byte_len)
+                .ok_or_else(|| "binary IVF code size overflow".to_string())?;
+            if cluster.ordinals.len() != count || cluster.codes.len() != expected_codes {
+                return Err("binary IVF cluster columns are inconsistent".to_string());
+            }
+            total = total
+                .checked_add(count)
+                .ok_or_else(|| "binary IVF vector count overflow".to_string())?;
+        }
+        if total != self.len {
+            return Err(format!(
+                "binary IVF vector count is {}, metadata says {}",
+                total, self.len
+            ));
+        }
+        Ok(())
+    }
+
     /// Train centroids via k-majority and build the index from packed vectors.
     ///
     /// `codes` is `n × byte_len` contiguous packed vectors;
@@ -85,10 +161,24 @@ impl BinaryIvfIndex {
         mut config: BinaryIvfConfig,
         codes: &[u8],
         doc_id_ordinals: &[(u32, u16)],
-    ) -> Self {
+    ) -> io::Result<Self> {
+        config
+            .validate()
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
         let byte_len = config.byte_len();
         let n = doc_id_ordinals.len();
-        debug_assert_eq!(codes.len(), n * byte_len);
+        let expected_codes = n.checked_mul(byte_len).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "binary IVF code size overflow")
+        })?;
+        if codes.len() != expected_codes {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "binary IVF needs {expected_codes} code bytes for {n} labels, got {}",
+                    codes.len()
+                ),
+            ));
+        }
 
         // Can't have more clusters than vectors
         config.num_clusters = config
@@ -157,7 +247,7 @@ impl BinaryIvfIndex {
         }
         index.len = n;
 
-        index
+        Ok(index)
     }
 
     /// Assign a packed code to its nearest centroid and append it.
@@ -182,12 +272,7 @@ impl BinaryIvfIndex {
             scores,
         );
         // batch_hamming_scores returns similarity (higher = closer)
-        scores
-            .iter()
-            .enumerate()
-            .max_by(|a, b| a.1.total_cmp(b.1))
-            .map(|(i, _)| i)
-            .unwrap_or(0)
+        argmax_score_lowest_index(scores)
     }
 
     /// Search: probe `nprobe` nearest clusters, exact Hamming within each.
@@ -215,32 +300,40 @@ impl BinaryIvfIndex {
         let mut order: Vec<usize> = (0..self.config.num_clusters).collect();
         if nprobe < order.len() {
             order.select_nth_unstable_by(nprobe, |&a, &b| {
-                centroid_scores[b].total_cmp(&centroid_scores[a])
+                centroid_scores[b]
+                    .total_cmp(&centroid_scores[a])
+                    .then_with(|| a.cmp(&b))
             });
             order.truncate(nprobe);
         }
 
         // Scan probed clusters with exact SIMD Hamming
         let mut collector = crate::query::ScoreCollector::new(k);
-        let mut scores: Vec<f32> = Vec::new();
+        let mut scores = vec![0.0f32; BINARY_IVF_SCORE_BATCH.min(self.len)];
         for &cluster_id in &order {
             let cluster = &self.clusters[cluster_id];
             let count = cluster.doc_ids.len();
             if count == 0 {
                 continue;
             }
-            scores.resize(count, 0.0);
-            batch_hamming_scores(
-                query,
-                &cluster.codes,
-                byte_len,
-                self.config.dim_bits,
-                &mut scores[..count],
-            );
-            let threshold = collector.threshold();
-            for (i, &score) in scores.iter().enumerate().take(count) {
-                if score > threshold {
-                    collector.insert_with_ordinal(cluster.doc_ids[i], score, cluster.ordinals[i]);
+            for batch_start in (0..count).step_by(BINARY_IVF_SCORE_BATCH) {
+                let batch_count = BINARY_IVF_SCORE_BATCH.min(count - batch_start);
+                let code_start = batch_start * byte_len;
+                let code_end = (batch_start + batch_count) * byte_len;
+                batch_hamming_scores(
+                    query,
+                    &cluster.codes[code_start..code_end],
+                    byte_len,
+                    self.config.dim_bits,
+                    &mut scores[..batch_count],
+                );
+                for (batch_idx, &score) in scores.iter().enumerate().take(batch_count) {
+                    let i = batch_start + batch_idx;
+                    let doc_id = cluster.doc_ids[i];
+                    let ordinal = cluster.ordinals[i];
+                    if collector.would_enter_candidate(doc_id, score, ordinal) {
+                        collector.insert_with_ordinal(doc_id, score, ordinal);
+                    }
                 }
             }
         }
@@ -297,9 +390,11 @@ impl BinaryIvfIndex {
 
     /// Deserialize from bytes.
     pub fn from_bytes(data: &[u8]) -> std::io::Result<Self> {
-        bincode::serde::decode_from_slice(data, bincode::config::standard())
-            .map(|(v, _)| v)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        let index: Self = crate::structures::vector::decode_ann_bincode_exact(data, "binary IVF")?;
+        index
+            .validate()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        Ok(index)
     }
 
     /// Estimated memory usage in bytes.
@@ -352,12 +447,7 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
         for (i, slot) in assignment.iter_mut().enumerate().take(n) {
             let code = vec_at(i);
             batch_hamming_scores(code, &centroids, byte_len, dim_bits, &mut scores);
-            let best = scores
-                .iter()
-                .enumerate()
-                .max_by(|a, b| a.1.total_cmp(b.1))
-                .map(|(c, _)| c as u32)
-                .unwrap_or(0);
+            let best = argmax_score_lowest_index(&scores) as u32;
             if *slot != best {
                 *slot = best;
                 changed += 1;
@@ -408,6 +498,25 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
 mod tests {
     use super::*;
 
+    #[test]
+    fn centroid_ties_prefer_the_lowest_cluster_id() {
+        assert_eq!(argmax_score_lowest_index(&[0.5, 1.0, 1.0, 0.25]), 1);
+    }
+
+    #[test]
+    fn duplicate_centroids_remain_searchable_with_one_probe() {
+        let codes = vec![0u8; 32];
+        let labels: Vec<_> = (0..32).map(|doc_id| (doc_id, 0)).collect();
+        let index = BinaryIvfIndex::build(BinaryIvfConfig::new(8, 4), &codes, &labels).unwrap();
+
+        let results = index.search(&[0], 5, Some(1));
+        assert_eq!(results.len(), 5);
+        assert_eq!(
+            results.iter().map(|result| result.0).collect::<Vec<_>>(),
+            vec![0, 1, 2, 3, 4]
+        );
+    }
+
     fn pack(bits: &[u8]) -> Vec<u8> {
         let mut out = vec![0u8; bits.len().div_ceil(8)];
         for (i, &b) in bits.iter().enumerate() {
@@ -445,7 +554,7 @@ mod tests {
         }
 
         let config = BinaryIvfConfig::new(dim, 2);
-        let index = BinaryIvfIndex::build(config, &codes, &labels);
+        let index = BinaryIvfIndex::build(config, &codes, &labels).unwrap();
         assert_eq!(index.len(), n);
 
         // Query: all ones — must retrieve cluster-A (even doc_ids) members
@@ -456,6 +565,71 @@ mod tests {
             assert_eq!(doc_id % 2, 0, "expected mostly-ones cluster members");
             assert!(score > 0.7);
         }
+    }
+
+    #[test]
+    fn search_retains_zero_score_ties_in_doc_id_order() {
+        let codes = vec![0xff; 5];
+        let labels: Vec<_> = (0..5).map(|doc_id| (doc_id, 0)).collect();
+        let index = BinaryIvfIndex::build(BinaryIvfConfig::new(8, 1), &codes, &labels).unwrap();
+
+        let results = index.search(&[0], 3, Some(1));
+        assert_eq!(results, vec![(0, 0, 0.0), (1, 0, 0.0), (2, 0, 0.0)]);
+    }
+
+    #[test]
+    fn deserialize_rejects_inconsistent_cluster_columns() {
+        let mut index = BinaryIvfIndex::build(BinaryIvfConfig::new(8, 1), &[0], &[(0, 0)]).unwrap();
+        index.clusters[0].ordinals.clear();
+        let bytes = index.to_bytes().unwrap();
+
+        assert!(BinaryIvfIndex::from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn build_rejects_invalid_config_and_code_lengths() {
+        let labels = [(0, 0)];
+
+        assert!(BinaryIvfIndex::build(BinaryIvfConfig::new(0, 1), &[], &labels).is_err());
+        assert!(BinaryIvfIndex::build(BinaryIvfConfig::new(7, 1), &[0], &labels).is_err());
+        assert!(BinaryIvfIndex::build(BinaryIvfConfig::new(8, 0), &[0], &labels).is_err());
+        assert!(
+            BinaryIvfIndex::build(
+                BinaryIvfConfig::new(8, MAX_BINARY_IVF_CLUSTERS + 1),
+                &[0],
+                &labels,
+            )
+            .is_err()
+        );
+        assert!(BinaryIvfIndex::build(BinaryIvfConfig::new(16, 1), &[0], &labels).is_err());
+    }
+
+    #[test]
+    fn search_scores_large_clusters_in_equivalent_chunks() {
+        let n = BINARY_IVF_SCORE_BATCH + 37;
+        let codes: Vec<u8> = (0..n).map(|i| i as u8).collect();
+        let labels: Vec<(u32, u16)> = (0..n as u32).map(|doc_id| (doc_id, 0)).collect();
+        let query = [0x5a];
+        let k = 64;
+
+        let index = BinaryIvfIndex::build(BinaryIvfConfig::new(8, 1), &codes, &labels).unwrap();
+        let actual = index.search(&query, k, Some(1));
+
+        let mut scores = vec![0.0; n];
+        batch_hamming_scores(&query, &codes, 1, 8, &mut scores);
+        let mut expected: Vec<_> = scores
+            .into_iter()
+            .enumerate()
+            .map(|(doc_id, score)| (doc_id as u32, 0, score))
+            .collect();
+        expected.sort_unstable_by(|a, b| {
+            b.2.total_cmp(&a.2)
+                .then_with(|| a.0.cmp(&b.0))
+                .then_with(|| a.1.cmp(&b.1))
+        });
+        expected.truncate(k);
+
+        assert_eq!(actual, expected);
     }
 
     /// Full probing must match brute force exactly (scanned distances are exact).
@@ -482,7 +656,7 @@ mod tests {
         truth.sort_by(|a, b| b.1.total_cmp(&a.1).then(a.0.cmp(&b.0)));
 
         let config = BinaryIvfConfig::new(dim, 8);
-        let index = BinaryIvfIndex::build(config, &codes, &labels);
+        let index = BinaryIvfIndex::build(config, &codes, &labels).unwrap();
         let results = index.search(&query, k, Some(8)); // probe all clusters
 
         assert_eq!(results.len(), k);
@@ -509,8 +683,10 @@ mod tests {
         let (codes1, labels1) = make(100, &mut rng);
         let (codes2, labels2) = make(80, &mut rng);
 
-        let mut index1 = BinaryIvfIndex::build(BinaryIvfConfig::new(dim, 4), &codes1, &labels1);
-        let index2 = BinaryIvfIndex::build(BinaryIvfConfig::new(dim, 4), &codes2, &labels2);
+        let mut index1 =
+            BinaryIvfIndex::build(BinaryIvfConfig::new(dim, 4), &codes1, &labels1).unwrap();
+        let index2 =
+            BinaryIvfIndex::build(BinaryIvfConfig::new(dim, 4), &codes2, &labels2).unwrap();
 
         index1.merge_into(&index2, 100);
         assert_eq!(index1.len(), 180);
@@ -530,7 +706,7 @@ mod tests {
         let codes: Vec<u8> = (0..50 * byte_len).map(|_| rng.random::<u8>()).collect();
         let labels: Vec<(u32, u16)> = (0..50u32).map(|i| (i, 0)).collect();
 
-        let index = BinaryIvfIndex::build(BinaryIvfConfig::new(dim, 4), &codes, &labels);
+        let index = BinaryIvfIndex::build(BinaryIvfConfig::new(dim, 4), &codes, &labels).unwrap();
         let bytes = index.to_bytes().unwrap();
         let mut streamed = Vec::new();
         let written = index.write_to(&mut streamed).unwrap();
@@ -538,6 +714,9 @@ mod tests {
         assert_eq!(streamed, bytes);
         let back = BinaryIvfIndex::from_bytes(&bytes).unwrap();
         assert_eq!(back.len(), index.len());
+        let mut with_trailing_data = bytes.clone();
+        with_trailing_data.push(0);
+        assert!(BinaryIvfIndex::from_bytes(&with_trailing_data).is_err());
 
         let query = &codes[..byte_len];
         assert_eq!(index.search(query, 5, None), back.search(query, 5, None));

--- a/hermes-core/src/structures/vector/index/ivf_pq.rs
+++ b/hermes-core/src/structures/vector/index/ivf_pq.rs
@@ -151,7 +151,7 @@ impl IVFPQIndex {
         // Find nprobe nearest coarse centroids
         let nearest_clusters = coarse_centroids.find_k_nearest(query, nprobe);
 
-        let mut candidates: Vec<(u32, u16, f32)> = Vec::new();
+        let mut candidates = super::BoundedDistanceCollector::new(k);
 
         for &cluster_id in &nearest_clusters {
             if let Some(cluster) = self.clusters.get(cluster_id) {
@@ -162,15 +162,12 @@ impl IVFPQIndex {
                 // Score all vectors in cluster using ADC (Asymmetric Distance Computation)
                 for (doc_id, ordinal, code) in cluster.iter() {
                     let dist = distance_table.compute_distance(&code.codes);
-                    candidates.push((doc_id, ordinal, dist));
+                    candidates.insert(doc_id, ordinal, dist);
                 }
             }
         }
 
-        // With SOAR, a spilled vector appears once per probed cluster it
-        // lives in — finalize dedups to the best estimate before top-k.
-        super::finalize_candidates(&mut candidates, k, coarse_centroids.soar_config.is_some());
-        candidates
+        candidates.into_sorted_results()
     }
 
     /// Search using inner product (MIPS - Maximum Inner Product Search)
@@ -192,7 +189,11 @@ impl IVFPQIndex {
         }
 
         // Re-sort by inner product (descending)
-        results.sort_unstable_by(|a, b| b.2.partial_cmp(&a.2).unwrap());
+        results.sort_unstable_by(|a, b| {
+            b.2.total_cmp(&a.2)
+                .then_with(|| a.0.cmp(&b.0))
+                .then_with(|| a.1.cmp(&b.1))
+        });
         results
     }
 
@@ -381,7 +382,7 @@ mod tests {
                     (i, d)
                 })
                 .collect();
-            exact.sort_unstable_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+            exact.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
             let exact_top_k: std::collections::HashSet<usize> =
                 exact[..k].iter().map(|(i, _)| *i).collect();
 

--- a/hermes-core/src/structures/vector/index/ivf_rabitq.rs
+++ b/hermes-core/src/structures/vector/index/ivf_rabitq.rs
@@ -152,7 +152,7 @@ impl IVFRaBitQIndex {
         // Find nprobe nearest coarse centroids
         let nearest_clusters = coarse_centroids.find_k_nearest(query, nprobe);
 
-        let mut candidates: Vec<(u32, u16, f32)> = Vec::new();
+        let mut candidates = super::BoundedDistanceCollector::new(k);
 
         for &cluster_id in &nearest_clusters {
             if let Some(cluster) = self.clusters.get(cluster_id) {
@@ -163,15 +163,12 @@ impl IVFRaBitQIndex {
                 // Score all vectors in cluster
                 for (doc_id, ordinal, code) in cluster.iter() {
                     let dist = codebook.estimate_distance(&prepared_query, code);
-                    candidates.push((doc_id, ordinal, dist));
+                    candidates.insert(doc_id, ordinal, dist);
                 }
             }
         }
 
-        // With SOAR, a spilled vector appears once per probed cluster it
-        // lives in — finalize dedups to the best estimate before top-k.
-        super::finalize_candidates(&mut candidates, k, coarse_centroids.soar_config.is_some());
-        candidates
+        candidates.into_sorted_results()
     }
 
     /// Merge another index into this one (instance method)

--- a/hermes-core/src/structures/vector/index/mod.rs
+++ b/hermes-core/src/structures/vector/index/mod.rs
@@ -15,38 +15,166 @@ pub use ivf_pq::{IVFPQConfig, IVFPQIndex};
 pub use ivf_rabitq::{IVFRaBitQConfig, IVFRaBitQIndex};
 pub use rabitq::RaBitQIndex;
 
-/// Collapse duplicate `(doc_id, ordinal)` candidates to their best (smallest)
-/// distance, in place with no allocation. Needed when SOAR multi-assignment
-/// is enabled: a vector spilled into a secondary cluster appears once per
-/// probed cluster it lives in.
-pub(crate) fn dedup_multi_assigned(candidates: &mut Vec<(u32, u16, f32)>) {
-    if candidates.len() < 2 {
-        return;
-    }
-    // Sort by key with distance ascending as tiebreaker, then keep the first
-    // (= smallest distance) entry per (doc_id, ordinal).
-    candidates.sort_unstable_by(|a, b| {
-        (a.0, a.1)
-            .cmp(&(b.0, b.1))
-            .then_with(|| a.2.total_cmp(&b.2))
-    });
-    candidates.dedup_by_key(|c| (c.0, c.1));
+#[derive(Clone, Copy)]
+struct DistanceEntry {
+    doc_id: u32,
+    ordinal: u16,
+    distance: f32,
 }
 
-/// Shared search epilogue for IVF-based indexes: optionally dedup SOAR-spilled
-/// candidates, then select the top-k by ascending distance.
-pub(crate) fn finalize_candidates(
-    candidates: &mut Vec<(u32, u16, f32)>,
+impl PartialEq for DistanceEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.distance.to_bits() == other.distance.to_bits()
+            && self.doc_id == other.doc_id
+            && self.ordinal == other.ordinal
+    }
+}
+
+impl Eq for DistanceEntry {}
+
+impl PartialOrd for DistanceEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DistanceEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.distance
+            .total_cmp(&other.distance)
+            .then_with(|| self.doc_id.cmp(&other.doc_id))
+            .then_with(|| self.ordinal.cmp(&other.ordinal))
+    }
+}
+
+/// Streaming, deduplicating top-k distance collector. IVF previously retained
+/// every vector in every probed cluster before truncation, so a full nprobe
+/// scan allocated O(segment vectors) per query.
+pub(crate) struct BoundedDistanceCollector {
     k: usize,
-    dedup_spilled: bool,
-) {
-    if dedup_spilled {
-        dedup_multi_assigned(candidates);
+    heap: std::collections::BinaryHeap<DistanceEntry>,
+    best: rustc_hash::FxHashMap<(u32, u16), f32>,
+}
+
+impl BoundedDistanceCollector {
+    pub(crate) fn new(k: usize) -> Self {
+        Self {
+            k,
+            heap: std::collections::BinaryHeap::with_capacity(k.min(8_192)),
+            best: rustc_hash::FxHashMap::with_capacity_and_hasher(k.min(8_192), Default::default()),
+        }
     }
-    // Partial sort: O(n + k log k) instead of O(n log n)
-    if candidates.len() > k {
-        candidates.select_nth_unstable_by(k, |a, b| a.2.partial_cmp(&b.2).unwrap());
-        candidates.truncate(k);
+
+    fn discard_stale_top(&mut self) {
+        while let Some(entry) = self.heap.peek() {
+            let current = self.best.get(&(entry.doc_id, entry.ordinal));
+            if current.is_some_and(|distance| distance.to_bits() == entry.distance.to_bits()) {
+                break;
+            }
+            self.heap.pop();
+        }
     }
-    candidates.sort_unstable_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
+
+    fn rebuild_if_needed(&mut self) {
+        // Improved duplicate entries leave stale heap nodes. Rebuild
+        // occasionally so even adversarial duplicate streams stay O(k).
+        if self.heap.len() > self.k.saturating_mul(2).max(16) {
+            self.heap = self
+                .best
+                .iter()
+                .map(|(&(doc_id, ordinal), &distance)| DistanceEntry {
+                    doc_id,
+                    ordinal,
+                    distance,
+                })
+                .collect();
+        }
+    }
+
+    pub(crate) fn insert(&mut self, doc_id: u32, ordinal: u16, distance: f32) {
+        if self.k == 0 || !distance.is_finite() {
+            return;
+        }
+        let key = (doc_id, ordinal);
+        if let Some(current) = self.best.get_mut(&key) {
+            if distance.total_cmp(current).is_lt() {
+                *current = distance;
+                self.heap.push(DistanceEntry {
+                    doc_id,
+                    ordinal,
+                    distance,
+                });
+                self.rebuild_if_needed();
+            }
+            return;
+        }
+
+        let candidate = DistanceEntry {
+            doc_id,
+            ordinal,
+            distance,
+        };
+        if self.best.len() >= self.k {
+            self.discard_stale_top();
+            let Some(worst) = self.heap.peek().copied() else {
+                return;
+            };
+            if candidate >= worst {
+                return;
+            }
+            self.heap.pop();
+            self.best.remove(&(worst.doc_id, worst.ordinal));
+        }
+        self.best.insert(key, distance);
+        self.heap.push(candidate);
+        self.rebuild_if_needed();
+    }
+
+    pub(crate) fn into_sorted_results(self) -> Vec<(u32, u16, f32)> {
+        let mut results: Vec<_> = self
+            .best
+            .into_iter()
+            .map(|((doc_id, ordinal), distance)| (doc_id, ordinal, distance))
+            .collect();
+        results.sort_unstable_by(|a, b| {
+            a.2.total_cmp(&b.2)
+                .then_with(|| a.0.cmp(&b.0))
+                .then_with(|| a.1.cmp(&b.1))
+        });
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BoundedDistanceCollector;
+
+    #[test]
+    fn bounded_collector_deduplicates_and_orders_ties() {
+        let mut collector = BoundedDistanceCollector::new(3);
+        collector.insert(9, 0, 2.0);
+        collector.insert(2, 1, 1.0);
+        collector.insert(2, 0, 1.0);
+        collector.insert(7, 0, 3.0);
+        collector.insert(9, 0, 0.5);
+        collector.insert(3, 0, 1.0);
+
+        assert_eq!(
+            collector.into_sorted_results(),
+            vec![(9, 0, 0.5), (2, 0, 1.0), (2, 1, 1.0)]
+        );
+    }
+
+    #[test]
+    fn bounded_collector_handles_zero_k_and_non_finite_distances() {
+        let mut zero = BoundedDistanceCollector::new(0);
+        zero.insert(1, 0, 1.0);
+        assert!(zero.into_sorted_results().is_empty());
+
+        let mut collector = BoundedDistanceCollector::new(2);
+        collector.insert(1, 0, f32::NAN);
+        collector.insert(2, 0, f32::INFINITY);
+        collector.insert(3, 0, 1.0);
+        assert_eq!(collector.into_sorted_results(), vec![(3, 0, 1.0)]);
+    }
 }

--- a/hermes-core/src/structures/vector/index/rabitq.rs
+++ b/hermes-core/src/structures/vector/index/rabitq.rs
@@ -31,6 +31,26 @@ pub struct RaBitQIndex {
 }
 
 impl RaBitQIndex {
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        self.codebook.validate()?;
+        let dim = self.codebook.config.dim;
+        if self.centroid.len() != dim || self.centroid.iter().any(|value| !value.is_finite()) {
+            return Err(format!("RaBitQ centroid is invalid for dimension {dim}"));
+        }
+        if self.doc_ids.len() != self.vectors.len() || self.ordinals.len() != self.vectors.len() {
+            return Err(format!(
+                "RaBitQ column lengths differ: docs={}, ordinals={}, vectors={}",
+                self.doc_ids.len(),
+                self.ordinals.len(),
+                self.vectors.len()
+            ));
+        }
+        for vector in &self.vectors {
+            self.codebook.validate_vector(vector)?;
+        }
+        Ok(())
+    }
+
     /// Create a new empty RaBitQ index
     pub fn new(config: RaBitQConfig) -> Self {
         let dim = config.dim;
@@ -113,26 +133,15 @@ impl RaBitQIndex {
     pub fn search(&self, query: &[f32], k: usize) -> Vec<(u32, u16, f32)> {
         let prepared = self.prepare_query(query);
 
-        // Phase 1: Estimate distances for all vectors
-        let mut candidates: Vec<(usize, f32)> = self
-            .vectors
-            .iter()
-            .enumerate()
-            .map(|(i, _)| (i, self.estimate_distance(&prepared, i)))
-            .collect();
-
-        // Partial sort: O(n + k log k) instead of O(n log n)
-        if candidates.len() > k {
-            candidates.select_nth_unstable_by(k, |a, b| a.1.total_cmp(&b.1));
-            candidates.truncate(k);
+        let mut candidates = super::BoundedDistanceCollector::new(k);
+        for idx in 0..self.vectors.len() {
+            candidates.insert(
+                self.doc_ids[idx],
+                self.ordinals[idx],
+                self.estimate_distance(&prepared, idx),
+            );
         }
-        candidates.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
-
-        // Map indices to (doc_id, ordinal, dist)
-        candidates
-            .into_iter()
-            .map(|(idx, dist)| (self.doc_ids[idx], self.ordinals[idx], dist))
-            .collect()
+        candidates.into_sorted_results()
     }
 
     /// Number of indexed vectors
@@ -181,7 +190,12 @@ impl RaBitQIndex {
 
     /// Deserialize from bytes
     pub fn from_bytes(data: &[u8]) -> io::Result<Self> {
-        serde_json::from_slice(data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        let index: Self = serde_json::from_slice(data)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        index
+            .validate()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(index)
     }
 }
 

--- a/hermes-core/src/structures/vector/ivf/coarse.rs
+++ b/hermes-core/src/structures/vector/ivf/coarse.rs
@@ -232,10 +232,10 @@ impl CoarseCentroids {
 
         // Partial sort: O(n + k log k) instead of O(n log n)
         if distances.len() > k {
-            distances.select_nth_unstable_by(k, |a, b| a.1.partial_cmp(&b.1).unwrap());
+            distances.select_nth_unstable_by(k, |a, b| a.1.total_cmp(&b.1));
             distances.truncate(k);
         }
-        distances.sort_unstable_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        distances.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
         distances.into_iter().map(|(c, _)| c).collect()
     }
 
@@ -255,10 +255,10 @@ impl CoarseCentroids {
 
         // Partial sort: O(n + k log k) instead of O(n log n)
         if distances.len() > k {
-            distances.select_nth_unstable_by(k, |a, b| a.1.partial_cmp(&b.1).unwrap());
+            distances.select_nth_unstable_by(k, |a, b| a.1.total_cmp(&b.1));
             distances.truncate(k);
         }
-        distances.sort_unstable_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        distances.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
         distances
     }
 
@@ -317,7 +317,7 @@ impl CoarseCentroids {
         // Partial sort by orthogonality (smallest dot product first)
         let take = config.num_secondary.min(candidates.len());
         if candidates.len() > take {
-            candidates.select_nth_unstable_by(take, |a, b| a.1.partial_cmp(&b.1).unwrap());
+            candidates.select_nth_unstable_by(take, |a, b| a.1.total_cmp(&b.1));
             candidates.truncate(take);
         }
 

--- a/hermes-core/src/structures/vector/mod.rs
+++ b/hermes-core/src/structures/vector/mod.rs
@@ -29,6 +29,100 @@ pub mod index;
 pub mod ivf;
 pub mod quantization;
 
+/// Hard ceiling for a single decoded ANN artifact. Bincode's limit accounts
+/// for claimed container storage as well as bytes consumed, preventing a tiny
+/// corrupt payload from advertising an effectively unbounded allocation.
+///
+/// The 4 GiB 64-bit ceiling still accommodates a 20M-document classic RaBitQ
+/// segment (roughly 3.5 GB decoded at 768 dimensions), while preventing one
+/// lazy decode from claiming an operationally unbounded fraction of RAM.
+#[cfg(target_pointer_width = "64")]
+pub(crate) const MAX_DENSE_ANN_DECODE_BYTES: usize = 4 * 1024 * 1024 * 1024;
+#[cfg(not(target_pointer_width = "64"))]
+pub(crate) const MAX_DENSE_ANN_DECODE_BYTES: usize = 512 * 1024 * 1024;
+
+const ANN_DECODE_EXPANSION_FACTOR: usize = 8;
+const ANN_DECODE_FIXED_HEADROOM: usize = 16 * 1024 * 1024;
+
+fn decode_ann_with_limit<T: serde::de::DeserializeOwned, const LIMIT: usize>(
+    data: &[u8],
+) -> std::io::Result<(T, usize)> {
+    bincode::serde::decode_from_slice(data, bincode::config::standard().with_limit::<LIMIT>())
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+#[cfg(target_pointer_width = "64")]
+fn decode_ann_with_relative_limit<T: serde::de::DeserializeOwned>(
+    data: &[u8],
+    budget: usize,
+) -> std::io::Result<(T, usize)> {
+    const MIB: usize = 1024 * 1024;
+    const GIB: usize = 1024 * MIB;
+    if budget <= 32 * MIB {
+        decode_ann_with_limit::<T, { 32 * MIB }>(data)
+    } else if budget <= 128 * MIB {
+        decode_ann_with_limit::<T, { 128 * MIB }>(data)
+    } else if budget <= 512 * MIB {
+        decode_ann_with_limit::<T, { 512 * MIB }>(data)
+    } else if budget <= GIB {
+        decode_ann_with_limit::<T, GIB>(data)
+    } else if budget <= 2 * GIB {
+        decode_ann_with_limit::<T, { 2 * GIB }>(data)
+    } else {
+        decode_ann_with_limit::<T, { 4 * GIB }>(data)
+    }
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+fn decode_ann_with_relative_limit<T: serde::de::DeserializeOwned>(
+    data: &[u8],
+    budget: usize,
+) -> std::io::Result<(T, usize)> {
+    const MIB: usize = 1024 * 1024;
+    if budget <= 32 * MIB {
+        decode_ann_with_limit::<T, { 32 * MIB }>(data)
+    } else if budget <= 128 * MIB {
+        decode_ann_with_limit::<T, { 128 * MIB }>(data)
+    } else {
+        decode_ann_with_limit::<T, { 512 * MIB }>(data)
+    }
+}
+
+/// Decode exactly one bincode-backed ANN artifact under a bounded allocation
+/// budget. Trailing bytes are corruption rather than a second ignored object.
+pub(crate) fn decode_ann_bincode_exact<T: serde::de::DeserializeOwned>(
+    data: &[u8],
+    description: &str,
+) -> std::io::Result<T> {
+    if data.len() > MAX_DENSE_ANN_DECODE_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{description} payload is {} bytes, exceeding the {}-byte decode limit",
+                data.len(),
+                MAX_DENSE_ANN_DECODE_BYTES
+            ),
+        ));
+    }
+    let budget = data
+        .len()
+        .checked_mul(ANN_DECODE_EXPANSION_FACTOR)
+        .and_then(|bytes| bytes.checked_add(ANN_DECODE_FIXED_HEADROOM))
+        .unwrap_or(MAX_DENSE_ANN_DECODE_BYTES)
+        .min(MAX_DENSE_ANN_DECODE_BYTES);
+    let (value, consumed) = decode_ann_with_relative_limit(data, budget)?;
+    if consumed != data.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "{description} payload contains {} trailing bytes",
+                data.len() - consumed
+            ),
+        ));
+    }
+    Ok(value)
+}
+
 // IVF core
 pub use ivf::{
     ClusterData, ClusterStorage, CoarseCentroids, CoarseConfig, MultiAssignment, QuantizedCode,
@@ -46,3 +140,30 @@ pub use index::{
     BinaryIvfConfig, BinaryIvfIndex, IVFPQConfig, IVFPQIndex, IVFRaBitQConfig, IVFRaBitQIndex,
     RaBitQIndex,
 };
+
+#[cfg(test)]
+mod decode_tests {
+    use super::decode_ann_bincode_exact;
+
+    #[test]
+    fn ann_bincode_decode_is_exact_and_rejects_large_claims_from_tiny_payloads() {
+        let encoded =
+            bincode::serde::encode_to_vec(vec![1u8, 2, 3], bincode::config::standard()).unwrap();
+        assert_eq!(
+            decode_ann_bincode_exact::<Vec<u8>>(&encoded, "test").unwrap(),
+            [1, 2, 3]
+        );
+
+        let mut trailing = encoded;
+        trailing.push(0);
+        assert!(decode_ann_bincode_exact::<Vec<u8>>(&trailing, "test").is_err());
+
+        // A serialized Vec starts with its usize length. This advertises a
+        // 64 MiB allocation from only a few bytes and must hit the 32 MiB tier
+        // before Vec can reserve it.
+        let oversized_claim =
+            bincode::serde::encode_to_vec(64usize * 1024 * 1024, bincode::config::standard())
+                .unwrap();
+        assert!(decode_ann_bincode_exact::<Vec<u8>>(&oversized_claim, "test").is_err());
+    }
+}

--- a/hermes-core/src/structures/vector/quantization/pq.rs
+++ b/hermes-core/src/structures/vector/quantization/pq.rs
@@ -212,6 +212,77 @@ pub struct PQCodebook {
 }
 
 impl PQCodebook {
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        let config = &self.config;
+        if config.dim == 0
+            || config.num_subspaces == 0
+            || config.dims_per_block == 0
+            || config.num_centroids == 0
+            || config.num_centroids > 256
+        {
+            return Err("PQ codebook has invalid zero/unbounded dimensions".to_string());
+        }
+        let covered_dim = config
+            .num_subspaces
+            .checked_mul(config.dims_per_block)
+            .ok_or_else(|| "PQ subspace dimension overflow".to_string())?;
+        if covered_dim != config.dim {
+            return Err(format!(
+                "PQ subspaces cover {covered_dim} dimensions, expected {}",
+                config.dim
+            ));
+        }
+        if !config.aniso_eta.is_finite()
+            || config.aniso_eta < 0.0
+            || !config.aniso_threshold.is_finite()
+        {
+            return Err(
+                "PQ anisotropic eta must be non-negative and all parameters must be finite"
+                    .to_string(),
+            );
+        }
+        let expected_centroids = config
+            .num_subspaces
+            .checked_mul(config.num_centroids)
+            .and_then(|count| count.checked_mul(config.dims_per_block))
+            .ok_or_else(|| "PQ centroid size overflow".to_string())?;
+        if self.centroids.len() != expected_centroids
+            || self.centroids.iter().any(|value| !value.is_finite())
+        {
+            return Err(format!(
+                "PQ centroid table is invalid: got {}, expected {expected_centroids}",
+                self.centroids.len()
+            ));
+        }
+        if let Some(rotation) = &self.rotation_matrix {
+            let expected = config
+                .dim
+                .checked_mul(config.dim)
+                .ok_or_else(|| "PQ rotation size overflow".to_string())?;
+            if rotation.len() != expected || rotation.iter().any(|value| !value.is_finite()) {
+                return Err(format!(
+                    "PQ rotation matrix is invalid: got {}, expected {expected}",
+                    rotation.len()
+                ));
+            }
+        }
+        if let Some(norms) = &self.centroid_norms {
+            let expected = config
+                .num_subspaces
+                .checked_mul(config.num_centroids)
+                .ok_or_else(|| "PQ norm table size overflow".to_string())?;
+            if norms.len() != expected
+                || norms.iter().any(|value| !value.is_finite() || *value < 0.0)
+            {
+                return Err(format!(
+                    "PQ centroid norm table is invalid: got {}, expected {expected}",
+                    norms.len()
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Train codebook with OPQ rotation and anisotropic loss
     #[cfg(feature = "native")]
     pub fn train(config: PQConfig, vectors: &[Vec<f32>], max_iters: usize) -> Self {
@@ -604,7 +675,7 @@ impl PQCodebook {
                     .sum();
                 (c, dist)
             })
-            .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+            .min_by(|a, b| a.1.total_cmp(&b.1))
             .map(|(c, _)| c)
             .unwrap_or(0)
     }

--- a/hermes-core/src/structures/vector/quantization/rabitq.rs
+++ b/hermes-core/src/structures/vector/quantization/rabitq.rs
@@ -138,6 +138,97 @@ pub struct RaBitQCodebook {
 }
 
 impl RaBitQCodebook {
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        let dim = self.config.dim;
+        if dim == 0 {
+            return Err("RaBitQ dimension must be greater than zero".to_string());
+        }
+        if !(1..=8).contains(&self.config.query_bits) {
+            return Err(format!(
+                "RaBitQ query_bits must be in 1..=8, got {}",
+                self.config.query_bits
+            ));
+        }
+        if self.config.ex_bits > 7 {
+            return Err(format!("RaBitQ ex_bits {} exceeds 7", self.config.ex_bits));
+        }
+        if self.random_signs.len() != dim || self.random_perm.len() != dim {
+            return Err(format!(
+                "RaBitQ transform lengths ({}, {}) do not match dimension {dim}",
+                self.random_signs.len(),
+                self.random_perm.len()
+            ));
+        }
+        if self
+            .random_signs
+            .iter()
+            .any(|&sign| sign != -1 && sign != 1)
+        {
+            return Err("RaBitQ random signs contain a value other than -1 or 1".to_string());
+        }
+        let mut seen = vec![false; dim];
+        for &source in &self.random_perm {
+            let source = source as usize;
+            if source >= dim || seen[source] {
+                return Err("RaBitQ random permutation is invalid".to_string());
+            }
+            seen[source] = true;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_vector(&self, vector: &QuantizedVector) -> Result<(), String> {
+        let expected_bits = self.config.dim.div_ceil(8);
+        if vector.bits.len() != expected_bits {
+            return Err(format!(
+                "RaBitQ code has {} sign bytes, expected {expected_bits}",
+                vector.bits.len()
+            ));
+        }
+        let expected_extended = self
+            .config
+            .dim
+            .checked_mul(self.config.ex_bits as usize)
+            .ok_or_else(|| "RaBitQ extended code size overflow".to_string())?
+            .div_ceil(8);
+        if vector.ex_code.len() != expected_extended {
+            return Err(format!(
+                "RaBitQ code has {} extended bytes, expected {expected_extended}",
+                vector.ex_code.len()
+            ));
+        }
+        if !vector.dist_to_centroid.is_finite()
+            || !vector.self_dot.is_finite()
+            || !vector.ex_scale.is_finite()
+            || !vector.ex_norm.is_finite()
+        {
+            return Err("RaBitQ code contains non-finite metadata".to_string());
+        }
+        if vector.dist_to_centroid < 0.0 || vector.ex_scale < 0.0 || vector.ex_norm < 0.0 {
+            return Err("RaBitQ code contains negative norm/scale metadata".to_string());
+        }
+        let actual_popcount: u32 = vector.bits.iter().map(|byte| byte.count_ones()).sum();
+        if vector.popcount != actual_popcount || vector.popcount as usize > self.config.dim {
+            return Err(format!(
+                "RaBitQ code popcount {} does not match packed bits {actual_popcount}",
+                vector.popcount
+            ));
+        }
+        let padding_bits = expected_bits
+            .checked_mul(8)
+            .and_then(|bits| bits.checked_sub(self.config.dim))
+            .ok_or_else(|| "RaBitQ padding size overflow".to_string())?;
+        if padding_bits > 0
+            && vector
+                .bits
+                .last()
+                .is_some_and(|last| last >> (8 - padding_bits) != 0)
+        {
+            return Err("RaBitQ code has non-zero padding bits".to_string());
+        }
+        Ok(())
+    }
+
     /// Create a new RaBitQ codebook with random transform
     pub fn new(config: RaBitQConfig) -> Self {
         let dim = config.dim;

--- a/hermes-server/README.md
+++ b/hermes-server/README.md
@@ -35,6 +35,55 @@ Options:
 - `-a, --addr`: Address to bind to (default: `0.0.0.0:50051`)
 - `-d, --data-dir`: Directory for storing indexes (default: `./data`)
 
+### Search resource controls
+
+`--search-threads` sets the width of a bounded Rayon pool shared by CPU-bound
+search work across every open index. When omitted, it defaults to one thread per
+four detected CPUs (minimum one). Nested parallel work, including fused queries,
+segment fan-out, phrase loading, and vector search, stays inside this same pool;
+Hermes does not create a pool per index or request.
+
+`--max-concurrent-searches` bounds expensive search pipelines across all HTTP/2
+connections; document lookup and metadata RPCs do not consume these permits.
+When omitted, Hermes allows one concurrent search per eight detected CPUs,
+clamped to `1..=8` (six searches on a 48-core host). Requests above that
+capacity fail promptly with gRPC `RESOURCE_EXHAUSTED`; clients should retry with
+bounded exponential backoff. This keeps overload from accumulating an
+unbounded in-process request queue. Completed or cancelled searches release
+their permit automatically.
+
+The server also rejects request sizes that could otherwise multiply into large
+per-segment heaps:
+
+| Request component                           |            Limit |
+| ------------------------------------------- | ---------------: |
+| Final search results                        |          `10000` |
+| Pagination window (`offset + limit`)        |          `50000` |
+| L1 reranker candidates                      |          `50000` |
+| Fusion candidates fetched per sub-query     |          `50000` |
+| Fusion sub-queries                          |             `16` |
+| Fusion fetch depth x number of sub-queries  |         `200000` |
+| Query nesting depth                         |             `32` |
+| Query nodes / aggregate clauses             |    `256` / `512` |
+| Clauses in one Boolean query                |            `128` |
+| Aggregate query text                        |         `64 KiB` |
+| Aggregate query vector payload              |          `1 MiB` |
+| Dense dimensions / sparse input dimensions  | `65536` / `4096` |
+| Binary query bytes                          |        `256 KiB` |
+| Stored fields requested                     |             `64` |
+| Aggregate requested-field name bytes        |         `16 KiB` |
+| Retained response / encoded response (each) |         `48 MiB` |
+
+Zero-valued defaults remain supported. Derived reranker and fusion defaults are
+checked and capped at the corresponding limit; explicit values over a limit
+return gRPC `INVALID_ARGUMENT`.
+
+The structural limits are checked iteratively before query conversion and
+before a search permit is acquired. Requested stored fields are resolved and
+deduplicated once, and response hydration is charged before field values are
+cloned into protobuf objects. A response that would exceed its memory/encoding
+budget fails with `RESOURCE_EXHAUSTED`; request fewer hits or fields.
+
 ### Background merge and reorder
 
 The server uses one BP CPU pool and one whole-pass gate across all indexes.
@@ -175,6 +224,15 @@ Merge all segments into one for optimal search performance.
 ```protobuf
 rpc ForceMerge(ForceMergeRequest) returns (ForceMergeResponse);
 ```
+
+#### RetrainVectorIndex
+
+Retraining global IVF/ScaNN centroids is accepted only while all committed
+segments for the affected fields are flat. ANN segments embed the artifact
+versions used to build them, so replacing the single global generation under
+existing ANN segments would make those segments unreadable. Hermes rejects
+that unsafe lifecycle transition instead of publishing mixed generations.
+Trained artifacts and metadata are validated and published all-or-nothing.
 
 #### DeleteIndex
 

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -3,8 +3,8 @@
 use std::sync::LazyLock;
 
 use hermes_core::query::{
-    BinaryDenseVectorQuery, DenseVectorQuery, LazyGlobalStats, MultiValueCombiner, RerankerConfig,
-    SparseVectorQuery,
+    BinaryDenseVectorQuery, DenseVectorQuery, LazyGlobalStats, MAX_DENSE_NPROBE,
+    MAX_DENSE_RERANK_FACTOR, MultiValueCombiner, RerankerConfig, SparseVectorQuery,
 };
 use hermes_core::structures::QueryWeighting;
 use hermes_core::tokenizer::{idf_weights_cache, tokenizer_cache};
@@ -19,6 +19,18 @@ static TOKENIZER_REGISTRY: LazyLock<TokenizerRegistry> = LazyLock::new(Tokenizer
 use crate::proto;
 use crate::proto::field_value::Value;
 use crate::proto::query::Query as ProtoQueryType;
+
+const MAX_TEXT_QUERY_TOKENS: usize = 256;
+const MAX_SPARSE_TOKEN_DIMENSIONS: usize = 4_096;
+
+fn validate_token_expansion(kind: &str, count: usize, maximum: usize) -> Result<(), String> {
+    if count > maximum {
+        return Err(format!(
+            "{kind} expands to {count} tokens; maximum is {maximum}"
+        ));
+    }
+    Ok(())
+}
 
 /// Convert proto combiner enum to core MultiValueCombiner
 /// Parameters (temperature, k, decay) are passed separately from the query message
@@ -77,6 +89,7 @@ pub fn convert_query(
                 .into_iter()
                 .map(|t| t.text)
                 .collect();
+            validate_token_expansion("TermQuery", tokens.len(), MAX_TEXT_QUERY_TOKENS)?;
             if tokens.is_empty() {
                 return Err(format!("No tokens in term '{}'", term_query.term));
             }
@@ -97,6 +110,9 @@ pub fn convert_query(
 
             // Trailing `*` → PrefixQuery (no tokenization, raw lowercased prefix)
             if let Some(prefix) = match_query.text.strip_suffix('*') {
+                if prefix.is_empty() {
+                    return Err("Prefix query must not be empty".to_string());
+                }
                 return Ok(Box::new(PrefixQuery::text(field, prefix)));
             }
 
@@ -115,6 +131,7 @@ pub fn convert_query(
                 .into_iter()
                 .map(|t| t.text)
                 .collect();
+            validate_token_expansion("MatchQuery", tokens.len(), MAX_TEXT_QUERY_TOKENS)?;
 
             if tokens.is_empty() {
                 return Err(format!(
@@ -139,6 +156,9 @@ pub fn convert_query(
             convert_boolean_query(bool_query, schema, global_stats, idf_cache_dir)
         }
         Some(ProtoQueryType::Boost(boost_query)) => {
+            if !boost_query.boost.is_finite() {
+                return Err("Boost must be a finite number".to_string());
+            }
             let inner = boost_query
                 .query
                 .as_ref()
@@ -158,12 +178,56 @@ pub fn convert_query(
             let field = schema
                 .get_field(&sv_query.field)
                 .ok_or_else(|| format!("Field '{}' not found", sv_query.field))?;
+            let field_entry = schema
+                .get_field_entry(field)
+                .ok_or_else(|| format!("Field entry for '{}' not found", sv_query.field))?;
+            if field_entry.field_type != hermes_core::FieldType::SparseVector {
+                return Err(format!(
+                    "SparseVectorQuery requires a sparse_vector field, but '{}' is {:?}",
+                    sv_query.field, field_entry.field_type
+                ));
+            }
+            if sv_query.text.is_empty() && sv_query.indices.len() != sv_query.values.len() {
+                return Err(format!(
+                    "Sparse query has {} indices but {} values",
+                    sv_query.indices.len(),
+                    sv_query.values.len()
+                ));
+            }
+            if let Some((index, value)) = sv_query
+                .values
+                .iter()
+                .enumerate()
+                .find(|(_, value)| !value.is_finite())
+            {
+                return Err(format!(
+                    "Sparse query contains non-finite value {value} at index {index}"
+                ));
+            }
+            if !sv_query.heap_factor.is_finite()
+                || sv_query.heap_factor < 0.0
+                || sv_query.heap_factor > 1.0
+            {
+                return Err(format!(
+                    "Sparse query heap_factor must be finite and in [0, 1], got {}",
+                    sv_query.heap_factor
+                ));
+            }
+            if !sv_query.weight_threshold.is_finite() || sv_query.weight_threshold < 0.0 {
+                return Err(format!(
+                    "Sparse query weight_threshold must be finite and non-negative, got {}",
+                    sv_query.weight_threshold
+                ));
+            }
+            if !sv_query.pruning.is_finite() || sv_query.pruning < 0.0 || sv_query.pruning > 1.0 {
+                return Err(format!(
+                    "Sparse query pruning must be finite and in [0, 1], got {}",
+                    sv_query.pruning
+                ));
+            }
 
             let vector: Vec<(u32, f32)> = if !sv_query.text.is_empty() {
                 // Text provided - tokenize server-side
-                let field_entry = schema
-                    .get_field_entry(field)
-                    .ok_or_else(|| format!("Field entry for '{}' not found", sv_query.field))?;
                 let sparse_config = field_entry.sparse_vector_config.as_ref().ok_or_else(|| {
                     format!("Field '{}' is not a sparse vector field", sv_query.field)
                 })?;
@@ -182,6 +246,11 @@ pub fn convert_query(
                 let token_counts = tokenizer
                     .tokenize(&sv_query.text)
                     .map_err(|e| format!("Tokenization failed: {}", e))?;
+                validate_token_expansion(
+                    "SparseVectorQuery.text",
+                    token_counts.len(),
+                    MAX_SPARSE_TOKEN_DIMENSIONS,
+                )?;
 
                 // Convert (token_id, count) to (token_id, weight)
                 // Apply IDF weighting if configured
@@ -348,13 +417,70 @@ pub fn convert_query(
             let field = schema
                 .get_field(&dv_query.field)
                 .ok_or_else(|| format!("Field '{}' not found", dv_query.field))?;
-            let mut query = DenseVectorQuery::new(field, dv_query.vector.clone());
-            if dv_query.nprobe > 0 {
-                query = query.with_nprobe(dv_query.nprobe as usize);
+            let entry = schema
+                .get_field_entry(field)
+                .ok_or_else(|| format!("Field entry for '{}' not found", dv_query.field))?;
+            if entry.field_type != hermes_core::FieldType::DenseVector {
+                return Err(format!(
+                    "DenseVectorQuery requires a dense_vector field, but '{}' is {:?}",
+                    dv_query.field, entry.field_type
+                ));
             }
-            if dv_query.rerank_factor > 0.0 {
-                query = query.with_rerank_factor(dv_query.rerank_factor);
+            let config = entry.dense_vector_config.as_ref().ok_or_else(|| {
+                format!(
+                    "Dense vector field '{}' has no dense vector configuration",
+                    dv_query.field
+                )
+            })?;
+            if dv_query.vector.is_empty() {
+                return Err("Dense query vector must not be empty".to_string());
             }
+            if dv_query.vector.len() != config.dim {
+                return Err(format!(
+                    "Dense query vector dimension {} does not match field '{}' dimension {}",
+                    dv_query.vector.len(),
+                    dv_query.field,
+                    config.dim
+                ));
+            }
+            if let Some((index, value)) = dv_query
+                .vector
+                .iter()
+                .enumerate()
+                .find(|(_, value)| !value.is_finite())
+            {
+                return Err(format!(
+                    "Dense query vector contains non-finite value {value} at index {index}"
+                ));
+            }
+
+            let nprobe = if dv_query.nprobe == 0 {
+                config.nprobe
+            } else {
+                dv_query.nprobe as usize
+            };
+            if nprobe > MAX_DENSE_NPROBE {
+                return Err(format!(
+                    "Dense query nprobe must be at most {MAX_DENSE_NPROBE}, got {nprobe}"
+                ));
+            }
+
+            let rerank_factor = if dv_query.rerank_factor == 0.0 {
+                3.0
+            } else {
+                dv_query.rerank_factor
+            };
+            if !rerank_factor.is_finite()
+                || !(1.0..=MAX_DENSE_RERANK_FACTOR).contains(&rerank_factor)
+            {
+                return Err(format!(
+                    "Dense query rerank_factor must be finite and in [1, {MAX_DENSE_RERANK_FACTOR}], got {rerank_factor}"
+                ));
+            }
+
+            let mut query = DenseVectorQuery::new(field, dv_query.vector.clone())
+                .with_nprobe(nprobe)
+                .with_rerank_factor(rerank_factor);
             let combiner = convert_combiner(
                 dv_query.combiner,
                 dv_query.combiner_temperature,
@@ -368,6 +494,29 @@ pub fn convert_query(
             let field = schema
                 .get_field(&bv_query.field)
                 .ok_or_else(|| format!("Field '{}' not found", bv_query.field))?;
+            let entry = schema
+                .get_field_entry(field)
+                .ok_or_else(|| format!("Field entry for '{}' not found", bv_query.field))?;
+            if entry.field_type != hermes_core::FieldType::BinaryDenseVector {
+                return Err(format!(
+                    "BinaryDenseVectorQuery requires a binary_dense_vector field, but '{}' is {:?}",
+                    bv_query.field, entry.field_type
+                ));
+            }
+            let config = entry.binary_dense_vector_config.as_ref().ok_or_else(|| {
+                format!(
+                    "Binary dense vector field '{}' has no configuration",
+                    bv_query.field
+                )
+            })?;
+            if bv_query.vector.len() != config.byte_len() {
+                return Err(format!(
+                    "Binary query byte length {} does not match field '{}' byte length {}",
+                    bv_query.vector.len(),
+                    bv_query.field,
+                    config.byte_len()
+                ));
+            }
             let mut query = BinaryDenseVectorQuery::new(field, bv_query.vector.clone());
             let combiner = convert_combiner(
                 bv_query.combiner,
@@ -383,6 +532,9 @@ pub fn convert_query(
             let field = schema
                 .get_field(&prefix_query.field)
                 .ok_or_else(|| format!("Field '{}' not found", prefix_query.field))?;
+            if prefix_query.prefix.is_empty() {
+                return Err("Prefix query must not be empty".to_string());
+            }
             Ok(Box::new(PrefixQuery::text(field, &prefix_query.prefix)))
         }
         Some(ProtoQueryType::Fusion(_)) => {
@@ -690,6 +842,13 @@ pub fn convert_reranker(
 
     let is_binary = entry.field_type == hermes_core::FieldType::BinaryDenseVector;
 
+    if !reranker.rrf_k.is_finite() || reranker.rrf_k < 0.0 {
+        return Err(format!(
+            "Reranker rrf_k must be finite and non-negative, got {}",
+            reranker.rrf_k
+        ));
+    }
+
     if entry.field_type != hermes_core::FieldType::DenseVector && !is_binary {
         return Err(format!(
             "Reranker field '{}' must be dense_vector or binary_dense_vector, got {:?}",
@@ -731,6 +890,16 @@ pub fn convert_reranker(
                 dv_config.dim
             ));
         }
+        if let Some((index, value)) = reranker
+            .vector
+            .iter()
+            .enumerate()
+            .find(|(_, value)| !value.is_finite())
+        {
+            return Err(format!(
+                "Reranker query vector contains non-finite value {value} at index {index}"
+            ));
+        }
     }
 
     // Default reranker combiner to WeightedTopK(k=3, decay=0.7) — decaying
@@ -759,6 +928,17 @@ pub fn convert_reranker(
     } else {
         None
     };
+    if is_binary && matryoshka_dims.is_some() {
+        return Err("Reranker matryoshka_dims is not supported for binary vectors".to_string());
+    }
+    if let (Some(dims), Some(config)) = (matryoshka_dims, entry.dense_vector_config.as_ref())
+        && dims > config.dim
+    {
+        return Err(format!(
+            "Reranker matryoshka_dims {dims} exceeds field '{}' dimension {}",
+            reranker.field, config.dim
+        ));
+    }
 
     Ok(RerankerConfig {
         field,
@@ -769,6 +949,27 @@ pub fn convert_reranker(
         matryoshka_dims,
         rrf_k: reranker.rrf_k,
     })
+}
+
+fn validate_binary_document_value(
+    name: &str,
+    field: hermes_core::Field,
+    bytes: &[u8],
+    schema: &Schema,
+) -> Result<(), String> {
+    let config = schema
+        .get_field_entry(field)
+        .and_then(|entry| entry.binary_dense_vector_config.as_ref())
+        .ok_or_else(|| format!("Field '{}' has no binary dense vector config", name))?;
+    if bytes.len() != config.byte_len() {
+        return Err(format!(
+            "Field '{}': binary vector byte length {} does not match schema byte length {}",
+            name,
+            bytes.len(),
+            config.byte_len()
+        ));
+    }
+    Ok(())
 }
 
 pub fn convert_proto_to_document(
@@ -819,13 +1020,31 @@ pub fn convert_proto_to_document(
             // ── Non-numeric types: no coercion needed ──
             // bytes_value coerced to binary_dense_vector when schema says so
             (Some(Value::BytesValue(b)), FieldType::BinaryDenseVector) => {
+                validate_binary_document_value(name, field, b, schema)?;
                 doc.add_binary_dense_vector(field, b.clone());
             }
             (Some(Value::BytesValue(b)), _) => doc.add_bytes(field, b.clone()),
-            (Some(Value::BinaryDenseVector(b)), _) => {
+            (Some(Value::BinaryDenseVector(b)), FieldType::BinaryDenseVector) => {
+                validate_binary_document_value(name, field, b, schema)?;
                 doc.add_binary_dense_vector(field, b.clone());
             }
-            (Some(Value::SparseVector(sv)), _) => {
+            (Some(Value::SparseVector(sv)), FieldType::SparseVector) => {
+                if sv.indices.len() != sv.values.len() {
+                    return Err(format!(
+                        "Field '{}': sparse vector has {} indices but {} values",
+                        name,
+                        sv.indices.len(),
+                        sv.values.len()
+                    ));
+                }
+                if let Some((index, value)) =
+                    sv.values.iter().enumerate().find(|(_, v)| !v.is_finite())
+                {
+                    return Err(format!(
+                        "Field '{}': sparse vector contains non-finite value {value} at index {index}",
+                        name
+                    ));
+                }
                 let entries: Vec<(u32, f32)> = sv
                     .indices
                     .iter()
@@ -834,8 +1053,40 @@ pub fn convert_proto_to_document(
                     .collect();
                 doc.add_sparse_vector(field, entries);
             }
-            (Some(Value::DenseVector(dv)), _) => {
+            (Some(Value::DenseVector(dv)), FieldType::DenseVector) => {
+                let expected_dim = schema
+                    .get_field_entry(field)
+                    .and_then(|field| field.dense_vector_config.as_ref())
+                    .map(|config| config.dim)
+                    .ok_or_else(|| format!("Field '{}' has no dense vector config", name))?;
+                if dv.values.len() != expected_dim {
+                    return Err(format!(
+                        "Field '{}': dense vector dimension {} does not match schema dimension {}",
+                        name,
+                        dv.values.len(),
+                        expected_dim
+                    ));
+                }
+                if let Some((index, value)) = dv
+                    .values
+                    .iter()
+                    .enumerate()
+                    .find(|(_, value)| !value.is_finite())
+                {
+                    return Err(format!(
+                        "Field '{}': dense vector contains non-finite value {value} at index {index}",
+                        name
+                    ));
+                }
                 doc.add_dense_vector(field, dv.values.clone());
+            }
+            (Some(Value::DenseVector(_)), got)
+            | (Some(Value::SparseVector(_)), got)
+            | (Some(Value::BinaryDenseVector(_)), got) => {
+                return Err(format!(
+                    "Field '{}': vector value does not match schema type {:?}",
+                    name, got
+                ));
             }
             // ── JSON: expand string arrays into multi-valued text fields ──
             // Python client serializes list[str] as json_value '["en","fr"]'
@@ -886,6 +1137,203 @@ pub fn convert_proto_to_document(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn token_expansion_is_bounded_before_query_construction() {
+        assert!(validate_token_expansion("test", 256, 256).is_ok());
+        assert!(validate_token_expansion("test", 257, 256).is_err());
+    }
+
+    fn dense_test_schema(nprobe: usize) -> Schema {
+        let mut builder = hermes_core::SchemaBuilder::default();
+        let mut config = hermes_core::dsl::DenseVectorConfig::new(3);
+        config.nprobe = nprobe;
+        builder.add_dense_vector_field_with_config("embedding", true, false, config);
+        builder.add_text_field("title", true, false);
+        builder.build()
+    }
+
+    fn dense_proto_query(vector: Vec<f32>) -> proto::Query {
+        proto::Query {
+            query: Some(ProtoQueryType::DenseVector(proto::DenseVectorQuery {
+                field: "embedding".to_string(),
+                vector,
+                ..Default::default()
+            })),
+        }
+    }
+
+    fn vector_test_schema() -> Schema {
+        let mut builder = hermes_core::SchemaBuilder::default();
+        builder.add_sparse_vector_field("sparse", true, false);
+        builder.add_binary_dense_vector_field("binary", 16, true, false);
+        builder.add_text_field("title", true, false);
+        builder.build()
+    }
+
+    #[test]
+    fn dense_query_uses_schema_nprobe_when_request_omits_it() {
+        let schema = dense_test_schema(17);
+        let query =
+            convert_query(&dense_proto_query(vec![1.0, 2.0, 3.0]), &schema, None, None).unwrap();
+
+        assert!(query.to_string().contains("nprobe=17"));
+    }
+
+    #[test]
+    fn dense_query_rejects_invalid_dimensions_and_values() {
+        let schema = dense_test_schema(17);
+        for vector in [
+            vec![],
+            vec![1.0, 2.0],
+            vec![1.0, 2.0, 3.0, 4.0],
+            vec![1.0, f32::NAN, 3.0],
+            vec![1.0, f32::INFINITY, 3.0],
+            vec![1.0, f32::NEG_INFINITY, 3.0],
+        ] {
+            assert!(
+                convert_query(&dense_proto_query(vector), &schema, None, None).is_err(),
+                "invalid vector should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn dense_query_rejects_wrong_field_and_unbounded_search_parameters() {
+        let schema = dense_test_schema(17);
+        let mut wrong_field = dense_proto_query(vec![1.0, 2.0, 3.0]);
+        let Some(ProtoQueryType::DenseVector(query)) = wrong_field.query.as_mut() else {
+            unreachable!()
+        };
+        query.field = "title".to_string();
+        assert!(convert_query(&wrong_field, &schema, None, None).is_err());
+
+        for rerank_factor in [
+            f32::NAN,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            -1.0,
+            MAX_DENSE_RERANK_FACTOR + 1.0,
+        ] {
+            let mut proto = dense_proto_query(vec![1.0, 2.0, 3.0]);
+            let Some(ProtoQueryType::DenseVector(query)) = proto.query.as_mut() else {
+                unreachable!()
+            };
+            query.rerank_factor = rerank_factor;
+            assert!(
+                convert_query(&proto, &schema, None, None).is_err(),
+                "rerank_factor {rerank_factor} should be rejected"
+            );
+        }
+
+        let mut proto = dense_proto_query(vec![1.0, 2.0, 3.0]);
+        let Some(ProtoQueryType::DenseVector(query)) = proto.query.as_mut() else {
+            unreachable!()
+        };
+        query.nprobe = MAX_DENSE_NPROBE as u32 + 1;
+        assert!(convert_query(&proto, &schema, None, None).is_err());
+    }
+
+    #[test]
+    fn prefix_query_rejects_empty_prefixes() {
+        let schema = dense_test_schema(17);
+        let match_all_prefix = proto::Query {
+            query: Some(ProtoQueryType::Match(proto::MatchQuery {
+                field: "title".to_string(),
+                text: "*".to_string(),
+            })),
+        };
+        let explicit_empty_prefix = proto::Query {
+            query: Some(ProtoQueryType::Prefix(proto::PrefixQuery {
+                field: "title".to_string(),
+                prefix: String::new(),
+            })),
+        };
+
+        assert!(convert_query(&match_all_prefix, &schema, None, None).is_err());
+        assert!(convert_query(&explicit_empty_prefix, &schema, None, None).is_err());
+    }
+
+    #[test]
+    fn binary_query_and_document_require_exact_schema_width() {
+        let schema = vector_test_schema();
+        let query = |field: &str, vector: Vec<u8>| proto::Query {
+            query: Some(ProtoQueryType::BinaryDenseVector(
+                proto::BinaryDenseVectorQuery {
+                    field: field.to_string(),
+                    vector,
+                    ..Default::default()
+                },
+            )),
+        };
+
+        assert!(convert_query(&query("binary", vec![0, 1]), &schema, None, None).is_ok());
+        assert!(convert_query(&query("binary", vec![0]), &schema, None, None).is_err());
+        assert!(convert_query(&query("title", vec![0, 1]), &schema, None, None).is_err());
+
+        let bad_document = [proto::FieldEntry {
+            name: "binary".to_string(),
+            value: Some(proto::FieldValue {
+                value: Some(Value::BinaryDenseVector(vec![0])),
+            }),
+        }];
+        assert!(convert_proto_to_document(&bad_document, &schema).is_err());
+    }
+
+    #[test]
+    fn sparse_query_rejects_malformed_arrays_and_parameters() {
+        let schema = vector_test_schema();
+        let query = |field: &str, indices: Vec<u32>, values: Vec<f32>| proto::Query {
+            query: Some(ProtoQueryType::SparseVector(proto::SparseVectorQuery {
+                field: field.to_string(),
+                indices,
+                values,
+                ..Default::default()
+            })),
+        };
+
+        assert!(convert_query(&query("sparse", vec![1], vec![1.0]), &schema, None, None).is_ok());
+        assert!(
+            convert_query(&query("sparse", vec![1, 2], vec![1.0]), &schema, None, None).is_err()
+        );
+        assert!(
+            convert_query(
+                &query("sparse", vec![1], vec![f32::NAN]),
+                &schema,
+                None,
+                None
+            )
+            .is_err()
+        );
+        assert!(convert_query(&query("title", vec![1], vec![1.0]), &schema, None, None).is_err());
+
+        let mut invalid_factor = query("sparse", vec![1], vec![1.0]);
+        let Some(ProtoQueryType::SparseVector(query)) = invalid_factor.query.as_mut() else {
+            unreachable!()
+        };
+        query.heap_factor = f32::INFINITY;
+        assert!(convert_query(&invalid_factor, &schema, None, None).is_err());
+    }
+
+    #[test]
+    fn reranker_rejects_invalid_rrf_and_matryoshka_dimensions() {
+        let schema = dense_test_schema(17);
+        let base = proto::Reranker {
+            field: "embedding".to_string(),
+            vector: vec![1.0, 2.0, 3.0],
+            ..Default::default()
+        };
+
+        for rrf_k in [f32::NAN, f32::INFINITY, -1.0] {
+            let mut reranker = base.clone();
+            reranker.rrf_k = rrf_k;
+            assert!(convert_reranker(&reranker, &schema).is_err());
+        }
+
+        let mut too_wide = base;
+        too_wide.matryoshka_dims = 4;
+        assert!(convert_reranker(&too_wide, &schema).is_err());
+    }
 
     #[test]
     fn test_schema_to_sdl_roundtrip() {

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -60,6 +60,16 @@ struct Args {
     #[arg(long)]
     worker_threads: Option<usize>,
 
+    /// Maximum number of search RPCs executing concurrently across all
+    /// connections (default: one per 8 CPUs, clamped to 1..=8)
+    #[arg(long)]
+    max_concurrent_searches: Option<usize>,
+
+    /// Rayon threads shared by CPU-bound search work across every index
+    /// (default: one per 4 CPUs, minimum 1)
+    #[arg(long)]
+    search_threads: Option<usize>,
+
     /// Validate all indexes on startup, remove corrupt segments
     #[arg(long)]
     doctor: bool,
@@ -192,6 +202,22 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
     let num_indexing_threads = args
         .indexing_threads
         .unwrap_or_else(|| (num_cpus::get() / 4).max(1));
+    let max_concurrent_searches = args
+        .max_concurrent_searches
+        .unwrap_or_else(|| (num_cpus::get() / 8).clamp(1, 8));
+    if max_concurrent_searches == 0 {
+        return Err(anyhow::anyhow!(
+            "--max-concurrent-searches must be greater than zero"
+        ));
+    }
+    let search_threads = args
+        .search_threads
+        .unwrap_or_else(hermes_core::default_search_threads);
+    if search_threads == 0 {
+        return Err(anyhow::anyhow!(
+            "--search-threads must be greater than zero"
+        ));
+    }
 
     let max_indexing_memory_bytes = args
         .max_indexing_memory_mb
@@ -222,6 +248,7 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
     };
 
     let config = IndexConfig {
+        num_threads: search_threads,
         max_indexing_memory_bytes,
         num_indexing_threads,
         reload_interval_ms: args.reload_interval_ms,
@@ -245,9 +272,8 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
         registry.doctor_all_indexes().await;
     }
 
-    let search_service = search_service::SearchServiceImpl {
-        registry: Arc::clone(&registry),
-    };
+    let search_service =
+        search_service::SearchServiceImpl::new(Arc::clone(&registry), max_concurrent_searches);
 
     let index_service = index_service::IndexServiceImpl {
         registry: Arc::clone(&registry),
@@ -274,6 +300,8 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
     info!("Max indexing memory: {} MB", args.max_indexing_memory_mb);
     info!("Indexing threads: {}", num_indexing_threads);
     info!("Worker threads: {}", worker_threads);
+    info!("Search CPU threads: {}", search_threads);
+    info!("Maximum concurrent searches: {}", max_concurrent_searches);
     info!("Reload interval: {} ms", args.reload_interval_ms);
     if args.optimizer_threads > 0 {
         info!(

--- a/hermes-server/src/search_service.rs
+++ b/hermes-server/src/search_service.rs
@@ -1,9 +1,12 @@
 //! Search service gRPC implementation
 
 use std::collections::HashMap;
+use std::io::Write;
 use std::sync::Arc;
 use std::time::Instant;
 
+use hermes_core::FieldValue as CoreFieldValue;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tonic::{Request, Response, Status};
 
 use crate::converters::{convert_field_value, convert_query, convert_reranker, schema_to_sdl};
@@ -11,9 +14,606 @@ use crate::proto::search_service_server::SearchService;
 use crate::proto::*;
 use crate::registry::IndexRegistry;
 
+const DEFAULT_SEARCH_LIMIT: usize = 10;
+const MAX_SEARCH_LIMIT: usize = 10_000;
+const MAX_SEARCH_WINDOW: usize = 50_000;
+const MAX_RERANK_CANDIDATES: usize = 50_000;
+const MAX_FUSION_FETCH_LIMIT: usize = 50_000;
+const MAX_FUSION_SUB_QUERIES: usize = hermes_core::query::MAX_FUSION_SUB_QUERIES;
+const MAX_FUSION_CANDIDATE_SLOTS: usize = hermes_core::query::MAX_FUSION_CANDIDATE_SLOTS;
+
+// The transport's 4 MiB decode limit bounds wire bytes, not decoded object
+// count or downstream expansion. Empty protobuf messages and strings are only
+// a few bytes on the wire, so keep independent structural budgets here.
+const MAX_QUERY_DEPTH: usize = 32;
+const MAX_QUERY_NODES: usize = 256;
+const MAX_QUERY_CLAUSES: usize = 512;
+const MAX_BOOLEAN_CLAUSES: usize = 128;
+const MAX_QUERY_TEXT_BYTES: usize = 64 * 1024;
+const MAX_FIELD_NAME_BYTES: usize = 255;
+const MAX_INDEX_NAME_BYTES: usize = 255;
+const MAX_DENSE_QUERY_DIMS: usize = 65_536;
+const MAX_SPARSE_QUERY_DIMS: usize = 4_096;
+const MAX_BINARY_QUERY_BYTES: usize = 256 * 1024;
+const MAX_TOTAL_QUERY_VECTOR_BYTES: usize = 1024 * 1024;
+const MAX_FIELDS_TO_LOAD: usize = 64;
+const MAX_FIELDS_TO_LOAD_NAME_BYTES: usize = 16 * 1024;
+
+// Leave headroom below tonic's 64 MiB response limit for compression and
+// framing, and also cap estimated retained heap while the response is built.
+const MAX_SEARCH_RESPONSE_BYTES: usize = 48 * 1024 * 1024;
+const UNKNOWN_INDEX_LABEL: &str = "unknown";
+
+#[derive(Default)]
+struct QueryShapeBudget {
+    nodes: usize,
+    clauses: usize,
+    text_bytes: usize,
+    vector_bytes: usize,
+}
+
+impl QueryShapeBudget {
+    fn add_limited(
+        current: &mut usize,
+        amount: usize,
+        maximum: usize,
+        description: &str,
+    ) -> Result<(), Status> {
+        let next = current
+            .checked_add(amount)
+            .ok_or_else(|| Status::invalid_argument(format!("{description} budget overflows")))?;
+        if next > maximum {
+            return Err(Status::invalid_argument(format!(
+                "{description} must not exceed {maximum} (got {next})"
+            )));
+        }
+        *current = next;
+        Ok(())
+    }
+
+    fn add_node(&mut self, depth: usize) -> Result<(), Status> {
+        if depth > MAX_QUERY_DEPTH {
+            return Err(Status::invalid_argument(format!(
+                "Query nesting depth must not exceed {MAX_QUERY_DEPTH}"
+            )));
+        }
+        Self::add_limited(&mut self.nodes, 1, MAX_QUERY_NODES, "Query node count")
+    }
+
+    fn add_clauses(&mut self, clauses: usize) -> Result<(), Status> {
+        Self::add_limited(
+            &mut self.clauses,
+            clauses,
+            MAX_QUERY_CLAUSES,
+            "Query clause count",
+        )
+    }
+
+    fn add_field_name(&mut self, name: &str, description: &str) -> Result<(), Status> {
+        if name.len() > MAX_FIELD_NAME_BYTES {
+            return Err(Status::invalid_argument(format!(
+                "{description} must not exceed {MAX_FIELD_NAME_BYTES} bytes"
+            )));
+        }
+        self.add_text(name.len())
+    }
+
+    fn add_text(&mut self, bytes: usize) -> Result<(), Status> {
+        Self::add_limited(
+            &mut self.text_bytes,
+            bytes,
+            MAX_QUERY_TEXT_BYTES,
+            "Aggregate query text bytes",
+        )
+    }
+
+    fn add_vector(
+        &mut self,
+        description: &str,
+        elements: usize,
+        element_bytes: usize,
+        maximum_elements: usize,
+    ) -> Result<(), Status> {
+        if elements > maximum_elements {
+            return Err(Status::invalid_argument(format!(
+                "{description} must not exceed {maximum_elements} elements (got {elements})"
+            )));
+        }
+        let bytes = elements
+            .checked_mul(element_bytes)
+            .ok_or_else(|| Status::invalid_argument(format!("{description} size overflows")))?;
+        Self::add_limited(
+            &mut self.vector_bytes,
+            bytes,
+            MAX_TOTAL_QUERY_VECTOR_BYTES,
+            "Aggregate query vector bytes",
+        )
+    }
+}
+
+/// Validate decoded request structure before acquiring scarce search capacity
+/// or recursively converting the protobuf query tree.
+fn validate_search_request_shape(req: &SearchRequest, root: &Query) -> Result<(), Status> {
+    if req.index_name.is_empty() || req.index_name.len() > MAX_INDEX_NAME_BYTES {
+        return Err(Status::invalid_argument(format!(
+            "SearchRequest.index_name must contain 1..={MAX_INDEX_NAME_BYTES} bytes"
+        )));
+    }
+    if req.fields_to_load.len() > MAX_FIELDS_TO_LOAD {
+        return Err(Status::invalid_argument(format!(
+            "SearchRequest.fields_to_load supports at most {MAX_FIELDS_TO_LOAD} names (got {})",
+            req.fields_to_load.len()
+        )));
+    }
+    let mut selected_name_bytes = 0usize;
+    for (index, name) in req.fields_to_load.iter().enumerate() {
+        if name.len() > MAX_FIELD_NAME_BYTES {
+            return Err(Status::invalid_argument(format!(
+                "SearchRequest.fields_to_load[{index}] must not exceed {MAX_FIELD_NAME_BYTES} bytes"
+            )));
+        }
+        selected_name_bytes = selected_name_bytes
+            .checked_add(name.len())
+            .ok_or_else(|| Status::invalid_argument("Field selection byte count overflows"))?;
+    }
+    if selected_name_bytes > MAX_FIELDS_TO_LOAD_NAME_BYTES {
+        return Err(Status::invalid_argument(format!(
+            "SearchRequest.fields_to_load names must total at most \
+             {MAX_FIELDS_TO_LOAD_NAME_BYTES} bytes (got {selected_name_bytes})"
+        )));
+    }
+
+    let mut budget = QueryShapeBudget::default();
+    let mut stack = vec![(root, 1usize)];
+    while let Some((query, depth)) = stack.pop() {
+        budget.add_node(depth)?;
+        let query = query
+            .query
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("Query type is required"))?;
+        match query {
+            query::Query::Term(term) => {
+                budget.add_field_name(&term.field, "TermQuery.field")?;
+                budget.add_text(term.term.len())?;
+            }
+            query::Query::Boolean(boolean) => {
+                let clauses = boolean
+                    .must
+                    .len()
+                    .checked_add(boolean.should.len())
+                    .and_then(|count| count.checked_add(boolean.must_not.len()))
+                    .ok_or_else(|| Status::invalid_argument("Boolean clause count overflows"))?;
+                if clauses > MAX_BOOLEAN_CLAUSES {
+                    return Err(Status::invalid_argument(format!(
+                        "Each BooleanQuery supports at most {MAX_BOOLEAN_CLAUSES} clauses \
+                         (got {clauses})"
+                    )));
+                }
+                budget.add_clauses(clauses)?;
+                stack.extend(
+                    boolean
+                        .must
+                        .iter()
+                        .chain(&boolean.should)
+                        .chain(&boolean.must_not)
+                        .map(|child| (child, depth + 1)),
+                );
+            }
+            query::Query::Boost(boost) => {
+                let child = boost.query.as_deref().ok_or_else(|| {
+                    Status::invalid_argument("BoostQuery requires an inner query")
+                })?;
+                budget.add_clauses(1)?;
+                stack.push((child, depth + 1));
+            }
+            query::Query::All(_) => {}
+            query::Query::SparseVector(sparse) => {
+                budget.add_field_name(&sparse.field, "SparseVectorQuery.field")?;
+                budget.add_text(sparse.text.len())?;
+                budget.add_vector(
+                    "SparseVectorQuery.indices",
+                    sparse.indices.len(),
+                    std::mem::size_of::<u32>(),
+                    MAX_SPARSE_QUERY_DIMS,
+                )?;
+                budget.add_vector(
+                    "SparseVectorQuery.values",
+                    sparse.values.len(),
+                    std::mem::size_of::<f32>(),
+                    MAX_SPARSE_QUERY_DIMS,
+                )?;
+            }
+            query::Query::DenseVector(dense) => {
+                budget.add_field_name(&dense.field, "DenseVectorQuery.field")?;
+                budget.add_vector(
+                    "DenseVectorQuery.vector",
+                    dense.vector.len(),
+                    std::mem::size_of::<f32>(),
+                    MAX_DENSE_QUERY_DIMS,
+                )?;
+            }
+            query::Query::Match(match_query) => {
+                budget.add_field_name(&match_query.field, "MatchQuery.field")?;
+                budget.add_text(match_query.text.len())?;
+            }
+            query::Query::Range(range) => {
+                budget.add_field_name(&range.field, "RangeQuery.field")?;
+            }
+            query::Query::Prefix(prefix) => {
+                budget.add_field_name(&prefix.field, "PrefixQuery.field")?;
+                budget.add_text(prefix.prefix.len())?;
+            }
+            query::Query::BinaryDenseVector(binary) => {
+                budget.add_field_name(&binary.field, "BinaryDenseVectorQuery.field")?;
+                budget.add_vector(
+                    "BinaryDenseVectorQuery.vector",
+                    binary.vector.len(),
+                    1,
+                    MAX_BINARY_QUERY_BYTES,
+                )?;
+            }
+            query::Query::Fusion(fusion) => {
+                if depth != 1 {
+                    return Err(Status::invalid_argument(
+                        "FusionQuery is only supported at the top level",
+                    ));
+                }
+                if fusion.queries.len() > MAX_FUSION_SUB_QUERIES {
+                    return Err(Status::invalid_argument(format!(
+                        "FusionQuery supports at most {MAX_FUSION_SUB_QUERIES} sub-queries \
+                         (got {})",
+                        fusion.queries.len()
+                    )));
+                }
+                budget.add_clauses(fusion.queries.len())?;
+                for weighted in &fusion.queries {
+                    let child = weighted
+                        .query
+                        .as_ref()
+                        .ok_or_else(|| Status::invalid_argument("Fusion sub-query is missing"))?;
+                    stack.push((child, depth + 1));
+                }
+            }
+        }
+    }
+
+    if let Some(reranker) = &req.reranker {
+        budget.add_field_name(&reranker.field, "Reranker.field")?;
+        budget.add_vector(
+            "Reranker.vector",
+            reranker.vector.len(),
+            std::mem::size_of::<f32>(),
+            MAX_DENSE_QUERY_DIMS,
+        )?;
+        budget.add_vector(
+            "Reranker.binary_vector",
+            reranker.binary_vector.len(),
+            1,
+            MAX_BINARY_QUERY_BYTES,
+        )?;
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedField {
+    id: hermes_core::dsl::Field,
+    name: String,
+}
+
+/// Resolve and deduplicate field names once. Unknown names retain the existing
+/// API behavior (they are ignored), while aliases/duplicates cannot multiply
+/// per-hit work or HashMap capacity.
+fn resolve_requested_fields(
+    schema: &hermes_core::Schema,
+    requested: &[String],
+) -> Vec<ResolvedField> {
+    let mut seen = rustc_hash::FxHashSet::default();
+    let mut resolved = Vec::with_capacity(requested.len().min(schema.num_fields()));
+    for name in requested {
+        let Some(id) = schema.get_field(name) else {
+            continue;
+        };
+        if !seen.insert(id.0) {
+            continue;
+        }
+        let canonical_name = schema.get_field_name(id).unwrap_or(name).to_owned();
+        resolved.push(ResolvedField {
+            id,
+            name: canonical_name,
+        });
+    }
+    resolved
+}
+
+#[derive(Debug)]
+struct SearchResponseBudget {
+    retained_bytes: usize,
+    encoded_bytes: usize,
+    maximum: usize,
+}
+
+impl SearchResponseBudget {
+    fn new() -> Self {
+        Self::with_maximum(MAX_SEARCH_RESPONSE_BYTES)
+    }
+
+    fn with_maximum(maximum: usize) -> Self {
+        Self {
+            retained_bytes: 0,
+            encoded_bytes: 0,
+            maximum,
+        }
+    }
+
+    fn reserve(counter: &mut usize, bytes: usize, maximum: usize) -> Result<(), Status> {
+        let next = counter.checked_add(bytes).ok_or_else(|| {
+            Status::resource_exhausted("Search response size accounting overflowed")
+        })?;
+        if next > maximum {
+            return Err(Status::resource_exhausted(format!(
+                "Search response exceeds the {maximum}-byte hydration budget; \
+                 request fewer hits or fields"
+            )));
+        }
+        *counter = next;
+        Ok(())
+    }
+
+    fn reserve_retained(&mut self, bytes: usize) -> Result<(), Status> {
+        Self::reserve(&mut self.retained_bytes, bytes, self.maximum)
+    }
+
+    fn reserve_hit(&mut self, hit: &SearchHit) -> Result<(), Status> {
+        let payload = prost::Message::encoded_len(hit);
+        let framed = payload
+            .checked_add(protobuf_varint_len(payload))
+            .and_then(|bytes| bytes.checked_add(1))
+            .ok_or_else(|| Status::resource_exhausted("Search response encoded size overflowed"))?;
+        Self::reserve(&mut self.encoded_bytes, framed, self.maximum)
+    }
+}
+
+fn protobuf_varint_len(mut value: usize) -> usize {
+    let mut bytes = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        bytes += 1;
+    }
+    bytes
+}
+
+#[derive(Default)]
+struct CountingWriter(usize);
+
+impl Write for CountingWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0 = self
+            .0
+            .checked_add(bytes.len())
+            .ok_or_else(|| std::io::Error::other("serialized JSON size overflow"))?;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Conservative retained-heap estimate charged before cloning a stored value
+/// into its protobuf counterpart. Doubling the value object accounts for Vec
+/// growth slack when a field has many tiny values.
+fn retained_field_value_bytes(value: &CoreFieldValue) -> Result<usize, Status> {
+    let payload = match value {
+        CoreFieldValue::Text(text) => text.len(),
+        CoreFieldValue::U64(_) | CoreFieldValue::I64(_) | CoreFieldValue::F64(_) => 0,
+        CoreFieldValue::Bytes(bytes) | CoreFieldValue::BinaryDenseVector(bytes) => bytes.len(),
+        CoreFieldValue::SparseVector(entries) => entries
+            .len()
+            .checked_mul(std::mem::size_of::<u32>() + std::mem::size_of::<f32>())
+            .ok_or_else(|| Status::resource_exhausted("Sparse field size overflowed"))?,
+        CoreFieldValue::DenseVector(values) => values
+            .len()
+            .checked_mul(std::mem::size_of::<f32>())
+            .ok_or_else(|| Status::resource_exhausted("Dense field size overflowed"))?,
+        CoreFieldValue::Json(json) => {
+            let mut writer = CountingWriter::default();
+            serde_json::to_writer(&mut writer, json).map_err(|error| {
+                Status::internal(format!("Failed to size JSON response field: {error}"))
+            })?;
+            writer.0
+        }
+    };
+    std::mem::size_of::<FieldValue>()
+        .saturating_mul(2)
+        .checked_add(payload)
+        .ok_or_else(|| Status::resource_exhausted("Response field size overflowed"))
+}
+
+fn retained_hit_base_bytes(ordinal_count: usize) -> Result<usize, Status> {
+    ordinal_count
+        .checked_mul(std::mem::size_of::<OrdinalScore>())
+        .and_then(|bytes| bytes.checked_add(std::mem::size_of::<SearchHit>()))
+        .and_then(|bytes| bytes.checked_add(32)) // segment-id String backing bytes
+        .ok_or_else(|| Status::resource_exhausted("Search hit size overflowed"))
+}
+
+fn retained_field_entry_bytes(name: &str) -> usize {
+    // HashMap growth keeps spare buckets. Charge two entries so many tiny
+    // fields cannot evade the payload budget through container overhead.
+    (std::mem::size_of::<String>() + std::mem::size_of::<FieldValueList>())
+        .saturating_mul(2)
+        .saturating_add(name.len())
+}
+
+fn canonical_metric_index_label(schema: &hermes_core::Schema) -> &str {
+    schema.index_label()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SearchBudget {
+    /// Number of results returned to the caller.
+    final_limit: usize,
+    /// Number of leading results skipped for pagination.
+    offset: usize,
+    /// Number of ranked results required before applying the offset.
+    search_limit: usize,
+    rerank_l1_limit: Option<usize>,
+    fusion_fetch_limit: Option<usize>,
+}
+
+fn bounded_limit(name: &str, value: u32, default: usize, max: usize) -> Result<usize, Status> {
+    let value = if value == 0 { default } else { value as usize };
+    if value > max {
+        return Err(Status::invalid_argument(format!(
+            "{name} must not exceed {max} (got {value})"
+        )));
+    }
+    Ok(value)
+}
+
+fn try_acquire_search_permit(permits: &Arc<Semaphore>) -> Result<OwnedSemaphorePermit, Status> {
+    Arc::clone(permits)
+        .try_acquire_owned()
+        .map_err(|_| Status::resource_exhausted("Search capacity is full; retry with backoff"))
+}
+
+/// Validate all request-controlled result and candidate depths before opening
+/// an index, constructing queries, or allocating candidate lists.
+fn validate_search_budget(req: &SearchRequest) -> Result<SearchBudget, Status> {
+    let query = req
+        .query
+        .as_ref()
+        .ok_or_else(|| Status::invalid_argument("Query is required"))?;
+    validate_search_request_shape(req, query)?;
+    let final_limit = bounded_limit(
+        "SearchRequest.limit",
+        req.limit,
+        DEFAULT_SEARCH_LIMIT,
+        MAX_SEARCH_LIMIT,
+    )?;
+    let offset = req.offset as usize;
+    let search_limit = offset
+        .checked_add(final_limit)
+        .ok_or_else(|| Status::invalid_argument("Search result window is too large"))?;
+    if search_limit > MAX_SEARCH_WINDOW {
+        return Err(Status::invalid_argument(format!(
+            "SearchRequest.offset + limit must not exceed {MAX_SEARCH_WINDOW} \
+             (got {offset} + {final_limit} = {search_limit})"
+        )));
+    }
+
+    let rerank_l1_limit = match &req.reranker {
+        Some(reranker) if reranker.limit > 0 => Some(bounded_limit(
+            "Reranker.limit",
+            reranker.limit,
+            search_limit,
+            MAX_RERANK_CANDIDATES,
+        )?),
+        Some(_) => Some(
+            search_limit
+                .checked_mul(10)
+                .ok_or_else(|| Status::invalid_argument("Reranker limit is too large"))?
+                .min(MAX_RERANK_CANDIDATES),
+        ),
+        None => None,
+    };
+    if req
+        .reranker
+        .as_ref()
+        .is_some_and(|reranker| reranker.limit > 0)
+        && rerank_l1_limit.is_some_and(|l1_limit| l1_limit < search_limit)
+    {
+        return Err(Status::invalid_argument(format!(
+            "Reranker.limit must be at least offset + limit ({search_limit})"
+        )));
+    }
+
+    let fusion_fetch_limit = if let Some(query::Query::Fusion(fusion)) = &query.query {
+        if fusion.queries.is_empty() {
+            return Err(Status::invalid_argument(
+                "FusionQuery requires at least one sub-query",
+            ));
+        }
+        if fusion.queries.len() > MAX_FUSION_SUB_QUERIES {
+            return Err(Status::invalid_argument(format!(
+                "FusionQuery supports at most {MAX_FUSION_SUB_QUERIES} sub-queries (got {})",
+                fusion.queries.len()
+            )));
+        }
+        if !fusion.rrf_k.is_finite() || fusion.rrf_k < 0.0 {
+            return Err(Status::invalid_argument(format!(
+                "FusionQuery.rrf_k must be finite and non-negative (got {})",
+                fusion.rrf_k
+            )));
+        }
+        for (index, weighted) in fusion.queries.iter().enumerate() {
+            if !weighted.weight.is_finite() || weighted.weight < 0.0 {
+                return Err(Status::invalid_argument(format!(
+                    "FusionQuery.queries[{index}].weight must be finite and non-negative \
+                     (got {})",
+                    weighted.weight
+                )));
+            }
+        }
+
+        let fused_limit = rerank_l1_limit.unwrap_or(search_limit);
+        let fetch_limit = if fusion.fetch_limit > 0 {
+            bounded_limit(
+                "FusionQuery.fetch_limit",
+                fusion.fetch_limit,
+                fused_limit,
+                MAX_FUSION_FETCH_LIMIT,
+            )?
+        } else {
+            fused_limit
+                .checked_mul(4)
+                .ok_or_else(|| Status::invalid_argument("Fusion fetch limit is too large"))?
+                .clamp(50, MAX_FUSION_FETCH_LIMIT)
+        };
+
+        let candidate_slots = fetch_limit
+            .checked_mul(fusion.queries.len())
+            .ok_or_else(|| Status::invalid_argument("Fusion candidate budget is too large"))?;
+        if candidate_slots > MAX_FUSION_CANDIDATE_SLOTS {
+            return Err(Status::invalid_argument(format!(
+                "FusionQuery candidate budget must not exceed {MAX_FUSION_CANDIDATE_SLOTS} \
+                 (fetch_limit {fetch_limit} x {} sub-queries = {candidate_slots})",
+                fusion.queries.len()
+            )));
+        }
+        Some(fetch_limit)
+    } else {
+        None
+    };
+
+    Ok(SearchBudget {
+        final_limit,
+        offset,
+        search_limit,
+        rerank_l1_limit,
+        fusion_fetch_limit,
+    })
+}
+
 /// Search service implementation
 pub struct SearchServiceImpl {
     pub registry: Arc<IndexRegistry>,
+    search_permits: Arc<Semaphore>,
+}
+
+impl SearchServiceImpl {
+    pub fn new(registry: Arc<IndexRegistry>, max_concurrent_searches: usize) -> Self {
+        assert!(
+            max_concurrent_searches > 0,
+            "max_concurrent_searches must be greater than zero"
+        );
+        Self {
+            registry,
+            search_permits: Arc::new(Semaphore::new(max_concurrent_searches)),
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -23,11 +623,28 @@ impl SearchService for SearchServiceImpl {
         request: Request<SearchRequest>,
     ) -> Result<Response<SearchResponse>, Status> {
         let req = request.into_inner();
-        let index_name = req.index_name.clone();
+        let metric_index = std::sync::OnceLock::new();
         let t = std::time::Instant::now();
         let result = async {
+        let budget = validate_search_budget(&req)?;
+
+        // Bound expensive pipelines across all HTTP/2 connections without an
+        // unbounded waiter queue retaining decoded requests under overload.
+        // Dropping the owned permit on completion/error/cancellation is safe.
+        let _search_permit = match try_acquire_search_permit(&self.search_permits) {
+            Ok(permit) => permit,
+            Err(status) => {
+                metrics::counter!(
+                    "hermes_search_admission_rejected_total",
+                    "index" => UNKNOWN_INDEX_LABEL,
+                )
+                .increment(1);
+                return Err(status);
+            }
+        };
 
         let index = self.registry.get_or_open_index(&req.index_name).await?;
+        let _ = metric_index.set(canonical_metric_index_label(index.schema()).to_owned());
         let reader = index
             .reader()
             .await
@@ -41,11 +658,9 @@ impl SearchService for SearchServiceImpl {
             .query
             .ok_or_else(|| Status::invalid_argument("Query is required"))?;
 
-        let limit = if req.limit == 0 {
-            10
-        } else {
-            req.limit as usize
-        };
+        // Rank enough results to cover the requested page, then apply the
+        // offset only after fusion/reranking so pagination preserves ranking.
+        let limit = budget.search_limit;
 
         // Optional L2 reranker config; the L1 pool it consumes is either a
         // single query's results or the fused union of sub-query results.
@@ -53,11 +668,9 @@ impl SearchService for SearchServiceImpl {
             Some(reranker) => {
                 let config = convert_reranker(reranker, reader.schema())
                     .map_err(|e| Status::invalid_argument(format!("Invalid reranker: {}", e)))?;
-                let l1_limit = if reranker.limit == 0 {
-                    limit * 10
-                } else {
-                    reranker.limit as usize
-                };
+                let l1_limit = budget
+                    .rerank_l1_limit
+                    .ok_or_else(|| Status::internal("Missing validated reranker budget"))?;
                 Some((config, l1_limit))
             }
             None => None,
@@ -94,12 +707,6 @@ impl SearchService for SearchServiceImpl {
                     };
                     sub_queries.push((core, weight));
                 }
-                if sub_queries.is_empty() {
-                    return Err(Status::invalid_argument(
-                        "FusionQuery requires at least one sub-query",
-                    ));
-                }
-
                 let method = match fusion.method() {
                     crate::proto::FusionMethod::FusionRrf => {
                         hermes_core::query::FusionMethod::Rrf {
@@ -117,11 +724,9 @@ impl SearchService for SearchServiceImpl {
 
                 // With a reranker, the fused list is the L1 candidate pool.
                 let fused_limit = rerank_setup.as_ref().map_or(limit, |&(_, l1)| l1);
-                let fetch_limit = if fusion.fetch_limit > 0 {
-                    fusion.fetch_limit as usize
-                } else {
-                    (fused_limit * 4).max(50)
-                };
+                let fetch_limit = budget
+                    .fusion_fetch_limit
+                    .ok_or_else(|| Status::internal("Missing validated fusion budget"))?;
 
                 // Chunk combiner for fused per-ordinal scores. Unset (0) maps
                 // to Max — LogSumExp is unsuitable at RRF score magnitudes.
@@ -143,22 +748,20 @@ impl SearchService for SearchServiceImpl {
                     query_desc
                 );
 
-                let mut lists = Vec::with_capacity(sub_queries.len());
-                let mut seen: u32 = 0;
-                for (sub, weight) in &sub_queries {
-                    let (sub_results, sub_seen) = searcher
-                        .search_with_positions(sub.as_ref(), fetch_limit)
-                        .await
-                        .map_err(crate::error::hermes_error_to_status)?;
-                    seen = seen.saturating_add(sub_seen);
-                    lists.push((sub_results, *weight));
-                }
-                let fused = hermes_core::query::fuse_ranked_lists_chunked(
-                    lists,
-                    method,
-                    combiner,
-                    fused_limit,
-                );
+                let query_refs: Vec<(&dyn hermes_core::query::Query, f32)> = sub_queries
+                    .iter()
+                    .map(|(query, weight)| (query.as_ref(), *weight))
+                    .collect();
+                let (fused, seen) = searcher
+                    .search_fused_with_count(
+                        &query_refs,
+                        fetch_limit,
+                        fused_limit,
+                        method,
+                        combiner,
+                    )
+                    .await
+                    .map_err(crate::error::hermes_error_to_status)?;
                 let rerank_config = rerank_setup.map(|(config, _)| (config, limit));
                 (fused, seen, rerank_config)
             } else {
@@ -203,25 +806,27 @@ impl SearchService for SearchServiceImpl {
         } else {
             results
         };
+        let results: Vec<_> = results
+            .into_iter()
+            .skip(budget.offset)
+            .take(budget.final_limit)
+            .collect();
         let rerank_us = t_rerank.elapsed().as_micros() as u64;
 
         // ── Phase 3: Document field loading ─────────────────────────────────
         let t_load = Instant::now();
 
-        // Resolve requested field names to field IDs once (not per-hit).
-        // Only vector fields in this set will be hydrated from flat storage.
+        // Resolve names once and iterate only canonical, unique fields per hit.
+        // The request-shape validator has already bounded the raw name list.
+        let requested_fields =
+            resolve_requested_fields(searcher.schema(), &req.fields_to_load);
         let requested_field_ids: Option<rustc_hash::FxHashSet<u32>> =
-            if req.fields_to_load.is_empty() {
-                None
-            } else {
-                Some(
-                    req.fields_to_load
-                        .iter()
-                        .filter_map(|name| searcher.schema().get_field(name))
-                        .map(|f| f.0)
-                        .collect(),
-                )
-            };
+            (!requested_fields.is_empty()).then(|| {
+                requested_fields
+                    .iter()
+                    .map(|requested| requested.id.0)
+                    .collect()
+            });
 
         // Debug: detect duplicate doc_ids across results (only in debug builds)
         #[cfg(debug_assertions)]
@@ -246,12 +851,28 @@ impl SearchService for SearchServiceImpl {
             }
         }
 
-        let num_fields = req.fields_to_load.len();
+        let mut response_budget = SearchResponseBudget::new();
         let mut hits = Vec::with_capacity(results.len());
         for result in results {
-            let mut fields: HashMap<String, FieldValueList> = HashMap::with_capacity(num_fields);
+            // Convert ordinal scores before hydration so their retained memory
+            // is charged before reading potentially large stored fields.
+            let ordinal_scores: Vec<OrdinalScore> = result
+                .positions
+                .iter()
+                .flat_map(|(_, scored_positions)| {
+                    scored_positions.iter().map(|sp| OrdinalScore {
+                        ordinal: sp.position, // vector position contains the ordinal
+                        score: sp.score,
+                    })
+                })
+                .collect();
+            response_budget.reserve_retained(retained_hit_base_bytes(ordinal_scores.len())?)?;
 
-            if !req.fields_to_load.is_empty() {
+            // Allocate map buckets only for fields that actually have values.
+            // Pre-sizing every hit from raw request count was an OOM multiplier.
+            let mut fields: HashMap<String, FieldValueList> = HashMap::new();
+
+            if !requested_fields.is_empty() {
                 let doc = searcher
                     .get_document_with_fields(
                         &hermes_core::query::DocAddress::new(result.segment_id, result.doc_id),
@@ -261,31 +882,30 @@ impl SearchService for SearchServiceImpl {
                     .map_err(crate::error::hermes_error_to_status)?;
 
                 if let Some(doc) = doc {
-                    for field_name in &req.fields_to_load {
-                        if let Some(field) = searcher.schema().get_field(field_name) {
-                            let values: Vec<_> =
-                                doc.get_all(field).map(convert_field_value).collect();
-                            if !values.is_empty() {
-                                fields.insert(field_name.clone(), FieldValueList { values });
-                            }
+                    for requested in &requested_fields {
+                        let mut values = Vec::new();
+                        for value in doc.get_all(requested.id) {
+                            // Charge retained payload before cloning it into
+                            // the response, so a single oversized value fails
+                            // without first doubling its memory footprint.
+                            response_budget
+                                .reserve_retained(retained_field_value_bytes(value)?)?;
+                            values.push(convert_field_value(value));
+                        }
+                        if !values.is_empty() {
+                            response_budget.reserve_retained(retained_field_entry_bytes(
+                                &requested.name,
+                            ))?;
+                            fields.insert(
+                                requested.name.clone(),
+                                FieldValueList { values },
+                            );
                         }
                     }
                 }
             }
 
-            // Convert ordinal scores from positions
-            let ordinal_scores: Vec<OrdinalScore> = result
-                .positions
-                .iter()
-                .flat_map(|(_, scored_positions)| {
-                    scored_positions.iter().map(|sp| OrdinalScore {
-                        ordinal: sp.position, // position contains the ordinal for vector fields
-                        score: sp.score,
-                    })
-                })
-                .collect();
-
-            hits.push(SearchHit {
+            let hit = SearchHit {
                 address: Some(DocAddress {
                     segment_id: format!("{:032x}", result.segment_id),
                     doc_id: result.doc_id,
@@ -293,7 +913,9 @@ impl SearchService for SearchServiceImpl {
                 score: result.score,
                 fields,
                 ordinal_scores,
-            });
+            };
+            response_budget.reserve_hit(&hit)?;
+            hits.push(hit);
         }
         let load_us = t_load.elapsed().as_micros() as u64;
 
@@ -329,15 +951,19 @@ impl SearchService for SearchServiceImpl {
             }
         .await;
         let status = if result.is_ok() { "ok" } else { "error" };
+        let metric_index = metric_index
+            .get()
+            .cloned()
+            .unwrap_or_else(|| UNKNOWN_INDEX_LABEL.to_owned());
         metrics::histogram!(
             "hermes_search_duration_seconds",
-            "index" => index_name.clone(),
+            "index" => metric_index.clone(),
             "status" => status,
         )
         .record(t.elapsed().as_secs_f64());
         metrics::counter!(
             "hermes_search_requests_total",
-            "index" => index_name,
+            "index" => metric_index,
             "status" => status,
         )
         .increment(1);
@@ -505,5 +1131,382 @@ impl SearchService for SearchServiceImpl {
             memory_stats: Some(memory_stats),
             vector_stats,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tonic::Code;
+
+    fn all_query() -> Query {
+        Query {
+            query: Some(query::Query::All(AllQuery::default())),
+        }
+    }
+
+    fn ordinary_request() -> SearchRequest {
+        SearchRequest {
+            index_name: "test-index".to_string(),
+            query: Some(all_query()),
+            ..Default::default()
+        }
+    }
+
+    fn fusion_request(sub_queries: usize, fetch_limit: u32) -> SearchRequest {
+        SearchRequest {
+            index_name: "test-index".to_string(),
+            query: Some(Query {
+                query: Some(query::Query::Fusion(FusionQuery {
+                    queries: (0..sub_queries)
+                        .map(|_| WeightedQuery {
+                            query: Some(all_query()),
+                            weight: 1.0,
+                        })
+                        .collect(),
+                    fetch_limit,
+                    ..Default::default()
+                })),
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn search_budget_applies_defaults() {
+        let budget = validate_search_budget(&ordinary_request()).unwrap();
+
+        assert_eq!(budget.final_limit, DEFAULT_SEARCH_LIMIT);
+        assert_eq!(budget.offset, 0);
+        assert_eq!(budget.search_limit, DEFAULT_SEARCH_LIMIT);
+        assert_eq!(budget.rerank_l1_limit, None);
+        assert_eq!(budget.fusion_fetch_limit, None);
+    }
+
+    #[test]
+    fn search_budget_rejects_missing_or_oversized_index_name() {
+        let mut req = ordinary_request();
+        req.index_name.clear();
+        assert_eq!(
+            validate_search_budget(&req).unwrap_err().code(),
+            Code::InvalidArgument
+        );
+
+        req.index_name = "x".repeat(MAX_INDEX_NAME_BYTES + 1);
+        assert_eq!(
+            validate_search_budget(&req).unwrap_err().code(),
+            Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn search_budget_rejects_excessive_final_limit() {
+        let mut req = ordinary_request();
+        req.limit = (MAX_SEARCH_LIMIT + 1) as u32;
+
+        let err = validate_search_budget(&req).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    #[test]
+    fn search_budget_accounts_for_offset_and_bounds_the_result_window() {
+        let mut req = ordinary_request();
+        req.limit = 100;
+        req.offset = 400;
+        let budget = validate_search_budget(&req).unwrap();
+        assert_eq!(budget.final_limit, 100);
+        assert_eq!(budget.offset, 400);
+        assert_eq!(budget.search_limit, 500);
+
+        req.limit = DEFAULT_SEARCH_LIMIT as u32;
+        req.offset = (MAX_SEARCH_WINDOW - DEFAULT_SEARCH_LIMIT) as u32;
+        assert!(validate_search_budget(&req).is_ok());
+
+        req.offset += 1;
+        let err = validate_search_budget(&req).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    #[test]
+    fn search_budget_bounds_default_and_explicit_rerank_depths() {
+        let mut default_req = ordinary_request();
+        default_req.limit = MAX_SEARCH_LIMIT as u32;
+        default_req.reranker = Some(Reranker::default());
+        assert_eq!(
+            validate_search_budget(&default_req)
+                .unwrap()
+                .rerank_l1_limit,
+            Some(MAX_RERANK_CANDIDATES)
+        );
+
+        let mut excessive_req = ordinary_request();
+        excessive_req.reranker = Some(Reranker {
+            limit: (MAX_RERANK_CANDIDATES + 1) as u32,
+            ..Default::default()
+        });
+        let err = validate_search_budget(&excessive_req).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+
+        let mut impossible_page = ordinary_request();
+        impossible_page.limit = 10;
+        impossible_page.offset = 1_000;
+        impossible_page.reranker = Some(Reranker {
+            limit: 100,
+            ..Default::default()
+        });
+        let err = validate_search_budget(&impossible_page).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    #[test]
+    fn search_admission_rejects_overload_without_queueing() {
+        let permits = Arc::new(Semaphore::new(1));
+        let permit = try_acquire_search_permit(&permits).unwrap();
+
+        let err = try_acquire_search_permit(&permits).unwrap_err();
+        assert_eq!(err.code(), Code::ResourceExhausted);
+
+        drop(permit);
+        assert!(try_acquire_search_permit(&permits).is_ok());
+    }
+
+    #[test]
+    fn fusion_budget_accepts_existing_fetch_depth() {
+        let req = fusion_request(2, 4_800);
+
+        assert_eq!(
+            validate_search_budget(&req).unwrap().fusion_fetch_limit,
+            Some(4_800)
+        );
+    }
+
+    #[test]
+    fn fusion_budget_rejects_too_many_sub_queries_before_conversion() {
+        let req = fusion_request(MAX_FUSION_SUB_QUERIES + 1, 50);
+
+        let err = validate_search_budget(&req).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    #[test]
+    fn fusion_budget_rejects_excessive_fetch_and_aggregate_work() {
+        let excessive_fetch = fusion_request(2, (MAX_FUSION_FETCH_LIMIT + 1) as u32);
+        assert_eq!(
+            validate_search_budget(&excessive_fetch).unwrap_err().code(),
+            Code::InvalidArgument
+        );
+
+        let excessive_aggregate = fusion_request(5, MAX_FUSION_FETCH_LIMIT as u32);
+        assert_eq!(
+            validate_search_budget(&excessive_aggregate)
+                .unwrap_err()
+                .code(),
+            Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn fusion_default_fetch_is_checked_and_capped() {
+        let mut req = fusion_request(2, 0);
+        req.limit = MAX_SEARCH_LIMIT as u32;
+        req.reranker = Some(Reranker::default());
+
+        let budget = validate_search_budget(&req).unwrap();
+        assert_eq!(budget.rerank_l1_limit, Some(MAX_RERANK_CANDIDATES));
+        assert_eq!(budget.fusion_fetch_limit, Some(MAX_FUSION_FETCH_LIMIT));
+    }
+
+    #[test]
+    fn fusion_budget_rejects_non_finite_or_negative_scoring_parameters() {
+        for rrf_k in [f32::NAN, f32::INFINITY, -1.0] {
+            let mut req = fusion_request(2, 50);
+            let Some(query::Query::Fusion(fusion)) =
+                req.query.as_mut().and_then(|query| query.query.as_mut())
+            else {
+                unreachable!();
+            };
+            fusion.rrf_k = rrf_k;
+            assert_eq!(
+                validate_search_budget(&req).unwrap_err().code(),
+                Code::InvalidArgument
+            );
+        }
+
+        for weight in [f32::NAN, f32::INFINITY, -1.0] {
+            let mut req = fusion_request(2, 50);
+            let Some(query::Query::Fusion(fusion)) =
+                req.query.as_mut().and_then(|query| query.query.as_mut())
+            else {
+                unreachable!();
+            };
+            fusion.queries[0].weight = weight;
+            assert_eq!(
+                validate_search_budget(&req).unwrap_err().code(),
+                Code::InvalidArgument
+            );
+        }
+    }
+
+    #[test]
+    fn request_shape_rejects_field_and_boolean_amplification() {
+        let mut too_many_fields = ordinary_request();
+        too_many_fields.fields_to_load = vec![String::new(); MAX_FIELDS_TO_LOAD + 1];
+        assert_eq!(
+            validate_search_budget(&too_many_fields).unwrap_err().code(),
+            Code::InvalidArgument
+        );
+
+        let mut too_many_clauses = ordinary_request();
+        too_many_clauses.query = Some(Query {
+            query: Some(query::Query::Boolean(BooleanQuery {
+                must: (0..=MAX_BOOLEAN_CLAUSES).map(|_| all_query()).collect(),
+                ..Default::default()
+            })),
+        });
+        assert_eq!(
+            validate_search_budget(&too_many_clauses)
+                .unwrap_err()
+                .code(),
+            Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn request_shape_rejects_depth_node_text_and_vector_expansion() {
+        let mut nested = all_query();
+        for _ in 0..MAX_QUERY_DEPTH {
+            nested = Query {
+                query: Some(query::Query::Boost(Box::new(BoostQuery {
+                    query: Some(Box::new(nested)),
+                    boost: 1.0,
+                }))),
+            };
+        }
+        let mut excessive_depth = ordinary_request();
+        excessive_depth.query = Some(nested);
+        assert_eq!(
+            validate_search_budget(&excessive_depth).unwrap_err().code(),
+            Code::InvalidArgument
+        );
+
+        // 1 root + 128 Boolean children + 128 leaves exceeds the node budget,
+        // while each Boolean and the aggregate clause count remain legal.
+        let branches = (0..MAX_BOOLEAN_CLAUSES)
+            .map(|_| Query {
+                query: Some(query::Query::Boolean(BooleanQuery {
+                    must: vec![all_query()],
+                    ..Default::default()
+                })),
+            })
+            .collect();
+        let mut excessive_nodes = ordinary_request();
+        excessive_nodes.query = Some(Query {
+            query: Some(query::Query::Boolean(BooleanQuery {
+                should: branches,
+                ..Default::default()
+            })),
+        });
+        assert_eq!(
+            validate_search_budget(&excessive_nodes).unwrap_err().code(),
+            Code::InvalidArgument
+        );
+
+        let mut excessive_text = ordinary_request();
+        excessive_text.query = Some(Query {
+            query: Some(query::Query::Match(MatchQuery {
+                field: "body".to_owned(),
+                text: "x".repeat(MAX_QUERY_TEXT_BYTES + 1),
+            })),
+        });
+        assert_eq!(
+            validate_search_budget(&excessive_text).unwrap_err().code(),
+            Code::InvalidArgument
+        );
+
+        let mut excessive_vector = ordinary_request();
+        excessive_vector.query = Some(Query {
+            query: Some(query::Query::DenseVector(DenseVectorQuery {
+                field: "embedding".to_owned(),
+                vector: vec![0.0; MAX_DENSE_QUERY_DIMS + 1],
+                ..Default::default()
+            })),
+        });
+        assert_eq!(
+            validate_search_budget(&excessive_vector)
+                .unwrap_err()
+                .code(),
+            Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn requested_fields_are_resolved_and_deduplicated_once() {
+        let mut builder = hermes_core::SchemaBuilder::default();
+        let title = builder.add_text_field("title", true, true);
+        let body = builder.add_text_field("body", true, true);
+        let schema = builder.build();
+        let requested = vec![
+            "title".to_owned(),
+            "missing".to_owned(),
+            "title".to_owned(),
+            "body".to_owned(),
+        ];
+
+        assert_eq!(
+            resolve_requested_fields(&schema, &requested),
+            vec![
+                ResolvedField {
+                    id: title,
+                    name: "title".to_owned(),
+                },
+                ResolvedField {
+                    id: body,
+                    name: "body".to_owned(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn response_budget_bounds_retained_and_encoded_bytes() {
+        let value = CoreFieldValue::Bytes(vec![0; 64]);
+        assert!(retained_field_value_bytes(&value).unwrap() > 64);
+
+        let mut retained = SearchResponseBudget::with_maximum(100);
+        retained.reserve_retained(80).unwrap();
+        let err = retained.reserve_retained(21).unwrap_err();
+        assert_eq!(err.code(), Code::ResourceExhausted);
+
+        let hit = SearchHit {
+            address: Some(DocAddress {
+                segment_id: "0".repeat(32),
+                doc_id: 1,
+            }),
+            score: 1.0,
+            fields: HashMap::from([(
+                "body".to_owned(),
+                FieldValueList {
+                    values: vec![FieldValue {
+                        value: Some(field_value::Value::Text("x".repeat(128))),
+                    }],
+                },
+            )]),
+            ordinal_scores: Vec::new(),
+        };
+        let mut encoded = SearchResponseBudget::with_maximum(64);
+        let err = encoded.reserve_hit(&hit).unwrap_err();
+        assert_eq!(err.code(), Code::ResourceExhausted);
+    }
+
+    #[test]
+    fn metrics_use_only_canonical_schema_labels() {
+        let mut builder = hermes_core::SchemaBuilder::default();
+        builder.add_text_field("title", true, true);
+        let mut schema = builder.build();
+
+        assert_eq!(UNKNOWN_INDEX_LABEL, "unknown");
+        assert_eq!(canonical_metric_index_label(&schema), UNKNOWN_INDEX_LABEL);
+        schema.set_index_name("known-index");
+        assert_eq!(canonical_metric_index_label(&schema), "known-index");
     }
 }


### PR DESCRIPTION
Bounds shared search and reorder CPU, request amplification, fusion, reranking, response memory, and ANN candidate work while reducing collector allocations. Makes merge/reorder ownership and trained-vector artifact publication cancellation-safe and fail-closed, preventing orphan segments, retry loops, starvation, and mixed generations. Hardens vector, sparse, store, SSTable, and fast-field decoding against corrupt ranges and oversized allocations, with expanded regression tests and operational documentation. Validated with the full hermes-core and hermes-server suites, strict clippy, formatting, and the native feature build.