### PR TITLE
Fix WASM search scoring build

### DIFF
--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -363,6 +363,7 @@ impl IndexMetadata {
     }
 
     /// Fallible schema-aware loader used for lifecycle publication.
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub(crate) async fn try_load_trained_from_fields<D: crate::directories::Directory>(
         vector_fields: &HashMap<u32, FieldVectorMeta>,
         schema: &Schema,

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -480,16 +480,17 @@ impl<D: Directory + 'static> Searcher<D> {
     }
 
     /// Run a bounded piece of CPU work inside this index's shared search pool.
-    /// Async-only/WASM builds execute inline because Rayon is not available.
+    #[cfg(feature = "sync")]
     pub(crate) fn install_search_cpu<R: Send>(&self, operation: impl FnOnce() -> R + Send) -> R {
-        #[cfg(feature = "sync")]
-        {
-            self.search_pool.install(operation)
-        }
-        #[cfg(not(feature = "sync"))]
-        {
-            operation()
-        }
+        self.search_pool.install(operation)
+    }
+
+    /// Async-only/WASM builds execute inline because Rayon is not available.
+    /// Keeping this overload free of `Send` bounds allows browser-backed file
+    /// handles, whose callbacks are deliberately thread-local, to be scored.
+    #[cfg(not(feature = "sync"))]
+    pub(crate) fn install_search_cpu<R>(&self, operation: impl FnOnce() -> R) -> R {
+        operation()
     }
 
     /// Get number of segments

--- a/hermes-core/src/segment/builder/dense.rs
+++ b/hermes-core/src/segment/builder/dense.rs
@@ -337,6 +337,7 @@ pub(super) fn build_vectors_streaming(
     // Stream binary dense vector fields (packed bits, Hamming distance)
     for ((field_id, builder), data_size) in binary_fields.into_iter().zip(binary_field_sizes) {
         let data_offset = current_offset;
+        #[cfg(feature = "native")]
         let num_vectors = builder.len();
 
         FlatVectorData::serialize_binary_from_bits_streaming(


### PR DESCRIPTION
Removes native Send bounds from the inline WASM CPU-scoring path so browser-backed file handles remain valid. Gates the native-only binary IVF vector count and suppresses the intentionally native-only artifact loader warning on non-native builds. Verified with the hermes-wasm target under RUSTFLAGS=-Dwarnings and strict native clippy.