### PR TITLE
perf(llm): optimize CUDA training and decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,7 @@ source = "git+https://github.com/tracel-ai/burn.git?rev=bd6e8fa2f23c2ecea1044af1
 dependencies = [
  "burn-backend",
  "burn-cubecl",
+ "burn-fusion",
  "cubecl",
 ]
 
@@ -591,6 +592,7 @@ source = "git+https://github.com/tracel-ai/burn.git?rev=bd6e8fa2f23c2ecea1044af1
 dependencies = [
  "burn-backend",
  "burn-cubecl",
+ "burn-fusion",
  "cubecl",
 ]
 
@@ -616,6 +618,7 @@ dependencies = [
  "burn-cuda",
  "burn-flex",
  "burn-ndarray",
+ "burn-remote",
  "burn-rocm",
  "burn-tch",
  "burn-wgpu",
@@ -725,13 +728,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "burn-remote"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn.git?rev=bd6e8fa2f23c2ecea1044af149bdc9e698a0848d#bd6e8fa2f23c2ecea1044af149bdc9e698a0848d"
+dependencies = [
+ "burn-backend",
+ "burn-fusion",
+ "burn-ir",
+ "burn-router",
+ "burn-std",
+ "bytes",
+ "futures-util",
+ "gloo-timers",
+ "log",
+ "rand 0.10.2",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "tokio",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
 source = "git+https://github.com/tracel-ai/burn.git?rev=bd6e8fa2f23c2ecea1044af149bdc9e698a0848d#bd6e8fa2f23c2ecea1044af149bdc9e698a0848d"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
+ "burn-fusion",
  "cubecl",
+]
+
+[[package]]
+name = "burn-router"
+version = "0.22.0-pre.1"
+source = "git+https://github.com/tracel-ai/burn.git?rev=bd6e8fa2f23c2ecea1044af149bdc9e698a0848d#bd6e8fa2f23c2ecea1044af149bdc9e698a0848d"
+dependencies = [
+ "burn-backend",
+ "burn-fusion",
+ "burn-ir",
+ "burn-std",
+ "hashbrown 0.16.1",
+ "log",
+ "serde",
+ "spin",
 ]
 
 [[package]]
@@ -811,6 +852,7 @@ source = "git+https://github.com/tracel-ai/burn.git?rev=bd6e8fa2f23c2ecea1044af1
 dependencies = [
  "burn-backend",
  "burn-cubecl",
+ "burn-fusion",
  "cubecl",
 ]
 
@@ -1449,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1465,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "backtrace",
  "bytemuck",
@@ -1506,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -1535,7 +1577,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1551,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -1577,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1595,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1624,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -1648,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -1665,7 +1707,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1676,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1694,7 +1736,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "ahash",
  "async-channel",
@@ -1726,7 +1768,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1742,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "async-channel",
  "bytemuck",
@@ -1768,7 +1810,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/tracel-ai/cubecl.git?rev=0a62060a2c7a66c94f717d7cac0be0dc259bb607#0a62060a2c7a66c94f717d7cac0be0dc259bb607"
+source = "git+https://github.com/ppodolsky/cubecl?rev=73bd0ea3054c5c9fc33b3fb3fd60320a90af6021#73bd0ea3054c5c9fc33b3fb3fd60320a90af6021"
 dependencies = [
  "derive-new",
  "serde",
@@ -2959,6 +3001,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "glow"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,6 +3206,8 @@ dependencies = [
  "burn-core",
  "burn-cubecl",
  "burn-cuda",
+ "burn-fusion",
+ "burn-ir",
  "burn-ndarray",
  "burn-nn",
  "burn-store",
@@ -5801,6 +5857,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,14 @@ hashbrown = "0.17"
 memmap2 = "0.9"
 uuid = { version = "1.19", features = ["v4"] }
 
-# Keep Burn's CubeK dependency on the same A100-safe revision used directly by
-# hermes-llm.
+# Keep Burn's CubeK dependency on the same strided-attention fix used directly
+# by hermes-llm.
 [patch."https://github.com/tracel-ai/cubek"]
 cubek = { git = "https://github.com/ppodolsky/cubek", rev = "058827ffef7231d48901983cbc1121f897ced752" }
+
+# Burn main still points at upstream CubeCL. Use our allocation-retry fix for
+# Burn's direct CubeCL dependencies as well as hermes-llm's.
+[patch."https://github.com/tracel-ai/cubecl"]
+cubecl = { git = "https://github.com/ppodolsky/cubecl", rev = "73bd0ea3054c5c9fc33b3fb3fd60320a90af6021" }
+cubecl-common = { git = "https://github.com/ppodolsky/cubecl", rev = "73bd0ea3054c5c9fc33b3fb3fd60320a90af6021" }
+cubecl-zspace = { git = "https://github.com/ppodolsky/cubecl", rev = "73bd0ea3054c5c9fc33b3fb3fd60320a90af6021" }

--- a/hermes-llm/Cargo.toml
+++ b/hermes-llm/Cargo.toml
@@ -24,7 +24,9 @@ burn-store = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23
     "std",
 ] }
 burn-cubecl = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", optional = true, default-features = false, features = ["std"] }
-cubecl = { git = "https://github.com/tracel-ai/cubecl.git", rev = "0a62060a2c7a66c94f717d7cac0be0dc259bb607", optional = true, default-features = false, features = ["std"] }
+burn-fusion = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", optional = true, default-features = false, features = ["std"] }
+burn-ir = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", optional = true, default-features = false, features = ["std"] }
+cubecl = { git = "https://github.com/ppodolsky/cubecl.git", rev = "73bd0ea3054c5c9fc33b3fb3fd60320a90af6021", optional = true, default-features = false, features = ["std"] }
 cubek = { git = "https://github.com/ppodolsky/cubek", rev = "058827ffef7231d48901983cbc1121f897ced752", optional = true, default-features = false, features = ["attention", "stdlib"] }
 
 # Tokenization (fancy-regex instead of onig to avoid objc2 on Linux)
@@ -60,7 +62,7 @@ default = ["remote"]
 # Load weights/config/tokenizer from s3://, gs://, http(s):// (downloads + caches)
 remote = ["dep:object_store", "dep:tokio", "dep:url", "dep:dirs"]
 metal = ["burn/metal", "burn/autotune", "dep:burn-wgpu", "dep:burn-cubecl", "dep:cubecl"]
-cuda = ["burn/cuda", "burn/autotune", "dep:burn-cuda", "dep:burn-cubecl", "dep:cubecl", "dep:cubek"]
+cuda = ["burn/cuda", "burn/autotune", "burn/fusion", "dep:burn-cuda", "dep:burn-cubecl", "dep:burn-fusion", "dep:burn-ir", "dep:cubecl", "dep:cubek"]
 
 [[bin]]
 name = "hermes-llm"

--- a/hermes-llm/Cargo.toml
+++ b/hermes-llm/Cargo.toml
@@ -62,7 +62,10 @@ default = ["remote"]
 # Load weights/config/tokenizer from s3://, gs://, http(s):// (downloads + caches)
 remote = ["dep:object_store", "dep:tokio", "dep:url", "dep:dirs"]
 metal = ["burn/metal", "burn/autotune", "dep:burn-wgpu", "dep:burn-cubecl", "dep:cubecl"]
-cuda = ["burn/cuda", "burn/autotune", "burn/fusion", "dep:burn-cuda", "dep:burn-cubecl", "dep:burn-fusion", "dep:burn-ir", "dep:cubecl", "dep:cubek"]
+cuda = ["burn/cuda", "burn/autotune", "dep:burn-cuda", "dep:burn-cubecl", "dep:cubecl", "dep:cubek"]
+# Lazy fusion pays off for large training graphs, but adds substantial graph
+# planning and kernel-launch overhead to single-token autoregressive decoding.
+training-fusion = ["cuda", "burn/fusion", "dep:burn-fusion", "dep:burn-ir"]
 
 [[bin]]
 name = "hermes-llm"

--- a/hermes-llm/src/main.rs
+++ b/hermes-llm/src/main.rs
@@ -133,6 +133,7 @@ fn main() -> Result<()> {
 
             let mut model = hermes_llm::Transformer::new(&config, &device)?;
             hermes_llm::load_safetensors(&mut model, &checkpoint_path)?;
+            model.prepare_inference();
 
             info!("Loaded model from {}", checkpoint_path.display());
 

--- a/hermes-llm/src/model/attention.rs
+++ b/hermes-llm/src/model/attention.rs
@@ -13,7 +13,7 @@ use burn_nn::{
 use crate::mal::{BlockDef, ModelDef};
 
 use super::fused_attention::{fused_attention, repeat_kv};
-use super::matmul::linear;
+use super::matmul::{linear, prepare_linear_for_inference};
 
 /// Preallocated KV cache for one attention layer, before GQA head expansion.
 #[derive(Debug, Clone)]
@@ -108,6 +108,11 @@ impl MultiHeadAttention {
             v: Some(Tensor::zeros(shape, device)),
             len: 0,
         }
+    }
+
+    pub(crate) fn prepare_inference(&mut self) {
+        prepare_linear_for_inference(&mut self.qkv_proj);
+        prepare_linear_for_inference(&mut self.o_proj);
     }
 
     /// Project and position per-head Q, K, and V tensors.

--- a/hermes-llm/src/model/backend.rs
+++ b/hermes-llm/src/model/backend.rs
@@ -2,14 +2,54 @@
 
 pub use burn::tensor::Device;
 
+#[cfg(all(feature = "cuda", not(feature = "metal")))]
+fn configure_cuda_memory() {
+    use std::sync::Once;
+
+    use burn_cubecl::cubecl::{
+        Runtime,
+        config::{
+            memory::{MemoryPoolConfig, MemoryPoolsConfig},
+            size::MemorySize,
+        },
+        cuda::{CudaDevice, CudaRuntime},
+    };
+
+    static CONFIGURE: Once = Once::new();
+    CONFIGURE.call_once(|| {
+        let client = CudaRuntime::client(&CudaDevice::default());
+        // Isolate allocations in power-of-two pages. The default sliced pools
+        // reserve multi-gigabyte backing pages for the largest training tensors;
+        // exclusive pages avoid that amplification, while CubeCL's allocation
+        // retry reclaims unused autotune pages only when memory is pressured.
+        let pools = (15..=34) // 32 KiB through 16 GiB.
+            .map(|shift| MemoryPoolConfig::Exclusive {
+                max_alloc_size: MemorySize(1_u64 << shift),
+                dealloc_period: None,
+            })
+            .collect();
+        assert!(
+            client.configure_memory_pools(&MemoryPoolsConfig::Explicit(pools)),
+            "CUDA memory pools must be configured before allocating tensors"
+        );
+    });
+}
+
 /// The default device for the active backend (best-available GPU, or CPU).
 pub fn default_device() -> Device {
     #[cfg(feature = "metal")]
-    return Device::metal(burn::tensor::DeviceKind::DefaultDevice);
+    {
+        Device::metal(burn::tensor::DeviceKind::DefaultDevice)
+    }
 
     #[cfg(all(feature = "cuda", not(feature = "metal")))]
-    return Device::cuda(burn::tensor::DeviceIndex::Default);
+    {
+        configure_cuda_memory();
+        Device::cuda(burn::tensor::DeviceIndex::Default)
+    }
 
     #[cfg(not(any(feature = "metal", feature = "cuda")))]
-    return Device::ndarray();
+    {
+        Device::ndarray()
+    }
 }

--- a/hermes-llm/src/model/block.rs
+++ b/hermes-llm/src/model/block.rs
@@ -104,6 +104,16 @@ impl TransformerBlock {
         }
     }
 
+    pub(crate) fn prepare_inference(&mut self) {
+        if let Some(attention) = &mut self.attention {
+            attention.prepare_inference();
+        }
+        if let Some(ssm) = &mut self.ssm {
+            ssm.prepare_inference();
+        }
+        self.feed_forward.prepare_inference();
+    }
+
     pub fn forward_with_state(
         &self,
         x: Tensor<3>,

--- a/hermes-llm/src/model/cube_attention.rs
+++ b/hermes-llm/src/model/cube_attention.rs
@@ -4,18 +4,38 @@ use burn::backend::{
     TensorMetadata,
     ops::{AttentionModuleOptions, FloatTensorOps},
 };
-use burn::tensor::{FloatDType, Shape};
+use burn::tensor::FloatDType;
 use burn_cubecl::CubeBackend;
-use burn_cubecl::cubecl::cuda::CudaRuntime;
+use burn_cubecl::cubecl::{cuda::CudaRuntime, prelude::*};
 use burn_cubecl::kernel::attention::{AttentionStrategy, attention};
 use burn_cubecl::tensor::CubeTensor;
 use cubek::attention::forward::routines::blackbox_accelerated::BlackboxAcceleratedStrategy;
 
-use super::cube_tensor::{empty_dtype_like, into_contiguous};
-use super::fused_attention::{AttentionBackend, chunked_attention_backward};
+use super::cube_tensor::{empty_like, into_contiguous};
+use super::fused_attention::AttentionBackend;
 
-const BACKWARD_CHUNK_ROWS: usize = 2048;
 const MAX_HEAD_DIM: usize = 128;
+const ELEMENTWISE_THREADS: u32 = 256;
+
+#[cube(launch)]
+fn causal_mask_kernel(
+    scores: &Tensor<f32>,
+    output: &mut Tensor<f32>,
+    rows: u32,
+    sequence: u32,
+    row_offset: u32,
+) {
+    let idx = ABSOLUTE_POS;
+    if idx < output.len() {
+        let column = idx % sequence as usize;
+        let row = (idx / sequence as usize) % rows as usize;
+        output[idx] = if column > row + row_offset as usize {
+            f32::NEG_INFINITY
+        } else {
+            scores[idx]
+        };
+    }
+}
 
 fn dimensions(query: &CubeTensor<CudaRuntime>, key: &CubeTensor<CudaRuntime>) -> [usize; 4] {
     let [batch, heads, sequence, head_dim] = query.shape().dims();
@@ -31,7 +51,6 @@ impl AttentionBackend for CubeBackend<CudaRuntime> {
         value: CubeTensor<CudaRuntime>,
         causal: bool,
     ) -> (
-        CubeTensor<CudaRuntime>,
         CubeTensor<CudaRuntime>,
         CubeTensor<CudaRuntime>,
         CubeTensor<CudaRuntime>,
@@ -75,39 +94,49 @@ impl AttentionBackend for CubeBackend<CudaRuntime> {
         })
         .expect("Burn attention fallback must support the validated Hermes shape");
         let output_default = Self::float_cast(output.clone(), output_dtype.into());
-        let stats = empty_dtype_like(&query, Shape::new([1, 1, 1, 1]), output_dtype);
-        (output_default, stats, query, key, value, output)
+        (output_default, query, key, value, output)
     }
 
-    fn attention_backward(
-        query: CubeTensor<CudaRuntime>,
-        key: CubeTensor<CudaRuntime>,
-        value: CubeTensor<CudaRuntime>,
-        output: CubeTensor<CudaRuntime>,
-        _stats: CubeTensor<CudaRuntime>,
-        grad_output: CubeTensor<CudaRuntime>,
-        causal: bool,
-    ) -> (
-        CubeTensor<CudaRuntime>,
-        CubeTensor<CudaRuntime>,
-        CubeTensor<CudaRuntime>,
-    ) {
-        // Forward deliberately saves Q/K/V in FP16. Keep them there for the
-        // recompute matmuls instead of expanding to Flex32 and recasting every
-        // query chunk. Only elementwise correction needs the output in Flex32.
-        let query = into_contiguous(query);
-        let key = into_contiguous(key);
-        let value = into_contiguous(value);
-        let output = Self::float_cast(into_contiguous(output), grad_output.dtype.into());
-        let grad_output = into_contiguous(grad_output);
-        chunked_attention_backward::<Self>(
-            query,
-            key,
-            value,
-            output,
-            grad_output,
-            causal,
-            BACKWARD_CHUNK_ROWS,
-        )
+    fn attention_causal_mask(
+        scores: CubeTensor<CudaRuntime>,
+        row_offset: usize,
+    ) -> CubeTensor<CudaRuntime> {
+        let scores = into_contiguous(scores);
+        let [_, _, rows, sequence] = scores.shape().dims();
+        assert!(row_offset + rows <= sequence);
+        let total = scores.meta.num_elements();
+        let cube_count = CubeCount::Static(
+            u32::try_from(total.div_ceil(ELEMENTWISE_THREADS as usize))
+                .expect("attention score tensor exceeds the CUDA launch grid"),
+            1,
+            1,
+        );
+        let client = scores.client.clone();
+        if scores.can_mut() && scores.is_nonoverlapping() {
+            causal_mask_kernel::launch::<CudaRuntime>(
+                &client,
+                cube_count,
+                CubeDim::new_1d(ELEMENTWISE_THREADS),
+                scores.clone().into_tensor_arg(),
+                scores.as_tensor_alias(0),
+                rows as u32,
+                sequence as u32,
+                row_offset as u32,
+            );
+            scores
+        } else {
+            let output = empty_like(&scores, scores.shape());
+            causal_mask_kernel::launch::<CudaRuntime>(
+                &client,
+                cube_count,
+                CubeDim::new_1d(ELEMENTWISE_THREADS),
+                scores.into_tensor_arg(),
+                output.clone().into_tensor_arg(),
+                rows as u32,
+                sequence as u32,
+                row_offset as u32,
+            );
+            output
+        }
     }
 }

--- a/hermes-llm/src/model/cube_tensor.rs
+++ b/hermes-llm/src/model/cube_tensor.rs
@@ -1,7 +1,5 @@
 //! Allocation helpers for custom CubeCL operators.
 
-#[cfg(feature = "cuda")]
-use burn::tensor::DType;
 use burn::tensor::Shape;
 use burn_cubecl::CubeRuntime;
 use burn_cubecl::tensor::CubeTensor;
@@ -16,20 +14,6 @@ pub(super) fn empty_like<R: CubeRuntime>(tensor: &CubeTensor<R>, shape: Shape) -
         tensor.device.clone(),
         shape,
         tensor.dtype,
-    )
-}
-
-#[cfg(feature = "cuda")]
-pub(super) fn empty_dtype_like<R: CubeRuntime>(
-    tensor: &CubeTensor<R>,
-    shape: Shape,
-    dtype: DType,
-) -> CubeTensor<R> {
-    burn_cubecl::ops::numeric::empty_device_contiguous_dtype(
-        tensor.client.clone(),
-        tensor.device.clone(),
-        shape,
-        dtype,
     )
 }
 

--- a/hermes-llm/src/model/ffn.rs
+++ b/hermes-llm/src/model/ffn.rs
@@ -8,7 +8,7 @@ use burn_nn::{Dropout, DropoutConfig, Linear, LinearConfig};
 
 use crate::mal::{Activation, BlockDef, ModelDef};
 
-use super::matmul::linear;
+use super::matmul::{linear, prepare_linear_for_inference};
 
 #[derive(Module, Debug)]
 pub struct FeedForward {
@@ -67,5 +67,10 @@ impl FeedForward {
             act(projected)
         };
         linear(&self.down_proj, self.dropout.forward(hidden))
+    }
+
+    pub(crate) fn prepare_inference(&mut self) {
+        prepare_linear_for_inference(&mut self.in_proj);
+        prepare_linear_for_inference(&mut self.down_proj);
     }
 }

--- a/hermes-llm/src/model/fused_attention.rs
+++ b/hermes-llm/src/model/fused_attention.rs
@@ -24,20 +24,6 @@ use burn_autodiff::ops::{Backward, Ops, OpsKind};
 #[cfg(feature = "cuda")]
 use super::matmul::{matmul_4, matmul_input};
 
-#[cfg(feature = "cuda")]
-struct CachedCausalMask {
-    device: Device,
-    sequence: usize,
-    mask: Tensor<4, Bool>,
-}
-
-#[cfg(feature = "cuda")]
-std::thread_local! {
-    static CAUSAL_MASK_CACHE: std::cell::RefCell<Option<CachedCausalMask>> = const {
-        std::cell::RefCell::new(None)
-    };
-}
-
 /// Backend capability used by full-sequence Transformer attention.
 #[cfg_attr(feature = "cuda", backend_extension(Cuda, Autodiff))]
 #[cfg_attr(
@@ -61,7 +47,6 @@ pub trait AttentionBackend: Backend {
         FloatTensor<Self>,
         FloatTensor<Self>,
         FloatTensor<Self>,
-        FloatTensor<Self>,
     );
 
     #[allow(clippy::too_many_arguments, unused_variables)]
@@ -70,11 +55,15 @@ pub trait AttentionBackend: Backend {
         key: FloatTensor<Self>,
         value: FloatTensor<Self>,
         output: FloatTensor<Self>,
-        _stats: FloatTensor<Self>,
         grad_output: FloatTensor<Self>,
         causal: bool,
     ) -> (FloatTensor<Self>, FloatTensor<Self>, FloatTensor<Self>) {
         panic!("custom attention only supports first-order autodiff")
+    }
+
+    #[allow(unused_variables)]
+    fn attention_causal_mask(scores: FloatTensor<Self>, row_offset: usize) -> FloatTensor<Self> {
+        panic!("custom causal masking is only available on CUDA")
     }
 }
 
@@ -135,26 +124,6 @@ fn causal_mask(sequence: usize, device: &Device) -> Tensor<4, Bool> {
         .reshape([1, 1, sequence, sequence])
 }
 
-#[cfg(feature = "cuda")]
-fn cached_causal_mask(sequence: usize, device: &Device) -> Tensor<4, Bool> {
-    CAUSAL_MASK_CACHE.with(|cache| {
-        let mut cache = cache.borrow_mut();
-        if let Some(cached) = cache.as_ref()
-            && cached.sequence == sequence
-            && cached.device == *device
-        {
-            return cached.mask.clone();
-        }
-        let mask = causal_mask(sequence, device);
-        *cache = Some(CachedCausalMask {
-            device: device.clone(),
-            sequence,
-            mask: mask.clone(),
-        });
-        mask
-    })
-}
-
 fn attention_probabilities(query: Tensor<4>, key: Tensor<4>, causal: bool) -> Tensor<4> {
     let [_, query_heads, sequence, head_dim] = query.dims();
     let key = repeat_kv(key, query_heads);
@@ -180,7 +149,6 @@ fn reference_attention<B: Backend>(
     FloatTensor<B>,
     FloatTensor<B>,
     FloatTensor<B>,
-    FloatTensor<B>,
 )
 where
     DispatchTensor: DispatchKindConversion<B>,
@@ -191,25 +159,13 @@ where
     let query = Tensor::<4>::from_primitive::<B>(query);
     let key = Tensor::<4>::from_primitive::<B>(key);
     let value = Tensor::<4>::from_primitive::<B>(value);
-    let [batch, query_heads, sequence, _] = query.dims();
+    let [_, query_heads, _, _] = query.dims();
     let probabilities = attention_probabilities(query, key, causal);
     let output = probabilities.matmul(repeat_kv(value, query_heads));
-    let stats = Tensor::<4>::zeros([batch, query_heads, sequence, 1], &output.device());
     let output = output
         .try_into_primitive::<B>()
         .expect("attention output stayed on its input backend");
-    (
-        output.clone(),
-        // The reference backward recomputes softmax. CUDA replaces this with
-        // per-row log-sum-exp statistics.
-        stats
-            .try_into_primitive::<B>()
-            .expect("attention stats stayed on its input backend"),
-        saved_query,
-        saved_key,
-        saved_value,
-        output,
-    )
+    (output.clone(), saved_query, saved_key, saved_value, output)
 }
 
 fn reference_attention_backward<B: Backend>(
@@ -261,7 +217,7 @@ where
 /// backend's accelerated matmuls while memory remains linear in sequence
 /// length for a fixed block size.
 #[cfg(feature = "cuda")]
-pub(super) fn chunked_attention_backward<B: Backend>(
+pub(super) fn chunked_attention_backward<B: AttentionBackend>(
     query: FloatTensor<B>,
     key: FloatTensor<B>,
     value: FloatTensor<B>,
@@ -283,15 +239,13 @@ where
     assert_eq!(value.dims(), [batch, heads, sequence, head_dim]);
     assert!(chunk_size > 0);
 
-    let device = query.device();
     let key_transposed = matmul_input(key.clone().transpose());
     let value_transposed = matmul_input(value.clone().transpose());
     let grad_output_compute = matmul_input(grad_output.clone());
     let scale = 1.0 / (head_dim as f32).sqrt();
-    let causal_mask = causal.then(|| cached_causal_mask(sequence, &device));
     let mut query_gradients = Vec::with_capacity(sequence.div_ceil(chunk_size));
-    let mut key_gradient = Tensor::zeros([batch, heads, sequence, head_dim], &device);
-    let mut value_gradient = Tensor::zeros([batch, heads, sequence, head_dim], &device);
+    let mut key_gradient = None;
+    let mut value_gradient = None;
 
     for start in (0..sequence).step_by(chunk_size) {
         let end = (start + chunk_size).min(sequence);
@@ -310,23 +264,34 @@ where
                 .clone()
                 .slice([0..batch, 0..heads, start..end, 0..head_dim]);
         let mut scores = matmul_4(query_chunk.clone(), key_transposed.clone()) * scale;
-        if let Some(mask) = causal_mask.as_ref() {
-            scores = scores.mask_fill(
-                mask.clone().slice([0..1, 0..1, start..end, 0..sequence]),
-                f32::NEG_INFINITY,
-            );
+        if causal {
+            let scores_primitive = scores
+                .try_into_primitive::<B>()
+                .expect("attention scores stayed on their input backend");
+            scores = Tensor::from_primitive::<B>(B::attention_causal_mask(scores_primitive, start));
         }
         let probabilities = softmax(scores, 3);
+        let output_chunk = output_chunk.cast(grad_output_chunk.dtype());
         let correction = (grad_output_chunk.clone() * output_chunk).sum_dim(3);
         let probability_gradient =
             matmul_4(grad_output_compute_chunk.clone(), value_transposed.clone());
+        let compute_dtype = probability_gradient.dtype();
+        let probabilities = probabilities.cast(compute_dtype);
+        let correction = correction.cast(compute_dtype);
         let score_gradient = probabilities.clone() * (probability_gradient - correction) * scale;
         let score_gradient_compute = matmul_input(score_gradient);
 
         query_gradients.push(matmul_4(score_gradient_compute.clone(), key.clone()));
-        key_gradient = key_gradient + matmul_4(score_gradient_compute.transpose(), query_chunk);
-        value_gradient =
-            value_gradient + matmul_4(probabilities.transpose(), grad_output_compute_chunk);
+        let key_chunk = matmul_4(score_gradient_compute.transpose(), query_chunk);
+        key_gradient = Some(match key_gradient {
+            Some(gradient) => gradient + key_chunk,
+            None => key_chunk,
+        });
+        let value_chunk = matmul_4(probabilities.transpose(), grad_output_compute_chunk);
+        value_gradient = Some(match value_gradient {
+            Some(gradient) => gradient + value_chunk,
+            None => value_chunk,
+        });
     }
 
     (
@@ -334,9 +299,11 @@ where
             .try_into_primitive::<B>()
             .expect("query gradient stayed on its input backend"),
         key_gradient
+            .expect("attention backward requires at least one query chunk")
             .try_into_primitive::<B>()
             .expect("key gradient stayed on its input backend"),
         value_gradient
+            .expect("attention backward requires at least one query chunk")
             .try_into_primitive::<B>()
             .expect("value gradient stayed on its input backend"),
     )
@@ -356,7 +323,6 @@ macro_rules! impl_reference_attention {
                 FloatTensor<Self>,
                 FloatTensor<Self>,
                 FloatTensor<Self>,
-                FloatTensor<Self>,
             ) {
                 reference_attention::<Self>(query, key, value, causal)
             }
@@ -366,7 +332,6 @@ macro_rules! impl_reference_attention {
                 key: FloatTensor<Self>,
                 value: FloatTensor<Self>,
                 output: FloatTensor<Self>,
-                _stats: FloatTensor<Self>,
                 grad_output: FloatTensor<Self>,
                 causal: bool,
             ) -> (FloatTensor<Self>, FloatTensor<Self>, FloatTensor<Self>) {
@@ -387,7 +352,6 @@ struct AttentionState<B: AttentionBackend> {
     key: FloatTensor<B>,
     value: FloatTensor<B>,
     output: FloatTensor<B>,
-    stats: FloatTensor<B>,
     causal: bool,
 }
 
@@ -411,7 +375,6 @@ impl<B: AttentionBackend> Backward<B, 3> for AttentionBackward {
             state.key,
             state.value,
             state.output,
-            state.stats,
             grad_output,
             state.causal,
         );
@@ -439,7 +402,6 @@ impl<B: AttentionBackend, C: CheckpointStrategy> AttentionBackend for Autodiff<B
         FloatTensor<Self>,
         FloatTensor<Self>,
         FloatTensor<Self>,
-        FloatTensor<Self>,
     ) {
         match AttentionBackward
             .prepare::<C>([query.node.clone(), key.node.clone(), value.node.clone()])
@@ -447,7 +409,7 @@ impl<B: AttentionBackend, C: CheckpointStrategy> AttentionBackend for Autodiff<B
             .stateful()
         {
             OpsKind::Tracked(prep) => {
-                let (output, stats, saved_query, saved_key, saved_value, saved_output) =
+                let (output, saved_query, saved_key, saved_value, saved_output) =
                     B::attention_inner(
                         query.primitive.clone(),
                         key.primitive.clone(),
@@ -459,12 +421,10 @@ impl<B: AttentionBackend, C: CheckpointStrategy> AttentionBackend for Autodiff<B
                     key: saved_key.clone(),
                     value: saved_value.clone(),
                     output: saved_output.clone(),
-                    stats: stats.clone(),
                     causal,
                 };
                 (
                     prep.finish(state, output),
-                    <Self as burn::backend::AutodiffBackend>::from_inner(stats),
                     <Self as burn::backend::AutodiffBackend>::from_inner(saved_query),
                     <Self as burn::backend::AutodiffBackend>::from_inner(saved_key),
                     <Self as burn::backend::AutodiffBackend>::from_inner(saved_value),
@@ -472,11 +432,10 @@ impl<B: AttentionBackend, C: CheckpointStrategy> AttentionBackend for Autodiff<B
                 )
             }
             OpsKind::UnTracked(prep) => {
-                let (output, stats, saved_query, saved_key, saved_value, saved_output) =
+                let (output, saved_query, saved_key, saved_value, saved_output) =
                     B::attention_inner(query.primitive, key.primitive, value.primitive, causal);
                 (
                     prep.finish(output),
-                    <Self as burn::backend::AutodiffBackend>::from_inner(stats),
                     <Self as burn::backend::AutodiffBackend>::from_inner(saved_query),
                     <Self as burn::backend::AutodiffBackend>::from_inner(saved_key),
                     <Self as burn::backend::AutodiffBackend>::from_inner(saved_value),
@@ -660,9 +619,13 @@ mod tests {
                 .into_data(),
         );
 
-        assert!(max_diff(expected.0, actual.0) < 0.01);
-        assert!(max_diff(expected.1, actual.1) < 0.02);
-        assert!(max_diff(expected.2, actual.2) < 0.02);
-        assert!(max_diff(expected.3, actual.3) < 0.02);
+        let output_diff = max_diff(expected.0, actual.0);
+        let query_diff = max_diff(expected.1, actual.1);
+        let key_diff = max_diff(expected.2, actual.2);
+        let value_diff = max_diff(expected.3, actual.3);
+        assert!(output_diff < 0.01, "output max diff: {output_diff}");
+        assert!(query_diff < 0.02, "query gradient max diff: {query_diff}");
+        assert!(key_diff < 0.02, "key gradient max diff: {key_diff}");
+        assert!(value_diff < 0.02, "value gradient max diff: {value_diff}");
     }
 }

--- a/hermes-llm/src/model/fused_attention.rs
+++ b/hermes-llm/src/model/fused_attention.rs
@@ -21,7 +21,7 @@ use burn_autodiff::checkpoint::{base::Checkpointer, strategy::CheckpointStrategy
 use burn_autodiff::grads::Gradients;
 use burn_autodiff::ops::{Backward, Ops, OpsKind};
 
-#[cfg(feature = "cuda")]
+#[cfg(feature = "training-fusion")]
 use super::matmul::{matmul_4, matmul_input};
 
 /// Backend capability used by full-sequence Transformer attention.
@@ -216,7 +216,7 @@ where
 /// Recompute attention a block of query rows at a time. Each block uses the
 /// backend's accelerated matmuls while memory remains linear in sequence
 /// length for a fixed block size.
-#[cfg(feature = "cuda")]
+#[cfg(feature = "training-fusion")]
 pub(super) fn chunked_attention_backward<B: AttentionBackend>(
     query: FloatTensor<B>,
     key: FloatTensor<B>,
@@ -528,7 +528,53 @@ mod tests {
 
     #[cfg(all(feature = "cuda", target_os = "linux"))]
     #[test]
-    fn cuda_attention_matches_cpu_reference_for_causal_gqa() {
+    fn cuda_attention_forward_matches_cpu_reference_for_causal_gqa() {
+        let cpu_device = Device::ndarray();
+        let cuda_device = Device::cuda(0);
+        let (batch, query_heads, kv_heads, sequence, head_dim) = (1, 4, 2, 64, 64);
+        let query_data = values(batch * query_heads * sequence * head_dim, 0.071);
+        let key_data = values(batch * kv_heads * sequence * head_dim, 0.097);
+        let value_data = values(batch * kv_heads * sequence * head_dim, 0.113);
+        let expected = attention_probabilities(
+            Tensor::<4>::from_data(
+                TensorData::new(query_data.clone(), [batch, query_heads, sequence, head_dim]),
+                &cpu_device,
+            ),
+            Tensor::<4>::from_data(
+                TensorData::new(key_data.clone(), [batch, kv_heads, sequence, head_dim]),
+                &cpu_device,
+            ),
+            true,
+        )
+        .matmul(repeat_kv(
+            Tensor::<4>::from_data(
+                TensorData::new(value_data.clone(), [batch, kv_heads, sequence, head_dim]),
+                &cpu_device,
+            ),
+            query_heads,
+        ));
+        let actual = fused_attention(
+            Tensor::<4>::from_data(
+                TensorData::new(query_data, [batch, query_heads, sequence, head_dim]),
+                &cuda_device,
+            ),
+            Tensor::<4>::from_data(
+                TensorData::new(key_data, [batch, kv_heads, sequence, head_dim]),
+                &cuda_device,
+            ),
+            Tensor::<4>::from_data(
+                TensorData::new(value_data, [batch, kv_heads, sequence, head_dim]),
+                &cuda_device,
+            ),
+            true,
+        );
+        let difference = max_diff(snapshot(expected), snapshot(actual));
+        assert!(difference < 0.01, "output max diff: {difference}");
+    }
+
+    #[cfg(all(feature = "training-fusion", target_os = "linux"))]
+    #[test]
+    fn cuda_attention_backward_matches_cpu_reference_for_causal_gqa() {
         let cpu_device = Device::ndarray().autodiff();
         let cuda_device = Device::cuda(0).autodiff();
         let (batch, query_heads, kv_heads, sequence, head_dim) = (1, 4, 2, 64, 64);

--- a/hermes-llm/src/model/fusion.rs
+++ b/hermes-llm/src/model/fusion.rs
@@ -1,0 +1,503 @@
+//! Lazy-fusion adapters for Hermes' custom CUDA operations.
+//!
+//! Burn can fuse the ordinary elementwise and reduction graph around these
+//! operations. The adapters record custom kernels as opaque operations while
+//! leaving attention's recompute backward visible to Burn's fusion planner.
+
+use std::marker::PhantomData;
+
+use burn::backend::tensor::FloatTensor;
+use burn::tensor::{DType, Shape};
+use burn_cubecl::{CubeBackend, fusion::FusionCubeRuntime};
+use burn_fusion::{
+    Fusion, FusionBackend, FusionRuntime,
+    stream::{Operation, StreamId},
+};
+use burn_ir::{CustomOpIr, HandleContainer, OperationIr, ScalarIr, TensorIr};
+use cubecl::cuda::CudaRuntime;
+
+use super::conv::DepthwiseConv1dBackend;
+use super::fused_attention::{AttentionBackend, chunked_attention_backward};
+use super::scan::{MambaBackend, scan_checkpoint_interval};
+
+const ATTENTION_BACKWARD_CHUNK_ROWS: usize = 2048;
+
+#[derive(Debug)]
+struct DepthwiseForward<B> {
+    desc: CustomOpIr,
+    backend: PhantomData<B>,
+}
+
+impl<B> Operation<B::FusionRuntime> for DepthwiseForward<B>
+where
+    B: FusionBackend + DepthwiseConv1dBackend,
+{
+    fn execute(
+        &self,
+        handles: &mut HandleContainer<<B::FusionRuntime as FusionRuntime>::FusionHandle>,
+    ) {
+        let ([input, weight, bias], [output_ir]) = self.desc.as_fixed();
+        let output = B::depthwise_conv1d_inner(
+            handles.get_float_tensor::<B>(input),
+            handles.get_float_tensor::<B>(weight),
+            handles.get_float_tensor::<B>(bias),
+        );
+        handles.register_float_tensor::<B>(&output_ir.id, output);
+    }
+}
+
+#[derive(Debug)]
+struct DepthwiseBackward<B> {
+    desc: CustomOpIr,
+    backend: PhantomData<B>,
+}
+
+impl<B> Operation<B::FusionRuntime> for DepthwiseBackward<B>
+where
+    B: FusionBackend + DepthwiseConv1dBackend,
+{
+    fn execute(
+        &self,
+        handles: &mut HandleContainer<<B::FusionRuntime as FusionRuntime>::FusionHandle>,
+    ) {
+        let ([input, weight, grad], [grad_input, grad_weight, grad_bias]) = self.desc.as_fixed();
+        let (input, weight, bias) = B::depthwise_conv1d_backward(
+            handles.get_float_tensor::<B>(input),
+            handles.get_float_tensor::<B>(weight),
+            handles.get_float_tensor::<B>(grad),
+        );
+        handles.register_float_tensor::<B>(&grad_input.id, input);
+        handles.register_float_tensor::<B>(&grad_weight.id, weight);
+        handles.register_float_tensor::<B>(&grad_bias.id, bias);
+    }
+}
+
+impl<B> DepthwiseConv1dBackend for Fusion<B>
+where
+    B: FusionBackend + DepthwiseConv1dBackend,
+{
+    fn depthwise_conv1d_inner(
+        input: FloatTensor<Self>,
+        weight: FloatTensor<Self>,
+        bias: FloatTensor<Self>,
+    ) -> FloatTensor<Self> {
+        let [batch, channels, input_len] = input.shape.dims();
+        let kernel_size = weight.shape.dims::<3>()[2];
+        let client = input.client.clone();
+        let output = TensorIr::uninit(
+            client.create_empty_handle(),
+            Shape::new([batch, channels, input_len - kernel_size + 1]),
+            input.dtype,
+        );
+        let desc = CustomOpIr::new(
+            "hermes_depthwise_conv1d",
+            &[input.into_ir(), weight.into_ir(), bias.into_ir()],
+            &[output],
+        );
+        client
+            .register(
+                StreamId::current(),
+                OperationIr::Custom(desc.clone()),
+                DepthwiseForward::<B> {
+                    desc,
+                    backend: PhantomData,
+                },
+            )
+            .remove(0)
+    }
+
+    fn depthwise_conv1d_backward(
+        input: FloatTensor<Self>,
+        weight: FloatTensor<Self>,
+        grad: FloatTensor<Self>,
+    ) -> (FloatTensor<Self>, FloatTensor<Self>, FloatTensor<Self>) {
+        let channels = input.shape.dims::<3>()[1];
+        let client = input.client.clone();
+        let grad_input = TensorIr::uninit(
+            client.create_empty_handle(),
+            input.shape.clone(),
+            input.dtype,
+        );
+        let grad_weight = TensorIr::uninit(
+            client.create_empty_handle(),
+            weight.shape.clone(),
+            weight.dtype,
+        );
+        let grad_bias = TensorIr::uninit(
+            client.create_empty_handle(),
+            Shape::new([channels]),
+            grad.dtype,
+        );
+        let desc = CustomOpIr::new(
+            "hermes_depthwise_conv1d_backward",
+            &[input.into_ir(), weight.into_ir(), grad.into_ir()],
+            &[grad_input, grad_weight, grad_bias],
+        );
+        let [input, weight, bias] = client
+            .register(
+                StreamId::current(),
+                OperationIr::Custom(desc.clone()),
+                DepthwiseBackward::<B> {
+                    desc,
+                    backend: PhantomData,
+                },
+            )
+            .try_into()
+            .expect("depthwise backward has three outputs");
+        (input, weight, bias)
+    }
+}
+
+#[derive(Debug)]
+struct ScanForward<B> {
+    desc: CustomOpIr,
+    state_dim: usize,
+    save_states: bool,
+    backend: PhantomData<B>,
+}
+
+impl<B> Operation<B::FusionRuntime> for ScanForward<B>
+where
+    B: FusionBackend + MambaBackend,
+{
+    fn execute(
+        &self,
+        handles: &mut HandleContainer<<B::FusionRuntime as FusionRuntime>::FusionHandle>,
+    ) {
+        let ([delta, xs, b_mat, c_mat, a, d, h], [y_ir, h_ir, states_ir]) = self.desc.as_fixed();
+        let (y, h, states) = B::selective_scan_inner(
+            handles.get_float_tensor::<B>(delta),
+            handles.get_float_tensor::<B>(xs),
+            handles.get_float_tensor::<B>(b_mat),
+            handles.get_float_tensor::<B>(c_mat),
+            handles.get_float_tensor::<B>(a),
+            handles.get_float_tensor::<B>(d),
+            handles.get_float_tensor::<B>(h),
+            self.state_dim,
+            self.save_states,
+        );
+        handles.register_float_tensor::<B>(&y_ir.id, y);
+        handles.register_float_tensor::<B>(&h_ir.id, h);
+        handles.register_float_tensor::<B>(&states_ir.id, states);
+    }
+}
+
+#[derive(Debug)]
+struct ScanBackward<B> {
+    desc: CustomOpIr,
+    state_dim: usize,
+    backend: PhantomData<B>,
+}
+
+impl<B> Operation<B::FusionRuntime> for ScanBackward<B>
+where
+    B: FusionBackend + MambaBackend,
+{
+    fn execute(
+        &self,
+        handles: &mut HandleContainer<<B::FusionRuntime as FusionRuntime>::FusionHandle>,
+    ) {
+        let (
+            [delta, xs, b_mat, c_mat, a, d, h, states, grad_y],
+            [grad_delta, grad_xs, grad_b, grad_c, grad_a, grad_d, grad_h],
+        ) = self.desc.as_fixed();
+        let output = B::selective_scan_backward(
+            handles.get_float_tensor::<B>(delta),
+            handles.get_float_tensor::<B>(xs),
+            handles.get_float_tensor::<B>(b_mat),
+            handles.get_float_tensor::<B>(c_mat),
+            handles.get_float_tensor::<B>(a),
+            handles.get_float_tensor::<B>(d),
+            handles.get_float_tensor::<B>(h),
+            handles.get_float_tensor::<B>(states),
+            handles.get_float_tensor::<B>(grad_y),
+            self.state_dim,
+        );
+        handles.register_float_tensor::<B>(&grad_delta.id, output.0);
+        handles.register_float_tensor::<B>(&grad_xs.id, output.1);
+        handles.register_float_tensor::<B>(&grad_b.id, output.2);
+        handles.register_float_tensor::<B>(&grad_c.id, output.3);
+        handles.register_float_tensor::<B>(&grad_a.id, output.4);
+        handles.register_float_tensor::<B>(&grad_d.id, output.5);
+        handles.register_float_tensor::<B>(&grad_h.id, output.6);
+    }
+}
+
+impl<B> MambaBackend for Fusion<B>
+where
+    B: FusionBackend + MambaBackend,
+{
+    fn selective_scan_inner(
+        delta: FloatTensor<Self>,
+        xs: FloatTensor<Self>,
+        b_mat: FloatTensor<Self>,
+        c_mat: FloatTensor<Self>,
+        a: FloatTensor<Self>,
+        d: FloatTensor<Self>,
+        h: FloatTensor<Self>,
+        state_dim: usize,
+        save_states: bool,
+    ) -> (FloatTensor<Self>, FloatTensor<Self>, FloatTensor<Self>) {
+        let [batch, seq_len, channels] = xs.shape.dims();
+        let client = xs.client.clone();
+        let dtype = xs.dtype;
+        let checkpoint_interval = scan_checkpoint_interval(batch, seq_len, channels, state_dim);
+        let y = TensorIr::uninit(
+            client.create_empty_handle(),
+            Shape::new([batch, seq_len, channels]),
+            dtype,
+        );
+        let h_out = TensorIr::uninit(
+            client.create_empty_handle(),
+            Shape::new([batch, channels, state_dim]),
+            dtype,
+        );
+        let states_shape = if save_states {
+            Shape::new([
+                batch,
+                seq_len.div_ceil(checkpoint_interval),
+                channels,
+                state_dim,
+            ])
+        } else {
+            Shape::new([batch, channels, state_dim])
+        };
+        let states = TensorIr::uninit(client.create_empty_handle(), states_shape, dtype);
+        let desc = CustomOpIr::with_scalars(
+            "hermes_selective_scan",
+            &[
+                delta.into_ir(),
+                xs.into_ir(),
+                b_mat.into_ir(),
+                c_mat.into_ir(),
+                a.into_ir(),
+                d.into_ir(),
+                h.into_ir(),
+            ],
+            &[y, h_out, states],
+            vec![
+                ScalarIr::UInt(state_dim as u64),
+                ScalarIr::Bool(save_states),
+            ],
+        );
+        let [y, h, states] = client
+            .register(
+                StreamId::current(),
+                OperationIr::Custom(desc.clone()),
+                ScanForward::<B> {
+                    desc,
+                    state_dim,
+                    save_states,
+                    backend: PhantomData,
+                },
+            )
+            .try_into()
+            .expect("selective scan has three outputs");
+        (y, h, states)
+    }
+
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
+    fn selective_scan_backward(
+        delta: FloatTensor<Self>,
+        xs: FloatTensor<Self>,
+        b_mat: FloatTensor<Self>,
+        c_mat: FloatTensor<Self>,
+        a: FloatTensor<Self>,
+        d: FloatTensor<Self>,
+        h: FloatTensor<Self>,
+        states: FloatTensor<Self>,
+        grad_y: FloatTensor<Self>,
+        state_dim: usize,
+    ) -> (
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+    ) {
+        let [batch, seq_len, channels] = xs.shape.dims();
+        let client = xs.client.clone();
+        let dtype = xs.dtype;
+        let delta_shape = Shape::new([batch, seq_len, channels]);
+        let bc_shape = Shape::new([batch, seq_len, state_dim]);
+        let a_shape = Shape::new([channels, state_dim]);
+        let d_shape = Shape::new([channels]);
+        let h_shape = Shape::new([batch, channels, state_dim]);
+        let outputs = [
+            TensorIr::uninit(client.create_empty_handle(), delta_shape.clone(), dtype),
+            TensorIr::uninit(client.create_empty_handle(), delta_shape, dtype),
+            TensorIr::uninit(client.create_empty_handle(), bc_shape.clone(), dtype),
+            TensorIr::uninit(client.create_empty_handle(), bc_shape, dtype),
+            TensorIr::uninit(client.create_empty_handle(), a_shape, dtype),
+            TensorIr::uninit(client.create_empty_handle(), d_shape, dtype),
+            TensorIr::uninit(client.create_empty_handle(), h_shape, dtype),
+        ];
+        let desc = CustomOpIr::with_scalars(
+            "hermes_selective_scan_backward",
+            &[
+                delta.into_ir(),
+                xs.into_ir(),
+                b_mat.into_ir(),
+                c_mat.into_ir(),
+                a.into_ir(),
+                d.into_ir(),
+                h.into_ir(),
+                states.into_ir(),
+                grad_y.into_ir(),
+            ],
+            &outputs,
+            vec![ScalarIr::UInt(state_dim as u64)],
+        );
+        let [grad_delta, grad_xs, grad_b, grad_c, grad_a, grad_d, grad_h] = client
+            .register(
+                StreamId::current(),
+                OperationIr::Custom(desc.clone()),
+                ScanBackward::<B> {
+                    desc,
+                    state_dim,
+                    backend: PhantomData,
+                },
+            )
+            .try_into()
+            .expect("selective scan backward has seven outputs");
+        (grad_delta, grad_xs, grad_b, grad_c, grad_a, grad_d, grad_h)
+    }
+}
+
+#[derive(Debug)]
+struct AttentionForward {
+    desc: CustomOpIr,
+    causal: bool,
+}
+
+#[derive(Debug)]
+struct AttentionCausalMask {
+    desc: CustomOpIr,
+    row_offset: usize,
+}
+
+impl Operation<FusionCubeRuntime<CudaRuntime>> for AttentionCausalMask {
+    fn execute(
+        &self,
+        handles: &mut HandleContainer<
+            <FusionCubeRuntime<CudaRuntime> as FusionRuntime>::FusionHandle,
+        >,
+    ) {
+        type B = CubeBackend<CudaRuntime>;
+        let ([scores], [output]) = self.desc.as_fixed();
+        let result =
+            B::attention_causal_mask(handles.get_float_tensor::<B>(scores), self.row_offset);
+        handles.register_float_tensor::<B>(&output.id, result);
+    }
+}
+
+impl Operation<FusionCubeRuntime<CudaRuntime>> for AttentionForward {
+    fn execute(
+        &self,
+        handles: &mut HandleContainer<
+            <FusionCubeRuntime<CudaRuntime> as FusionRuntime>::FusionHandle,
+        >,
+    ) {
+        type B = CubeBackend<CudaRuntime>;
+        let ([query, key, value], [output, saved_query, saved_key, saved_value, saved_output]) =
+            self.desc.as_fixed();
+        let result = B::attention_inner(
+            handles.get_float_tensor::<B>(query),
+            handles.get_float_tensor::<B>(key),
+            handles.get_float_tensor::<B>(value),
+            self.causal,
+        );
+        handles.register_float_tensor::<B>(&output.id, result.0);
+        handles.register_float_tensor::<B>(&saved_query.id, result.1);
+        handles.register_float_tensor::<B>(&saved_key.id, result.2);
+        handles.register_float_tensor::<B>(&saved_value.id, result.3);
+        handles.register_float_tensor::<B>(&saved_output.id, result.4);
+    }
+}
+
+impl AttentionBackend for Fusion<CubeBackend<CudaRuntime>> {
+    fn attention_inner(
+        query: FloatTensor<Self>,
+        key: FloatTensor<Self>,
+        value: FloatTensor<Self>,
+        causal: bool,
+    ) -> (
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+        FloatTensor<Self>,
+    ) {
+        let client = query.client.clone();
+        let shape = query.shape.clone();
+        let dtype = query.dtype;
+        let f16 = DType::F16;
+        let outputs = [
+            TensorIr::uninit(client.create_empty_handle(), shape.clone(), dtype),
+            TensorIr::uninit(client.create_empty_handle(), shape.clone(), f16),
+            TensorIr::uninit(client.create_empty_handle(), key.shape.clone(), f16),
+            TensorIr::uninit(client.create_empty_handle(), value.shape.clone(), f16),
+            TensorIr::uninit(client.create_empty_handle(), shape, f16),
+        ];
+        let desc = CustomOpIr::with_scalars(
+            "hermes_flash_attention",
+            &[query.into_ir(), key.into_ir(), value.into_ir()],
+            &outputs,
+            vec![ScalarIr::Bool(causal)],
+        );
+        let [output, query, key, value, saved_output] = client
+            .register(
+                StreamId::current(),
+                OperationIr::Custom(desc.clone()),
+                AttentionForward { desc, causal },
+            )
+            .try_into()
+            .expect("attention forward has five outputs");
+        (output, query, key, value, saved_output)
+    }
+
+    fn attention_backward(
+        query: FloatTensor<Self>,
+        key: FloatTensor<Self>,
+        value: FloatTensor<Self>,
+        output: FloatTensor<Self>,
+        grad_output: FloatTensor<Self>,
+        causal: bool,
+    ) -> (FloatTensor<Self>, FloatTensor<Self>, FloatTensor<Self>) {
+        // Keep the recompute graph visible to Burn so its softmax correction,
+        // casts, and reductions fuse around the accelerated matmuls.
+        chunked_attention_backward::<Self>(
+            query,
+            key,
+            value,
+            output,
+            grad_output,
+            causal,
+            ATTENTION_BACKWARD_CHUNK_ROWS,
+        )
+    }
+
+    fn attention_causal_mask(scores: FloatTensor<Self>, row_offset: usize) -> FloatTensor<Self> {
+        let client = scores.client.clone();
+        let output = TensorIr::uninit(
+            client.create_empty_handle(),
+            scores.shape.clone(),
+            scores.dtype,
+        );
+        let desc = CustomOpIr::with_scalars(
+            "hermes_attention_causal_mask",
+            &[scores.into_ir()],
+            &[output],
+            vec![ScalarIr::UInt(row_offset as u64)],
+        );
+        client
+            .register(
+                StreamId::current(),
+                OperationIr::Custom(desc.clone()),
+                AttentionCausalMask { desc, row_offset },
+            )
+            .remove(0)
+    }
+}

--- a/hermes-llm/src/model/mamba.rs
+++ b/hermes-llm/src/model/mamba.rs
@@ -12,7 +12,7 @@ use burn_nn::{Linear, LinearConfig};
 use crate::mal::{ModelDef, SsmDef};
 
 use super::conv::depthwise_conv1d;
-use super::matmul::linear;
+use super::matmul::{linear, prepare_linear_for_inference};
 use super::scan::selective_scan;
 
 /// Recurrent state for one Mamba layer.
@@ -88,6 +88,17 @@ impl MambaMixer {
         MambaState {
             conv: Tensor::zeros([batch, self.d_inner, self.conv_kernel - 1], device),
             h: Tensor::zeros([batch, self.d_inner, self.state_dim], device),
+        }
+    }
+
+    pub(crate) fn prepare_inference(&mut self) {
+        for layer in [
+            &mut self.in_proj,
+            &mut self.x_proj,
+            &mut self.dt_proj,
+            &mut self.out_proj,
+        ] {
+            prepare_linear_for_inference(layer);
         }
     }
 

--- a/hermes-llm/src/model/matmul.rs
+++ b/hermes-llm/src/model/matmul.rs
@@ -5,6 +5,26 @@ use burn::prelude::*;
 use burn::tensor::{DType, FloatDType};
 use burn_nn::Linear;
 
+pub(super) fn prepare_linear_for_inference(layer: &mut Linear) {
+    #[cfg(feature = "cuda")]
+    {
+        if !layer.weight.val().device().supports_dtype(DType::F16) {
+            return;
+        }
+        layer.weight = layer
+            .weight
+            .clone()
+            .map(|weight| weight.cast(FloatDType::F16));
+        layer.bias = layer
+            .bias
+            .take()
+            .map(|bias| bias.map(|value| value.cast(FloatDType::F16)));
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    let _ = layer;
+}
+
 pub(super) fn matmul_input<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
     #[cfg(feature = "cuda")]
     {
@@ -45,7 +65,7 @@ pub(super) fn matmul_2(lhs: Tensor<2>, rhs: Tensor<2>) -> Tensor<2> {
     lhs.matmul(rhs)
 }
 
-#[cfg(feature = "cuda")]
+#[cfg(feature = "training-fusion")]
 pub(super) fn matmul_4(lhs: Tensor<4>, rhs: Tensor<4>) -> Tensor<4> {
     if lhs.device().supports_dtype(DType::F16) {
         return matmul_input(lhs)

--- a/hermes-llm/src/model/matmul.rs
+++ b/hermes-llm/src/model/matmul.rs
@@ -5,20 +5,29 @@ use burn::prelude::*;
 use burn::tensor::{DType, FloatDType};
 use burn_nn::Linear;
 
+#[cfg(feature = "cuda")]
+fn matmul_dtype(device: &Device) -> Option<FloatDType> {
+    // BF16 keeps FP32's exponent range during training; decode uses F16 for
+    // compact prepared weights and equally fast A100 tensor-core matmuls.
+    #[cfg(feature = "training-fusion")]
+    let (dtype, float_dtype) = (DType::BF16, FloatDType::BF16);
+    #[cfg(not(feature = "training-fusion"))]
+    let (dtype, float_dtype) = (DType::F16, FloatDType::F16);
+
+    device.supports_dtype(dtype).then_some(float_dtype)
+}
+
 pub(super) fn prepare_linear_for_inference(layer: &mut Linear) {
     #[cfg(feature = "cuda")]
     {
-        if !layer.weight.val().device().supports_dtype(DType::F16) {
+        let Some(dtype) = matmul_dtype(&layer.weight.val().device()) else {
             return;
-        }
-        layer.weight = layer
-            .weight
-            .clone()
-            .map(|weight| weight.cast(FloatDType::F16));
+        };
+        layer.weight = layer.weight.clone().map(|weight| weight.cast(dtype));
         layer.bias = layer
             .bias
             .take()
-            .map(|bias| bias.map(|value| value.cast(FloatDType::F16)));
+            .map(|bias| bias.map(|value| value.cast(dtype)));
     }
 
     #[cfg(not(feature = "cuda"))]
@@ -28,8 +37,8 @@ pub(super) fn prepare_linear_for_inference(layer: &mut Linear) {
 pub(super) fn matmul_input<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
     #[cfg(feature = "cuda")]
     {
-        if tensor.device().supports_dtype(DType::F16) {
-            return tensor.cast(FloatDType::F16);
+        if let Some(dtype) = matmul_dtype(&tensor.device()) {
+            return tensor.cast(dtype);
         }
     }
 
@@ -39,7 +48,7 @@ pub(super) fn matmul_input<const D: usize>(tensor: Tensor<D>) -> Tensor<D> {
 pub(super) fn linear<const D: usize>(layer: &Linear, input: Tensor<D>) -> Tensor<D> {
     #[cfg(feature = "cuda")]
     {
-        if input.device().supports_dtype(DType::F16) {
+        if matmul_dtype(&input.device()).is_some() {
             return burn::tensor::module::linear(
                 matmul_input(input),
                 matmul_input(layer.weight.val()),
@@ -55,7 +64,7 @@ pub(super) fn linear<const D: usize>(layer: &Linear, input: Tensor<D>) -> Tensor
 pub(super) fn matmul_2(lhs: Tensor<2>, rhs: Tensor<2>) -> Tensor<2> {
     #[cfg(feature = "cuda")]
     {
-        if lhs.device().supports_dtype(DType::F16) {
+        if matmul_dtype(&lhs.device()).is_some() {
             return matmul_input(lhs)
                 .matmul(matmul_input(rhs))
                 .cast(FloatDType::F32);
@@ -67,7 +76,7 @@ pub(super) fn matmul_2(lhs: Tensor<2>, rhs: Tensor<2>) -> Tensor<2> {
 
 #[cfg(feature = "training-fusion")]
 pub(super) fn matmul_4(lhs: Tensor<4>, rhs: Tensor<4>) -> Tensor<4> {
-    if lhs.device().supports_dtype(DType::F16) {
+    if matmul_dtype(&lhs.device()).is_some() {
         return matmul_input(lhs)
             .matmul(matmul_input(rhs))
             .cast(FloatDType::F32);

--- a/hermes-llm/src/model/matmul.rs
+++ b/hermes-llm/src/model/matmul.rs
@@ -25,7 +25,7 @@ pub(super) fn linear<const D: usize>(layer: &Linear, input: Tensor<D>) -> Tensor
                 matmul_input(layer.weight.val()),
                 layer.bias.as_ref().map(|bias| matmul_input(bias.val())),
             )
-            .cast(FloatDType::Flex32);
+            .cast(FloatDType::F32);
         }
     }
 
@@ -38,7 +38,7 @@ pub(super) fn matmul_2(lhs: Tensor<2>, rhs: Tensor<2>) -> Tensor<2> {
         if lhs.device().supports_dtype(DType::F16) {
             return matmul_input(lhs)
                 .matmul(matmul_input(rhs))
-                .cast(FloatDType::Flex32);
+                .cast(FloatDType::F32);
         }
     }
 
@@ -50,7 +50,7 @@ pub(super) fn matmul_4(lhs: Tensor<4>, rhs: Tensor<4>) -> Tensor<4> {
     if lhs.device().supports_dtype(DType::F16) {
         return matmul_input(lhs)
             .matmul(matmul_input(rhs))
-            .cast(FloatDType::Flex32);
+            .cast(FloatDType::F32);
     }
 
     lhs.matmul(rhs)

--- a/hermes-llm/src/model/mod.rs
+++ b/hermes-llm/src/model/mod.rs
@@ -10,7 +10,7 @@ mod cube_attention;
 mod cube_tensor;
 mod ffn;
 mod fused_attention;
-#[cfg(feature = "cuda")]
+#[cfg(feature = "training-fusion")]
 mod fusion;
 mod linear_cross_entropy;
 mod mamba;
@@ -69,7 +69,24 @@ mod tests {
     use burn_nn::RotaryEncodingConfig;
 
     use super::*;
-    use crate::mal::{NormType, PositionEncoding, get_builtin_model};
+    use crate::mal::{ModelDef, NormType, PositionEncoding, get_builtin_model};
+
+    fn hybrid_test_config() -> ModelDef {
+        let mut config = get_builtin_model("hybrid-tiny").unwrap();
+        config.vocab_size = 32;
+        config.hidden_size = 8;
+        config.num_layers = 3;
+        config.max_seq_len = 16;
+        if let Some(pattern) = config.pattern.as_mut() {
+            for block in pattern {
+                block.ffn.hidden_dim = Some(16);
+                block.attention.num_heads = Some(2);
+                block.attention.num_kv_heads = Some(1);
+                block.attention.head_dim = Some(4);
+            }
+        }
+        config
+    }
 
     fn max_abs_diff<const D: usize>(a: Tensor<D>, b: Tensor<D>) -> f32 {
         let a = a.into_data().convert::<f32>().to_vec::<f32>().unwrap();
@@ -186,19 +203,7 @@ mod tests {
 
     #[test]
     fn test_hybrid_transformer_stateful_matches_stateless() {
-        let mut config = get_builtin_model("hybrid-tiny").unwrap();
-        config.vocab_size = 32;
-        config.hidden_size = 8;
-        config.num_layers = 3;
-        config.max_seq_len = 16;
-        if let Some(pattern) = config.pattern.as_mut() {
-            for block in pattern {
-                block.ffn.hidden_dim = Some(16);
-                block.attention.num_heads = Some(2);
-                block.attention.num_kv_heads = Some(1);
-                block.attention.head_dim = Some(4);
-            }
-        }
+        let config = hybrid_test_config();
         let device = Device::ndarray();
         device.seed(19);
         let model = Transformer::new(&config, &device).unwrap();
@@ -221,6 +226,31 @@ mod tests {
         assert!(max_abs_diff(prefill, full.clone().slice([0..1, 0..4, 0..32])) < 1e-4);
         assert!(max_abs_diff(decode, full.slice([0..1, 4..6, 0..32])) < 1e-4);
         assert_eq!(state.pos(), 6);
+    }
+
+    #[cfg(all(feature = "cuda", target_os = "linux"))]
+    #[test]
+    fn test_cuda_prepared_inference_matches_ephemeral_weight_casts() {
+        let config = hybrid_test_config();
+        let device = default_device();
+        device.seed(29);
+        let mut model = Transformer::new(&config, &device).unwrap();
+        let input = Tensor::<2, Int>::from_data(
+            TensorData::new(vec![1_i64, 7, 3, 9, 2, 5], [1, 6]),
+            &device,
+        );
+        let before = model.forward(input.clone(), 0).into_data();
+        model.prepare_inference();
+        let after = model.forward(input, 0).into_data();
+        let difference = before
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .unwrap()
+            .into_iter()
+            .zip(after.convert::<f32>().to_vec::<f32>().unwrap())
+            .map(|(left, right)| (left - right).abs())
+            .fold(0.0, f32::max);
+        assert!(difference < 1e-3, "maximum logit difference: {difference}");
     }
 
     #[test]

--- a/hermes-llm/src/model/mod.rs
+++ b/hermes-llm/src/model/mod.rs
@@ -10,6 +10,8 @@ mod cube_attention;
 mod cube_tensor;
 mod ffn;
 mod fused_attention;
+#[cfg(feature = "cuda")]
+mod fusion;
 mod linear_cross_entropy;
 mod mamba;
 mod matmul;

--- a/hermes-llm/src/model/scan.rs
+++ b/hermes-llm/src/model/scan.rs
@@ -22,6 +22,34 @@ use burn_autodiff::ops::{Backward, Ops, OpsKind};
 
 use super::conv::DepthwiseConv1dBackend;
 
+#[cfg(any(feature = "metal", feature = "cuda", test))]
+const CHECKPOINTED_SCAN_INTERVAL: usize = 32;
+#[cfg(any(feature = "metal", feature = "cuda", test))]
+const MAX_FULL_STATE_BATCH: usize = 2;
+#[cfg(any(feature = "metal", feature = "cuda", test))]
+const MAX_FULL_STATE_BYTES: usize = 512 * 1024 * 1024;
+
+/// Keep every recurrent state when a small training batch fits a bounded
+/// per-layer budget; larger batches trade one recurrence recompute for memory.
+#[cfg(any(feature = "metal", feature = "cuda", test))]
+pub(super) fn scan_checkpoint_interval(
+    batch: usize,
+    seq_len: usize,
+    channels: usize,
+    state_dim: usize,
+) -> usize {
+    let state_bytes = batch
+        .saturating_mul(seq_len)
+        .saturating_mul(channels)
+        .saturating_mul(state_dim)
+        .saturating_mul(size_of::<f32>());
+    if batch <= MAX_FULL_STATE_BATCH && state_bytes <= MAX_FULL_STATE_BYTES {
+        1
+    } else {
+        CHECKPOINTED_SCAN_INTERVAL
+    }
+}
+
 fn stable_softplus<const D: usize>(value: Tensor<D>) -> Tensor<D> {
     relu(value.clone()) + (-value.abs()).exp().add_scalar(1.0).log()
 }
@@ -531,11 +559,15 @@ mod gpu {
     use burn_cubecl::tensor::CubeTensor;
     use burn_cubecl::{CubeBackend, CubeRuntime};
 
-    use super::MambaBackend;
+    use super::{MambaBackend, scan_checkpoint_interval};
     use crate::model::cube_tensor::{empty_like, into_contiguous, zeros_like};
 
     const THREADS_PER_CUBE: u32 = 128;
     const PLANE_WIDTH: u32 = 32;
+    const FORWARD_CHANNELS: u32 = THREADS_PER_CUBE / PLANE_WIDTH;
+    // A100 measurements favor serial recurrence once this many independent
+    // blocks are available; smaller grids benefit from parallel state lanes.
+    const SERIAL_SCAN_MIN_BLOCKS: u32 = 128;
     const BACKWARD_CHANNELS: usize = 16;
 
     #[cube]
@@ -633,70 +665,131 @@ mod gpu {
         }
     }
 
-    /// Parallelize the recurrent state dimension. Each thread still follows
-    /// one exact scalar recurrence through time, while a separate kernel
-    /// reduces the small state dimension into the output.
+    /// One thread owns a batch/channel pair. This avoids a plane reduction
+    /// when the batch/channel grid already has enough blocks to fill the GPU.
+    #[allow(clippy::manual_div_ceil)]
     #[cube(launch)]
-    fn selective_scan_states(
+    fn selective_scan_forward_serial(
         delta: &Tensor<f32>,
         xs: &Tensor<f32>,
         b_mat: &Tensor<f32>,
+        c_mat: &Tensor<f32>,
         a: &Tensor<f32>,
+        d: &Tensor<f32>,
         h_in: &Tensor<f32>,
-        states: &mut Tensor<f32>,
+        y: &mut Tensor<f32>,
+        checkpoints: &mut Tensor<f32>,
         h_out: &mut Tensor<f32>,
         channels: u32,
         seq_len: u32,
         #[comptime] state_dim: usize,
+        #[comptime] checkpoint_interval: usize,
+        #[comptime] save_checkpoints: bool,
     ) {
         let channels = channels as usize;
         let seq_len = seq_len as usize;
         let idx = ABSOLUTE_POS;
-        if idx < h_out.len() {
-            let n = idx % state_dim;
-            let batch_channel = idx / state_dim;
-            let batch = batch_channel / channels;
-            let channel = batch_channel % channels;
-            let mut state = h_in[idx];
-            let av = a[channel * state_dim + n];
+        let batch_channels = xs.len() / seq_len;
+        if idx < batch_channels {
+            let batch = idx / channels;
+            let channel = idx % channels;
+            let state_base = idx * state_dim;
+            let a_base = channel * state_dim;
+            let checkpoint_count = (seq_len + checkpoint_interval - 1) / checkpoint_interval;
+            let mut state = Array::<f32>::new(state_dim);
+            for n in 0..state_dim {
+                state[n] = h_in[state_base + n];
+            }
 
             for t in 0..seq_len {
                 let btc = (batch * seq_len + t) * channels + channel;
-                let btn = (batch * seq_len + t) * state_dim + n;
+                let btn = (batch * seq_len + t) * state_dim;
                 let dt = delta[btc];
                 let x = xs[btc];
-                state = state * (dt * av).exp() + dt * b_mat[btn] * x;
-                states[btc * state_dim + n] = state;
+                let mut out = 0.0f32;
+                for n in 0..state_dim {
+                    state[n] = state[n] * (dt * a[a_base + n]).exp() + dt * b_mat[btn + n] * x;
+                    out += state[n] * c_mat[btn + n];
+                }
+                y[btc] = out + x * d[channel];
+
+                if save_checkpoints && ((t + 1) % checkpoint_interval == 0 || t + 1 == seq_len) {
+                    let checkpoint = t / checkpoint_interval;
+                    let checkpoint_base =
+                        ((batch * checkpoint_count + checkpoint) * channels + channel) * state_dim;
+                    for n in 0..state_dim {
+                        checkpoints[checkpoint_base + n] = state[n];
+                    }
+                }
             }
-            h_out[idx] = state;
+            for n in 0..state_dim {
+                h_out[state_base + n] = state[n];
+            }
         }
     }
 
+    /// One plane owns a batch/channel pair. This exposes the state dimension
+    /// as parallel work when a small batch would otherwise underfill the GPU.
+    #[allow(clippy::manual_div_ceil)]
     #[cube(launch)]
-    fn selective_scan_output(
+    fn selective_scan_forward_parallel(
+        delta: &Tensor<f32>,
         xs: &Tensor<f32>,
+        b_mat: &Tensor<f32>,
         c_mat: &Tensor<f32>,
+        a: &Tensor<f32>,
         d: &Tensor<f32>,
-        states: &Tensor<f32>,
+        h_in: &Tensor<f32>,
         y: &mut Tensor<f32>,
+        checkpoints: &mut Tensor<f32>,
+        h_out: &mut Tensor<f32>,
         channels: u32,
         seq_len: u32,
         #[comptime] state_dim: usize,
+        #[comptime] checkpoint_interval: usize,
+        #[comptime] save_checkpoints: bool,
     ) {
         let channels = channels as usize;
         let seq_len = seq_len as usize;
-        let btc = ABSOLUTE_POS;
-        if btc < xs.len() {
-            let channel = btc % channels;
-            let batch_time = btc / channels;
-            let batch = batch_time / seq_len;
-            let t = batch_time % seq_len;
+        let n = UNIT_POS_X as usize;
+        let local_channel = UNIT_POS_Y as usize;
+        let batch = CUBE_POS_Y as usize;
+        let channel = CUBE_POS_X as usize * FORWARD_CHANNELS as usize + local_channel;
+        let active_channel = channel < channels;
+        let active = active_channel && n < state_dim;
+        let state_base = (batch * channels + channel) * state_dim;
+        let a_base = channel * state_dim;
+        let checkpoint_count = (seq_len + checkpoint_interval - 1) / checkpoint_interval;
+        let mut state = if active { h_in[state_base + n] } else { 0.0f32 };
+
+        for t in 0..seq_len {
+            let btc = (batch * seq_len + t) * channels + channel;
             let btn = (batch * seq_len + t) * state_dim;
-            let mut out = 0.0f32;
-            for n in 0..state_dim {
-                out += states[btc * state_dim + n] * c_mat[btn + n];
+            let dt = if active_channel { delta[btc] } else { 0.0f32 };
+            let x = if active_channel { xs[btc] } else { 0.0f32 };
+            let contribution = if active {
+                state = state * (dt * a[a_base + n]).exp() + dt * b_mat[btn + n] * x;
+                state * c_mat[btn + n]
+            } else {
+                0.0f32
+            };
+            let out = plane_sum(contribution);
+            if n == 0 && active_channel {
+                y[btc] = out + x * d[channel];
             }
-            y[btc] = out + xs[btc] * d[channel];
+
+            if active
+                && save_checkpoints
+                && ((t + 1) % checkpoint_interval == 0 || t + 1 == seq_len)
+            {
+                let checkpoint = t / checkpoint_interval;
+                let checkpoint_base =
+                    ((batch * checkpoint_count + checkpoint) * channels + channel) * state_dim;
+                checkpoints[checkpoint_base + n] = state;
+            }
+        }
+        if active {
+            h_out[state_base + n] = state;
         }
     }
 
@@ -704,7 +797,7 @@ mod gpu {
     /// gradient while following the reverse recurrence exactly once. The
     /// channel and state reductions share the per-token contributions in
     /// workgroup memory instead of launching a second recurrent kernel.
-    #[allow(clippy::useless_conversion)]
+    #[allow(clippy::manual_div_ceil, clippy::useless_conversion)]
     #[cube(launch)]
     fn selective_scan_backward_fused(
         delta: &Tensor<f32>,
@@ -715,7 +808,7 @@ mod gpu {
         a: &Tensor<f32>,
         d: &Tensor<f32>,
         h_in: &Tensor<f32>,
-        states: &Tensor<f32>,
+        checkpoints: &Tensor<f32>,
         grad_y: &Tensor<f32>,
         grad_delta: &mut Tensor<f32>,
         grad_xs: &mut Tensor<f32>,
@@ -727,6 +820,7 @@ mod gpu {
         channels: u32,
         seq_len: u32,
         #[comptime] state_dim: usize,
+        #[comptime] checkpoint_interval: usize,
     ) {
         let channels = channels as usize;
         let seq_len = seq_len as usize;
@@ -747,59 +841,98 @@ mod gpu {
         let mut adjoint = 0.0f32;
         let mut grad_a_local = 0.0f32;
         let mut grad_d_local = 0.0f32;
+        let checkpoint_count = (seq_len + checkpoint_interval - 1) / checkpoint_interval;
 
-        for step in 0..seq_len {
-            let t = seq_len - step - 1;
-            let btc = (batch * seq_len + t) * channels + channel;
-            let btn = (batch * seq_len + t) * state_dim;
-            let dt = if active { delta[btc] } else { 0.0f32 };
-            let raw_dt = if active { delta_raw[btc] } else { 0.0f32 };
-            let x = if active { xs[btc] } else { 0.0f32 };
-            let dy = if active { grad_y[btc] } else { 0.0f32 };
-            let av = if active { a[a_index] } else { 0.0f32 };
-            let bv = if active { b_mat[btn + n] } else { 0.0f32 };
-            let cv = if active { c_mat[btn + n] } else { 0.0f32 };
-            let alpha = (dt * av).exp();
-            let h_prev = if active {
-                if t == 0 {
+        for checkpoint_step in 0..checkpoint_count {
+            let checkpoint = checkpoint_count - checkpoint_step - 1;
+            let start = checkpoint * checkpoint_interval;
+            let mut end = start + checkpoint_interval;
+            if end > seq_len {
+                end = seq_len;
+            }
+            let chunk_len = end - start;
+            let state_before = if active {
+                if checkpoint == 0 {
                     h_in[state_index]
                 } else {
-                    states[((batch * seq_len + t - 1) * channels + channel) * state_dim + n]
+                    checkpoints[((batch * checkpoint_count + checkpoint - 1) * channels + channel)
+                        * state_dim
+                        + n]
                 }
             } else {
                 0.0f32
             };
-            let h_t = if active {
-                states[btc * state_dim + n]
-            } else {
-                0.0f32
-            };
-            let g = adjoint + dy * cv;
-            let shared_offset = (step % 2) * shared_len;
-            grad_dt_shared[shared_offset + shared_index] = g * (h_prev * alpha * av + bv * x);
-            grad_x_shared[shared_offset + shared_index] = g * dt * bv;
-            let grad_b_sum = half_plane_sum(g * dt * x, local_channel);
-            let grad_c_sum = half_plane_sum(dy * h_t, local_channel);
-            sync_cube();
+            let av = if active { a[a_index] } else { 0.0f32 };
+            let mut state = state_before;
+            let mut chunk_states = Array::<f32>::new(checkpoint_interval);
 
-            if n == 0 && active_channel {
-                let mut grad_dt = 0.0f32;
-                let mut grad_x = 0.0f32;
-                for state in 0..state_dim {
-                    let index = shared_offset + state * BACKWARD_CHANNELS + local_channel;
-                    grad_dt += grad_dt_shared[index];
-                    grad_x += grad_x_shared[index];
+            if checkpoint_interval == 1 {
+                chunk_states[0] = if active {
+                    checkpoints[((batch * checkpoint_count + checkpoint) * channels + channel)
+                        * state_dim
+                        + n]
+                } else {
+                    0.0f32
+                };
+            } else {
+                for offset in 0..chunk_len {
+                    let t = start + offset;
+                    let btc = (batch * seq_len + t) * channels + channel;
+                    let btn = (batch * seq_len + t) * state_dim;
+                    let dt = if active { delta[btc] } else { 0.0f32 };
+                    let x = if active { xs[btc] } else { 0.0f32 };
+                    let bv = if active { b_mat[btn + n] } else { 0.0f32 };
+                    state = state * (dt * av).exp() + dt * bv * x;
+                    chunk_states[offset] = state;
                 }
-                grad_delta[btc] = grad_dt * stable_sigmoid(raw_dt);
-                grad_xs[btc] = dy * d[channel] + grad_x;
-                grad_d_local += dy * x;
             }
-            if local_channel == 0 {
-                atomic_add_f32(&mut grad_b[btn + n], grad_b_sum);
-                atomic_add_f32(&mut grad_c[btn + n], grad_c_sum);
+
+            for reverse_offset in 0..chunk_len {
+                let offset = chunk_len - reverse_offset - 1;
+                let t = start + offset;
+                let btc = (batch * seq_len + t) * channels + channel;
+                let btn = (batch * seq_len + t) * state_dim;
+                let dt = if active { delta[btc] } else { 0.0f32 };
+                let raw_dt = if active { delta_raw[btc] } else { 0.0f32 };
+                let x = if active { xs[btc] } else { 0.0f32 };
+                let dy = if active { grad_y[btc] } else { 0.0f32 };
+                let bv = if active { b_mat[btn + n] } else { 0.0f32 };
+                let cv = if active { c_mat[btn + n] } else { 0.0f32 };
+                let alpha = (dt * av).exp();
+                let h_prev = if offset == 0 {
+                    state_before
+                } else {
+                    chunk_states[offset - 1]
+                };
+                let h_t = chunk_states[offset];
+                let g = adjoint + dy * cv;
+                let step = seq_len - t - 1;
+                let shared_offset = (step % 2) * shared_len;
+                grad_dt_shared[shared_offset + shared_index] = g * (h_prev * alpha * av + bv * x);
+                grad_x_shared[shared_offset + shared_index] = g * dt * bv;
+                let grad_b_sum = half_plane_sum(g * dt * x, local_channel);
+                let grad_c_sum = half_plane_sum(dy * h_t, local_channel);
+                sync_cube();
+
+                if n == 0 && active_channel {
+                    let mut grad_dt = 0.0f32;
+                    let mut grad_x = 0.0f32;
+                    for state in 0..state_dim {
+                        let index = shared_offset + state * BACKWARD_CHANNELS + local_channel;
+                        grad_dt += grad_dt_shared[index];
+                        grad_x += grad_x_shared[index];
+                    }
+                    grad_delta[btc] = grad_dt * stable_sigmoid(raw_dt);
+                    grad_xs[btc] = dy * d[channel] + grad_x;
+                    grad_d_local += dy * x;
+                }
+                if local_channel == 0 {
+                    atomic_add_f32(&mut grad_b[btn + n], grad_b_sum);
+                    atomic_add_f32(&mut grad_c[btn + n], grad_c_sum);
+                }
+                grad_a_local += g * h_prev * alpha * dt;
+                adjoint = g * alpha;
             }
-            grad_a_local += g * h_prev * alpha * dt;
-            adjoint = g * alpha;
         }
 
         if active {
@@ -824,6 +957,10 @@ mod gpu {
             save_states: bool,
         ) -> (CubeTensor<R>, CubeTensor<R>, CubeTensor<R>) {
             let [batch, seq_len, channels] = xs.shape().dims();
+            assert!(
+                state_dim <= PLANE_WIDTH as usize,
+                "GPU selective scan supports at most {PLANE_WIDTH} states"
+            );
             let delta_raw = into_contiguous(delta);
             let xs = into_contiguous(xs);
             let b_mat = into_contiguous(b_mat);
@@ -834,9 +971,18 @@ mod gpu {
             let y = empty_like(&xs, Shape::new([batch, seq_len, channels]));
             let h_out = empty_like(&xs, Shape::new([batch, channels, state_dim]));
             let delta = empty_like(&xs, Shape::new([batch, seq_len, channels]));
-            let parallel_scan = save_states || seq_len > 1;
-            let states = if parallel_scan {
-                empty_like(&xs, Shape::new([batch, seq_len, channels, state_dim]))
+            let checkpoint_interval = scan_checkpoint_interval(batch, seq_len, channels, state_dim);
+            let full_sequence_scan = save_states || seq_len > 1;
+            let states = if save_states {
+                empty_like(
+                    &xs,
+                    Shape::new([
+                        batch,
+                        seq_len.div_ceil(checkpoint_interval),
+                        channels,
+                        state_dim,
+                    ]),
+                )
             } else {
                 h_out.clone()
             };
@@ -850,37 +996,55 @@ mod gpu {
                 delta_raw.into_tensor_arg(),
                 delta.clone().into_tensor_arg(),
             );
-            if parallel_scan {
-                let state_total = (batch * channels * state_dim) as u32;
-                selective_scan_states::launch::<R>(
-                    &client,
-                    CubeCount::Static(state_total.div_ceil(THREADS_PER_CUBE), 1, 1),
-                    CubeDim::new_1d(THREADS_PER_CUBE),
-                    delta.clone().into_tensor_arg(),
-                    xs.clone().into_tensor_arg(),
-                    b_mat.clone().into_tensor_arg(),
-                    a.clone().into_tensor_arg(),
-                    h.clone().into_tensor_arg(),
-                    states.clone().into_tensor_arg(),
-                    h_out.clone().into_tensor_arg(),
-                    channels as u32,
-                    seq_len as u32,
-                    state_dim,
-                );
-                let output_total = (batch * seq_len * channels) as u32;
-                selective_scan_output::launch::<R>(
-                    &client,
-                    CubeCount::Static(output_total.div_ceil(THREADS_PER_CUBE), 1, 1),
-                    CubeDim::new_1d(THREADS_PER_CUBE),
-                    xs.clone().into_tensor_arg(),
-                    c_mat.into_tensor_arg(),
-                    d.into_tensor_arg(),
-                    states.clone().into_tensor_arg(),
-                    y.clone().into_tensor_arg(),
-                    channels as u32,
-                    seq_len as u32,
-                    state_dim,
-                );
+            if full_sequence_scan {
+                let serial_blocks = ((batch * channels) as u32).div_ceil(THREADS_PER_CUBE);
+                if serial_blocks >= SERIAL_SCAN_MIN_BLOCKS {
+                    selective_scan_forward_serial::launch::<R>(
+                        &client,
+                        CubeCount::Static(serial_blocks, 1, 1),
+                        CubeDim::new_1d(THREADS_PER_CUBE),
+                        delta.clone().into_tensor_arg(),
+                        xs.clone().into_tensor_arg(),
+                        b_mat.clone().into_tensor_arg(),
+                        c_mat.into_tensor_arg(),
+                        a.clone().into_tensor_arg(),
+                        d.into_tensor_arg(),
+                        h.clone().into_tensor_arg(),
+                        y.clone().into_tensor_arg(),
+                        states.clone().into_tensor_arg(),
+                        h_out.clone().into_tensor_arg(),
+                        channels as u32,
+                        seq_len as u32,
+                        state_dim,
+                        checkpoint_interval,
+                        save_states,
+                    );
+                } else {
+                    selective_scan_forward_parallel::launch::<R>(
+                        &client,
+                        CubeCount::Static(
+                            (channels as u32).div_ceil(FORWARD_CHANNELS),
+                            batch as u32,
+                            1,
+                        ),
+                        CubeDim::new_2d(PLANE_WIDTH, FORWARD_CHANNELS),
+                        delta.clone().into_tensor_arg(),
+                        xs.clone().into_tensor_arg(),
+                        b_mat.clone().into_tensor_arg(),
+                        c_mat.into_tensor_arg(),
+                        a.clone().into_tensor_arg(),
+                        d.into_tensor_arg(),
+                        h.clone().into_tensor_arg(),
+                        y.clone().into_tensor_arg(),
+                        states.clone().into_tensor_arg(),
+                        h_out.clone().into_tensor_arg(),
+                        channels as u32,
+                        seq_len as u32,
+                        state_dim,
+                        checkpoint_interval,
+                        save_states,
+                    );
+                }
             } else {
                 let total = (batch * channels) as u32;
                 selective_scan_step::launch::<R>(
@@ -946,6 +1110,7 @@ mod gpu {
             let grad_d = zeros_like(&xs, Shape::new([channels]));
             let grad_h = empty_like(&xs, Shape::new([batch, channels, state_dim]));
             let delta = empty_like(&xs, Shape::new([batch, seq_len, channels]));
+            let checkpoint_interval = scan_checkpoint_interval(batch, seq_len, channels, state_dim);
             let client = xs.client.clone();
 
             let delta_total = (batch * seq_len * channels) as u32;
@@ -985,10 +1150,29 @@ mod gpu {
                 channels as u32,
                 seq_len as u32,
                 state_dim,
+                checkpoint_interval,
             );
 
             (grad_delta, grad_xs, grad_b, grad_c, grad_a, grad_d, grad_h)
         }
+    }
+}
+
+#[cfg(test)]
+mod policy_tests {
+    use super::{CHECKPOINTED_SCAN_INTERVAL, scan_checkpoint_interval};
+
+    #[test]
+    fn full_states_are_limited_to_small_bounded_batches() {
+        assert_eq!(scan_checkpoint_interval(2, 4096, 1024, 16), 1);
+        assert_eq!(
+            scan_checkpoint_interval(16, 1024, 1024, 16),
+            CHECKPOINTED_SCAN_INTERVAL
+        );
+        assert_eq!(
+            scan_checkpoint_interval(2, 8192, 1024, 16),
+            CHECKPOINTED_SCAN_INTERVAL
+        );
     }
 }
 
@@ -1011,7 +1195,7 @@ mod tests {
     fn test_cubecl_selective_scan_matches_ndarray_reference() {
         let cpu = Device::ndarray();
         let gpu = gpu_device();
-        let (batch, seq_len, channels, state_dim) = (2, 5, 3, 4);
+        let (batch, seq_len, channels, state_dim) = (2, 35, 3, 4);
 
         let delta = values(batch * seq_len * channels, 0.13, 0.08);
         let xs = values(batch * seq_len * channels, 0.17, -0.03);
@@ -1052,11 +1236,10 @@ mod tests {
         assert!(max_diff(cpu_h.into_data(), gpu_h.into_data()) < 1e-5);
     }
 
-    #[test]
-    fn test_cubecl_selective_scan_backward_matches_ndarray() {
+    fn assert_cubecl_selective_scan_backward(batch: usize) {
         let cpu = Device::ndarray().autodiff();
         let gpu = gpu_device().autodiff();
-        let (batch, seq_len, channels, state_dim) = (2, 4, 3, 4);
+        let (seq_len, channels, state_dim) = (37, 3, 4);
         let shapes = (
             [batch, seq_len, channels],
             [batch, seq_len, state_dim],
@@ -1128,5 +1311,15 @@ mod tests {
             let difference = max_diff(cpu, gpu);
             assert!(difference < 2e-4, "{name} gradient max diff: {difference}");
         }
+    }
+
+    #[test]
+    fn test_cubecl_selective_scan_full_state_backward_matches_ndarray() {
+        assert_cubecl_selective_scan_backward(2);
+    }
+
+    #[test]
+    fn test_cubecl_selective_scan_checkpointed_backward_matches_ndarray() {
+        assert_cubecl_selective_scan_backward(3);
     }
 }

--- a/hermes-llm/src/model/transformer.rs
+++ b/hermes-llm/src/model/transformer.rs
@@ -14,7 +14,7 @@ use super::matmul::matmul_2;
 use super::{InferenceState, Norm, TransformerBlock};
 
 const EMBEDDING_STD: f64 = 0.02;
-const LOSS_CHUNK_TOKENS: usize = 512;
+const LOSS_CHUNKS: usize = 4;
 
 #[derive(Module, Debug)]
 pub struct Transformer {
@@ -207,16 +207,17 @@ impl Transformer {
     /// so full-vocabulary logits are never retained for every input token.
     pub fn forward_loss(&self, input_ids: Tensor<2, Int>, targets: Tensor<2, Int>) -> Tensor<1> {
         let [batch, seq_len] = targets.dims();
+        let tokens = batch * seq_len;
         let hidden = self
             .forward_hidden(input_ids, 0)
-            .reshape([batch * seq_len, self.config.hidden_size]);
+            .reshape([tokens, self.config.hidden_size]);
         let (weight, bias) = self.output_parameters();
         linear_cross_entropy(
             hidden,
             weight,
             bias,
-            targets.reshape([batch * seq_len]),
-            LOSS_CHUNK_TOKENS,
+            targets.reshape([tokens]),
+            tokens.div_ceil(LOSS_CHUNKS),
         )
     }
 

--- a/hermes-llm/src/model/transformer.rs
+++ b/hermes-llm/src/model/transformer.rs
@@ -10,7 +10,7 @@ use burn_nn::{RotaryEncoding, RotaryEncodingConfig};
 use crate::mal::{BlockDef, ModelDef, PositionEncoding};
 
 use super::linear_cross_entropy::linear_cross_entropy;
-use super::matmul::matmul_2;
+use super::matmul::{matmul_2, matmul_input, prepare_linear_for_inference};
 use super::{InferenceState, Norm, TransformerBlock};
 
 const EMBEDDING_STD: f64 = 0.02;
@@ -26,6 +26,9 @@ pub struct Transformer {
     lm_head: Option<Linear>,
     /// Output bias when the embedding matrix is reused as the output matrix.
     tied_output_bias: Option<Param<Tensor<1>>>,
+    /// Mixed-precision view of tied output weights, prepared once for decoding.
+    #[module(skip)]
+    inference_output_weight: Option<Tensor<2>>,
     rope: RotaryEncoding,
     #[module(skip)]
     embedding_scale: Option<f64>,
@@ -169,6 +172,7 @@ impl Transformer {
             final_norm,
             lm_head,
             tied_output_bias,
+            inference_output_weight: None,
             rope,
             embedding_scale: config.embeddings.scale,
             config: config.clone(),
@@ -255,9 +259,30 @@ impl Transformer {
                 head.bias.as_ref().map(Param::val),
             ),
             None => (
-                self.embedding.weight.val(),
+                self.inference_output_weight
+                    .clone()
+                    .unwrap_or_else(|| self.embedding.weight.val()),
                 self.tied_output_bias.as_ref().map(Param::val),
             ),
+        }
+    }
+
+    /// Prepare immutable mixed-precision weights once for low-latency decode.
+    ///
+    /// Call this after loading a checkpoint and before creating inference
+    /// state. Training never calls it, so optimizer parameters remain F32.
+    pub fn prepare_inference(&mut self) {
+        assert!(
+            !self.embedding.weight.val().device().is_autodiff(),
+            "inference preparation requires a non-autodiff model"
+        );
+        for layer in &mut self.layers {
+            layer.prepare_inference();
+        }
+        if let Some(head) = &mut self.lm_head {
+            prepare_linear_for_inference(head);
+        } else {
+            self.inference_output_weight = Some(matmul_input(self.embedding.weight.val()));
         }
     }
 

--- a/hermes-train/Cargo.toml
+++ b/hermes-train/Cargo.toml
@@ -27,7 +27,7 @@ tempfile.workspace = true
 [features]
 default = []
 metal = ["hermes-llm/metal"]
-cuda = ["hermes-llm/cuda"]
+cuda = ["hermes-llm/training-fusion"]
 
 [[bin]]
 name = "hermes-train"

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -576,7 +576,7 @@ fn train(args: TrainArgs) -> Result<()> {
     if let Some(path) = &args.checkpoint {
         load_safetensors(&mut initial_model, path)?;
     }
-    let muon_parameter_ids = initial_model.muon_parameter_ids();
+    let mut muon_parameter_ids = initial_model.muon_parameter_ids();
     ensure!(
         !muon_parameter_ids.is_empty(),
         "model has no hidden matrix parameters for Muon"
@@ -597,6 +597,7 @@ fn train(args: TrainArgs) -> Result<()> {
             &device,
         )?;
         adamw_optimizer = optimizer;
+        muon_parameter_ids = initial_model.muon_parameter_ids();
         ensure!(
             state.step < total_steps,
             "checkpoint step {} has already reached requested total {total_steps}",
@@ -899,8 +900,8 @@ mod tests {
         .unwrap();
 
         let mut resumed = Transformer::new(&config, &device).unwrap();
-        let resumed_ids = resumed.muon_parameter_ids();
-        let mut resumed_muon = BatchedMuon::new(resumed_ids);
+        let mut resumed_ids = resumed.muon_parameter_ids();
+        let mut resumed_muon = BatchedMuon::new(resumed_ids.clone());
         let resumed_adamw = AdamWConfig::new()
             .with_beta_2(0.95)
             .with_epsilon(1e-8)
@@ -918,19 +919,29 @@ mod tests {
         assert_eq!(resumed_state.stage, state.stage);
         assert_eq!(resumed_state.epoch, state.epoch);
         assert_eq!(resumed_state.samples_in_stage, state.samples_in_stage);
+        let restored_ids = resumed.muon_parameter_ids();
+        assert_ne!(resumed_ids, restored_ids);
+        assert_eq!(muon_parameter_ids, restored_ids);
+        resumed_ids = restored_ids;
 
-        let advance =
-            |mut model: Transformer, muon: &mut BatchedMuon, adamw: &mut AdamWOptimizer| {
-                let (input, target) = batch();
-                let mut grads = model.forward_loss(input, target).backward();
-                let muon_ids = model.muon_parameter_ids();
-                let muon_grads = GradientsParams::from_params(&mut grads, &model, &muon_ids);
-                let adamw_grads = GradientsParams::from_module(&mut grads, &model);
-                model = muon.step(2e-2, model, muon_grads).unwrap();
-                adamw.step(1e-3.into(), model, adamw_grads)
-            };
-        model = advance(model, &mut muon_optimizer, &mut adamw_optimizer);
-        resumed = advance(resumed, &mut resumed_muon, &mut resumed_adamw);
+        let advance = |mut model: Transformer,
+                       muon: &mut BatchedMuon,
+                       adamw: &mut AdamWOptimizer,
+                       muon_ids: &[ParamId]| {
+            let (input, target) = batch();
+            let mut grads = model.forward_loss(input, target).backward();
+            let muon_grads = GradientsParams::from_params(&mut grads, &model, muon_ids);
+            let adamw_grads = GradientsParams::from_module(&mut grads, &model);
+            model = muon.step(2e-2, model, muon_grads).unwrap();
+            adamw.step(1e-3.into(), model, adamw_grads)
+        };
+        model = advance(
+            model,
+            &mut muon_optimizer,
+            &mut adamw_optimizer,
+            &muon_parameter_ids,
+        );
+        resumed = advance(resumed, &mut resumed_muon, &mut resumed_adamw, &resumed_ids);
 
         let valid = model.valid();
         let loaded = resumed.valid();

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -715,6 +715,14 @@ fn train(args: TrainArgs) -> Result<()> {
                     if micro_step == args.grad_accum {
                         let lr = learning_rate(&args, step + 1, total_steps);
                         let muon_lr = lr * MUON_LR_SCALE;
+                        let loss = loss_sum
+                            .take()
+                            .expect("an optimizer step must contain a loss")
+                            .div_scalar(args.grad_accum as f32);
+                        let loss = scalar_value(loss)?;
+                        if !loss.is_finite() {
+                            bail!("non-finite loss at optimizer step {}: {loss}", step + 1);
+                        }
                         let mut muon_grads = muon_accumulator.grads();
                         let mut adamw_grads = adamw_accumulator.grads();
                         let grad_norm = gradient_norm_and_clip(
@@ -723,19 +731,17 @@ fn train(args: TrainArgs) -> Result<()> {
                             &mut adamw_grads,
                             args.grad_clip,
                         )?;
+                        if !grad_norm.is_finite() {
+                            bail!(
+                                "non-finite gradient norm at optimizer step {}: {grad_norm}",
+                                step + 1
+                            );
+                        }
                         let current = model.take().unwrap();
                         let current = muon_optimizer.step(muon_lr, current, muon_grads)?;
                         model = Some(adamw_optimizer.step(lr.into(), current, adamw_grads));
                         step += 1;
                         training_state.step = step;
-                        let loss = loss_sum
-                            .take()
-                            .expect("an optimizer step must contain a loss")
-                            .div_scalar(args.grad_accum as f32);
-                        let loss = scalar_value(loss)?;
-                        if !loss.is_finite() {
-                            bail!("non-finite loss at optimizer step {step}: {loss}");
-                        }
                         let step_seconds = optimizer_step_started.elapsed().as_secs_f64();
                         let step_tokens = args.batch_size * args.grad_accum * args.seq_len;
                         let tokens_per_second = step_tokens as f64 / step_seconds;

--- a/hermes-train/src/muon.rs
+++ b/hermes-train/src/muon.rs
@@ -180,7 +180,7 @@ fn to_compute_dtype(tensor: Tensor<3>) -> Tensor<3> {
 
 #[cfg(feature = "cuda")]
 fn from_compute_dtype(tensor: Tensor<3>) -> Tensor<3> {
-    tensor.cast(FloatDType::Flex32)
+    tensor.cast(FloatDType::F32)
 }
 
 #[cfg(not(feature = "cuda"))]


### PR DESCRIPTION
## Summary

- enable Burn lazy fusion around Hermes custom CUDA convolution, selective-scan, and attention operations
- add adaptive serial/plane-parallel selective scan scheduling and bounded recurrent-state checkpointing
- replace the materialized causal mask with an index-based CubeCL kernel and remove unused attention state
- configure exclusive CUDA memory pools and pin the CubeCL allocation-retry fix
- use BF16 CUDA matmuls for training to match A100/PyTorch autocast range while keeping F16 prepared weights for lean decoding
- keep matmul and Muon outputs concretely FP32 to avoid mixed-dtype fusion failures
- reduce output-loss launch overhead with four adaptive chunks
- refresh restored Muon parameter IDs in the training loop and reject non-finite loss/gradients before optimizer mutation
- split CUDA execution features so training keeps lazy fusion while autoregressive decoding avoids its graph-planning overhead
- prepare immutable CUDA linear and tied-output weights once for mixed-precision decoding instead of casting them on every token

## Validation

- `cargo +1.97 test --workspace`: 729 core + all LLM/trainer/workspace tests passed
- A100 inference CUDA suite: 21/21 passed
- A100 training-fusion CUDA suite: 22/22 passed
- Clippy with `-D warnings` for inference CUDA, training-fusion CUDA, and the CUDA trainer
- Cargo Machete reports no unused dependencies
- exact step-600 GCS resume reproduced the old FP16 NaN at step 639; the same frozen step-638 weights and failing batch are finite under BF16
- full BF16 resume passed steps 639–642 with finite loss/gradients
- batch 16 x seq 1024 x accum 8: 26.125k–26.144k tok/s steady
- production batch 2 x seq 4096 x accum 56: 14.511k–14.620k tok/s steady after warmup
- production-shape checkpoint save completed without OOM
- prepared decode removes about 145 GPU launches/token; warm 64-token greedy generation improved from 18.95s to 14.00s with identical output
- direct `gs://` checkpoint/config/tokenizer loading and CUDA generation validated against step 550

The current CubeCL fork commit is based on upstream main and retries an allocation once after forced cache cleanup.
