### PR TITLE
fix: harden indexing, segment lifecycle, and commit durability

### DIFF
--- a/hermes-core/src/directories/directory.rs
+++ b/hermes-core/src/directories/directory.rs
@@ -655,6 +655,21 @@ pub trait DirectoryWriter: Directory {
     /// Create/overwrite a file with data
     async fn write(&self, path: &Path, data: &[u8]) -> io::Result<()>;
 
+    /// Create/overwrite a file with data, durably.
+    ///
+    /// [`Self::write`] does not guarantee the bytes reach stable storage
+    /// before returning (filesystem implementations leave them in the OS
+    /// page cache). Any file that durably-published metadata will reference
+    /// (e.g. segment `.meta`) must be written through this method instead:
+    /// it routes through [`Self::streaming_writer`], whose `finish()` fsyncs
+    /// on filesystem implementations.
+    async fn write_durable(&self, path: &Path, data: &[u8]) -> io::Result<()> {
+        use io::Write as _;
+        let mut writer = self.streaming_writer(path).await?;
+        writer.write_all(data)?;
+        writer.finish()
+    }
+
     /// Delete a file
     async fn delete(&self, path: &Path) -> io::Result<()>;
 
@@ -850,7 +865,12 @@ impl FsDirectory {
 impl Directory for FsDirectory {
     async fn exists(&self, path: &Path) -> io::Result<bool> {
         let full_path = self.resolve(path);
-        Ok(tokio::fs::try_exists(&full_path).await.unwrap_or(false))
+        // `try_exists` maps NotFound to Ok(false); any other stat failure
+        // (EACCES, EIO, ...) must propagate so callers can distinguish a
+        // genuinely missing file from a transient IO error — swallowing it
+        // as `false` quarantines a healthy segment as "missing mandatory
+        // files" instead of retrying.
+        tokio::fs::try_exists(&full_path).await
     }
 
     async fn file_size(&self, path: &Path) -> io::Result<u64> {
@@ -1105,6 +1125,42 @@ mod tests {
         // Delete
         dir.delete(Path::new("test.txt")).await.unwrap();
         assert!(!dir.exists(Path::new("test.txt")).await.unwrap());
+    }
+
+    /// A transient stat failure (EACCES here, EIO on flaky storage) must
+    /// surface as `Err`, not `Ok(false)`: callers classify a missing
+    /// mandatory segment file as deterministic corruption and quarantine
+    /// the segment until restart.
+    #[cfg(all(unix, feature = "native"))]
+    #[tokio::test]
+    async fn test_fs_exists_propagates_stat_errors_instead_of_reporting_missing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let dir = FsDirectory::new(temp_dir.path());
+        dir.write(Path::new("locked/seg.meta"), b"data")
+            .await
+            .unwrap();
+
+        // Removing search permission from the parent makes stat on the child
+        // fail with EACCES while the file itself still exists.
+        let locked = temp_dir.path().join("locked");
+        let original = std::fs::metadata(&locked).unwrap().permissions();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::metadata(locked.join("seg.meta")).is_ok() {
+            // Running as root: directory permissions are not enforced, so the
+            // stat failure cannot be provoked.
+            std::fs::set_permissions(&locked, original).unwrap();
+            return;
+        }
+        let result = dir.exists(Path::new("locked/seg.meta")).await;
+        std::fs::set_permissions(&locked, original).unwrap();
+
+        let error =
+            result.expect_err("stat failure must propagate as Err, not be misreported as missing");
+        assert_ne!(error.kind(), io::ErrorKind::NotFound);
+        // Once stat succeeds again the file is reported present.
+        assert!(dir.exists(Path::new("locked/seg.meta")).await.unwrap());
     }
 
     #[tokio::test]

--- a/hermes-core/src/directories/mmap.rs
+++ b/hermes-core/src/directories/mmap.rs
@@ -73,7 +73,12 @@ impl Clone for MmapDirectory {
 impl Directory for MmapDirectory {
     async fn exists(&self, path: &Path) -> io::Result<bool> {
         let full_path = self.resolve(path);
-        Ok(tokio::fs::try_exists(&full_path).await.unwrap_or(false))
+        // `try_exists` maps NotFound to Ok(false); any other stat failure
+        // (EACCES, EIO, ...) must propagate so callers can distinguish a
+        // genuinely missing file from a transient IO error — swallowing it
+        // as `false` quarantines a healthy segment as "missing mandatory
+        // files" instead of retrying.
+        tokio::fs::try_exists(&full_path).await
     }
 
     async fn file_size(&self, path: &Path) -> io::Result<u64> {
@@ -217,6 +222,42 @@ mod tests {
         // Read range
         let range_bytes = dir.read_range(Path::new("test.txt"), 7..12).await.unwrap();
         assert_eq!(range_bytes.as_slice(), b"mmap ");
+    }
+
+    /// A transient stat failure (EACCES here, EIO on flaky storage) must
+    /// surface as `Err`, not `Ok(false)`: callers classify a missing
+    /// mandatory segment file as deterministic corruption and quarantine
+    /// the segment until restart.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_mmap_exists_propagates_stat_errors_instead_of_reporting_missing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let dir = MmapDirectory::new(temp_dir.path());
+        dir.write(Path::new("locked/seg.meta"), b"data")
+            .await
+            .unwrap();
+
+        // Removing search permission from the parent makes stat on the child
+        // fail with EACCES while the file itself still exists.
+        let locked = temp_dir.path().join("locked");
+        let original = std::fs::metadata(&locked).unwrap().permissions();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::metadata(locked.join("seg.meta")).is_ok() {
+            // Running as root: directory permissions are not enforced, so the
+            // stat failure cannot be provoked.
+            std::fs::set_permissions(&locked, original).unwrap();
+            return;
+        }
+        let result = dir.exists(Path::new("locked/seg.meta")).await;
+        std::fs::set_permissions(&locked, original).unwrap();
+
+        let error =
+            result.expect_err("stat failure must propagate as Err, not be misreported as missing");
+        assert_ne!(error.kind(), io::ErrorKind::NotFound);
+        // Once stat succeeds again the file is reported present.
+        assert!(dir.exists(Path::new("locked/seg.meta")).await.unwrap());
     }
 
     #[tokio::test]

--- a/hermes-core/src/dsl/schema.rs
+++ b/hermes-core/src/dsl/schema.rs
@@ -827,10 +827,16 @@ impl SchemaBuilder {
         }
     }
 
-    /// Mark a field as the primary key (unique constraint)
+    /// Mark a field as the primary key (unique constraint).
+    ///
+    /// Primary key implies fast + indexed (dedup looks committed keys up in
+    /// the fast-field text dictionary) — kept in sync with the SDL path,
+    /// which forces the same attributes.
     pub fn set_primary_key(&mut self, field: Field) {
         if let Some(entry) = self.fields.get_mut(field.0 as usize) {
             entry.primary_key = true;
+            entry.fast = true;
+            entry.indexed = true;
         }
     }
 
@@ -1255,6 +1261,26 @@ mod tests {
         assert_eq!(schema.get_field("body"), Some(body));
         assert_eq!(schema.get_field("count"), Some(count));
         assert_eq!(schema.get_field("nonexistent"), None);
+    }
+
+    #[test]
+    fn test_set_primary_key_forces_fast_and_indexed() {
+        // Regression: the SDL path forces fast + indexed on primary-key fields
+        // (needed for dedup lookups against the fast-field text dict). The
+        // programmatic builder must do the same, otherwise committed-key dedup
+        // is silently inert after every commit.
+        let mut builder = Schema::builder();
+        let id = builder.add_text_field("id", false, true);
+        builder.set_primary_key(id);
+        let schema = builder.build();
+
+        let entry = schema.get_field_entry(id).unwrap();
+        assert!(entry.primary_key);
+        assert!(
+            entry.fast,
+            "primary key must imply fast (dedup reads the fast-field text dict)"
+        );
+        assert!(entry.indexed, "primary key must imply indexed");
     }
 
     #[test]

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -23,6 +23,14 @@ pub const INDEX_META_FILENAME: &str = "metadata.json";
 /// Temp file for atomic writes (write here, then rename to INDEX_META_FILENAME)
 const INDEX_META_TMP_FILENAME: &str = "metadata.json.tmp";
 
+/// Current metadata.json format version written by this build.
+///
+/// `load` refuses metadata stamped with a newer version: serde_json silently
+/// drops fields it does not know about, so loading newer metadata would
+/// misread index state and the next save would destructively rewrite the
+/// unknown fields away.
+pub const INDEX_META_FORMAT_VERSION: u32 = 1;
+
 /// Index-level centroids/codebooks are deliberately bounded before they are
 /// read or decoded. Besides limiting ordinary corruption damage, the matching
 /// bincode limit prevents a tiny forged collection length from requesting an
@@ -121,7 +129,7 @@ impl IndexMetadata {
     /// Create new metadata with schema
     pub fn new(schema: Schema) -> Self {
         Self {
-            version: 1,
+            version: INDEX_META_FORMAT_VERSION,
             schema,
             segment_metas: HashMap::new(),
             vector_fields: HashMap::new(),
@@ -277,21 +285,39 @@ impl IndexMetadata {
         match dir.open_read(path).await {
             Ok(slice) => {
                 let bytes = slice.read_bytes().await?;
-                serde_json::from_slice(bytes.as_slice())
-                    .map_err(|e| Error::Serialization(e.to_string()))
+                Self::deserialize_versioned(bytes.as_slice())
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // Try recovering from temp file (crash between write and rename)
                 let tmp_path = Path::new(INDEX_META_TMP_FILENAME);
                 let slice = dir.open_read(tmp_path).await?;
                 let bytes = slice.read_bytes().await?;
-                let meta: Self = serde_json::from_slice(bytes.as_slice())
-                    .map_err(|e| Error::Serialization(e.to_string()))?;
+                let meta = Self::deserialize_versioned(bytes.as_slice())?;
                 log::warn!("Recovered metadata from temp file (previous crash during save)");
                 Ok(meta)
             }
             Err(e) => Err(Error::Io(e)),
         }
+    }
+
+    /// Deserialize metadata bytes, refusing formats newer than this build.
+    ///
+    /// serde_json silently drops unknown fields, so loading newer metadata
+    /// would misread index state and the next save would destructively
+    /// rewrite the newer fields away. Fail loud instead.
+    fn deserialize_versioned(bytes: &[u8]) -> Result<Self> {
+        let meta: Self =
+            serde_json::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))?;
+        if meta.version > INDEX_META_FORMAT_VERSION {
+            return Err(Error::Corruption(format!(
+                "metadata.json format version {} is newer than this build supports (max {}). \
+                 Refusing to load: unknown fields would be silently dropped and destructively \
+                 rewritten on the next save. Open this index with a hermes build that \
+                 understands metadata format version {}",
+                meta.version, INDEX_META_FORMAT_VERSION, meta.version
+            )));
+        }
+        Ok(meta)
     }
 
     /// Save to directory (atomic: write temp file, then rename)
@@ -743,6 +769,40 @@ mod tests {
         meta.init_field(0, VectorIndexType::IvfRaBitQ);
         assert!(!meta.is_field_built(0));
         assert!(meta.vector_fields.contains_key(&0));
+    }
+
+    #[tokio::test]
+    async fn load_refuses_metadata_stamped_with_a_newer_format_version() {
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(test_schema());
+        metadata.version = 2;
+        metadata.save(&directory).await.unwrap();
+
+        let error = IndexMetadata::load(&directory)
+            .await
+            .expect_err("metadata from a newer format version must be refused, not silently pruned")
+            .to_string();
+        assert!(error.contains("version 2"), "{error}");
+        assert!(error.contains("newer"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn tmp_recovery_refuses_metadata_stamped_with_a_newer_format_version() {
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(test_schema());
+        metadata.version = 2;
+        let bytes = metadata.serialize_to_bytes().unwrap();
+        // Simulate a crash between write and rename: only the temp file exists.
+        directory
+            .write(Path::new(INDEX_META_TMP_FILENAME), &bytes)
+            .await
+            .unwrap();
+
+        let error = IndexMetadata::load(&directory)
+            .await
+            .expect_err("temp-file recovery must apply the same version gate")
+            .to_string();
+        assert!(error.contains("version 2"), "{error}");
     }
 
     #[tokio::test]

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -38,7 +38,7 @@ pub use reader::IndexReader;
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 pub use wasm_writer::IndexWriter as WasmIndexWriter;
 #[cfg(feature = "native")]
-pub use writer::{IndexWriter, PreparedCommit};
+pub use writer::{IndexWriter, PreparedCommit, WRITER_LOCK_FILENAME};
 
 mod metadata;
 pub use metadata::{
@@ -242,6 +242,22 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
         let schema = Arc::new(schema);
         // Directory-layer metrics (cold writes, lazy reads) carry the index label
         directory.set_index_label(schema.index_label());
+
+        // Refuse to clobber an existing index: persisting a fresh empty
+        // metadata.json would orphan every committed segment, and the next
+        // writer open's orphan sweep would permanently delete them.
+        if directory
+            .exists(std::path::Path::new(INDEX_META_FILENAME))
+            .await?
+        {
+            return Err(crate::Error::Internal(format!(
+                "refusing to create index: {} already exists in this directory; \
+                 use Index::open to open the existing index, or delete the \
+                 directory first if you really want to start over",
+                INDEX_META_FILENAME
+            )));
+        }
+
         let metadata = IndexMetadata::new((*schema).clone());
 
         let segment_manager = Arc::new(crate::merge::SegmentManager::new(

--- a/hermes-core/src/index/reader.rs
+++ b/hermes-core/src/index/reader.rs
@@ -132,15 +132,23 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
         segment_manager: &Arc<crate::merge::SegmentManager<D>>,
         resources: SearcherResources,
     ) -> Result<Searcher<D>> {
+        // Use SegmentManager's acquire_snapshot - non-blocking RwLock read.
+        //
+        // The snapshot MUST be acquired before reading trained centroids:
+        // segment producers capture trained structures only after the ArcSwap
+        // publication, so any ANN segment visible in the snapshot is always
+        // satisfiable by a trained value loaded after the snapshot. The
+        // reverse order can leave an ANN segment without centroids — and the
+        // miss is sticky, because reused readers are never re-injected on
+        // later reloads.
+        let snapshot = segment_manager.acquire_snapshot().await;
+
         // Read trained centroids from ArcSwap (lock-free)
         let trained = segment_manager.trained();
         let trained_centroids = trained
             .as_ref()
             .map(|t| t.centroids.clone())
             .unwrap_or_default();
-
-        // Use SegmentManager's acquire_snapshot - non-blocking RwLock read
-        let snapshot = segment_manager.acquire_snapshot().await;
 
         Searcher::from_snapshot(
             segment_manager.directory(),
@@ -258,14 +266,18 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
         let existing_segments: Vec<Arc<crate::segment::SegmentReader>> =
             self.state.load().searcher.segment_readers().to_vec();
 
+        // Acquire the snapshot BEFORE reading trained centroids: producers
+        // capture trained structures only after the ArcSwap publication, so
+        // any ANN segment visible in the snapshot is always satisfiable by a
+        // trained value loaded after the snapshot (see create_reader).
+        let snapshot = self.segment_manager.acquire_snapshot().await;
+
         // Read trained centroids from ArcSwap (lock-free)
         let trained = self.segment_manager.trained();
         let trained_centroids = trained
             .as_ref()
             .map(|t| t.centroids.clone())
             .unwrap_or_default();
-
-        let snapshot = self.segment_manager.acquire_snapshot().await;
 
         let new_reader = Searcher::from_snapshot_reuse(
             self.segment_manager.directory(),

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -302,12 +302,19 @@ impl<D: Directory + 'static> Searcher<D> {
             .map(|seg| (seg.meta().id, Arc::clone(seg)))
             .collect();
 
-        // Parse segment IDs and filter invalid ones
-        let valid_segments: Vec<(usize, SegmentId)> = segment_ids
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, id_str)| SegmentId::from_hex(id_str).map(|sid| (idx, sid)))
-            .collect();
+        // Parse segment IDs from metadata. A key that fails to parse means the
+        // metadata is corrupt; fail loud instead of silently serving results
+        // without that segment's documents (the merge path errors with
+        // Corruption on the same input — search must not disagree).
+        let mut valid_segments: Vec<(usize, SegmentId)> = Vec::with_capacity(segment_ids.len());
+        for (idx, id_str) in segment_ids.iter().enumerate() {
+            let sid = SegmentId::from_hex(id_str).ok_or_else(|| {
+                crate::error::Error::Corruption(format!(
+                    "Invalid segment ID in metadata: {id_str:?}"
+                ))
+            })?;
+            valid_segments.push((idx, sid));
+        }
 
         // Separate into reusable and new segments
         let mut reused: Vec<(usize, Arc<SegmentReader>)> = Vec::new();
@@ -1102,6 +1109,31 @@ fn process_rss_mb() -> f64 {
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
         0.0
+    }
+}
+
+#[cfg(test)]
+mod load_segments_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn searcher_open_fails_loud_on_corrupt_metadata_segment_id() {
+        let directory = Arc::new(crate::directories::RamDirectory::new());
+        let schema = Arc::new(crate::dsl::SchemaBuilder::default().build());
+
+        let result =
+            Searcher::open(directory, schema, &["not-a-hex-segment-id".to_string()], 8).await;
+
+        match result {
+            Ok(searcher) => panic!(
+                "corrupt segment ID must fail loud instead of silently serving {} segments",
+                searcher.segment_readers().len()
+            ),
+            Err(crate::error::Error::Corruption(message)) => {
+                assert!(message.contains("not-a-hex-segment-id"), "{message}");
+            }
+            Err(other) => panic!("expected Corruption error for invalid segment ID, got: {other}"),
+        }
     }
 }
 

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -14,6 +14,11 @@ fn bmp_config() -> SparseVectorConfig {
         format: SparseFormat::Bmp,
         weight_quantization: WeightQuantization::UInt8,
         bmp_block_size: 64,
+        // The rare-dim corpora emit dim_ids up to ~108k, past the default
+        // SPLADE vocabulary (105879). Out-of-range dims are now rejected at
+        // add time instead of silently dropped from the grid, so declare a
+        // vocabulary large enough for every corpus in this file.
+        dims: Some(120_000),
         ..SparseVectorConfig::default()
     }
 }
@@ -2065,6 +2070,8 @@ fn bmp_schema_with_config(
 async fn test_bmp_block_size_256_build_merge_reorder_search() {
     let (schema, _title, sparse) = bmp_schema_with_config(SparseVectorConfig {
         bmp_block_size: 256,
+        // This corpus carries shared "hay" dims at 900_000+.
+        dims: Some(1_000_000),
         ..bmp_config()
     });
     let dir = RamDirectory::new();

--- a/hermes-core/src/index/vector_builder.rs
+++ b/hermes-core/src/index/vector_builder.rs
@@ -167,13 +167,30 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             .collect_vectors_for_training(segment_ids, &fields_to_build)
             .await?;
 
-        // Train every requested field before changing metadata. If any field
-        // fails, all durable field states remain Flat and the successfully
-        // written files are merely unreferenced retry targets.
+        self.train_and_publish_fields(
+            &fields_to_build,
+            &all_vectors,
+            &total_vectors,
+            artifact_update,
+        )
+        .await
+    }
+
+    /// Train every requested field from pre-collected samples, then durably
+    /// publish the artifacts. If any field fails, all durable field states
+    /// remain Flat and the successfully written files are merely unreferenced
+    /// retry targets.
+    async fn train_and_publish_fields(
+        &self,
+        fields_to_build: &[(Field, DenseVectorConfig)],
+        all_vectors: &FxHashMap<u32, Vec<Vec<f32>>>,
+        total_vectors: &FxHashMap<u32, usize>,
+        artifact_update: &crate::merge::VectorArtifactUpdateGuard,
+    ) -> Result<()> {
         let mut updates = Vec::with_capacity(fields_to_build.len());
-        for (field, config) in &fields_to_build {
+        for (field, config) in fields_to_build {
             if let Some(update) = self
-                .train_field_index(*field, config, &all_vectors, &total_vectors)
+                .train_field_index(*field, config, all_vectors, total_vectors)
                 .await?
             {
                 updates.push(update);
@@ -181,8 +198,15 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         }
 
         if updates.is_empty() {
-            log::info!("No vectors available for trained vector-index fields");
-            return Ok(());
+            // Fail loud: training was explicitly requested and produced
+            // nothing — reporting success would leave callers believing the
+            // fields are Built.
+            let field_ids: Vec<u32> = fields_to_build.iter().map(|(field, _)| field.0).collect();
+            return Err(Error::Schema(format!(
+                "cannot train vector index: no training vectors were collected for \
+                 field(s) {field_ids:?}; commit documents containing these fields \
+                 before building"
+            )));
         }
 
         // Durable metadata and the complete validated ArcSwap set advance in a
@@ -228,6 +252,42 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         self.reject_rebuild_with_ann_segments(snapshot.segment_ids(), &field_ids)
             .await?;
 
+        // Reject malformed explicit settings before collecting samples.
+        for (_, config) in &dense_fields {
+            if config.uses_ivf() {
+                validate_explicit_ivf_num_clusters(config)?;
+            }
+        }
+
+        // Collect the retraining samples BEFORE the durable Built -> Flat
+        // reset: a read failure (propagated by collect_vectors_for_training)
+        // or an empty sample for a Built field must not destructively
+        // downgrade the published artifact generation.
+        let (all_vectors, total_vectors) = self
+            .collect_vectors_for_training(snapshot.segment_ids(), &dense_fields)
+            .await?;
+        let built_fields: Vec<u32> = self
+            .segment_manager
+            .read_metadata(|meta| {
+                field_ids
+                    .iter()
+                    .filter(|field_id| meta.is_field_built(**field_id))
+                    .copied()
+                    .collect()
+            })
+            .await;
+        let starved_built: Vec<u32> = built_fields
+            .into_iter()
+            .filter(|field_id| all_vectors.get(field_id).is_none_or(|v| v.is_empty()))
+            .collect();
+        if !starved_built.is_empty() {
+            return Err(Error::Schema(format!(
+                "cannot retrain vector index: no training vectors could be collected \
+                 for built field(s) {starved_built:?}; the existing trained artifacts \
+                 are left in place"
+            )));
+        }
+
         // Reset metadata and the ArcSwap set together. Old fixed-name artifact
         // files are left in place until the atomic writer replaces them; this
         // avoids a cancellation window and does not accumulate generations.
@@ -244,10 +304,15 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             })
             .await?;
 
-        log::info!("Reset vector index state to Flat, triggering rebuild...");
+        log::info!("Reset vector index state to Flat, retraining from collected samples...");
 
-        self.build_vector_index_locked(&dense_fields, &artifact_update)
-            .await
+        self.train_and_publish_fields(
+            &dense_fields,
+            &all_vectors,
+            &total_vectors,
+            &artifact_update,
+        )
+        .await
     }
 
     // ========================================================================
@@ -403,7 +468,10 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     total_skipped += n - indices.len();
                 }
 
-                // Batch-read and dequantize instead of one-by-one get_vector()
+                // Batch-read and dequantize instead of one-by-one get_vector().
+                // Read failures propagate: silently skipping vectors would
+                // train on an arbitrarily biased sample (or none at all) with
+                // no observability.
                 const BATCH: usize = 1024;
                 let mut f32_buf = vec![0f32; BATCH * dim];
                 for chunk in indices.chunks(BATCH) {
@@ -412,29 +480,31 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     let end = *chunk.last().unwrap();
                     if end - start + 1 == chunk.len() {
                         // Contiguous — single batch read
-                        if let Ok(batch_bytes) =
-                            lazy_flat.read_vectors_batch(start, chunk.len()).await
-                        {
-                            let floats = chunk.len() * dim;
-                            f32_buf.resize(floats, 0.0);
-                            crate::segment::dequantize_raw(
-                                batch_bytes.as_slice(),
-                                quant,
-                                floats,
-                                &mut f32_buf,
-                            )
+                        let batch_bytes = lazy_flat
+                            .read_vectors_batch(start, chunk.len())
+                            .await
                             .map_err(crate::Error::Io)?;
-                            for i in 0..chunk.len() {
-                                entry.push(f32_buf[i * dim..(i + 1) * dim].to_vec());
-                            }
+                        let floats = chunk.len() * dim;
+                        f32_buf.resize(floats, 0.0);
+                        crate::segment::dequantize_raw(
+                            batch_bytes.as_slice(),
+                            quant,
+                            floats,
+                            &mut f32_buf,
+                        )
+                        .map_err(crate::Error::Io)?;
+                        for i in 0..chunk.len() {
+                            entry.push(f32_buf[i * dim..(i + 1) * dim].to_vec());
                         }
                     } else {
                         // Non-contiguous (sampled) — read individually but reuse buffer
                         f32_buf.resize(dim, 0.0);
                         for &idx in chunk {
-                            if let Ok(()) = lazy_flat.read_vector_into(idx, &mut f32_buf).await {
-                                entry.push(f32_buf[..dim].to_vec());
-                            }
+                            lazy_flat
+                                .read_vector_into(idx, &mut f32_buf)
+                                .await
+                                .map_err(crate::Error::Io)?;
+                            entry.push(f32_buf[..dim].to_vec());
                         }
                     }
                 }
@@ -697,5 +767,245 @@ mod tests {
         let error = writer.write_all(&[3, 4]).unwrap_err().to_string();
         assert!(error.contains("3-byte safety limit"), "{error}");
         assert_eq!(output, vec![1, 2]);
+    }
+
+    // ===== rebuild destructive-downgrade regression tests =====
+
+    use std::path::Path;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use crate::directories::{
+        Directory, DirectoryWriter as DirectoryWriterTrait, FileHandle, RamDirectory, RangeReadFn,
+    };
+    use crate::dsl::{Document, SchemaBuilder};
+    use crate::index::{IndexConfig, IndexWriter};
+
+    const READ_FAIL_DOCS: usize = 5;
+    const READ_FAIL_DIM: usize = 4;
+    /// Flat entry layout of a single-field, flat-only `.vectors` file written
+    /// by the segment builder (data-first format): header (16 bytes) + raw f32
+    /// vectors + doc-id map + TOC + footer. Only the raw vector region is read
+    /// by training collection; segment open touches the header, doc-id map,
+    /// TOC, and footer, which all live outside this byte range.
+    const VEC_REGION_START: u64 = 16;
+    const VEC_REGION_END: u64 = VEC_REGION_START + (READ_FAIL_DOCS * READ_FAIL_DIM * 4) as u64;
+
+    /// RamDirectory wrapper whose `.vectors` handles fail range reads of the
+    /// raw vector region while `fail_vector_reads` is armed. Segment open
+    /// keeps succeeding, so exactly the training-collection batch reads fail —
+    /// the I/O the rebuild path used to swallow with `if let Ok`.
+    #[derive(Clone, Default)]
+    struct VectorReadFailDirectory {
+        inner: RamDirectory,
+        fail_vector_reads: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Directory for VectorReadFailDirectory {
+        async fn exists(&self, path: &Path) -> std::io::Result<bool> {
+            self.inner.exists(path).await
+        }
+
+        async fn file_size(&self, path: &Path) -> std::io::Result<u64> {
+            self.inner.file_size(path).await
+        }
+
+        async fn open_read(&self, path: &Path) -> std::io::Result<FileHandle> {
+            self.inner.open_read(path).await
+        }
+
+        async fn read_range(
+            &self,
+            path: &Path,
+            range: std::ops::Range<u64>,
+        ) -> std::io::Result<crate::directories::OwnedBytes> {
+            self.inner.read_range(path, range).await
+        }
+
+        async fn list_files(&self, prefix: &Path) -> std::io::Result<Vec<std::path::PathBuf>> {
+            self.inner.list_files(prefix).await
+        }
+
+        async fn open_lazy(&self, path: &Path) -> std::io::Result<FileHandle> {
+            let handle = self.inner.open_lazy(path).await?;
+            if path.extension().is_some_and(|ext| ext == "vectors") {
+                let armed = Arc::clone(&self.fail_vector_reads);
+                let len = handle.len();
+                let read_fn: RangeReadFn = Arc::new(move |range: std::ops::Range<u64>| {
+                    let handle = handle.clone();
+                    let armed = Arc::clone(&armed);
+                    Box::pin(async move {
+                        if armed.load(Ordering::SeqCst)
+                            && range.start >= VEC_REGION_START
+                            && range.end <= VEC_REGION_END
+                        {
+                            return Err(std::io::Error::other("injected vector data read failure"));
+                        }
+                        handle.read_bytes_range(range).await
+                    })
+                });
+                return Ok(FileHandle::lazy(len, read_fn));
+            }
+            Ok(handle)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl DirectoryWriterTrait for VectorReadFailDirectory {
+        async fn write(&self, path: &Path, data: &[u8]) -> std::io::Result<()> {
+            self.inner.write(path, data).await
+        }
+
+        async fn delete(&self, path: &Path) -> std::io::Result<()> {
+            self.inner.delete(path).await
+        }
+
+        async fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+            self.inner.rename(from, to).await
+        }
+
+        async fn sync(&self) -> std::io::Result<()> {
+            self.inner.sync().await
+        }
+
+        async fn streaming_writer(
+            &self,
+            path: &Path,
+        ) -> std::io::Result<Box<dyn crate::directories::StreamingWriter>> {
+            self.inner.streaming_writer(path).await
+        }
+    }
+
+    /// Regression: rebuild_vector_index used to durably reset Built fields to
+    /// Flat first and then swallow per-batch vector read errors with
+    /// `if let Ok` during training collection, reporting success while the
+    /// published trained generation had been destroyed. Read failures must
+    /// propagate, and the durable Built -> Flat reset must not happen.
+    #[tokio::test]
+    async fn rebuild_propagates_vector_read_errors_without_downgrading_built_state() {
+        let mut sb = SchemaBuilder::default();
+        let embedding = sb.add_dense_vector_field_with_config(
+            "embedding",
+            true,
+            true,
+            DenseVectorConfig::with_ivf(READ_FAIL_DIM, Some(1), 1),
+        );
+        let schema = sb.build();
+
+        let dir = VectorReadFailDirectory::default();
+        let config = IndexConfig {
+            merge_policy: Box::new(crate::merge::NoMergePolicy),
+            num_indexing_threads: 1,
+            ..Default::default()
+        };
+        let mut writer = IndexWriter::create(dir.clone(), schema, config)
+            .await
+            .unwrap();
+        for i in 0..READ_FAIL_DOCS {
+            let mut doc = Document::new();
+            doc.add_dense_vector(embedding, vec![i as f32 + 1.0; READ_FAIL_DIM]);
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+        writer.build_vector_index().await.unwrap();
+        assert!(
+            writer
+                .segment_manager
+                .read_metadata(|meta| meta.is_field_built(embedding.0))
+                .await
+        );
+        assert!(writer.segment_manager.trained().is_some());
+
+        // Vector data reads now fail (transient I/O error).
+        dir.fail_vector_reads.store(true, Ordering::SeqCst);
+        let error = writer
+            .rebuild_vector_index()
+            .await
+            .expect_err("failed sample collection must fail the rebuild")
+            .to_string();
+        assert!(
+            error.contains("injected vector data read failure"),
+            "{error}"
+        );
+
+        // The published generation survives: no durable Built -> Flat reset.
+        assert!(
+            writer
+                .segment_manager
+                .read_metadata(|meta| meta.is_field_built(embedding.0))
+                .await,
+            "a failed rebuild must not durably downgrade the field to Flat"
+        );
+        assert!(
+            writer.segment_manager.trained().is_some(),
+            "a failed rebuild must not clear the published trained artifacts"
+        );
+    }
+
+    /// Regression: rebuild_vector_index used to return Ok(()) after durably
+    /// resetting a Built field to Flat even when no training vectors could be
+    /// collected at all, silently discarding the trained generation. An empty
+    /// training sample for a Built field must be a hard error raised BEFORE
+    /// the durable reset.
+    #[tokio::test]
+    async fn rebuild_errors_before_reset_when_built_field_has_no_training_vectors() {
+        let mut sb = SchemaBuilder::default();
+        let title = sb.add_text_field("title", true, true);
+        let embedding = sb.add_dense_vector_field_with_config(
+            "embedding",
+            true,
+            true,
+            DenseVectorConfig::with_ivf(4, Some(1), 1),
+        );
+        let schema = sb.build();
+
+        let dir = RamDirectory::new();
+        let config = IndexConfig {
+            merge_policy: Box::new(crate::merge::NoMergePolicy),
+            num_indexing_threads: 1,
+            ..Default::default()
+        };
+        let mut writer = IndexWriter::create(dir.clone(), schema, config)
+            .await
+            .unwrap();
+        // Committed segments carry no vectors for the field.
+        for i in 0..3 {
+            let mut doc = Document::new();
+            doc.add_text(title, format!("doc {i}"));
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+
+        // Metadata says Built while no committed segment holds vectors for the
+        // field — the state a crash/degradation can leave behind. Rebuilding
+        // must refuse to destroy the referenced artifacts.
+        writer
+            .segment_manager
+            .update_metadata(|meta| {
+                meta.init_field(embedding.0, VectorIndexType::IvfRaBitQ);
+                meta.mark_field_built(
+                    embedding.0,
+                    5,
+                    1,
+                    format!("field_{}_centroids.bin", embedding.0),
+                    None,
+                );
+            })
+            .await
+            .unwrap();
+
+        let error = writer
+            .rebuild_vector_index()
+            .await
+            .expect_err("an empty training sample must fail the rebuild")
+            .to_string();
+        assert!(error.contains("no training vectors"), "{error}");
+        assert!(
+            writer
+                .segment_manager
+                .read_metadata(|meta| meta.is_field_built(embedding.0))
+                .await,
+            "an empty training sample must not durably downgrade the field to Flat"
+        );
     }
 }

--- a/hermes-core/src/index/wasm_writer.rs
+++ b/hermes-core/src/index/wasm_writer.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use rustc_hash::FxHashMap;
 
 use crate::directories::DirectoryWriter;
-use crate::dsl::{Document, Field, FieldType, Schema};
+use crate::dsl::{Document, Field, FieldType, FieldValue, Schema};
 use crate::error::Result;
 use crate::index::IndexMetadata;
 use crate::segment::{SegmentBuilder, SegmentBuilderConfig, SegmentId};
@@ -63,6 +63,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         config: IndexConfig,
         builder_config: SegmentBuilderConfig,
     ) -> Result<Self> {
+        Self::reject_primary_key_schema(&schema)?;
         let directory = Arc::new(directory);
         let schema = Arc::new(schema);
         let metadata = IndexMetadata::new((*schema).clone());
@@ -90,6 +91,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     ) -> Result<Self> {
         let directory = Arc::new(directory);
         let metadata = IndexMetadata::load(directory.as_ref()).await?;
+        Self::reject_primary_key_schema(&metadata.schema)?;
         let schema = Arc::new(metadata.schema.clone());
 
         Ok(Self::new_with_parts(
@@ -155,6 +157,25 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         self.tokenizers.insert(field, Box::new(tokenizer));
     }
 
+    /// Primary-key deduplication is native-only (`index/primary_key.rs` does
+    /// not exist on the wasm branch), so a `[primary]` schema constraint would
+    /// be silently unenforced here: duplicate keys would be durably committed.
+    /// Fail loud at writer creation instead.
+    fn reject_primary_key_schema(schema: &Schema) -> Result<()> {
+        if let Some(field) = schema.primary_field() {
+            let name = schema
+                .get_field_entry(field)
+                .map(|e| e.name.as_str())
+                .unwrap_or("<unknown>");
+            return Err(crate::Error::Schema(format!(
+                "schema declares primary key field '{name}', but primary-key \
+                 deduplication is not supported by the WASM IndexWriter; remove \
+                 the [primary] attribute from the schema or index natively"
+            )));
+        }
+        Ok(())
+    }
+
     fn ensure_builder(&mut self) -> Result<&mut SegmentBuilder> {
         if self.builder.is_none() {
             let mut b = SegmentBuilder::new(Arc::clone(&self.schema), self.builder_config.clone())?;
@@ -166,11 +187,169 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         Ok(self.builder.as_mut().unwrap())
     }
 
+    /// Pre-validate a document against the schema before it reaches the
+    /// `SegmentBuilder`.
+    ///
+    /// `SegmentBuilder::add_document` is not transactional: it advances its
+    /// internal doc id and writes postings before the fallible per-field work
+    /// and only writes the document store afterwards, so an error part-way
+    /// through leaves the store one document short of the doc count. Every
+    /// later `build()` of that builder then fails with a "Store doc count
+    /// mismatch", losing the whole buffered batch. The builder cannot be
+    /// rolled back from here, so invalid documents are rejected BEFORE any
+    /// builder state is mutated. These checks mirror the fallible validations
+    /// reachable in `SegmentBuilder::add_document` on the wasm build (the
+    /// native-only spill paths do not exist here); all of them are pure
+    /// functions of (document, schema).
+    fn validate_document(&self, doc: &Document) -> Result<()> {
+        let mut vector_values_per_field: FxHashMap<u32, u32> = FxHashMap::default();
+        let mut stored_count: usize = 0;
+
+        for (field, value) in doc.field_values() {
+            let Some(entry) = self.schema.get_field_entry(*field) else {
+                continue;
+            };
+
+            // Mirrors `write_document_to_store` / `serialize_document_into`
+            // limits: stored field ids and the stored-field count are u16 on
+            // the wire.
+            let stored_in_store = entry.stored
+                && !matches!(
+                    value,
+                    FieldValue::DenseVector(_) | FieldValue::BinaryDenseVector(_)
+                );
+            if stored_in_store {
+                stored_count += 1;
+                if field.0 > u16::MAX as u32 {
+                    return Err(crate::Error::Document(format!(
+                        "stored field id {} exceeds u16",
+                        field.0
+                    )));
+                }
+            }
+
+            // Mirrors `SegmentBuilder::next_vector_ordinal`: vector ordinals
+            // are u16, so at most u16::MAX + 1 values per field per document.
+            let mut count_vector_value = |field_id: u32| -> Result<()> {
+                let count = vector_values_per_field.entry(field_id).or_insert(0);
+                *count += 1;
+                if *count > u16::MAX as u32 + 1 {
+                    return Err(crate::Error::Document(format!(
+                        "field {field_id} has more than {} vector values in one document",
+                        u16::MAX as usize + 1
+                    )));
+                }
+                Ok(())
+            };
+
+            match (&entry.field_type, value) {
+                (FieldType::DenseVector, FieldValue::DenseVector(vec))
+                    if entry.indexed || entry.stored =>
+                {
+                    count_vector_value(field.0)?;
+                    let expected_dim = entry
+                        .dense_vector_config
+                        .as_ref()
+                        .map(|config| config.dim)
+                        .ok_or_else(|| {
+                            crate::Error::Schema("DenseVector field missing config".to_string())
+                        })?;
+                    if vec.len() != expected_dim {
+                        return Err(crate::Error::Schema(format!(
+                            "Dense vector dimension mismatch: schema expects {}, got {}",
+                            expected_dim,
+                            vec.len()
+                        )));
+                    }
+                    if let Some((index, v)) = vec.iter().enumerate().find(|(_, v)| !v.is_finite()) {
+                        return Err(crate::Error::Document(format!(
+                            "dense vector contains non-finite value {v} at index {index}"
+                        )));
+                    }
+                }
+                (FieldType::BinaryDenseVector, FieldValue::BinaryDenseVector(bytes))
+                    if entry.indexed || entry.stored =>
+                {
+                    count_vector_value(field.0)?;
+                    let dim_bits = entry
+                        .binary_dense_vector_config
+                        .as_ref()
+                        .map(|c| c.dim)
+                        .ok_or_else(|| {
+                            crate::Error::Schema(
+                                "BinaryDenseVector field missing config".to_string(),
+                            )
+                        })?;
+                    if dim_bits == 0 || !dim_bits.is_multiple_of(8) {
+                        return Err(crate::Error::Schema(format!(
+                            "Binary vector dimension must be a positive multiple of 8, got {dim_bits}"
+                        )));
+                    }
+                    let expected_byte_len = dim_bits.div_ceil(8);
+                    if bytes.len() != expected_byte_len {
+                        return Err(crate::Error::Schema(format!(
+                            "Binary vector byte length mismatch: expected {} (dim={}), got {}",
+                            expected_byte_len,
+                            dim_bits,
+                            bytes.len()
+                        )));
+                    }
+                }
+                (FieldType::SparseVector, FieldValue::SparseVector(entries))
+                    if entry.indexed || entry.fast =>
+                {
+                    count_vector_value(field.0)?;
+                    if let Some((index, (_, weight))) = entries
+                        .iter()
+                        .enumerate()
+                        .find(|(_, (_, weight))| !weight.is_finite())
+                    {
+                        return Err(crate::Error::Document(format!(
+                            "sparse vector contains non-finite weight {weight} at index {index}"
+                        )));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if stored_count > u16::MAX as usize {
+            return Err(crate::Error::Document(
+                "too many stored fields in one document (max 65535)".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Add a document. Automatically builds a segment when memory budget is exceeded.
+    ///
+    /// All-or-nothing: an invalid document is rejected without mutating any
+    /// writer/builder state, so buffered documents stay committable.
     pub async fn add_document(&mut self, doc: Document) -> Result<()> {
+        // Validate before touching the builder — see `validate_document`.
+        self.validate_document(&doc)?;
         self.ensure_builder()?;
         let b = self.builder.as_mut().unwrap();
-        b.add_document(doc)?;
+        if let Err(e) = b.add_document(doc) {
+            // Defensive: `validate_document` mirrors every fallible path in
+            // `SegmentBuilder::add_document`, so this should be unreachable.
+            // If a new fallible path slips through, the builder is poisoned
+            // (doc id advanced without a store write) and committing it would
+            // fail with a doc-count mismatch, silently losing every buffered
+            // document. Drop the poisoned builder loudly and keep the writer
+            // (and already-flushed pending segments) usable.
+            let buffered = self.builder.take().map(|b| b.num_docs()).unwrap_or(0);
+            let lost = buffered.saturating_sub(1);
+            log::warn!(
+                "[wasm_writer] segment builder poisoned by failed add_document ({e}); \
+                 discarding {lost} buffered document(s)"
+            );
+            return Err(crate::Error::Internal(format!(
+                "document failed mid-indexing and poisoned the segment builder: {e}; \
+                 {lost} buffered document(s) were discarded — re-add and commit them"
+            )));
+        }
 
         // Check memory budget (with 20% headroom for build overhead)
         let effective_budget = self.memory_budget * 4 / 5;
@@ -224,11 +403,20 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             return Ok(false);
         }
 
-        // Update in-memory metadata and save to directory
-        for (seg_hex, num_docs) in self.pending_segments.drain(..) {
-            self.metadata.add_segment(seg_hex, num_docs);
+        // Stage the fallible durable save on a clone first: if the save
+        // fails, in-memory metadata and pending_segments are left untouched,
+        // so the caller can retry commit() without stranding the built
+        // segments (durable-before-visible, same invariant as the native
+        // SegmentManager::commit).
+        let mut next = self.metadata.clone();
+        for (seg_hex, num_docs) in &self.pending_segments {
+            next.add_segment(seg_hex.clone(), *num_docs);
         }
-        self.metadata.save(self.directory.as_ref()).await?;
+        next.save(self.directory.as_ref()).await?;
+
+        // The save succeeded — publish the new state in memory.
+        self.metadata = next;
+        self.pending_segments.clear();
 
         Ok(true)
     }

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -46,6 +46,81 @@ use super::IndexConfig;
 /// Total pipeline capacity (in documents).
 const PIPELINE_MAX_SIZE_IN_DOCS: usize = 10_000;
 
+/// File name of the advisory single-writer lock inside the index directory.
+pub const WRITER_LOCK_FILENAME: &str = ".hermes_writer.lock";
+
+/// Advisory single-writer lock state.
+///
+/// Two independent writers on one index directory silently destroy each
+/// other's data: the orphan sweep at writer open deletes the other process's
+/// unpublished segment files, and metadata saves are last-writer-wins. For
+/// directories rooted on a local filesystem the writer therefore holds an OS
+/// advisory lock for its whole lifetime; the kernel releases it automatically
+/// when the process dies.
+enum WriterLock {
+    /// Lock acquired. Closing the file (writer drop) releases it.
+    Held { _file: std::fs::File },
+    /// The directory has no lockable local filesystem root (e.g. RAM or
+    /// remote directories) — cross-process locking is not applicable.
+    NotApplicable,
+    /// Another writer holds the lock. Every mutating operation fails loudly
+    /// with this message instead of silently double-writing.
+    Unavailable { reason: String },
+}
+
+/// Local filesystem root of the index directory, when the directory type
+/// exposes one.
+fn writer_lock_root<D: DirectoryWriter + 'static>(directory: &D) -> Option<std::path::PathBuf> {
+    let any: &dyn std::any::Any = directory;
+    if let Some(mmap) = any.downcast_ref::<crate::directories::MmapDirectory>() {
+        return Some(mmap.root().to_path_buf());
+    }
+    // FsDirectory does not expose its root path, so the single-writer lock
+    // cannot be enforced for it yet. Say so loudly instead of silently
+    // skipping protection for a filesystem-backed writer.
+    if any
+        .downcast_ref::<crate::directories::FsDirectory>()
+        .is_some()
+    {
+        log::warn!(
+            "[writer_lock] FsDirectory exposes no root path; single-writer locking \
+             is not enforced for this writer — do not open a second writer for the \
+             same index directory"
+        );
+    }
+    None
+}
+
+/// Try to take the exclusive single-writer lock for `directory`.
+///
+/// Returns `WriterLock::Unavailable` (not `Err`) on conflict so infallible
+/// constructors can defer the failure to their first mutating operation.
+fn try_acquire_writer_lock<D: DirectoryWriter + 'static>(directory: &D) -> Result<WriterLock> {
+    let Some(root) = writer_lock_root(directory) else {
+        return Ok(WriterLock::NotApplicable);
+    };
+    std::fs::create_dir_all(&root)?;
+    let lock_path = root.join(WRITER_LOCK_FILENAME);
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)?;
+    match file.try_lock() {
+        Ok(()) => Ok(WriterLock::Held { _file: file }),
+        Err(std::fs::TryLockError::WouldBlock) => Ok(WriterLock::Unavailable {
+            reason: format!(
+                "another IndexWriter already holds the single-writer lock for this \
+                 index ({}); Hermes supports one writer per index directory — stop \
+                 the other writer (e.g. a running hermes-server or hermes-tool) \
+                 before opening this one",
+                lock_path.display()
+            ),
+        }),
+        Err(std::fs::TryLockError::Error(error)) => Err(Error::Io(error)),
+    }
+}
+
 /// Async IndexWriter for adding documents and committing segments.
 ///
 /// **Backpressure:** `add_document()` is sync and O(1). It returns
@@ -81,6 +156,13 @@ pub struct IndexWriter<D: DirectoryWriter + 'static> {
     /// requesting future may disappear, but a second commit generation must
     /// not start until this one has made publication and worker state agree.
     commit_finalization: Arc<CommitFinalizationState>,
+    /// True while a failed post-commit PK refresh has left the uncommitted
+    /// reservations as the ONLY record of already-committed keys (fail-closed,
+    /// see `finalize_prepared_commit`). While set, abort paths must NOT clear
+    /// the reservations or duplicate primary keys could be admitted.
+    pk_reservations_retained: Arc<AtomicBool>,
+    /// Advisory single-writer lock, held for the writer's lifetime.
+    writer_lock: WriterLock,
 }
 
 #[derive(Default)]
@@ -226,6 +308,27 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let schema = Arc::new(schema);
         // Directory-layer metrics (cold writes, lazy reads) carry the index label
         directory.set_index_label(schema.index_label());
+
+        // Refuse a second writer before touching any index state.
+        let writer_lock = try_acquire_writer_lock(directory.as_ref())?;
+        if let WriterLock::Unavailable { reason } = &writer_lock {
+            return Err(Error::Internal(reason.clone()));
+        }
+        // Refuse to clobber an existing index: persisting a fresh empty
+        // metadata.json would orphan every committed segment, and the next
+        // writer open's orphan sweep would permanently delete them.
+        if directory
+            .exists(std::path::Path::new(super::INDEX_META_FILENAME))
+            .await?
+        {
+            return Err(Error::Internal(format!(
+                "refusing to create index: {} already exists in this directory; \
+                 use IndexWriter::open to open the existing index, or delete the \
+                 directory first if you really want to start over",
+                super::INDEX_META_FILENAME
+            )));
+        }
+
         let metadata = super::IndexMetadata::new((*schema).clone());
 
         let segment_manager = Arc::new(crate::merge::SegmentManager::new(
@@ -249,15 +352,18 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             config,
             builder_config,
             segment_manager,
+            writer_lock,
         ))
     }
 
     /// Open an existing index for exclusive writing.
     ///
-    /// Multiple independent writers for the same directory are unsupported:
-    /// this path removes crash-leftover outputs before starting its workers.
-    /// Use [`Index::writer`](super::Index::writer) to share lifecycle state
-    /// with an already-open search index.
+    /// Multiple independent writers for the same directory are unsupported;
+    /// for filesystem-rooted directories this is enforced with an advisory
+    /// single-writer lock ([`WRITER_LOCK_FILENAME`]) held for the writer's
+    /// lifetime. This path removes crash-leftover outputs before starting its
+    /// workers. Use [`Index::writer`](super::Index::writer) to share lifecycle
+    /// state with an already-open search index.
     pub async fn open(directory: D, config: IndexConfig) -> Result<Self> {
         Self::open_with_config(directory, config, SegmentBuilderConfig::default()).await
     }
@@ -269,6 +375,14 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         builder_config: SegmentBuilderConfig,
     ) -> Result<Self> {
         let directory = Arc::new(directory);
+
+        // The lock must be held before the orphan sweep below: sweeping while
+        // another process's writer is live deletes its in-flight outputs.
+        let writer_lock = try_acquire_writer_lock(directory.as_ref())?;
+        if let WriterLock::Unavailable { reason } = &writer_lock {
+            return Err(Error::Internal(reason.clone()));
+        }
+
         let metadata = super::IndexMetadata::load(directory.as_ref()).await?;
         let schema = Arc::new(metadata.schema.clone());
         // Directory-layer metrics (cold writes, lazy reads) carry the index label
@@ -302,18 +416,33 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             config,
             builder_config,
             segment_manager,
+            writer_lock,
         ))
     }
 
     /// Create an IndexWriter from an existing Index.
     /// Shares the SegmentManager for consistent segment lifecycle management.
+    ///
+    /// This constructor is infallible, so a single-writer lock conflict is
+    /// deferred: the returned writer fails loudly on its first mutating
+    /// operation instead of silently double-writing next to another writer.
     pub fn from_index(index: &super::Index<D>) -> Self {
+        let writer_lock = match try_acquire_writer_lock(index.directory.as_ref()) {
+            Ok(lock) => lock,
+            Err(error) => WriterLock::Unavailable {
+                reason: format!("failed to acquire the single-writer lock: {error}"),
+            },
+        };
+        if let WriterLock::Unavailable { reason } = &writer_lock {
+            log::error!("[writer_lock] {reason}");
+        }
         Self::new_with_parts(
             Arc::clone(&index.directory),
             Arc::clone(&index.schema),
             index.config.clone(),
             SegmentBuilderConfig::default(),
             Arc::clone(&index.segment_manager),
+            writer_lock,
         )
     }
 
@@ -328,6 +457,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         config: IndexConfig,
         builder_config: SegmentBuilderConfig,
         segment_manager: Arc<crate::merge::SegmentManager<D>>,
+        writer_lock: WriterLock,
     ) -> Self {
         // Auto-configure tokenizers from schema for all text fields
         let registry = crate::tokenizer::TokenizerRegistry::new();
@@ -374,6 +504,38 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             flushed_segments: Arc::new(parking_lot::Mutex::new(Vec::new())),
             primary_key_index: Arc::new(parking_lot::RwLock::new(None)),
             commit_finalization: Arc::new(CommitFinalizationState::default()),
+            pk_reservations_retained: Arc::new(AtomicBool::new(false)),
+            writer_lock,
+        }
+    }
+
+    /// Fail loudly when another writer owns the single-writer lock.
+    fn ensure_writer_lock(&self) -> Result<()> {
+        if let WriterLock::Unavailable { reason } = &self.writer_lock {
+            return Err(Error::Internal(reason.clone()));
+        }
+        Ok(())
+    }
+
+    /// Clear primary-key reservations after an aborted or failed generation.
+    ///
+    /// Skipped while a failed post-commit PK refresh has left the uncommitted
+    /// reservations as the ONLY record of already-committed keys (fail-closed,
+    /// see `finalize_prepared_commit`): wiping them would admit duplicate
+    /// primary keys. Retaining the aborted generation's keys as well is
+    /// deliberately conservative — they clear on the next successful commit's
+    /// refresh.
+    fn clear_uncommitted_pk_reservations(&self) {
+        if self.pk_reservations_retained.load(Ordering::Acquire) {
+            log::warn!(
+                "[primary_key] keeping uncommitted reservations through abort: a \
+                 failed post-commit refresh left them as the only record of \
+                 committed keys; they are cleared by the next successful commit"
+            );
+            return;
+        }
+        if let Some(pk_index) = self.primary_key_index.write().as_mut() {
+            pk_index.clear_uncommitted();
         }
     }
 
@@ -549,6 +711,12 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             *self.primary_key_index.write() = Some(pk_index);
         }
 
+        // The freshly built index covers every committed segment, so any
+        // reservations retained after a failed post-commit refresh are
+        // superseded by committed_data.
+        self.pk_reservations_retained
+            .store(false, Ordering::Release);
+
         Ok(())
     }
 
@@ -578,6 +746,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Returns an explicit backpressure error when the queue is at capacity or
     /// a prepared commit generation is not yet resolved.
     pub fn add_document(&self, doc: Document) -> Result<()> {
+        self.ensure_writer_lock()?;
         if self.worker_state.shutdown.load(Ordering::Acquire) {
             return Err(Error::IndexClosed);
         }
@@ -749,9 +918,14 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             // prepare_commit from hanging)
             let prev = state.flush_count.fetch_add(1, Ordering::Release);
             if prev + 1 == state.num_workers {
-                // Last worker — wake prepare_commit
+                // Last worker — wake prepare_commit. notify_all, not
+                // notify_one: a cancelled commit leaves its detached
+                // spawn_blocking waiter parked on this condvar, and with a
+                // single notification that dead waiter would consume the
+                // only wakeup, stalling a retried prepare_commit for its
+                // full deadline.
                 let _lock = state.flush_mutex.lock();
-                state.flush_cvar.notify_one();
+                state.flush_cvar.notify_all();
             }
 
             // Wait for resume (new channel) or shutdown.
@@ -949,7 +1123,11 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     }
 
     /// Clean up orphan segment files not registered in metadata.
+    ///
+    /// Requires the single-writer lock: sweeping while another process's
+    /// writer is live would delete its in-flight segment outputs.
     pub async fn cleanup_orphan_segments(&self) -> Result<usize> {
+        self.ensure_writer_lock()?;
         self.segment_manager.cleanup_orphan_segments().await
     }
 
@@ -964,6 +1142,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     ///
     /// `add_document` returns `CommitInProgress` until commit/abort resumes workers.
     pub async fn prepare_commit(&mut self) -> Result<PreparedCommit<'_, D>> {
+        self.ensure_writer_lock()?;
         if self.worker_state.shutdown.load(Ordering::Acquire) {
             return Err(Error::IndexClosed);
         }
@@ -1024,9 +1203,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             // guarantee. Their RAII drops retain ownership through deletion.
             self.flushed_segments.lock().clear();
             self.worker_state.built_segments.lock().clear();
-            if let Some(pk_index) = self.primary_key_index.write().as_mut() {
-                pk_index.clear_uncommitted();
-            }
+            self.clear_uncommitted_pk_reservations();
             self.resume_workers();
             return Err(Error::Internal(format!(
                 "indexing generation failed; no documents from this batch were committed: {error}"
@@ -1211,6 +1388,7 @@ struct OwnedCommitFinalization<D: DirectoryWriter + 'static> {
     prepared: PreparedSegmentsGuard<D>,
     finalization: Option<CommitFinalizationGuard<D>>,
     publication_observed: Arc<AtomicBool>,
+    pk_reservations_retained: Arc<AtomicBool>,
 }
 
 async fn refresh_primary_key_after_commit<D: DirectoryWriter + 'static>(
@@ -1296,7 +1474,7 @@ async fn finalize_prepared_commit<D: DirectoryWriter + 'static>(
     // retaining the generation's uncommitted keys may cause conservative
     // duplicate rejections, but can never admit a duplicate or turn a durable
     // commit into an API error.
-    if let Err(error) = refresh_primary_key_after_commit(
+    match refresh_primary_key_after_commit(
         &commit.directory,
         &commit.schema,
         &commit.segment_manager,
@@ -1304,11 +1482,25 @@ async fn finalize_prepared_commit<D: DirectoryWriter + 'static>(
     )
     .await
     {
-        log::error!(
-            "[primary_key] committed metadata but failed to refresh dedup state; \
-             retaining reservations until a later successful commit: {}",
-            error,
-        );
+        // A successful refresh folded every committed key into committed_data
+        // and cleared the reservations — nothing retained anymore.
+        Ok(()) => commit
+            .pk_reservations_retained
+            .store(false, Ordering::Release),
+        Err(error) => {
+            // The retained reservations are now the ONLY record of the
+            // published segments' keys. Abort paths must not clear them
+            // (see clear_uncommitted_pk_reservations) or duplicates would
+            // be admitted.
+            commit
+                .pk_reservations_retained
+                .store(true, Ordering::Release);
+            log::error!(
+                "[primary_key] committed metadata but failed to refresh dedup state; \
+                 retaining reservations until a later successful commit: {}",
+                error,
+            );
+        }
     }
 
     // Merge scheduling is optional post-commit work and may briefly wait on
@@ -1360,6 +1552,7 @@ impl<'a, D: DirectoryWriter + 'static> PreparedCommit<'a, D> {
                 resume_workers: false,
             }),
             publication_observed: Arc::clone(&publication_observed),
+            pk_reservations_retained: Arc::clone(&self.writer.pk_reservations_retained),
         };
 
         // From this point the owned value, not this cancel-sensitive guard,
@@ -1411,9 +1604,7 @@ impl<'a, D: DirectoryWriter + 'static> PreparedCommit<'a, D> {
     pub fn abort(mut self) {
         self.is_resolved = true;
         self.writer.flushed_segments.lock().clear();
-        if let Some(pk_index) = self.writer.primary_key_index.write().as_mut() {
-            pk_index.clear_uncommitted();
-        }
+        self.writer.clear_uncommitted_pk_reservations();
         self.writer.resume_workers();
     }
 }
@@ -1423,9 +1614,7 @@ impl<D: DirectoryWriter + 'static> Drop for PreparedCommit<'_, D> {
         if !self.is_resolved {
             log::warn!("PreparedCommit dropped without commit/abort — auto-aborting");
             self.writer.flushed_segments.lock().clear();
-            if let Some(pk_index) = self.writer.primary_key_index.write().as_mut() {
-                pk_index.clear_uncommitted();
-            }
+            self.writer.clear_uncommitted_pk_reservations();
             self.writer.resume_workers();
         }
     }

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -73,6 +73,12 @@ use super::{MergePolicy, SegmentInfo};
 struct ActiveOperationState {
     segment_ids: HashSet<String>,
     operation_tokens: HashSet<u64>,
+    /// Subset of `operation_tokens` owned by indexing producers. Their guards
+    /// travel with built-but-uncommitted `PreparedSegment`s and are released
+    /// only by a later commit/abort, so drain barriers must not wait on them:
+    /// the commit that would release them can be blocked on the barrier's own
+    /// caller (writer write lock / `&mut self`).
+    indexing_tokens: HashSet<u64>,
     next_operation_token: u64,
     accepting: bool,
 }
@@ -89,6 +95,7 @@ impl ActiveSegmentOperations {
             inner: parking_lot::Mutex::new(ActiveOperationState {
                 segment_ids: HashSet::new(),
                 operation_tokens: HashSet::new(),
+                indexing_tokens: HashSet::new(),
                 next_operation_token: 0,
                 accepting: true,
             }),
@@ -97,9 +104,27 @@ impl ActiveSegmentOperations {
         }
     }
 
-    /// Try to claim IDs for an operation. Returns a guard on success, `None`
-    /// if any requested ID is already owned by another active operation.
+    /// Try to claim IDs for a self-draining lifecycle operation (merge,
+    /// reorder, cleanup). Returns a guard on success, `None` if any requested
+    /// ID is already owned by another active operation.
     fn try_register(self: &Arc<Self>, segment_ids: Vec<String>) -> Option<SegmentOperationGuard> {
+        self.try_register_kind(segment_ids, false)
+    }
+
+    /// Try to claim IDs for an indexing producer whose guard is held until
+    /// metadata publication (commit) rather than task completion.
+    fn try_register_indexing(
+        self: &Arc<Self>,
+        segment_ids: Vec<String>,
+    ) -> Option<SegmentOperationGuard> {
+        self.try_register_kind(segment_ids, true)
+    }
+
+    fn try_register_kind(
+        self: &Arc<Self>,
+        segment_ids: Vec<String>,
+        indexing: bool,
+    ) -> Option<SegmentOperationGuard> {
         let mut inner = self.inner.lock();
         if !inner.accepting {
             log::debug!("[segment_lifecycle] rejected operation during shutdown");
@@ -128,6 +153,9 @@ impl ActiveSegmentOperations {
         }
         inner.next_operation_token = next_operation_token;
         inner.operation_tokens.insert(operation_token);
+        if indexing {
+            inner.indexing_tokens.insert(operation_token);
+        }
         Some(SegmentOperationGuard {
             active_operations: Arc::clone(self),
             segment_ids,
@@ -140,12 +168,24 @@ impl ActiveSegmentOperations {
         self.inner.lock().segment_ids.clone()
     }
 
-    /// Exact operation identities active at one instant. Unlike segment IDs,
-    /// tokens cannot be reused by a later retry, so an artifact-update barrier
-    /// can drain only pre-gate producers without being starved by new flat
-    /// producers.
-    fn operation_tokens_snapshot(&self) -> HashSet<u64> {
-        self.inner.lock().operation_tokens.clone()
+    /// Exact identities of self-draining operations (merge/reorder/cleanup)
+    /// active at one instant, plus the number of indexing tokens excluded.
+    /// Unlike segment IDs, tokens cannot be reused by a later retry, so an
+    /// artifact-update barrier can drain only pre-gate producers without being
+    /// starved by new flat producers.
+    ///
+    /// Indexing tokens are deliberately excluded: their guards are parked in
+    /// built-but-uncommitted `PreparedSegment`s and only a later commit — which
+    /// may be blocked on the barrier's caller — releases them, so waiting on
+    /// them deadlocks (see `begin_vector_artifact_update`).
+    fn draining_operation_tokens_snapshot(&self) -> (HashSet<u64>, usize) {
+        let inner = self.inner.lock();
+        let tokens = inner
+            .operation_tokens
+            .difference(&inner.indexing_tokens)
+            .copied()
+            .collect();
+        (tokens, inner.indexing_tokens.len())
     }
 
     /// Atomically prevent new lifecycle work from starting. Existing guards
@@ -215,6 +255,7 @@ impl Drop for SegmentOperationGuard {
             inner.segment_ids.remove(id);
         }
         inner.operation_tokens.remove(&self.operation_token);
+        inner.indexing_tokens.remove(&self.operation_token);
         // Token barriers need notification on every completion, not only the
         // transition to complete global idleness.
         self.active_operations.idle.notify_waiters();
@@ -266,6 +307,48 @@ fn merge_retry_delay(consecutive_failures: u32) -> std::time::Duration {
         .checked_mul(1u32 << shift)
         .unwrap_or(MERGE_RETRY_MAX_DELAY)
         .min(MERGE_RETRY_MAX_DELAY)
+}
+
+/// Merge JoinHandles taken out of the shared list for draining.
+///
+/// Drain futures are awaited inline by RPC handlers (force_merge/reorder) and
+/// can be dropped at any await when a client disconnects. Handles are awaited
+/// through this guard and removed only after completion, so a cancelled drain
+/// returns every un-awaited (and possibly still-running) merge to the shared
+/// list instead of silently detaching it from shutdown, abort, and
+/// force-merge tracking.
+struct DrainedMergeHandles<'a> {
+    shared: &'a parking_lot::Mutex<Vec<JoinHandle<()>>>,
+    drained: Vec<JoinHandle<()>>,
+}
+
+impl<'a> DrainedMergeHandles<'a> {
+    fn take(shared: &'a parking_lot::Mutex<Vec<JoinHandle<()>>>) -> Self {
+        let drained = std::mem::take(&mut *shared.lock());
+        Self { shared, drained }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.drained.is_empty()
+    }
+
+    /// Await the next handle. It stays owned by this guard while being polled
+    /// and is discarded only once it has completed, so cancellation at the
+    /// await reinserts it via `Drop`.
+    async fn join_next(&mut self) -> Option<std::result::Result<(), tokio::task::JoinError>> {
+        let handle = self.drained.last_mut()?;
+        let result = handle.await;
+        self.drained.pop();
+        Some(result)
+    }
+}
+
+impl Drop for DrainedMergeHandles<'_> {
+    fn drop(&mut self) {
+        if !self.drained.is_empty() {
+            self.shared.lock().append(&mut self.drained);
+        }
+    }
 }
 
 /// Spawn and register auxiliary lifecycle work as one synchronous operation.
@@ -416,6 +499,11 @@ pub struct SegmentManager<D: DirectoryWriter + 'static> {
     /// forever when no later commit happens to re-run merge policy evaluation.
     global_merge_wakeup_pending: AtomicBool,
 
+    /// Times `force_merge` observed a conflicting active operation and retried.
+    /// Test-only observability for the conflict-retry backoff.
+    #[cfg(test)]
+    force_merge_conflict_retries: std::sync::atomic::AtomicU64,
+
     /// Auxiliary lifecycle tasks: metadata transactions, deferred deletes,
     /// and capacity wakeups. Handles registered here are drained before index
     /// removal.
@@ -557,6 +645,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             reorder_retries: parking_lot::Mutex::new(HashMap::new()),
             merge_handles: parking_lot::Mutex::new(Vec::new()),
             global_merge_wakeup_pending: AtomicBool::new(false),
+            #[cfg(test)]
+            force_merge_conflict_retries: std::sync::atomic::AtomicU64::new(0),
             lifecycle_handles,
             trained: Arc::new(ArcSwapOption::new(None)),
             vector_artifact_update: Arc::new(AtomicBool::new(false)),
@@ -698,7 +788,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     pub(crate) fn protect_new_segment(&self, segment_id: String) -> Result<SegmentOperationGuard> {
         match self
             .active_operations
-            .try_register(vec![segment_id.clone()])
+            .try_register_indexing(vec![segment_id.clone()])
         {
             Some(operation) => Ok(operation),
             None if !self.active_operations.is_accepting() => Err(Error::IndexClosed),
@@ -944,13 +1034,21 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         }
     }
 
-    /// Start an exclusive trained-artifact update and drain producers that may
-    /// already hold the previous generation.
+    /// Start an exclusive trained-artifact update and drain merge/reorder
+    /// producers that may already hold the previous generation.
     ///
     /// New segment operations may continue while this waits, but they observe
     /// the gate through `trained_for_segment_build` and therefore emit flat
     /// vector data. The guard is cancellation-safe: dropping the requesting
     /// future reopens ANN production without leaving the manager wedged.
+    ///
+    /// Indexing tokens are NOT waited on: their guards are parked inside
+    /// built-but-uncommitted `PreparedSegment`s and are released only by a
+    /// later commit. That commit typically needs the writer this update's
+    /// caller already holds (server write lock / embedded `&mut self`), so
+    /// waiting on them would permanently wedge build/rebuild_vector_index.
+    /// Segments those tokens own were built against the previous generation
+    /// and surface to the rebuild safety check once committed.
     pub(crate) async fn begin_vector_artifact_update(&self) -> Result<VectorArtifactUpdateGuard> {
         self.vector_artifact_update
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -962,7 +1060,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 updating: Arc::clone(&self.vector_artifact_update),
             }),
         };
-        let preexisting = self.active_operations.operation_tokens_snapshot();
+        let (preexisting, parked_indexing) =
+            self.active_operations.draining_operation_tokens_snapshot();
+        if parked_indexing > 0 {
+            log::warn!(
+                "[trained] artifact update proceeding past {} in-flight/uncommitted indexing \
+                 segment(s); segments built before this update keep the previous artifact \
+                 generation and become visible to rebuild safety checks once committed",
+                parked_indexing,
+            );
+        }
         self.active_operations
             .wait_until_operations_finish(&preexisting)
             .await;
@@ -1366,16 +1473,36 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 sm.maybe_merge().await;
             } else if let Some(retry_delay) = retry_delay {
                 // A backoff without a wakeup can strand eligible segments
-                // forever when no later commit happens. Keep this sleep inside
-                // the tracked merge task so shutdown can await it safely.
-                tokio::select! {
-                    () = tokio::time::sleep(retry_delay) => {
-                        sm.maybe_merge().await;
-                    }
-                    () = sm.active_operations.wait_for_shutdown() => {}
-                }
+                // forever when no later commit happens. The sleep runs as a
+                // tracked *lifecycle* task, not inside this merge JoinHandle:
+                // wait_for_all_merges/force_merge/reorder drain merge handles,
+                // and a pure backoff timer with no work in flight must not
+                // stall them for up to MERGE_RETRY_MAX_DELAY.
+                sm.schedule_merge_retry_wakeup(retry_delay);
             }
         }))
+    }
+
+    /// Re-evaluate merge policy after a failure backoff, outside the tracked
+    /// merge JoinHandles that merge waiters drain. Shutdown still drains this
+    /// task deterministically (lifecycle handles) and interrupts its sleep.
+    fn schedule_merge_retry_wakeup(self: &Arc<Self>, retry_delay: std::time::Duration) {
+        let manager = Arc::clone(self);
+        let future = async move {
+            tokio::select! {
+                () = tokio::time::sleep(retry_delay) => {
+                    manager.maybe_merge().await;
+                }
+                () = manager.active_operations.wait_for_shutdown() => {}
+            }
+        };
+        let runtime = tokio::runtime::Handle::current();
+        if !try_spawn_lifecycle(&self.lifecycle_handles, &runtime, future) {
+            log::warn!(
+                "[merge] runtime rejected merge-retry wakeup task; eligible segments may stay \
+                 unmerged until the next commit re-runs merge policy evaluation"
+            );
+        }
     }
 
     /// Atomically replace old segments with a new merged segment.
@@ -1685,14 +1812,17 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     /// merge-time BP still owned an `OffsetWriter`, allowing index deletion or
     /// orphan cleanup to race a live writer. Awaiting is the only sound generic
     /// behavior until every merge phase supports cooperative cancellation.
+    ///
+    /// Cancellation-safe: dropping this future mid-drain returns un-awaited
+    /// handles to `merge_handles` so later drains still see in-flight merges.
     pub async fn abort_merges(&self) {
         loop {
-            let handles: Vec<JoinHandle<()>> = { std::mem::take(&mut *self.merge_handles.lock()) };
+            let mut handles = DrainedMergeHandles::take(&self.merge_handles);
             if handles.is_empty() {
                 return;
             }
-            for handle in handles {
-                if let Err(error) = handle.await
+            while let Some(result) = handles.join_next().await {
+                if let Err(error) = result
                     && error.is_panic()
                 {
                     log::error!("[merge] background task panicked while draining: {}", error);
@@ -1702,27 +1832,29 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     }
 
     /// Wait for all current in-flight merges to complete.
+    ///
+    /// Cancellation-safe: dropping this future mid-drain returns un-awaited
+    /// handles to `merge_handles` so later drains still see in-flight merges.
     pub async fn wait_for_merging_thread(self: &Arc<Self>) {
-        let handles: Vec<JoinHandle<()>> = { std::mem::take(&mut *self.merge_handles.lock()) };
-        for h in handles {
-            let _ = h.await;
-        }
+        let mut handles = DrainedMergeHandles::take(&self.merge_handles);
+        while handles.join_next().await.is_some() {}
     }
 
     /// Wait for all eligible merges to complete, including cascading merges.
     ///
     /// Drains current handles, then loops. Each completed merge auto-triggers
     /// `maybe_merge` (which pushes new handles) before its JoinHandle resolves,
-    /// so by the time `h.await` returns all cascading handles are registered.
+    /// so by the time `join_next` returns all cascading handles are registered.
+    ///
+    /// Cancellation-safe: dropping this future mid-drain returns un-awaited
+    /// handles to `merge_handles` so later drains still see in-flight merges.
     pub async fn wait_for_all_merges(self: &Arc<Self>) {
         loop {
-            let handles: Vec<JoinHandle<()>> = { std::mem::take(&mut *self.merge_handles.lock()) };
+            let mut handles = DrainedMergeHandles::take(&self.merge_handles);
             if handles.is_empty() {
                 break;
             }
-            for h in handles {
-                let _ = h.await;
-            }
+            while handles.join_next().await.is_some() {}
         }
     }
 
@@ -1758,6 +1890,12 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     /// `maybe_merge` from spawning a conflicting background merge.
     pub async fn force_merge(self: &Arc<Self>) -> Result<()> {
         const FORCE_MERGE_BATCH: usize = 64;
+        // Conflicting owners that never appear in `merge_handles` (background
+        // reorders, a concurrent force-merge) can hold a batch segment for
+        // minutes to hours; retrying without parking would busy-spin a runtime
+        // worker and hammer the state mutex for that whole window.
+        const FORCE_MERGE_CONFLICT_BACKOFF: std::time::Duration =
+            std::time::Duration::from_millis(100);
 
         let max_segment_docs = {
             let st = self.state.lock().await;
@@ -1848,8 +1986,22 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     return Err(Error::IndexClosed);
                 }
                 None => {
-                    // A background merge slipped in — wait for it, then retry the loop
+                    #[cfg(test)]
+                    self.force_merge_conflict_retries
+                        .fetch_add(1, Ordering::Relaxed);
+                    // Do not reserve application-wide merge capacity while
+                    // parked on a conflict.
+                    drop(_global_merge_permit);
+                    // A tracked background merge may have slipped in — drain
+                    // those first. The conflicting owner can also be a reorder
+                    // or another force-merge, which never appear in
+                    // merge_handles; back off so the retry loop cannot spin hot
+                    // for their entire duration.
+                    let had_tracked_merges = !self.merge_handles.lock().is_empty();
                     self.wait_for_merging_thread().await;
+                    if !had_tracked_merges {
+                        tokio::time::sleep(FORCE_MERGE_CONFLICT_BACKOFF).await;
+                    }
                     continue;
                 }
             };
@@ -2375,7 +2527,8 @@ mod tests {
     async fn operation_barrier_ignores_producers_started_after_snapshot() {
         let active = Arc::new(ActiveSegmentOperations::new());
         let before_gate = active.try_register(vec!["old".into()]).unwrap();
-        let barrier = active.operation_tokens_snapshot();
+        let (barrier, parked_indexing) = active.draining_operation_tokens_snapshot();
+        assert_eq!(parked_indexing, 0);
         let after_gate = active.try_register(vec!["new-flat".into()]).unwrap();
 
         let waiter = {
@@ -2562,5 +2715,281 @@ mod tests {
         assert!(manager.paused_reorder_segments().contains("source"));
         manager.clear_reorder_retry("source");
         assert!(!manager.paused_reorder_segments().contains("source"));
+    }
+
+    /// Fails `exists` with the transient I/O error class that sends a
+    /// background merge into its generic retry backoff (not source quarantine).
+    #[derive(Default)]
+    struct FailingExistsDirectory(crate::directories::RamDirectory);
+
+    #[async_trait::async_trait]
+    impl crate::directories::Directory for FailingExistsDirectory {
+        async fn exists(&self, _path: &std::path::Path) -> std::io::Result<bool> {
+            Err(std::io::Error::from(std::io::ErrorKind::TimedOut))
+        }
+
+        async fn file_size(&self, path: &std::path::Path) -> std::io::Result<u64> {
+            self.0.file_size(path).await
+        }
+
+        async fn open_read(
+            &self,
+            path: &std::path::Path,
+        ) -> std::io::Result<crate::directories::FileHandle> {
+            self.0.open_read(path).await
+        }
+
+        async fn read_range(
+            &self,
+            path: &std::path::Path,
+            range: std::ops::Range<u64>,
+        ) -> std::io::Result<crate::directories::OwnedBytes> {
+            self.0.read_range(path, range).await
+        }
+
+        async fn list_files(
+            &self,
+            prefix: &std::path::Path,
+        ) -> std::io::Result<Vec<std::path::PathBuf>> {
+            self.0.list_files(prefix).await
+        }
+
+        async fn open_lazy(
+            &self,
+            path: &std::path::Path,
+        ) -> std::io::Result<crate::directories::FileHandle> {
+            self.0.open_lazy(path).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::directories::DirectoryWriter for FailingExistsDirectory {
+        async fn write(&self, path: &std::path::Path, data: &[u8]) -> std::io::Result<()> {
+            self.0.write(path, data).await
+        }
+
+        async fn delete(&self, path: &std::path::Path) -> std::io::Result<()> {
+            self.0.delete(path).await
+        }
+
+        async fn rename(
+            &self,
+            from: &std::path::Path,
+            to: &std::path::Path,
+        ) -> std::io::Result<()> {
+            self.0.rename(from, to).await
+        }
+
+        async fn sync(&self) -> std::io::Result<()> {
+            self.0.sync().await
+        }
+
+        async fn streaming_writer(
+            &self,
+            path: &std::path::Path,
+        ) -> std::io::Result<Box<dyn crate::directories::StreamingWriter>> {
+            self.0.streaming_writer(path).await
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct MergeEverythingPolicy;
+
+    impl MergePolicy for MergeEverythingPolicy {
+        fn find_merges(&self, segments: &[SegmentInfo]) -> Vec<crate::merge::MergeCandidate> {
+            if segments.len() < 2 {
+                return Vec::new();
+            }
+            vec![crate::merge::MergeCandidate {
+                segment_ids: segments.iter().map(|s| s.id.clone()).collect(),
+            }]
+        }
+
+        fn clone_box(&self) -> Box<dyn MergePolicy> {
+            Box::new(self.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn artifact_update_does_not_wait_for_built_uncommitted_indexing_segments() {
+        let manager = lifecycle_test_manager();
+        // Simulates a memory-budget mid-cycle segment build whose guard is
+        // parked inside a PreparedSegment: only a later commit releases this
+        // token, and that commit can be blocked on the very caller of the
+        // artifact update (writer write lock / &mut self).
+        let parked_indexing = manager
+            .protect_new_segment("00000000000000000000000000000abc".into())
+            .unwrap();
+
+        let guard = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            manager.begin_vector_artifact_update(),
+        )
+        .await
+        .expect("begin_vector_artifact_update deadlocked on a built-but-uncommitted segment")
+        .unwrap();
+
+        drop(guard);
+        drop(parked_indexing);
+    }
+
+    #[tokio::test]
+    async fn artifact_update_still_drains_preexisting_lifecycle_operations() {
+        let manager = lifecycle_test_manager();
+        let merge_like = manager
+            .active_operations
+            .try_register(vec!["merge-source".into()])
+            .unwrap();
+
+        let waiter = {
+            let manager = Arc::clone(&manager);
+            tokio::spawn(async move { manager.begin_vector_artifact_update().await })
+        };
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            !waiter.is_finished(),
+            "artifact update must drain merge/reorder producers that may hold the previous generation"
+        );
+
+        drop(merge_like);
+        tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("artifact update missed the lifecycle guard release")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_merge_drain_returns_unawaited_handles_to_shared_state() {
+        let manager = lifecycle_test_manager();
+        let release = Arc::new(Semaphore::new(0));
+        let merge_task = {
+            let release = Arc::clone(&release);
+            tokio::spawn(async move {
+                let _permit = release.acquire().await.unwrap();
+            })
+        };
+        manager.merge_handles.lock().push(merge_task);
+
+        let waiter = {
+            let manager = Arc::clone(&manager);
+            tokio::spawn(async move { manager.wait_for_all_merges().await })
+        };
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        assert!(!waiter.is_finished());
+        // Simulates tonic dropping a force_merge/reorder RPC future at the
+        // JoinHandle await when the client disconnects.
+        waiter.abort();
+        let join_error = waiter.await.unwrap_err();
+        assert!(join_error.is_cancelled());
+
+        assert!(
+            !manager.merge_handles.lock().is_empty(),
+            "cancelled drain detached an in-flight merge from shutdown/force-merge tracking"
+        );
+
+        // A later drain must still see and await the real in-flight merge.
+        release.add_permits(1);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            manager.wait_for_all_merges(),
+        )
+        .await
+        .expect("subsequent drain missed the reinserted merge handle");
+        assert!(manager.merge_handles.lock().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn force_merge_conflict_retry_backs_off_instead_of_busy_spinning() {
+        let manager = lifecycle_test_manager();
+        {
+            let mut state = manager.state.lock().await;
+            state
+                .metadata
+                .add_segment("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(), 10);
+            state
+                .metadata
+                .add_segment("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".into(), 10);
+        }
+        // A background reorder (or a concurrent force-merge) owns one segment
+        // in the batch but never appears in merge_handles.
+        let reorder_like = manager
+            .active_operations
+            .try_register(vec!["aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()])
+            .unwrap();
+
+        let force_merge = {
+            let manager = Arc::clone(&manager);
+            tokio::spawn(async move { manager.force_merge().await })
+        };
+
+        tokio::time::sleep(std::time::Duration::from_millis(600)).await;
+        let retries = manager.force_merge_conflict_retries.load(Ordering::Relaxed);
+        assert!(
+            retries >= 1,
+            "force_merge never observed the conflicting owner (retries={retries})"
+        );
+        assert!(
+            retries < 20,
+            "force_merge busy-spun on a conflict that is not a tracked merge (retries={retries})"
+        );
+
+        drop(reorder_like);
+        // With the conflict gone the loop proceeds; the batch then fails fast
+        // in do_merge (the test IDs have no files), proving the loop exited.
+        let result = tokio::time::timeout(std::time::Duration::from_secs(10), force_merge)
+            .await
+            .expect("force_merge kept spinning after the conflicting owner released")
+            .unwrap();
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn merge_failure_retry_backoff_does_not_stall_merge_waiters() {
+        let schema = crate::dsl::SchemaBuilder::default().build();
+        let mut metadata = IndexMetadata::new(schema.clone());
+        metadata.add_segment("00000000000000000000000000000001".into(), 10);
+        metadata.add_segment("00000000000000000000000000000002".into(), 10);
+        let manager = Arc::new(SegmentManager::new(
+            Arc::new(FailingExistsDirectory::default()),
+            Arc::new(schema),
+            metadata,
+            Box::new(MergeEverythingPolicy),
+            0,
+            1,
+            Arc::new(Semaphore::new(1)),
+            None,
+            1024,
+            Arc::new(Semaphore::new(1)),
+            None,
+        ));
+
+        // Spawns a background merge that fails with a transient I/O error and
+        // arms the 30s..30min retry backoff.
+        manager.maybe_merge().await;
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            manager.wait_for_all_merges(),
+        )
+        .await
+        .expect("wait_for_all_merges stalled behind a pure retry-backoff timer");
+        assert!(
+            manager.merge_retry_is_paused(),
+            "the failed merge should have armed the retry backoff"
+        );
+
+        // Shutdown still drains the pending backoff wakeup deterministically.
+        manager.begin_shutdown();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            manager.wait_for_shutdown(),
+        )
+        .await
+        .expect("shutdown did not drain the merge retry wakeup task");
     }
 }

--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -227,6 +227,22 @@ pub(crate) fn build_bmp_blob(
     let mut dim_ids: Vec<u32> = postings.keys().copied().collect();
     dim_ids.sort_unstable();
 
+    // The block-max grid only has rows for dim_id < dims; postings beyond
+    // that would be written into block data but never into the grid, making
+    // those dimensions silently unsearchable. Fail loud instead.
+    if let Some(&max_dim) = dim_ids.last()
+        && max_dim >= dims
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "BMP postings contain dim_id {max_dim} out of range for the configured \
+                 dims={dims}: dimensions >= dims have no block-max grid row and can never \
+                 match a query; raise `dims` in the field's sparse_vector config"
+            ),
+        ));
+    }
+
     // Phase 2: K-way merge over per-dim cursors
     //
     // Take ownership of per-dim posting Vecs. This drains the HashMap so
@@ -695,6 +711,21 @@ pub(crate) fn stream_write_grids(
     }
     let packed_bytes = (num_dims * packed_row_size) as u64;
 
+    // Entries with dim_id >= num_dims sort past the cursor and have no grid
+    // row: they would be dropped silently, leaving those dimensions
+    // unsearchable. The segment builder rejects them at add/build time, so
+    // leftovers here mean a legacy blob or a caller bug — say so loudly.
+    if gi < grid_entries.len() {
+        log::warn!(
+            "[bmp] {} grid entries with dim_id >= dims={} dropped from the block-max grid \
+             (first dim_id={}); these dimensions are unsearchable — raise `dims` in the \
+             field's sparse_vector config and rebuild",
+            grid_entries.len() - gi,
+            num_dims,
+            grid_entries[gi].0,
+        );
+    }
+
     // Section E: 8-bit superblock grid, one dim row at a time
     gi = 0;
     for dim_id in 0..num_dims as u32 {
@@ -834,6 +865,20 @@ pub(crate) fn stream_write_grids_merged(
     }
     let packed_bytes = (num_dims * packed_row_size) as u64;
 
+    // Same silent-drop hazard as `stream_write_grids`: any entry still
+    // pending after the dim sweep has dim_id >= dims and no grid row.
+    for reader in run_readers.iter() {
+        if let Some((dim_id, _, _)) = reader.current {
+            log::warn!(
+                "[bmp] grid run contains entries with dim_id >= dims={num_dims} \
+                 (first dim_id={dim_id}) that were dropped from the block-max grid; \
+                 these dimensions are unsearchable — raise `dims` in the field's \
+                 sparse_vector config and rebuild",
+            );
+            break;
+        }
+    }
+
     // Reset all readers for pass 2
     for reader in run_readers.iter_mut() {
         reader.reset()?;
@@ -909,6 +954,25 @@ mod tests {
         let footer_start = buf.len() - 4;
         let magic = u32::from_le_bytes(buf[footer_start..].try_into().unwrap());
         assert_eq!(magic, BMP_BLOB_MAGIC_V14);
+    }
+
+    #[test]
+    fn test_build_bmp_blob_rejects_dim_id_out_of_range() {
+        // The grid only has rows for dim_id < dims; postings beyond that were
+        // silently dropped from the grid (unsearchable). Must fail loud.
+        let mut postings = FxHashMap::default();
+        postings.insert(2u32, vec![(0u32, 0u16, 1.0f32)]);
+        postings.insert(7u32, vec![(1u32, 0u16, 0.5f32)]); // >= dims (4)
+
+        let mut buf = Vec::new();
+        let err = build_bmp_blob(postings, 64, 4, 0.0, None, 4, 5.0, 4, &mut buf)
+            .expect_err("dim_id >= dims must be rejected at build time");
+        let msg = err.to_string();
+        assert!(msg.contains('7'), "error must name the dim_id: {msg}");
+        assert!(
+            msg.contains('4'),
+            "error must name the configured dims: {msg}"
+        );
     }
 
     #[test]

--- a/hermes-core/src/segment/builder/mod.rs
+++ b/hermes-core/src/segment/builder/mod.rs
@@ -121,6 +121,49 @@ const INTERN_OVERHEAD: usize = size_of::<Spur>() + 2 * size_of::<usize>();
 const NEW_POS_TERM_OVERHEAD: usize =
     size_of::<TermKey>() + size_of::<PositionPostingListBuilder>() + 24;
 
+/// Packed position encoding is `(element_ordinal << 20) | token_position`:
+/// 12 bits of element ordinal, 20 bits of token position. Values beyond these
+/// maxima must saturate — a plain shift/or silently corrupts the neighboring
+/// bit field (ordinal 4096 wraps to 0 and aliases element 0; token positions
+/// >= 2^20 bleed into the ordinal bits).
+const MAX_POSITION_ELEMENT_ORDINAL: u32 = (1 << 12) - 1;
+const MAX_TOKEN_POSITION: u32 = (1 << 20) - 1;
+
+/// Default BMP vocabulary size when `dims` is unset in the sparse vector
+/// config (SPLADE unigram vocabulary). Must match the build-time defaults in
+/// `builder/sparse.rs` and `merger/sparse.rs`.
+const DEFAULT_BMP_SPARSE_DIMS: u32 = 105879;
+
+/// Human-readable name of a schema field type (matches the SDL/serde names).
+fn field_type_name(field_type: &FieldType) -> &'static str {
+    match field_type {
+        FieldType::Text => "text",
+        FieldType::U64 => "u64",
+        FieldType::I64 => "i64",
+        FieldType::F64 => "f64",
+        FieldType::Bytes => "bytes",
+        FieldType::SparseVector => "sparse_vector",
+        FieldType::DenseVector => "dense_vector",
+        FieldType::Json => "json",
+        FieldType::BinaryDenseVector => "binary_dense_vector",
+    }
+}
+
+/// Human-readable name of a document field value's type (matches SDL names).
+fn field_value_type_name(value: &FieldValue) -> &'static str {
+    match value {
+        FieldValue::Text(_) => "text",
+        FieldValue::U64(_) => "u64",
+        FieldValue::I64(_) => "i64",
+        FieldValue::F64(_) => "f64",
+        FieldValue::Bytes(_) => "bytes",
+        FieldValue::SparseVector(_) => "sparse_vector",
+        FieldValue::DenseVector(_) => "dense_vector",
+        FieldValue::Json(_) => "json",
+        FieldValue::BinaryDenseVector(_) => "binary_dense_vector",
+    }
+}
+
 /// Segment builder with optimized memory usage
 ///
 /// Features:
@@ -204,6 +247,10 @@ pub struct SegmentBuilder {
 
     /// Current element ordinal for multi-valued fields (reset per document)
     current_element_ordinal: FxHashMap<u32, u32>,
+
+    /// Whether the once-per-segment position-encoding saturation warning
+    /// has already been emitted (see MAX_POSITION_ELEMENT_ORDINAL).
+    position_saturation_warned: bool,
 
     /// Incrementally tracked memory estimate (avoids expensive stats() calls)
     estimated_memory: usize,
@@ -326,6 +373,7 @@ impl SegmentBuilder {
             position_index: HashMap::new(),
             position_enabled_fields,
             current_element_ordinal: FxHashMap::default(),
+            position_saturation_warned: false,
             estimated_memory: 0,
             doc_serialize_buffer: Vec::with_capacity(256),
             fast_fields,
@@ -496,8 +544,88 @@ impl SegmentBuilder {
         }
     }
 
+    /// Fail-loud pre-validation of a document's field values against the
+    /// schema. Runs BEFORE any builder state is mutated, so a rejected
+    /// document never poisons the builder (doc id advanced, postings written,
+    /// store write skipped).
+    ///
+    /// - A value whose runtime type does not match the schema field type
+    ///   would previously fall through `add_document`'s match silently: the
+    ///   value was stored but never indexed, so queries on the field could
+    ///   never match the document. Reject it loudly instead.
+    /// - Sparse entries destined for a BMP-format field must fit the
+    ///   configured `dims`: the block-max grid only has rows for
+    ///   `dim_id < dims`, so out-of-range entries would be silently dropped
+    ///   from the grid and silently filtered from queries — permanently
+    ///   unsearchable.
+    fn validate_document_against_schema(&self, doc: &Document) -> Result<()> {
+        for (field, value) in doc.field_values() {
+            let Some(entry) = self.schema.get_field_entry(*field) else {
+                continue;
+            };
+
+            // Mirror the indexing skip below: values that are neither indexed
+            // nor fast (and are not vector types) are only stored verbatim.
+            if !matches!(
+                &entry.field_type,
+                FieldType::DenseVector | FieldType::BinaryDenseVector
+            ) && !entry.indexed
+                && !entry.fast
+            {
+                continue;
+            }
+
+            match (&entry.field_type, value) {
+                (FieldType::SparseVector, FieldValue::SparseVector(entries)) => {
+                    if let Some(config) = entry.sparse_vector_config.as_ref()
+                        && config.format == crate::structures::SparseFormat::Bmp
+                    {
+                        let dims = config.dims.unwrap_or(DEFAULT_BMP_SPARSE_DIMS);
+                        if let Some(&(dim_id, _)) =
+                            entries.iter().find(|&&(dim_id, _)| dim_id >= dims)
+                        {
+                            return Err(crate::Error::Schema(format!(
+                                "sparse vector for field '{}' contains dim_id {} out of \
+                                 range for the configured BMP dims={}: dimensions >= dims \
+                                 are never written to the block-max grid and can never \
+                                 match a query; raise `dims` in the field's sparse_vector \
+                                 config or fix the embedding model",
+                                entry.name, dim_id, dims
+                            )));
+                        }
+                    }
+                }
+                // Matching (type, value) pairs — indexed by `add_document`.
+                (FieldType::Text, FieldValue::Text(_))
+                | (FieldType::U64, FieldValue::U64(_))
+                | (FieldType::I64, FieldValue::I64(_))
+                | (FieldType::F64, FieldValue::F64(_))
+                | (FieldType::DenseVector, FieldValue::DenseVector(_))
+                | (FieldType::BinaryDenseVector, FieldValue::BinaryDenseVector(_))
+                // Stored-only types: no indexing support, value stored verbatim.
+                | (FieldType::Bytes, FieldValue::Bytes(_))
+                | (FieldType::Json, FieldValue::Json(_)) => {}
+                (expected, got) => {
+                    return Err(crate::Error::Schema(format!(
+                        "type mismatch for field '{}': schema expects a {} value, got {}; \
+                         the value would be stored but never indexed, so queries on this \
+                         field could never match the document — fix the document or the \
+                         schema",
+                        entry.name,
+                        field_type_name(expected),
+                        field_value_type_name(got),
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Add a document - streams to disk immediately
     pub fn add_document(&mut self, doc: Document) -> Result<DocId> {
+        // Reject schema-mismatched values before mutating any builder state.
+        self.validate_document_against_schema(&doc)?;
+
         let doc_id = self.next_doc_id;
         self.next_doc_id += 1;
 
@@ -589,6 +717,10 @@ impl SegmentBuilder {
                     let ordinal = self.next_vector_ordinal(field.0)?;
                     self.index_sparse_vector_field(*field, doc_id, ordinal, entries)?;
                 }
+                // Only reachable for stored-only types (bytes/json) and for
+                // vector values on fields that are neither indexed nor
+                // stored: type-mismatched values are rejected loudly by
+                // `validate_document_against_schema` before this loop.
                 _ => {}
             }
         }
@@ -623,6 +755,21 @@ impl SegmentBuilder {
             .copied()
             .flatten();
 
+        // Saturate the packed 12-bit ordinal field instead of letting the
+        // shift silently wrap (ordinal 4096 << 20 == 0, aliasing element 0).
+        let encoded_ordinal = if position_mode.is_some_and(|m| m.tracks_ordinal())
+            && element_ordinal > MAX_POSITION_ELEMENT_ORDINAL
+        {
+            self.warn_position_saturation(
+                "element ordinal",
+                element_ordinal,
+                MAX_POSITION_ELEMENT_ORDINAL,
+            );
+            MAX_POSITION_ELEMENT_ORDINAL
+        } else {
+            element_ordinal
+        };
+
         // Phase 1: Aggregate term frequencies within this document
         // Also collect positions if enabled
         // Reuse buffers to avoid allocations
@@ -653,9 +800,11 @@ impl SegmentBuilder {
 
                 if let Some(mode) = position_mode {
                     let encoded_pos = match mode {
-                        PositionMode::Ordinal => element_ordinal << 20,
+                        PositionMode::Ordinal => encoded_ordinal << 20,
                         PositionMode::TokenPosition => token.position,
-                        PositionMode::Full => (element_ordinal << 20) | token.position,
+                        PositionMode::Full => {
+                            (encoded_ordinal << 20) | self.saturate_token_position(token.position)
+                        }
                     };
                     self.local_positions
                         .entry(term_spur)
@@ -691,9 +840,11 @@ impl SegmentBuilder {
 
                 if let Some(mode) = position_mode {
                     let encoded_pos = match mode {
-                        PositionMode::Ordinal => element_ordinal << 20,
+                        PositionMode::Ordinal => encoded_ordinal << 20,
                         PositionMode::TokenPosition => token_position,
-                        PositionMode::Full => (element_ordinal << 20) | token_position,
+                        PositionMode::Full => {
+                            (encoded_ordinal << 20) | self.saturate_token_position(token_position)
+                        }
                     };
                     self.local_positions
                         .entry(term_spur)
@@ -788,6 +939,32 @@ impl SegmentBuilder {
         }
 
         Ok(token_position)
+    }
+
+    /// Saturate a token position at the 20-bit packed-encoding maximum so it
+    /// cannot bleed into the element-ordinal bits.
+    #[inline]
+    fn saturate_token_position(&mut self, token_position: u32) -> u32 {
+        if token_position > MAX_TOKEN_POSITION {
+            self.warn_position_saturation("token position", token_position, MAX_TOKEN_POSITION);
+            MAX_TOKEN_POSITION
+        } else {
+            token_position
+        }
+    }
+
+    /// Warn once per segment when the packed position encoding saturates.
+    #[cold]
+    fn warn_position_saturation(&mut self, what: &str, value: u32, max: u32) {
+        if !self.position_saturation_warned {
+            self.position_saturation_warned = true;
+            log::warn!(
+                "[segment_builder] {what} {value} exceeds the position-encoding limit {max}; \
+                 saturating — phrase/ordinal matching degrades for the overflowing \
+                 elements/tokens instead of corrupting other documents' matches \
+                 (further occurrences in this segment are not logged)"
+            );
+        }
     }
 
     fn index_numeric_field(&mut self, field: Field, doc_id: DocId, value: u64) -> Result<()> {
@@ -1019,6 +1196,10 @@ impl SegmentBuilder {
             self.store_buffer
                 .write_u32::<LittleEndian>(self.doc_serialize_buffer.len() as u32)?;
             self.store_buffer.write_all(&self.doc_serialize_buffer)?;
+            // The in-memory store buffer is often the largest allocation on
+            // the wasm branch (native streams docs to a temp file instead).
+            // Count it so the memory-budget flush check can see it.
+            self.estimated_memory += size_of::<u32>() + self.doc_serialize_buffer.len();
         }
 
         Ok(())
@@ -1260,7 +1441,11 @@ impl SegmentBuilder {
             field_stats: self.field_stats.clone(),
         };
 
-        dir.write(&files.meta, &meta.serialize()?).await?;
+        // Durable: committed metadata.json will reference this segment, so a
+        // torn/unsynced .meta after power loss would make the commit
+        // unreadable (every other segment file is fsynced by its streaming
+        // writer's finish()).
+        dir.write_durable(&files.meta, &meta.serialize()?).await?;
 
         // Cleanup temp files
         #[cfg(feature = "native")]
@@ -1315,5 +1500,277 @@ impl Drop for SegmentBuilder {
         if self.posting_spill_file.is_some() {
             let _ = std::fs::remove_file(&self.posting_spill_path);
         }
+    }
+}
+
+#[cfg(test)]
+impl SegmentBuilder {
+    /// Test helper: all encoded positions recorded for `(field, term)`.
+    fn positions_for_term(&self, field: Field, term: &str) -> Vec<u32> {
+        let Some(spur) = self.term_interner.get(term) else {
+            return Vec::new();
+        };
+        let key = TermKey {
+            field: field.0,
+            term: spur,
+        };
+        self.position_index
+            .get(&key)
+            .map(|b| {
+                b.postings
+                    .iter()
+                    .flat_map(|(_, ps)| ps.iter().copied())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dsl::SchemaBuilder;
+
+    fn builder_for(schema: Schema) -> SegmentBuilder {
+        SegmentBuilder::new(Arc::new(schema), SegmentBuilderConfig::default()).unwrap()
+    }
+
+    // ------------------------------------------------------------------
+    // Finding: field values whose runtime type does not match the schema
+    // field type fell into `_ => {}` and were silently not indexed while
+    // still being stored — queries could never match the document.
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_add_document_rejects_type_mismatched_field_value() {
+        let mut sb = SchemaBuilder::default();
+        let views = sb.add_u64_field("views", true, true);
+        let mut builder = builder_for(sb.build());
+
+        let mut doc = Document::new();
+        doc.add_text(views, "123");
+        let err = builder
+            .add_document(doc)
+            .expect_err("schema-mismatched value must be rejected loudly, not silently unindexed");
+        let msg = err.to_string();
+        assert!(msg.contains("views"), "error must name the field: {msg}");
+        assert!(
+            msg.contains("u64"),
+            "error must name the expected type: {msg}"
+        );
+        assert!(msg.contains("text"), "error must name the got type: {msg}");
+
+        // The rejected document must not have consumed a doc id (no poisoning).
+        assert_eq!(builder.num_docs(), 0);
+
+        // A well-typed document still indexes fine afterwards.
+        let mut doc = Document::new();
+        doc.add_u64(views, 123);
+        builder.add_document(doc).unwrap();
+        assert_eq!(builder.num_docs(), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // Finding: sparse entries with dim_id >= the configured BMP `dims`
+    // were accepted at index time but silently dropped from the BMP grid
+    // and silently filtered from queries — permanently unsearchable.
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_add_document_rejects_bmp_sparse_dim_out_of_range() {
+        use crate::structures::{SparseFormat, SparseVectorConfig};
+
+        let mut sb = SchemaBuilder::default();
+        let config = SparseVectorConfig {
+            format: SparseFormat::Bmp,
+            dims: Some(100),
+            ..Default::default()
+        };
+        let spv = sb.add_sparse_vector_field_with_config("spv", true, false, config);
+        let mut builder = builder_for(sb.build());
+
+        // In-range dims are accepted.
+        let mut doc = Document::new();
+        doc.add_sparse_vector(spv, vec![(50, 1.0)]);
+        builder.add_document(doc).unwrap();
+
+        // dim_id >= dims must be rejected with an actionable error.
+        let mut doc = Document::new();
+        doc.add_sparse_vector(spv, vec![(50, 1.0), (150, 2.0)]);
+        let err = builder
+            .add_document(doc)
+            .expect_err("out-of-range BMP dim must be rejected, not silently unsearchable");
+        let msg = err.to_string();
+        assert!(msg.contains("spv"), "error must name the field: {msg}");
+        assert!(msg.contains("150"), "error must name the dim_id: {msg}");
+        assert!(
+            msg.contains("100"),
+            "error must name the configured dims: {msg}"
+        );
+        assert_eq!(
+            builder.num_docs(),
+            1,
+            "rejected doc must not consume a doc id"
+        );
+    }
+
+    #[test]
+    fn test_add_document_maxscore_sparse_dims_unbounded() {
+        // MaxScore-format sparse fields have no dims bound — large dim ids
+        // stay legal (the per-dim TOC addresses any u32 dimension).
+        let mut sb = SchemaBuilder::default();
+        let spv = sb.add_sparse_vector_field("spv", true, false);
+        let mut builder = builder_for(sb.build());
+
+        let mut doc = Document::new();
+        doc.add_sparse_vector(spv, vec![(3_000_000, 1.0)]);
+        builder.add_document(doc).unwrap();
+    }
+
+    // ------------------------------------------------------------------
+    // Finding: `(element_ordinal << 20) | token_position` silently
+    // corrupted when element_ordinal >= 4096 (shifted out of the u32,
+    // aliasing element 0) or token_position >= 2^20 (bleeding into the
+    // ordinal bits). Both must saturate at their field maxima.
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_position_element_ordinal_overflow_saturates_instead_of_wrapping() {
+        use crate::dsl::PositionMode;
+
+        let mut sb = SchemaBuilder::default();
+        let body = sb.add_text_field("body", true, false);
+        sb.set_positions(body, PositionMode::Full);
+        let mut builder = builder_for(sb.build());
+
+        // 4097 values: element ordinal 4096 does not fit the 12-bit ordinal
+        // field ((4096u32 << 20) wraps to 0, colliding with element 0).
+        let mut doc = Document::new();
+        doc.add_text(body, "anchor");
+        for _ in 0..4095 {
+            doc.add_text(body, "filler");
+        }
+        doc.add_text(body, "needle");
+        builder.add_document(doc).unwrap();
+
+        let positions = builder.positions_for_term(body, "needle");
+        assert_eq!(positions.len(), 1);
+        let encoded = positions[0];
+        assert_ne!(
+            encoded >> 20,
+            0,
+            "element ordinal 4096 must not alias element 0"
+        );
+        assert_eq!(
+            encoded >> 20,
+            4095,
+            "overflowing element ordinal must saturate at 4095"
+        );
+    }
+
+    #[test]
+    fn test_position_token_position_overflow_saturates_instead_of_bleeding() {
+        use crate::dsl::PositionMode;
+
+        let mut sb = SchemaBuilder::default();
+        let body = sb.add_text_field("body", true, false);
+        sb.set_positions(body, PositionMode::Full);
+        let mut builder = builder_for(sb.build());
+
+        // One value with 2^20 + 1 tokens: the last token's position does not
+        // fit the 20-bit position field and would bleed into ordinal bit 0.
+        let mut text = "w ".repeat(1 << 20);
+        text.push_str("needle");
+        let mut doc = Document::new();
+        doc.add_text(body, text);
+        builder.add_document(doc).unwrap();
+
+        let positions = builder.positions_for_term(body, "needle");
+        assert_eq!(positions.len(), 1);
+        let encoded = positions[0];
+        assert_eq!(
+            encoded >> 20,
+            0,
+            "token position overflow must not decode as a different element ordinal"
+        );
+        assert_eq!(
+            encoded & 0xFFFFF,
+            0xFFFFF,
+            "overflowing token position must saturate at 2^20 - 1"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Finding: a posting-list spill firing between two values of the same
+    // document split that document's postings across the spilled range and
+    // the in-memory tail; the build-time merge concatenated them without
+    // deduplication (inflated doc_freq, doc visited twice, split tf).
+    // ------------------------------------------------------------------
+    #[cfg(feature = "native")]
+    #[tokio::test]
+    async fn test_spill_mid_document_does_not_duplicate_postings() {
+        use crate::directories::RamDirectory;
+        use crate::structures::TERMINATED;
+
+        let mut sb = SchemaBuilder::default();
+        let body = sb.add_text_field("body", true, false);
+        let schema = Arc::new(sb.build());
+        let mut builder =
+            SegmentBuilder::new(Arc::clone(&schema), SegmentBuilderConfig::default()).unwrap();
+
+        // Docs 0..16382 each contribute one posting for "hot", leaving the
+        // in-memory posting list one entry short of SPILL_THRESHOLD (16384).
+        for _ in 0..16383 {
+            let mut doc = Document::new();
+            doc.add_text(body, "hot");
+            builder.add_document(doc).unwrap();
+        }
+
+        // Doc 16383 has TWO values containing "hot": indexing the first value
+        // reaches the spill threshold and spills the list INCLUDING this doc's
+        // entry; the second value then re-adds the same doc to the now-empty
+        // in-memory tail.
+        let mut doc = Document::new();
+        doc.add_text(body, "hot");
+        doc.add_text(body, "hot");
+        let boundary_doc = builder.add_document(doc).unwrap();
+        assert_eq!(boundary_doc, 16383);
+
+        let dir = RamDirectory::new();
+        let segment_id = crate::segment::SegmentId::new();
+        builder.build(&dir, segment_id, None).await.unwrap();
+
+        let reader = crate::segment::SegmentReader::open(&dir, segment_id, schema, 16)
+            .await
+            .unwrap();
+        let postings = reader
+            .get_postings(body, b"hot")
+            .await
+            .unwrap()
+            .expect("postings for 'hot'");
+        assert_eq!(
+            postings.doc_count(),
+            16384,
+            "each document must appear exactly once per term (spill-boundary duplicate)"
+        );
+
+        // Doc ids must be strictly increasing and the boundary document's
+        // split term frequency must be merged into a single posting.
+        let mut it = postings.iterator();
+        let mut prev: Option<DocId> = None;
+        let mut boundary_tf = 0u32;
+        let mut d = it.doc();
+        while d != TERMINATED {
+            if let Some(p) = prev {
+                assert!(p < d, "duplicate/unordered doc id {d} after {p}");
+            }
+            if d == boundary_doc {
+                boundary_tf = it.term_freq();
+            }
+            prev = Some(d);
+            d = it.advance();
+        }
+        assert_eq!(prev, Some(boundary_doc));
+        assert_eq!(
+            boundary_tf, 2,
+            "boundary doc's term frequency must combine both values"
+        );
     }
 }

--- a/hermes-core/src/segment/builder/postings.rs
+++ b/hermes-core/src/segment/builder/postings.rs
@@ -202,6 +202,22 @@ pub(super) fn build_postings_streaming(
             for (term_key, mut spilled) in per_term {
                 if let Some(builder) = index.get_mut(&term_key) {
                     spilled.append(&mut builder.postings);
+                    // A spill can fire mid-document (between two values of a
+                    // multi-valued field), splitting one document's postings
+                    // for this term across the spilled range and the in-memory
+                    // tail — or, with repeated spills, across two spilled
+                    // ranges. Doc ids are non-decreasing across the
+                    // concatenation, so merge adjacent same-doc entries to
+                    // keep one posting per (term, doc) with the combined
+                    // term frequency.
+                    spilled.dedup_by(|later, earlier| {
+                        if earlier.doc_id == later.doc_id {
+                            earlier.term_freq = earlier.term_freq.saturating_add(later.term_freq);
+                            true
+                        } else {
+                            false
+                        }
+                    });
                     builder.postings = spilled;
                     builder.spilled_count = 0;
                 }

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -478,18 +478,29 @@ impl SegmentMerger {
             .count();
 
         // --- Try O(1) cluster merge for homogeneous ScaNN ---
+        // Pair each ANN index with its own segment's doc offset BEFORE
+        // filtering: segments without the field are dropped from the list, so
+        // zipping the filtered list against the full `doc_offs` array would
+        // remap every later segment's vectors with the wrong offset.
         let scann_indexes: Vec<_> = segments
             .iter()
-            .filter_map(|s| s.get_scann_vector_index(field))
+            .enumerate()
+            .filter_map(|(seg_idx, s)| {
+                s.get_scann_vector_index(field)
+                    .map(|index| (doc_offs[seg_idx], index))
+            })
             .collect();
 
         if scann_indexes.len() == segments_with_flat && !scann_indexes.is_empty() {
-            let refs: Vec<&crate::structures::IVFPQIndex> =
-                scann_indexes.iter().map(|(idx, _)| idx.as_ref()).collect();
-            let codebook = scann_indexes.first().map(|(_, cb)| cb);
+            let refs: Vec<&crate::structures::IVFPQIndex> = scann_indexes
+                .iter()
+                .map(|(_, (idx, _))| idx.as_ref())
+                .collect();
+            let offsets: Vec<u32> = scann_indexes.iter().map(|(off, _)| *off).collect();
+            let codebook = scann_indexes.first().map(|(_, (_, cb))| cb);
 
             match (
-                crate::structures::IVFPQIndex::merge(&refs, doc_offs),
+                crate::structures::IVFPQIndex::merge(&refs, &offsets),
                 codebook,
             ) {
                 (Ok(merged), Some(codebook)) => {
@@ -512,18 +523,26 @@ impl SegmentMerger {
         }
 
         // --- Try O(1) cluster merge for homogeneous IVF-RaBitQ ---
+        // Same offset pairing as ScaNN above: enumerate before filtering.
         let ivf_indexes: Vec<_> = segments
             .iter()
-            .filter_map(|s| s.get_ivf_vector_index(field))
+            .enumerate()
+            .filter_map(|(seg_idx, s)| {
+                s.get_ivf_vector_index(field)
+                    .map(|index| (doc_offs[seg_idx], index))
+            })
             .collect();
 
         if ivf_indexes.len() == segments_with_flat && !ivf_indexes.is_empty() {
-            let refs: Vec<&crate::structures::IVFRaBitQIndex> =
-                ivf_indexes.iter().map(|(idx, _)| idx.as_ref()).collect();
-            let codebook = ivf_indexes.first().map(|(_, cb)| cb);
+            let refs: Vec<&crate::structures::IVFRaBitQIndex> = ivf_indexes
+                .iter()
+                .map(|(_, (idx, _))| idx.as_ref())
+                .collect();
+            let offsets: Vec<u32> = ivf_indexes.iter().map(|(off, _)| *off).collect();
+            let codebook = ivf_indexes.first().map(|(_, (_, cb))| cb);
 
             match (
-                crate::structures::IVFRaBitQIndex::merge(&refs, doc_offs),
+                crate::structures::IVFRaBitQIndex::merge(&refs, &offsets),
                 codebook,
             ) {
                 (Ok(merged), Some(codebook)) => {
@@ -673,5 +692,158 @@ impl SegmentMerger {
             ann_start.elapsed().as_secs_f64()
         );
         Ok(Some((index_type, bytes)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::SegmentMerger;
+    use crate::directories::RamDirectory;
+    use crate::dsl::{DenseVectorConfig, Document, SchemaBuilder};
+    use crate::index::{IndexConfig, IndexWriter};
+    use crate::segment::reader::SegmentReader;
+    use crate::segment::types::SegmentId;
+
+    async fn committed_segment_ids(dir: &RamDirectory) -> Vec<String> {
+        crate::index::IndexMetadata::load(dir)
+            .await
+            .unwrap()
+            .segment_ids()
+    }
+
+    async fn newly_committed_segment(dir: &RamDirectory, known: &mut Vec<String>) -> String {
+        let ids = committed_segment_ids(dir).await;
+        let new: Vec<String> = ids
+            .iter()
+            .filter(|id| !known.contains(id))
+            .cloned()
+            .collect();
+        assert_eq!(
+            new.len(),
+            1,
+            "expected exactly one new segment, got {new:?}"
+        );
+        *known = ids;
+        new.into_iter().next().unwrap()
+    }
+
+    /// Regression: the O(1) IVF/ScaNN cluster merge used to zip the FILTERED
+    /// list of per-field ANN indexes against the FULL per-segment doc-offset
+    /// array. With merge sources [A(has field), B(no field), C(has field)],
+    /// C's vectors were remapped with B's offset instead of its own, silently
+    /// persisting wrong doc ids in the merged ANN index.
+    #[tokio::test]
+    async fn o1_ann_cluster_merge_skips_offsets_of_segments_without_the_field() {
+        let dim = 8;
+        let mut sb = SchemaBuilder::default();
+        let title = sb.add_text_field("title", true, true);
+        let embedding = sb.add_dense_vector_field_with_config(
+            "embedding",
+            true,
+            true,
+            DenseVectorConfig::with_scann(dim, Some(1), 1),
+        );
+        let schema = sb.build();
+
+        let dir = RamDirectory::new();
+        let config = IndexConfig {
+            merge_policy: Box::new(crate::merge::NoMergePolicy),
+            num_indexing_threads: 1,
+            ..Default::default()
+        };
+        let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config)
+            .await
+            .unwrap();
+
+        // Training segment: provides the sample, stays out of the merge.
+        for i in 0..4 {
+            let mut doc = Document::new();
+            doc.add_text(title, format!("train {i}"));
+            doc.add_dense_vector(embedding, vec![i as f32 + 1.0; dim]);
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+        let mut known = committed_segment_ids(&dir).await;
+        writer.build_vector_index().await.unwrap();
+
+        // Segment A: 2 docs WITH the field (gets a per-segment IVF at flush).
+        for i in 0..2 {
+            let mut doc = Document::new();
+            doc.add_text(title, format!("a {i}"));
+            doc.add_dense_vector(embedding, vec![0.5; dim]);
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+        let seg_a = newly_committed_segment(&dir, &mut known).await;
+
+        // Segment B: 3 docs WITHOUT the field (no flat entry, no ANN entry).
+        for i in 0..3 {
+            let mut doc = Document::new();
+            doc.add_text(title, format!("b {i}"));
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+        let seg_b = newly_committed_segment(&dir, &mut known).await;
+
+        // Segment C: 2 docs WITH the field.
+        for i in 0..2 {
+            let mut doc = Document::new();
+            doc.add_text(title, format!("c {i}"));
+            doc.add_dense_vector(embedding, vec![0.25; dim]);
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+        let seg_c = newly_committed_segment(&dir, &mut known).await;
+
+        // Open the merge sources in a fixed order: [A, B, C].
+        let schema = Arc::new(schema);
+        let mut readers = Vec::new();
+        for id in [&seg_a, &seg_b, &seg_c] {
+            readers.push(
+                SegmentReader::open(
+                    &dir,
+                    SegmentId::from_hex(id).unwrap(),
+                    Arc::clone(&schema),
+                    16,
+                )
+                .await
+                .unwrap(),
+            );
+        }
+        assert!(readers[0].get_scann_vector_index(embedding).is_some());
+        assert!(
+            readers[1].get_scann_vector_index(embedding).is_none(),
+            "segment B must not carry the dense field"
+        );
+        assert!(readers[2].get_scann_vector_index(embedding).is_some());
+
+        let merged_id = SegmentId::new();
+        SegmentMerger::new(Arc::clone(&schema))
+            .merge(&dir, &readers, merged_id, None)
+            .await
+            .unwrap();
+
+        let merged = SegmentReader::open(&dir, merged_id, Arc::clone(&schema), 16)
+            .await
+            .unwrap();
+        let (scann, _codebook) = merged
+            .get_scann_vector_index(embedding)
+            .expect("homogeneous ScaNN sources must take the O(1) cluster-merge path");
+
+        let mut doc_ids: Vec<u32> = scann
+            .clusters
+            .iter()
+            .flat_map(|(_, cluster)| cluster.iter().map(|(doc_id, _, _)| doc_id))
+            .collect();
+        doc_ids.sort_unstable();
+        // A occupies merged docs 0..2, B (no vectors) 2..5, C 5..7. C's
+        // vectors must be remapped with C's own offset (5), not B's (2).
+        assert_eq!(
+            doc_ids,
+            vec![0, 1, 5, 6],
+            "merged ANN doc ids must use each field-bearing segment's own offset"
+        );
     }
 }

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -373,7 +373,10 @@ impl SegmentMerger {
             field_stats: merged_field_stats,
         };
 
-        dir.write(&files.meta, &meta.serialize()?).await?;
+        // Durable: replace_segments deletes the fsynced source segments right
+        // after publishing this output, so a non-durable .meta could be the
+        // only copy of the merged documents across a power failure.
+        dir.write_durable(&files.meta, &meta.serialize()?).await?;
 
         let label = if trained.is_some() {
             "ANN merge"

--- a/hermes-core/src/segment/merger/postings.rs
+++ b/hermes-core/src/segment/merger/postings.rs
@@ -295,8 +295,7 @@ impl SegmentMerger {
                     .collect();
                 let offset = positions_out.offset();
                 let (_doc_count, bytes_written) =
-                    PositionPostingList::concatenate_streaming(&refs, positions_out)
-                        .map_err(crate::Error::Io)?;
+                    PositionPostingList::concatenate_streaming(&refs, positions_out)?;
                 return Ok(TermInfo::external_with_positions(
                     posting_offset,
                     posting_len,

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -343,7 +343,10 @@ pub async fn reorder_segment<D: Directory + DirectoryWriter>(
         num_docs: src_meta.num_docs,
         field_stats: src_meta.field_stats.clone(),
     };
-    dir.write(&dst_files.meta, &meta.serialize()?).await?;
+    // Durable: the reordered segment replaces its fsynced source, so a
+    // non-durable .meta could be the only copy across a power failure.
+    dir.write_durable(&dst_files.meta, &meta.serialize()?)
+        .await?;
 
     Ok((output_id.to_hex(), num_docs, bp_converged))
 }

--- a/hermes-core/src/structures/postings/positions.rs
+++ b/hermes-core/src/structures/postings/positions.rs
@@ -438,10 +438,14 @@ impl PositionPostingList {
     /// Block data flows source → output writer without intermediate buffering.
     ///
     /// Returns `(doc_count, bytes_written)`.
+    ///
+    /// Returns `Error::Corruption` if any source is shorter than its footer:
+    /// metas are paired with sources positionally, so a short/corrupt source
+    /// must fail loudly instead of misassigning every subsequent source.
     pub fn concatenate_streaming<W: Write>(
         sources: &[(&[u8], u32)],
         writer: &mut W,
-    ) -> io::Result<(u32, usize)> {
+    ) -> crate::Result<(u32, usize)> {
         // Parse only footers (16 bytes each) — no skip entries materialized
         struct SourceMeta {
             data_len: usize,
@@ -451,9 +455,13 @@ impl PositionPostingList {
         let mut metas: Vec<SourceMeta> = Vec::with_capacity(sources.len());
         let mut total_docs = 0u32;
 
-        for (raw, _) in sources {
+        for (source_index, (raw, _)) in sources.iter().enumerate() {
             if raw.len() < 16 {
-                continue;
+                return Err(crate::Error::Corruption(format!(
+                    "position posting source {} is shorter than its footer: {} bytes < 16",
+                    source_index,
+                    raw.len(),
+                )));
             }
             let f = raw.len() - 16;
             let data_len = u64::from_le_bytes(raw[f..f + 8].try_into().unwrap()) as usize;
@@ -995,6 +1003,27 @@ mod tests {
             assert_eq!(r.0, s.0, "doc_id mismatch at {}", i);
             assert_eq!(r.1, s.1, "positions mismatch at doc {}", r.0);
         }
+    }
+
+    #[test]
+    fn test_position_concatenate_streaming_short_source_returns_corruption() {
+        // A source shorter than the 16-byte footer must fail loudly.
+        // Silently skipping it pairs every later source with the wrong
+        // metadata (metas[i] vs sources[i]) — panicking or emitting garbage.
+        let ppl_a = build_ppl(&[(0, vec![1, 5]), (3, vec![2])]);
+        let ppl_c = build_ppl(&[(1, vec![4]), (2, vec![7, 9])]);
+        let bytes_a = serialize_ppl(&ppl_a);
+        let bytes_c = serialize_ppl(&ppl_c);
+        let short = vec![0u8; 15]; // corrupt: shorter than footer
+
+        let sources: Vec<(&[u8], u32)> = vec![(&bytes_a, 0), (&short, 100), (&bytes_c, 200)];
+        let mut out = Vec::new();
+        let result = PositionPostingList::concatenate_streaming(&sources, &mut out);
+        assert!(
+            matches!(result, Err(crate::Error::Corruption(_))),
+            "short/corrupt source must be a Corruption error, not silently skipped: {:?}",
+            result.map(|r| r.0)
+        );
     }
 
     #[test]

--- a/hermes-core/src/structures/postings/posting.rs
+++ b/hermes-core/src/structures/postings/posting.rs
@@ -564,10 +564,14 @@ impl BlockPostingList {
     /// Block data flows source → output writer without intermediate buffering.
     ///
     /// Returns `(doc_count, bytes_written)`.
+    ///
+    /// Returns `Error::Corruption` if any source is shorter than its footer:
+    /// metas are paired with sources positionally, so a short/corrupt source
+    /// must fail loudly instead of misassigning every subsequent source.
     pub fn concatenate_streaming<W: Write>(
         sources: &[(&[u8], u32)], // (serialized_bytes, doc_offset)
         writer: &mut W,
-    ) -> io::Result<(u32, usize)> {
+    ) -> crate::Result<(u32, usize)> {
         struct SourceMeta {
             stream_len: usize,
             l0_count: usize,
@@ -577,9 +581,14 @@ impl BlockPostingList {
         let mut total_docs = 0u32;
         let mut merged_max_tf = 0u32;
 
-        for (raw, _) in sources {
+        for (source_index, (raw, _)) in sources.iter().enumerate() {
             if raw.len() < FOOTER_SIZE {
-                continue;
+                return Err(crate::Error::Corruption(format!(
+                    "posting list source {} is shorter than its footer: {} bytes < {}",
+                    source_index,
+                    raw.len(),
+                    FOOTER_SIZE,
+                )));
             }
             let f = raw.len() - FOOTER_SIZE;
             let stream_len = u64::from_le_bytes(raw[f..f + 8].try_into().unwrap()) as usize;
@@ -622,7 +631,8 @@ impl BlockPostingList {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         "posting list stream exceeds u32::MAX bytes during streaming merge",
-                    ));
+                    )
+                    .into());
                 }
                 write_l0(
                     &mut out_l0,
@@ -1209,6 +1219,28 @@ mod tests {
         for (i, (r, s)) in ref_postings.iter().zip(stream_postings.iter()).enumerate() {
             assert_eq!(r, s, "mismatch at posting {}", i);
         }
+    }
+
+    #[test]
+    fn test_concatenate_streaming_short_source_returns_corruption() {
+        // A source shorter than the 24-byte footer (e.g. a corrupt TermInfo
+        // (offset, len) pointing at truncated bytes) must fail loudly.
+        // Silently skipping it pairs every later source with the wrong
+        // metadata (metas[i] vs sources[i]) — panicking or emitting garbage.
+        let seg_a: Vec<(u32, u32)> = (0..250).map(|i| (i * 2, (i % 7) + 1)).collect();
+        let seg_c: Vec<(u32, u32)> = (0..90).map(|i| (i * 10, (i % 11) + 1)).collect();
+        let bytes_a = serialize_bpl(&build_bpl(&seg_a));
+        let bytes_c = serialize_bpl(&build_bpl(&seg_c));
+        let short = vec![0u8; FOOTER_SIZE - 1]; // corrupt: shorter than footer
+
+        let sources: Vec<(&[u8], u32)> = vec![(&bytes_a, 0), (&short, 1000), (&bytes_c, 2000)];
+        let mut out = Vec::new();
+        let result = BlockPostingList::concatenate_streaming(&sources, &mut out);
+        assert!(
+            matches!(result, Err(crate::Error::Corruption(_))),
+            "short/corrupt source must be a Corruption error, not silently skipped: {:?}",
+            result.map(|r| r.0)
+        );
     }
 
     #[test]

--- a/hermes-core/tests/index_writer_regressions.rs
+++ b/hermes-core/tests/index_writer_regressions.rs
@@ -1,0 +1,369 @@
+//! Regression tests for IndexWriter lifecycle safety:
+//!
+//! 1. `create()` on a directory that already contains an index must fail
+//!    loudly instead of silently replacing metadata.json (which orphans every
+//!    committed segment for the next orphan sweep to delete).
+//! 2. A second writer for the same filesystem index directory must be
+//!    rejected via the advisory single-writer lock, not silently allowed to
+//!    double-write and sweep the first writer's in-flight outputs.
+//! 3. `PreparedCommit::abort()` must not clear the fail-closed primary-key
+//!    reservations retained after a failed post-commit PK refresh — wiping
+//!    them admits duplicate primary keys.
+//! 4. A commit cancelled mid-flush (client disconnect drops the future)
+//!    leaves a detached waiter on the flush condvar; the retried commit must
+//!    still observe the flush completion instead of stalling to its deadline.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use hermes_core::directories::{
+    Directory, DirectoryWriter, FileHandle, OwnedBytes, RamDirectory, StreamingWriter,
+};
+use hermes_core::{Document, Error, Index, IndexConfig, IndexWriter, MmapDirectory, Schema};
+
+/// RamDirectory wrapper with two test hooks:
+/// - `fail_fast_reads`: reads of `*.fast` files fail (injects a transient IO
+///   error into the post-commit primary-key refresh).
+/// - `gate_open`: while false, `streaming_writer` blocks, holding worker
+///   segment flushes open at a deterministic point.
+#[derive(Clone)]
+struct HookedDirectory {
+    inner: RamDirectory,
+    fail_fast_reads: Arc<AtomicBool>,
+    gate_open: Arc<AtomicBool>,
+}
+
+impl HookedDirectory {
+    fn new() -> Self {
+        Self {
+            inner: RamDirectory::new(),
+            fail_fast_reads: Arc::new(AtomicBool::new(false)),
+            gate_open: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    fn injected_fast_failure(&self, path: &Path) -> Option<std::io::Error> {
+        if self.fail_fast_reads.load(Ordering::Acquire)
+            && path.extension().is_some_and(|ext| ext == "fast")
+        {
+            // NOT ErrorKind::NotFound: the fast-field loader treats missing
+            // files as "no fast fields" instead of an error.
+            return Some(std::io::Error::other("injected .fast read failure"));
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl Directory for HookedDirectory {
+    async fn exists(&self, path: &Path) -> std::io::Result<bool> {
+        self.inner.exists(path).await
+    }
+
+    async fn file_size(&self, path: &Path) -> std::io::Result<u64> {
+        self.inner.file_size(path).await
+    }
+
+    async fn open_read(&self, path: &Path) -> std::io::Result<FileHandle> {
+        if let Some(error) = self.injected_fast_failure(path) {
+            return Err(error);
+        }
+        self.inner.open_read(path).await
+    }
+
+    async fn read_range(
+        &self,
+        path: &Path,
+        range: std::ops::Range<u64>,
+    ) -> std::io::Result<OwnedBytes> {
+        if let Some(error) = self.injected_fast_failure(path) {
+            return Err(error);
+        }
+        self.inner.read_range(path, range).await
+    }
+
+    async fn list_files(&self, prefix: &Path) -> std::io::Result<Vec<PathBuf>> {
+        self.inner.list_files(prefix).await
+    }
+
+    async fn open_lazy(&self, path: &Path) -> std::io::Result<FileHandle> {
+        if let Some(error) = self.injected_fast_failure(path) {
+            return Err(error);
+        }
+        self.inner.open_lazy(path).await
+    }
+}
+
+#[async_trait]
+impl DirectoryWriter for HookedDirectory {
+    async fn write(&self, path: &Path, data: &[u8]) -> std::io::Result<()> {
+        self.inner.write(path, data).await
+    }
+
+    async fn delete(&self, path: &Path) -> std::io::Result<()> {
+        self.inner.delete(path).await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        self.inner.rename(from, to).await
+    }
+
+    async fn sync(&self) -> std::io::Result<()> {
+        self.inner.sync().await
+    }
+
+    async fn streaming_writer(&self, path: &Path) -> std::io::Result<Box<dyn StreamingWriter>> {
+        while !self.gate_open.load(Ordering::Acquire) {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        self.inner.streaming_writer(path).await
+    }
+}
+
+fn title_schema() -> (Schema, hermes_core::Field) {
+    let mut builder = Schema::builder();
+    let title = builder.add_text_field("title", true, true);
+    (builder.build(), title)
+}
+
+fn title_doc(field: hermes_core::Field, text: &str) -> Document {
+    let mut doc = Document::new();
+    doc.add_text(field, text);
+    doc
+}
+
+// ---------------------------------------------------------------------------
+// 1. create() must refuse to clobber an existing index
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_create_on_existing_index_fails_instead_of_clobbering() {
+    let (schema, title) = title_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+    writer
+        .add_document(title_doc(title, "committed document"))
+        .unwrap();
+    writer.commit().await.unwrap();
+    drop(writer);
+
+    // IndexWriter::create on the populated directory must fail loudly...
+    let err = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .err()
+        .expect("IndexWriter::create over an existing index must fail");
+    assert!(
+        err.to_string().contains("already exists"),
+        "error must be actionable, got: {err}"
+    );
+
+    // ...and so must Index::create.
+    let err = Index::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .err()
+        .expect("Index::create over an existing index must fail");
+    assert!(
+        err.to_string().contains("already exists"),
+        "error must be actionable, got: {err}"
+    );
+
+    // The committed data survived the refused creates.
+    let index = Index::open(dir, config).await.unwrap();
+    assert_eq!(index.num_docs().await.unwrap(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// 2. single-writer lock for filesystem-rooted directories
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_second_writer_open_is_rejected_while_writer_lock_held() {
+    let (schema, title) = title_schema();
+    let tmp = tempfile::tempdir().unwrap();
+    let config = IndexConfig::default();
+
+    let mut writer_a = IndexWriter::create(MmapDirectory::new(tmp.path()), schema, config.clone())
+        .await
+        .unwrap();
+    writer_a
+        .add_document(title_doc(title, "writer A owns this index"))
+        .unwrap();
+    writer_a.commit().await.unwrap();
+
+    // A concurrent second writer process would sweep writer A's in-flight
+    // outputs and clobber metadata.json — it must be rejected instead.
+    let err = IndexWriter::open(MmapDirectory::new(tmp.path()), config.clone())
+        .await
+        .err()
+        .expect("second writer for a locked index directory must be rejected");
+    assert!(
+        err.to_string().contains("single-writer lock"),
+        "error must name the lock, got: {err}"
+    );
+
+    // Dropping the first writer releases the OS advisory lock.
+    drop(writer_a);
+    IndexWriter::open(MmapDirectory::new(tmp.path()), config)
+        .await
+        .expect("lock must be released when the previous writer is dropped");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_writer_from_index_defers_lock_conflict_to_first_write() {
+    let (schema, title) = title_schema();
+    let tmp = tempfile::tempdir().unwrap();
+    let config = IndexConfig::default();
+
+    let index = Index::create(MmapDirectory::new(tmp.path()), schema, config.clone())
+        .await
+        .unwrap();
+    let writer_a = index.writer();
+
+    // `Index::writer` is infallible, so the conflict surfaces on the first
+    // mutating operation instead of silently double-writing.
+    let writer_b = index.writer();
+    let err = writer_b
+        .add_document(title_doc(title, "must be rejected"))
+        .expect_err("second writer's mutations must fail while the lock is held");
+    assert!(
+        err.to_string().contains("single-writer lock"),
+        "error must name the lock, got: {err}"
+    );
+
+    // The writer holding the lock keeps working.
+    writer_a.add_document(title_doc(title, "accepted")).unwrap();
+
+    // An external writer (e.g. hermes-tool against a served index) is
+    // rejected at open while the from_index writer is alive.
+    let err = IndexWriter::open(MmapDirectory::new(tmp.path()), config)
+        .await
+        .err()
+        .expect("external writer must be rejected while Index::writer is alive");
+    assert!(err.to_string().contains("single-writer lock"));
+}
+
+// ---------------------------------------------------------------------------
+// 3. abort must keep fail-closed PK reservations after a failed refresh
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_abort_after_failed_pk_refresh_keeps_fail_closed_reservations() {
+    let mut builder = Schema::builder();
+    let id = builder.add_text_field("id", true, true);
+    builder.set_primary_key(id);
+    let title = builder.add_text_field("title", true, true);
+    let schema = builder.build();
+
+    let dir = HookedDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), schema, IndexConfig::default())
+        .await
+        .unwrap();
+    writer.init_primary_key_dedup().await.unwrap();
+
+    let make_doc = |key: &str| {
+        let mut doc = Document::new();
+        doc.add_text(id, key);
+        doc.add_text(title, "body");
+        doc
+    };
+
+    writer.add_document(make_doc("k1")).unwrap();
+
+    // Publication succeeds, but the post-commit PK refresh fails (transient
+    // IO error loading the new segment's fast fields). The commit still
+    // reports success and deliberately retains k1's reservation as the only
+    // record that k1 is committed (fail-closed).
+    dir.fail_fast_reads.store(true, Ordering::Release);
+    assert!(writer.commit().await.unwrap());
+    dir.fail_fast_reads.store(false, Ordering::Release);
+
+    // Sanity: the retained reservation still rejects duplicates.
+    assert!(matches!(
+        writer.add_document(make_doc("k1")),
+        Err(Error::DuplicatePrimaryKey(_))
+    ));
+
+    // A later generation is prepared and aborted (e.g. the caller's external
+    // WAL write failed). This must clear only that generation's reservations
+    // — never the fail-closed ones retained above.
+    writer.add_document(make_doc("k2")).unwrap();
+    let prepared = writer.prepare_commit().await.unwrap();
+    prepared.abort();
+
+    // The committed key must STILL be rejected: k1 exists in a durably
+    // committed segment, and admitting it here would durably commit a
+    // duplicate primary key.
+    let err = writer
+        .add_document(make_doc("k1"))
+        .expect_err("duplicate of a committed primary key must stay rejected after abort");
+    assert!(
+        matches!(err, Error::DuplicatePrimaryKey(ref k) if k == "k1"),
+        "expected DuplicatePrimaryKey(k1), got: {err:?}"
+    );
+
+    // Fresh keys are still accepted — the writer is not wedged.
+    writer.add_document(make_doc("k3")).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 4. retried prepare_commit survives a cancelled commit's dead flush waiter
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_retried_prepare_commit_survives_cancelled_commit_waiter() {
+    let (schema, title) = title_schema();
+    let dir = HookedDirectory::new();
+    let config = IndexConfig {
+        num_indexing_threads: 1,
+        ..Default::default()
+    };
+
+    let mut writer = IndexWriter::create(dir.clone(), schema, config)
+        .await
+        .unwrap();
+    writer
+        .add_document(title_doc(title, "gated document"))
+        .unwrap();
+
+    // Hold the worker's segment flush open so prepare_commit blocks in its
+    // flush wait.
+    dir.gate_open.store(false, Ordering::Release);
+
+    // First commit attempt is cancelled mid-flush (tonic drops the handler
+    // future on client disconnect). Its spawn_blocking waiter stays parked
+    // on the flush condvar.
+    {
+        let fut = writer.prepare_commit();
+        tokio::pin!(fut);
+        let poll = tokio::time::timeout(std::time::Duration::from_millis(500), &mut fut).await;
+        assert!(
+            poll.is_err(),
+            "prepare_commit must still be waiting on the gated flush"
+        );
+        // Dropping the future here detaches the parked waiter.
+    }
+
+    // Release the flush shortly after the retry has parked its own waiter.
+    let gate = Arc::clone(&dir.gate_open);
+    let opener = tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        gate.store(true, Ordering::Release);
+    });
+
+    // The retried commit must observe the flush completion promptly. With a
+    // single notify_one, the dead waiter above consumes the wakeup and this
+    // stalls for the full 300s flush deadline.
+    let prepared =
+        tokio::time::timeout(std::time::Duration::from_secs(30), writer.prepare_commit())
+            .await
+            .expect("retried prepare_commit must not miss the flush wakeup")
+            .expect("retried prepare_commit must succeed");
+    assert!(prepared.commit().await.unwrap());
+    opener.await.unwrap();
+}

--- a/hermes-core/tests/primary_key_builder_forces_fast.rs
+++ b/hermes-core/tests/primary_key_builder_forces_fast.rs
@@ -1,0 +1,42 @@
+//! Regression tests: `SchemaBuilder::set_primary_key` must force the same
+//! field attributes the SDL path forces (fast + indexed). Without `fast`, the
+//! committed-key dedup lookup silently finds no fast-field text dictionary and
+//! accepts duplicates of any committed primary key.
+
+use hermes_core::{Document, Error, IndexConfig, IndexWriter, RamDirectory, Schema};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_builder_primary_key_dedup_across_commit_without_explicit_set_fast() {
+    let mut builder = Schema::builder();
+    // Deliberately NO builder.set_fast(id, true): set_primary_key must force
+    // fast + indexed itself, matching the SDL path.
+    let id = builder.add_text_field("id", true, true);
+    builder.set_primary_key(id);
+    let title = builder.add_text_field("title", true, true);
+    let schema = builder.build();
+
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir, schema, IndexConfig::default())
+        .await
+        .unwrap();
+    writer.init_primary_key_dedup().await.unwrap();
+
+    let mut doc = Document::new();
+    doc.add_text(id, "key1");
+    doc.add_text(title, "first");
+    writer.add_document(doc).unwrap();
+    writer.commit().await.unwrap();
+
+    // After commit the uncommitted-key set is cleared; the duplicate must be
+    // caught by the committed-key lookup (fast-field text dict).
+    let mut dup = Document::new();
+    dup.add_text(id, "key1");
+    dup.add_text(title, "duplicate");
+    let err = writer
+        .add_document(dup)
+        .expect_err("duplicate of a committed primary key must be rejected");
+    match err {
+        Error::DuplicatePrimaryKey(k) => assert_eq!(k, "key1"),
+        other => panic!("expected DuplicatePrimaryKey, got {:?}", other),
+    }
+}

--- a/hermes-core/tests/segment_meta_durability.rs
+++ b/hermes-core/tests/segment_meta_durability.rs
@@ -1,0 +1,166 @@
+//! Regression test: segment `.meta` files must be written through the
+//! durable (fsyncing) write path.
+//!
+//! Every other segment file goes through `streaming_writer`, whose
+//! filesystem `finish()` calls `File::sync_all`. The `.meta` file was the
+//! one exception (bare `DirectoryWriter::write` = `tokio::fs::write`, page
+//! cache only), so a power failure after an acknowledged commit could leave
+//! durably-published metadata.json referencing a segment whose `.meta` is
+//! torn or empty — committed documents become unreadable, and for merge /
+//! reorder outputs (whose fsynced sources are deleted right after publish)
+//! permanently lost.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use hermes_core::directories::{
+    Directory, DirectoryWriter, FileHandle, OwnedBytes, RamDirectory, StreamingWriter,
+};
+use hermes_core::{Document, IndexConfig, IndexWriter, SchemaBuilder};
+
+/// RamDirectory wrapper recording which paths were written via the
+/// non-durable `write()` vs the fsyncing `streaming_writer()` path.
+#[derive(Clone, Default)]
+struct RecordingDirectory {
+    inner: RamDirectory,
+    plain_writes: Arc<Mutex<HashSet<PathBuf>>>,
+    streaming_writes: Arc<Mutex<HashSet<PathBuf>>>,
+}
+
+#[async_trait]
+impl Directory for RecordingDirectory {
+    async fn exists(&self, path: &Path) -> std::io::Result<bool> {
+        self.inner.exists(path).await
+    }
+
+    async fn file_size(&self, path: &Path) -> std::io::Result<u64> {
+        self.inner.file_size(path).await
+    }
+
+    async fn open_read(&self, path: &Path) -> std::io::Result<FileHandle> {
+        self.inner.open_read(path).await
+    }
+
+    async fn read_range(
+        &self,
+        path: &Path,
+        range: std::ops::Range<u64>,
+    ) -> std::io::Result<OwnedBytes> {
+        self.inner.read_range(path, range).await
+    }
+
+    async fn list_files(&self, prefix: &Path) -> std::io::Result<Vec<PathBuf>> {
+        self.inner.list_files(prefix).await
+    }
+
+    async fn open_lazy(&self, path: &Path) -> std::io::Result<FileHandle> {
+        self.inner.open_lazy(path).await
+    }
+}
+
+#[async_trait]
+impl DirectoryWriter for RecordingDirectory {
+    async fn write(&self, path: &Path, data: &[u8]) -> std::io::Result<()> {
+        self.plain_writes.lock().unwrap().insert(path.to_path_buf());
+        self.inner.write(path, data).await
+    }
+
+    async fn delete(&self, path: &Path) -> std::io::Result<()> {
+        self.inner.delete(path).await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        self.inner.rename(from, to).await
+    }
+
+    async fn sync(&self) -> std::io::Result<()> {
+        self.inner.sync().await
+    }
+
+    async fn streaming_writer(&self, path: &Path) -> std::io::Result<Box<dyn StreamingWriter>> {
+        self.streaming_writes
+            .lock()
+            .unwrap()
+            .insert(path.to_path_buf());
+        self.inner.streaming_writer(path).await
+    }
+}
+
+fn is_segment_meta(path: &Path) -> bool {
+    path.extension().is_some_and(|e| e == "meta")
+}
+
+/// Build (flush), merge, and reorder outputs must all route their `.meta`
+/// through the fsyncing streaming-writer path, never bare `write()`.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_segment_meta_written_through_durable_path() {
+    let mut schema_builder = SchemaBuilder::default();
+    let title = schema_builder.add_text_field("title", true, true);
+    let schema = schema_builder.build();
+
+    let dir = RecordingDirectory::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, IndexConfig::default())
+        .await
+        .unwrap();
+
+    // Two commits -> two segments, so force_merge below produces a merged
+    // segment (a third .meta) and reorder rewrites it (a fourth).
+    for batch in 0..2 {
+        for i in 0..50 {
+            let mut doc = Document::new();
+            doc.add_text(title, format!("hello world batch {batch} doc {i}"));
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+
+    writer.force_merge().await.unwrap();
+    writer.reorder().await.unwrap();
+    writer.wait_for_all_merges().await;
+
+    let streaming = dir.streaming_writes.lock().unwrap();
+    let metas_durable: Vec<_> = streaming.iter().filter(|p| is_segment_meta(p)).collect();
+    assert!(
+        !metas_durable.is_empty(),
+        "expected at least one segment .meta to be produced"
+    );
+
+    let plain = dir.plain_writes.lock().unwrap();
+    let metas_plain: Vec<_> = plain.iter().filter(|p| is_segment_meta(p)).collect();
+    assert!(
+        metas_plain.is_empty(),
+        "segment .meta written via non-durable DirectoryWriter::write \
+         (page cache only, lost on power failure): {metas_plain:?}"
+    );
+}
+
+/// Sanity: the flow above must actually produce segment .meta files (via
+/// either path) — guards the main test against becoming vacuous if the
+/// commit flow changes.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_segment_meta_files_are_produced_at_all() {
+    let mut schema_builder = SchemaBuilder::default();
+    let title = schema_builder.add_text_field("title", true, true);
+    let schema = schema_builder.build();
+
+    let dir = RecordingDirectory::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, IndexConfig::default())
+        .await
+        .unwrap();
+    let mut doc = Document::new();
+    doc.add_text(title, "hello");
+    writer.add_document(doc).unwrap();
+    writer.commit().await.unwrap();
+
+    let all: Vec<PathBuf> = {
+        let plain = dir.plain_writes.lock().unwrap();
+        let streaming = dir.streaming_writes.lock().unwrap();
+        plain.iter().chain(streaming.iter()).cloned().collect()
+    };
+    assert!(
+        all.iter().any(|p| is_segment_meta(p)),
+        "no segment .meta produced by commit at all; files seen: {all:?}"
+    );
+}

--- a/hermes-core/tests/wasm_builder_store_memory_regression.rs
+++ b/hermes-core/tests/wasm_builder_store_memory_regression.rs
@@ -1,0 +1,46 @@
+//! Regression test: on the wasm branch the in-memory document store buffer
+//! (`SegmentBuilder::store_buffer`) must be counted in the builder's
+//! estimated memory. Otherwise the wasm `IndexWriter`'s memory-budget
+//! auto-flush never fires for stored-heavy workloads and the buffer grows
+//! unboundedly until the browser tab OOMs, losing all uncommitted documents.
+//!
+//! Run with: `cargo test -p hermes-core --no-default-features \
+//!   --features wasm,http --test wasm_builder_store_memory_regression`
+#![cfg(all(feature = "wasm", not(feature = "native")))]
+
+use hermes_core::directories::RamDirectory;
+use hermes_core::{Document, IndexConfig, Schema, WasmIndexWriter};
+
+#[tokio::test]
+async fn test_wasm_store_buffer_counts_against_memory_budget() {
+    let mut builder = Schema::builder();
+    // Stored-but-unindexed field: contributes nothing to postings memory,
+    // everything to the in-memory store buffer.
+    let body = builder.add_text_field("body", false, true);
+    let schema = builder.build();
+
+    let config = IndexConfig {
+        max_indexing_memory_bytes: 1024 * 1024, // 1 MiB budget
+        ..Default::default()
+    };
+    let mut writer = WasmIndexWriter::create(RamDirectory::new(), schema, config)
+        .await
+        .expect("create");
+
+    // 120 docs x 64 KiB stored payload ~= 7.5 MiB of store buffer — far past
+    // the 1 MiB budget (the auto-flush also requires >= 100 buffered docs).
+    let payload = "x".repeat(64 * 1024);
+    for i in 0..120 {
+        let mut doc = Document::new();
+        doc.add_text(body, format!("{i} {payload}"));
+        writer.add_document(doc).await.expect("add_document");
+    }
+    writer.commit().await.expect("commit");
+
+    assert!(
+        writer.metadata().segment_metas.len() >= 2,
+        "stored-heavy workload must trip the memory-budget auto-flush; the \
+         store buffer is invisible to estimated_memory — got {} segment(s)",
+        writer.metadata().segment_metas.len()
+    );
+}

--- a/hermes-core/tests/wasm_writer_regressions.rs
+++ b/hermes-core/tests/wasm_writer_regressions.rs
@@ -1,0 +1,343 @@
+//! Regression tests for the WASM `IndexWriter` (`WasmIndexWriter`).
+//!
+//! Pins transactional / fail-loud behavior of the wasm writer:
+//! - a rejected `add_document` must not poison the segment builder
+//!   (doc counts skewed forever, whole buffered batch lost at commit)
+//! - a failed metadata save during `commit()` must be retryable
+//!   (pending segments must not be drained before the durable save)
+//! - schemas declaring a primary key must be rejected loudly, because
+//!   primary-key deduplication does not exist on the wasm branch
+//!
+//! Run with: `cargo test -p hermes-core --no-default-features \
+//!   --features wasm,http --test wasm_writer_regressions`
+#![cfg(all(feature = "wasm", not(feature = "native")))]
+
+use std::future::Future;
+use std::io;
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use hermes_core::directories::{
+    Directory, DirectoryWriter, FileHandle, OwnedBytes, RamDirectory, StreamingWriter,
+};
+use hermes_core::{Document, IndexConfig, IndexMetadata, Schema, WasmIndexWriter};
+
+fn total_docs(metadata: &IndexMetadata) -> u32 {
+    metadata.segment_metas.values().map(|m| m.num_docs).sum()
+}
+
+// ---------------------------------------------------------------------------
+// Finding: a single failed add_document poisons the builder (doc_id advanced,
+// store write skipped), so commit() later fails with "Store doc count
+// mismatch" and every buffered document is lost.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_wasm_add_document_rejecting_invalid_vector_does_not_poison_builder() {
+    let mut builder = Schema::builder();
+    let title = builder.add_text_field("title", true, true);
+    let emb = builder.add_dense_vector_field("emb", 3, true, true);
+    let spv = builder.add_sparse_vector_field("spv", true, false);
+    let bin = builder.add_binary_dense_vector_field("bin", 8, true, false);
+    let schema = builder.build();
+
+    let mut writer = WasmIndexWriter::create(RamDirectory::new(), schema, IndexConfig::default())
+        .await
+        .expect("create");
+
+    let valid_doc = |i: usize| {
+        let mut d = Document::new();
+        d.add_text(title, format!("hello document {i}"));
+        d.add_dense_vector(emb, vec![0.1, 0.2, 0.3]);
+        d.add_sparse_vector(spv, vec![(1, 0.5), (7, 1.5)]);
+        d.add_binary_dense_vector(bin, vec![0b1010_1010]);
+        d
+    };
+
+    for i in 0..2 {
+        writer.add_document(valid_doc(i)).await.expect("valid doc");
+    }
+    assert_eq!(writer.pending_docs(), 2);
+
+    // Dense vector with the wrong dimension must be rejected...
+    let mut bad_dim = Document::new();
+    bad_dim.add_text(title, "bad dim");
+    bad_dim.add_dense_vector(emb, vec![0.1, 0.2]);
+    let err = writer.add_document(bad_dim).await.unwrap_err();
+    assert!(
+        err.to_string().contains("dimension mismatch"),
+        "unexpected error: {err}"
+    );
+    // ...WITHOUT advancing builder state (all-or-nothing).
+    assert_eq!(
+        writer.pending_docs(),
+        2,
+        "rejected document must not advance the builder doc count"
+    );
+
+    // Non-finite dense value.
+    let mut nan_dense = Document::new();
+    nan_dense.add_text(title, "nan dense");
+    nan_dense.add_dense_vector(emb, vec![0.1, f32::NAN, 0.3]);
+    writer.add_document(nan_dense).await.unwrap_err();
+    assert_eq!(writer.pending_docs(), 2);
+
+    // Non-finite sparse weight.
+    let mut nan_sparse = Document::new();
+    nan_sparse.add_text(title, "nan sparse");
+    nan_sparse.add_sparse_vector(spv, vec![(3, f32::INFINITY)]);
+    writer.add_document(nan_sparse).await.unwrap_err();
+    assert_eq!(writer.pending_docs(), 2);
+
+    // Binary vector with the wrong byte length.
+    let mut bad_bin = Document::new();
+    bad_bin.add_text(title, "bad bin");
+    bad_bin.add_binary_dense_vector(bin, vec![0xFF, 0xFF]);
+    writer.add_document(bad_bin).await.unwrap_err();
+    assert_eq!(writer.pending_docs(), 2);
+
+    // The writer keeps accepting valid documents after the rejections...
+    for i in 2..4 {
+        writer.add_document(valid_doc(i)).await.expect("valid doc");
+    }
+    assert_eq!(writer.pending_docs(), 4);
+
+    // ...and commit succeeds with exactly the 4 valid documents.
+    let committed = writer
+        .commit()
+        .await
+        .expect("commit must not fail after a rejected document");
+    assert!(committed);
+    assert_eq!(total_docs(writer.metadata()), 4);
+}
+
+// ---------------------------------------------------------------------------
+// Finding: commit() drains pending_segments into in-memory metadata BEFORE the
+// durable save; when save fails, a retried commit() returns Ok(false) and the
+// segments are never durably registered — silent data loss on reload.
+// ---------------------------------------------------------------------------
+
+type BoxFut<'r, T> = Pin<Box<dyn Future<Output = T> + Send + 'r>>;
+
+/// DirectoryWriter test double: delegates to an inner `RamDirectory` but fails
+/// `rename` while `fail_renames` is set. `IndexMetadata::save` publishes
+/// metadata.json via write-tmp-then-rename, so this makes exactly the durable
+/// metadata save fail while segment file writes stay healthy.
+struct RenameFailDirectory {
+    inner: RamDirectory,
+    fail_renames: Arc<AtomicBool>,
+}
+
+impl Directory for RenameFailDirectory {
+    fn exists<'a, 'b, 'r>(&'a self, path: &'b Path) -> BoxFut<'r, io::Result<bool>>
+    where
+        'a: 'r,
+        'b: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.exists(path))
+    }
+
+    fn file_size<'a, 'b, 'r>(&'a self, path: &'b Path) -> BoxFut<'r, io::Result<u64>>
+    where
+        'a: 'r,
+        'b: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.file_size(path))
+    }
+
+    fn open_read<'a, 'b, 'r>(&'a self, path: &'b Path) -> BoxFut<'r, io::Result<FileHandle>>
+    where
+        'a: 'r,
+        'b: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.open_read(path))
+    }
+
+    fn read_range<'a, 'b, 'r>(
+        &'a self,
+        path: &'b Path,
+        range: Range<u64>,
+    ) -> BoxFut<'r, io::Result<OwnedBytes>>
+    where
+        'a: 'r,
+        'b: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.read_range(path, range))
+    }
+
+    fn list_files<'a, 'b, 'r>(&'a self, prefix: &'b Path) -> BoxFut<'r, io::Result<Vec<PathBuf>>>
+    where
+        'a: 'r,
+        'b: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.list_files(prefix))
+    }
+
+    fn open_lazy<'a, 'b, 'r>(&'a self, path: &'b Path) -> BoxFut<'r, io::Result<FileHandle>>
+    where
+        'a: 'r,
+        'b: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.open_lazy(path))
+    }
+}
+
+impl DirectoryWriter for RenameFailDirectory {
+    fn write<'a, 'b, 'c, 'r>(&'a self, path: &'b Path, data: &'c [u8]) -> BoxFut<'r, io::Result<()>>
+    where
+        'a: 'r,
+        'b: 'r,
+        'c: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.write(path, data))
+    }
+
+    fn delete<'a, 'b, 'r>(&'a self, path: &'b Path) -> BoxFut<'r, io::Result<()>>
+    where
+        'a: 'r,
+        'b: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.delete(path))
+    }
+
+    fn rename<'a, 'b, 'c, 'r>(&'a self, from: &'b Path, to: &'c Path) -> BoxFut<'r, io::Result<()>>
+    where
+        'a: 'r,
+        'b: 'r,
+        'c: 'r,
+        Self: 'r,
+    {
+        Box::pin(async move {
+            if self.fail_renames.load(Ordering::SeqCst) {
+                return Err(io::Error::other("injected rename failure"));
+            }
+            self.inner.rename(from, to).await
+        })
+    }
+
+    fn sync<'a, 'r>(&'a self) -> BoxFut<'r, io::Result<()>>
+    where
+        'a: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.sync())
+    }
+
+    fn streaming_writer<'a, 'b, 'r>(
+        &'a self,
+        path: &'b Path,
+    ) -> BoxFut<'r, io::Result<Box<dyn StreamingWriter>>>
+    where
+        'a: 'r,
+        'b: 'r,
+        Self: 'r,
+    {
+        Box::pin(self.inner.streaming_writer(path))
+    }
+}
+
+#[tokio::test]
+async fn test_wasm_commit_failed_metadata_save_is_retryable() {
+    let fail_renames = Arc::new(AtomicBool::new(false));
+    let dir = RenameFailDirectory {
+        inner: RamDirectory::new(),
+        fail_renames: Arc::clone(&fail_renames),
+    };
+
+    let mut builder = Schema::builder();
+    let title = builder.add_text_field("title", true, true);
+    let schema = builder.build();
+
+    let mut writer = WasmIndexWriter::create(dir, schema, IndexConfig::default())
+        .await
+        .expect("create");
+
+    let mut doc = Document::new();
+    doc.add_text(title, "hello world");
+    writer.add_document(doc).await.expect("add");
+
+    // First commit: metadata save fails after the segment files are built.
+    fail_renames.store(true, Ordering::SeqCst);
+    writer
+        .commit()
+        .await
+        .expect_err("commit must surface the failed metadata save");
+
+    // A failed save must leave the pending segments intact so the commit is
+    // retryable once the storage recovers.
+    fail_renames.store(false, Ordering::SeqCst);
+    let committed = writer.commit().await.expect("retried commit");
+    assert!(
+        committed,
+        "retried commit must re-attempt the durable metadata save (pending \
+         segments must survive a failed save)"
+    );
+
+    // The durable metadata must now reference the committed segment.
+    let durable = IndexMetadata::load(writer.directory().as_ref())
+        .await
+        .expect("load metadata");
+    assert_eq!(total_docs(&durable), 1);
+    assert_eq!(total_docs(writer.metadata()), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Finding: schemas with a `[primary]` field are silently accepted by the wasm
+// writer even though no primary-key deduplication exists on the wasm branch.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_wasm_writer_create_rejects_primary_key_schema_loudly() {
+    let mut builder = Schema::builder();
+    let id = builder.add_text_field("id", true, true);
+    builder.add_text_field("title", true, true);
+    builder.set_primary_key(id);
+    let schema = builder.build();
+
+    let err =
+        match WasmIndexWriter::create(RamDirectory::new(), schema, IndexConfig::default()).await {
+            Ok(_) => panic!("wasm writer must reject primary-key schemas: dedup is not enforced"),
+            Err(e) => e,
+        };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("primary key") && msg.contains("id"),
+        "error must name the primary-key field and the missing capability: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn test_wasm_writer_open_rejects_primary_key_schema_loudly() {
+    let mut builder = Schema::builder();
+    let id = builder.add_text_field("id", true, true);
+    builder.set_primary_key(id);
+    let schema = builder.build();
+
+    // Simulate an existing (e.g. natively built) index with a PK schema.
+    let dir = RamDirectory::new();
+    IndexMetadata::new(schema)
+        .save(&dir)
+        .await
+        .expect("save metadata");
+
+    let err = match WasmIndexWriter::open(dir, IndexConfig::default()).await {
+        Ok(_) => panic!("wasm writer must refuse to open an index whose schema declares a PK"),
+        Err(e) => e,
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("primary key") && msg.contains("id"),
+        "error must name the primary-key field and the missing capability: {msg}"
+    );
+}

--- a/hermes-tool/src/index_ops.rs
+++ b/hermes-tool/src/index_ops.rs
@@ -60,6 +60,7 @@ async fn index_from_reader<R: BufRead>(
     let schema = writer.schema().clone();
     let mut count = 0usize;
     let mut errors = 0usize;
+    let mut duplicates = 0usize;
     let start_time = std::time::Instant::now();
 
     for line in reader.lines() {
@@ -90,7 +91,17 @@ async fn index_from_reader<R: BufRead>(
             }
         };
 
-        writer.add_document(doc)?;
+        match writer.add_document(doc) {
+            Ok(()) => {}
+            Err(hermes_core::Error::DuplicatePrimaryKey(key)) => {
+                if duplicates < 10 {
+                    tracing::warn!("Skipping document with duplicate primary key: {}", key);
+                }
+                duplicates += 1;
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        }
         count += 1;
 
         if progress_interval > 0 && count.is_multiple_of(progress_interval) {
@@ -117,6 +128,12 @@ async fn index_from_reader<R: BufRead>(
 
     if errors > 0 {
         tracing::warn!("Skipped {} documents due to parse errors", errors);
+    }
+    if duplicates > 0 {
+        tracing::warn!(
+            "Skipped {} documents with duplicate primary keys",
+            duplicates
+        );
     }
 
     info!(
@@ -153,6 +170,11 @@ pub async fn index_documents(
         ..default_config
     };
     let mut writer = IndexWriter::open(dir, config.clone()).await?;
+
+    // Enforce the schema's primary-key unique constraint (no-op when the
+    // schema declares no primary key). Mirrors hermes-server, which always
+    // initializes dedup when opening a writer.
+    writer.init_primary_key_dedup().await?;
 
     info!("Opened index at {:?}", index_path);
     info!(
@@ -577,4 +599,95 @@ pub async fn warmup_cache(index_path: PathBuf, cache_size: usize) -> Result<()> 
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: the CLI `index` command must enforce a schema-declared
+    /// primary-key unique constraint (init_primary_key_dedup, mirroring
+    /// hermes-server). Duplicate keys are skipped with a warning, both within
+    /// one run and against keys committed by a previous run.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cli_index_enforces_primary_key_dedup() {
+        let tmp = std::env::temp_dir().join(format!(
+            "hermes_tool_pk_dedup_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&tmp).unwrap();
+        let index_path = tmp.join("idx");
+
+        let schema_path = tmp.join("schema.sdl");
+        fs::write(
+            &schema_path,
+            "index t {\n    field id: text [indexed, stored, primary]\n    field body: text [indexed, stored]\n}\n",
+        )
+        .unwrap();
+        create_index(index_path.clone(), schema_path).await.unwrap();
+
+        let docs_path = tmp.join("docs.jsonl");
+        fs::write(
+            &docs_path,
+            concat!(
+                "{\"id\":\"a\",\"body\":\"one\"}\n",
+                "{\"id\":\"b\",\"body\":\"two\"}\n",
+                "{\"id\":\"a\",\"body\":\"duplicate\"}\n",
+            ),
+        )
+        .unwrap();
+
+        index_documents(
+            index_path.clone(),
+            Some(docs_path.clone()),
+            false,
+            0,
+            256,
+            None,
+            None,
+            hermes_core::structures::IndexOptimization::default(),
+        )
+        .await
+        .unwrap();
+
+        let index = hermes_core::Index::open(FsDirectory::new(&index_path), IndexConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            index.num_docs().await.unwrap(),
+            2,
+            "duplicate primary key must be rejected during CLI ingestion"
+        );
+        drop(index);
+
+        // Second run over the same file: every id is already committed, so
+        // nothing new must be indexed (committed-key dedup on a fresh writer).
+        index_documents(
+            index_path.clone(),
+            Some(docs_path),
+            false,
+            0,
+            256,
+            None,
+            None,
+            hermes_core::structures::IndexOptimization::default(),
+        )
+        .await
+        .unwrap();
+
+        let index = hermes_core::Index::open(FsDirectory::new(&index_path), IndexConfig::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            index.num_docs().await.unwrap(),
+            2,
+            "keys committed by a previous CLI run must still dedup"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
 }

--- a/hermes-wasm/src/local_index.rs
+++ b/hermes-wasm/src/local_index.rs
@@ -439,6 +439,12 @@ impl LocalIndex {
     }
 
     /// Sync new/changed files to storage (if any).
+    ///
+    /// Ordering is crash-safety-critical (see [`plan_storage_sync`]): data
+    /// files are persisted first, `metadata.json` — the commit point on
+    /// reload — second, and stale-file deletions last. If the tab closes or
+    /// a storage write rejects mid-sync, the previously stored metadata.json
+    /// still references a complete file set, so the index stays openable.
     async fn sync_to_storage(&mut self) -> Result<(), JsValue> {
         let adapter = match &self.storage {
             Some(a) => a,
@@ -457,29 +463,125 @@ impl LocalIndex {
             .map(|p| p.to_string_lossy().to_string())
             .collect();
 
+        let (writes, removed) = plan_storage_sync(&current_set, &self.persisted_files);
+
         // Write new files and metadata.json (always changes on commit)
-        for path in &current_files {
-            let path_str = path.to_string_lossy();
-            if !self.persisted_files.contains(path_str.as_ref()) || path_str == "metadata.json" {
-                let data = dir
-                    .read_file_sync(path)
-                    .map_err(|e| JsValue::from_str(&format!("Read error: {}", e)))?;
-                adapter.write(&path_str, &data).await?;
-            }
+        for path_str in &writes {
+            let data = dir
+                .read_file_sync(Path::new(path_str))
+                .map_err(|e| JsValue::from_str(&format!("Read error: {}", e)))?;
+            adapter.write(path_str, &data).await?;
         }
 
-        // Delete removed files (e.g. after merge)
-        let removed: Vec<String> = self
-            .persisted_files
-            .iter()
-            .filter(|p| !current_set.contains(p.as_str()))
-            .cloned()
-            .collect();
+        // Delete removed files (e.g. after merge) — only after the new
+        // metadata is stored, so a crash mid-sync cannot drop files that the
+        // stored metadata still references.
         if !removed.is_empty() {
             adapter.delete(&removed).await?;
         }
 
         self.persisted_files = current_set;
         Ok(())
+    }
+}
+
+/// Name of the index metadata file — the durable commit point for a synced index.
+const METADATA_FILE: &str = "metadata.json";
+
+/// Compute the storage sync plan for [`LocalIndex::sync_to_storage`].
+///
+/// Returns `(writes, deletes)`:
+/// - `writes`: new files in deterministic (sorted) order, with
+///   `metadata.json` (rewritten on every commit) strictly LAST. The order is
+///   crash-safety-critical: metadata.json is the commit point that names the
+///   other files, so persisting it before them would let a crash/tab-close
+///   mid-sync store metadata referencing files that were never written,
+///   bricking the index on reload.
+/// - `deletes`: previously persisted files no longer present; removed only
+///   after the new metadata is stored.
+fn plan_storage_sync(
+    current: &HashSet<String>,
+    persisted: &HashSet<String>,
+) -> (Vec<String>, Vec<String>) {
+    let mut writes: Vec<String> = current
+        .iter()
+        .filter(|name| name.as_str() != METADATA_FILE && !persisted.contains(name.as_str()))
+        .cloned()
+        .collect();
+    writes.sort_unstable();
+    if current.contains(METADATA_FILE) {
+        writes.push(METADATA_FILE.to_string());
+    }
+
+    let mut deletes: Vec<String> = persisted
+        .iter()
+        .filter(|name| !current.contains(name.as_str()))
+        .cloned()
+        .collect();
+    deletes.sort_unstable();
+
+    (writes, deletes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plan_storage_sync;
+    use std::collections::HashSet;
+
+    /// A crash/tab-close between persisting metadata.json and the segment
+    /// files it references leaves the stored index permanently unopenable.
+    /// The sync plan must therefore order every new data file BEFORE
+    /// metadata.json, deterministically.
+    #[test]
+    fn test_sync_plan_persists_metadata_json_last_after_all_new_data_files() {
+        let mut current: HashSet<String> = HashSet::new();
+        let mut persisted: HashSet<String> = HashSet::new();
+
+        // Previous generation, already persisted.
+        for name in ["seg_old.term_dict", "seg_old.postings", "seg_old.store"] {
+            current.insert(name.to_string());
+            persisted.insert(name.to_string());
+        }
+        persisted.insert("metadata.json".to_string());
+        // Retired by a merge — present in storage, gone from the directory.
+        persisted.insert("seg_retired.store".to_string());
+
+        // New commit output: enough files that arbitrary HashSet iteration
+        // order cannot accidentally satisfy the assertions.
+        for i in 0..64 {
+            current.insert(format!("seg_new_{i:02}.store"));
+        }
+        current.insert("metadata.json".to_string());
+
+        let (writes, deletes) = plan_storage_sync(&current, &persisted);
+
+        // metadata.json is the commit point: it must be stored strictly
+        // after every data file it references.
+        assert_eq!(
+            writes.last().map(String::as_str),
+            Some("metadata.json"),
+            "metadata.json must be persisted last: {writes:?}"
+        );
+        assert_eq!(
+            writes
+                .iter()
+                .filter(|w| w.as_str() == "metadata.json")
+                .count(),
+            1
+        );
+
+        // Exactly the new data files are written, in deterministic order;
+        // unchanged persisted files are not rewritten.
+        let data_writes = &writes[..writes.len() - 1];
+        assert_eq!(data_writes.len(), 64);
+        assert!(data_writes.iter().all(|w| w.starts_with("seg_new_")));
+        assert!(
+            data_writes.windows(2).all(|w| w[0] < w[1]),
+            "data files must be written in deterministic sorted order: {data_writes:?}"
+        );
+
+        // Retired files are deleted (sync_to_storage runs deletions only
+        // after the metadata write).
+        assert_eq!(deletes, vec!["seg_retired.store".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

Full correctness audit of indexing, segment management, and the segment-lifecycle state machine, run as a multi-agent review (8 dimension-specific finders + a coverage-critic round; every finding adversarially verified by independent reproduce/refute agents with tiebreak judging). **27 findings confirmed, all fixed here; 5 claims refuted and not acted on.** Every fix follows failing-test-first; 5 new integration-test files.

## Highlights by area

### Durability / crash safety
- **Segment `.meta` was the only segment file written without fsync** while commit durably publishes `metadata.json` referencing it — power loss after an acked commit could make committed docs unreadable, and merge/reorder delete their fsynced sources right after publish, so the torn output could be the only copy. All three producers (build/merge/reorder) now use a durable `write_durable` path (`hermes-core/tests/segment_meta_durability.rs`).
- Metadata **format version gate**: refuse newer-format metadata instead of silently pruning unknown fields and destructively rewriting.
- `IndexWriter::create` on an existing index now **fails loudly** instead of orphaning every committed segment for the next orphan sweep to delete.
- **Advisory single-writer lock** (`.hermes_writer.lock`): a second writer errors instead of silently double-writing; the orphan sweep only runs under the lock.

### Segment lifecycle / concurrency
- `begin_vector_artifact_update` **deadlock** on operation tokens held by built-but-uncommitted segments.
- `wait_for_all_merges`/`abort_merges` **cancellation-safety**: dropped RPC futures no longer strand in-flight merge handles (take-then-await removed).
- Merge **retry backoff (30s–30min) no longer sleeps inside tracked JoinHandles** that waiters drain; `force_merge` conflict retry backs off instead of busy-spinning a runtime worker.
- Flush condvar `notify_all`: a cancelled commit can no longer eat the wakeup of a retried commit.
- Searcher reload re-injects current trained centroids; corrupt segment IDs in metadata are hard errors; `exists()` propagates stat errors (EIO/EACCES) instead of quarantining healthy segments.

### Indexing correctness
- **Spill-boundary duplicate postings**: a document split across the spilled range and in-memory tail no longer produces duplicate doc_ids (inflated doc_freq, doc scored twice).
- **ANN cluster merge misalignment**: per-field indexes are paired with their own segment's doc offset — a merge source lacking the field no longer silently corrupts every later segment's vector remapping.
- Posting-list concatenation returns `Corruption` on short sources instead of positionally misassigning all subsequent lists.
- Fail-loud schema misuse: type-mismatched field values and out-of-range BMP `dim_id`s are rejected with actionable errors instead of silently unindexed/unsearchable.
- Position encoding saturates at field maxima (with warning) instead of corrupting neighboring docs' phrase positions.
- Vector training collection propagates read errors; no destructive Built→Flat downgrade on empty/failed collection.

### Primary keys
- `PreparedCommit::abort` no longer wipes fail-closed PK reservations retained after a failed post-commit refresh (duplicate-PK admission).
- `hermes-tool index` now enforces declared PK uniqueness; `SchemaBuilder::set_primary_key` forces fast+indexed like the SDL path.

### WASM
- `add_document` is all-or-nothing (a failed doc no longer poisons the builder permanently).
- `commit` saves metadata durably **before** mutating in-memory state (failed save is retryable; no stranded segments).
- `sync_to_storage` persists data files → metadata → removals, in that order, so a tab-close mid-sync can't persist metadata referencing unwritten files.
- PK schemas rejected loudly (dedup unenforced on wasm); store buffer counted against the memory budget.

## Verification
- `cargo clippy --workspace --exclude hermes-llm --exclude hermes-train --all-targets --all-features -- -D warnings` clean (hermes-llm has pre-existing unused-`Metal`-import failures under `--all-features`, untouched by this PR)
- `cargo test --workspace --exclude hermes-llm --exclude hermes-train --all-features`: **893 passed, 0 failed**
- `hermes-wasm/build.sh` builds successfully
- Every fix has a named regression test that failed before the fix (crash-durability and concurrency cases use test doubles / deterministic gating)

Full audit trail (verified findings with call-path evidence) preserved in the workspace `.context/audit-findings.json`.