### PR TITLE
perf(train): background sample reader thread — 51,877 tok/s @B27

### DIFF
--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -675,21 +675,35 @@ fn train(args: TrainArgs) -> Result<()> {
             };
             let mut batch = Vec::with_capacity(args.batch_size);
             let shuffle_seed = args.seed.wrapping_add((stage * args.epochs + epoch) as u64);
-            visit_samples(
-                path,
-                &tokenizer,
-                args.seq_len,
-                args.shuffle_buffer,
-                shuffle_seed,
-                |sample| {
+            // Reading, decompression, and tokenization run on a background
+            // thread; the bounded channel keeps two batches of samples ready
+            // so the accelerator never idles on batch preparation. Dropping
+            // the receiver (early stop or an error) hangs up the sender and
+            // the reader unwinds cleanly.
+            let seq_len = args.seq_len;
+            let shuffle_buffer = args.shuffle_buffer;
+            let tokenizer_ref = &tokenizer;
+            std::thread::scope(|threads| -> Result<()> {
+                let (sender, receiver) = std::sync::mpsc::sync_channel(args.batch_size * 2);
+                let reader = threads.spawn(move || {
+                    visit_samples(
+                        path,
+                        tokenizer_ref,
+                        seq_len,
+                        shuffle_buffer,
+                        shuffle_seed,
+                        |sample| Ok(sender.send(sample).is_ok()),
+                    )
+                });
+                for sample in &receiver {
                     samples_in_stage += 1;
                     training_state.samples_in_stage = samples_in_stage;
                     if samples_in_stage <= samples_to_skip {
-                        return Ok(true);
+                        continue;
                     }
                     batch.push(sample);
                     if batch.len() < args.batch_size {
-                        return Ok(true);
+                        continue;
                     }
 
                     let (inputs, targets) = make_batch(&batch, args.seq_len, &device);
@@ -780,10 +794,17 @@ fn train(args: TrainArgs) -> Result<()> {
                             println!("checkpointed {}", args.output.display());
                         }
                         micro_step = 0;
+                        if step >= total_steps {
+                            break;
+                        }
                     }
-                    Ok(step < total_steps)
-                },
-            )?;
+                }
+                drop(receiver);
+                reader
+                    .join()
+                    .expect("sample reader thread panicked")
+                    .map(|_| ())
+            })?;
             if step >= total_steps {
                 break 'stages;
             }


### PR DESCRIPTION
Follow-up to #64: reading/decompression/tokenization move to a scoped background thread feeding the training loop through a bounded channel, so the GPU never idles on batch preparation after the per-step metrics readback. Sample order, resume counting, and checkpoint semantics unchanged — grad norms and losses match exactly. Measured: 51,769 → **51,877 tok/s** @B27 (+0.2% here; larger on real corpora where tokenization is heavier). hermes-train suite green.