### PR TITLE
fix(ci): drop unused burn-cuda dep and stray test cfg on scan constant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,7 +3205,6 @@ dependencies = [
  "burn-autodiff",
  "burn-core",
  "burn-cubecl",
- "burn-cuda",
  "burn-fusion",
  "burn-ir",
  "burn-ndarray",

--- a/hermes-llm/Cargo.toml
+++ b/hermes-llm/Cargo.toml
@@ -18,7 +18,6 @@ burn-autodiff = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2
 burn-nn = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std"] }
 burn-ndarray = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std"] }
 burn-wgpu = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", optional = true, default-features = false, features = ["std", "metal", "autotune"] }
-burn-cuda = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", optional = true, default-features = false, features = ["std", "autotune"] }
 burn-store = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = [
     "safetensors",
     "std",
@@ -63,7 +62,7 @@ default = ["remote"]
 # Load weights/config/tokenizer from s3://, gs://, http(s):// (downloads + caches)
 remote = ["dep:object_store", "dep:tokio", "dep:url", "dep:dirs"]
 metal = ["burn/metal", "burn/autotune", "dep:burn-wgpu", "dep:burn-cubecl", "dep:cubecl", "dep:half"]
-cuda = ["burn/cuda", "burn/autotune", "dep:burn-cuda", "dep:burn-cubecl", "dep:cubecl", "dep:cubek", "dep:half"]
+cuda = ["burn/cuda", "burn/autotune", "dep:burn-cubecl", "dep:cubecl", "dep:cubek", "dep:half"]
 # Lazy fusion pays off for large training graphs, but adds substantial graph
 # planning and kernel-launch overhead to single-token autoregressive decoding.
 training-fusion = ["cuda", "burn/fusion", "dep:burn-fusion", "dep:burn-ir"]
@@ -71,8 +70,3 @@ training-fusion = ["cuda", "burn/fusion", "dep:burn-fusion", "dep:burn-ir"]
 [[bin]]
 name = "hermes-llm"
 path = "src/main.rs"
-
-[package.metadata.cargo-machete]
-# `#[cube]` macro expansion requires the direct crate even though static source
-# analysis only sees it behind the GPU feature gates.
-ignored = ["cubecl", "cubek"]

--- a/hermes-llm/src/model/scan/mod.rs
+++ b/hermes-llm/src/model/scan/mod.rs
@@ -39,7 +39,7 @@ use reference::reference_selective_scan_tensor;
 /// every sequence length works via partial-tail guards. The fusion IR and
 /// both dispatch functions must agree on this value, which is why it is
 /// the single source of the saved-states shape.
-#[cfg(any(feature = "metal", feature = "cuda", test))]
+#[cfg(any(feature = "metal", feature = "cuda"))]
 pub(super) const CHECKPOINTED_SCAN_INTERVAL: usize = 32;
 
 fn stable_softplus<const D: usize>(value: Tensor<D>) -> Tensor<D> {


### PR DESCRIPTION
CI has been red on main since the kernel-family refactor series (#67–#69). Two independent breakages, both in hermes-llm:

1. **Rust CI / clippy** (`--all-targets`, default features): `CHECKPOINTED_SCAN_INTERVAL`'s cfg gate kept a `test` leaf, so the const existed in featureless lib-test builds where every consumer (`fusion.rs` behind `training-fusion`, `scan/gpu.rs` behind `metal`/`cuda`) is compiled out → `dead_code` under `-D warnings`. The refactor removed the last featureless test consumer; the gate is now `metal|cuda` only.
2. **Cargo Machete**: `burn-cuda` is no longer referenced anywhere (kernels moved to cubek/cubecl) — dependency and its `dep:` entry in the `cuda` feature removed. Also removed the stale machete ignores for `cubecl`/`cubek`, which machete itself now flags as "marked as ignored, but is actually used".

Verified locally: `cargo clippy -p hermes-llm --all-targets -- -D warnings` clean, `cargo machete` clean ("didn't find any unused dependencies"), and `cargo tree --features cuda` resolution intact (CUDA can't compile on this macOS host; CI's featureless clippy is the gate that was failing).