### PR TITLE
fix(llm): normalize tokenizer whitespace markers

### DIFF
--- a/hermes-llm/src/trace.rs
+++ b/hermes-llm/src/trace.rs
@@ -738,7 +738,7 @@ fn channel_labels(columns: usize, bins: usize) -> Vec<String> {
 
 fn visible_token(piece: &str) -> String {
     let visible = piece
-        .replace(' ', "·")
+        .replace([' ', 'Ġ', '▁'], "·")
         .replace('\n', "↵")
         .replace('\r', "⏎")
         .replace('\t', "⇥");
@@ -920,6 +920,13 @@ mod tests {
         assert_eq!(heatmap.values, vec![2.0, -3.0, 3.0, -2.0]);
         assert_eq!(heatmap.original_cols, 4);
         assert_eq!(heatmap.cols, 2);
+    }
+
+    #[test]
+    fn visible_token_normalizes_tokenizer_whitespace_markers() {
+        assert_eq!(visible_token("Ġretrieval"), "·retrieval");
+        assert_eq!(visible_token("▁planning"), "·planning");
+        assert_eq!(visible_token(" literal"), "·literal");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- render GPT byte-level BPE whitespace markers as the existing visible middle-dot separator
- normalize SentencePiece whitespace markers the same way while preserving the raw token piece
- add regression coverage for both tokenizer families and literal whitespace

## Validation

- cargo test -p hermes-llm
- cargo clippy -p hermes-llm --all-targets -- -D warnings
- repository pre-push hooks