### PR TITLE
fix(llm): smooth model lab flow rendering

### DIFF
--- a/docs/llm-visualization-lab.md
+++ b/docs/llm-visualization-lab.md
@@ -100,8 +100,16 @@ limits. Static assets and the API share an origin; no CORS permission is added.
 After a live response, the page selects the generated answer token and plays the
 captured sequence from embedding through every block to final norm. Play/pause,
 previous/next, and speed controls update the existing stage selector, heatmap,
-attention/Mamba view, and selected layer; no synthetic intermediate values are
-invented.
+attention/Mamba view, and selected layer. A labeled flow rail makes that route
+explicit and lets a user jump to any captured stage.
+
+Playback interpolates the displayed residual values between adjacent captured
+stages with a bounded ease curve. Those animation frames are presentation only:
+the endpoints are the exact captured tensors and no interpolated frame is
+reported as a model checkpoint. The activation canvas remains allocated while
+values move so stage changes do not flash through an empty chart; controls and
+secondary charts update once at the captured endpoint. Reduced-motion clients
+switch stages immediately without interpolation.
 
 ## Failure and safety behavior
 

--- a/hermes-llm/src/tokenizer.rs
+++ b/hermes-llm/src/tokenizer.rs
@@ -65,12 +65,26 @@ impl Tokenizer {
     }
 
     /// Vocabulary piece for one token ID, without decoder cleanup. This is
-    /// preferable to decoding tokens independently in diagnostic UIs because
-    /// byte-level tokenizers may only form valid text across token boundaries.
+    /// retained in traces so diagnostics never lose the tokenizer's exact
+    /// representation.
     pub fn token_piece(&self, id: u32) -> Result<String> {
         self.inner
             .id_to_token(id)
             .ok_or_else(|| anyhow::anyhow!("tokenizer has no vocabulary entry for token ID {id}"))
+    }
+
+    /// Human-readable rendering of one vocabulary piece using the tokenizer's
+    /// configured decoder. Byte-level vocabularies represent punctuation and
+    /// whitespace with glyph sequences such as `âĢĻ`, `Ġ`, and `Ċ`; exposing
+    /// those implementation markers in a token inspector is misleading.
+    ///
+    /// The raw piece remains available through [`Self::token_piece`]. A token
+    /// that contains only part of a multi-byte character can still decode as a
+    /// replacement glyph because its text genuinely spans token boundaries.
+    pub fn display_piece(&self, id: u32) -> Result<String> {
+        self.inner.decode(&[id], false).map_err(|e| {
+            anyhow::anyhow!("failed to decode vocabulary entry for token ID {id}: {e}")
+        })
     }
 
     pub fn vocab_size(&self) -> usize {
@@ -79,5 +93,42 @@ impl Tokenizer {
 
     pub fn eos_token_id(&self) -> u32 {
         self.eos_token_id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokenizers::{models::wordlevel::WordLevel, pre_tokenizers::byte_level::ByteLevel};
+
+    #[test]
+    fn display_piece_uses_the_configured_byte_level_decoder() {
+        let vocab = [
+            ("<unk>".to_owned(), 0),
+            ("<eos>".to_owned(), 1),
+            ("âĢĻ".to_owned(), 2),
+            ("ĠâĢĶ".to_owned(), 3),
+            ("âĢ¦".to_owned(), 4),
+            ("Ċ".to_owned(), 5),
+        ]
+        .into_iter()
+        .collect();
+        let model = WordLevel::builder()
+            .vocab(vocab)
+            .unk_token("<unk>".to_owned())
+            .build()
+            .unwrap();
+        let mut inner = HfTokenizer::new(model);
+        inner.with_decoder(Some(ByteLevel::default()));
+        let tokenizer = Tokenizer {
+            inner,
+            eos_token_id: 1,
+        };
+
+        assert_eq!(tokenizer.display_piece(2).unwrap(), "’");
+        assert_eq!(tokenizer.display_piece(3).unwrap(), " —");
+        assert_eq!(tokenizer.display_piece(4).unwrap(), "…");
+        assert_eq!(tokenizer.display_piece(5).unwrap(), "\n");
+        assert_eq!(tokenizer.token_piece(2).unwrap(), "âĢĻ");
     }
 }

--- a/hermes-llm/src/trace.rs
+++ b/hermes-llm/src/trace.rs
@@ -301,10 +301,11 @@ pub fn capture_bundle(
         .map(|(local_index, &id)| {
             let original_index = token_offset + local_index;
             let piece = tokenizer.token_piece(id)?;
+            let decoded_piece = tokenizer.display_piece(id)?;
             Ok(TokenTrace {
                 original_index,
                 id,
-                display: visible_token(&piece),
+                display: visible_token(&decoded_piece),
                 piece,
                 source: if original_index < prompt_token_count {
                     "prompt"

--- a/hermes-web/model-lab.html
+++ b/hermes-web/model-lab.html
@@ -136,6 +136,7 @@
               <span id="flow-position" class="quiet" aria-live="polite"></span>
             </div>
           </div>
+          <div id="flow-rail" class="flow-rail" aria-label="Embedding to final normalization flow"></div>
           <div class="token-context">
             <span class="quiet">Nearby tokens</span>
             <div id="token-strip" class="token-strip"></div>

--- a/hermes-web/src/model-lab/main.js
+++ b/hermes-web/src/model-lab/main.js
@@ -4,6 +4,7 @@ import {
   availableMetrics,
   formatCount,
   formatValue,
+  interpolateHeatmap,
   layerGradientHeatmap,
   metricSeries,
   normalizedMetricHeatmap,
@@ -14,6 +15,7 @@ import {
 const $ = (id) => document.getElementById(id)
 const css = (name) => window.getComputedStyle(document.documentElement).getPropertyValue(name).trim()
 const svgNamespace = 'http://www.w3.org/2000/svg'
+const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
 
 const state = {
   trace: null,
@@ -30,6 +32,9 @@ const state = {
   playing: false,
   playbackDelay: 700,
   playbackTimer: null,
+  animationFrame: null,
+  animating: false,
+  animationTarget: null,
 }
 
 function showError(message) {
@@ -116,9 +121,8 @@ function renderArchitecture() {
       stopPlayback()
       state.selectedLayer = index
       const stageIndex = state.trace.inference.stages.findIndex((stage) => stage.layer_index === layer.index)
-      if (stageIndex >= 0) state.selectedStage = stageIndex
-      syncArchitectureSelection()
-      $('stage-select').value = String(state.selectedStage)
+      if (stageIndex >= 0) commitStage(stageIndex, { render: false })
+      else syncArchitectureSelection()
     })
     grid.append(button)
   })
@@ -205,63 +209,199 @@ function populateInferenceControls() {
     tokenSelect.append(option)
   })
   tokenSelect.value = String(state.selectedToken)
+  renderFlowRail()
 }
 
-function updatePlaybackControls() {
+function renderFlowRail() {
+  const rail = $('flow-rail')
+  rail.replaceChildren()
+  const stages = state.trace.inference.stages
+  stages.forEach((stage, index) => {
+    const button = document.createElement('button')
+    button.type = 'button'
+    button.className = 'flow-node'
+    button.dataset.stageIndex = String(index)
+    button.dataset.mixer = stage.mixer ?? (index === 0 || index === stages.length - 1 ? 'endpoint' : 'block')
+    button.setAttribute('aria-label', `Stage ${index + 1} of ${stages.length}: ${stage.label}`)
+
+    const marker = document.createElement('span')
+    marker.className = 'flow-node-marker'
+    marker.setAttribute('aria-hidden', 'true')
+    const label = document.createElement('span')
+    label.className = 'flow-node-label'
+    label.textContent = index === 0 ? 'Emb' : index === stages.length - 1 ? 'Norm' : `L${stage.layer_index ?? index}`
+    button.append(marker, label)
+    button.addEventListener('click', () => transitionToStage(index))
+    rail.append(button)
+  })
+  updateFlowRail(state.selectedStage)
+}
+
+function updateFlowRail(progress = state.selectedStage) {
+  const rail = $('flow-rail')
+  const current = Math.round(progress)
+  rail.dataset.animating = String(state.animating)
+  rail.querySelectorAll('.flow-node').forEach((button) => {
+    const index = Number(button.dataset.stageIndex)
+    button.dataset.state = index === current ? 'current' : index < progress ? 'past' : 'future'
+    if (index === current) button.setAttribute('aria-current', 'step')
+    else button.removeAttribute('aria-current')
+    const incomingFill = Math.max(0, Math.min(1, progress - index + 1))
+    const segmentFill = Math.max(0, Math.min(1, progress - index))
+    button.style.setProperty('--flow-incoming', `${incomingFill * 100}%`)
+    button.style.setProperty('--flow-fill', `${segmentFill * 100}%`)
+  })
+}
+
+function updatePlaybackControls(progress = state.selectedStage) {
   if (!state.trace) return
   const count = state.trace.inference.stages.length
   const atStart = state.selectedStage === 0
   const atEnd = state.selectedStage === count - 1
-  $('flow-prev').disabled = atStart
-  $('flow-next').disabled = atEnd
+  $('flow-prev').disabled = state.animating || atStart
+  $('flow-next').disabled = state.animating || atEnd
   $('flow-play').textContent = state.playing ? 'Pause' : 'Play'
   $('flow-play').setAttribute('aria-pressed', String(state.playing))
-  $('flow-progress').max = count
-  $('flow-progress').value = state.selectedStage + 1
-  setText('flow-position', `${state.selectedStage + 1} / ${count}`)
+  $('flow-progress').max = Math.max(1, count - 1)
+  $('flow-progress').value = Math.max(0, Math.min(count - 1, progress))
+  const position = state.animating && Number.isInteger(state.animationTarget)
+    ? `${state.selectedStage + 1} → ${state.animationTarget + 1} / ${count}`
+    : `${state.selectedStage + 1} / ${count}`
+  setText('flow-position', position)
+  updateFlowRail(progress)
 }
 
-function stopPlayback() {
+function cancelAnimation() {
+  const wasAnimating = state.animating
+  if (state.animationFrame !== null) window.cancelAnimationFrame(state.animationFrame)
+  state.animationFrame = null
+  state.animating = false
+  state.animationTarget = null
+  $('view-inference').removeAttribute('aria-busy')
+  return wasAnimating
+}
+
+function stopPlayback({ settle = true } = {}) {
   if (state.playbackTimer !== null) window.clearTimeout(state.playbackTimer)
   state.playbackTimer = null
   state.playing = false
-  updatePlaybackControls()
+  const wasAnimating = cancelAnimation()
+  if (settle && wasAnimating && state.trace) renderInference({ renderTokens: false })
+  else updatePlaybackControls()
 }
 
-function setStage(index, { pause = true } = {}) {
-  if (pause) stopPlayback()
+function commitStage(index, { render = true } = {}) {
   const lastStage = state.trace.inference.stages.length - 1
   state.selectedStage = Math.max(0, Math.min(lastStage, index))
   state.selectedHead = 0
   syncLayerFromStage()
   syncArchitectureSelection()
-  renderInference()
+  if (render) renderInference({ renderTokens: false })
+  else {
+    $('stage-select').value = String(state.selectedStage)
+    updatePlaybackControls()
+  }
+}
+
+function easeInOutCubic(progress) {
+  return progress < 0.5
+    ? 4 * progress * progress * progress
+    : 1 - Math.pow(-2 * progress + 2, 3) / 2
+}
+
+function animateAdjacentStage(target, duration, onComplete) {
+  const source = state.selectedStage
+  const from = state.trace.inference.stages[source]
+  const to = state.trace.inference.stages[target]
+  if (reducedMotion.matches || duration <= 0) {
+    commitStage(target)
+    onComplete()
+    return
+  }
+
+  const scale = interpolateHeatmap(from.activation, to.activation, 0)
+  renderScale(scale, $('activation-scale'))
+  setText('activation-title', `${from.label} → ${to.label}`)
+  state.animating = true
+  state.animationTarget = target
+  $('view-inference').setAttribute('aria-busy', 'true')
+  updatePlaybackControls(source)
+  const startedAt = window.performance.now()
+
+  const frame = (now) => {
+    const linear = Math.min(1, (now - startedAt) / duration)
+    const eased = easeInOutCubic(linear)
+    const progress = source + (target - source) * eased
+    const heatmap = interpolateHeatmap(from.activation, to.activation, eased)
+    renderHeatmap($('activation-heatmap'), heatmap, {
+      divergent: true,
+      minHeight: 320,
+      label: `${from.label} to ${to.label} residual-stream transition`,
+    })
+    updatePlaybackControls(progress)
+    if (linear < 1) {
+      state.animationFrame = window.requestAnimationFrame(frame)
+      return
+    }
+
+    state.animationFrame = null
+    state.animating = false
+    state.animationTarget = null
+    $('view-inference').removeAttribute('aria-busy')
+    commitStage(target)
+    onComplete()
+  }
+  state.animationFrame = window.requestAnimationFrame(frame)
+}
+
+function runStageSequence(target, duration, onComplete) {
+  if (state.selectedStage === target) {
+    onComplete?.()
+    return
+  }
+  const next = state.selectedStage + Math.sign(target - state.selectedStage)
+  animateAdjacentStage(next, duration, () => runStageSequence(target, duration, onComplete))
+}
+
+function transitionToStage(index, { pause = true, onComplete = null } = {}) {
+  if (pause) stopPlayback()
+  const lastStage = state.trace.inference.stages.length - 1
+  const target = Math.max(0, Math.min(lastStage, index))
+  if (target === state.selectedStage) {
+    updatePlaybackControls()
+    onComplete?.()
+    return
+  }
+  const distance = Math.abs(target - state.selectedStage)
+  const duration = distance === 1
+    ? Math.max(220, Math.min(650, state.playbackDelay * 0.72))
+    : Math.max(70, Math.min(180, 1000 / distance))
+  runStageSequence(target, duration, onComplete)
 }
 
 function schedulePlayback() {
-  if (!state.playing) return
+  if (!state.playing || state.animating) return
+  const delay = reducedMotion.matches ? state.playbackDelay : Math.max(70, state.playbackDelay * 0.18)
   state.playbackTimer = window.setTimeout(() => {
+    state.playbackTimer = null
     if (state.selectedStage >= state.trace.inference.stages.length - 1) {
       stopPlayback()
       return
     }
-    setStage(state.selectedStage + 1, { pause: false })
-    schedulePlayback()
-  }, state.playbackDelay)
+    transitionToStage(state.selectedStage + 1, { pause: false, onComplete: schedulePlayback })
+  }, delay)
 }
 
 function startPlayback() {
   if (state.trace.inference.stages.length < 2) return
   stopPlayback()
-  if (state.selectedStage >= state.trace.inference.stages.length - 1) {
-    setStage(0, { pause: false })
-  }
+  if (state.selectedStage >= state.trace.inference.stages.length - 1) commitStage(0)
   state.playing = true
   updatePlaybackControls()
   schedulePlayback()
 }
 
-function renderInference() {
+function renderInference({ renderTokens = true } = {}) {
   const { inference } = state.trace
   const stage = inference.stages[state.selectedStage]
   $('stage-select').value = String(state.selectedStage)
@@ -269,7 +409,7 @@ function renderInference() {
   setText('activation-title', stage.label)
   renderScale(stage.activation, $('activation-scale'))
   renderHeatmap($('activation-heatmap'), stage.activation, { divergent: true, minHeight: 320, label: `${stage.label} residual-stream activation` })
-  renderTokenStrip()
+  if (renderTokens) renderTokenStrip()
   renderRmsChart()
   renderMixerTrace(stage)
   setText('generated-text', inference.generated_text || 'The generation stopped without a decoded continuation.')
@@ -295,7 +435,7 @@ function renderTokenStrip() {
     button.dataset.source = token.source
     button.setAttribute('aria-pressed', String(index === state.selectedToken))
     button.textContent = token.display
-    button.setAttribute('aria-label', `Token ${token.original_index}, ${token.piece}, ${token.source}`)
+    button.setAttribute('aria-label', `Token ${token.original_index}, ${token.display}, ${token.source}`)
     button.addEventListener('click', () => {
       stopPlayback()
       state.selectedToken = index
@@ -318,7 +458,7 @@ function renderRmsChart() {
     selectedIndex: state.selectedStage,
     compact: true,
   })
-  setText('rms-selection', `Token ${token.original_index} “${token.piece || token.display}” · ${state.trace.inference.stages[state.selectedStage].label}: ${formatValue(series[state.selectedStage].value)}`)
+  setText('rms-selection', `Token ${token.original_index} “${token.display}” · ${state.trace.inference.stages[state.selectedStage].label}: ${formatValue(series[state.selectedStage].value)}`)
 }
 
 function renderMixerTrace(stage) {
@@ -403,23 +543,31 @@ function parseColor(value) {
 }
 
 function mixColor(left, right, amount) {
-  const a = parseColor(left)
-  const b = parseColor(right)
   const t = Math.max(0, Math.min(1, amount))
-  return `rgb(${a.map((value, index) => Math.round(value + (b[index] - value) * t)).join(' ')})`
+  return `rgb(${left.map((value, index) => Math.round(value + (right[index] - value) * t)).join(' ')})`
 }
 
-function heatColor(value, heatmap, options) {
+function heatPalette() {
+  return {
+    negative: parseColor(css('--heat-negative')),
+    zero: parseColor(css('--heat-zero')),
+    positive: parseColor(css('--heat-positive')),
+    sequentialLow: parseColor(css('--heat-sequential-low')),
+    sequentialHigh: parseColor(css('--heat-sequential-high')),
+  }
+}
+
+function heatColor(value, heatmap, options, palette) {
   if (options.sequential) {
     const range = heatmap.max - heatmap.min
     const t = range === 0 ? 0.5 : (value - heatmap.min) / range
-    return mixColor(css('--heat-sequential-low'), css('--heat-sequential-high'), t)
+    return mixColor(palette.sequentialLow, palette.sequentialHigh, t)
   }
   const maximum = Math.max(Math.abs(heatmap.min), Math.abs(heatmap.max), Number.EPSILON)
   const t = Math.min(1, Math.abs(value) / maximum)
   return value < 0
-    ? mixColor(css('--heat-zero'), css('--heat-negative'), t)
-    : mixColor(css('--heat-zero'), css('--heat-positive'), t)
+    ? mixColor(palette.zero, palette.negative, t)
+    : mixColor(palette.zero, palette.positive, t)
 }
 
 function renderHeatmap(canvas, heatmap, options = {}) {
@@ -427,9 +575,11 @@ function renderHeatmap(canvas, heatmap, options = {}) {
   const cssWidth = Math.max(280, wrap.clientWidth)
   const cssHeight = Math.max(options.minHeight ?? 280, Math.min(520, heatmap.rows * 18 + 82))
   const ratio = Math.min(window.devicePixelRatio || 1, 2)
-  canvas.width = Math.round(cssWidth * ratio)
-  canvas.height = Math.round(cssHeight * ratio)
-  canvas.style.height = `${cssHeight}px`
+  const pixelWidth = Math.round(cssWidth * ratio)
+  const pixelHeight = Math.round(cssHeight * ratio)
+  if (canvas.width !== pixelWidth) canvas.width = pixelWidth
+  if (canvas.height !== pixelHeight) canvas.height = pixelHeight
+  if (canvas.style.height !== `${cssHeight}px`) canvas.style.height = `${cssHeight}px`
   canvas.setAttribute('role', 'img')
   canvas.setAttribute('aria-label', options.label ?? `${heatmap.rows} by ${heatmap.cols} heatmap`)
   const context = canvas.getContext('2d')
@@ -441,10 +591,11 @@ function renderHeatmap(canvas, heatmap, options = {}) {
   const plotHeight = cssHeight - margins.top - margins.bottom
   const cellWidth = plotWidth / heatmap.cols
   const cellHeight = plotHeight / heatmap.rows
+  const palette = heatPalette()
   for (let row = 0; row < heatmap.rows; row += 1) {
     for (let column = 0; column < heatmap.cols; column += 1) {
       const value = heatmap.values[row * heatmap.cols + column]
-      context.fillStyle = heatColor(value, heatmap, options)
+      context.fillStyle = heatColor(value, heatmap, options, palette)
       context.fillRect(margins.left + column * cellWidth, margins.top + row * cellHeight, Math.ceil(cellWidth + 0.3), Math.ceil(cellHeight + 0.3))
     }
   }
@@ -709,7 +860,7 @@ $('trace-file').addEventListener('change', async (event) => {
 
 $('load-demo').addEventListener('click', () => setTrace(demoTrace, 'Synthetic example'))
 $('stage-select').addEventListener('change', (event) => {
-  setStage(Number(event.target.value))
+  transitionToStage(Number(event.target.value))
 })
 $('token-select').addEventListener('change', (event) => {
   stopPlayback()
@@ -732,15 +883,15 @@ $('live-prompt').addEventListener('keydown', (event) => {
     $('live-query-form').requestSubmit()
   }
 })
-$('flow-prev').addEventListener('click', () => setStage(state.selectedStage - 1))
-$('flow-next').addEventListener('click', () => setStage(state.selectedStage + 1))
+$('flow-prev').addEventListener('click', () => transitionToStage(state.selectedStage - 1))
+$('flow-next').addEventListener('click', () => transitionToStage(state.selectedStage + 1))
 $('flow-play').addEventListener('click', () => {
   if (state.playing) stopPlayback()
   else startPlayback()
 })
 $('flow-speed').addEventListener('change', (event) => {
   state.playbackDelay = Number(event.target.value)
-  if (state.playing) {
+  if (state.playing && !state.animating) {
     if (state.playbackTimer !== null) window.clearTimeout(state.playbackTimer)
     schedulePlayback()
   }
@@ -757,7 +908,7 @@ window.addEventListener('resize', () => {
   window.requestAnimationFrame(() => {
     resizeQueued = false
     const visibleView = document.querySelector('.view:not([hidden])')?.id
-    if (visibleView === 'view-inference') renderInference()
+    if (visibleView === 'view-inference') renderInference({ renderTokens: false })
     if (visibleView === 'view-training') renderTraining()
   })
 })

--- a/hermes-web/src/model-lab/styles.css
+++ b/hermes-web/src/model-lab/styles.css
@@ -155,7 +155,23 @@ select { min-height: 36px; margin-left: 7px; border: 1px solid var(--line-strong
 .flow-progress-wrap progress { width: 100%; height: 7px; border: 0; border-radius: 999px; overflow: hidden; background: var(--line); accent-color: var(--accent); }
 .flow-progress-wrap progress::-webkit-progress-bar { border-radius: 999px; background: var(--line); }
 .flow-progress-wrap progress::-webkit-progress-value { border-radius: 999px; background: var(--accent); }
-.flow-position { min-width: 6.5ch; font-size: .76rem; font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap; }
+#flow-position { min-width: 9.5ch; font-size: .76rem; font-variant-numeric: tabular-nums; text-align: right; white-space: nowrap; }
+.flow-rail { display: grid; grid-template-columns: repeat(auto-fit, minmax(42px, 1fr)); gap: 4px; margin: 0 0 18px; }
+.flow-node { --flow-incoming: 0%; --flow-fill: 0%; position: relative; display: grid; min-width: 0; border: 0; background: transparent; padding: 0 2px 5px; color: var(--muted); place-items: center; cursor: pointer; }
+.flow-node::before, .flow-node::after { position: absolute; z-index: 0; top: 7px; width: 50%; height: 2px; content: ""; }
+.flow-node::before { left: 0; background: linear-gradient(to right, var(--accent) 0 var(--flow-incoming), var(--line-strong) var(--flow-incoming) 100%); }
+.flow-node::after { left: 50%; background: linear-gradient(to right, var(--accent) 0 var(--flow-fill), var(--line-strong) var(--flow-fill) 100%); }
+.flow-node:first-child::before { display: none; }
+.flow-node:last-child::after { display: none; }
+.flow-node-marker { position: relative; z-index: 1; width: 15px; height: 15px; border: 2px solid var(--line-strong); border-radius: 999px; background: var(--surface); transition: background-color 160ms ease, border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease; }
+.flow-node[data-mixer="attention"] .flow-node-marker { border-color: var(--attention); }
+.flow-node[data-mixer="mamba"] .flow-node-marker { border-color: var(--mamba); border-radius: 3px; transform: rotate(45deg); }
+.flow-node[data-mixer="endpoint"] .flow-node-marker { width: 22px; border-color: var(--accent); border-radius: 4px; }
+.flow-node[data-state="past"] .flow-node-marker { border-color: var(--accent); background: var(--accent-soft); }
+.flow-node[data-state="current"] .flow-node-marker { border-color: var(--accent); background: var(--accent); box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 18%, transparent); transform: scale(1.12); }
+.flow-node[data-state="current"][data-mixer="mamba"] .flow-node-marker { transform: rotate(45deg) scale(1.12); }
+.flow-node-label { overflow: hidden; width: 100%; margin-top: 6px; font-size: .7rem; font-variant-numeric: tabular-nums; text-align: center; text-overflow: ellipsis; white-space: nowrap; }
+.flow-node[data-state="current"] .flow-node-label { color: var(--ink); font-weight: 500; }
 
 .architecture-layout { display: grid; grid-template-columns: minmax(0, 1.7fr) minmax(290px, .7fr); gap: 26px; align-items: start; }
 .endpoint { display: flex; align-items: center; justify-content: space-between; border: 1px solid var(--line); border-radius: 12px; background: var(--surface-raised); padding: 13px 16px; }
@@ -245,6 +261,7 @@ footer { margin-top: 30px; border-top: 1px solid var(--line); padding-top: 18px;
   .flow-controls > *, .flow-progress-wrap { width: 100%; }
   .playback-buttons > button { flex: 1; }
   .flow-progress-wrap { grid-template-columns: minmax(0, 1fr) auto; }
+  .flow-rail { grid-template-columns: repeat(auto-fit, minmax(36px, 1fr)); }
   .summary-stats { grid-template-columns: 1fr; }
   .summary-stats div { border-left: 0; border-top: 1px solid var(--line); padding: 10px 0 0; }
   .tabs { overflow-x: auto; }

--- a/hermes-web/src/model-lab/trace-utils.js
+++ b/hermes-web/src/model-lab/trace-utils.js
@@ -24,6 +24,19 @@ export function validateHeatmap(heatmap, path) {
   return heatmap
 }
 
+export function interpolateHeatmap(from, to, progress) {
+  if (from.rows !== to.rows || from.cols !== to.cols || from.values.length !== to.values.length) {
+    fail('Cannot interpolate heatmaps with different shapes')
+  }
+  const amount = Math.max(0, Math.min(1, progress))
+  return {
+    ...from,
+    values: from.values.map((value, index) => value + (to.values[index] - value) * amount),
+    min: Math.min(from.min, to.min),
+    max: Math.max(from.max, to.max),
+  }
+}
+
 export function validateTrace(trace) {
   if (!isObject(trace)) fail('Trace bundle must be a JSON object')
   if (trace.kind !== TRACE_KIND) fail(`Unsupported trace kind: ${String(trace.kind)}`)

--- a/hermes-web/src/model-lab/trace-utils.test.js
+++ b/hermes-web/src/model-lab/trace-utils.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { demoTrace } from './demo-trace.js'
-import { layerGradientHeatmap, normalizedMetricHeatmap, validateTrace } from './trace-utils.js'
+import { interpolateHeatmap, layerGradientHeatmap, normalizedMetricHeatmap, validateTrace } from './trace-utils.js'
 
 const clone = (value) => JSON.parse(JSON.stringify(value))
 
@@ -20,6 +20,24 @@ test('reader rejects heatmaps whose dense shape does not match values', () => {
   const trace = clone(demoTrace)
   trace.inference.stages[0].activation.values.pop()
   assert.throws(() => validateTrace(trace), /entries; expected/)
+})
+
+test('heatmap interpolation moves values while keeping a stable endpoint scale', () => {
+  const from = { rows: 1, cols: 2, values: [-2, 2], min: -2, max: 2 }
+  const to = { rows: 1, cols: 2, values: [4, -4], min: -4, max: 4 }
+  const middle = interpolateHeatmap(from, to, 0.5)
+
+  assert.deepEqual(middle.values, [1, -1])
+  assert.equal(middle.min, -4)
+  assert.equal(middle.max, 4)
+  assert.deepEqual(interpolateHeatmap(from, to, -1).values, from.values)
+  assert.deepEqual(interpolateHeatmap(from, to, 2).values, to.values)
+})
+
+test('heatmap interpolation rejects incompatible captures', () => {
+  const from = { rows: 1, cols: 1, values: [0], min: 0, max: 0 }
+  const to = { rows: 2, cols: 1, values: [0, 1], min: 0, max: 1 }
+  assert.throws(() => interpolateHeatmap(from, to, 0.5), /different shapes/)
 })
 
 test('training heatmaps retain metric and layer axes', () => {


### PR DESCRIPTION
## Summary
- interpolate captured residual activations between adjacent stages without reallocating the canvas
- add a labeled embedding-to-layer-to-norm flow rail with reduced-motion behavior
- decode byte-level tokenizer pieces for readable token cards while preserving raw pieces in trace bundles

## Validation
- cargo test -p hermes-llm
- cargo clippy -p hermes-llm --all-targets -- -D warnings
- node --test src/model-lab/*.test.js
- eslint src/model-lab
- vite build --config model-lab.vite.config.js