### PR TITLE
feat(llm): add educational signal flow graph

### DIFF
--- a/docs/llm-visualization-lab.md
+++ b/docs/llm-visualization-lab.md
@@ -62,6 +62,19 @@ not channel-binned, but only the requested leading heads are retained. Mamba
 state is reduced over contiguous inner-channel bins. Every reduction records
 the original and captured dimensions in `capture`; nothing is silently dropped.
 
+For the selected token, the inference view also renders a compact signal-flow
+graph across model depth. Its log-scaled vertical position reports the exact RMS
+captured from the full hidden vector, and the thickness of each incoming edge
+reports the exact RMS of that block's residual update. Attention, Mamba, and
+endpoint stages use different node shapes. Small positive/negative bars
+summarize the squared energy of the captured signed channel-bin means; this sign
+balance is explicitly approximate because values were aggregated before they
+reached the browser.
+Dense models retain every graph segment but reduce stage labels and glyphs to
+fit the available width. Playback moves one probe over the graph instead of
+rebuilding it, and the visible readout reports the interpolated display value
+between exact captured endpoints.
+
 Training rows retain the original JSON objects. If their count exceeds the
 configured limit, deterministic evenly spaced sampling keeps the first and last
 row and records total rows, retained rows, and sampling stride.

--- a/hermes-web/model-lab.html
+++ b/hermes-web/model-lab.html
@@ -141,6 +141,14 @@
             <span class="quiet">Nearby tokens</span>
             <div id="token-strip" class="token-strip"></div>
           </div>
+          <section class="visual-panel signal-flow-panel" aria-labelledby="signal-flow-title">
+            <div class="panel-heading">
+              <div><p class="eyebrow">Selected token · compressed hidden state</p><h3 id="signal-flow-title">Signal flow across layers</h3></div>
+              <p id="signal-flow-compression" class="signal-flow-compression quiet"></p>
+            </div>
+            <svg id="signal-flow-chart" class="signal-flow-chart" role="img" aria-labelledby="signal-flow-title signal-flow-description"></svg>
+            <p id="signal-flow-description" class="chart-selection quiet" aria-live="polite"></p>
+          </section>
           <div class="visual-grid">
             <section class="visual-panel wide-panel">
               <div class="panel-heading">
@@ -148,11 +156,6 @@
                 <div id="activation-scale" class="scale-legend"></div>
               </div>
               <div class="heatmap-wrap"><canvas id="activation-heatmap"></canvas></div>
-            </section>
-            <section class="visual-panel">
-              <div class="panel-heading"><div><p class="eyebrow">Across depth</p><h3>Selected-token energy</h3></div></div>
-              <svg id="rms-chart" class="line-chart" role="img" aria-label="Selected token RMS across model stages"></svg>
-              <p id="rms-selection" class="chart-selection quiet"></p>
             </section>
           </div>
           <div id="mixer-visuals" class="visual-grid mixer-visuals">

--- a/hermes-web/src/model-lab/main.js
+++ b/hermes-web/src/model-lab/main.js
@@ -9,6 +9,7 @@ import {
   metricSeries,
   normalizedMetricHeatmap,
   parseTraceJson,
+  tokenSignalSeries,
   validateTrace,
 } from './trace-utils.js'
 
@@ -269,6 +270,7 @@ function updatePlaybackControls(progress = state.selectedStage) {
     : `${state.selectedStage + 1} / ${count}`
   setText('flow-position', position)
   updateFlowRail(progress)
+  updateSignalFlow(progress)
 }
 
 function cancelAnimation() {
@@ -401,7 +403,7 @@ function startPlayback() {
   schedulePlayback()
 }
 
-function renderInference({ renderTokens = true } = {}) {
+function renderInference({ renderTokens = true, renderSignal = renderTokens } = {}) {
   const { inference } = state.trace
   const stage = inference.stages[state.selectedStage]
   $('stage-select').value = String(state.selectedStage)
@@ -410,7 +412,7 @@ function renderInference({ renderTokens = true } = {}) {
   renderScale(stage.activation, $('activation-scale'))
   renderHeatmap($('activation-heatmap'), stage.activation, { divergent: true, minHeight: 320, label: `${stage.label} residual-stream activation` })
   if (renderTokens) renderTokenStrip()
-  renderRmsChart()
+  if (renderSignal) renderSignalFlowChart()
   renderMixerTrace(stage)
   setText('generated-text', inference.generated_text || 'The generation stopped without a decoded continuation.')
   setText('prompt-token-count', inference.prompt_token_count)
@@ -443,22 +445,6 @@ function renderTokenStrip() {
     })
     strip.append(button)
   }
-}
-
-function renderRmsChart() {
-  const token = state.trace.inference.tokens[state.selectedToken]
-  const series = state.trace.inference.stages.map((stage, index) => ({
-    step: index,
-    value: stage.token_rms[state.selectedToken],
-    stage: stage.label,
-  }))
-  renderLineChart($('rms-chart'), series, {
-    xLabel: 'model depth',
-    yLabel: 'RMS',
-    selectedIndex: state.selectedStage,
-    compact: true,
-  })
-  setText('rms-selection', `Token ${token.original_index} “${token.display}” · ${state.trace.inference.stages[state.selectedStage].label}: ${formatValue(series[state.selectedStage].value)}`)
 }
 
 function renderMixerTrace(stage) {
@@ -656,6 +642,265 @@ function svgElement(name, attributes = {}) {
   const element = document.createElementNS(svgNamespace, name)
   for (const [key, value] of Object.entries(attributes)) element.setAttribute(key, String(value))
   return element
+}
+
+function renderSignalFlowChart() {
+  const svg = $('signal-flow-chart')
+  const series = tokenSignalSeries(state.trace.inference, state.selectedToken)
+  svg.replaceChildren()
+  if (series.length < 2) return
+
+  const measuredWidth = svg.getBoundingClientRect().width
+  const width = Math.max(300, Math.round(measuredWidth || 960))
+  const height = 330
+  const margin = { left: width < 480 ? 42 : 54, right: 18, top: 42 }
+  const rmsBottom = 190
+  const signBaseline = 242
+  const labelY = 286
+  const plotWidth = width - margin.left - margin.right
+  const positiveRms = series.map((point) => point.rms).filter((value) => value > 0)
+  const rmsMin = Math.max(Math.min(...positiveRms, 1) * 0.82, Number.EPSILON)
+  const rmsMax = Math.max(...series.map((point) => point.rms), rmsMin) * 1.08
+  const logMin = Math.log10(rmsMin)
+  const logMax = Math.max(Math.log10(rmsMax), logMin + 0.1)
+  const updateMax = Math.max(...series.map((point) => point.updateRms ?? 0), Number.EPSILON)
+  const x = (stageIndex) => margin.left + stageIndex / (series.length - 1) * plotWidth
+  const y = (rms) => {
+    const normalized = (Math.log10(Math.max(rms, rmsMin)) - logMin) / (logMax - logMin)
+    return rmsBottom - normalized * (rmsBottom - margin.top)
+  }
+
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
+  const title = svgElement('title')
+  title.textContent = 'Selected-token signal flow across model depth'
+  const description = svgElement('desc')
+  description.textContent = 'Log-scaled vertical position reports exact token RMS, edge width reports residual update RMS, node shape is mixer type, and diverging bars approximate positive and negative energy in captured channel bins.'
+  svg.append(title, description)
+
+  const encoding = svgElement('text', {
+    x: margin.left,
+    y: 17,
+    class: 'signal-flow-encoding',
+  })
+  encoding.textContent = width < 590
+    ? 'RMS(log) line · Δ edge · +/− bins'
+    : 'height: token RMS (log) · edge width: residual update · bars: +/− captured-bin energy'
+  svg.append(encoding)
+  if (width >= 700) {
+    const mixers = svgElement('text', {
+      x: width - margin.right,
+      y: 17,
+      class: 'signal-flow-encoding',
+      'text-anchor': 'end',
+    })
+    mixers.textContent = '○ attention · ◇ Mamba'
+    svg.append(mixers)
+  }
+
+  const rmsTicks = [rmsMin, Math.sqrt(rmsMin * rmsMax), rmsMax]
+  for (const value of rmsTicks) {
+    const position = y(value)
+    svg.append(svgElement('line', {
+      x1: margin.left,
+      x2: width - margin.right,
+      y1: position,
+      y2: position,
+      class: 'signal-flow-grid',
+    }))
+    const label = svgElement('text', {
+      x: margin.left - 8,
+      y: position + 4,
+      class: 'signal-flow-axis-label',
+      'text-anchor': 'end',
+    })
+    label.textContent = formatValue(value)
+    svg.append(label)
+  }
+
+  const yLabel = svgElement('text', {
+    x: 13,
+    y: (margin.top + rmsBottom) / 2,
+    class: 'signal-flow-axis-label',
+    transform: `rotate(-90 13 ${(margin.top + rmsBottom) / 2})`,
+    'text-anchor': 'middle',
+  })
+  yLabel.textContent = 'token RMS · log'
+  const signLine = svgElement('line', {
+    x1: margin.left,
+    x2: width - margin.right,
+    y1: signBaseline,
+    y2: signBaseline,
+    class: 'signal-flow-sign-axis',
+  })
+  const signLabel = svgElement('text', {
+    x: margin.left - 8,
+    y: signBaseline + 4,
+    class: 'signal-flow-axis-label',
+    'text-anchor': 'end',
+  })
+  signLabel.textContent = '+/−'
+  const xLabel = svgElement('text', {
+    x: margin.left + plotWidth / 2,
+    y: height - 5,
+    class: 'signal-flow-axis-label',
+    'text-anchor': 'middle',
+  })
+  xLabel.textContent = 'embedding → transformer depth → final norm'
+  svg.append(yLabel, signLine, signLabel, xLabel)
+
+  const edges = []
+  for (let index = 1; index < series.length; index += 1) {
+    const from = series[index - 1]
+    const to = series[index]
+    const left = x(from.stageIndex)
+    const right = x(to.stageIndex)
+    const middle = (left + right) / 2
+    const update = to.updateRms ?? 0
+    const edge = svgElement('path', {
+      d: `M ${left.toFixed(2)} ${y(from.rms).toFixed(2)} C ${middle.toFixed(2)} ${y(from.rms).toFixed(2)}, ${middle.toFixed(2)} ${y(to.rms).toFixed(2)}, ${right.toFixed(2)} ${y(to.rms).toFixed(2)}`,
+      class: 'signal-flow-edge',
+      'stroke-width': 1.4 + 7 * Math.log1p(update) / Math.log1p(updateMax),
+    })
+    const edgeTitle = svgElement('title')
+    edgeTitle.textContent = `${from.label} → ${to.label}: residual update RMS ${formatValue(to.updateRms)}`
+    edge.append(edgeTitle)
+    svg.append(edge)
+    edges.push({ stageIndex: index, element: edge })
+  }
+
+  const probeGuide = svgElement('line', {
+    y1: margin.top,
+    y2: signBaseline + 31,
+    class: 'signal-flow-probe-guide',
+  })
+  svg.append(probeGuide)
+
+  const glyphTarget = Math.max(8, Math.floor(width / 34))
+  const glyphStride = Math.max(1, Math.ceil(series.length / glyphTarget))
+  const labelTarget = Math.max(4, Math.floor(width / 72))
+  const labelStride = Math.max(1, Math.ceil(series.length / labelTarget))
+  const nodes = []
+  series.forEach((point, index) => {
+    const showGlyph = index === 0 || index === series.length - 1 || index % glyphStride === 0
+    const showLabel = index === 0 || index === series.length - 1 || index % labelStride === 0
+    if (showGlyph) {
+      const group = svgElement('g', {
+        class: 'signal-flow-stage',
+        'data-stage-index': index,
+        'data-mixer': point.mixer ?? 'endpoint',
+      })
+      const stageTitle = svgElement('title')
+      stageTitle.textContent = `${point.label}: RMS ${formatValue(point.rms)}, update ${formatValue(point.updateRms)}, positive-bin energy ${(point.positiveBinEnergy * 100).toFixed(1)}%`
+      group.append(stageTitle)
+
+      const positiveHeight = point.positiveBinEnergy * 30
+      const negativeHeight = point.negativeBinEnergy * 30
+      group.append(
+        svgElement('rect', {
+          x: x(index) - 3,
+          y: signBaseline - positiveHeight,
+          width: 6,
+          height: positiveHeight,
+          class: 'signal-flow-positive',
+        }),
+        svgElement('rect', {
+          x: x(index) - 3,
+          y: signBaseline,
+          width: 6,
+          height: negativeHeight,
+          class: 'signal-flow-negative',
+        }),
+      )
+
+      const yPosition = y(point.rms)
+      let shape
+      if (point.mixer === 'attention') {
+        shape = svgElement('circle', { cx: x(index), cy: yPosition, r: 5.5, class: 'signal-flow-node-shape' })
+      } else if (point.mixer === 'mamba') {
+        shape = svgElement('polygon', {
+          points: `${x(index)},${yPosition - 6} ${x(index) + 6},${yPosition} ${x(index)},${yPosition + 6} ${x(index) - 6},${yPosition}`,
+          class: 'signal-flow-node-shape',
+        })
+      } else {
+        shape = svgElement('rect', { x: x(index) - 7, y: yPosition - 5, width: 14, height: 10, rx: 3, class: 'signal-flow-node-shape' })
+      }
+      group.append(shape)
+      svg.append(group)
+      nodes.push({ stageIndex: index, element: group })
+    }
+
+    if (showLabel) {
+      const label = svgElement('text', {
+        x: x(index),
+        y: labelY,
+        class: 'signal-flow-stage-label',
+        'text-anchor': 'middle',
+      })
+      label.textContent = index === 0 ? 'Emb' : index === series.length - 1 ? 'Norm' : `L${point.layerIndex ?? index}`
+      svg.append(label)
+    }
+  })
+
+  const probeHalo = svgElement('circle', { r: 10, class: 'signal-flow-probe-halo' })
+  const probe = svgElement('circle', { r: 4.5, class: 'signal-flow-probe' })
+  const probeValue = svgElement('text', { class: 'signal-flow-probe-value' })
+  svg.append(probeHalo, probe, probeValue)
+  svg.__signalFlow = { series, width, x, y, probe, probeHalo, probeGuide, probeValue, nodes, edges }
+
+  const hiddenChannels = state.trace.capture?.original_hidden_channels ?? state.trace.model.hidden_size
+  setText('signal-flow-compression', `${formatCount(hiddenChannels)} hidden values → ${series[0].capturedBins} signed bins · RMS/Δ exact`)
+  updateSignalFlow(state.selectedStage)
+}
+
+function updateSignalFlow(progress = state.selectedStage) {
+  const svg = $('signal-flow-chart')
+  const rendered = svg.__signalFlow
+  if (!rendered) return
+  const last = rendered.series.length - 1
+  const bounded = Math.max(0, Math.min(last, progress))
+  const leftIndex = Math.floor(bounded)
+  const rightIndex = Math.ceil(bounded)
+  const amount = bounded - leftIndex
+  const left = rendered.series[leftIndex]
+  const right = rendered.series[rightIndex]
+  const interpolate = (from, to) => from + (to - from) * amount
+  const rms = interpolate(left.rms, right.rms)
+  const positive = interpolate(left.positiveBinEnergy, right.positiveBinEnergy)
+  const negative = interpolate(left.negativeBinEnergy, right.negativeBinEnergy)
+  const binMean = interpolate(left.binMean, right.binMean)
+  const xPosition = rendered.x(bounded)
+  const yPosition = rendered.y(rms)
+  for (const element of [rendered.probe, rendered.probeHalo]) {
+    element.setAttribute('cx', xPosition)
+    element.setAttribute('cy', yPosition)
+  }
+  rendered.probeGuide.setAttribute('x1', xPosition)
+  rendered.probeGuide.setAttribute('x2', xPosition)
+  const labelOnLeft = xPosition > rendered.width - 92
+  rendered.probeValue.setAttribute('x', xPosition + (labelOnLeft ? -10 : 10))
+  rendered.probeValue.setAttribute('y', Math.max(34, yPosition - 11))
+  rendered.probeValue.setAttribute('text-anchor', labelOnLeft ? 'end' : 'start')
+  rendered.probeValue.textContent = `RMS ${formatValue(rms)}`
+
+  const current = Math.round(bounded)
+  rendered.nodes.forEach((node) => {
+    node.element.dataset.state = node.stageIndex === current ? 'current' : node.stageIndex < bounded ? 'past' : 'future'
+  })
+  const activeEdge = Number.isInteger(bounded) ? -1 : Math.ceil(bounded)
+  rendered.edges.forEach((edge) => {
+    edge.element.dataset.state = edge.stageIndex === activeEdge ? 'current' : edge.stageIndex <= bounded ? 'past' : 'future'
+  })
+
+  const token = state.trace.inference.tokens[state.selectedToken]
+  const stageLabel = leftIndex === rightIndex ? left.label : `${left.label} → ${right.label}`
+  const update = leftIndex === rightIndex
+    ? left.updateRms
+    : (right.updateRms ?? 0) * amount
+  const signedMean = `${binMean > 0 ? '+' : ''}${formatValue(binMean)}`
+  setText(
+    'signal-flow-description',
+    `Token ${token.original_index} “${token.display}” · ${stageLabel} · RMS ${formatValue(rms)} · ${update === null ? 'input embedding' : `Δ ${formatValue(update)}`} · bins +${(positive * 100).toFixed(0)}% / −${(negative * 100).toFixed(0)}% · mean ${signedMean}`,
+  )
 }
 
 function renderLineChart(svg, series, options = {}) {
@@ -908,7 +1153,9 @@ window.addEventListener('resize', () => {
   window.requestAnimationFrame(() => {
     resizeQueued = false
     const visibleView = document.querySelector('.view:not([hidden])')?.id
-    if (visibleView === 'view-inference') renderInference({ renderTokens: false })
+    if (visibleView === 'view-inference' && !state.animating) {
+      renderInference({ renderTokens: false, renderSignal: true })
+    }
     if (visibleView === 'view-training') renderTraining()
   })
 })

--- a/hermes-web/src/model-lab/styles.css
+++ b/hermes-web/src/model-lab/styles.css
@@ -210,8 +210,31 @@ select { min-height: 36px; margin-left: 7px; border: 1px solid var(--line-strong
 .token-chip[data-source="generated"] { border-bottom-color: var(--attention); }
 .token-chip[aria-pressed="true"] { border-color: var(--accent); background: var(--accent-soft); color: var(--accent-ink); }
 
+.signal-flow-panel { margin-bottom: 18px; }
+.signal-flow-compression { margin: 0; font-size: .76rem; text-align: right; }
+.signal-flow-chart { display: block; width: 100%; height: 330px; overflow: visible; }
+.signal-flow-encoding, .signal-flow-axis-label, .signal-flow-stage-label { fill: var(--muted); font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+.signal-flow-encoding, .signal-flow-axis-label { font-size: 11px; }
+.signal-flow-stage-label { font-size: 10px; font-variant-numeric: tabular-nums; }
+.signal-flow-grid { stroke: var(--grid); stroke-width: 1; }
+.signal-flow-sign-axis { stroke: var(--line-strong); stroke-width: 1; }
+.signal-flow-edge { fill: none; stroke: var(--line-strong); stroke-linecap: round; opacity: .55; }
+.signal-flow-edge[data-state="past"] { stroke: var(--accent); opacity: .45; }
+.signal-flow-edge[data-state="current"] { stroke: var(--accent); opacity: .95; }
+.signal-flow-stage .signal-flow-node-shape { fill: var(--surface); stroke: var(--line-strong); stroke-width: 2; }
+.signal-flow-stage[data-mixer="attention"] .signal-flow-node-shape { stroke: var(--attention); }
+.signal-flow-stage[data-mixer="mamba"] .signal-flow-node-shape { stroke: var(--mamba); }
+.signal-flow-stage[data-state="past"] .signal-flow-node-shape { fill: var(--accent-soft); stroke: var(--accent); }
+.signal-flow-stage[data-state="current"] .signal-flow-node-shape { fill: var(--accent); stroke: var(--surface); stroke-width: 3; }
+.signal-flow-positive { fill: var(--heat-positive); opacity: .78; }
+.signal-flow-negative { fill: var(--heat-negative); opacity: .78; }
+.signal-flow-probe-guide { stroke: var(--accent); stroke-width: 1; opacity: .25; }
+.signal-flow-probe-halo { fill: var(--accent-soft); opacity: .8; }
+.signal-flow-probe { fill: var(--accent); stroke: var(--surface); stroke-width: 2; }
+.signal-flow-probe-value { fill: var(--ink); stroke: var(--surface); stroke-width: 4; paint-order: stroke; font-size: 11px; font-weight: 500; }
+
 .visual-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; align-items: start; }
-.wide-panel { grid-column: span 1; }
+.wide-panel { grid-column: 1 / -1; }
 .visual-panel { min-width: 0; padding: 18px; }
 .panel-heading { align-items: flex-start; margin-bottom: 14px; }
 .panel-heading .eyebrow { margin-bottom: 5px; }
@@ -221,8 +244,7 @@ select { min-height: 36px; margin-left: 7px; border: 1px solid var(--line-strong
 .square-map canvas { min-height: 420px; }
 .scale-legend { display: flex; align-items: center; gap: 7px; color: var(--muted); font-size: .72rem; }
 .scale-gradient { width: 88px; height: 8px; border-radius: 999px; background: linear-gradient(90deg, var(--heat-negative), var(--heat-zero), var(--heat-positive)); }
-.line-chart, .training-chart { display: block; width: 100%; overflow: visible; }
-.line-chart { min-height: 300px; }
+.training-chart { display: block; width: 100%; overflow: visible; }
 .training-chart { min-height: 330px; }
 .chart-selection { margin: 8px 0 0; }
 .mixer-visuals { margin-top: 18px; }
@@ -270,6 +292,8 @@ footer { margin-top: 30px; border-top: 1px solid var(--line); padding-top: 18px;
   .inline-controls { justify-content: flex-start; }
   .layer-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .token-context { align-items: flex-start; flex-direction: column; }
+  .signal-flow-compression { text-align: left; }
+  .signal-flow-chart { height: 310px; }
   .heatmap-wrap, .heatmap-wrap canvas { min-height: 240px; }
   .square-map, .square-map canvas { min-height: 310px; }
 }

--- a/hermes-web/src/model-lab/trace-utils.js
+++ b/hermes-web/src/model-lab/trace-utils.js
@@ -37,6 +37,36 @@ export function interpolateHeatmap(from, to, progress) {
   }
 }
 
+export function tokenSignalSeries(inference, tokenIndex) {
+  if (!isObject(inference) || !Array.isArray(inference.tokens) || !Array.isArray(inference.stages)) {
+    fail('Inference trace is malformed')
+  }
+  if (!integer(tokenIndex) || tokenIndex >= inference.tokens.length) {
+    fail(`Token index ${tokenIndex} is outside the captured trace`)
+  }
+  return inference.stages.map((stage, stageIndex) => {
+    const start = tokenIndex * stage.activation.cols
+    const bins = stage.activation.values.slice(start, start + stage.activation.cols)
+    const totalEnergy = bins.reduce((sum, value) => sum + value * value, 0)
+    const positiveEnergy = bins.reduce((sum, value) => value > 0 ? sum + value * value : sum, 0)
+    const negativeEnergy = bins.reduce((sum, value) => value < 0 ? sum + value * value : sum, 0)
+    return {
+      stageIndex,
+      stage: stage.stage,
+      label: stage.label,
+      layerIndex: stage.layer_index,
+      mixer: stage.mixer,
+      rms: stage.token_rms[tokenIndex],
+      updateRms: finite(stage.token_delta_rms?.[tokenIndex]) ? stage.token_delta_rms[tokenIndex] : null,
+      binMean: bins.reduce((sum, value) => sum + value, 0) / bins.length,
+      binRms: Math.sqrt(totalEnergy / bins.length),
+      positiveBinEnergy: totalEnergy === 0 ? 0 : positiveEnergy / totalEnergy,
+      negativeBinEnergy: totalEnergy === 0 ? 0 : negativeEnergy / totalEnergy,
+      capturedBins: bins.length,
+    }
+  })
+}
+
 export function validateTrace(trace) {
   if (!isObject(trace)) fail('Trace bundle must be a JSON object')
   if (trace.kind !== TRACE_KIND) fail(`Unsupported trace kind: ${String(trace.kind)}`)

--- a/hermes-web/src/model-lab/trace-utils.test.js
+++ b/hermes-web/src/model-lab/trace-utils.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { demoTrace } from './demo-trace.js'
-import { interpolateHeatmap, layerGradientHeatmap, normalizedMetricHeatmap, validateTrace } from './trace-utils.js'
+import { interpolateHeatmap, layerGradientHeatmap, normalizedMetricHeatmap, tokenSignalSeries, validateTrace } from './trace-utils.js'
 
 const clone = (value) => JSON.parse(JSON.stringify(value))
 
@@ -38,6 +38,20 @@ test('heatmap interpolation rejects incompatible captures', () => {
   const from = { rows: 1, cols: 1, values: [0], min: 0, max: 0 }
   const to = { rows: 2, cols: 1, values: [0, 1], min: 0, max: 1 }
   assert.throws(() => interpolateHeatmap(from, to, 0.5), /different shapes/)
+})
+
+test('selected-token signal flow preserves exact RMS and summarizes captured bins', () => {
+  const series = tokenSignalSeries(demoTrace.inference, 0)
+  assert.equal(series.length, demoTrace.inference.stages.length)
+  assert.equal(series[0].rms, demoTrace.inference.stages[0].token_rms[0])
+  assert.equal(series[0].updateRms, null)
+  assert.equal(series[0].capturedBins, demoTrace.inference.stages[0].activation.cols)
+  for (const point of series) {
+    assert.ok(Number.isFinite(point.binMean))
+    assert.ok(Number.isFinite(point.binRms))
+    assert.ok(Math.abs(point.positiveBinEnergy + point.negativeBinEnergy - 1) < 1e-12)
+  }
+  assert.throws(() => tokenSignalSeries(demoTrace.inference, -1), /outside the captured trace/)
 })
 
 test('training heatmaps retain metric and layer axes', () => {


### PR DESCRIPTION
## Summary
- replace the redundant selected-token RMS chart with a layer-by-layer signal-flow graph
- encode exact token RMS, exact residual-update RMS, mixer type, and approximate signed-bin energy in one aligned view
- synchronize a moving numeric probe with smooth inference playback and collapse labels/glyphs responsively for dense models

## Validation
- node --test src/model-lab/*.test.js
- eslint src/model-lab
- vite build --config model-lab.vite.config.js
- pre-push Rust Clippy and formatting hooks