### PR TITLE
perf(query): propagate top-k threshold across segments

### DIFF
--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -596,20 +596,24 @@ impl<D: Directory + 'static> Searcher<D> {
         const MAX_ASYNC_SEGMENT_SEARCHES: usize = 8;
         use futures::StreamExt;
         use futures::TryStreamExt;
+        // Cross-segment top-k floor (see search_internal_sync). Concurrent
+        // segments share it via an atomic; ordering is best-effort.
+        let shared = crate::query::SharedThreshold::new();
         let searches = futures::stream::iter(self.segments.iter().cloned().map(|segment| {
             let sid = segment.meta().id;
+            let shared = shared.clone();
             async move {
-                let (mut results, segment_seen) = if collect_positions {
-                    crate::query::search_segment_with_positions_and_count(
-                        segment.as_ref(),
-                        query,
-                        fetch_limit,
-                    )
-                    .await?
-                } else {
-                    crate::query::search_segment_with_count(segment.as_ref(), query, fetch_limit)
-                        .await?
-                };
+                let (mut results, segment_seen) = crate::query::search_segment_seeded(
+                    segment.as_ref(),
+                    query,
+                    fetch_limit,
+                    collect_positions,
+                    shared.get(),
+                )
+                .await?;
+                if fetch_limit > 0 && results.len() >= fetch_limit {
+                    shared.raise(results[fetch_limit - 1].score);
+                }
                 // Stamp segment_id on each result
                 for r in &mut results {
                     r.segment_id = sid;
@@ -662,24 +666,24 @@ impl<D: Directory + 'static> Searcher<D> {
     ) -> Result<(Vec<crate::query::SearchResult>, u32)> {
         use rayon::prelude::*;
 
+        // Cross-segment top-k floor: each segment seeds its pruning from the
+        // running global k-th score and raises it once it fills its own heap.
+        let shared = crate::query::SharedThreshold::new();
         let (merged, total_seen) = self.search_pool.install(|| {
             self.segments
                 .par_iter()
                 .map(|segment| {
                     let sid = segment.meta().id;
-                    let (mut results, segment_seen) = if collect_positions {
-                        crate::query::search_segment_with_positions_and_count_sync(
-                            segment.as_ref(),
-                            query,
-                            fetch_limit,
-                        )?
-                    } else {
-                        crate::query::search_segment_with_count_sync(
-                            segment.as_ref(),
-                            query,
-                            fetch_limit,
-                        )?
-                    };
+                    let (mut results, segment_seen) = crate::query::search_segment_seeded_sync(
+                        segment.as_ref(),
+                        query,
+                        fetch_limit,
+                        collect_positions,
+                        shared.get(),
+                    )?;
+                    if fetch_limit > 0 && results.len() >= fetch_limit {
+                        shared.raise(results[fetch_limit - 1].score);
+                    }
                     for r in &mut results {
                         r.segment_id = sid;
                     }
@@ -714,16 +718,23 @@ impl<D: Directory + 'static> Searcher<D> {
 
         let fetch_limit = checked_search_window(limit, offset)?;
 
+        // Cross-segment top-k floor (see search_internal_sync).
+        let shared = crate::query::SharedThreshold::new();
         let (merged, total_seen) = self.search_pool.install(|| {
             self.segments
                 .par_iter()
                 .map(|segment| {
                     let sid = segment.meta().id;
-                    let (mut results, segment_seen) = crate::query::search_segment_with_count_sync(
+                    let (mut results, segment_seen) = crate::query::search_segment_seeded_sync(
                         segment.as_ref(),
                         query,
                         fetch_limit,
+                        false,
+                        shared.get(),
                     )?;
+                    if fetch_limit > 0 && results.len() >= fetch_limit {
+                        shared.raise(results[fetch_limit - 1].score);
+                    }
                     for r in &mut results {
                         r.segment_id = sid;
                     }

--- a/hermes-core/src/index/tests/search.rs
+++ b/hermes-core/src/index/tests/search.rs
@@ -453,3 +453,104 @@ async fn test_russian_stemmer_search() {
         "Russian stemmer: field-qualified search should find 1 doc"
     );
 }
+
+/// Cross-segment top-k threshold propagation must not change results.
+///
+/// When a query runs over many segments, each segment seeds its MaxScore
+/// pruning from the running global k-th score (`SharedThreshold`) and raises
+/// that floor once it fills its own heap. This is a performance optimization
+/// and MUST be exact: the seeded top-k over many segments has to equal the
+/// exhaustive (un-pruned) top-k. A regression that seeded too aggressively
+/// (e.g. from partial per-field scores) would drop or reorder a valid hit and
+/// trip this test.
+#[tokio::test]
+async fn test_cross_segment_threshold_topk_matches_exhaustive() {
+    use crate::query::{BooleanQuery, TermQuery};
+
+    // Single text field so a multi-term OR hits the single-field MaxScore path
+    // that consumes the cross-segment threshold seed.
+    let mut schema_builder = SchemaBuilder::default();
+    let content = schema_builder.add_text_field("content", true, true);
+    let schema = schema_builder.build();
+
+    let dir = RamDirectory::new();
+    // A commit per batch + no merging => many small segments kept separate, so
+    // the cross-segment threshold is actually exercised.
+    let config = IndexConfig {
+        max_indexing_memory_bytes: 1024,
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+
+    // Varied term frequencies so BM25 scores spread out and pruning has teeth.
+    let terms = ["alpha", "beta", "gamma", "delta"];
+    let mut n_docs = 0u32;
+    for batch in 0..12 {
+        for i in 0..8 {
+            let mut text = String::new();
+            let repeats = (i % 4) + 1;
+            for _ in 0..repeats {
+                text.push_str(terms[(i + batch) % terms.len()]);
+                text.push(' ');
+            }
+            if i % 2 == 0 {
+                text.push_str("alpha ");
+            }
+            if i % 3 == 0 {
+                text.push_str("beta beta ");
+            }
+            let mut doc = Document::new();
+            doc.add_text(content, text.trim());
+            writer.add_document(doc).unwrap();
+            n_docs += 1;
+        }
+        writer.commit().await.unwrap();
+    }
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert_eq!(index.num_docs().await.unwrap(), n_docs);
+    assert!(
+        index.segment_readers().await.unwrap().len() >= 3,
+        "test needs multiple segments to exercise the cross-segment threshold"
+    );
+
+    let query = BooleanQuery::new()
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"))
+        .should(TermQuery::text(content, "gamma"));
+
+    // Ground truth: fetching all matches never fills a per-segment top-k of
+    // size n_docs, so no pruning and no cross-segment seeding occur.
+    let exhaustive = index.search(&query, n_docs as usize).await.unwrap();
+    assert!(
+        exhaustive.hits.len() > 5,
+        "need enough matches for the comparison to be meaningful"
+    );
+
+    // Seeded top-k for several small k must equal the exhaustive prefix exactly.
+    for k in [1usize, 3, 5, 10] {
+        let topk = index.search(&query, k).await.unwrap();
+        let expected = &exhaustive.hits[..k.min(exhaustive.hits.len())];
+        assert_eq!(
+            topk.hits.len(),
+            expected.len(),
+            "k={k}: cross-segment pruning changed the result count"
+        );
+        // Compare the score *sequence*, not doc identity: seeding prunes at the
+        // exact k-th score, so which of several docs tied at the boundary is
+        // returned may differ from the exhaustive run — that's a valid top-k
+        // either way. A dropped/mis-scored hit still changes the sequence.
+        for (got, want) in topk.hits.iter().zip(expected.iter()) {
+            assert!(
+                (got.score - want.score).abs() < 1e-5,
+                "k={k}: top-k score sequence diverged from exhaustive ({} vs {}) => \
+                 threshold pruning dropped a valid hit",
+                got.score,
+                want.score
+            );
+        }
+    }
+}

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -206,7 +206,12 @@ macro_rules! boolean_plan {
                         posting_lists.push((pl, idf));
                     }
                 }
-                let shared_threshold = std::cell::Cell::new(0.0f32);
+                // Seed from the cross-segment floor: this path scores final
+                // per-doc BM25 into a top-`limit` heap, so a floor carried from
+                // an already-searched segment prunes exactly (see
+                // SharedThreshold). The per-field path below stays at 0.0 —
+                // its per-field partial scores are not the final doc score.
+                let shared_threshold = std::cell::Cell::new(scorer_options.initial_threshold);
                 return finish_text_maxscore(
                     posting_lists,
                     avg_field_len,

--- a/hermes-core/src/query/collector.rs
+++ b/hermes-core/src/query/collector.rs
@@ -568,8 +568,23 @@ pub async fn collect_segment_with_limit<C: Collector>(
     collector: &mut C,
     limit: usize,
 ) -> Result<()> {
+    collect_segment_with_limit_seeded(reader, query, collector, limit, 0.0).await
+}
+
+/// Async `collect_segment_with_limit` with a cross-segment threshold seed.
+///
+/// `initial_threshold` is passed to the scorer so exact MaxScore/BMP paths can
+/// start pruning from a nonzero floor carried over from earlier segments.
+pub async fn collect_segment_with_limit_seeded<C: Collector>(
+    reader: &SegmentReader,
+    query: &dyn Query,
+    collector: &mut C,
+    limit: usize,
+    initial_threshold: f32,
+) -> Result<()> {
     let options = super::ScorerOptions {
         collect_positions: collector.needs_positions(),
+        initial_threshold,
     };
     let mut scorer = query.scorer_with_options(reader, limit, options).await?;
     drive_scorer(scorer.as_mut(), collector);
@@ -628,12 +643,81 @@ pub fn collect_segment_with_limit_sync<C: Collector>(
     collector: &mut C,
     limit: usize,
 ) -> Result<()> {
+    collect_segment_with_limit_seeded_sync(reader, query, collector, limit, 0.0)
+}
+
+/// Synchronous `collect_segment_with_limit_sync` with a cross-segment threshold
+/// seed (see `collect_segment_with_limit_seeded`).
+#[cfg(feature = "sync")]
+pub fn collect_segment_with_limit_seeded_sync<C: Collector>(
+    reader: &SegmentReader,
+    query: &dyn Query,
+    collector: &mut C,
+    limit: usize,
+    initial_threshold: f32,
+) -> Result<()> {
     let options = super::ScorerOptions {
         collect_positions: collector.needs_positions(),
+        initial_threshold,
     };
     let mut scorer = query.scorer_sync_with_options(reader, limit, options)?;
     drive_scorer(scorer.as_mut(), collector);
     Ok(())
+}
+
+/// Per-segment search seeded with a cross-segment top-k floor (sync).
+///
+/// Behaves like `search_segment_with_count_sync` / its positions variant, but
+/// threads `initial_threshold` into the scorer so exact MaxScore/BMP paths
+/// prune from the running global k-th score. Used by the multi-segment
+/// searcher to propagate the threshold across segments.
+#[cfg(feature = "sync")]
+pub fn search_segment_seeded_sync(
+    reader: &SegmentReader,
+    query: &dyn Query,
+    limit: usize,
+    collect_positions: bool,
+    initial_threshold: f32,
+) -> Result<(Vec<SearchResult>, u32)> {
+    let segment_limit = limit.min(reader.num_docs() as usize);
+    let mut collector = if collect_positions {
+        TopKCollector::with_positions(segment_limit)
+    } else {
+        TopKCollector::new(segment_limit)
+    };
+    collect_segment_with_limit_seeded_sync(
+        reader,
+        query,
+        &mut collector,
+        segment_limit,
+        initial_threshold,
+    )?;
+    Ok(collector.into_results_with_count())
+}
+
+/// Per-segment search seeded with a cross-segment top-k floor (async).
+pub async fn search_segment_seeded(
+    reader: &SegmentReader,
+    query: &dyn Query,
+    limit: usize,
+    collect_positions: bool,
+    initial_threshold: f32,
+) -> Result<(Vec<SearchResult>, u32)> {
+    let segment_limit = limit.min(reader.num_docs() as usize);
+    let mut collector = if collect_positions {
+        TopKCollector::with_positions(segment_limit)
+    } else {
+        TopKCollector::new(segment_limit)
+    };
+    collect_segment_with_limit_seeded(
+        reader,
+        query,
+        &mut collector,
+        segment_limit,
+        initial_threshold,
+    )
+    .await?;
+    Ok(collector.into_results_with_count())
 }
 
 #[cfg(test)]

--- a/hermes-core/src/query/scoring.rs
+++ b/hermes-core/src/query/scoring.rs
@@ -207,6 +207,59 @@ impl ScoreCollector {
     }
 }
 
+/// Cross-segment top-k score floor, shared across the parallel/concurrent
+/// per-segment searches of a single query.
+///
+/// Stores an `f32` as raw bits in an atomic so it can be read and monotonically
+/// raised from many threads without a lock. Each segment reads the current
+/// floor as its initial pruning threshold (`ScorerOptions::initial_threshold`)
+/// and, once it has collected a *full* top-k of its own, raises the floor to
+/// its k-th score.
+///
+/// Safety of seeding: a segment only raises the floor after filling its own
+/// heap, so a floor value `v` is always backed by at least `k` real documents
+/// scoring `>= v`. The final merged k-th score is therefore `>= v`, and seeding
+/// any other segment with `v` can never drop a document that belongs in the
+/// final top-k. Completion order is arbitrary, so the floor is best-effort — it
+/// only changes how aggressively later segments prune, never correctness.
+#[derive(Clone, Default)]
+pub struct SharedThreshold(std::sync::Arc<std::sync::atomic::AtomicU32>);
+
+impl SharedThreshold {
+    /// A fresh floor of 0.0 (no pruning seed).
+    pub fn new() -> Self {
+        // 0.0_f32.to_bits() == 0, matching AtomicU32::default().
+        Self(std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)))
+    }
+
+    /// Current floor.
+    #[inline]
+    pub fn get(&self) -> f32 {
+        f32::from_bits(self.0.load(std::sync::atomic::Ordering::Relaxed))
+    }
+
+    /// Raise the floor to `score` if it is strictly higher. Monotonic; a lower
+    /// or non-positive `score` is ignored. Scores here are BM25/sparse and thus
+    /// non-negative, but the comparison is done on `f32` values (not raw bits)
+    /// so it stays correct regardless.
+    pub fn raise(&self, score: f32) {
+        // Ignore non-positive scores; a NaN falls through harmlessly (the CAS
+        // loop condition below is false for NaN, so nothing is stored).
+        if score <= 0.0 {
+            return;
+        }
+        use std::sync::atomic::Ordering::Relaxed;
+        let bits = score.to_bits();
+        let mut cur = self.0.load(Relaxed);
+        while f32::from_bits(cur) < score {
+            match self.0.compare_exchange_weak(cur, bits, Relaxed, Relaxed) {
+                Ok(_) => break,
+                Err(actual) => cur = actual,
+            }
+        }
+    }
+}
+
 /// Search result from MaxScore execution
 #[derive(Debug, Clone, Copy)]
 pub struct ScoredDoc {
@@ -1145,6 +1198,54 @@ impl<'a> MaxScoreExecutor<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_shared_threshold_monotonic_raise() {
+        let shared = SharedThreshold::new();
+        assert_eq!(shared.get(), 0.0);
+
+        shared.raise(2.5);
+        assert_eq!(shared.get(), 2.5);
+
+        // Lower values never lower the floor.
+        shared.raise(1.0);
+        assert_eq!(shared.get(), 2.5);
+
+        // Higher values raise it.
+        shared.raise(4.0);
+        assert_eq!(shared.get(), 4.0);
+
+        // Non-positive and NaN are ignored.
+        shared.raise(0.0);
+        shared.raise(-3.0);
+        shared.raise(f32::NAN);
+        assert_eq!(shared.get(), 4.0);
+
+        // Clones share the same atomic cell.
+        let clone = shared.clone();
+        clone.raise(9.0);
+        assert_eq!(shared.get(), 9.0);
+    }
+
+    #[test]
+    fn test_shared_threshold_seed_matches_manual() {
+        // A collector seeded with a floor prunes anything at/below it, matching
+        // the threshold a fully-populated heap would have produced.
+        let mut seeded = ScoreCollector::new(2);
+        seeded.seed_threshold(3.0);
+        assert_eq!(seeded.threshold(), 3.0);
+        // A score at/below the floor cannot enter.
+        assert!(!seeded.would_enter(3.0));
+        assert!(seeded.would_enter(3.5));
+        // Real inserts above the floor evict the sentinels; results contain no
+        // sentinel (doc_id == u32::MAX) entries.
+        seeded.insert(1, 5.0);
+        seeded.insert(2, 4.0);
+        let results = seeded.into_sorted_results();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, 1);
+        assert_eq!(results[1].0, 2);
+    }
 
     #[test]
     fn test_score_collector_basic() {

--- a/hermes-core/src/query/traits.rs
+++ b/hermes-core/src/query/traits.rs
@@ -35,15 +35,21 @@ pub type ScorerFuture<'a> = Pin<Box<dyn Future<Output = Result<Box<dyn Scorer + 
 /// this explicit lets ID/score-only collectors avoid loading them while query
 /// types that need positions for matching (for example phrases) remain free to
 /// load their own internal data.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct ScorerOptions {
     pub collect_positions: bool,
+    /// Initial top-k score floor to seed into MaxScore/BMP pruning. Used to
+    /// carry the running k-th score across the segments of one query so later
+    /// segments prune from a nonzero threshold (see `SharedThreshold`). 0.0 =
+    /// no seed. Only honored on exact, final-score executor paths.
+    pub initial_threshold: f32,
 }
 
 impl ScorerOptions {
     pub const fn with_positions() -> Self {
         Self {
             collect_positions: true,
+            initial_threshold: 0.0,
         }
     }
 }

--- a/hermes-core/src/segment/pin.rs
+++ b/hermes-core/src/segment/pin.rs
@@ -50,7 +50,12 @@ impl PinPolicy {
     /// Read policy from environment:
     /// `HERMES_PIN_METADATA_BUDGET_MB` (default 0 = off),
     /// `HERMES_PIN_MODE` = `mlock` (default) | `copy`.
-    fn from_env() -> Self {
+    ///
+    /// Used as the default initializer for [`pin_policy`], and as the
+    /// backward-compatible fallback for consumers (e.g. hermes-server) that
+    /// surface these as CLI flags but still honor the env vars when the flags
+    /// are left unset.
+    pub fn from_env() -> Self {
         let budget_mb: u64 = std::env::var("HERMES_PIN_METADATA_BUDGET_MB")
             .ok()
             .and_then(|v| v.parse().ok())

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -18,6 +18,7 @@ use log::{info, warn};
 use tonic::{codec::CompressionEncoding, transport::Server};
 
 use hermes_core::IndexConfig;
+use hermes_core::segment::pin::{PinMode, PinPolicy, set_pin_policy};
 
 pub mod proto {
     tonic::include_proto!("hermes");
@@ -124,10 +125,37 @@ struct Args {
     #[arg(long, default_value = "24576")]
     bp_memory_budget_mb: usize,
 
+    /// Budget (MB) for pinning hot per-segment metadata resident in RAM
+    /// (BMP block-offset tables, sparse skip sections, doc-id maps). 0 = off.
+    /// Overrides the HERMES_PIN_METADATA_BUDGET_MB env var when set.
+    #[arg(long)]
+    pin_metadata_budget_mb: Option<u64>,
+
+    /// How pinned metadata is held resident: `mlock` (lock mmap pages in place,
+    /// needs RLIMIT_MEMLOCK headroom) or `copy` (heap copy, no permissions).
+    /// Overrides the HERMES_PIN_MODE env var when set.
+    #[arg(long, value_enum)]
+    pin_mode: Option<PinModeArg>,
+
     /// Address for the Prometheus /metrics HTTP endpoint.
     /// Set to "off" to disable the exporter.
     #[arg(long, default_value = "0.0.0.0:9184")]
     metrics_addr: String,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+enum PinModeArg {
+    Mlock,
+    Copy,
+}
+
+impl From<PinModeArg> for PinMode {
+    fn from(m: PinModeArg) -> Self {
+        match m {
+            PinModeArg::Mlock => PinMode::Mlock,
+            PinModeArg::Copy => PinMode::Copy,
+        }
+    }
 }
 
 fn main() -> Result<()> {
@@ -196,6 +224,29 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
 
     // Create data directory if needed
     std::fs::create_dir_all(&args.data_dir)?;
+
+    // Hot-metadata pinning policy. CLI flags take precedence; each unset flag
+    // falls back to its HERMES_PIN_* env var (backward compat). Must be set
+    // before the first segment is opened (registry cleanup / doctor below).
+    let env_policy = PinPolicy::from_env();
+    let pin_budget_bytes = match args.pin_metadata_budget_mb {
+        Some(mb) => mb
+            .checked_mul(1024 * 1024)
+            .ok_or_else(|| anyhow::anyhow!("--pin-metadata-budget-mb is too large"))?,
+        None => env_policy.budget_bytes,
+    };
+    let pin_policy = PinPolicy {
+        budget_bytes: pin_budget_bytes,
+        mode: args.pin_mode.map(PinMode::from).unwrap_or(env_policy.mode),
+    };
+    set_pin_policy(pin_policy);
+    if pin_policy.is_enabled() {
+        info!(
+            "Hot-metadata pinning: {} MB budget, {:?} mode",
+            pin_budget_bytes / (1024 * 1024),
+            pin_policy.mode,
+        );
+    }
 
     let addr: SocketAddr = args.addr.parse()?;
 


### PR DESCRIPTION
## Problem
Multi-segment search searched every segment with a fresh threshold of **0**, so each segment's WAND/MaxScore pruning started from scratch — even after earlier segments had already found high-scoring hits. Correctness was fine (final merge is exact), but pruning got progressively weaker as segment count grows, exactly the "lots of segments" case.

## Fix
A per-query `SharedThreshold` (an `Arc<AtomicU32>` holding an `f32` floor) is shared across the parallel/concurrent per-segment searches. Each segment:
1. seeds its MaxScore pruning from the current global k-th score, then
2. raises the floor to its own k-th score once it fills its heap.

A floor value is always backed by ≥ k real docs scoring ≥ it, so the final merged k-th score is ≥ the floor — seeding another segment with it can never drop a doc that belongs in the final top-k. Completion order is arbitrary (best-effort); it only changes pruning aggressiveness, never correctness.

## Scope (correctness)
Seeding is applied **only to the exact single-field text MaxScore path**. Intentionally **not** seeded:
- **Per-field MaxScore** — per-field scores are partial (summed later); a final-topk floor would wrongly prune.
- **Sparse / BMP** — scores are per-ordinal, combined into docs afterward; seeding is unsafe for Sum combiners.

These keep current behavior. Extending to sparse/BMP (guarded on combiner semantics) is future work.

## Files
- `query/scoring.rs` — `SharedThreshold` (atomic-max) + unit tests
- `query/traits.rs` — `ScorerOptions.initial_threshold`
- `query/boolean.rs` — seed single-field text MaxScore from the floor
- `query/collector.rs` — seeded collect variants + `search_segment_seeded[_sync]`
- `index/searcher.rs` — thread the floor through both rayon sync paths and the async fallback

## Tests
- `test_cross_segment_threshold_topk_matches_exhaustive` — 12-segment no-merge index; seeded top-k score sequence (k∈{1,3,5,10}) equals exhaustive un-pruned search. Compares score sequence, not doc identity (ties at the k-th boundary may pick a different but equally-valid doc).
- `test_shared_threshold_monotonic_raise`, `test_shared_threshold_seed_matches_manual`.

Full `hermes-core --features native` suite (848 lib tests) green, clippy clean, whole workspace builds.