### PR TITLE
fix(index): recover the writer lock after the holder exits; fail-loud batch errors

### DIFF
--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -162,7 +162,10 @@ pub struct IndexWriter<D: DirectoryWriter + 'static> {
     /// the reservations or duplicate primary keys could be admitted.
     pk_reservations_retained: Arc<AtomicBool>,
     /// Advisory single-writer lock, held for the writer's lifetime.
-    writer_lock: WriterLock,
+    /// `Unavailable` is retryable: the conflicting holder may exit at any
+    /// time (the kernel then releases its lock), so `ensure_writer_lock`
+    /// re-attempts acquisition instead of caching the conflict forever.
+    writer_lock: parking_lot::RwLock<WriterLock>,
 }
 
 #[derive(Default)]
@@ -505,16 +508,43 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             primary_key_index: Arc::new(parking_lot::RwLock::new(None)),
             commit_finalization: Arc::new(CommitFinalizationState::default()),
             pk_reservations_retained: Arc::new(AtomicBool::new(false)),
-            writer_lock,
+            writer_lock: parking_lot::RwLock::new(writer_lock),
         }
     }
 
     /// Fail loudly when another writer owns the single-writer lock.
+    ///
+    /// A deferred conflict (`from_index` during a writer handover, e.g. a
+    /// rolling pod restart) is not permanent: the holder exits and the kernel
+    /// releases its advisory lock. Re-attempt acquisition on every call in
+    /// the `Unavailable` state so the writer recovers as soon as the lock
+    /// frees, instead of rejecting all writes for its lifetime.
     fn ensure_writer_lock(&self) -> Result<()> {
-        if let WriterLock::Unavailable { reason } = &self.writer_lock {
-            return Err(Error::Internal(reason.clone()));
+        // Fast path: uncontended read on the healthy states.
+        if !matches!(&*self.writer_lock.read(), WriterLock::Unavailable { .. }) {
+            return Ok(());
         }
-        Ok(())
+
+        let mut lock = self.writer_lock.write();
+        // Another thread may have recovered while we waited for the write lock.
+        if !matches!(&*lock, WriterLock::Unavailable { .. }) {
+            return Ok(());
+        }
+        match try_acquire_writer_lock(self.directory.as_ref())? {
+            acquired @ (WriterLock::Held { .. } | WriterLock::NotApplicable) => {
+                log::info!(
+                    "[writer_lock] single-writer lock acquired after retry; \
+                     the previous holder has released it — resuming writes"
+                );
+                *lock = acquired;
+                Ok(())
+            }
+            WriterLock::Unavailable { reason } => {
+                let err = Error::Internal(reason.clone());
+                *lock = WriterLock::Unavailable { reason };
+                Err(err)
+            }
+        }
     }
 
     /// Clear primary-key reservations after an aborted or failed generation.

--- a/hermes-core/tests/index_writer_regressions.rs
+++ b/hermes-core/tests/index_writer_regressions.rs
@@ -367,3 +367,48 @@ async fn test_retried_prepare_commit_survives_cancelled_commit_waiter() {
     assert!(prepared.commit().await.unwrap());
     opener.await.unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// Writer-lock recovery: a deferred conflict must not outlive the conflict
+// ---------------------------------------------------------------------------
+
+/// Prod regression (k8s rolling update): the new pod's `Index::writer()` hit
+/// the old pod's live advisory lock and cached `Unavailable`; the old pod
+/// exited seconds later (the kernel released its lock), but the new writer
+/// kept rejecting every batch forever. An `Unavailable` writer must re-attempt
+/// acquisition on its next mutating operation instead of caching the conflict
+/// for its lifetime.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_writer_lock_reacquired_after_holder_releases() {
+    let (schema, title) = title_schema();
+    let tmp = tempfile::tempdir().unwrap();
+    let config = IndexConfig::default();
+
+    let index = Index::create(MmapDirectory::new(tmp.path()), schema, config.clone())
+        .await
+        .unwrap();
+    let writer_a = index.writer();
+    let mut writer_b = index.writer();
+
+    // While A is alive, B must keep failing loudly.
+    writer_b
+        .add_document(title_doc(title, "must be rejected"))
+        .expect_err("second writer's mutations must fail while the lock is held");
+
+    // A exits (pod terminated); the kernel releases its advisory lock.
+    drop(writer_a);
+
+    // B's next mutation must acquire the now-free lock and succeed.
+    writer_b
+        .add_document(title_doc(title, "accepted after holder exit"))
+        .expect("writer must recover once the previous holder released the lock");
+    writer_b.commit().await.unwrap();
+
+    // And the recovered writer really owns the lock: an external open is
+    // rejected again.
+    let err = IndexWriter::open(MmapDirectory::new(tmp.path()), config)
+        .await
+        .err()
+        .expect("recovered writer must hold the single-writer lock");
+    assert!(err.to_string().contains("single-writer lock"));
+}

--- a/hermes-server/src/index_service.rs
+++ b/hermes-server/src/index_service.rs
@@ -169,10 +169,32 @@ impl IndexService for IndexServiceImpl {
 
         let error_count = conversion_errors + doc_errors.len() as u32;
 
-        debug!(
-            "Batch indexed documents: index={}, indexed={}, errors={}",
-            req.index_name, indexed_count, error_count
-        );
+        // Fail loud: a failed batch must not hide at DEBUG (a wedged writer
+        // once rejected 100% of documents and it was only visible there).
+        if error_count > 0 {
+            let sample = doc_errors
+                .first()
+                .map(|e| e.error.as_str())
+                .unwrap_or("document conversion failed");
+            if indexed_count == 0 {
+                log::error!(
+                    "Batch indexing failed completely: index={}, indexed=0, errors={} (first error: {})",
+                    req.index_name,
+                    error_count,
+                    sample
+                );
+            } else {
+                warn!(
+                    "Batch indexed with errors: index={}, indexed={}, errors={} (first error: {})",
+                    req.index_name, indexed_count, error_count, sample
+                );
+            }
+        } else {
+            debug!(
+                "Batch indexed documents: index={}, indexed={}, errors={}",
+                req.index_name, indexed_count, error_count
+            );
+        }
 
         Ok(Response::new(BatchIndexDocumentsResponse {
             indexed_count,


### PR DESCRIPTION
## Prod incident
During a k8s rolling update, the new pod's `Index::writer()` hit the old pod's still-live advisory lock and cached `WriterLock::Unavailable`. The old pod exited seconds later — the kernel released its flock — but the new writer kept rejecting **100% of writes for its lifetime**, visible only as a DEBUG line (`Batch indexed: indexed=0, errors=1000`).

## Fixes
1. **`ensure_writer_lock` retries while `Unavailable`** (`hermes-core/src/index/writer.rs`). The lock state now lives behind a `RwLock`: healthy states take an uncontended read (hot path unchanged); the `Unavailable` state re-attempts `try_acquire_writer_lock` on each mutating operation, so the writer resumes as soon as the conflicting holder releases the lock. Recovery logs at INFO; continued conflict keeps failing loudly per operation.
2. **Batch failures no longer hide at DEBUG** (`hermes-server/src/index_service.rs`): all-failed batches log at ERROR, partial failures at WARN — both with the first error message — clean batches stay at DEBUG. (Per the repo fail-loud rule.)

## Tests
- New `test_writer_lock_reacquired_after_holder_releases` (verified failing first): while the holder lives, the second writer fails; after the holder drops, its next `add_document` succeeds, commits, and the recovered writer owns the lock (external open rejected again).
- All 6 writer-lock/regression tests + full `hermes-core --features native` lib suite (849) pass; clippy clean across both crates.