### PR TITLE
perf(query): prune BMP across segments

### DIFF
--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -603,12 +603,12 @@ impl<D: Directory + 'static> Searcher<D> {
             let sid = segment.meta().id;
             let shared = shared.clone();
             async move {
-                let (mut results, segment_seen) = crate::query::search_segment_seeded(
+                let (mut results, segment_seen) = crate::query::search_segment_shared(
                     segment.as_ref(),
                     query,
                     fetch_limit,
                     collect_positions,
-                    shared.get(),
+                    shared.clone(),
                 )
                 .await?;
                 if fetch_limit > 0 && results.len() >= fetch_limit {
@@ -674,12 +674,12 @@ impl<D: Directory + 'static> Searcher<D> {
                 .par_iter()
                 .map(|segment| {
                     let sid = segment.meta().id;
-                    let (mut results, segment_seen) = crate::query::search_segment_seeded_sync(
+                    let (mut results, segment_seen) = crate::query::search_segment_shared_sync(
                         segment.as_ref(),
                         query,
                         fetch_limit,
                         collect_positions,
-                        shared.get(),
+                        shared.clone(),
                     )?;
                     if fetch_limit > 0 && results.len() >= fetch_limit {
                         shared.raise(results[fetch_limit - 1].score);
@@ -725,12 +725,12 @@ impl<D: Directory + 'static> Searcher<D> {
                 .par_iter()
                 .map(|segment| {
                     let sid = segment.meta().id;
-                    let (mut results, segment_seen) = crate::query::search_segment_seeded_sync(
+                    let (mut results, segment_seen) = crate::query::search_segment_shared_sync(
                         segment.as_ref(),
                         query,
                         fetch_limit,
                         false,
-                        shared.get(),
+                        shared.clone(),
                     )?;
                     if fetch_limit > 0 && results.len() >= fetch_limit {
                         shared.raise(results[fetch_limit - 1].score);

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -116,6 +116,116 @@ async fn test_bmp_needle_in_haystack() {
     assert_eq!(results.len(), 0);
 }
 
+/// A live global BMP floor may change traversal work, never the exact top-k.
+/// This also exercises physical single-value detection on many small segments:
+/// each segment should collect `k`, not the sparse query's default `2k`.
+#[tokio::test]
+async fn test_bmp_cross_segment_threshold_matches_exhaustive() {
+    let (schema, _title, sparse) = bmp_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        max_indexing_memory_bytes: 1024,
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    let mut num_docs = 0usize;
+    for segment in 0..12 {
+        for doc_index in 0..16 {
+            let rank = segment * 16 + doc_index;
+            let mut doc = Document::new();
+            doc.add_sparse_vector(
+                sparse,
+                vec![
+                    (0, 0.1 + rank as f32 * 0.003),
+                    (1, 0.2 + (rank % 11) as f32 * 0.04),
+                    (2, 0.05 + (rank % 7) as f32 * 0.02),
+                ],
+            );
+            writer.add_document(doc).unwrap();
+            num_docs += 1;
+        }
+        writer.commit().await.unwrap();
+    }
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert!(index.segment_readers().await.unwrap().len() >= 10);
+    let query =
+        SparseVectorQuery::new(sparse, vec![(0, 1.0), (1, 0.7), (2, 0.3)]).with_heap_factor(1.0);
+    let exhaustive = index.search(&query, num_docs).await.unwrap();
+    assert!(exhaustive.hits.len() > 32);
+
+    for k in [1usize, 3, 10, 32] {
+        let topk = index.search(&query, k).await.unwrap();
+        let expected = &exhaustive.hits[..k];
+        assert_eq!(topk.hits.len(), expected.len(), "k={k}");
+        for (got, want) in topk.hits.iter().zip(expected) {
+            assert!(
+                (got.score - want.score).abs() < 1e-5,
+                "k={k}: BMP shared-floor score diverged ({} vs {})",
+                got.score,
+                want.score,
+            );
+        }
+    }
+}
+
+/// Multi-value `Max` can safely consume a document-score floor because its
+/// final score is one raw ordinal score. Aggregating combiners cannot: several
+/// individually sub-floor ordinals may combine above it.
+#[tokio::test]
+async fn test_bmp_multi_value_threshold_is_combiner_scoped() {
+    use crate::query::{MultiValueCombiner, SharedThreshold, search_segment_shared};
+
+    let (schema, _title, sparse) = bmp_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    for i in 0..20 {
+        let mut doc = Document::new();
+        doc.add_sparse_vector(sparse, vec![(0, 0.5 + i as f32 * 0.1)]);
+        doc.add_sparse_vector(sparse, vec![(1, 0.4 + i as f32 * 0.08)]);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    let segment = index.segment_readers().await.unwrap().pop().unwrap();
+
+    let max_query = SparseVectorQuery::new(sparse, vec![(0, 1.0), (1, 1.0)])
+        .with_combiner(MultiValueCombiner::Max)
+        .with_heap_factor(1.0);
+    let exhaustive = index.search(&max_query, 20).await.unwrap();
+    let max_floor = exhaustive.hits[4].score;
+    let max_shared = SharedThreshold::new();
+    max_shared.raise(max_floor);
+    let (seeded_max, _) = search_segment_shared(segment.as_ref(), &max_query, 5, false, max_shared)
+        .await
+        .unwrap();
+    assert_eq!(seeded_max.len(), 5);
+    for (got, want) in seeded_max.iter().zip(&exhaustive.hits[..5]) {
+        assert!((got.score - want.score).abs() < 1e-5);
+    }
+
+    // This deliberately impossible floor would erase every raw ordinal if it
+    // leaked into Sum. The planner must strip it and still produce a full k.
+    let sum_query = SparseVectorQuery::new(sparse, vec![(0, 1.0), (1, 1.0)])
+        .with_combiner(MultiValueCombiner::Sum)
+        .with_heap_factor(1.0);
+    let unsafe_shared = SharedThreshold::new();
+    unsafe_shared.raise(100.0);
+    let (sum_results, _) =
+        search_segment_shared(segment.as_ref(), &sum_query, 5, false, unsafe_shared)
+            .await
+            .unwrap();
+    assert_eq!(sum_results.len(), 5);
+}
+
 /// BMP multi-segment merge: build two segments, merge, verify query correctness.
 #[tokio::test]
 async fn test_bmp_merge() {

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -37,7 +37,7 @@
 //! - **Thread-local scratch**: Zero per-query allocation for large buffers
 //! - **Early termination**: stop when superblock/block UB < top-k threshold
 
-use super::scoring::{ScoreCollector, ScoredDoc};
+use super::scoring::{ScoreCollector, ScoredDoc, SharedThreshold};
 use crate::segment::{
     BMP_SUPERBLOCK_SIZE, BmpIndex, accumulate_grid_u32, block_term_postings, compute_block_masks,
     find_dim_in_block_data,
@@ -155,6 +155,18 @@ thread_local! {
         std::cell::RefCell::new(BmpScratch::default());
 }
 
+/// A correctness-approved cross-segment score floor for BMP. The planner only
+/// supplies this when raw ordinal scores are also final document scores
+/// (physically single-valued data or the `Max` combiner).
+#[derive(Clone, Copy, Default)]
+pub(crate) struct BmpThreshold<'a> {
+    pub initial: f32,
+    pub shared: Option<&'a SharedThreshold>,
+    /// A raw BMP heap can publish its k-th score only when its entries are
+    /// guaranteed to represent distinct documents.
+    pub publish: bool,
+}
+
 /// Execute a BMP query against the given index.
 ///
 /// Returns top-k results sorted by score descending.
@@ -175,6 +187,7 @@ thread_local! {
 /// - **>0**: stop after visiting this many superblocks
 ///
 /// Based on Mallia et al. (SIGIR 2024) and Carlson et al. (arXiv 2602.02883).
+#[allow(dead_code)]
 pub fn execute_bmp(
     index: &BmpIndex,
     index_label: &str,
@@ -193,6 +206,32 @@ pub fn execute_bmp(
         heap_factor,
         max_superblocks,
         None,
+        BmpThreshold::default(),
+    )
+}
+
+/// BMP execution with a planner-validated live cross-segment threshold.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn execute_bmp_with_threshold(
+    index: &BmpIndex,
+    index_label: &str,
+    field_label: &str,
+    query_terms: &[(u32, f32)],
+    k: usize,
+    heap_factor: f32,
+    max_superblocks: usize,
+    threshold: BmpThreshold<'_>,
+) -> crate::Result<Vec<ScoredDoc>> {
+    execute_bmp_inner(
+        index,
+        index_label,
+        field_label,
+        query_terms,
+        k,
+        heap_factor,
+        max_superblocks,
+        None,
+        threshold,
     )
 }
 
@@ -202,6 +241,7 @@ pub fn execute_bmp(
 /// The predicate is checked during scoring (not post-filter), so the collector
 /// only contains valid documents and the threshold evolves correctly.
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub fn execute_bmp_filtered(
     index: &BmpIndex,
     index_label: &str,
@@ -221,6 +261,33 @@ pub fn execute_bmp_filtered(
         heap_factor,
         max_superblocks,
         Some(predicate),
+        BmpThreshold::default(),
+    )
+}
+
+/// Filtered BMP execution with a planner-validated live threshold.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn execute_bmp_filtered_with_threshold(
+    index: &BmpIndex,
+    index_label: &str,
+    field_label: &str,
+    query_terms: &[(u32, f32)],
+    k: usize,
+    heap_factor: f32,
+    max_superblocks: usize,
+    predicate: &dyn Fn(crate::DocId) -> bool,
+    threshold: BmpThreshold<'_>,
+) -> crate::Result<Vec<ScoredDoc>> {
+    execute_bmp_inner(
+        index,
+        index_label,
+        field_label,
+        query_terms,
+        k,
+        heap_factor,
+        max_superblocks,
+        Some(predicate),
+        threshold,
     )
 }
 
@@ -234,6 +301,7 @@ fn execute_bmp_inner(
     heap_factor: f32,
     max_superblocks: usize,
     predicate: Option<&dyn Fn(crate::DocId) -> bool>,
+    threshold_source: BmpThreshold<'_>,
 ) -> crate::Result<Vec<ScoredDoc>> {
     if query_terms.is_empty() || index.num_blocks == 0 || k == 0 {
         return Ok(Vec::new());
@@ -493,8 +561,17 @@ fn execute_bmp_inner(
         let mut docmap_lookups = 0u32;
         let mut sbs_scored = 0u32;
         let mut collector = ScoreCollector::new(collector_k);
+        let initial_threshold = threshold_source
+            .shared
+            .map(SharedThreshold::get)
+            .unwrap_or(0.0)
+            .max(threshold_source.initial);
+        collector.seed_threshold(initial_threshold);
 
         for (idx, &sb_id) in scratch.sb_order.iter().enumerate() {
+            if let Some(shared) = threshold_source.shared {
+                collector.seed_threshold(shared.get());
+            }
             // LSP/0: hard cap on superblock visits
             if max_superblocks > 0 && idx >= max_superblocks {
                 break;
@@ -626,6 +703,13 @@ fn execute_bmp_inner(
                 },
             );
 
+            if threshold_source.publish
+                && collector.real_len() >= collector_k
+                && let Some(shared) = threshold_source.shared
+            {
+                shared.raise(collector.threshold());
+            }
+
             // Cross-superblock lookahead: prefetch next superblock's block_data_starts.
             // Gives offsets time to arrive during pruning check + UB/mask computation.
             // Range includes the sentinel at next_end (needed by block_data_range).
@@ -643,6 +727,7 @@ fn execute_bmp_inner(
 
         let elapsed_ms = t_start.elapsed().as_secs_f64() * 1000.0;
         let threshold = collector.threshold();
+        let returned = collector.real_len();
         crate::observe::bmp_query(
             index_label,
             field_label,
@@ -655,25 +740,29 @@ fn execute_bmp_inner(
         );
         if elapsed_ms > 500.0 {
             log::warn!(
-                "slow BMP: {:.1}ms, sbs={}/{}, blocks={}/{}, returned={}, threshold={:.4}, alpha={:.2}",
+                "slow BMP: {:.1}ms, sbs={}/{}, blocks={}/{}, k={}, returned={}, seed={:.4}, threshold={:.4}, alpha={:.2}",
                 elapsed_ms,
                 sbs_scored,
                 num_superblocks_total,
                 blocks_scored,
                 num_blocks,
-                collector.len(),
+                collector_k,
+                returned,
+                initial_threshold,
                 threshold,
                 alpha,
             );
         } else {
             log::debug!(
-                "BMP execute: {:.1}ms, sbs={}/{}, blocks={}/{}, returned={}, threshold={:.4}, alpha={:.2}",
+                "BMP execute: {:.1}ms, sbs={}/{}, blocks={}/{}, k={}, returned={}, seed={:.4}, threshold={:.4}, alpha={:.2}",
                 elapsed_ms,
                 sbs_scored,
                 num_superblocks_total,
                 blocks_scored,
                 num_blocks,
-                collector.len(),
+                collector_k,
+                returned,
+                initial_threshold,
                 threshold,
                 alpha,
             );

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -226,7 +226,7 @@ macro_rules! boolean_plan {
             // Auto-detect: BMP executor if field has BMP index, else MaxScore
             if let Some(infos) = extract_all_sparse_infos(should) {
                 if let Some((raw, info)) =
-                    build_sparse_bmp_results(&infos, reader, limit)
+                    build_sparse_bmp_results(&infos, reader, limit, &scorer_options)
                 {
                     return Ok(combine_sparse_results(raw, info.combiner, info.field, limit));
                 }
@@ -270,7 +270,11 @@ macro_rules! boolean_plan {
                     }
                 }
                 for &idx in &grouping.fallback_indices {
-                    scorers.push(should[idx].$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
+                    scorers.push(should[idx].$scorer_fn(
+                        reader,
+                        limit,
+                        scorer_options.without_threshold(),
+                    ) $(. $aw)* ?);
                 }
                 return Ok(build_should_scorer(scorers));
             }
@@ -307,11 +311,15 @@ macro_rules! boolean_plan {
                         predicates.push(Box::new(move |doc_id| bitset.contains(doc_id)));
                     } else {
                         log::debug!("BooleanQuery planner 3a: MUST clause → verifier scorer ({})", q);
-                        must_verifiers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
+                        must_verifiers.push(q.$scorer_fn(
+                            reader, limit, scorer_options.without_threshold()
+                        ) $(. $aw)* ?);
                     }
                 } else {
                     log::debug!("BooleanQuery planner 3a: MUST clause → verifier scorer ({})", q);
-                    must_verifiers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
+                    must_verifiers.push(q.$scorer_fn(
+                        reader, limit, scorer_options.without_threshold()
+                    ) $(. $aw)* ?);
                 }
             }
             // Compile MUST_NOT → negated predicates vs verifier scorers
@@ -326,10 +334,14 @@ macro_rules! boolean_plan {
                         log::debug!("BooleanQuery planner 3a: MUST_NOT clause → bitset predicate ({})", q);
                         predicates.push(Box::new(move |doc_id| !bitset.contains(doc_id)));
                     } else {
-                        must_not_verifiers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
+                        must_not_verifiers.push(q.$scorer_fn(
+                            reader, limit, scorer_options.without_threshold()
+                        ) $(. $aw)* ?);
                     }
                 } else {
-                    must_not_verifiers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
+                    must_not_verifiers.push(q.$scorer_fn(
+                        reader, limit, scorer_options.without_threshold()
+                    ) $(. $aw)* ?);
                 }
             }
 
@@ -345,7 +357,9 @@ macro_rules! boolean_plan {
                     if let Some(ref bitset) = bitset_result {
                         let bitset_pred = |doc_id: crate::DocId| bitset.contains(doc_id);
                         if let Some((raw, info)) =
-                            build_sparse_bmp_results_filtered(&infos, reader, limit, &bitset_pred)
+                            build_sparse_bmp_results_filtered(
+                                &infos, reader, limit, &bitset_pred, &scorer_options
+                            )
                         {
                             log::debug!(
                                 "BooleanQuery planner: bitset-aware sparse BMP, {} dims, {} matching docs",
@@ -359,7 +373,9 @@ macro_rules! boolean_plan {
                     // Fallback: closure predicate (for queries that don't support bitsets)
                     let combined = chain_predicates(predicates);
                     if let Some((raw, info)) =
-                        build_sparse_bmp_results_filtered(&infos, reader, limit, &*combined)
+                        build_sparse_bmp_results_filtered(
+                            &infos, reader, limit, &*combined, &scorer_options
+                        )
                     {
                         log::debug!(
                             "BooleanQuery planner: predicate-aware sparse BMP, {} dims",
@@ -407,7 +423,9 @@ macro_rules! boolean_plan {
                 || !must_not_verifiers.is_empty();
             let should_limit = if has_filters { limit * 4 } else { limit };
             let should_scorer = if should.len() == 1 {
-                should[0].$scorer_fn(reader, should_limit, scorer_options) $(. $aw)* ?
+                should[0].$scorer_fn(
+                    reader, should_limit, scorer_options.without_threshold()
+                ) $(. $aw)* ?
             } else {
                 let sub = BooleanQuery {
                     must: Vec::new(),
@@ -415,7 +433,9 @@ macro_rules! boolean_plan {
                     must_not: Vec::new(),
                     global_stats: global_stats.cloned(),
                 };
-                sub.$scorer_fn(reader, should_limit, scorer_options) $(. $aw)* ?
+                sub.$scorer_fn(
+                    reader, should_limit, scorer_options.without_threshold()
+                ) $(. $aw)* ?
             };
 
             let use_predicated =
@@ -453,15 +473,21 @@ macro_rules! boolean_plan {
         // ── 4. Standard BooleanScorer fallback ───────────────────────────
         let mut must_scorers = Vec::with_capacity(must.len());
         for q in must {
-            must_scorers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
+            must_scorers.push(q.$scorer_fn(
+                reader, limit, scorer_options.without_threshold()
+            ) $(. $aw)* ?);
         }
         let mut should_scorers = Vec::with_capacity(should.len());
         for q in should {
-            should_scorers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
+            should_scorers.push(q.$scorer_fn(
+                reader, limit, scorer_options.without_threshold()
+            ) $(. $aw)* ?);
         }
         let mut must_not_scorers = Vec::with_capacity(must_not.len());
         for q in must_not {
-            must_not_scorers.push(q.$scorer_fn(reader, limit, scorer_options) $(. $aw)* ?);
+            must_not_scorers.push(q.$scorer_fn(
+                reader, limit, scorer_options.without_threshold()
+            ) $(. $aw)* ?);
         }
         let mut scorer = BooleanScorer {
             must: must_scorers,

--- a/hermes-core/src/query/boost.rs
+++ b/hermes-core/src/query/boost.rs
@@ -56,7 +56,14 @@ impl Query for BoostQuery {
                     "boost must be a finite number".to_string(),
                 ));
             }
-            let inner_scorer = inner.scorer_with_options(reader, limit, options).await?;
+            let inner_options = if boost == 1.0 {
+                options
+            } else {
+                options.without_threshold()
+            };
+            let inner_scorer = inner
+                .scorer_with_options(reader, limit, inner_options)
+                .await?;
             Ok(Box::new(BoostScorer {
                 inner: inner_scorer,
                 boost,
@@ -85,9 +92,14 @@ impl Query for BoostQuery {
                 "boost must be a finite number".to_string(),
             ));
         }
+        let inner_options = if self.boost == 1.0 {
+            options
+        } else {
+            options.without_threshold()
+        };
         let inner_scorer = self
             .inner
-            .scorer_sync_with_options(reader, limit, options)?;
+            .scorer_sync_with_options(reader, limit, inner_options)?;
         Ok(Box::new(BoostScorer {
             inner: inner_scorer,
             boost: self.boost,

--- a/hermes-core/src/query/collector.rs
+++ b/hermes-core/src/query/collector.rs
@@ -585,6 +585,7 @@ pub async fn collect_segment_with_limit_seeded<C: Collector>(
     let options = super::ScorerOptions {
         collect_positions: collector.needs_positions(),
         initial_threshold,
+        shared_threshold: None,
     };
     let mut scorer = query.scorer_with_options(reader, limit, options).await?;
     drive_scorer(scorer.as_mut(), collector);
@@ -659,6 +660,7 @@ pub fn collect_segment_with_limit_seeded_sync<C: Collector>(
     let options = super::ScorerOptions {
         collect_positions: collector.needs_positions(),
         initial_threshold,
+        shared_threshold: None,
     };
     let mut scorer = query.scorer_sync_with_options(reader, limit, options)?;
     drive_scorer(scorer.as_mut(), collector);
@@ -695,6 +697,31 @@ pub fn search_segment_seeded_sync(
     Ok(collector.into_results_with_count())
 }
 
+/// Per-segment search with a live cross-segment top-k floor (sync).
+#[cfg(feature = "sync")]
+pub fn search_segment_shared_sync(
+    reader: &SegmentReader,
+    query: &dyn Query,
+    limit: usize,
+    collect_positions: bool,
+    shared_threshold: super::SharedThreshold,
+) -> Result<(Vec<SearchResult>, u32)> {
+    let segment_limit = limit.min(reader.num_docs() as usize);
+    let mut collector = if collect_positions {
+        TopKCollector::with_positions(segment_limit)
+    } else {
+        TopKCollector::new(segment_limit)
+    };
+    let options = super::ScorerOptions {
+        collect_positions,
+        initial_threshold: shared_threshold.get(),
+        shared_threshold: Some(shared_threshold),
+    };
+    let mut scorer = query.scorer_sync_with_options(reader, segment_limit, options)?;
+    drive_scorer(scorer.as_mut(), &mut collector);
+    Ok(collector.into_results_with_count())
+}
+
 /// Per-segment search seeded with a cross-segment top-k floor (async).
 pub async fn search_segment_seeded(
     reader: &SegmentReader,
@@ -717,6 +744,32 @@ pub async fn search_segment_seeded(
         initial_threshold,
     )
     .await?;
+    Ok(collector.into_results_with_count())
+}
+
+/// Per-segment search with a live cross-segment top-k floor (async).
+pub async fn search_segment_shared(
+    reader: &SegmentReader,
+    query: &dyn Query,
+    limit: usize,
+    collect_positions: bool,
+    shared_threshold: super::SharedThreshold,
+) -> Result<(Vec<SearchResult>, u32)> {
+    let segment_limit = limit.min(reader.num_docs() as usize);
+    let mut collector = if collect_positions {
+        TopKCollector::with_positions(segment_limit)
+    } else {
+        TopKCollector::new(segment_limit)
+    };
+    let options = super::ScorerOptions {
+        collect_positions,
+        initial_threshold: shared_threshold.get(),
+        shared_threshold: Some(shared_threshold),
+    };
+    let mut scorer = query
+        .scorer_with_options(reader, segment_limit, options)
+        .await?;
+    drive_scorer(scorer.as_mut(), &mut collector);
     Ok(collector.into_results_with_count())
 }
 

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -183,6 +183,53 @@ pub(super) fn bounded_sparse_executor_limit(limit: usize, over_fetch_factor: f32
     (derived as usize).min(MAX_SPARSE_EXECUTOR_RESULTS)
 }
 
+/// Physical single-value BMP segments need no ordinal over-fetch: every raw
+/// hit is already a distinct final document. Genuine multi-value segments
+/// retain the configured budget because aggregation can collapse many raw
+/// ordinals into one document.
+fn bmp_executor_limit(
+    limit: usize,
+    over_fetch_factor: f32,
+    bmp: &crate::segment::reader::bmp::BmpIndex,
+) -> usize {
+    bmp_executor_limit_for_counts(
+        limit,
+        over_fetch_factor,
+        bmp.is_single_valued(),
+        bmp.num_real_docs() as usize,
+        bmp.num_virtual_docs as usize,
+    )
+}
+
+fn bmp_executor_limit_for_counts(
+    limit: usize,
+    over_fetch_factor: f32,
+    single_valued: bool,
+    num_real_docs: usize,
+    num_virtual_docs: usize,
+) -> usize {
+    if single_valued {
+        limit.min(num_real_docs)
+    } else {
+        bounded_sparse_executor_limit(limit, over_fetch_factor).min(num_virtual_docs)
+    }
+}
+
+fn bmp_threshold<'a>(
+    options: &'a super::ScorerOptions,
+    combiner: MultiValueCombiner,
+    single_valued: bool,
+) -> super::bmp::BmpThreshold<'a> {
+    if !single_valued && combiner != MultiValueCombiner::Max {
+        return super::bmp::BmpThreshold::default();
+    }
+    super::bmp::BmpThreshold {
+        initial: options.initial_threshold,
+        shared: options.shared_threshold.as_ref(),
+        publish: single_valued,
+    }
+}
+
 /// Build a sparse MaxScoreExecutor from decomposed sparse infos.
 ///
 /// Returns the executor + representative info (for combiner/field), or None
@@ -229,6 +276,7 @@ pub(crate) fn build_sparse_bmp_results(
     infos: &[SparseTermQueryInfo],
     reader: &SegmentReader,
     limit: usize,
+    options: &super::ScorerOptions,
 ) -> Option<(Vec<ScoredDoc>, SparseTermQueryInfo)> {
     let field = infos[0].field;
     let bmp = reader.bmp_index(field)?;
@@ -239,11 +287,10 @@ pub(crate) fn build_sparse_bmp_results(
     if query_terms.is_empty() {
         return None;
     }
-    let executor_limit = bounded_sparse_executor_limit(limit, infos[0].over_fetch_factor)
-        .min(bmp.num_virtual_docs as usize);
+    let executor_limit = bmp_executor_limit(limit, infos[0].over_fetch_factor, bmp);
     let max_sb = infos[0].max_superblocks;
     let field_label = reader.schema().get_field_name(field).unwrap_or("?");
-    match super::bmp::execute_bmp(
+    match super::bmp::execute_bmp_with_threshold(
         bmp,
         reader.schema().index_label(),
         field_label,
@@ -251,6 +298,7 @@ pub(crate) fn build_sparse_bmp_results(
         executor_limit,
         infos[0].heap_factor,
         max_sb,
+        bmp_threshold(options, infos[0].combiner, bmp.is_single_valued()),
     ) {
         Ok(results) => Some((results, infos[0])),
         Err(e) => {
@@ -269,6 +317,7 @@ pub(crate) fn build_sparse_bmp_results_filtered(
     reader: &SegmentReader,
     limit: usize,
     predicate: &dyn Fn(crate::DocId) -> bool,
+    options: &super::ScorerOptions,
 ) -> Option<(Vec<ScoredDoc>, SparseTermQueryInfo)> {
     let field = infos[0].field;
     let bmp = reader.bmp_index(field)?;
@@ -279,11 +328,10 @@ pub(crate) fn build_sparse_bmp_results_filtered(
     if query_terms.is_empty() {
         return None;
     }
-    let executor_limit = bounded_sparse_executor_limit(limit, infos[0].over_fetch_factor)
-        .min(bmp.num_virtual_docs as usize);
+    let executor_limit = bmp_executor_limit(limit, infos[0].over_fetch_factor, bmp);
     let max_sb = infos[0].max_superblocks;
     let field_label = reader.schema().get_field_name(field).unwrap_or("?");
-    match super::bmp::execute_bmp_filtered(
+    match super::bmp::execute_bmp_filtered_with_threshold(
         bmp,
         reader.schema().index_label(),
         field_label,
@@ -292,6 +340,7 @@ pub(crate) fn build_sparse_bmp_results_filtered(
         infos[0].heap_factor,
         max_sb,
         predicate,
+        bmp_threshold(options, infos[0].combiner, bmp.is_single_valued()),
     ) {
         Ok(results) => Some((results, infos[0])),
         Err(e) => {
@@ -594,5 +643,47 @@ impl Scorer for VectorTopKResultScorer {
             .map(|&(ordinal, score)| ScoredPosition::new(ordinal, score))
             .collect();
         Some(vec![(self.field_id, scored_positions)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bmp_single_value_limit_does_not_overfetch() {
+        assert_eq!(
+            bmp_executor_limit_for_counts(320, 2.0, true, 10_000, 10_048),
+            320
+        );
+        assert_eq!(
+            bmp_executor_limit_for_counts(320, 2.0, false, 10_000, 10_048),
+            640
+        );
+    }
+
+    #[test]
+    fn bmp_threshold_is_only_used_in_final_score_space() {
+        let shared = super::super::SharedThreshold::new();
+        shared.raise(7.0);
+        let options = super::super::ScorerOptions {
+            collect_positions: false,
+            initial_threshold: 5.0,
+            shared_threshold: Some(shared),
+        };
+
+        let single_sum = bmp_threshold(&options, MultiValueCombiner::Sum, true);
+        assert_eq!(single_sum.initial, 5.0);
+        assert!(single_sum.shared.is_some());
+        assert!(single_sum.publish);
+
+        let multi_max = bmp_threshold(&options, MultiValueCombiner::Max, false);
+        assert!(multi_max.shared.is_some());
+        assert!(!multi_max.publish);
+
+        let multi_sum = bmp_threshold(&options, MultiValueCombiner::Sum, false);
+        assert_eq!(multi_sum.initial, 0.0);
+        assert!(multi_sum.shared.is_none());
+        assert!(!multi_sum.publish);
     }
 }

--- a/hermes-core/src/query/scoring.rs
+++ b/hermes-core/src/query/scoring.rs
@@ -68,6 +68,9 @@ pub struct ScoreCollector {
     /// Cached threshold: avoids repeated heap.peek() in hot loops.
     /// Updated only when the heap changes (insert/pop).
     cached_threshold: f32,
+    /// Number of real entries in the heap. Threshold seeding fills unused
+    /// slots with sentinels, so `heap.len()` alone cannot answer this.
+    real_len: usize,
 }
 
 impl ScoreCollector {
@@ -79,6 +82,7 @@ impl ScoreCollector {
             heap: BinaryHeap::with_capacity(capacity),
             k,
             cached_threshold: 0.0,
+            real_len: 0,
         }
     }
 
@@ -119,6 +123,7 @@ impl ScoreCollector {
         };
         if self.heap.len() < self.k {
             self.heap.push(entry);
+            self.real_len += 1;
             // Only recompute threshold when heap just became full
             if self.heap.len() == self.k {
                 self.update_threshold();
@@ -126,7 +131,13 @@ impl ScoreCollector {
             true
         } else if self.heap.peek().is_some_and(|worst| entry < *worst) {
             self.heap.push(entry);
-            self.heap.pop(); // Remove lowest
+            if self
+                .heap
+                .pop()
+                .is_some_and(|evicted| evicted.doc_id == u32::MAX)
+            {
+                self.real_len += 1;
+            }
             self.update_threshold();
             true
         } else {
@@ -161,6 +172,12 @@ impl ScoreCollector {
         self.heap.len()
     }
 
+    /// Number of real results retained, excluding threshold sentinels.
+    #[inline]
+    pub fn real_len(&self) -> usize {
+        self.real_len
+    }
+
     /// Check if collector is empty
     #[inline]
     pub fn is_empty(&self) -> bool {
@@ -169,20 +186,37 @@ impl ScoreCollector {
 
     /// Seed the threshold from a cross-segment shared value.
     ///
-    /// Pre-fills the heap with `k` dummy entries at the given score so that
-    /// pruning kicks in immediately. Only has effect if called before any
-    /// real inserts and `initial_threshold > 0.0`.
+    /// Fills unused slots and replaces retained entries below the new floor
+    /// with dummy entries. This can be called repeatedly while another
+    /// segment raises the shared threshold; equal-scoring real candidates win
+    /// the deterministic doc-id tie break over sentinels.
     pub fn seed_threshold(&mut self, initial_threshold: f32) {
-        if initial_threshold > 0.0 && self.heap.is_empty() {
-            for _ in 0..self.k {
-                self.heap.push(HeapEntry {
-                    doc_id: u32::MAX,
-                    score: initial_threshold,
-                    ordinal: 0,
-                });
-            }
-            self.update_threshold();
+        if initial_threshold <= 0.0
+            || self.k == 0
+            || (self.heap.len() >= self.k && initial_threshold <= self.cached_threshold)
+        {
+            return;
         }
+
+        let sentinel = HeapEntry {
+            doc_id: u32::MAX,
+            score: initial_threshold,
+            ordinal: 0,
+        };
+        while self.heap.len() < self.k {
+            self.heap.push(sentinel);
+        }
+        while self.heap.peek().is_some_and(|worst| sentinel < *worst) {
+            self.heap.push(sentinel);
+            if self
+                .heap
+                .pop()
+                .is_some_and(|evicted| evicted.doc_id != u32::MAX)
+            {
+                self.real_len -= 1;
+            }
+        }
+        self.update_threshold();
     }
 
     /// Convert to sorted top-k results (descending by score).
@@ -222,7 +256,7 @@ impl ScoreCollector {
 /// any other segment with `v` can never drop a document that belongs in the
 /// final top-k. Completion order is arbitrary, so the floor is best-effort — it
 /// only changes how aggressively later segments prune, never correctness.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SharedThreshold(std::sync::Arc<std::sync::atomic::AtomicU32>);
 
 impl SharedThreshold {
@@ -1245,6 +1279,28 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].0, 1);
         assert_eq!(results[1].0, 2);
+    }
+
+    #[test]
+    fn test_shared_threshold_can_raise_after_real_inserts() {
+        let mut collector = ScoreCollector::new(3);
+        collector.insert(1, 10.0);
+        collector.insert(2, 4.0);
+        assert_eq!(collector.real_len(), 2);
+
+        // Raising the floor after traversal has started removes retained work
+        // that can no longer reach the global top-k.
+        collector.seed_threshold(6.0);
+        assert_eq!(collector.threshold(), 6.0);
+        assert_eq!(collector.real_len(), 1);
+
+        // A real candidate tied with the floor displaces the sentinel because
+        // its doc id wins the canonical tie break.
+        assert!(collector.would_enter_candidate(3, 6.0, 0));
+        assert!(collector.insert(3, 6.0));
+        assert_eq!(collector.real_len(), 2);
+        let results = collector.into_sorted_results();
+        assert_eq!(results, vec![(1, 10.0, 0), (3, 6.0, 0)]);
     }
 
     #[test]

--- a/hermes-core/src/query/traits.rs
+++ b/hermes-core/src/query/traits.rs
@@ -35,7 +35,7 @@ pub type ScorerFuture<'a> = Pin<Box<dyn Future<Output = Result<Box<dyn Scorer + 
 /// this explicit lets ID/score-only collectors avoid loading them while query
 /// types that need positions for matching (for example phrases) remain free to
 /// load their own internal data.
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Default)]
 pub struct ScorerOptions {
     pub collect_positions: bool,
     /// Initial top-k score floor to seed into MaxScore/BMP pruning. Used to
@@ -43,6 +43,10 @@ pub struct ScorerOptions {
     /// segments prune from a nonzero threshold (see `SharedThreshold`). 0.0 =
     /// no seed. Only honored on exact, final-score executor paths.
     pub initial_threshold: f32,
+    /// Live form of `initial_threshold`. Exact final-score executors may read
+    /// it during traversal so concurrently searched segments benefit as soon
+    /// as another segment establishes a stronger global floor.
+    pub shared_threshold: Option<super::scoring::SharedThreshold>,
 }
 
 impl ScorerOptions {
@@ -50,6 +54,18 @@ impl ScorerOptions {
         Self {
             collect_positions: true,
             initial_threshold: 0.0,
+            shared_threshold: None,
+        }
+    }
+
+    /// Preserve collection behavior while preventing a nested/component
+    /// scorer from applying a floor expressed in the outer query's score
+    /// space.
+    pub fn without_threshold(&self) -> Self {
+        Self {
+            collect_positions: self.collect_positions,
+            initial_threshold: 0.0,
+            shared_threshold: None,
         }
     }
 }

--- a/hermes-core/src/query/vector/sparse.rs
+++ b/hermes-core/src/query/vector/sparse.rs
@@ -437,6 +437,15 @@ impl SparseVectorQuery {
 
 impl Query for SparseVectorQuery {
     fn scorer<'a>(&self, reader: &'a SegmentReader, limit: usize) -> ScorerFuture<'a> {
+        self.scorer_with_options(reader, limit, crate::query::ScorerOptions::with_positions())
+    }
+
+    fn scorer_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: crate::query::ScorerOptions,
+    ) -> ScorerFuture<'a> {
         let validation = self.validate(reader);
         let infos = self.sparse_infos();
 
@@ -448,7 +457,7 @@ impl Query for SparseVectorQuery {
 
             // Auto-detect: try BMP executor first (coupled to index format)
             if let Some((raw, info)) =
-                crate::query::planner::build_sparse_bmp_results(&infos, reader, limit)
+                crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, &options)
             {
                 return Ok(crate::query::planner::combine_sparse_results(
                     raw,
@@ -481,6 +490,16 @@ impl Query for SparseVectorQuery {
         reader: &'a SegmentReader,
         limit: usize,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        self.scorer_sync_with_options(reader, limit, crate::query::ScorerOptions::with_positions())
+    }
+
+    #[cfg(feature = "sync")]
+    fn scorer_sync_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: crate::query::ScorerOptions,
+    ) -> crate::Result<Box<dyn Scorer + 'a>> {
         self.validate(reader)?;
         let infos = self.sparse_infos();
         if infos.is_empty() {
@@ -489,7 +508,7 @@ impl Query for SparseVectorQuery {
 
         // Auto-detect: try BMP executor first (coupled to index format)
         if let Some((raw, info)) =
-            crate::query::planner::build_sparse_bmp_results(&infos, reader, limit)
+            crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, &options)
         {
             return Ok(crate::query::planner::combine_sparse_results(
                 raw,
@@ -622,27 +641,25 @@ impl SparseTermQuery {
         &self,
         reader: &'a SegmentReader,
         limit: usize,
+        options: &crate::query::ScorerOptions,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
-        if let Some(bmp) = reader.bmp_index(self.field) {
-            let executor_limit =
-                crate::query::planner::bounded_sparse_executor_limit(limit, self.over_fetch_factor)
-                    .min(bmp.num_virtual_docs as usize);
-            let results = crate::query::bmp::execute_bmp(
-                bmp,
-                reader.schema().index_label(),
-                reader.schema().get_field_name(self.field).unwrap_or("?"),
-                &[(self.dim_id, self.weight)],
-                executor_limit,
-                self.heap_factor,
-                0,
-            )?;
-            let combined = crate::segment::combine_ordinal_results(
-                results.into_iter().map(|r| (r.doc_id, r.ordinal, r.score)),
-                self.combiner,
+        let infos = [crate::query::SparseTermQueryInfo {
+            field: self.field,
+            dim_id: self.dim_id,
+            weight: self.weight,
+            heap_factor: self.heap_factor,
+            combiner: self.combiner,
+            over_fetch_factor: self.over_fetch_factor,
+            max_superblocks: 0,
+        }];
+        if let Some((raw, info)) =
+            crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, options)
+        {
+            return Ok(crate::query::planner::combine_sparse_results(
+                raw,
+                info.combiner,
+                info.field,
                 limit,
-            );
-            return Ok(Box::new(
-                crate::query::planner::VectorTopKResultScorer::new(combined, self.field.0),
             ));
         }
         Ok(Box::new(crate::query::EmptyScorer))
@@ -680,12 +697,21 @@ impl SparseTermQuery {
 
 impl Query for SparseTermQuery {
     fn scorer<'a>(&self, reader: &'a SegmentReader, limit: usize) -> ScorerFuture<'a> {
+        self.scorer_with_options(reader, limit, crate::query::ScorerOptions::with_positions())
+    }
+
+    fn scorer_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: crate::query::ScorerOptions,
+    ) -> ScorerFuture<'a> {
         let query = self.clone();
         Box::pin(async move {
             query.validate(reader)?;
             let mut scorer = match query.make_scorer(reader)? {
                 Some(s) => s,
-                None => return query.bmp_fallback_scorer(reader, limit),
+                None => return query.bmp_fallback_scorer(reader, limit, &options),
             };
             scorer.cursor.ensure_block_loaded().await.ok();
             Ok(Box::new(scorer) as Box<dyn Scorer + 'a>)
@@ -698,10 +724,20 @@ impl Query for SparseTermQuery {
         reader: &'a SegmentReader,
         limit: usize,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        self.scorer_sync_with_options(reader, limit, crate::query::ScorerOptions::with_positions())
+    }
+
+    #[cfg(feature = "sync")]
+    fn scorer_sync_with_options<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+        options: crate::query::ScorerOptions,
+    ) -> crate::Result<Box<dyn Scorer + 'a>> {
         self.validate(reader)?;
         let mut scorer = match self.make_scorer(reader)? {
             Some(s) => s,
-            None => return self.bmp_fallback_scorer(reader, limit),
+            None => return self.bmp_fallback_scorer(reader, limit, &options),
         };
         scorer.cursor.ensure_block_loaded_sync().ok();
         Ok(Box::new(scorer) as Box<dyn Scorer + 'a>)

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -108,6 +108,10 @@ pub struct BmpIndex {
     grid_bits: u8,
     /// Actual vector count before padding
     num_real_docs: u32,
+    /// True when every stored vector is ordinal zero. This is derived from
+    /// the physical document map rather than the schema so legacy segments
+    /// whose `multi` flag was inaccurate still get correct query planning.
+    single_valued: bool,
 
     // ── Zero-copy OwnedBytes sections (keeps backing store alive) ────
     /// Section A: block_data_starts[block_id] = byte offset into block_data_bytes
@@ -229,6 +233,7 @@ impl BmpIndex {
                 packed_row_size: 0,
                 grid_bits,
                 num_real_docs,
+                single_valued: true,
                 block_data_starts_bytes: OwnedBytes::empty(),
                 block_data_bytes: OwnedBytes::empty(),
                 grid_bytes: OwnedBytes::empty(),
@@ -369,6 +374,10 @@ impl BmpIndex {
         let sb_grid_bytes = blob.slice(sb_grid_start..sb_grid_end);
         let doc_map_ids_bytes = blob.slice(dm_start..dm_ids_end);
         let doc_map_ordinals_bytes = blob.slice(dm_ids_end..dm_ords_end);
+        let single_valued = doc_map_ordinals_bytes
+            .as_slice()
+            .chunks_exact(2)
+            .all(|ordinal| ordinal == [0, 0]);
 
         // This compact table is cheap to validate in full and is the trust
         // boundary for every later raw-pointer block access.
@@ -419,7 +428,7 @@ impl BmpIndex {
         log::debug!(
             "BMP V14 index loaded: num_blocks={}, num_superblocks={}, dims={}, bmp_block_size={}, \
              num_virtual_docs={}, num_real_docs={}, max_weight_scale={:.4}, postings={}, \
-             packed_row_size={}, block_data={}B, doc_map={}B",
+             packed_row_size={}, single_valued={}, block_data={}B, doc_map={}B",
             num_blocks,
             num_superblocks,
             dims,
@@ -429,6 +438,7 @@ impl BmpIndex {
             max_weight_scale,
             total_postings,
             packed_row_size,
+            single_valued,
             bds_start,
             num_virtual_docs as usize * 6,
         );
@@ -445,6 +455,7 @@ impl BmpIndex {
             packed_row_size,
             grid_bits,
             num_real_docs,
+            single_valued,
             block_data_starts_bytes,
             block_data_bytes,
             grid_bytes,
@@ -716,6 +727,13 @@ impl BmpIndex {
     /// Actual vector count before block-alignment padding.
     pub fn num_real_docs(&self) -> u32 {
         self.num_real_docs
+    }
+
+    /// Whether this segment physically contains at most one vector per
+    /// document. Unlike the schema's `multi` flag, this remains reliable for
+    /// old or externally-created segments with inaccurate metadata.
+    pub fn is_single_valued(&self) -> bool {
+        self.single_valued
     }
 
     /// Estimated memory usage in bytes (mmap-backed region sizes).
@@ -1816,6 +1834,22 @@ mod safety_tests {
         let starts = grid_offset - (num_blocks + 1) * 8;
         blob[starts..starts + 8].copy_from_slice(&1u64.to_le_bytes());
         assert!(matches!(parse(blob), Err(crate::Error::Corruption(_))));
+    }
+
+    #[test]
+    fn physical_single_value_detection_uses_ordinal_map() {
+        let single = parse(test_blob()).unwrap();
+        assert!(single.is_single_valued());
+
+        let mut postings = FxHashMap::default();
+        postings.insert(3, vec![(0, 0, 1.0), (0, 1, 0.8), (1, 0, 0.5)]);
+        let mut blob = Vec::new();
+        crate::segment::builder::bmp::build_bmp_blob(
+            postings, 64, 4, 0.0, None, 16, 5.0, 0, &mut blob,
+        )
+        .unwrap();
+        let multi = parse(blob).unwrap();
+        assert!(!multi.is_single_valued());
     }
 }
 


### PR DESCRIPTION
## Summary
- detect physically single-valued BMP segments and avoid unnecessary ordinal over-fetch
- propagate a live cross-segment threshold during BMP superblock traversal with combiner-safe guards
- expose collector depth and threshold seeding in BMP diagnostics

## Correctness
- single-valued segments use the requested top-k depth
- multi-valued Max may consume the global document-score floor
- Sum, LogSumExp, Avg, and WeightedTopK remain unseeded because raw ordinal scores are not final document scores

## Validation
- cargo test -p hermes-core --all-features --lib (857 passed, 8 ignored)
- targeted single-value, multi-value Max/Sum, and many-segment exhaustive parity tests
- cargo clippy -p hermes-core --all-features --all-targets -- -D warnings