### PR TITLE
feat(vector): make ANN retraining atomic and scalable

### DIFF
--- a/hermes-core/src/directories/directory.rs
+++ b/hermes-core/src/directories/directory.rs
@@ -676,6 +676,18 @@ pub trait DirectoryWriter: Directory {
     /// Atomic rename
     async fn rename(&self, from: &Path, to: &Path) -> io::Result<()>;
 
+    /// Create another immutable name for an existing file without copying its
+    /// contents when the backend supports it. Segment rewrites use this to
+    /// retain unchanged multi-gigabyte files while replacing only one index
+    /// payload. Backends without link semantics return `Unsupported`; callers
+    /// then fall back to a streaming copy.
+    async fn link(&self, _from: &Path, _to: &Path) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "directory backend does not support immutable file links",
+        ))
+    }
+
     /// Sync all pending writes
     async fn sync(&self) -> io::Result<()>;
 
@@ -822,6 +834,18 @@ impl DirectoryWriter for RamDirectory {
         if let Some(data) = files.remove(from) {
             files.insert(to.to_path_buf(), data);
         }
+        Ok(())
+    }
+
+    async fn link(&self, from: &Path, to: &Path) -> io::Result<()> {
+        let mut files = self.files.write();
+        let data = files.get(from).cloned().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("source file {from:?} does not exist"),
+            )
+        })?;
+        files.insert(to.to_path_buf(), data);
         Ok(())
     }
 
@@ -976,6 +1000,10 @@ impl DirectoryWriter for FsDirectory {
         // though the rename later succeeded. The caller must update its
         // in-memory metadata in the same poll after this returns.
         std::fs::rename(&from_path, &to_path)
+    }
+
+    async fn link(&self, from: &Path, to: &Path) -> io::Result<()> {
+        std::fs::hard_link(self.resolve(from), self.resolve(to))
     }
 
     async fn sync(&self) -> io::Result<()> {

--- a/hermes-core/src/directories/mmap.rs
+++ b/hermes-core/src/directories/mmap.rs
@@ -161,6 +161,10 @@ impl DirectoryWriter for MmapDirectory {
         std::fs::rename(&from_path, &to_path)
     }
 
+    async fn link(&self, from: &Path, to: &Path) -> io::Result<()> {
+        std::fs::hard_link(self.resolve(from), self.resolve(to))
+    }
+
     async fn sync(&self) -> io::Result<()> {
         // fsync the directory
         let dir = std::fs::File::open(&self.root)?;

--- a/hermes-core/src/directories/slice_cache.rs
+++ b/hermes-core/src/directories/slice_cache.rs
@@ -797,6 +797,12 @@ impl<D: super::DirectoryWriter> super::DirectoryWriter for SliceCachingDirectory
         self.inner.rename(from, to).await
     }
 
+    async fn link(&self, from: &Path, to: &Path) -> io::Result<()> {
+        // A link creates an immutable alias. Do not copy cache entries: the
+        // destination starts cold and is populated under its own path.
+        self.inner.link(from, to).await
+    }
+
     async fn sync(&self) -> io::Result<()> {
         self.inner.sync().await
     }

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -6,9 +6,10 @@
 //! - Trained centroids/codebooks paths
 //!
 //! The workflow is:
-//! 1. During accumulation: segments store Flat vectors, state is Flat
-//! 2. When threshold crossed: train ONCE, update state to Built
-//! 3. On index open: load metadata, skip re-training if already built
+//! 1. During initial accumulation, segments store flat vectors.
+//! 2. A manual build trains the first global codebook and ANN generation.
+//! 3. A manual retrain stages and atomically publishes a replacement generation.
+//! 4. On index open, metadata loads the currently published codebooks.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -385,25 +386,6 @@ impl IndexMetadata {
         Ok(())
     }
 
-    /// Compatibility loader for callers that only have the persisted field
-    /// map. Invalid/incomplete state is logged and returns `None` rather than a
-    /// partial set.
-    ///
-    /// Index open/build paths use the fallible, schema-aware
-    /// [`Self::try_load_trained_from_fields`] method below.
-    pub async fn load_trained_from_fields<D: crate::directories::Directory>(
-        vector_fields: &HashMap<u32, FieldVectorMeta>,
-        dir: &D,
-    ) -> Option<crate::segment::TrainedVectorStructures> {
-        match Self::load_trained_from_fields_impl(vector_fields, None, dir).await {
-            Ok(trained) => trained,
-            Err(error) => {
-                log::error!("[trained] refusing incomplete/corrupt artifact set: {error}");
-                None
-            }
-        }
-    }
-
     /// Fallible schema-aware loader used for lifecycle publication.
     #[cfg_attr(not(feature = "native"), allow(dead_code))]
     pub(crate) async fn try_load_trained_from_fields<D: crate::directories::Directory>(
@@ -411,7 +393,7 @@ impl IndexMetadata {
         schema: &Schema,
         dir: &D,
     ) -> Result<Option<crate::segment::TrainedVectorStructures>> {
-        Self::load_trained_from_fields_impl(vector_fields, Some(schema), dir).await
+        Self::load_trained_from_fields_impl(vector_fields, schema, dir).await
     }
 
     /// Load and validate the complete trained-artifact set described by a
@@ -425,7 +407,7 @@ impl IndexMetadata {
     /// restart.
     async fn load_trained_from_fields_impl<D: crate::directories::Directory>(
         vector_fields: &HashMap<u32, FieldVectorMeta>,
-        schema: Option<&Schema>,
+        schema: &Schema,
         dir: &D,
     ) -> Result<Option<crate::segment::TrainedVectorStructures>> {
         use std::sync::Arc;
@@ -476,30 +458,31 @@ impl IndexMetadata {
             })?;
             match field_meta.index_type {
                 VectorFieldIndexType::Float(index_type @ VectorIndexType::IvfPq) => {
-                    let schema_config = schema
-                        .map(|schema| {
-                            let entry = schema
-                                .get_field_entry(crate::dsl::Field(*field_id))
-                                .ok_or_else(|| Error::Corruption(format!(
-                                    "trained vector metadata references missing field {field_id}"
-                                )))?;
-                            let config = entry.dense_vector_config.as_ref().filter(|_| {
-                                entry.field_type == crate::dsl::FieldType::DenseVector
-                            }).ok_or_else(|| Error::Corruption(format!(
+                    let entry = schema
+                        .get_field_entry(crate::dsl::Field(*field_id))
+                        .ok_or_else(|| {
+                            Error::Corruption(format!(
+                                "trained vector metadata references missing field {field_id}"
+                            ))
+                        })?;
+                    let schema_config = entry
+                        .dense_vector_config
+                        .as_ref()
+                        .filter(|_| entry.field_type == crate::dsl::FieldType::DenseVector)
+                        .ok_or_else(|| {
+                            Error::Corruption(format!(
                                 "trained vector metadata field {field_id} is not a float dense field"
-                            )))?;
-                            if config.index_type != index_type {
-                                return Err(Error::Corruption(format!(
-                                    "trained vector metadata field {field_id} uses {index_type:?}, schema requires {:?}",
-                                    config.index_type
-                                )));
-                            }
-                            Ok(config)
-                        })
-                        .transpose()?;
+                            ))
+                        })?;
+                    if schema_config.index_type != index_type {
+                        return Err(Error::Corruption(format!(
+                            "trained vector metadata field {field_id} uses {index_type:?}, schema requires {:?}",
+                            schema_config.index_type
+                        )));
+                    }
                     let c: crate::structures::CoarseCentroids =
                         load_trained_artifact(dir, *field_id, "centroids", centroids_file).await?;
-                    let expected_dim = schema_config.map_or(c.dim, |config| config.dim);
+                    let expected_dim = schema_config.dim;
                     let actual_clusters = c.num_clusters as usize;
                     let expected_values =
                         actual_clusters.checked_mul(expected_dim).ok_or_else(|| {
@@ -518,13 +501,12 @@ impl IndexMetadata {
                             "trained centroids for field {field_id} do not match metadata/schema"
                         )));
                     }
-                    if let Some(config) = schema_config {
-                        c.validate_routing(config.ivf_routing).map_err(|error| {
+                    c.validate_routing(schema_config.ivf_routing)
+                        .map_err(|error| {
                             Error::Corruption(format!(
                                 "invalid trained centroid routing for field {field_id}: {error}"
                             ))
                         })?;
-                    }
                     let codebook_file = field_meta.codebook_file.as_deref().ok_or_else(|| {
                         Error::Corruption(format!(
                             "trained float IVF-PQ field {field_id} has no codebook_file"
@@ -547,21 +529,25 @@ impl IndexMetadata {
                     centroids.insert(*field_id, Arc::new(c));
                 }
                 VectorFieldIndexType::Binary(BinaryIndexType::Ivf) => {
-                    let schema_config = schema
-                        .map(|schema| {
-                            let entry = schema
-                                .get_field_entry(crate::dsl::Field(*field_id))
-                                .ok_or_else(|| Error::Corruption(format!(
-                                    "trained vector metadata references missing field {field_id}"
-                                )))?;
-                            entry.binary_dense_vector_config.as_ref().filter(|config| {
-                                entry.field_type == crate::dsl::FieldType::BinaryDenseVector
-                                    && config.index_type == BinaryIndexType::Ivf
-                            }).ok_or_else(|| Error::Corruption(format!(
-                                "trained vector metadata field {field_id} is not a binary IVF field"
-                            )))
+                    let entry = schema
+                        .get_field_entry(crate::dsl::Field(*field_id))
+                        .ok_or_else(|| {
+                            Error::Corruption(format!(
+                                "trained vector metadata references missing field {field_id}"
+                            ))
+                        })?;
+                    let schema_config = entry
+                        .binary_dense_vector_config
+                        .as_ref()
+                        .filter(|config| {
+                            entry.field_type == crate::dsl::FieldType::BinaryDenseVector
+                                && config.index_type == BinaryIndexType::Ivf
                         })
-                        .transpose()?;
+                        .ok_or_else(|| {
+                            Error::Corruption(format!(
+                                "trained vector metadata field {field_id} is not a binary IVF field"
+                            ))
+                        })?;
                     let quantizer: crate::structures::BinaryCoarseQuantizer =
                         load_trained_artifact(dir, *field_id, "binary centroids", centroids_file)
                             .await?;
@@ -572,21 +558,19 @@ impl IndexMetadata {
                     })?;
                     let actual_clusters = quantizer.num_clusters as usize;
                     if actual_clusters > expected_clusters
-                        || schema_config.is_some_and(|config| config.dim != quantizer.dim_bits)
+                        || schema_config.dim != quantizer.dim_bits
                     {
                         return Err(Error::Corruption(format!(
                             "binary coarse quantizer for field {field_id} does not match metadata/schema"
                         )));
                     }
-                    if let Some(config) = schema_config {
-                        quantizer
-                            .validate_routing(config.ivf_routing)
-                            .map_err(|error| {
-                                Error::Corruption(format!(
-                                    "invalid binary centroid routing for field {field_id}: {error}"
-                                ))
-                            })?;
-                    }
+                    quantizer
+                        .validate_routing(schema_config.ivf_routing)
+                        .map_err(|error| {
+                            Error::Corruption(format!(
+                                "invalid binary centroid routing for field {field_id}: {error}"
+                            ))
+                        })?;
                     binary_quantizers.insert(*field_id, Arc::new(quantizer));
                 }
                 unsupported => {
@@ -906,12 +890,6 @@ mod tests {
         .to_string();
         assert!(error.contains("field_1_centroids.bin"), "{error}");
         assert!(error.contains("field 1"), "{error}");
-        assert!(
-            IndexMetadata::load_trained_from_fields(&metadata.vector_fields, &directory)
-                .await
-                .is_none(),
-            "the compatibility API must also fail closed instead of returning the valid subset"
-        );
     }
 
     #[tokio::test]

--- a/hermes-core/src/index/reader.rs
+++ b/hermes-core/src/index/reader.rs
@@ -126,26 +126,18 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
 
     /// Create a new reader with fresh snapshot from segment manager
     ///
-    /// Reads trained centroids from SegmentManager's ArcSwap (lock-free).
+    /// Captures segment IDs and their trained vector generation together.
     async fn create_reader(
         schema: &Arc<Schema>,
         segment_manager: &Arc<crate::merge::SegmentManager<D>>,
         resources: SearcherResources,
     ) -> Result<Searcher<D>> {
-        // Use SegmentManager's acquire_snapshot - non-blocking RwLock read.
-        //
-        // The snapshot MUST be acquired before reading trained centroids:
-        // segment producers capture trained structures only after the ArcSwap
-        // publication, so any ANN segment visible in the snapshot is always
-        // satisfiable by a trained value loaded after the snapshot. The
-        // reverse order can leave an ANN segment without centroids — and the
-        // miss is sticky, because reused readers are never re-injected on
-        // later reloads.
         let snapshot = segment_manager.acquire_snapshot().await;
 
-        // Read one immutable trained-artifact generation from ArcSwap.
-        let trained = segment_manager
-            .trained()
+        // The snapshot carries the exact trained-artifact generation paired
+        // with its segment IDs. This remains correct across atomic retrains.
+        let trained = snapshot
+            .trained_vectors()
             .unwrap_or_else(|| Arc::new(crate::segment::TrainedVectorStructures::default()));
 
         Searcher::from_snapshot(
@@ -264,16 +256,11 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
         let existing_segments: Vec<Arc<crate::segment::SegmentReader>> =
             self.state.load().searcher.segment_readers().to_vec();
 
-        // Acquire the snapshot BEFORE reading trained centroids: producers
-        // capture trained structures only after the ArcSwap publication, so
-        // any ANN segment visible in the snapshot is always satisfiable by a
-        // trained value loaded after the snapshot (see create_reader).
         let snapshot = self.segment_manager.acquire_snapshot().await;
 
-        // Read one immutable trained-artifact generation from ArcSwap.
-        let trained = self
-            .segment_manager
-            .trained()
+        // Use the trained-artifact generation captured with this snapshot.
+        let trained = snapshot
+            .trained_vectors()
             .unwrap_or_else(|| Arc::new(crate::segment::TrainedVectorStructures::default()));
 
         let new_reader = Searcher::from_snapshot_reuse(

--- a/hermes-core/src/index/tests/vector.rs
+++ b/hermes-core/src/index/tests/vector.rs
@@ -27,7 +27,10 @@ async fn test_vector_index_threshold_switch() {
     let schema = schema_builder.build();
 
     let dir = RamDirectory::new();
-    let config = IndexConfig::default();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
 
     // Phase 1: Add vectors below threshold (should use Flat index)
     let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
@@ -97,6 +100,11 @@ async fn test_vector_index_threshold_switch() {
 
     // Search should still work
     let segments = index.segment_readers().await.unwrap();
+    assert_eq!(segments.len(), 2, "test requires two unmerged segments");
+    assert!(segments.iter().all(|segment| matches!(
+        segment.vector_indexes().get(&embedding.0),
+        Some(crate::segment::VectorIndex::IvfPq(_))
+    )));
     let results = segments[0]
         .search_dense_vector(
             embedding,
@@ -124,107 +132,111 @@ async fn test_vector_index_threshold_switch() {
 }
 
 #[tokio::test]
-async fn rebuild_rejects_segments_bound_to_the_current_artifact_generation() {
+async fn test_vector_retrain_atomically_replaces_the_complete_generation() {
+    use crate::directories::Directory;
     use crate::dsl::DenseVectorConfig;
+    use crate::query::DenseVectorQuery;
 
-    let mut schema_builder = SchemaBuilder::default();
-    let embedding = schema_builder.add_dense_vector_field_with_config(
+    let mut sb = SchemaBuilder::default();
+    let embedding = sb.add_dense_vector_field_with_config(
         "embedding",
         true,
         true,
-        DenseVectorConfig::with_ivf_pq(4, Some(1), 1),
+        DenseVectorConfig::with_ivf_pq(8, Some(4), 2),
     );
-    let schema = schema_builder.build();
+    let schema = sb.build();
     let dir = RamDirectory::new();
     let config = IndexConfig {
         merge_policy: Box::new(crate::merge::NoMergePolicy),
+        num_indexing_threads: 1,
         ..Default::default()
     };
-    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+    let live_index = Index::create(dir.clone(), schema, config.clone())
         .await
         .unwrap();
+    let mut writer = live_index.writer();
 
-    // Segments committed before training remain flat and provide the sample.
-    for i in 0..4 {
+    for batch in 0..2 {
+        for i in 0..24 {
+            let n = (batch * 24 + i) as f32;
+            let mut doc = Document::new();
+            doc.add_dense_vector(
+                embedding,
+                (0..8).map(|dim| (n * (dim + 1) as f32).sin()).collect(),
+            );
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+    writer.build_vector_index().await.unwrap();
+
+    // Hold a searcher for generation 1 across the complete retrain. It must
+    // retain both its old segments and their matching old codebook.
+    let old_reader = live_index.reader().await.unwrap();
+    let old_searcher = old_reader.searcher().await.unwrap();
+    let first_version = writer.segment_manager.trained().unwrap().codebooks[&embedding.0].version;
+
+    // A materially different third segment changes the training sample and is
+    // initially encoded with generation 1 by normal ingestion.
+    for i in 0..24 {
         let mut doc = Document::new();
-        doc.add_dense_vector(embedding, vec![i as f32; 4]);
+        doc.add_dense_vector(
+            embedding,
+            (0..8)
+                .map(|dim| 1000.0 + i as f32 * 17.0 + dim as f32 * 31.0)
+                .collect(),
+        );
         writer.add_document(doc).unwrap();
     }
     writer.commit().await.unwrap();
-    writer.build_vector_index().await.unwrap();
-    let old_version = writer.segment_manager.trained().unwrap().centroids[&embedding.0].version;
+    let before_ids = writer.segment_manager.get_segment_ids().await;
 
-    // Once trained, a newly committed segment embeds that exact centroid
-    // generation in its IVF data.
-    let mut doc = Document::new();
-    doc.add_dense_vector(embedding, vec![10.0; 4]);
-    writer.add_document(doc).unwrap();
-    writer.commit().await.unwrap();
-
-    let index = Index::open(dir, config).await.unwrap();
-    assert!(
-        index
-            .segment_readers()
-            .await
-            .unwrap()
-            .iter()
-            .any(|segment| matches!(
-                segment.vector_indexes().get(&embedding.0),
-                Some(crate::segment::VectorIndex::IvfPq(_))
-            ))
+    writer.retrain_vector_index().await.unwrap();
+    let trained = writer.segment_manager.trained().unwrap();
+    let second_version = trained.codebooks[&embedding.0].version;
+    assert_ne!(
+        first_version, second_version,
+        "the expanded corpus must retrain the PQ codebook"
     );
-    drop(index);
 
-    let error = writer
-        .rebuild_vector_index()
+    let after_ids = writer.segment_manager.get_segment_ids().await;
+    assert_eq!(after_ids.len(), before_ids.len());
+    assert!(
+        after_ids.iter().all(|id| !before_ids.contains(id)),
+        "every segment using the old codebook must be replaced in one generation"
+    );
+    let current_index = Index::open(dir.clone(), config).await.unwrap();
+    for segment in current_index.segment_readers().await.unwrap() {
+        let index = segment
+            .get_ivf_pq_vector_index(embedding)
+            .expect("every current segment must contain IVF-PQ");
+        assert_eq!(index.codebook_version, second_version);
+        assert_eq!(
+            index.centroids_version,
+            trained.centroids[&embedding.0].version
+        );
+    }
+
+    let old_results = old_searcher
+        .search(&DenseVectorQuery::new(embedding, vec![0.25; 8]), 5)
         .await
-        .expect_err("retraining must reject an existing IVF generation")
-        .to_string();
-    assert!(error.contains("already contains an IVF index"), "{error}");
-    assert!(
-        writer
-            .segment_manager
-            .read_metadata(|metadata| metadata.is_field_built(embedding.0))
-            .await
-    );
-    assert_eq!(
-        writer.segment_manager.trained().unwrap().centroids[&embedding.0].version,
-        old_version,
-        "a rejected rebuild must leave the published generation untouched"
-    );
+        .expect("an old reader must remain paired with generation 1");
+    assert!(!old_results.is_empty());
 
-    // Simulate metadata left Flat by a crash-interrupted rebuild from an older
-    // Hermes release. The ordinary build entry point must inspect the segment
-    // generation too; trusting metadata alone would silently replace artifacts
-    // still required by the committed IVF segment.
-    writer
-        .segment_manager
-        .update_metadata(|metadata| {
-            let field = metadata.vector_fields.get_mut(&embedding.0).unwrap();
-            field.state = crate::index::VectorIndexState::Flat;
-            field.centroids_file = None;
-            field.codebook_file = None;
-            metadata.refresh_total_vectors();
+    let artifacts = dir
+        .list_files(std::path::Path::new(""))
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("vector_artifact_"))
         })
-        .await
-        .unwrap();
-    let error = writer
-        .build_vector_index()
-        .await
-        .expect_err("ordinary training must reject a stale Flat metadata state")
-        .to_string();
-    assert!(error.contains("already contains an IVF index"), "{error}");
-    assert!(
-        !writer
-            .segment_manager
-            .read_metadata(|metadata| metadata.is_field_built(embedding.0))
-            .await,
-        "a rejected recovery build must not mutate metadata"
-    );
+        .count();
     assert_eq!(
-        writer.segment_manager.trained().unwrap().centroids[&embedding.0].version,
-        old_version,
-        "a rejected recovery build must not replace the published generation"
+        artifacts, 2,
+        "only the published centroid/codebook pair remains"
     );
 }
 
@@ -1209,10 +1221,41 @@ async fn test_binary_ivf_end_to_end() {
     }
     writer.commit().await.unwrap();
     writer.build_vector_index().await.unwrap();
-    let mut merge_trigger = Document::new();
-    merge_trigger.add_binary_dense_vector(bvec, vec![0; byte_len]);
-    writer.add_document(merge_trigger).unwrap();
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let built_segments = index.segment_readers().await.unwrap();
+    assert_eq!(built_segments.len(), 1);
+    assert!(matches!(
+        built_segments[0].get_vector_index(bvec),
+        Some(crate::segment::VectorIndex::BinaryIvf(_))
+    ));
+    drop(index);
+    let first_quantizer =
+        writer.segment_manager.trained().unwrap().binary_quantizers[&bvec.0].version;
+
+    // Expand the corpus with the complementary bit distribution, then verify
+    // that explicit retraining rebuilds every binary segment against the new
+    // global quantizer before an ordinary force merge.
+    for i in 0..200u16 {
+        let mut doc = Document::new();
+        let mut vector = vec![0xAA; byte_len];
+        vector[(i as usize) % byte_len] ^= (i as u8).rotate_left((i % 8) as u32);
+        doc.add_binary_dense_vector(bvec, vector);
+        writer.add_document(doc).unwrap();
+    }
     writer.commit().await.unwrap();
+    writer.retrain_vector_index().await.unwrap();
+    let second_quantizer =
+        writer.segment_manager.trained().unwrap().binary_quantizers[&bvec.0].version;
+    assert_ne!(first_quantizer, second_quantizer);
+    let retrained = Index::open(dir.clone(), config.clone()).await.unwrap();
+    for segment in retrained.segment_readers().await.unwrap() {
+        let Some(crate::segment::VectorIndex::BinaryIvf(lazy)) = segment.get_vector_index(bvec)
+        else {
+            panic!("every retrained binary segment must contain IVF");
+        };
+        assert_eq!(lazy.get().unwrap().quantizer_version, second_quantizer);
+    }
+    drop(retrained);
     writer.force_merge().await.unwrap();
 
     let index = Index::open(dir, config).await.unwrap();

--- a/hermes-core/src/index/vector_builder.rs
+++ b/hermes-core/src/index/vector_builder.rs
@@ -1,8 +1,8 @@
 //! Vector index building for IndexWriter
 //!
 //! Training is **manual-only** — decoupled from commit.
-//! Call `build_vector_index()` explicitly when ready.
-//! ANN indexes are built naturally during subsequent merges.
+//! `build_vector_index()` creates missing codebooks; `retrain_vector_index()`
+//! replaces existing codebooks. Both finish every committed ANN segment.
 
 use std::io::Write;
 use std::sync::Arc;
@@ -24,6 +24,9 @@ const MAX_IVF_CLUSTERS: usize = 1_048_576;
 /// Faiss-style clustering quality floor: fewer points per centroid generally
 /// overfits the training sample and leaves unstable/empty cells.
 const MIN_TRAINING_POINTS_PER_CENTROID: usize = 39;
+/// Generation-qualified filenames make retraining crash-safe: the currently
+/// published metadata never points at a file being overwritten in place.
+const VECTOR_ARTIFACT_PREFIX: &str = "vector_artifact_";
 
 struct TrainedFieldUpdate {
     field_id: u32,
@@ -32,6 +35,20 @@ struct TrainedFieldUpdate {
     num_clusters: usize,
     centroids_file: String,
     codebook_file: Option<String>,
+}
+
+enum TrainedFieldArtifacts {
+    Float {
+        centroids: crate::structures::CoarseCentroids,
+        codebook: crate::structures::PQCodebook,
+        pq_sample_count: usize,
+    },
+    Binary(crate::structures::BinaryCoarseQuantizer),
+}
+
+struct TrainedFieldModel {
+    update: TrainedFieldUpdate,
+    artifacts: TrainedFieldArtifacts,
 }
 
 #[derive(Clone)]
@@ -73,6 +90,12 @@ impl IvfFieldConfig {
 enum TrainingSample {
     Float(Vec<Vec<f32>>),
     Binary(Vec<u8>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum VectorGenerationMode {
+    BuildMissing,
+    RetrainAll,
 }
 
 impl TrainingSample {
@@ -208,14 +231,25 @@ fn effective_ivf_num_clusters(
 impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Train vector index from accumulated Flat vectors (manual, not auto-triggered).
     ///
-    /// 1. Acquires a snapshot (segments safe to read)
-    /// 2. Collects vectors for training
-    /// 3. Trains centroids/codebooks
-    /// 4. Updates metadata (marks fields as Built)
-    /// 5. Publishes to ArcSwap — merges will use these automatically
-    ///
-    /// Existing flat segments get ANN during normal merges. No rebuild needed.
+    /// 1. Acquires a stable segment snapshot.
+    /// 2. Trains missing global codebooks.
+    /// 3. Stages ANN replacements for every affected segment.
+    /// 4. Publishes the complete segment/codebook generation atomically.
     pub async fn build_vector_index(&self) -> Result<()> {
+        self.build_vector_generation(VectorGenerationMode::BuildMissing)
+            .await
+    }
+
+    /// Train a fresh global codebook from the current corpus and rebuild every
+    /// ANN segment into that generation. The replacement is atomic for search
+    /// readers: the old segment/codebook pair remains live until all new files
+    /// have been staged and durably committed together.
+    pub async fn retrain_vector_index(&self) -> Result<()> {
+        self.build_vector_generation(VectorGenerationMode::RetrainAll)
+            .await
+    }
+
+    async fn build_vector_generation(&self, mode: VectorGenerationMode) -> Result<()> {
         let dense_fields = self.get_ivf_vector_fields();
         if dense_fields.is_empty() {
             log::info!("No dense vector fields configured for ANN indexing");
@@ -223,219 +257,209 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         }
 
         let artifact_update = self.segment_manager.begin_vector_artifact_update().await?;
-        self.build_vector_index_locked(&dense_fields, &artifact_update)
-            .await
-    }
+        self.cleanup_unreferenced_vector_artifacts().await;
 
-    /// Build while the SegmentManager's artifact-update gate is held.
-    async fn build_vector_index_locked(
-        &self,
-        dense_fields: &[(Field, IvfFieldConfig)],
-        artifact_update: &crate::merge::VectorArtifactUpdateGuard,
-    ) -> Result<()> {
-        // Check which fields need building (skip already built)
-        let fields_to_build = self.get_fields_to_build(dense_fields).await;
-        if fields_to_build.is_empty() {
-            log::info!("All vector fields already built, skipping training");
-            return Ok(());
-        }
-
-        // Reject malformed explicit settings before opening segments or
-        // allocating the bounded training samples.
-        for (_, config) in &fields_to_build {
+        let fields_to_train = match mode {
+            VectorGenerationMode::BuildMissing => self.get_fields_to_build(&dense_fields).await,
+            VectorGenerationMode::RetrainAll => dense_fields.clone(),
+        };
+        for (_, config) in &fields_to_train {
             validate_explicit_cluster_count(config.num_clusters())?;
         }
 
-        // Acquire snapshot — segments won't be deleted while we read them
         let snapshot = self.segment_manager.acquire_snapshot().await;
-        let segment_ids = snapshot.segment_ids();
-        if segment_ids.is_empty() {
+        if snapshot.is_empty() {
+            if mode == VectorGenerationMode::RetrainAll {
+                return Err(Error::Schema(
+                    "cannot retrain vector codebooks without committed segments".into(),
+                ));
+            }
             return Ok(());
         }
 
-        // Collect vectors for training
-        let (all_vectors, total_vectors) = self
-            .collect_vectors_for_training(segment_ids, &fields_to_build)
-            .await?;
-
-        self.train_and_publish_fields(
-            &fields_to_build,
-            &all_vectors,
-            &total_vectors,
-            artifact_update,
-        )
-        .await
-    }
-
-    /// Train every requested field from pre-collected samples, then durably
-    /// publish the artifacts. If any field fails, all durable field states
-    /// remain Flat and the successfully written files are merely unreferenced
-    /// retry targets.
-    async fn train_and_publish_fields(
-        &self,
-        fields_to_build: &[(Field, IvfFieldConfig)],
-        all_vectors: &FxHashMap<u32, TrainingSample>,
-        total_vectors: &FxHashMap<u32, usize>,
-        artifact_update: &crate::merge::VectorArtifactUpdateGuard,
-    ) -> Result<()> {
-        let mut updates = Vec::with_capacity(fields_to_build.len());
-        for (field, config) in fields_to_build {
-            if let Some(update) = self
-                .train_field_index(*field, config, all_vectors, total_vectors)
-                .await?
-            {
-                updates.push(update);
+        let mut candidate_metadata = self.segment_manager.read_metadata(Clone::clone).await;
+        if !fields_to_train.is_empty() {
+            let (all_vectors, total_vectors) = self
+                .collect_vectors_for_training(
+                    snapshot.segment_ids(),
+                    &fields_to_train,
+                    mode == VectorGenerationMode::BuildMissing,
+                )
+                .await?;
+            let artifact_generation = SegmentId::new().to_hex();
+            let updates = self
+                .train_fields(
+                    &fields_to_train,
+                    &all_vectors,
+                    &total_vectors,
+                    &artifact_generation,
+                )
+                .await?;
+            for update in &updates {
+                candidate_metadata.init_field(update.field_id, update.index_type);
+                candidate_metadata.mark_field_built(
+                    update.field_id,
+                    update.vector_count,
+                    update.num_clusters,
+                    update.centroids_file.clone(),
+                    update.codebook_file.clone(),
+                );
             }
         }
 
-        if updates.is_empty() {
-            // Fail loud: training was explicitly requested and produced
-            // nothing — reporting success would leave callers believing the
-            // fields are Built.
-            let field_ids: Vec<u32> = fields_to_build.iter().map(|(field, _)| field.0).collect();
-            return Err(Error::Schema(format!(
-                "cannot train vector index: no training vectors were collected for \
-                 field(s) {field_ids:?}; commit documents containing these fields \
-                 before building"
-            )));
-        }
-
-        // Durable metadata and the complete validated ArcSwap set advance in a
-        // single cancellation-safe SegmentManager transaction.
-        self.segment_manager
-            .update_vector_metadata_and_publish(artifact_update, |meta| {
-                for update in &updates {
-                    meta.init_field(update.field_id, update.index_type);
-                    meta.mark_field_built(
-                        update.field_id,
-                        update.vector_count,
-                        update.num_clusters,
-                        update.centroids_file.clone(),
-                        update.codebook_file.clone(),
-                    );
-                }
+        let target_field_ids = dense_fields
+            .iter()
+            .filter_map(|(field, _)| {
+                candidate_metadata
+                    .is_field_built(field.0)
+                    .then_some(field.0)
             })
-            .await?;
-
-        log::info!("Vector index training complete, ANN will be built during merges");
-
-        Ok(())
-    }
-
-    /// Rebuild vector index by retraining centroids/codebooks.
-    ///
-    /// Rebuilding a global artifact generation is only safe while every
-    /// committed segment is still flat. IVF-PQ segments embed the artifact
-    /// versions they were built with and cannot be interpreted by freshly
-    /// trained centroids/codebooks.
-    pub async fn rebuild_vector_index(&self) -> Result<()> {
-        let dense_fields = self.get_ivf_vector_fields();
-        if dense_fields.is_empty() {
+            .collect::<Vec<_>>();
+        if target_field_ids.is_empty() {
             return Ok(());
         }
 
-        // Raise the producer gate and drain operations that may already have
-        // captured the previous trained generation. New producers continue in
-        // flat mode until this guard drops.
-        let artifact_update = self.segment_manager.begin_vector_artifact_update().await?;
-        let snapshot = self.segment_manager.acquire_snapshot().await;
-        let field_ids: Vec<u32> = dense_fields.iter().map(|(field, _)| field.0).collect();
-        self.reject_rebuild_with_ann_segments(snapshot.segment_ids(), &field_ids)
-            .await?;
+        let candidate_trained = super::IndexMetadata::try_load_trained_from_fields(
+            &candidate_metadata.vector_fields,
+            self.schema.as_ref(),
+            self.directory.as_ref(),
+        )
+        .await?
+        .map(Arc::new)
+        .ok_or_else(|| Error::Internal("candidate vector generation has no artifacts".into()))?;
 
-        // Reject malformed explicit settings before collecting samples.
-        for (_, config) in &dense_fields {
-            validate_explicit_cluster_count(config.num_clusters())?;
-        }
-
-        // Collect the retraining samples BEFORE the durable Built -> Flat
-        // reset: a read failure (propagated by collect_vectors_for_training)
-        // or an empty sample for a Built field must not destructively
-        // downgrade the published artifact generation.
-        let (all_vectors, total_vectors) = self
-            .collect_vectors_for_training(snapshot.segment_ids(), &dense_fields)
-            .await?;
-        let built_fields: Vec<u32> = self
+        let staged = self
             .segment_manager
-            .read_metadata(|meta| {
-                field_ids
-                    .iter()
-                    .filter(|field_id| meta.is_field_built(**field_id))
-                    .copied()
-                    .collect()
-            })
-            .await;
-        let starved_built: Vec<u32> = built_fields
-            .into_iter()
-            .filter(|field_id| {
-                let dim = dense_fields
-                    .iter()
-                    .find(|(field, _)| field.0 == *field_id)
-                    .map_or(1, |(_, config)| config.dim());
-                all_vectors
-                    .get(field_id)
-                    .is_none_or(|sample| sample.len(dim) == 0)
-            })
-            .collect();
-        if !starved_built.is_empty() {
+            .stage_vector_generation(
+                &artifact_update,
+                snapshot.segment_ids(),
+                &target_field_ids,
+                Arc::clone(&candidate_trained),
+                mode == VectorGenerationMode::RetrainAll,
+            )
+            .await?;
+        self.segment_manager
+            .publish_vector_generation(
+                &artifact_update,
+                candidate_metadata.vector_fields,
+                candidate_trained,
+                staged,
+            )
+            .await?;
+
+        // Old readers retain the old snapshot and deserialized codebook. Once
+        // this local training snapshot drops, retired source files can be
+        // reclaimed. Reopening producers after the lease sees only the new set.
+        drop(snapshot);
+        drop(artifact_update);
+
+        // A producer that started while training was gated writes flat data.
+        // Catch already committed outputs; later commits carry their own
+        // targeted upgrade marker in PreparedSegment.
+        self.segment_manager
+            .rewrite_vector_segments(&target_field_ids)
+            .await?;
+        self.cleanup_unreferenced_vector_artifacts().await;
+        log::info!(
+            "Vector generation {:?} complete for {} field(s)",
+            mode,
+            target_field_ids.len(),
+        );
+        Ok(())
+    }
+
+    async fn train_fields(
+        &self,
+        fields: &[(Field, IvfFieldConfig)],
+        all_vectors: &FxHashMap<u32, TrainingSample>,
+        total_vectors: &FxHashMap<u32, usize>,
+        artifact_generation: &str,
+    ) -> Result<Vec<TrainedFieldUpdate>> {
+        let training_pool = self.segment_manager.background_cpu_pool();
+        let mut missing = Vec::new();
+        let mut updates = Vec::with_capacity(fields.len());
+        for (field, config) in fields {
+            // Field working sets are intentionally serialized. Each field can
+            // still use every thread in the bounded background Rayon pool,
+            // but its sample, centroids, and clustering scratch cannot overlap
+            // another field's multi-gigabyte training allocations.
+            let model = crate::segment::block_in_place_if_multithread(|| {
+                training_pool.install(|| {
+                    Self::train_field_model(
+                        *field,
+                        config,
+                        all_vectors,
+                        total_vectors,
+                        artifact_generation,
+                    )
+                })
+            })?;
+            match model {
+                Some(model) => updates.push(self.save_trained_field(model).await?),
+                None => missing.push(field.0),
+            }
+        }
+        if updates.is_empty() && !fields.is_empty() {
             return Err(Error::Schema(format!(
-                "cannot retrain vector index: no training vectors could be collected \
-                 for built field(s) {starved_built:?}; the existing trained artifacts \
-                 are left in place"
+                "cannot train vector codebooks: no committed vectors for field(s) {missing:?}"
             )));
         }
+        if !missing.is_empty() {
+            log::info!(
+                "Skipping vector field(s) {missing:?}: the current corpus contains no vectors"
+            );
+        }
+        Ok(updates)
+    }
 
-        // Reset metadata and the ArcSwap set together. Old fixed-name artifact
-        // files are left in place until the atomic writer replaces them; this
-        // avoids a cancellation window and does not accumulate generations.
-        self.segment_manager
-            .update_vector_metadata_and_publish(&artifact_update, |meta| {
-                for field_id in &field_ids {
-                    if let Some(field_meta) = meta.vector_fields.get_mut(field_id) {
-                        field_meta.state = super::VectorIndexState::Flat;
-                        field_meta.centroids_file = None;
-                        field_meta.codebook_file = None;
-                    }
-                }
-                meta.refresh_total_vectors();
+    /// Remove abandoned generation-qualified codebooks from cancelled or
+    /// crash-interrupted attempts. The metadata references are the complete
+    /// live set, and the exclusive update lease prevents another trainer from
+    /// creating a candidate concurrently with this sweep.
+    async fn cleanup_unreferenced_vector_artifacts(&self) {
+        let referenced = self
+            .segment_manager
+            .read_metadata(|metadata| {
+                metadata
+                    .vector_fields
+                    .values()
+                    .flat_map(|field| {
+                        field
+                            .centroids_file
+                            .iter()
+                            .chain(field.codebook_file.iter())
+                    })
+                    .cloned()
+                    .collect::<std::collections::HashSet<_>>()
             })
-            .await?;
-
-        log::info!("Reset vector index state to Flat, retraining from collected samples...");
-
-        self.train_and_publish_fields(
-            &dense_fields,
-            &all_vectors,
-            &total_vectors,
-            &artifact_update,
-        )
-        .await
+            .await;
+        let files = match self.directory.list_files(std::path::Path::new("")).await {
+            Ok(files) => files,
+            Err(error) => {
+                log::warn!("[trained] failed listing abandoned vector artifacts: {error}");
+                return;
+            }
+        };
+        for path in files {
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if !name.starts_with(VECTOR_ARTIFACT_PREFIX)
+                || referenced.contains(path.to_string_lossy().as_ref())
+            {
+                continue;
+            }
+            if let Err(error) = self.directory.delete(&path).await
+                && error.kind() != std::io::ErrorKind::NotFound
+            {
+                log::warn!("[trained] failed deleting abandoned artifact {path:?}: {error}");
+            }
+        }
     }
 
     // ========================================================================
     // Helper methods
     // ========================================================================
-
-    async fn reject_rebuild_with_ann_segments(
-        &self,
-        segment_ids: &[String],
-        field_ids: &[u32],
-    ) -> Result<()> {
-        for id_str in segment_ids {
-            let segment_id = SegmentId::from_hex(id_str)
-                .ok_or_else(|| Error::Corruption(format!("Invalid segment ID: {id_str}")))?;
-            let reader = SegmentReader::open_with_cache_blocks(
-                self.directory.as_ref(),
-                segment_id,
-                Arc::clone(&self.schema),
-                self.config.term_cache_blocks,
-                self.config.store_cache_blocks,
-            )
-            .await?;
-            Self::reject_ann_in_reader(&reader, id_str, field_ids)?;
-        }
-        Ok(())
-    }
 
     fn reject_ann_in_reader(reader: &SegmentReader, id_str: &str, field_ids: &[u32]) -> Result<()> {
         for &field_id in field_ids {
@@ -445,9 +469,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     | Some(crate::segment::VectorIndex::BinaryIvf(_))
             ) {
                 return Err(Error::Schema(format!(
-                    "cannot retrain vector artifacts for field {field_id}: segment {id_str} \
-                     already contains an IVF index built with the current generation; \
-                     rebuild requires all committed segments for the field to be flat"
+                    "metadata-flat field {field_id} already has ANN data in segment {id_str}; \
+                     recreate the index instead of mixing vector generations"
                 )));
             }
         }
@@ -510,6 +533,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         &self,
         segment_ids: &[String],
         fields_to_build: &[(Field, IvfFieldConfig)],
+        require_flat_generation: bool,
     ) -> Result<(FxHashMap<u32, TrainingSample>, FxHashMap<u32, usize>)> {
         // At the one-billion-vector default, two million training points allow
         // about 51K stable cells at the 39-points-per-centroid quality floor.
@@ -521,7 +545,9 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let mut total_vectors: FxHashMap<u32, usize> = FxHashMap::default();
         let field_ids: Vec<u32> = fields_to_build.iter().map(|(field, _)| field.0).collect();
 
-        // First pass: validate generations and count every field globally.
+        // First pass counts every field globally. Initial construction rejects
+        // ANN payloads for metadata-flat fields; an explicit retrain reads the
+        // exact flat vectors retained beside the current ANN generation.
         for id_str in segment_ids {
             let segment_id = SegmentId::from_hex(id_str)
                 .ok_or_else(|| Error::Corruption(format!("Invalid segment ID: {}", id_str)))?;
@@ -534,12 +560,9 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             )
             .await?;
 
-            // `build_vector_index` is also effectively a retrain whenever
-            // metadata says Flat. A crash-interrupted rebuild from an older
-            // Hermes version can leave that state beside committed ANN
-            // segments, so validate generation safety during the same segment
-            // scan that collects the samples.
-            Self::reject_ann_in_reader(&reader, id_str, &field_ids)?;
+            if require_flat_generation {
+                Self::reject_ann_in_reader(&reader, id_str, &field_ids)?;
+            }
 
             for (field, _) in fields_to_build {
                 if let Some(flat) = reader.flat_vectors().get(&field.0) {
@@ -618,7 +641,9 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 let base = *global_offsets.entry(field.0).or_default();
                 let end = base.saturating_add(lazy_flat.num_vectors);
                 *global_offsets.get_mut(&field.0).unwrap() = end;
-                let ordinals = &selected_ordinals[&field.0];
+                let Some(ordinals) = selected_ordinals.get(&field.0) else {
+                    continue;
+                };
                 let cursor = sample_cursors.entry(field.0).or_default();
                 let first = *cursor;
                 while *cursor < ordinals.len() && ordinals[*cursor] < end {
@@ -704,14 +729,15 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         Ok((all_vectors, total_vectors))
     }
 
-    /// Train index for a single field
-    async fn train_field_index(
-        &self,
+    /// Train one field. Called from the shared bounded Rayon pool, so fields
+    /// and each field's internal clustering work compose without extra pools.
+    fn train_field_model(
         field: Field,
         config: &IvfFieldConfig,
         all_vectors: &FxHashMap<u32, TrainingSample>,
         total_vectors: &FxHashMap<u32, usize>,
-    ) -> Result<Option<TrainedFieldUpdate>> {
+        artifact_generation: &str,
+    ) -> Result<Option<TrainedFieldModel>> {
         let field_id = field.0;
         let sample = match all_vectors.get(&field_id) {
             Some(sample) if sample.len(config.dim()) > 0 => sample,
@@ -735,41 +761,42 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             dim,
         );
 
-        let centroids_filename = format!("field_{}_centroids.bin", field_id);
+        let centroids_filename =
+            format!("{VECTOR_ARTIFACT_PREFIX}{artifact_generation}_field_{field_id}_centroids.bin");
         let mut codebook_filename = None;
 
-        let actual_num_clusters = match (config, sample) {
+        let artifacts = match (config, sample) {
             (IvfFieldConfig::Float(config), TrainingSample::Float(vectors))
                 if config.index_type == VectorIndexType::IvfPq =>
             {
-                codebook_filename = Some(format!("field_{}_codebook.bin", field_id));
-                self.train_ivf_pq(
-                    field_id,
+                codebook_filename = Some(format!(
+                    "{VECTOR_ARTIFACT_PREFIX}{artifact_generation}_field_{field_id}_codebook.bin"
+                ));
+                let (centroids, codebook, pq_sample_count) = Self::train_ivf_pq_model(
                     dim,
                     num_clusters,
                     config.ivf_routing,
                     config.soar.clone(),
                     vectors,
-                    &centroids_filename,
-                    codebook_filename.as_ref().unwrap(),
-                )
-                .await?
+                );
+                TrainedFieldArtifacts::Float {
+                    centroids,
+                    codebook,
+                    pq_sample_count,
+                }
             }
             (IvfFieldConfig::Binary(config), TrainingSample::Binary(codes)) => {
                 let mut binary_config = crate::structures::BinaryIvfConfig::new(dim, num_clusters);
                 binary_config.max_train_samples = sample_count;
                 binary_config.routing = config.ivf_routing;
-                let quantizer = crate::segment::block_in_place_if_multithread(|| {
+                TrainedFieldArtifacts::Binary(
                     crate::structures::BinaryCoarseQuantizer::train(
                         binary_config,
                         codes,
                         sample_count,
                     )
-                })
-                .map_err(Error::Io)?;
-                self.save_trained_artifact(&quantizer, &centroids_filename)
-                    .await?;
-                quantizer.num_clusters as usize
+                    .map_err(Error::Io)?,
+                )
             }
             _ => {
                 return Err(Error::Internal(format!(
@@ -778,14 +805,59 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             }
         };
 
-        Ok(Some(TrainedFieldUpdate {
-            field_id,
-            index_type: config.index_type(),
-            vector_count: corpus_count,
-            num_clusters: actual_num_clusters,
-            centroids_file: centroids_filename,
-            codebook_file: codebook_filename,
+        let actual_num_clusters = match &artifacts {
+            TrainedFieldArtifacts::Float { centroids, .. } => centroids.num_clusters as usize,
+            TrainedFieldArtifacts::Binary(quantizer) => quantizer.num_clusters as usize,
+        };
+        Ok(Some(TrainedFieldModel {
+            update: TrainedFieldUpdate {
+                field_id,
+                index_type: config.index_type(),
+                vector_count: corpus_count,
+                num_clusters: actual_num_clusters,
+                centroids_file: centroids_filename,
+                codebook_file: codebook_filename,
+            },
+            artifacts,
         }))
+    }
+
+    async fn save_trained_field(&self, model: TrainedFieldModel) -> Result<TrainedFieldUpdate> {
+        let TrainedFieldModel { update, artifacts } = model;
+        match artifacts {
+            TrainedFieldArtifacts::Float {
+                centroids,
+                codebook,
+                pq_sample_count,
+            } => {
+                let codebook_file = update.codebook_file.as_deref().ok_or_else(|| {
+                    Error::Internal(format!(
+                        "trained IVF-PQ field {} has no codebook filename",
+                        update.field_id,
+                    ))
+                })?;
+                tokio::try_join!(
+                    self.save_trained_artifact(&centroids, &update.centroids_file),
+                    self.save_trained_artifact(&codebook, codebook_file),
+                )?;
+                log::info!(
+                    "Saved IVF-PQ artifacts for field {} ({} clusters, {} PQ samples)",
+                    update.field_id,
+                    centroids.num_clusters,
+                    pq_sample_count,
+                );
+            }
+            TrainedFieldArtifacts::Binary(quantizer) => {
+                self.save_trained_artifact(&quantizer, &update.centroids_file)
+                    .await?;
+                log::info!(
+                    "Saved binary IVF artifact for field {} ({} clusters)",
+                    update.field_id,
+                    quantizer.num_clusters,
+                );
+            }
+        }
+        Ok(update)
     }
 
     /// Serialize a trained structure to bincode and save to an index-level file.
@@ -828,29 +900,25 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         Ok(())
     }
 
-    /// Train the global IVF-PQ centroids and residual codebook.
-    #[allow(clippy::too_many_arguments)]
-    async fn train_ivf_pq(
-        &self,
-        field_id: u32,
+    /// Train the global IVF-PQ centroids and residual codebook. The caller is
+    /// already running inside the bounded background Rayon pool.
+    fn train_ivf_pq_model(
         dim: usize,
         num_clusters: usize,
         routing: crate::dsl::IvfRoutingMode,
         soar: Option<crate::structures::SoarConfig>,
         vectors: &[Vec<f32>],
-        centroids_filename: &str,
-        codebook_filename: &str,
-    ) -> Result<usize> {
+    ) -> (
+        crate::structures::CoarseCentroids,
+        crate::structures::PQCodebook,
+        usize,
+    ) {
         let mut coarse_config =
             crate::structures::CoarseConfig::new(dim, num_clusters).with_routing(routing);
         if let Some(soar) = soar {
             coarse_config = coarse_config.with_soar(soar);
         }
-        let centroids = crate::segment::block_in_place_if_multithread(|| {
-            crate::structures::CoarseCentroids::train(&coarse_config, vectors)
-        });
-        self.save_trained_artifact(&centroids, centroids_filename)
-            .await?;
+        let centroids = crate::structures::CoarseCentroids::train(&coarse_config, vectors);
 
         // Faiss' established PQ training ceiling is 256 samples per one-byte
         // subquantizer centroid. More points multiply every subspace's Lloyd
@@ -861,35 +929,24 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let pq_sample_count = vectors
             .len()
             .min(PQ_CENTROIDS * PQ_TRAINING_POINTS_PER_CENTROID);
-        let pq_residuals = crate::segment::block_in_place_if_multithread(|| {
-            (0..pq_sample_count)
-                .map(|sample_index| {
-                    let vector_index = sample_index.saturating_mul(vectors.len()) / pq_sample_count;
-                    let vector = &vectors[vector_index];
-                    let cluster = centroids
-                        .probe(vector, 1, routing)
-                        .cluster_ids
-                        .first()
-                        .copied()
-                        .unwrap_or(0);
-                    centroids.compute_residual(vector, cluster)
-                })
-                .collect::<Vec<_>>()
-        });
+        use rayon::prelude::*;
+        let pq_residuals = (0..pq_sample_count)
+            .into_par_iter()
+            .map(|sample_index| {
+                let vector_index = sample_index.saturating_mul(vectors.len()) / pq_sample_count;
+                let vector = &vectors[vector_index];
+                let cluster = centroids
+                    .probe(vector, 1, routing)
+                    .cluster_ids
+                    .first()
+                    .copied()
+                    .unwrap_or(0);
+                centroids.compute_residual(vector, cluster)
+            })
+            .collect::<Vec<_>>();
         let pq_config = crate::structures::PQConfig::new(dim);
-        let codebook = crate::segment::block_in_place_if_multithread(|| {
-            crate::structures::PQCodebook::train(pq_config, &pq_residuals, 10)
-        });
-        self.save_trained_artifact(&codebook, codebook_filename)
-            .await?;
-
-        log::info!(
-            "Saved IVF-PQ centroids and residual codebook for field {} ({} clusters, {} PQ samples)",
-            field_id,
-            centroids.num_clusters,
-            pq_sample_count,
-        );
-        Ok(centroids.num_clusters as usize)
+        let codebook = crate::structures::PQCodebook::train(pq_config, &pq_residuals, 10);
+        (centroids, codebook, pq_sample_count)
     }
 }
 
@@ -985,6 +1042,7 @@ mod tests {
     struct VectorReadFailDirectory {
         inner: RamDirectory,
         fail_vector_reads: Arc<AtomicBool>,
+        fail_all_vector_reads: Arc<AtomicBool>,
     }
 
     #[async_trait::async_trait]
@@ -1017,14 +1075,17 @@ mod tests {
             let handle = self.inner.open_lazy(path).await?;
             if path.extension().is_some_and(|ext| ext == "vectors") {
                 let armed = Arc::clone(&self.fail_vector_reads);
+                let fail_all = Arc::clone(&self.fail_all_vector_reads);
                 let len = handle.len();
                 let read_fn: RangeReadFn = Arc::new(move |range: std::ops::Range<u64>| {
                     let handle = handle.clone();
                     let armed = Arc::clone(&armed);
+                    let fail_all = Arc::clone(&fail_all);
                     Box::pin(async move {
-                        if armed.load(Ordering::SeqCst)
-                            && range.start >= VEC_REGION_START
-                            && range.end <= VEC_REGION_END
+                        if fail_all.load(Ordering::SeqCst)
+                            || (armed.load(Ordering::SeqCst)
+                                && range.start >= VEC_REGION_START
+                                && range.end <= VEC_REGION_END)
                         {
                             return Err(std::io::Error::other("injected vector data read failure"));
                         }
@@ -1063,13 +1124,10 @@ mod tests {
         }
     }
 
-    /// Regression: rebuild_vector_index used to durably reset Built fields to
-    /// Flat first and then swallow per-batch vector read errors with
-    /// `if let Ok` during training collection, reporting success while the
-    /// published trained generation had been destroyed. Read failures must
-    /// propagate, and the durable Built -> Flat reset must not happen.
+    /// A failed read from the flat staging generation must abort training
+    /// before artifacts or Built metadata are published.
     #[tokio::test]
-    async fn rebuild_propagates_vector_read_errors_without_downgrading_built_state() {
+    async fn build_propagates_vector_read_errors_without_publishing_artifacts() {
         let mut sb = SchemaBuilder::default();
         let embedding = sb.add_dense_vector_field_with_config(
             "embedding",
@@ -1094,59 +1152,41 @@ mod tests {
             writer.add_document(doc).unwrap();
         }
         writer.commit().await.unwrap();
-        writer.build_vector_index().await.unwrap();
-        assert!(
-            writer
-                .segment_manager
-                .read_metadata(|meta| meta.is_field_built(embedding.0))
-                .await
-        );
-        assert!(writer.segment_manager.trained().is_some());
-
-        // Vector data reads now fail (transient I/O error).
         dir.fail_vector_reads.store(true, Ordering::SeqCst);
         let error = writer
-            .rebuild_vector_index()
+            .build_vector_index()
             .await
-            .expect_err("failed sample collection must fail the rebuild")
+            .expect_err("failed sample collection must fail the build")
             .to_string();
         assert!(
             error.contains("injected vector data read failure"),
             "{error}"
         );
 
-        // The published generation survives: no durable Built -> Flat reset.
         assert!(
-            writer
+            !writer
                 .segment_manager
                 .read_metadata(|meta| meta.is_field_built(embedding.0))
                 .await,
-            "a failed rebuild must not durably downgrade the field to Flat"
+            "a failed build must not publish Built metadata"
         );
         assert!(
-            writer.segment_manager.trained().is_some(),
-            "a failed rebuild must not clear the published trained artifacts"
+            writer.segment_manager.trained().is_none(),
+            "a failed build must not publish trained artifacts"
         );
     }
 
-    /// Regression: rebuild_vector_index used to return Ok(()) after durably
-    /// resetting a Built field to Flat even when no training vectors could be
-    /// collected at all, silently discarding the trained generation. An empty
-    /// training sample for a Built field must be a hard error raised BEFORE
-    /// the durable reset.
     #[tokio::test]
-    async fn rebuild_errors_before_reset_when_built_field_has_no_training_vectors() {
+    async fn retrain_read_failure_keeps_the_complete_published_generation() {
         let mut sb = SchemaBuilder::default();
-        let title = sb.add_text_field("title", true, true);
         let embedding = sb.add_dense_vector_field_with_config(
             "embedding",
             true,
             true,
-            DenseVectorConfig::with_ivf_pq(4, Some(1), 1),
+            DenseVectorConfig::with_ivf_pq(READ_FAIL_DIM, Some(1), 1),
         );
         let schema = sb.build();
-
-        let dir = RamDirectory::new();
+        let dir = VectorReadFailDirectory::default();
         let config = IndexConfig {
             merge_policy: Box::new(crate::merge::NoMergePolicy),
             num_indexing_threads: 1,
@@ -1155,44 +1195,45 @@ mod tests {
         let mut writer = IndexWriter::create(dir.clone(), schema, config)
             .await
             .unwrap();
-        // Committed segments carry no vectors for the field.
-        for i in 0..3 {
+        for i in 0..READ_FAIL_DOCS {
             let mut doc = Document::new();
-            doc.add_text(title, format!("doc {i}"));
+            doc.add_dense_vector(embedding, vec![i as f32 + 1.0; READ_FAIL_DIM]);
             writer.add_document(doc).unwrap();
         }
         writer.commit().await.unwrap();
+        writer.build_vector_index().await.unwrap();
 
-        // Metadata says Built while no committed segment holds vectors for the
-        // field — the state a crash/degradation can leave behind. Rebuilding
-        // must refuse to destroy the referenced artifacts.
-        writer
+        let old_ids = writer.segment_manager.get_segment_ids().await;
+        let old_meta = writer
             .segment_manager
-            .update_metadata(|meta| {
-                meta.init_field(embedding.0, VectorIndexType::IvfPq);
-                meta.mark_field_built(
-                    embedding.0,
-                    5,
-                    1,
-                    format!("field_{}_centroids.bin", embedding.0),
-                    None,
-                );
-            })
+            .read_metadata(|metadata| metadata.get_field_meta(embedding.0).cloned())
             .await
             .unwrap();
+        let old_version = writer.segment_manager.trained().unwrap().codebooks[&embedding.0].version;
 
+        dir.fail_all_vector_reads.store(true, Ordering::SeqCst);
         let error = writer
-            .rebuild_vector_index()
+            .retrain_vector_index()
             .await
-            .expect_err("an empty training sample must fail the rebuild")
+            .expect_err("failed sample collection must abort the retrain")
             .to_string();
-        assert!(error.contains("no training vectors"), "{error}");
         assert!(
+            error.contains("injected vector data read failure"),
+            "{error}"
+        );
+        assert_eq!(writer.segment_manager.get_segment_ids().await, old_ids);
+        assert_eq!(
             writer
                 .segment_manager
-                .read_metadata(|meta| meta.is_field_built(embedding.0))
+                .read_metadata(|metadata| metadata
+                    .get_field_meta(embedding.0)
+                    .map(|field| (field.centroids_file.clone(), field.codebook_file.clone())))
                 .await,
-            "an empty training sample must not durably downgrade the field to Flat"
+            Some((old_meta.centroids_file, old_meta.codebook_file)),
+        );
+        assert_eq!(
+            writer.segment_manager.trained().unwrap().codebooks[&embedding.0].version,
+            old_version,
         );
     }
 }

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -252,6 +252,7 @@ struct PreparedSegment<D: DirectoryWriter + 'static> {
     segment_manager: Arc<crate::merge::SegmentManager<D>>,
     operation: Option<crate::merge::SegmentOperationGuard>,
     runtime: tokio::runtime::Handle,
+    needs_vector_upgrade: bool,
     published: bool,
 }
 
@@ -1031,6 +1032,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             segment_manager: Arc::clone(&state.segment_manager),
             operation: Some(operation),
             runtime: handle.clone(),
+            needs_vector_upgrade: trained.is_none(),
             published: false,
         };
 
@@ -1370,6 +1372,16 @@ impl<D: DirectoryWriter + 'static> PreparedSegmentsGuard<D> {
     fn take_published(&mut self) -> Vec<PreparedSegment<D>> {
         self.segments.take().unwrap_or_default()
     }
+
+    fn vector_upgrade_segment_ids(&self) -> Vec<String> {
+        self.segments
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .filter(|segment| segment.needs_vector_upgrade)
+            .map(|segment| segment.id.clone())
+            .collect()
+    }
 }
 
 impl<D: DirectoryWriter + 'static> Drop for PreparedSegmentsGuard<D> {
@@ -1479,6 +1491,7 @@ async fn finalize_prepared_commit<D: DirectoryWriter + 'static>(
     mut commit: OwnedCommitFinalization<D>,
 ) -> Result<bool> {
     let metadata_entries = commit.prepared.metadata_entries();
+    let published_segment_ids = commit.prepared.vector_upgrade_segment_ids();
 
     // This entire future is owned by a Tokio task. Cancelling the RPC only
     // drops its JoinHandle; it cannot split durable metadata publication from
@@ -1491,6 +1504,9 @@ async fn finalize_prepared_commit<D: DirectoryWriter + 'static>(
         segment.mark_published();
     }
     drop(published);
+    commit
+        .segment_manager
+        .schedule_vector_segment_upgrades(published_segment_ids);
     // Publication is irreversible. From here onward every exit path, including
     // panic unwind, must make the writer available again while PK reservations
     // remain fail-closed until refresh succeeds.

--- a/hermes-core/src/merge/mod.rs
+++ b/hermes-core/src/merge/mod.rs
@@ -10,7 +10,7 @@ mod segment_manager;
 #[cfg(feature = "native")]
 pub use segment_manager::SegmentManager;
 #[cfg(feature = "native")]
-pub(crate) use segment_manager::{SegmentOperationGuard, VectorArtifactUpdateGuard};
+pub(crate) use segment_manager::SegmentOperationGuard;
 
 /// Information about a segment for merge decisions
 #[derive(Debug, Clone)]

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -47,7 +47,7 @@ use std::sync::{Arc, OnceLock};
 
 use arc_swap::ArcSwapOption;
 use tokio::sync::Mutex as AsyncMutex;
-use tokio::sync::{Notify, Semaphore};
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 
 use crate::directories::DirectoryWriter;
@@ -81,6 +81,10 @@ struct ActiveOperationState {
     indexing_tokens: HashSet<u64>,
     next_operation_token: u64,
     accepting: bool,
+    /// Retraining stages a complete replacement segment generation. Ordinary
+    /// merge/reorder work is paused so its source set cannot change midway;
+    /// indexing producers remain allowed and deliberately emit flat vectors.
+    non_indexing_paused: bool,
 }
 
 struct ActiveSegmentOperations {
@@ -98,6 +102,7 @@ impl ActiveSegmentOperations {
                 indexing_tokens: HashSet::new(),
                 next_operation_token: 0,
                 accepting: true,
+                non_indexing_paused: false,
             }),
             idle: Notify::new(),
             shutdown: Notify::new(),
@@ -108,7 +113,7 @@ impl ActiveSegmentOperations {
     /// reorder, cleanup). Returns a guard on success, `None` if any requested
     /// ID is already owned by another active operation.
     fn try_register(self: &Arc<Self>, segment_ids: Vec<String>) -> Option<SegmentOperationGuard> {
-        self.try_register_kind(segment_ids, false)
+        self.try_register_kind(segment_ids, false, false)
     }
 
     /// Try to claim IDs for an indexing producer whose guard is held until
@@ -117,17 +122,31 @@ impl ActiveSegmentOperations {
         self: &Arc<Self>,
         segment_ids: Vec<String>,
     ) -> Option<SegmentOperationGuard> {
-        self.try_register_kind(segment_ids, true)
+        self.try_register_kind(segment_ids, true, false)
+    }
+
+    /// Claim source/output IDs for the exclusive vector-generation updater,
+    /// which is the only non-indexing producer allowed through its own pause.
+    fn try_register_vector_update(
+        self: &Arc<Self>,
+        segment_ids: Vec<String>,
+    ) -> Option<SegmentOperationGuard> {
+        self.try_register_kind(segment_ids, false, true)
     }
 
     fn try_register_kind(
         self: &Arc<Self>,
         segment_ids: Vec<String>,
         indexing: bool,
+        vector_update: bool,
     ) -> Option<SegmentOperationGuard> {
         let mut inner = self.inner.lock();
         if !inner.accepting {
             log::debug!("[segment_lifecycle] rejected operation during shutdown");
+            return None;
+        }
+        if !indexing && !vector_update && inner.non_indexing_paused {
+            log::debug!("[segment_lifecycle] deferred operation during vector retraining");
             return None;
         }
         // Check for overlap with any active lifecycle operation.
@@ -197,6 +216,15 @@ impl ActiveSegmentOperations {
         if inner.segment_ids.is_empty() {
             self.idle.notify_waiters();
         }
+    }
+
+    fn pause_non_indexing(&self) {
+        self.inner.lock().non_indexing_paused = true;
+    }
+
+    fn resume_non_indexing(&self) {
+        self.inner.lock().non_indexing_paused = false;
+        self.idle.notify_waiters();
     }
 
     fn is_accepting(&self) -> bool {
@@ -270,15 +298,16 @@ impl Drop for SegmentOperationGuard {
 /// Segment producers consult this gate before capturing the current trained
 /// structures. Once the gate is raised, new producers deliberately emit flat
 /// vector data; waiting for already-active producers to drain then guarantees
-/// that no segment using the previous generation can appear after a rebuild
-/// safety check.
+/// that the committed source set stays stable while replacements are staged.
 struct VectorArtifactUpdateLease {
     updating: Arc<AtomicBool>,
+    active_operations: Arc<ActiveSegmentOperations>,
 }
 
 impl Drop for VectorArtifactUpdateLease {
     fn drop(&mut self) {
         self.updating.store(false, Ordering::Release);
+        self.active_operations.resume_non_indexing();
     }
 }
 
@@ -465,6 +494,36 @@ fn classify_source_error(segment_id: String, error: Error) -> MergeTaskError {
 
 #[cfg(feature = "native")]
 type MergeTaskResult<T> = std::result::Result<T, MergeTaskError>;
+
+#[derive(Clone, Copy)]
+enum ReplacementLayout {
+    Recomputed {
+        reordered: bool,
+        bp_converged: bool,
+    },
+    /// A vector-only rewrite leaves document order and sparse layout exactly
+    /// unchanged, so its persisted BP progress must not be reset or advanced.
+    PreserveSingleSource,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum VectorSegmentRewriteOutcome {
+    Rewritten,
+    AlreadyCurrent,
+    SourceGone,
+    Conflict,
+    Deferred,
+}
+
+/// Complete but unpublished vector-only replacement. Its lifecycle claim and
+/// cleanup guard stay armed until the whole codebook generation commits.
+pub(crate) struct StagedVectorSegment {
+    source_id: String,
+    output_id: SegmentId,
+    doc_count: u32,
+    _operation: SegmentOperationGuard,
+    cleanup: OutputCleanupGuard,
+}
 
 /// Segment manager — coordinates segment commit, background merging, and trained structures.
 ///
@@ -665,9 +724,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         }
     }
 
-    /// Bounded rayon pool for background CPU (merge-time BP, manual reorder).
-    /// Query scoring uses the global rayon pool; keeping background BP off it
-    /// prevents a large merge from queueing every search behind gain passes.
+    /// Bounded rayon pool for background CPU (merge-time BP, manual reorder,
+    /// and global vector-codebook training).
+    /// Query scoring uses a dedicated search pool; keeping background work on
+    /// this separate bounded pool prevents a merge or retrain from queueing
+    /// every search behind its CPU passes.
     pub fn background_cpu_pool(&self) -> Arc<rayon::ThreadPool> {
         if let Some(pool) = &self.background_reorder_pool {
             return Arc::clone(pool);
@@ -1039,14 +1100,15 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     ///
     /// New segment operations may continue while this waits, but they observe
     /// the gate through `trained_for_segment_build` and therefore emit flat
-    /// vector data. The guard is cancellation-safe: dropping the requesting
-    /// future reopens ANN production without leaving the manager wedged.
+    /// vector data until the replacement generation is published. The guard
+    /// is cancellation-safe: dropping the requesting future reopens ANN
+    /// production without leaving the manager wedged.
     ///
     /// Indexing tokens cannot be waited on: their guards are parked inside
     /// built-but-uncommitted `PreparedSegment`s and are released only by a
     /// later commit. That commit typically needs the writer this update's
     /// caller already holds (server write lock / embedded `&mut self`), so
-    /// waiting would permanently wedge build/rebuild_vector_index. They also
+    /// waiting would permanently wedge vector-index finalization. They also
     /// cannot be ignored: such a segment may already contain ANN data bound to
     /// the previous artifact generation and could otherwise be committed after
     /// the new generation is published. Reject promptly and let the caller
@@ -1057,9 +1119,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             .map_err(|_| {
                 Error::Internal("a trained-vector artifact update is already in progress".into())
             })?;
+        self.active_operations.pause_non_indexing();
         let guard = VectorArtifactUpdateGuard {
             _lease: Arc::new(VectorArtifactUpdateLease {
                 updating: Arc::clone(&self.vector_artifact_update),
+                active_operations: Arc::clone(&self.active_operations),
             }),
         };
         let (preexisting, parked_indexing) =
@@ -1075,15 +1139,6 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             .wait_until_operations_finish(&preexisting)
             .await;
         Ok(guard)
-    }
-
-    /// Compatibility entry point: load the complete trained set or clear the
-    /// published generation and log the validation failure.
-    pub async fn load_and_publish_trained(&self) {
-        if let Err(error) = self.try_load_and_publish_trained().await {
-            self.trained.store(None);
-            log::error!("[trained] refusing to publish trained artifacts: {error}");
-        }
     }
 
     /// Load trained structures from disk and publish to ArcSwap.
@@ -1109,34 +1164,59 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         Ok(())
     }
 
-    /// Persist vector metadata and publish its fully validated artifact set as
-    /// one cancellation-safe lifecycle transaction.
+    /// Atomically publish a fully staged vector generation.
     ///
-    /// Validation happens before the durable metadata commit. Once the rename
-    /// commits, both in-memory metadata and ArcSwap publication are completed by
-    /// the tracked transaction even if the requesting RPC is cancelled.
-    pub(crate) async fn update_vector_metadata_and_publish<F>(
+    /// Every replacement segment and its global codebook is complete before
+    /// this transaction starts. Metadata, tracker ownership, and the lock-free
+    /// trained pointer advance under the same state lock; snapshots therefore
+    /// observe either the complete old generation or the complete new one.
+    pub(crate) async fn publish_vector_generation(
         self: &Arc<Self>,
         artifact_update: &VectorArtifactUpdateGuard,
-        update: F,
-    ) -> Result<()>
-    where
-        F: FnOnce(&mut IndexMetadata),
-    {
+        vector_fields: HashMap<u32, crate::index::FieldVectorMeta>,
+        next_trained: Arc<TrainedVectorStructures>,
+        mut staged: Vec<StagedVectorSegment>,
+    ) -> Result<()> {
+        if !self.vector_artifact_update.load(Ordering::Acquire) {
+            return Err(Error::Internal(
+                "vector generation publication lost its exclusive update lease".into(),
+            ));
+        }
+
+        for replacement in &staged {
+            self.validate_completed_segment(&replacement.output_id.to_hex(), replacement.doc_count)
+                .await?;
+        }
+
         let mut st = Arc::clone(&self.state).lock_owned().await;
         let mut next = st.metadata.clone();
-        update(&mut next);
+        next.vector_fields = vector_fields;
+        next.refresh_total_vectors();
 
-        let next_trained = IndexMetadata::try_load_trained_from_fields(
-            &next.vector_fields,
-            self.schema.as_ref(),
-            self.directory.as_ref(),
-        )
-        .await?
-        .map(Arc::new);
+        for replacement in &staged {
+            let source_info = next
+                .segment_metas
+                .remove(&replacement.source_id)
+                .ok_or_else(|| {
+                    Error::Corruption(format!(
+                        "vector generation source {} disappeared before publication",
+                        replacement.source_id,
+                    ))
+                })?;
+            let output_hex = replacement.output_id.to_hex();
+            if next.segment_metas.contains_key(&output_hex) {
+                return Err(Error::Corruption(format!(
+                    "vector generation output {output_hex} is already metadata-live"
+                )));
+            }
+            // A vector-only rewrite changes neither document order nor merge
+            // lineage, so preserve the complete lifecycle record verbatim.
+            next.add_segment_meta(output_hex, source_info);
+        }
 
         let directory = Arc::clone(&self.directory);
         let trained = Arc::clone(&self.trained);
+        let tracker = Arc::clone(&self.tracker);
         // Keep the producer gate raised if the requesting future is cancelled
         // after the metadata transaction has been detached. The last guard
         // clone drops only after durable metadata and ArcSwap state agree.
@@ -1144,8 +1224,36 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         self.run_lifecycle_transaction(async move {
             let _artifact_update = artifact_update;
             next.save(directory.as_ref()).await?;
+
+            for replacement in &staged {
+                tracker.register(&replacement.output_id.to_hex());
+            }
             st.metadata = next;
-            trained.store(next_trained);
+            trained.store(Some(next_trained));
+
+            // Outputs are now durably live. Disarm unwind cleanup before
+            // retiring the old generation and releasing operation ownership.
+            for replacement in &mut staged {
+                replacement.cleanup.disarm();
+            }
+            let retired = staged
+                .iter()
+                .map(|replacement| replacement.source_id.clone())
+                .collect::<Vec<_>>();
+            let ready_to_delete = tracker.mark_for_deletion(&retired);
+            drop(st);
+            for &segment_id in &ready_to_delete {
+                if let Err(error) =
+                    crate::segment::delete_segment(directory.as_ref(), segment_id).await
+                {
+                    log::warn!(
+                        "[segment_cleanup] immediate vector-generation delete failed for {}: {}",
+                        segment_id.to_hex(),
+                        error,
+                    );
+                }
+            }
+            tracker.complete_deletion(&ready_to_delete);
             Ok(())
         })
         .await
@@ -1180,15 +1288,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     /// Acquire a snapshot of current segments for reading.
     /// The snapshot holds references — segments won't be deleted while snapshot exists.
     pub async fn acquire_snapshot(&self) -> SegmentSnapshot {
-        let acquired = {
+        let (acquired, trained) = {
             let st = self.state.lock().await;
             let segment_ids = st.metadata.segment_ids();
-            self.tracker.acquire(&segment_ids)
+            (self.tracker.acquire(&segment_ids), self.trained.load_full())
         };
 
-        SegmentSnapshot::with_delete_fn(
+        SegmentSnapshot::with_generation(
             Arc::clone(&self.tracker),
             acquired,
+            trained,
             Arc::clone(&self.delete_fn),
         )
     }
@@ -1419,8 +1528,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                             &ids,
                             new_id,
                             doc_count,
-                            sm.reorder_on_merge,
-                            bp_converged,
+                            ReplacementLayout::Recomputed {
+                                reordered: sm.reorder_on_merge,
+                                bp_converged,
+                            },
                         )
                         .await
                     {
@@ -1514,8 +1625,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         old_ids: &[String],
         new_id: String,
         doc_count: u32,
-        reordered: bool,
-        bp_converged: bool,
+        layout: ReplacementLayout,
     ) -> Result<()> {
         // The operation guard owns the output during validation. Publication
         // below replaces that ownership with metadata + tracker atomically.
@@ -1563,41 +1673,65 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             )));
         }
 
-        let parent_generation = old_ids
-            .iter()
-            .filter_map(|id| st.metadata.segment_metas.get(id))
-            .map(|info| info.generation)
-            .max()
-            .unwrap_or(0)
-            .checked_add(1)
-            .ok_or_else(|| Error::Corruption("merge generation exceeds u32::MAX".into()))?;
-        let parent_unconverged_passes = old_ids
-            .iter()
-            .filter_map(|id| st.metadata.segment_metas.get(id))
-            .map(|info| info.bp_unconverged_passes)
-            .max()
-            .unwrap_or(0);
-        let bp_unconverged_passes = if reordered && !bp_converged {
-            parent_unconverged_passes.saturating_add(1)
-        } else {
-            0
+        let replacement_info = match layout {
+            ReplacementLayout::Recomputed {
+                reordered,
+                bp_converged,
+            } => {
+                let generation = old_ids
+                    .iter()
+                    .filter_map(|id| st.metadata.segment_metas.get(id))
+                    .map(|info| info.generation)
+                    .max()
+                    .unwrap_or(0)
+                    .checked_add(1)
+                    .ok_or_else(|| Error::Corruption("merge generation exceeds u32::MAX".into()))?;
+                let parent_unconverged_passes = old_ids
+                    .iter()
+                    .filter_map(|id| st.metadata.segment_metas.get(id))
+                    .map(|info| info.bp_unconverged_passes)
+                    .max()
+                    .unwrap_or(0);
+                let passes = if reordered && !bp_converged {
+                    parent_unconverged_passes.saturating_add(1)
+                } else {
+                    0
+                };
+                SegmentMetaInfo {
+                    num_docs: doc_count,
+                    ancestors: old_ids.to_vec(),
+                    generation,
+                    reordered,
+                    bp_converged,
+                    bp_unconverged_passes: passes,
+                }
+            }
+            ReplacementLayout::PreserveSingleSource => {
+                let [source_id] = old_ids else {
+                    return Err(Error::Internal(
+                        "layout-preserving replacement requires exactly one source".into(),
+                    ));
+                };
+                let mut source = st
+                    .metadata
+                    .segment_metas
+                    .get(source_id)
+                    .cloned()
+                    .ok_or_else(|| {
+                        Error::Corruption(format!(
+                            "layout-preserving replacement source {source_id} disappeared"
+                        ))
+                    })?;
+                source.num_docs = doc_count;
+                source
+            }
         };
         let retired_ids = old_ids.to_vec();
         let mut next = st.metadata.clone();
         for id in old_ids {
             next.remove_segment(id);
         }
-        next.add_segment_meta(
-            new_id.clone(),
-            SegmentMetaInfo {
-                num_docs: doc_count,
-                ancestors: retired_ids.clone(),
-                generation: parent_generation,
-                reordered,
-                bp_converged,
-                bp_unconverged_passes,
-            },
-        );
+        next.add_segment_meta(new_id.clone(), replacement_info);
 
         let directory = Arc::clone(&self.directory);
         let tracker = Arc::clone(&self.tracker);
@@ -2101,8 +2235,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     &batch,
                     new_segment_id,
                     total_docs,
-                    self.reorder_on_merge,
-                    bp_converged,
+                    ReplacementLayout::Recomputed {
+                        reordered: self.reorder_on_merge,
+                        bp_converged,
+                    },
                 )
                 .await
             {
@@ -2114,6 +2250,404 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             output_cleanup.disarm();
 
             // _guard drops here, releasing operation ownership.
+        }
+    }
+
+    fn segment_needs_vector_rewrite(
+        &self,
+        reader: &SegmentReader,
+        field_ids: &[u32],
+        rewrite_existing: bool,
+    ) -> Result<bool> {
+        for &field_id in field_ids {
+            let flat = reader.flat_vectors().get(&field_id);
+            let ann = reader.vector_indexes().get(&field_id);
+            if ann.is_some() && flat.is_none() {
+                return Err(Error::Corruption(format!(
+                    "segment {:032x} field {field_id} has ANN data without the required flat vectors",
+                    reader.meta().id,
+                )));
+            }
+
+            let Some(flat) = flat else {
+                continue;
+            };
+            if flat.num_vectors == 0 {
+                continue;
+            }
+            if rewrite_existing {
+                return Ok(true);
+            }
+            let field = crate::dsl::Field(field_id);
+            let entry = self.schema.get_field_entry(field).ok_or_else(|| {
+                Error::Corruption(format!(
+                    "segment {:032x} references unknown vector field {field_id}",
+                    reader.meta().id,
+                ))
+            })?;
+            let current = match entry.field_type {
+                crate::dsl::FieldType::DenseVector => {
+                    matches!(ann, Some(crate::segment::VectorIndex::IvfPq(_)))
+                }
+                crate::dsl::FieldType::BinaryDenseVector => {
+                    matches!(ann, Some(crate::segment::VectorIndex::BinaryIvf(_)))
+                }
+                _ => false,
+            };
+            if !current {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    async fn acquire_vector_rewrite_capacity(
+        &self,
+    ) -> Result<(OwnedSemaphorePermit, OwnedSemaphorePermit)> {
+        let global = tokio::select! {
+            biased;
+            () = self.active_operations.wait_for_shutdown() => {
+                return Err(Error::IndexClosed);
+            }
+            permit = Arc::clone(&self.global_merge_permits).acquire_owned() => {
+                permit.map_err(|_| Error::Internal(
+                    "global background merge scheduler is closed".into()
+                ))?
+            }
+        };
+        let local = tokio::select! {
+            biased;
+            () = self.active_operations.wait_for_shutdown() => {
+                return Err(Error::IndexClosed);
+            }
+            permit = Arc::clone(&self.merge_permits).acquire_owned() => {
+                permit.map_err(|_| Error::Internal(
+                    "background merge scheduler is closed".into()
+                ))?
+            }
+        };
+        Ok((global, local))
+    }
+
+    async fn build_vector_replacement(
+        self: &Arc<Self>,
+        segment_id: &str,
+        source_id: SegmentId,
+        output_id: SegmentId,
+        trained: &TrainedVectorStructures,
+        failure_context: &'static str,
+    ) -> Result<(String, u32, OutputCleanupGuard)> {
+        let mut cleanup = self.output_cleanup_guard(output_id);
+        match crate::segment::reorder::rewrite_vector_segment(
+            self.directory.as_ref(),
+            &self.schema,
+            source_id,
+            output_id,
+            self.term_cache_blocks,
+            trained,
+            Some(self.background_cpu_pool()),
+        )
+        .await
+        {
+            Ok((new_id, doc_count)) => {
+                self.validate_completed_segment(&new_id, doc_count).await?;
+                Ok((new_id, doc_count, cleanup))
+            }
+            Err(error) => {
+                self.delete_output_if_unregistered(output_id, failure_context)
+                    .await;
+                cleanup.disarm();
+                if is_deterministic_source_error(&error) {
+                    self.quarantine_segment(segment_id, &error);
+                }
+                Err(error)
+            }
+        }
+    }
+
+    /// Build every required replacement segment without exposing any of them.
+    /// The returned guards keep both source and output generations alive until
+    /// [`Self::publish_vector_generation`] commits the complete set.
+    pub(crate) async fn stage_vector_generation(
+        self: &Arc<Self>,
+        _artifact_update: &VectorArtifactUpdateGuard,
+        segment_ids: &[String],
+        field_ids: &[u32],
+        trained: Arc<TrainedVectorStructures>,
+        rewrite_existing: bool,
+    ) -> Result<Vec<StagedVectorSegment>> {
+        if !self.vector_artifact_update.load(Ordering::Acquire) {
+            return Err(Error::Internal(
+                "cannot stage a vector generation without an exclusive update lease".into(),
+            ));
+        }
+
+        let mut staged = Vec::new();
+        for segment_id in segment_ids {
+            if self.quarantined_segments.lock().contains(segment_id) {
+                return Err(Error::Corruption(format!(
+                    "segment {segment_id} is quarantined after a deterministic source failure"
+                )));
+            }
+            let source_id = SegmentId::from_hex(segment_id).ok_or_else(|| {
+                Error::Corruption(format!("invalid vector rewrite segment ID: {segment_id}"))
+            })?;
+
+            // A single rewrite may hold several gigabytes while assigning all
+            // vectors. Reuse the ordinary local and process-wide merge bounds.
+            let _capacity = self.acquire_vector_rewrite_capacity().await?;
+
+            let output_id = SegmentId::new();
+            let output_hex = output_id.to_hex();
+            let operation = {
+                let st = self.state.lock().await;
+                if !st.metadata.has_segment(segment_id) {
+                    return Err(Error::Corruption(format!(
+                        "vector generation source {segment_id} disappeared while lifecycle work was paused"
+                    )));
+                }
+                self.active_operations
+                    .try_register_vector_update(vec![segment_id.clone(), output_hex.clone()])
+            }
+            .ok_or_else(|| {
+                if self.active_operations.is_accepting() {
+                    Error::Internal(format!(
+                        "vector generation could not claim stable source {segment_id}"
+                    ))
+                } else {
+                    Error::IndexClosed
+                }
+            })?;
+
+            let reader = SegmentReader::open(
+                self.directory.as_ref(),
+                source_id,
+                Arc::clone(&self.schema),
+                self.term_cache_blocks,
+            )
+            .await?;
+            if !self.segment_needs_vector_rewrite(&reader, field_ids, rewrite_existing)? {
+                continue;
+            }
+            drop(reader);
+
+            let (new_id, doc_count, cleanup) = self
+                .build_vector_replacement(
+                    segment_id,
+                    source_id,
+                    output_id,
+                    trained.as_ref(),
+                    "vector generation staging failure",
+                )
+                .await?;
+            debug_assert_eq!(new_id, output_hex);
+            let output_reader = SegmentReader::open(
+                self.directory.as_ref(),
+                output_id,
+                Arc::clone(&self.schema),
+                self.term_cache_blocks,
+            )
+            .await?;
+            if self.segment_needs_vector_rewrite(&output_reader, field_ids, false)? {
+                return Err(Error::Corruption(format!(
+                    "staged vector segment {new_id} does not match its candidate codebook generation"
+                )));
+            }
+
+            staged.push(StagedVectorSegment {
+                source_id: segment_id.clone(),
+                output_id,
+                doc_count,
+                _operation: operation,
+                cleanup,
+            });
+        }
+        Ok(staged)
+    }
+
+    async fn rewrite_vector_segment_once(
+        self: &Arc<Self>,
+        segment_id: &str,
+        field_ids: &[u32],
+    ) -> Result<VectorSegmentRewriteOutcome> {
+        if self.quarantined_segments.lock().contains(segment_id) {
+            return Err(Error::Corruption(format!(
+                "segment {segment_id} is quarantined after a deterministic source failure; repair it before ANN finalization"
+            )));
+        }
+        let source_id = SegmentId::from_hex(segment_id).ok_or_else(|| {
+            Error::Corruption(format!("invalid vector rewrite segment ID: {segment_id}"))
+        })?;
+
+        // Match ordinary merge lock ordering: capacity before lifecycle
+        // ownership. A vector rewrite can hold several gigabytes while it
+        // assigns vectors, so it participates in both local and process-wide
+        // merge limits.
+        let _capacity = self.acquire_vector_rewrite_capacity().await?;
+
+        let output_id = SegmentId::new();
+        let output_hex = output_id.to_hex();
+        let all_ids = vec![segment_id.to_owned(), output_hex];
+        let operation = {
+            let st = self.state.lock().await;
+            if !st.metadata.has_segment(segment_id) {
+                return Ok(VectorSegmentRewriteOutcome::SourceGone);
+            }
+            self.active_operations.try_register(all_ids)
+        };
+        let _operation = match operation {
+            Some(operation) => operation,
+            None if !self.active_operations.is_accepting() => return Err(Error::IndexClosed),
+            None => return Ok(VectorSegmentRewriteOutcome::Conflict),
+        };
+
+        let Some(trained) = self.trained_for_segment_build() else {
+            return Ok(VectorSegmentRewriteOutcome::Deferred);
+        };
+
+        let reader = SegmentReader::open(
+            self.directory.as_ref(),
+            source_id,
+            Arc::clone(&self.schema),
+            self.term_cache_blocks,
+        )
+        .await?;
+        if !self.segment_needs_vector_rewrite(&reader, field_ids, false)? {
+            return Ok(VectorSegmentRewriteOutcome::AlreadyCurrent);
+        }
+        drop(reader);
+
+        let (new_id, doc_count, mut output_cleanup) = self
+            .build_vector_replacement(
+                segment_id,
+                source_id,
+                output_id,
+                trained.as_ref(),
+                "vector rewrite failure",
+            )
+            .await?;
+
+        if let Err(error) = self
+            .replace_segments(
+                &[segment_id.to_owned()],
+                new_id,
+                doc_count,
+                ReplacementLayout::PreserveSingleSource,
+            )
+            .await
+        {
+            self.delete_output_if_unregistered(output_id, "vector replacement failure")
+                .await;
+            output_cleanup.disarm();
+            return Err(error);
+        }
+        output_cleanup.disarm();
+        Ok(VectorSegmentRewriteOutcome::Rewritten)
+    }
+
+    /// Finalize every committed flat vector segment against the published
+    /// global ANN generation.
+    /// Unlike force-merge this handles one segment and segments already at the
+    /// merge policy's maximum size.
+    pub(crate) async fn rewrite_vector_segments(
+        self: &Arc<Self>,
+        field_ids: &[u32],
+    ) -> Result<usize> {
+        if field_ids.is_empty() {
+            return Ok(0);
+        }
+        let mut rewritten = 0usize;
+        loop {
+            let segment_ids = self.get_segment_ids().await;
+            let mut conflicted = false;
+            let mut changed = false;
+            for segment_id in segment_ids {
+                match self
+                    .rewrite_vector_segment_once(&segment_id, field_ids)
+                    .await?
+                {
+                    VectorSegmentRewriteOutcome::Rewritten => {
+                        rewritten += 1;
+                        changed = true;
+                    }
+                    VectorSegmentRewriteOutcome::Conflict => conflicted = true,
+                    VectorSegmentRewriteOutcome::Deferred => {
+                        return Err(Error::Internal(
+                            "ANN finalization lost the published trained generation".into(),
+                        ));
+                    }
+                    VectorSegmentRewriteOutcome::AlreadyCurrent
+                    | VectorSegmentRewriteOutcome::SourceGone => {}
+                }
+            }
+            if !conflicted && !changed {
+                log::info!(
+                    "[vector_rewrite] ANN finalization complete ({} segment(s) rewritten)",
+                    rewritten,
+                );
+                return Ok(rewritten);
+            }
+            tokio::select! {
+                biased;
+                () = self.active_operations.wait_for_shutdown() => {
+                    return Err(Error::IndexClosed);
+                }
+                () = tokio::time::sleep(std::time::Duration::from_millis(100)) => {}
+            }
+        }
+    }
+
+    /// A producer that started in the force-flat phase can commit after the
+    /// main finalization snapshot. Upgrade exactly those new segments in a
+    /// tracked background task; ordinary producers already using the current
+    /// generation are detected and skipped without rewriting.
+    pub(crate) fn schedule_vector_segment_upgrades(self: &Arc<Self>, segment_ids: Vec<String>) {
+        if segment_ids.is_empty() || self.trained_for_segment_build().is_none() {
+            return;
+        }
+        let manager = Arc::clone(self);
+        let future = async move {
+            let field_ids = manager
+                .read_metadata(|metadata| {
+                    metadata
+                        .vector_fields
+                        .keys()
+                        .filter(|field_id| metadata.is_field_built(**field_id))
+                        .copied()
+                        .collect::<Vec<_>>()
+                })
+                .await;
+            for segment_id in segment_ids {
+                loop {
+                    match manager
+                        .rewrite_vector_segment_once(&segment_id, &field_ids)
+                        .await
+                    {
+                        Ok(VectorSegmentRewriteOutcome::Conflict) => {
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        }
+                        Ok(VectorSegmentRewriteOutcome::Deferred) => break,
+                        Ok(_) => break,
+                        Err(error) => {
+                            log::error!(
+                                "[vector_rewrite] failed to upgrade newly committed segment {}: {}",
+                                segment_id,
+                                error,
+                            );
+                            break;
+                        }
+                    }
+                }
+            }
+        };
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            log::warn!(
+                "[vector_rewrite] runtime unavailable; newly committed flat segment upgrade deferred"
+            );
+            return;
+        };
+        if !try_spawn_lifecycle(&self.lifecycle_handles, &runtime, future) {
+            log::warn!("[vector_rewrite] runtime rejected newly committed flat segment upgrade");
         }
     }
 
@@ -2369,8 +2903,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 &[seg_id.to_string()],
                 new_id,
                 total_docs,
-                true,
-                ladder_converged,
+                ReplacementLayout::Recomputed {
+                    reordered: true,
+                    bp_converged: ladder_converged,
+                },
             )
             .await
         {
@@ -2632,6 +3168,33 @@ mod tests {
         );
         drop(detached_transaction_guard);
         assert!(manager.trained_for_segment_build().is_some());
+    }
+
+    #[tokio::test]
+    async fn artifact_update_pauses_lifecycle_rewrites_but_allows_flat_indexing() {
+        let manager = lifecycle_test_manager();
+        let guard = manager.begin_vector_artifact_update().await.unwrap();
+        assert!(
+            manager
+                .active_operations
+                .try_register(vec!["merge".into()])
+                .is_none(),
+            "ordinary merge/reorder work must not change staged sources"
+        );
+        let indexing = manager
+            .active_operations
+            .try_register_indexing(vec!["fresh".into()])
+            .expect("indexing remains available in flat mode");
+        drop(indexing);
+
+        drop(guard);
+        assert!(!manager.vector_artifact_update.load(Ordering::Acquire));
+        assert!(
+            manager
+                .active_operations
+                .try_register(vec!["merge".into()])
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/hermes-core/src/segment/builder/dense.rs
+++ b/hermes-core/src/segment/builder/dense.rs
@@ -232,10 +232,18 @@ pub(super) fn build_vectors_streaming(
                             centroids,
                             codebook,
                         );
-                        for (i, (doc_id, ordinal)) in builder.doc_ids.iter().enumerate() {
-                            let v = &builder.vectors[i * dim..(i + 1) * dim];
-                            index.add_vector(centroids, codebook, *doc_id, *ordinal, v);
-                        }
+                        index
+                            .add_vectors_parallel(
+                                centroids,
+                                codebook,
+                                &builder.doc_ids,
+                                &builder.vectors,
+                            )
+                            .map_err(|error| {
+                                crate::Error::Internal(format!(
+                                    "parallel IVF-PQ build failed for field {field_id}: {error}"
+                                ))
+                            })?;
                         super::super::ann_build::serialize_ivf_pq(index)
                             .map(|b| (super::super::ann_build::IVF_PQ_TYPE, b))
                     }

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -48,7 +48,7 @@ async fn feed_segment(
     segment: &SegmentReader,
     field: crate::dsl::Field,
     doc_id_offset: u32,
-    mut add_fn: impl FnMut(u32, u16, &[f32]),
+    mut add_batch: impl FnMut(&[(u32, u16)], &[f32]) -> Result<()>,
 ) -> crate::Result<usize> {
     let lazy_flat = match segment.flat_vectors().get(&field.0) {
         Some(f) => f,
@@ -64,6 +64,7 @@ async fn feed_segment(
     // Only allocate dequantize buffer for non-f32 quantizations
     let needs_dequant = quant != DenseVectorQuantization::F32;
     let mut f32_buf: Vec<f32> = Vec::new();
+    let mut labels = Vec::with_capacity(VECTOR_BATCH_SIZE);
 
     for batch_start in (0..n).step_by(VECTOR_BATCH_SIZE) {
         let batch_count = VECTOR_BATCH_SIZE.min(n - batch_start);
@@ -93,15 +94,13 @@ async fn feed_segment(
             unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const f32, batch_floats) }
         };
 
+        labels.clear();
         for i in 0..batch_count {
             let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
-            add_fn(
-                doc_id_offset + doc_id,
-                ordinal,
-                &vectors[i * dim..(i + 1) * dim],
-            );
-            count += 1;
+            labels.push((doc_id_offset + doc_id, ordinal));
         }
+        add_batch(&labels, vectors)?;
+        count += batch_count;
     }
     Ok(count)
 }
@@ -185,7 +184,7 @@ impl SegmentMerger {
     /// is streamed. Peak memory = one ANN blob at a time, not all simultaneously.
     ///
     /// No document store reads — all vector data comes from .vectors files.
-    pub(super) async fn merge_dense_vectors<D: Directory + DirectoryWriter>(
+    pub(crate) async fn merge_dense_vectors<D: Directory + DirectoryWriter>(
         &self,
         dir: &D,
         segments: &[SegmentReader],
@@ -557,7 +556,23 @@ impl SegmentMerger {
             })
             .collect();
 
-        if ivf_pq_indexes.len() == segments_with_flat && !ivf_pq_indexes.is_empty() {
+        let matches_published_generation = trained
+            .and_then(|trained| {
+                trained
+                    .centroids
+                    .get(&field.0)
+                    .zip(trained.codebooks.get(&field.0))
+            })
+            .is_some_and(|(centroids, codebook)| {
+                ivf_pq_indexes.iter().all(|(_, index)| {
+                    index.centroids_version == centroids.version
+                        && index.codebook_version == codebook.version
+                })
+            });
+        if matches_published_generation
+            && ivf_pq_indexes.len() == segments_with_flat
+            && !ivf_pq_indexes.is_empty()
+        {
             let refs: Vec<&crate::structures::IVFPQIndex> = ivf_pq_indexes
                 .iter()
                 .map(|(_, index)| index.as_ref())
@@ -628,8 +643,22 @@ impl SegmentMerger {
 
                 for (seg_idx, segment) in segments.iter().enumerate() {
                     let offset = doc_offs[seg_idx];
-                    let fed = feed_segment(segment, field, offset, |doc_id, ordinal, vec| {
-                        index.add_vector(centroids, codebook, doc_id, ordinal, vec);
+                    let fed = feed_segment(segment, field, offset, |labels, vectors| {
+                        super::block_in_place_if_multithread(|| {
+                            let mut add =
+                                || index.add_vectors_parallel(centroids, codebook, labels, vectors);
+                            if let Some(pool) = &self.background_pool {
+                                pool.install(add)
+                            } else {
+                                add()
+                            }
+                        })
+                        .map_err(|error| {
+                            crate::Error::Internal(format!(
+                                "parallel IVF-PQ rebuild failed for field {}: {error}",
+                                field.0,
+                            ))
+                        })
                     })
                     .await?;
                     total_fed += fed;
@@ -740,8 +769,8 @@ mod tests {
             writer.add_document(doc).unwrap();
         }
         writer.commit().await.unwrap();
-        let mut known = committed_segment_ids(&dir).await;
         writer.build_vector_index().await.unwrap();
+        let mut known = committed_segment_ids(&dir).await;
 
         // Segment A: 2 docs WITH the field (gets a per-segment IVF at flush).
         for i in 0..2 {
@@ -795,8 +824,9 @@ mod tests {
         assert!(readers[2].get_ivf_pq_vector_index(embedding).is_some());
 
         let merged_id = SegmentId::new();
+        let trained = writer.segment_manager().trained().unwrap();
         SegmentMerger::new(Arc::clone(&schema))
-            .merge(&dir, &readers, merged_id, None)
+            .merge(&dir, &readers, merged_id, Some(trained.as_ref()))
             .await
             .unwrap();
 

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -15,10 +15,10 @@ use std::sync::Arc;
 use crate::Result;
 use crate::directories::{Directory, DirectoryWriter};
 use crate::dsl::{FieldType, Schema};
-use crate::segment::OffsetWriter;
 use crate::segment::format::{SparseFieldToc, write_sparse_toc_and_footer};
 use crate::segment::reader::SegmentReader;
 use crate::segment::types::{SegmentFiles, SegmentId, SegmentMeta};
+use crate::segment::{OffsetWriter, SegmentMerger, TrainedVectorStructures};
 use crate::structures::SparseFormat;
 
 /// Default memory budget for forward index during BP (24 GB). A cap, not an
@@ -316,7 +316,7 @@ pub async fn reorder_segment<D: Directory + DirectoryWriter>(
             !reader.vector_indexes().is_empty() || !reader.flat_vectors().is_empty(),
         ),
     ] {
-        copy_segment_file(dir, src, dst, required).await?;
+        clone_segment_file(dir, src, dst, required).await?;
     }
     log::info!(
         "[reorder] copied files in {:.1}s",
@@ -351,24 +351,119 @@ pub async fn reorder_segment<D: Directory + DirectoryWriter>(
     Ok((output_id.to_hex(), num_docs, bp_converged))
 }
 
-/// Copy a segment file via streaming I/O (4 MB chunks).
+/// Rewrite only a segment's dense-vector file while retaining every immutable
+/// non-vector file. Filesystem backends hard-link unchanged data, so upgrading
+/// a max-sized segment does not duplicate its postings, store, sparse index, or
+/// fast fields. Backends without links use the bounded streaming fallback.
+pub async fn rewrite_vector_segment<D: Directory + DirectoryWriter>(
+    dir: &D,
+    schema: &Arc<Schema>,
+    source_id: SegmentId,
+    output_id: SegmentId,
+    term_cache_blocks: usize,
+    trained: &TrainedVectorStructures,
+    rayon_pool: Option<Arc<rayon::ThreadPool>>,
+) -> Result<(String, u32)> {
+    let reader = SegmentReader::open(dir, source_id, Arc::clone(schema), term_cache_blocks).await?;
+    let num_docs = reader.num_docs();
+    let src_files = SegmentFiles::new(source_id.0);
+    let dst_files = SegmentFiles::new(output_id.0);
+
+    log::info!(
+        "[vector_rewrite] finalizing segment {} → {} ({} docs)",
+        source_id.to_hex(),
+        output_id.to_hex(),
+        num_docs,
+    );
+
+    for (src, dst, required) in [
+        (&src_files.term_dict, &dst_files.term_dict, true),
+        (&src_files.postings, &dst_files.postings, true),
+        (
+            &src_files.positions,
+            &dst_files.positions,
+            reader.has_positions_file(),
+        ),
+        (&src_files.store, &dst_files.store, true),
+        (
+            &src_files.fast,
+            &dst_files.fast,
+            !reader.fast_fields().is_empty(),
+        ),
+        (
+            &src_files.sparse,
+            &dst_files.sparse,
+            !reader.sparse_indexes().is_empty() || !reader.bmp_indexes().is_empty(),
+        ),
+    ] {
+        clone_segment_file(dir, src, dst, required).await?;
+    }
+
+    let merger = SegmentMerger::new(Arc::clone(schema)).with_background_pool(rayon_pool);
+    let vector_bytes = merger
+        .merge_dense_vectors(
+            dir,
+            std::slice::from_ref(&reader),
+            &dst_files,
+            Some(trained),
+        )
+        .await?;
+    if vector_bytes == 0 {
+        return Err(crate::Error::Corruption(format!(
+            "vector rewrite source {} has no flat vector payload",
+            source_id.to_hex(),
+        )));
+    }
+
+    let src_meta = reader.meta();
+    let meta = SegmentMeta {
+        id: output_id.0,
+        num_docs: src_meta.num_docs,
+        field_stats: src_meta.field_stats.clone(),
+    };
+    dir.write_durable(&dst_files.meta, &meta.serialize()?)
+        .await?;
+
+    Ok((output_id.to_hex(), num_docs))
+}
+
+/// Retain an immutable segment file with a hard link when possible, falling
+/// back to streaming I/O in 4 MB chunks.
 ///
 /// No-op if an optional source file does not exist. A file observed by the
 /// source reader is required: losing it during the copy is corruption, not an
 /// empty optional field.
 /// Empty files are still created (SegmentReader requires their existence).
-async fn copy_segment_file<D: Directory + DirectoryWriter>(
+async fn clone_segment_file<D: Directory + DirectoryWriter>(
     dir: &D,
     src: &Path,
     dst: &Path,
     required: bool,
 ) -> Result<()> {
+    match dir.link(src, dst).await {
+        Ok(()) => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound && !required => return Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(crate::Error::Corruption(format!(
+                "required segment source file {src:?} disappeared before link"
+            )));
+        }
+        Err(error) => {
+            log::debug!(
+                "[segment_clone] link {:?} → {:?} unavailable ({}), streaming instead",
+                src,
+                dst,
+                error,
+            );
+        }
+    }
+
     let handle = match dir.open_read(src).await {
         Ok(h) => h,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound && !required => return Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return Err(crate::Error::Corruption(format!(
-                "required reorder source file {src:?} disappeared before copy"
+                "required segment source file {src:?} disappeared before copy"
             )));
         }
         Err(error) => return Err(crate::Error::Io(error)),
@@ -396,14 +491,14 @@ async fn copy_segment_file<D: Directory + DirectoryWriter>(
         })
         .await
         .map_err(|error| {
-            crate::Error::Internal(format!("reorder copy worker failed for {src:?}: {error}"))
+            crate::Error::Internal(format!("segment clone worker failed for {src:?}: {error}"))
         })?
         .map_err(crate::Error::Io)?;
         offset = end;
     }
     if writer.bytes_written() != source_len {
         return Err(crate::Error::Corruption(format!(
-            "short reorder copy from {:?} to {:?}: wrote {} of {} bytes",
+            "short segment clone from {:?} to {:?}: wrote {} of {} bytes",
             src,
             dst,
             writer.bytes_written(),
@@ -414,7 +509,7 @@ async fn copy_segment_file<D: Directory + DirectoryWriter>(
         .await
         .map_err(|error| {
             crate::Error::Internal(format!(
-                "reorder copy finalizer failed for {dst:?}: {error}"
+                "segment clone finalizer failed for {dst:?}: {error}"
             ))
         })?
         .map_err(crate::Error::Io)?;
@@ -477,7 +572,7 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
             reader.meta().id,
         );
         let src_files = SegmentFiles::new(reader.meta().id);
-        copy_segment_file(dir, &src_files.sparse, &dst_files.sparse, true).await?;
+        clone_segment_file(dir, &src_files.sparse, &dst_files.sparse, true).await?;
         return Ok(true);
     }
 
@@ -532,9 +627,8 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                     .unwrap_or(bmp_idx.max_weight_scale);
                 let total_vectors = bmp_idx.total_vectors;
 
-                // Clone BmpIndex (cheap: Arc ref bumps on OwnedBytes) and move
-                // OffsetWriter + field_tocs into spawn_blocking so the entire
-                // CPU-heavy reorder runs off tokio worker threads.
+                // One field owns the output writer and BP working set at a
+                // time. The field itself still uses the bounded Rayon pool.
                 let bmp_sources = vec![(bmp_idx.clone(), 0u32)];
                 let fid = field.0;
                 let fname = field_name.clone();
@@ -1790,12 +1884,12 @@ mod grid_run_prefix_tests {
         let missing = std::path::Path::new("missing");
         let output = std::path::Path::new("output");
 
-        super::copy_segment_file(&dir, missing, output, false)
+        super::clone_segment_file(&dir, missing, output, false)
             .await
             .unwrap();
         assert!(!dir.exists(output).await.unwrap());
 
-        let error = super::copy_segment_file(&dir, missing, output, true)
+        let error = super::clone_segment_file(&dir, missing, output, true)
             .await
             .unwrap_err();
         assert!(matches!(error, crate::Error::Corruption(_)));
@@ -1809,7 +1903,7 @@ mod grid_run_prefix_tests {
         let data = vec![0x5a; 4 * 1024 * 1024 + 17];
         dir.write(source, &data).await.unwrap();
 
-        super::copy_segment_file(&dir, source, output, true)
+        super::clone_segment_file(&dir, source, output, true)
             .await
             .unwrap();
 

--- a/hermes-core/src/segment/tracker.rs
+++ b/hermes-core/src/segment/tracker.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use crate::segment::SegmentId;
+use crate::segment::TrainedVectorStructures;
 
 /// Internal state protected by single Mutex
 struct TrackerInner {
@@ -164,6 +165,10 @@ impl Default for SegmentTracker {
 pub struct SegmentSnapshot {
     tracker: Arc<SegmentTracker>,
     segment_ids: Vec<String>,
+    /// The index-global ANN artifacts paired with exactly this segment set.
+    /// Keeping the pair in one snapshot lets a codebook retrain atomically
+    /// replace every segment without old readers observing the new codebook.
+    trained_vectors: Option<Arc<TrainedVectorStructures>>,
     /// Callback to delete segment files when they become ready for deletion.
     delete_fn: Option<Arc<dyn Fn(Vec<SegmentId>) + Send + Sync>>,
 }
@@ -174,6 +179,7 @@ impl SegmentSnapshot {
         Self {
             tracker,
             segment_ids,
+            trained_vectors: None,
             delete_fn: None,
         }
     }
@@ -187,6 +193,23 @@ impl SegmentSnapshot {
         Self {
             tracker,
             segment_ids,
+            trained_vectors: None,
+            delete_fn: Some(delete_fn),
+        }
+    }
+
+    /// Create a native index snapshot whose segment IDs and trained vector
+    /// structures were captured under the same publication lock.
+    pub(crate) fn with_generation(
+        tracker: Arc<SegmentTracker>,
+        segment_ids: Vec<String>,
+        trained_vectors: Option<Arc<TrainedVectorStructures>>,
+        delete_fn: Arc<dyn Fn(Vec<SegmentId>) + Send + Sync>,
+    ) -> Self {
+        Self {
+            tracker,
+            segment_ids,
+            trained_vectors,
             delete_fn: Some(delete_fn),
         }
     }
@@ -194,6 +217,11 @@ impl SegmentSnapshot {
     /// Get the segment IDs in this snapshot
     pub fn segment_ids(&self) -> &[String] {
         &self.segment_ids
+    }
+
+    /// Return the global ANN artifacts belonging to this segment snapshot.
+    pub(crate) fn trained_vectors(&self) -> Option<Arc<TrainedVectorStructures>> {
+        self.trained_vectors.clone()
     }
 
     /// Check if this snapshot is empty

--- a/hermes-core/src/structures/vector/index/binary_ivf.rs
+++ b/hermes-core/src/structures/vector/index/binary_ivf.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::io;
 
 use crate::dsl::IvfRoutingMode;
-use crate::structures::simd::batch_hamming_scores;
+use crate::structures::simd::{batch_hamming_scores, hamming_distance};
 use crate::structures::vector::ivf::routing::{
     HNSW_AUTO_THRESHOLD, HnswRoutingGraph, IvfProbePlan, IvfRoutingTopology,
     allocate_child_clusters, binary_probe_fingerprint, effective_routing_mode, parent_probe_count,
@@ -38,16 +38,20 @@ fn argmax_score_lowest_index(scores: &[f32]) -> usize {
         .unwrap_or(0)
 }
 
+#[inline]
+fn nearest_binary_centroid(
+    code: &[u8],
+    centroids: &[u8],
+    byte_len: usize,
+    dim_bits: usize,
+    scores: &mut [f32],
+) -> u32 {
+    batch_hamming_scores(code, centroids, byte_len, dim_bits, scores);
+    argmax_score_lowest_index(scores) as u32
+}
+
 const MAX_BINARY_IVF_CLUSTERS: usize = 1_048_576;
 const BINARY_IVF_SCORE_BATCH: usize = 8_192;
-
-#[inline]
-fn packed_hamming_distance(left: &[u8], right: &[u8]) -> u32 {
-    left.iter()
-        .zip(right)
-        .map(|(&a, &b)| (a ^ b).count_ones())
-        .sum()
-}
 
 /// Global Hamming coarse quantizer shared by every segment of a field.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,7 +109,7 @@ impl BinaryCoarseQuantizer {
                     let graph = HnswRoutingGraph::build(
                         config.num_clusters,
                         |left, right| {
-                            packed_hamming_distance(
+                            hamming_distance(
                                 &leaves[left as usize * byte_len..(left as usize + 1) * byte_len],
                                 &leaves[right as usize * byte_len..(right as usize + 1) * byte_len],
                             ) as f32
@@ -225,7 +229,7 @@ impl BinaryCoarseQuantizer {
         (0..self.num_clusters)
             .min_by_key(|&cluster| {
                 let offset = cluster as usize * self.byte_len();
-                packed_hamming_distance(query, &self.centroids[offset..offset + self.byte_len()])
+                hamming_distance(query, &self.centroids[offset..offset + self.byte_len()])
             })
             .unwrap_or(0)
     }
@@ -296,7 +300,7 @@ impl BinaryCoarseQuantizer {
         let byte_len = self.byte_len();
         graph.search(
             |leaf| {
-                packed_hamming_distance(
+                hamming_distance(
                     query,
                     &self.centroids[leaf as usize * byte_len..(leaf as usize + 1) * byte_len],
                 ) as f32
@@ -311,7 +315,7 @@ impl BinaryCoarseQuantizer {
         };
         let byte_len = self.byte_len();
         graph.search_one(|leaf| {
-            packed_hamming_distance(
+            hamming_distance(
                 query,
                 &self.centroids[leaf as usize * byte_len..(leaf as usize + 1) * byte_len],
             ) as f32
@@ -636,12 +640,16 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
     let dim_bits = config.dim_bits;
     let mut rng = rand::rngs::StdRng::seed_from_u64(config.seed);
 
-    // Bound training cost: iterate over a sample, assign everything later
+    // Bound training cost: iterate over a sample, assign everything later. Do
+    // not materialize a random permutation when the complete input is used:
+    // the indirection destroys locality for the billion-scale global training
+    // sample without changing which points participate.
     let sample_len = config.max_train_samples.max(k).min(n);
-    let sample = rand::seq::index::sample(&mut rng, n, sample_len).into_vec();
-    let n = sample.len();
+    let sample =
+        (sample_len < n).then(|| rand::seq::index::sample(&mut rng, n, sample_len).into_vec());
+    let n = sample_len;
     let vec_at = |i: usize| -> &[u8] {
-        let vi = sample[i];
+        let vi = sample.as_ref().map_or(i, |sample| sample[i]);
         &codes[vi * byte_len..(vi + 1) * byte_len]
     };
 
@@ -653,25 +661,28 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
     let mut min_dist_sq = vec![f64::INFINITY; n];
     for centroid_id in 1..k {
         let previous = &centroids[(centroid_id - 1) * byte_len..centroid_id * byte_len];
-        let mut total_weight = 0.0;
-        for (index, min_distance) in min_dist_sq.iter_mut().enumerate() {
-            let distance: u32 = vec_at(index)
-                .iter()
-                .zip(previous)
-                .map(|(&left, &right)| (left ^ right).count_ones())
-                .sum();
-            *min_distance = min_distance.min((distance as f64) * (distance as f64));
-            total_weight += *min_distance;
-        }
-        let chosen = if total_weight > 0.0 {
-            let mut target = rng.random::<f64>() * total_weight;
+        #[cfg(feature = "native")]
+        {
+            use rayon::prelude::*;
             min_dist_sq
-                .iter()
-                .position(|weight| {
-                    target -= *weight;
-                    target <= 0.0
-                })
-                .unwrap_or(n - 1)
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(index, min_distance)| {
+                    let distance = hamming_distance(vec_at(index), previous);
+                    *min_distance = min_distance.min((distance as f64) * (distance as f64));
+                });
+        }
+        #[cfg(not(feature = "native"))]
+        for (index, min_distance) in min_dist_sq.iter_mut().enumerate() {
+            let distance = hamming_distance(vec_at(index), previous);
+            *min_distance = min_distance.min((distance as f64) * (distance as f64));
+        }
+
+        let chosen = if let Some(chosen) = crate::structures::vector::kmeans::weighted_sample_index(
+            &min_dist_sq,
+            rng.random::<f64>(),
+        ) {
+            chosen
         } else {
             rng.random_range(0..n)
         };
@@ -680,59 +691,139 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
     }
 
     let mut assignment = vec![u32::MAX; n];
-    let mut scores = vec![0f32; k];
+    let mut members: Vec<Vec<usize>> = (0..k).map(|_| Vec::new()).collect();
 
     for _iter in 0..config.train_iters {
-        // Assign
-        let mut changed = 0usize;
-        for (i, slot) in assignment.iter_mut().enumerate().take(n) {
-            let code = vec_at(i);
-            batch_hamming_scores(code, &centroids, byte_len, dim_bits, &mut scores);
-            let best = argmax_score_lowest_index(&scores) as u32;
-            if *slot != best {
-                *slot = best;
-                changed += 1;
-            }
-        }
+        // Assignment is point-independent. Give every rayon worker its own
+        // score buffer so the O(N*K) scan uses all available training CPUs
+        // without synchronization or per-point allocation.
+        #[cfg(feature = "native")]
+        let changed: usize = {
+            use rayon::prelude::*;
+            assignment
+                .par_iter_mut()
+                .enumerate()
+                .map_init(
+                    || vec![0f32; k],
+                    |scores, (i, slot)| {
+                        let best = nearest_binary_centroid(
+                            vec_at(i),
+                            &centroids,
+                            byte_len,
+                            dim_bits,
+                            scores,
+                        );
+                        usize::from(std::mem::replace(slot, best) != best)
+                    },
+                )
+                .sum()
+        };
+        #[cfg(not(feature = "native"))]
+        let changed: usize = {
+            let mut scores = vec![0f32; k];
+            assignment
+                .iter_mut()
+                .enumerate()
+                .map(|(i, slot)| {
+                    let best = nearest_binary_centroid(
+                        vec_at(i),
+                        &centroids,
+                        byte_len,
+                        dim_bits,
+                        &mut scores,
+                    );
+                    usize::from(std::mem::replace(slot, best) != best)
+                })
+                .sum()
+        };
         if changed == 0 {
             break;
         }
 
-        // Update: per-bit majority vote
-        let mut bit_counts = vec![0u32; k * dim_bits];
-        let mut member_counts = vec![0u32; k];
+        // Group point IDs once, in input order. Updating one centroid per task
+        // is both deterministic and much more cache-friendly than writing a
+        // K*D counter matrix at a data-dependent cluster offset for every bit.
+        for cluster_members in &mut members {
+            cluster_members.clear();
+        }
         for (i, &slot) in assignment.iter().enumerate().take(n) {
-            let c = slot as usize;
-            member_counts[c] += 1;
-            let code = vec_at(i);
-            for bit in 0..dim_bits {
-                if (code[bit / 8] >> (bit % 8)) & 1 == 1 {
-                    bit_counts[c * dim_bits + bit] += 1;
-                }
+            members[slot as usize].push(i);
+        }
+
+        #[cfg(feature = "native")]
+        {
+            use rayon::prelude::*;
+            centroids
+                .par_chunks_mut(byte_len)
+                .zip(members.par_iter())
+                .filter(|(_, cluster_members)| !cluster_members.is_empty())
+                .for_each(|(centroid, cluster_members)| {
+                    update_binary_centroid(
+                        centroid,
+                        cluster_members,
+                        sample.as_deref(),
+                        codes,
+                        byte_len,
+                    );
+                });
+        }
+        #[cfg(not(feature = "native"))]
+        for (centroid, cluster_members) in centroids.chunks_mut(byte_len).zip(&members) {
+            if !cluster_members.is_empty() {
+                update_binary_centroid(
+                    centroid,
+                    cluster_members,
+                    sample.as_deref(),
+                    codes,
+                    byte_len,
+                );
             }
         }
 
-        for c in 0..k {
-            let members = member_counts[c];
-            if members == 0 {
+        // Re-seed empty clusters serially so RNG consumption and the resulting
+        // model remain deterministic across thread counts.
+        for (c, cluster_members) in members.iter().enumerate() {
+            if cluster_members.is_empty() {
                 // Re-seed empty cluster with a random sampled vector
-                let vi = sample[rng.random_range(0..n)];
-                centroids[c * byte_len..(c + 1) * byte_len]
-                    .copy_from_slice(&codes[vi * byte_len..(vi + 1) * byte_len]);
-                continue;
-            }
-            let half = members / 2;
-            let centroid = &mut centroids[c * byte_len..(c + 1) * byte_len];
-            centroid.fill(0);
-            for bit in 0..dim_bits {
-                if bit_counts[c * dim_bits + bit] > half {
-                    centroid[bit / 8] |= 1 << (bit % 8);
-                }
+                let sample_index = rng.random_range(0..n);
+                centroids[c * byte_len..(c + 1) * byte_len].copy_from_slice(vec_at(sample_index));
             }
         }
     }
 
     centroids
+}
+
+/// Compute one Hamming-space centroid using a per-byte bit histogram. Member
+/// IDs arrive in input order, so the result is deterministic regardless of
+/// which centroids rayon updates concurrently.
+fn update_binary_centroid(
+    centroid: &mut [u8],
+    members: &[usize],
+    sample: Option<&[usize]>,
+    codes: &[u8],
+    byte_len: usize,
+) {
+    let mut bit_counts = vec![[0usize; 8]; centroid.len()];
+    for &member in members {
+        let vector_index = sample.map_or(member, |sample| sample[member]);
+        let vector = &codes[vector_index * byte_len..(vector_index + 1) * byte_len];
+        for (&byte, counts) in vector.iter().zip(&mut bit_counts) {
+            for (bit, count) in counts.iter_mut().enumerate() {
+                *count += usize::from((byte >> bit) & 1);
+            }
+        }
+    }
+
+    let half = members.len() / 2;
+    for (byte, counts) in centroid.iter_mut().zip(bit_counts) {
+        *byte = counts
+            .into_iter()
+            .enumerate()
+            .fold(0u8, |packed, (bit, count)| {
+                packed | (u8::from(count > half) << bit)
+            });
+    }
 }
 
 /// Hierarchical k-majority training keeps large global codebooks tractable:
@@ -759,14 +850,13 @@ fn train_k_majority_hierarchical(
         assignments.par_iter_mut().enumerate().for_each_init(
             || vec![0.0; parent_count],
             |scores, (index, assignment)| {
-                batch_hamming_scores(
+                *assignment = nearest_binary_centroid(
                     &codes[index * byte_len..(index + 1) * byte_len],
                     &parents,
                     byte_len,
                     config.dim_bits,
                     scores,
                 );
-                *assignment = argmax_score_lowest_index(scores) as u32;
             },
         );
     }
@@ -774,14 +864,13 @@ fn train_k_majority_hierarchical(
     {
         let mut scores = vec![0.0; parent_count];
         for (index, assignment) in assignments.iter_mut().enumerate() {
-            batch_hamming_scores(
+            *assignment = nearest_binary_centroid(
                 &codes[index * byte_len..(index + 1) * byte_len],
                 &parents,
                 byte_len,
                 config.dim_bits,
                 &mut scores,
             );
-            *assignment = argmax_score_lowest_index(&scores) as u32;
         }
     }
     for &assignment in &assignments {
@@ -872,6 +961,33 @@ mod tests {
         });
         expected.truncate(20);
         assert_eq!(actual, expected);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn k_majority_is_deterministic_across_thread_counts() {
+        let dim_bits = 128;
+        let byte_len = dim_bits / 8;
+        let points = 1_024;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xfeed_cafe);
+        let mut codes = vec![0u8; points * byte_len];
+        rng.fill_bytes(&mut codes);
+
+        let mut config = BinaryIvfConfig::new(dim_bits, 32);
+        config.train_iters = 4;
+        config.max_train_samples = points;
+        let one_thread = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap()
+            .install(|| train_k_majority(&config, &codes, points));
+        let four_threads = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap()
+            .install(|| train_k_majority(&config, &codes, points));
+
+        assert_eq!(one_thread, four_threads);
     }
 
     #[test]

--- a/hermes-core/src/structures/vector/index/ivf_pq.rs
+++ b/hermes-core/src/structures/vector/index/ivf_pq.rs
@@ -88,6 +88,13 @@ impl PqCluster {
         self.ordinals.extend_from_slice(&source.ordinals);
         self.codes.extend_from_slice(&source.codes);
     }
+
+    #[cfg(feature = "native")]
+    fn append_owned(&mut self, mut source: Self) {
+        self.doc_ids.append(&mut source.doc_ids);
+        self.ordinals.append(&mut source.ordinals);
+        self.codes.append(&mut source.codes);
+    }
 }
 
 /// Configuration for IVF-PQ index
@@ -206,6 +213,87 @@ impl IVFPQIndex {
                 vector,
             );
         }
+    }
+
+    /// Add one contiguous vector batch in parallel while preserving input
+    /// order inside every leaf. Callers can install this work on their bounded
+    /// Rayon pool; normal segment builds use the current Rayon pool.
+    #[cfg(feature = "native")]
+    pub fn add_vectors_parallel(
+        &mut self,
+        coarse_centroids: &CoarseCentroids,
+        codebook: &PQCodebook,
+        doc_id_ordinals: &[(u32, u16)],
+        vectors: &[f32],
+    ) -> Result<(), &'static str> {
+        use rayon::prelude::*;
+
+        let vector_count = doc_id_ordinals.len();
+        let expected = vector_count
+            .checked_mul(self.config.dim)
+            .ok_or("IVF-PQ input size overflow")?;
+        if vectors.len() != expected {
+            return Err("IVF-PQ vector and label matrices are inconsistent");
+        }
+        if vector_count == 0 {
+            return Ok(());
+        }
+
+        // A small multiple of the worker count supplies enough tasks for load
+        // balancing without creating one hash map per vector. Indexed collect
+        // retains chunk order, so merging the partials also retains the input
+        // order within each leaf.
+        let target_tasks = rayon::current_num_threads().saturating_mul(4).max(1);
+        let chunk_vectors = vector_count.div_ceil(target_tasks).max(64);
+        let config = self.config.clone();
+        let centroids_version = self.centroids_version;
+        let codebook_version = self.codebook_version;
+        let partials: Vec<Self> = doc_id_ordinals
+            .par_chunks(chunk_vectors)
+            .enumerate()
+            .map(|(chunk_index, labels)| {
+                let first = chunk_index * chunk_vectors;
+                let chunk = &vectors[first * config.dim..(first + labels.len()) * config.dim];
+                let mut partial = Self::new(config.clone(), centroids_version, codebook_version);
+                for (&(doc_id, ordinal), vector) in
+                    labels.iter().zip(chunk.chunks_exact(config.dim))
+                {
+                    partial.add_vector(coarse_centroids, codebook, doc_id, ordinal, vector);
+                }
+                partial
+            })
+            .collect();
+
+        for partial in partials {
+            self.append_owned(partial)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "native")]
+    fn append_owned(&mut self, mut other: Self) -> Result<(), &'static str> {
+        if self.centroids_version != other.centroids_version
+            || self.codebook_version != other.codebook_version
+            || self.config != other.config
+        {
+            return Err("Cannot merge IVF-PQ payloads from different generations");
+        }
+        let other_len = other.len;
+        for (cluster_id, source) in other.clusters.drain() {
+            match self.clusters.entry(cluster_id) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().append_owned(source);
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(source);
+                }
+            }
+        }
+        self.len = self
+            .len
+            .checked_add(other_len)
+            .ok_or("IVF-PQ vector count overflow during parallel build")?;
+        Ok(())
     }
 
     fn add_to_cluster(
@@ -531,6 +619,46 @@ mod tests {
             "IVF-PQ recall too low: {:.1}%",
             avg_recall * 100.0
         );
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn parallel_batch_build_matches_sequential_multi_value_payload() {
+        let dim = 8;
+        let vector_count = 512;
+        let vectors: Vec<Vec<f32>> = (0..vector_count)
+            .map(|index| {
+                (0..dim)
+                    .map(|column| ((index * 31 + column * 17) as f32).sin())
+                    .collect()
+            })
+            .collect();
+        let flat: Vec<f32> = vectors.iter().flatten().copied().collect();
+        let labels: Vec<(u32, u16)> = (0..vector_count)
+            .map(|index| ((index / 3) as u32, (index % 3) as u16))
+            .collect();
+        let centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 16), &vectors);
+        let codebook = PQCodebook::train(PQConfig::new(dim).with_opq(false, 0), &vectors, 2);
+        let config = IVFPQConfig::new(dim, codebook.config.num_subspaces);
+
+        let mut sequential = IVFPQIndex::new(config.clone(), centroids.version, codebook.version);
+        for (&(doc_id, ordinal), vector) in labels.iter().zip(vectors.iter()) {
+            sequential.add_vector(&centroids, &codebook, doc_id, ordinal, vector);
+        }
+
+        let mut parallel = IVFPQIndex::new(config, centroids.version, codebook.version);
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap()
+            .install(|| {
+                parallel
+                    .add_vectors_parallel(&centroids, &codebook, &labels, &flat)
+                    .unwrap();
+            });
+
+        assert_eq!(parallel.len(), sequential.len());
+        assert_eq!(parallel.to_bytes().unwrap(), sequential.to_bytes().unwrap());
     }
 
     #[test]

--- a/hermes-core/src/structures/vector/kmeans.rs
+++ b/hermes-core/src/structures/vector/kmeans.rs
@@ -6,6 +6,8 @@
 
 use rand::prelude::*;
 
+const WEIGHT_REDUCTION_BLOCK: usize = 16 * 1024;
+
 pub(crate) struct EuclideanKMeans {
     pub centroids: Vec<f32>,
     pub assignments: Vec<usize>,
@@ -34,6 +36,72 @@ fn nearest(centroids: &[f32], point: &[f32], dim: usize) -> (usize, f32) {
     best
 }
 
+fn update_centroid(centroid: &mut [f32], members: &[usize], data: &[f32], dim: usize) {
+    for &point_index in members {
+        let point = &data[point_index * dim..(point_index + 1) * dim];
+        for (sum, &value) in centroid.iter_mut().zip(point) {
+            *sum += value;
+        }
+    }
+    let inverse = 1.0 / members.len() as f32;
+    for value in centroid {
+        *value *= inverse;
+    }
+}
+
+/// Draw from non-negative weights with a fixed reduction topology. Parallel
+/// block sums remove the serial O(N) bottleneck from every k-means++ seed while
+/// producing the same choice for every rayon thread count.
+pub(crate) fn weighted_sample_index(weights: &[f64], draw: f64) -> Option<usize> {
+    if weights.is_empty() {
+        return None;
+    }
+    #[cfg(feature = "native")]
+    let block_totals: Vec<f64> = {
+        use rayon::prelude::*;
+        weights
+            .par_chunks(WEIGHT_REDUCTION_BLOCK)
+            .map(|block| block.iter().sum())
+            .collect()
+    };
+    #[cfg(not(feature = "native"))]
+    let block_totals: Vec<f64> = weights
+        .chunks(WEIGHT_REDUCTION_BLOCK)
+        .map(|block| block.iter().sum())
+        .collect();
+
+    let total: f64 = block_totals.iter().sum();
+    if !total.is_finite() || total <= 0.0 {
+        return None;
+    }
+    let mut target = draw * total;
+    let block = block_totals
+        .iter()
+        .position(|weight| {
+            if target < *weight {
+                true
+            } else {
+                target -= *weight;
+                false
+            }
+        })
+        .unwrap_or(block_totals.len() - 1);
+    let start = block * WEIGHT_REDUCTION_BLOCK;
+    let end = (start + WEIGHT_REDUCTION_BLOCK).min(weights.len());
+    weights[start..end]
+        .iter()
+        .position(|weight| {
+            if target < *weight {
+                true
+            } else {
+                target -= *weight;
+                false
+            }
+        })
+        .map(|index| start + index)
+        .or_else(|| end.checked_sub(1))
+}
+
 fn initialize_kmeans_plus_plus(
     data: &[f32],
     points: usize,
@@ -49,21 +117,27 @@ fn initialize_kmeans_plus_plus(
 
     while centroids.len() < clusters * dim {
         let latest = &centroids[centroids.len() - dim..];
-        let mut total = 0.0f64;
+        #[cfg(feature = "native")]
+        {
+            use rayon::prelude::*;
+            minimum_distances
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(index, minimum)| {
+                    let point = &data[index * dim..(index + 1) * dim];
+                    *minimum = minimum.min(squared_l2(point, latest) as f64);
+                });
+        }
+        #[cfg(not(feature = "native"))]
         for (index, minimum) in minimum_distances.iter_mut().enumerate() {
             let point = &data[index * dim..(index + 1) * dim];
             *minimum = minimum.min(squared_l2(point, latest) as f64);
-            total += *minimum;
         }
-        let selected = if total.is_finite() && total > 0.0 {
-            let mut target = rng.random::<f64>() * total;
-            minimum_distances
-                .iter()
-                .position(|weight| {
-                    target -= *weight;
-                    target <= 0.0
-                })
-                .unwrap_or(points - 1)
+
+        let selected = if let Some(selected) =
+            weighted_sample_index(&minimum_distances, rng.random::<f64>())
+        {
+            selected
         } else {
             // All points are identical (or all remaining distances underflow).
             // A deterministic duplicate is the only representable centroid.
@@ -88,6 +162,7 @@ pub(crate) fn train_euclidean_kmeans(
 
     let mut centroids = initialize_kmeans_plus_plus(data, points, dim, clusters, seed);
     let mut assignments = vec![usize::MAX; points];
+    let mut members: Vec<Vec<usize>> = (0..clusters).map(|_| Vec::new()).collect();
 
     for _ in 0..max_iters.max(1) {
         #[cfg(feature = "native")]
@@ -115,28 +190,36 @@ pub(crate) fn train_euclidean_kmeans(
             *assignment = next;
         }
 
-        let mut next_centroids = vec![0.0f32; clusters * dim];
-        let mut counts = vec![0usize; clusters];
-        for (point_index, &cluster) in assignments.iter().enumerate() {
-            counts[cluster] += 1;
-            let source = &data[point_index * dim..(point_index + 1) * dim];
-            let target = &mut next_centroids[cluster * dim..(cluster + 1) * dim];
-            for (sum, &value) in target.iter_mut().zip(source) {
-                *sum += value;
-            }
+        for cluster_members in &mut members {
+            cluster_members.clear();
         }
-        for (cluster, &count) in counts.iter().enumerate() {
-            if count > 0 {
-                let inverse = 1.0 / count as f32;
-                for value in &mut next_centroids[cluster * dim..(cluster + 1) * dim] {
-                    *value *= inverse;
-                }
+        for (point_index, &cluster) in assignments.iter().enumerate() {
+            members[cluster].push(point_index);
+        }
+
+        let mut next_centroids = vec![0.0f32; clusters * dim];
+        #[cfg(feature = "native")]
+        {
+            use rayon::prelude::*;
+            next_centroids
+                .par_chunks_mut(dim)
+                .zip(members.par_iter())
+                .filter(|(_, cluster_members)| !cluster_members.is_empty())
+                .for_each(|(centroid, cluster_members)| {
+                    update_centroid(centroid, cluster_members, data, dim);
+                });
+        }
+        #[cfg(not(feature = "native"))]
+        for (centroid, cluster_members) in next_centroids.chunks_mut(dim).zip(&members) {
+            if cluster_members.is_empty() {
+                continue;
             }
+            update_centroid(centroid, cluster_members, data, dim);
         }
 
         // Empty cells are re-seeded from the currently worst represented
         // points, a standard Lloyd recovery that avoids zero-vector cells.
-        if counts.contains(&0) {
+        if members.iter().any(Vec::is_empty) {
             let mut farthest: Vec<usize> = (0..points).collect();
             farthest.sort_unstable_by(|&left, &right| {
                 nearest_points[right]
@@ -145,8 +228,8 @@ pub(crate) fn train_euclidean_kmeans(
                     .then_with(|| left.cmp(&right))
             });
             let mut replacement = 0usize;
-            for (cluster, &count) in counts.iter().enumerate() {
-                if count == 0 {
+            for (cluster, cluster_members) in members.iter().enumerate() {
+                if cluster_members.is_empty() {
                     let point = farthest[replacement % farthest.len()];
                     replacement += 1;
                     next_centroids[cluster * dim..(cluster + 1) * dim]
@@ -186,6 +269,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn weighted_sampling_selects_across_fixed_reduction_blocks() {
+        let mut weights = vec![0.0; WEIGHT_REDUCTION_BLOCK * 2 + 3];
+        weights[7] = 1.0;
+        weights[WEIGHT_REDUCTION_BLOCK + 11] = 2.0;
+        weights[WEIGHT_REDUCTION_BLOCK * 2 + 2] = 1.0;
+        assert_eq!(weighted_sample_index(&weights, 0.10), Some(7));
+        assert_eq!(weighted_sample_index(&weights, 0.0), Some(7));
+        assert_eq!(
+            weighted_sample_index(&weights, 0.50),
+            Some(WEIGHT_REDUCTION_BLOCK + 11)
+        );
+        assert_eq!(
+            weighted_sample_index(&weights, 0.99),
+            Some(WEIGHT_REDUCTION_BLOCK * 2 + 2)
+        );
+        assert_eq!(weighted_sample_index(&[0.0, 0.0], 0.5), None);
+    }
+
+    #[test]
     fn deterministic_kmeans_plus_plus_finds_separated_groups() {
         let data = [0.0, 0.1, -0.1, 10.0, 9.9, 10.1];
         let first = train_euclidean_kmeans(&data, 6, 1, 2, 20, 42);
@@ -196,5 +298,35 @@ mod tests {
         centroids.sort_unstable_by(f32::total_cmp);
         assert!((centroids[0] - 0.0).abs() < 0.01);
         assert!((centroids[1] - 10.0).abs() < 0.01);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn training_is_deterministic_across_thread_counts() {
+        let points = 2_048;
+        let dim = 16;
+        let clusters = 32;
+        let data: Vec<f32> = (0..points * dim)
+            .map(|index| {
+                let mixed = (index as u64)
+                    .wrapping_mul(0x9e37_79b9_7f4a_7c15)
+                    .rotate_left(17);
+                (mixed as u32) as f32 / u32::MAX as f32
+            })
+            .collect();
+
+        let one_thread = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap()
+            .install(|| train_euclidean_kmeans(&data, points, dim, clusters, 4, 42));
+        let four_threads = rayon::ThreadPoolBuilder::new()
+            .num_threads(4)
+            .build()
+            .unwrap()
+            .install(|| train_euclidean_kmeans(&data, points, dim, clusters, 4, 42));
+
+        assert_eq!(one_thread.centroids, four_threads.centroids);
+        assert_eq!(one_thread.assignments, four_threads.assignments);
     }
 }

--- a/hermes-proto/hermes.proto
+++ b/hermes-proto/hermes.proto
@@ -40,7 +40,7 @@ service IndexService {
   // List all indexes
   rpc ListIndexes(ListIndexesRequest) returns (ListIndexesResponse);
 
-  // Retrain vector index (re-cluster centroids/codebooks from current data)
+  // Retrain global vector codebooks and atomically rebuild every ANN segment
   rpc RetrainVectorIndex(RetrainVectorIndexRequest) returns (RetrainVectorIndexResponse);
 }
 

--- a/hermes-server/README.md
+++ b/hermes-server/README.md
@@ -227,12 +227,13 @@ rpc ForceMerge(ForceMergeRequest) returns (ForceMergeResponse);
 
 #### RetrainVectorIndex
 
-Retraining global IVF centroids and PQ codebooks is accepted only while all committed
-segments for the affected fields are flat. ANN segments embed the artifact
-versions used to build them, so replacing the single global generation under
-existing ANN segments would make those segments unreadable. Hermes rejects
-that unsafe lifecycle transition instead of publishing mixed generations.
-Trained artifacts and metadata are validated and published all-or-nothing.
+Train new global IVF-PQ or binary-IVF codebooks from the current corpus and
+rebuild every ANN segment. The complete segment/codebook generation is
+published atomically; existing readers keep the previous generation.
+
+```protobuf
+rpc RetrainVectorIndex(RetrainVectorIndexRequest) returns (RetrainVectorIndexResponse);
+```
 
 #### DeleteIndex
 

--- a/hermes-server/src/index_service.rs
+++ b/hermes-server/src/index_service.rs
@@ -443,13 +443,23 @@ impl IndexService for IndexServiceImpl {
         request: Request<RetrainVectorIndexRequest>,
     ) -> Result<Response<RetrainVectorIndexResponse>, Status> {
         let req = request.into_inner();
-        let _index = self.registry.get_or_open_index(&req.index_name).await?;
+        let index = self.registry.get_or_open_index(&req.index_name).await?;
         let writer = self.registry.get_writer(&req.index_name).await?;
 
         writer
             .write()
             .await
-            .rebuild_vector_index()
+            .retrain_vector_index()
+            .await
+            .map_err(crate::error::hermes_error_to_status)?;
+
+        // New requests must immediately see the atomically published
+        // segment/codebook generation. In-flight searchers retain the old pair.
+        index
+            .reader()
+            .await
+            .map_err(crate::error::hermes_error_to_status)?
+            .reload()
             .await
             .map_err(crate::error::hermes_error_to_status)?;
 


### PR DESCRIPTION
## Summary
- retain exact flat vectors and atomically publish codebook plus segment generations
- rebuild float and binary ANN segments through one generic retraining path
- add bounded HNSW routing, document-level candidate collection, and parallel inner encoding
- serialize fields during retraining and BP to cap peak memory
- expose RetrainVectorIndex through the server API

## Verification
- cargo check -p hermes-core --all-targets
- cargo clippy -p hermes-core --all-targets -- -D warnings
- cargo check -p hermes-core -p hermes-server
- focused float retrain, binary retrain, multi-field BP, and multi-valued IVF-PQ tests