### PR TITLE
fix(wasm): gate native ANN helpers

### DIFF
--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -584,14 +584,19 @@ impl IndexMetadata {
         if centroids.is_empty() && binary_quantizers.is_empty() {
             Ok(None)
         } else {
-            let mut trained = crate::segment::TrainedVectorStructures {
+            let trained = crate::segment::TrainedVectorStructures {
+                #[cfg(feature = "native")]
+                _ann_pins: Default::default(),
                 centroids,
                 binary_quantizers,
                 codebooks,
-                ..Default::default()
             };
             #[cfg(feature = "native")]
-            trained.pin_ann_structures(crate::segment::pin::pin_policy());
+            let trained = {
+                let mut trained = trained;
+                trained.pin_ann_structures(crate::segment::pin::pin_policy());
+                trained
+            };
             Ok(Some(trained))
         }
     }

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -10,15 +10,21 @@
 use std::cmp::Reverse;
 #[cfg(feature = "native")]
 use std::collections::BinaryHeap;
-use std::io::{self, Write};
+use std::io;
+#[cfg(feature = "native")]
+use std::io::Write;
 use std::ops::Range;
 
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "native")]
+use byteorder::WriteBytesExt;
+use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::directories::OwnedBytes;
 use crate::dsl::IvfRoutingMode;
+use crate::structures::IvfPqQueryPlan;
 use crate::structures::vector::index::BoundedAnnCollector;
-use crate::structures::{BinaryIvfIndex, IVFPQIndex, IvfPqQueryPlan};
+#[cfg(feature = "native")]
+use crate::structures::{BinaryIvfIndex, IVFPQIndex};
 
 const ANN_HEADER_MAGIC: u32 = 0x3152_4e41; // "ANR1"
 const ANN_FOOTER_MAGIC: u32 = 0x3146_4e41; // "ANF1"
@@ -26,6 +32,7 @@ const ANN_DISK_VERSION: u16 = 1;
 const ANN_HEADER_SIZE: usize = 56;
 const ANN_RUN_SIZE: usize = 48;
 const ANN_FOOTER_SIZE: usize = 24;
+#[cfg(feature = "native")]
 const COPY_CHUNK: usize = 8 * 1024 * 1024;
 const BINARY_SCORE_BATCH: usize = 8_192;
 
@@ -428,6 +435,7 @@ pub(crate) fn write_built_binary_ivf(
     )
 }
 
+#[cfg(feature = "native")]
 struct BuildRun<'a> {
     cluster_id: u32,
     doc_ids: &'a [u32],
@@ -435,6 +443,7 @@ struct BuildRun<'a> {
     codes: &'a [u8],
 }
 
+#[cfg(feature = "native")]
 struct RunRecord {
     cluster_id: u32,
     doc_base: u32,
@@ -627,6 +636,7 @@ pub(crate) fn write_merged_ann(
     finish_footer(writer, directory_offset, written_runs)
 }
 
+#[cfg(feature = "native")]
 fn relocate_payload_offset(output_payload_start: u64, source_offset: usize) -> io::Result<u64> {
     let relative = source_offset
         .checked_sub(ANN_HEADER_SIZE)
@@ -639,6 +649,7 @@ fn relocate_payload_offset(output_payload_start: u64, source_offset: usize) -> i
         .ok_or_else(|| invalid_data("merged ANN payload offset overflows u64"))
 }
 
+#[cfg(feature = "native")]
 fn headers_compatible(left: &AnnDiskHeader, right: &AnnDiskHeader) -> bool {
     left.kind == right.kind
         && left.routing == right.routing
@@ -649,6 +660,7 @@ fn headers_compatible(left: &AnnDiskHeader, right: &AnnDiskHeader) -> bool {
         && left.codebook_version == right.codebook_version
 }
 
+#[cfg(feature = "native")]
 fn finish_layout(
     writer: &mut (impl Write + ?Sized),
     directory_offset: u64,
@@ -660,6 +672,7 @@ fn finish_layout(
     finish_footer(writer, directory_offset, records.len())
 }
 
+#[cfg(feature = "native")]
 fn write_run_record(writer: &mut (impl Write + ?Sized), record: &RunRecord) -> io::Result<()> {
     writer.write_u32::<LittleEndian>(record.cluster_id)?;
     writer.write_u32::<LittleEndian>(record.doc_base)?;
@@ -672,6 +685,7 @@ fn write_run_record(writer: &mut (impl Write + ?Sized), record: &RunRecord) -> i
     Ok(())
 }
 
+#[cfg(feature = "native")]
 fn finish_footer(
     writer: &mut (impl Write + ?Sized),
     directory_offset: u64,
@@ -693,6 +707,7 @@ fn finish_footer(
         .ok_or_else(|| invalid_data("ANN final size overflows u64"))
 }
 
+#[cfg(feature = "native")]
 fn write_header(writer: &mut (impl Write + ?Sized), header: &AnnDiskHeader) -> io::Result<()> {
     writer.write_u32::<LittleEndian>(ANN_HEADER_MAGIC)?;
     writer.write_u8(header.kind as u8)?;
@@ -716,6 +731,7 @@ fn write_header(writer: &mut (impl Write + ?Sized), header: &AnnDiskHeader) -> i
     Ok(())
 }
 
+#[cfg(feature = "native")]
 fn write_u32_column(
     writer: &mut (impl Write + ?Sized),
     values: &[u32],
@@ -732,6 +748,7 @@ fn write_u32_column(
     Ok(())
 }
 
+#[cfg(feature = "native")]
 fn write_u16_column(
     writer: &mut (impl Write + ?Sized),
     values: &[u16],
@@ -748,6 +765,7 @@ fn write_u16_column(
     Ok(())
 }
 
+#[cfg(feature = "native")]
 fn copy_range(
     writer: &mut (impl Write + ?Sized),
     bytes: &[u8],
@@ -759,6 +777,7 @@ fn copy_range(
     Ok(())
 }
 
+#[cfg(feature = "native")]
 fn checked_advance(offset: u64, length: usize) -> io::Result<u64> {
     offset
         .checked_add(
@@ -804,6 +823,7 @@ fn run_doc_id(bytes: &[u8], run: &AnnRun, index: usize) -> io::Result<u32> {
         .ok_or_else(|| invalid_data("ANN run document ID overflows u32"))
 }
 
+#[cfg(feature = "native")]
 fn routing_to_u8(routing: IvfRoutingMode) -> u8 {
     match routing {
         IvfRoutingMode::Auto => 0,

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -30,6 +30,7 @@ pub struct VectorsFileData {
     pub flat_vectors: FxHashMap<u32, LazyFlatVectorData>,
     /// ANN field IDs declared by the validated TOC. Training-only callers use
     /// this without opening corpus-sized ANN payloads.
+    #[cfg(feature = "native")]
     pub ann_fields: Vec<u32>,
 }
 
@@ -271,6 +272,7 @@ pub async fn load_vectors_file<D: Directory>(
 /// Open only selected flat-vector fields for training. The TOC and flat
 /// payloads receive the same validation as search loading, but ANN run columns
 /// are not mapped or parsed.
+#[cfg(feature = "native")]
 pub(crate) async fn load_flat_vectors_file<D: Directory>(
     dir: &D,
     files: &SegmentFiles,
@@ -294,6 +296,7 @@ async fn load_vectors_file_impl<D: Directory>(
     let empty = || VectorsFileData {
         indexes: FxHashMap::default(),
         flat_vectors: FxHashMap::default(),
+        #[cfg(feature = "native")]
         ann_fields: Vec::new(),
     };
 
@@ -384,7 +387,9 @@ async fn load_vectors_file_impl<D: Directory>(
             )));
         }
     }
+    #[cfg(feature = "native")]
     let mut ann_fields: Vec<_> = ann_toc_fields.into_iter().collect();
+    #[cfg(feature = "native")]
     ann_fields.sort_unstable();
 
     // Load each entry — a field can have both flat and mmap-backed ANN data.
@@ -519,6 +524,7 @@ async fn load_vectors_file_impl<D: Directory>(
     Ok(VectorsFileData {
         indexes,
         flat_vectors,
+        #[cfg(feature = "native")]
         ann_fields,
     })
 }

--- a/hermes-core/src/structures/vector/index/binary_ivf.rs
+++ b/hermes-core/src/structures/vector/index/binary_ivf.rs
@@ -205,6 +205,7 @@ impl BinaryCoarseQuantizer {
 
     /// Visit compact routing topology and parent arrays before the potentially
     /// much larger leaf centroid matrix.
+    #[cfg(feature = "native")]
     pub(crate) fn visit_routing_regions(&self, visit: &mut dyn FnMut(&'static str, &[u8])) {
         if let Some(router) = &self.routing_index {
             match router {
@@ -220,6 +221,7 @@ impl BinaryCoarseQuantizer {
         }
     }
 
+    #[cfg(feature = "native")]
     pub(crate) fn visit_leaf_centroid_region(&self, visit: &mut dyn FnMut(&'static str, &[u8])) {
         visit("binary leaf centroids", &self.centroids);
     }

--- a/hermes-core/src/structures/vector/index/mod.rs
+++ b/hermes-core/src/structures/vector/index/mod.rs
@@ -6,6 +6,7 @@
 mod binary_ivf;
 mod ivf_pq;
 
+#[cfg(feature = "native")]
 pub(crate) use binary_ivf::BinaryIvfBuilder;
 pub use binary_ivf::{BinaryCoarseQuantizer, BinaryIvfConfig, BinaryIvfIndex};
 pub use ivf_pq::{IVFPQConfig, IVFPQIndex, IvfPqQueryPlan};

--- a/hermes-core/src/structures/vector/ivf/coarse.rs
+++ b/hermes-core/src/structures/vector/ivf/coarse.rs
@@ -562,6 +562,7 @@ impl CoarseCentroids {
 
     /// Visit compact routing topology and parent arrays before the potentially
     /// much larger leaf centroid matrix.
+    #[cfg(feature = "native")]
     pub(crate) fn visit_routing_regions(&self, visit: &mut dyn FnMut(&'static str, &[u8])) {
         if let Some(router) = &self.routing_index {
             match router {
@@ -580,6 +581,7 @@ impl CoarseCentroids {
         }
     }
 
+    #[cfg(feature = "native")]
     pub(crate) fn visit_leaf_centroid_region(&self, visit: &mut dyn FnMut(&'static str, &[u8])) {
         visit(
             "float leaf centroids",

--- a/hermes-core/src/structures/vector/ivf/routing.rs
+++ b/hermes-core/src/structures/vector/ivf/routing.rs
@@ -370,6 +370,7 @@ impl HnswRoutingGraph {
 
     /// Visit the compact, immutable arrays touched by every HNSW route.
     /// Query scratch is thread-local and intentionally excluded.
+    #[cfg(feature = "native")]
     pub(crate) fn visit_resident_regions(&self, visit: &mut dyn FnMut(&'static str, &[u8])) {
         visit("HNSW node levels", bytes_of_slice(&self.node_levels));
         visit("HNSW node offsets", bytes_of_slice(&self.node_offsets));
@@ -622,6 +623,7 @@ impl IvfRoutingTopology {
             }
     }
 
+    #[cfg(feature = "native")]
     pub(crate) fn visit_resident_regions(&self, visit: &mut dyn FnMut(&'static str, &[u8])) {
         visit(
             "two-level child offsets",
@@ -633,6 +635,7 @@ impl IvfRoutingTopology {
 
 /// View an initialized plain-data slice as bytes for residency operations.
 /// The returned slice cannot outlive the source and is never mutated.
+#[cfg(feature = "native")]
 pub(crate) fn bytes_of_slice<T>(slice: &[T]) -> &[u8] {
     let byte_len = std::mem::size_of_val(slice);
     if byte_len == 0 {

--- a/hermes-core/src/structures/vector/quantization/pq.rs
+++ b/hermes-core/src/structures/vector/quantization/pq.rs
@@ -474,6 +474,7 @@ impl PQCodebook {
 
     /// Visit the small, index-global tables required to build every IVF-PQ
     /// query plan and distance table.
+    #[cfg(feature = "native")]
     pub(crate) fn visit_resident_regions(&self, visit: &mut dyn FnMut(&'static str, &[u8])) {
         if let Some(rotation) = &self.rotation_matrix {
             visit(


### PR DESCRIPTION
## Summary
- keep ANN merge writers and mlock residency visitors native-only
- keep training-only vector loader metadata out of WASM builds
- construct trained structures without target-dependent lint warnings

## Validation
- `cd hermes-wasm && bash build.sh`
- `cargo clippy -p hermes-core --all-targets --features native,sync -- -D warnings`
- `cargo test -p hermes-core --features native` (845 passed, 7 ignored, integration/doc tests passed)
- `cargo fmt --all -- --check`
- `git diff --check`