### PR TITLE
perf(search): unify candidate overfetch budget

### DIFF
--- a/hermes-client-typescript/src/generated/hermes.ts
+++ b/hermes-client-typescript/src/generated/hermes.ts
@@ -141,7 +141,7 @@ export interface FusionQuery {
   method: FusionMethod;
   /** RRF rank constant; 0 = default 60 */
   rrfK: number;
-  /** Per-sub-query candidate depth; 0 = max(4x limit, 50) */
+  /** Per-sub-query candidate depth; 0 = shared 2x result-window budget */
   fetchLimit: number;
   /**
    * Combiner for fused per-chunk (ordinal) scores into a document score.
@@ -272,7 +272,7 @@ export interface Reranker {
   field: string;
   /** Query vector (f32, for dense fields) */
   vector: number[];
-  /** L1 candidate count (0 = 10x final limit) */
+  /** L1 candidate count (0 = 2x result window, maximum: 2x) */
   limit: number;
   combiner: MultiValueCombiner;
   combinerTemperature: number;

--- a/hermes-client-typescript/src/types.ts
+++ b/hermes-client-typescript/src/types.ts
@@ -123,7 +123,7 @@ export interface DenseVectorQuery {
   vector: number[];
   /** Number of clusters to probe (for IVF indexes) */
   nprobe?: number;
-  /** Re-ranking factor (multiplied by k) */
+  /** Exact-rerank factor multiplied by k (default and maximum: 2) */
   rerankFactor?: number;
   combiner?: Combiner;
   /** Temperature for LogSumExp combiner (default: 1.5) */
@@ -180,7 +180,7 @@ export interface FusionQuery {
   method?: "rrf" | "normalized_weighted_sum";
   /** RRF rank constant (default: 60) */
   rrfK?: number;
-  /** Per-sub-query candidate depth (default: max(4x limit, 50)) */
+  /** Per-sub-query candidate depth (default and maximum: 2x result window) */
   fetchLimit?: number;
   /**
    * Combiner for fused per-chunk (ordinal) scores into a document score.
@@ -212,7 +212,7 @@ export interface Reranker {
   field: string;
   /** Query vector (f32, for dense fields) */
   vector?: number[];
-  /** L1 candidate count (0 = 10x final limit) */
+  /** L1 candidate count (0 = 2x result window, maximum: 2x) */
   limit?: number;
   combiner?: Combiner;
   combinerTemperature?: number;

--- a/hermes-core/src/dsl/ql/mod.rs
+++ b/hermes-core/src/dsl/ql/mod.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use super::query_field_router::{QueryFieldRouter, RoutingMode};
 use super::schema::{Field, Schema};
-use crate::query::{BooleanQuery, PrefixQuery, Query, TermQuery};
+use crate::query::{BooleanQuery, DEFAULT_DENSE_RERANK_FACTOR, PrefixQuery, Query, TermQuery};
 use crate::tokenizer::{BoxedTokenizer, TokenizerRegistry};
 
 #[derive(Parser)]
@@ -351,12 +351,12 @@ impl QueryLanguageParser {
         Ok(ParsedQuery::Phrase { field, phrase })
     }
 
-    /// Parse an ANN query: field:ann([1.0, 2.0, 3.0], nprobe=32, rerank=3)
+    /// Parse an ANN query: field:ann([1.0, 2.0, 3.0], nprobe=32, rerank=2)
     fn parse_ann_query(&self, pair: pest::iterators::Pair<Rule>) -> Result<ParsedQuery, String> {
         let mut field = String::new();
         let mut vector = Vec::new();
         let mut nprobe = 32usize;
-        let mut rerank = 3.0f32;
+        let mut rerank = DEFAULT_DENSE_RERANK_FACTOR;
 
         for inner in pair.into_inner() {
             match inner.as_rule() {
@@ -849,7 +849,7 @@ mod tests {
             assert_eq!(field, "embedding");
             assert_eq!(vector, vec![1.0, 2.0, 3.0]);
             assert_eq!(nprobe, 32);
-            assert_eq!(rerank, 3.0); // default
+            assert_eq!(rerank, 2.0); // default
         } else {
             panic!("Expected Ann query, got: {:?}", result);
         }

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -775,9 +775,9 @@ impl<D: Directory + 'static> Searcher<D> {
     /// carry per-chunk `positions`.
     ///
     /// Each query is paired with a weight scaling its contribution.
-    /// `fetch_limit` is the per-query candidate depth. The server defaults to
-    /// `4 * limit` (min 50) without reranking, but uses the already
-    /// oversubscribed rerank pool directly when one is configured.
+    /// `fetch_limit` is the per-query candidate depth. Request-facing adapters
+    /// default to at most [`crate::query::MAX_CANDIDATE_OVERSUBSCRIPTION`] times
+    /// the result window and never multiply an existing rerank pool again.
     pub async fn search_fused(
         &self,
         queries: &[(&dyn crate::query::Query, f32)],

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -284,7 +284,6 @@ macro_rules! boolean_plan {
         if !scorer_options.collect_positions
             && !should.is_empty()
             && !must.is_empty()
-            && limit < usize::MAX / 4
         {
             // Pre-check: is SHOULD all-sparse? This determines whether we can
             // use bitset fallback for MUST clauses that lack fast-field predicates.
@@ -417,11 +416,16 @@ macro_rules! boolean_plan {
                 }
             }
 
-            // 3c. PredicatedScorer fallback (over-fetch 4x when any filter is present)
+            // 3c. PredicatedScorer fallback. Filters can discard candidates,
+            // so use the same bounded candidate budget as other query paths.
             let has_filters = !predicates.is_empty()
                 || !must_verifiers.is_empty()
                 || !must_not_verifiers.is_empty();
-            let should_limit = if has_filters { limit * 4 } else { limit };
+            let should_limit = if has_filters {
+                super::max_candidate_limit(limit)
+            } else {
+                limit
+            };
             let should_scorer = if should.len() == 1 {
                 should[0].$scorer_fn(
                     reader, should_limit, scorer_options.without_threshold()

--- a/hermes-core/src/query/mod.rs
+++ b/hermes-core/src/query/mod.rs
@@ -4,6 +4,19 @@
 /// Queries exceeding this limit are trimmed to the top-weighted terms.
 pub const MAX_QUERY_TERMS: usize = 64;
 
+/// Maximum candidate depth relative to the result window.
+///
+/// This is the single query-level oversubscription policy used by fusion,
+/// vector reranking, and request-facing adapters. A caller that already asks
+/// for an expanded result window may explicitly use that window as its
+/// candidate depth; no layer multiplies an explicit depth again.
+pub const MAX_CANDIDATE_OVERSUBSCRIPTION: usize = 2;
+
+/// Largest default candidate pool for a requested result window.
+pub const fn max_candidate_limit(result_window: usize) -> usize {
+    result_window.saturating_mul(MAX_CANDIDATE_OVERSUBSCRIPTION)
+}
+
 mod bm25;
 pub(crate) mod bmp;
 mod boolean;

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -136,10 +136,7 @@ pub(super) fn prepare_per_field_grouping(
         return None;
     }
 
-    let num_groups = field_groups.len() + non_term_indices.len();
-    let per_field_limit = limit
-        .saturating_mul(num_groups)
-        .min(reader.num_docs() as usize);
+    let per_field_limit = super::max_candidate_limit(limit).min(reader.num_docs() as usize);
     let num_docs = reader.num_docs() as f32;
 
     let mut multi_term_groups = Vec::new();
@@ -172,7 +169,7 @@ const MAX_SPARSE_EXECUTOR_RESULTS: usize = 200_000;
 
 pub(super) fn bounded_sparse_executor_limit(limit: usize, over_fetch_factor: f32) -> usize {
     let factor = if over_fetch_factor.is_finite() && over_fetch_factor >= 1.0 {
-        over_fetch_factor as f64
+        over_fetch_factor.min(super::MAX_CANDIDATE_OVERSUBSCRIPTION as f32) as f64
     } else {
         1.0
     };
@@ -652,6 +649,7 @@ mod tests {
 
     #[test]
     fn bmp_single_value_limit_does_not_overfetch() {
+        assert_eq!(bounded_sparse_executor_limit(320, 99.0), 640);
         assert_eq!(
             bmp_executor_limit_for_counts(320, 2.0, true, 10_000, 10_048),
             320

--- a/hermes-core/src/query/reranker.rs
+++ b/hermes-core/src/query/reranker.rs
@@ -515,7 +515,7 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
                 // Matryoshka pre-filter
                 if let Some(mdims) = config.matryoshka_dims
                     && mdims < query_dim
-                    && n > final_limit.saturating_mul(2)
+                    && n > crate::query::max_candidate_limit(final_limit)
                 {
                     let trunc_dim = mdims;
                     let trunc_pq = PrecompQuery {
@@ -590,7 +590,8 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
                         });
                     });
                     let approximate_docs = ranked.len();
-                    let survivor_doc_limit = final_limit.saturating_mul(2).min(approximate_docs);
+                    let survivor_doc_limit =
+                        crate::query::max_candidate_limit(final_limit).min(approximate_docs);
                     let survivor_docs: FxHashSet<usize> = ranked
                         .into_iter()
                         .take(survivor_doc_limit)
@@ -716,7 +717,11 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
     // Sort flat buffer by candidate_idx so contiguous runs belong to the same doc
     all_scores.sort_unstable_by_key(|&(ci, _, _)| ci);
 
-    let mut scored: Vec<SearchResult> = Vec::with_capacity(candidates.len().min(final_limit * 2));
+    let mut scored: Vec<SearchResult> = Vec::with_capacity(
+        candidates
+            .len()
+            .min(crate::query::max_candidate_limit(final_limit)),
+    );
     let mut ordinal_pairs: Vec<(u32, f32)> = Vec::new();
     let mut i = 0;
     while i < all_scores.len() {

--- a/hermes-core/src/query/vector/dense.rs
+++ b/hermes-core/src/query/vector/dense.rs
@@ -15,10 +15,10 @@ use crate::query::traits::{CountFuture, Query, Scorer, ScorerFuture};
 pub const MAX_DENSE_NPROBE: usize = 65_536;
 
 /// Maximum exact-rerank candidate multiplier accepted by dense search.
-///
-/// Normal deployments use 2-5x. 32x leaves ample room for recall tuning while
-/// bounding the heap and raw-vector buffers derived from the requested top-k.
-pub const MAX_DENSE_RERANK_FACTOR: f32 = 32.0;
+pub const MAX_DENSE_RERANK_FACTOR: f32 = crate::query::MAX_CANDIDATE_OVERSUBSCRIPTION as f32;
+
+/// Default exact-rerank candidate multiplier for dense search.
+pub const DEFAULT_DENSE_RERANK_FACTOR: f32 = MAX_DENSE_RERANK_FACTOR;
 
 /// Dense vector query for similarity search
 #[derive(Debug, Clone)]
@@ -29,7 +29,7 @@ pub struct DenseVectorQuery {
     pub vector: Vec<f32>,
     /// Number of clusters to probe (for IVF indexes)
     pub nprobe: usize,
-    /// Re-ranking factor (multiplied by k for candidate selection, e.g. 3.0)
+    /// Re-ranking factor multiplied by k for candidate selection (1x to 2x)
     pub rerank_factor: f32,
     /// How to combine scores for multi-valued documents
     pub combiner: MultiValueCombiner,
@@ -59,7 +59,7 @@ impl DenseVectorQuery {
             field,
             vector,
             nprobe: 64,
-            rerank_factor: 3.0,
+            rerank_factor: DEFAULT_DENSE_RERANK_FACTOR,
             combiner: MultiValueCombiner::Max,
             probe_cache: Arc::new(Mutex::new(None)),
         }
@@ -74,7 +74,7 @@ impl DenseVectorQuery {
         self
     }
 
-    /// Set the re-ranking factor (e.g. 3.0 = fetch 3x candidates for reranking)
+    /// Set the re-ranking factor (e.g. 2.0 = fetch 2x candidates for reranking)
     ///
     /// Values are validated when the query is executed. See
     /// [`MAX_DENSE_RERANK_FACTOR`].
@@ -144,13 +144,11 @@ mod tests {
 
     #[test]
     fn test_dense_vector_query_builder() {
-        let query = DenseVectorQuery::new(Field(0), vec![1.0, 2.0, 3.0])
-            .with_nprobe(64)
-            .with_rerank_factor(5.0);
+        let query = DenseVectorQuery::new(Field(0), vec![1.0, 2.0, 3.0]).with_nprobe(64);
 
         assert_eq!(query.field, Field(0));
         assert_eq!(query.vector.len(), 3);
         assert_eq!(query.nprobe, 64);
-        assert_eq!(query.rerank_factor, 5.0);
+        assert_eq!(query.rerank_factor, 2.0);
     }
 }

--- a/hermes-core/src/query/vector/mod.rs
+++ b/hermes-core/src/query/vector/mod.rs
@@ -7,7 +7,9 @@ mod sparse;
 
 pub use binary_dense::BinaryDenseVectorQuery;
 pub use combiner::MultiValueCombiner;
-pub use dense::{DenseVectorQuery, MAX_DENSE_NPROBE, MAX_DENSE_RERANK_FACTOR};
+pub use dense::{
+    DEFAULT_DENSE_RERANK_FACTOR, DenseVectorQuery, MAX_DENSE_NPROBE, MAX_DENSE_RERANK_FACTOR,
+};
 pub use sparse::{SparseTermQuery, SparseVectorQuery};
 
 use crate::segment::VectorSearchResult;

--- a/hermes-core/src/query/vector/sparse.rs
+++ b/hermes-core/src/query/vector/sparse.rs
@@ -8,6 +8,8 @@ use super::combiner::MultiValueCombiner;
 use crate::query::ScoredPosition;
 use crate::query::traits::{CountFuture, MatchedPositions, Query, Scorer, ScorerFuture};
 
+const DEFAULT_SPARSE_OVER_FETCH_FACTOR: f32 = crate::query::MAX_CANDIDATE_OVERSUBSCRIPTION as f32;
+
 /// Sparse vector query for similarity search
 #[derive(Debug, Clone)]
 pub struct SparseVectorQuery {
@@ -73,7 +75,7 @@ impl SparseVectorQuery {
             max_query_dims: Some(crate::query::MAX_QUERY_TERMS),
             pruning: None,
             min_query_dims: 4,
-            over_fetch_factor: 2.0,
+            over_fetch_factor: DEFAULT_SPARSE_OVER_FETCH_FACTOR,
             max_superblocks: 0,
             pruned: None,
         };
@@ -114,9 +116,11 @@ impl SparseVectorQuery {
                 self.heap_factor
             )));
         }
-        if !self.over_fetch_factor.is_finite() || self.over_fetch_factor < 1.0 {
+        if !self.over_fetch_factor.is_finite()
+            || !(1.0..=DEFAULT_SPARSE_OVER_FETCH_FACTOR).contains(&self.over_fetch_factor)
+        {
             return Err(crate::Error::Query(format!(
-                "sparse over_fetch_factor must be finite and at least 1, got {}",
+                "sparse over_fetch_factor must be finite and in [1, {DEFAULT_SPARSE_OVER_FETCH_FACTOR}], got {}",
                 self.over_fetch_factor
             )));
         }
@@ -134,7 +138,7 @@ impl SparseVectorQuery {
     /// this multiplier compensates by fetching more from the executor.
     /// (1.0 = no over-fetch, 2.0 = fetch 2x then combine down)
     pub fn with_over_fetch_factor(mut self, factor: f32) -> Self {
-        self.over_fetch_factor = factor.max(1.0);
+        self.over_fetch_factor = factor.clamp(1.0, DEFAULT_SPARSE_OVER_FETCH_FACTOR);
         self
     }
 
@@ -586,7 +590,7 @@ impl SparseTermQuery {
             weight,
             heap_factor: 1.0,
             combiner: MultiValueCombiner::default(),
-            over_fetch_factor: 2.0,
+            over_fetch_factor: DEFAULT_SPARSE_OVER_FETCH_FACTOR,
         }
     }
 
@@ -601,7 +605,7 @@ impl SparseTermQuery {
     }
 
     pub fn with_over_fetch_factor(mut self, factor: f32) -> Self {
-        self.over_fetch_factor = factor.max(1.0);
+        self.over_fetch_factor = factor.clamp(1.0, DEFAULT_SPARSE_OVER_FETCH_FACTOR);
         self
     }
 
@@ -627,9 +631,11 @@ impl SparseTermQuery {
                 self.heap_factor
             )));
         }
-        if !self.over_fetch_factor.is_finite() || self.over_fetch_factor < 1.0 {
+        if !self.over_fetch_factor.is_finite()
+            || !(1.0..=DEFAULT_SPARSE_OVER_FETCH_FACTOR).contains(&self.over_fetch_factor)
+        {
             return Err(crate::Error::Query(format!(
-                "sparse over_fetch_factor must be finite and at least 1, got {}",
+                "sparse over_fetch_factor must be finite and in [1, {DEFAULT_SPARSE_OVER_FETCH_FACTOR}], got {}",
                 self.over_fetch_factor
             )));
         }
@@ -855,5 +861,20 @@ mod tests {
         assert_eq!(query.pruned_dims().len(), crate::query::MAX_QUERY_TERMS);
         // Pruning retains the dimensions with the largest absolute weights.
         assert!(query.pruned_dims().iter().all(|(dim, _)| *dim >= 36));
+    }
+
+    #[test]
+    fn sparse_over_fetch_factor_uses_shared_candidate_bound() {
+        let query = SparseVectorQuery::new(Field(0), vec![]).with_over_fetch_factor(99.0);
+        let term = SparseTermQuery::new(Field(0), 1, 1.0).with_over_fetch_factor(99.0);
+
+        assert_eq!(
+            query.over_fetch_factor,
+            crate::query::MAX_CANDIDATE_OVERSUBSCRIPTION as f32
+        );
+        assert_eq!(
+            term.over_fetch_factor,
+            crate::query::MAX_CANDIDATE_OVERSUBSCRIPTION as f32
+        );
     }
 }

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -2792,6 +2792,7 @@ mod dense_search_safety_tests {
             f32::NEG_INFINITY,
             0.0,
             0.5,
+            2.01,
             MAX_DENSE_RERANK_FACTOR + 1.0,
         ] {
             assert!(
@@ -2844,8 +2845,8 @@ mod dense_search_safety_tests {
     #[test]
     fn dense_fetch_count_rounds_up_and_detects_overflow() {
         assert_eq!(checked_dense_fetch_k(3, 1.5).unwrap(), 5);
-        assert_eq!(checked_dense_fetch_k(5_000, 3.0).unwrap(), 15_000);
-        assert!(checked_dense_fetch_k(50_000, 3.0).is_err());
+        assert_eq!(checked_dense_fetch_k(10_000, 2.0).unwrap(), 20_000);
+        assert!(checked_dense_fetch_k(10_001, 2.0).is_err());
         assert!(checked_dense_fetch_k(usize::MAX, 2.0).is_err());
     }
 

--- a/hermes-proto/hermes.proto
+++ b/hermes-proto/hermes.proto
@@ -82,7 +82,9 @@ message FusionQuery {
   repeated WeightedQuery queries = 1;
   FusionMethod method = 2;
   float rrf_k = 3;         // RRF rank constant; 0 = default 60
-  uint32 fetch_limit = 4;  // Per-sub-query candidate depth; 0 = max(4x limit, 50)
+  // Per-sub-query candidate depth. 0 uses the shared 2x result-window budget;
+  // explicit values must be between the result window and that 2x ceiling.
+  uint32 fetch_limit = 4;
   // Combiner for fused per-chunk (ordinal) scores into a document score.
   // Fusion runs at chunk granularity: same-chunk hits across sub-queries
   // compound, and results carry per-chunk ordinal_scores.
@@ -121,7 +123,7 @@ message DenseVectorQuery {
   string field = 1;
   repeated float vector = 2;
   uint32 nprobe = 3;           // Number of clusters to probe (for IVF indexes)
-  float rerank_factor = 4;     // Re-ranking factor (multiplied by k, e.g. 3.0)
+  float rerank_factor = 4;     // Exact-rerank factor multiplied by k (0 = 2x default, max 2x)
   MultiValueCombiner combiner = 5;  // How to combine scores for multi-value fields
   float combiner_temperature = 6;   // Temperature for LogSumExp (default: 1.5)
   uint32 combiner_top_k = 7;        // K for WeightedTopK (default: 5)
@@ -187,7 +189,7 @@ message PrefixQuery {
 message Reranker {
   string field = 1;                    // Vector field (dense or binary dense)
   repeated float vector = 2;           // Query vector (f32, for dense fields)
-  uint32 limit = 3;                    // L1 candidate count (0 = 10x final limit)
+  uint32 limit = 3;                    // L1 candidates (0 = 2x result window, max 2x)
   MultiValueCombiner combiner = 4;
   float combiner_temperature = 5;
   uint32 combiner_top_k = 6;

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -3,8 +3,9 @@
 use std::sync::LazyLock;
 
 use hermes_core::query::{
-    BinaryDenseVectorQuery, DenseVectorQuery, LazyGlobalStats, MAX_DENSE_NPROBE,
-    MAX_DENSE_RERANK_FACTOR, MultiValueCombiner, RerankerConfig, SparseVectorQuery,
+    BinaryDenseVectorQuery, DEFAULT_DENSE_RERANK_FACTOR, DenseVectorQuery, LazyGlobalStats,
+    MAX_DENSE_NPROBE, MAX_DENSE_RERANK_FACTOR, MultiValueCombiner, RerankerConfig,
+    SparseVectorQuery,
 };
 use hermes_core::structures::QueryWeighting;
 use hermes_core::tokenizer::{idf_weights_cache, tokenizer_cache};
@@ -466,7 +467,7 @@ pub fn convert_query(
             }
 
             let rerank_factor = if dv_query.rerank_factor == 0.0 {
-                3.0
+                DEFAULT_DENSE_RERANK_FACTOR
             } else {
                 dv_query.rerank_factor
             };
@@ -1255,6 +1256,7 @@ mod tests {
             f32::INFINITY,
             f32::NEG_INFINITY,
             -1.0,
+            2.01,
             MAX_DENSE_RERANK_FACTOR + 1.0,
         ] {
             let mut proto = dense_proto_query(vec![1.0, 2.0, 3.0]);

--- a/hermes-server/src/search_service.rs
+++ b/hermes-server/src/search_service.rs
@@ -17,10 +17,7 @@ use crate::registry::IndexRegistry;
 const DEFAULT_SEARCH_LIMIT: usize = 10;
 const MAX_SEARCH_LIMIT: usize = 10_000;
 const MAX_SEARCH_WINDOW: usize = 50_000;
-const MAX_RERANK_CANDIDATES: usize = 50_000;
-const MAX_FUSION_FETCH_LIMIT: usize = 50_000;
-const DEFAULT_RERANK_OVERSUBSCRIPTION: usize = 5;
-const DEFAULT_FUSION_OVERSUBSCRIPTION: usize = 4;
+const MAX_CANDIDATE_LIMIT: usize = 50_000;
 const MAX_FUSION_SUB_QUERIES: usize = hermes_core::query::MAX_FUSION_SUB_QUERIES;
 const MAX_FUSION_CANDIDATE_SLOTS: usize = hermes_core::query::MAX_FUSION_CANDIDATE_SLOTS;
 
@@ -505,20 +502,17 @@ fn validate_search_budget(req: &SearchRequest) -> Result<SearchBudget, Status> {
              (got {offset} + {final_limit} = {search_limit})"
         )));
     }
+    let max_candidate_limit =
+        hermes_core::query::max_candidate_limit(search_limit).min(MAX_CANDIDATE_LIMIT);
 
     let rerank_l1_limit = match &req.reranker {
         Some(reranker) if reranker.limit > 0 => Some(bounded_limit(
             "Reranker.limit",
             reranker.limit,
             search_limit,
-            MAX_RERANK_CANDIDATES,
+            max_candidate_limit,
         )?),
-        Some(_) => Some(
-            search_limit
-                .checked_mul(DEFAULT_RERANK_OVERSUBSCRIPTION)
-                .ok_or_else(|| Status::invalid_argument("Reranker limit is too large"))?
-                .min(MAX_RERANK_CANDIDATES),
-        ),
+        Some(_) => Some(max_candidate_limit),
         None => None,
     };
     if req
@@ -566,19 +560,19 @@ fn validate_search_budget(req: &SearchRequest) -> Result<SearchBudget, Status> {
                 "FusionQuery.fetch_limit",
                 fusion.fetch_limit,
                 fused_limit,
-                MAX_FUSION_FETCH_LIMIT,
+                max_candidate_limit,
             )?
         } else if rerank_l1_limit.is_some() {
-            // The rerank pool is already an oversubscribed candidate budget.
-            // Multiplying it again made a 4× rerank pool become 16× per
-            // fusion branch (and 32× inside multi-value sparse execution).
-            fused_limit.min(MAX_FUSION_FETCH_LIMIT)
+            // The rerank pool is already the shared candidate budget.
+            fused_limit
         } else {
-            search_limit
-                .checked_mul(DEFAULT_FUSION_OVERSUBSCRIPTION)
-                .ok_or_else(|| Status::invalid_argument("Fusion fetch limit is too large"))?
-                .clamp(50, MAX_FUSION_FETCH_LIMIT)
+            max_candidate_limit
         };
+        if fetch_limit < fused_limit {
+            return Err(Status::invalid_argument(format!(
+                "FusionQuery.fetch_limit must be at least the fused result window ({fused_limit})"
+            )));
+        }
 
         let candidate_slots = fetch_limit
             .checked_mul(fusion.queries.len())
@@ -1235,7 +1229,7 @@ mod tests {
     }
 
     #[test]
-    fn search_budget_bounds_default_and_explicit_rerank_depths() {
+    fn search_budget_caps_rerank_depth_at_two_x_the_result_window() {
         let mut ordinary_default = ordinary_request();
         ordinary_default.limit = 300;
         ordinary_default.reranker = Some(Reranker::default());
@@ -1243,7 +1237,7 @@ mod tests {
             validate_search_budget(&ordinary_default)
                 .unwrap()
                 .rerank_l1_limit,
-            Some(1_500)
+            Some(600)
         );
 
         let mut default_req = ordinary_request();
@@ -1253,12 +1247,13 @@ mod tests {
             validate_search_budget(&default_req)
                 .unwrap()
                 .rerank_l1_limit,
-            Some(MAX_RERANK_CANDIDATES)
+            Some(MAX_SEARCH_LIMIT * 2)
         );
 
         let mut excessive_req = ordinary_request();
+        excessive_req.limit = 100;
         excessive_req.reranker = Some(Reranker {
-            limit: (MAX_RERANK_CANDIDATES + 1) as u32,
+            limit: 201,
             ..Default::default()
         });
         let err = validate_search_budget(&excessive_req).unwrap_err();
@@ -1288,27 +1283,23 @@ mod tests {
     }
 
     #[test]
-    fn fusion_budget_accepts_existing_fetch_depth() {
-        let req = fusion_request(2, 4_800);
+    fn fusion_budget_rejects_more_than_two_x_the_result_window() {
+        let mut req = fusion_request(2, 201);
+        req.limit = 100;
 
-        assert_eq!(
-            validate_search_budget(&req).unwrap().fusion_fetch_limit,
-            Some(4_800)
-        );
+        let err = validate_search_budget(&req).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
     }
 
     #[test]
     fn fusion_default_does_not_multiply_an_existing_rerank_pool() {
         let mut req = fusion_request(2, 0);
-        req.limit = 300;
-        req.reranker = Some(Reranker {
-            limit: 1_200,
-            ..Default::default()
-        });
+        req.limit = 100;
+        req.reranker = Some(Reranker::default());
 
         let budget = validate_search_budget(&req).unwrap();
-        assert_eq!(budget.rerank_l1_limit, Some(1_200));
-        assert_eq!(budget.fusion_fetch_limit, Some(1_200));
+        assert_eq!(budget.rerank_l1_limit, Some(200));
+        assert_eq!(budget.fusion_fetch_limit, Some(200));
     }
 
     #[test]
@@ -1321,13 +1312,15 @@ mod tests {
 
     #[test]
     fn fusion_budget_rejects_excessive_fetch_and_aggregate_work() {
-        let excessive_fetch = fusion_request(2, (MAX_FUSION_FETCH_LIMIT + 1) as u32);
+        let excessive_fetch = fusion_request(2, (MAX_CANDIDATE_LIMIT + 1) as u32);
         assert_eq!(
             validate_search_budget(&excessive_fetch).unwrap_err().code(),
             Code::InvalidArgument
         );
 
-        let excessive_aggregate = fusion_request(5, MAX_FUSION_FETCH_LIMIT as u32);
+        let mut excessive_aggregate = fusion_request(5, MAX_CANDIDATE_LIMIT as u32);
+        excessive_aggregate.limit = MAX_SEARCH_LIMIT as u32;
+        excessive_aggregate.offset = (MAX_SEARCH_WINDOW - MAX_SEARCH_LIMIT) as u32;
         assert_eq!(
             validate_search_budget(&excessive_aggregate)
                 .unwrap_err()
@@ -1343,8 +1336,8 @@ mod tests {
         req.reranker = Some(Reranker::default());
 
         let budget = validate_search_budget(&req).unwrap();
-        assert_eq!(budget.rerank_l1_limit, Some(MAX_RERANK_CANDIDATES));
-        assert_eq!(budget.fusion_fetch_limit, Some(MAX_FUSION_FETCH_LIMIT));
+        assert_eq!(budget.rerank_l1_limit, Some(MAX_SEARCH_LIMIT * 2));
+        assert_eq!(budget.fusion_fetch_limit, Some(MAX_SEARCH_LIMIT * 2));
     }
 
     #[test]

--- a/hermes-wasm/src/query.rs
+++ b/hermes-wasm/src/query.rs
@@ -211,8 +211,14 @@ pub(crate) async fn execute_structured_search<D: Directory>(
             }
         };
 
-        let fused_limit = req.limit + req.offset;
-        let fetch_limit = fusion.fetch_limit.unwrap_or((fused_limit * 4).max(50));
+        let fused_limit = req.limit.saturating_add(req.offset);
+        let max_fetch_limit = hermes_core::query::max_candidate_limit(fused_limit);
+        let fetch_limit = fusion.fetch_limit.unwrap_or(max_fetch_limit);
+        if !(fused_limit..=max_fetch_limit).contains(&fetch_limit) {
+            return Err(JsValue::from_str(&format!(
+                "fusion fetchLimit must be between {fused_limit} and {max_fetch_limit}"
+            )));
+        }
         let refs: Vec<(&dyn Query, f32)> =
             sub_queries.iter().map(|(q, w)| (q.as_ref(), *w)).collect();
         let mut fused = searcher


### PR DESCRIPTION
## Summary
- centralize query-level candidate oversubscription at a maximum of 2x
- stop Fusion, reranking, sparse, dense, Boolean, and WASM paths from stacking independent multipliers
- validate explicit candidate depths and update client/protobuf contracts

## Verification
- cargo test -p hermes-core
- cargo test -p hermes-server
- cargo test -p hermes-wasm
- cargo clippy -p hermes-core -p hermes-server -p hermes-wasm --all-targets --all-features -- -D warnings