### PR TITLE
fix(release): fail on incomplete crate publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
         id: current
         run: |
           VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Current version: $VERSION"
 
       - name: Calculate new version
@@ -85,7 +85,7 @@ jobs:
           esac
 
           NEW_VERSION="$MAJOR.$MINOR.$PATCH"
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "New version: $NEW_VERSION"
 
       - name: Update Cargo.toml versions
@@ -145,39 +145,21 @@ jobs:
 
       - name: Publish hermes-core
         run: cargo publish -p hermes-core --no-verify
-        continue-on-error: true
 
       - name: Wait for crates.io index
         run: sleep 30
 
       - name: Publish hermes-mal
         run: cargo publish -p hermes-mal --no-verify
-        continue-on-error: true
-
-      - name: Wait for crates.io index
-        run: sleep 30
-
-      - name: Publish hermes-llm
-        run: cargo publish -p hermes-llm --no-verify
-        continue-on-error: true
-
-      - name: Wait for crates.io index
-        run: sleep 30
-
-      - name: Publish hermes-train
-        run: cargo publish -p hermes-train --no-verify
-        continue-on-error: true
 
       - name: Wait for crates.io index
         run: sleep 30
 
       - name: Publish hermes-server
         run: cargo publish -p hermes-server --no-verify
-        continue-on-error: true
 
       - name: Publish hermes-tool
         run: cargo publish -p hermes-tool --no-verify
-        continue-on-error: true
 
   publish-npm:
     name: Publish to NPM

--- a/hermes-llm/Cargo.toml
+++ b/hermes-llm/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 description = "LLM inference and model definition; training lives in hermes-train"
 keywords = ["llm", "transformer", "deep-learning", "gpt", "inference"]
 categories = ["science"]
+publish = false
 
 [dependencies]
 # Burn is the sole inference runtime. CPU uses ndarray; GPU backends and the

--- a/hermes-train/Cargo.toml
+++ b/hermes-train/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 description = "Training for MAL-defined Hermes language models"
+publish = false
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
## Summary
- mark the fork-dependent LLM/training crates as private because their Burn 0.22 pre-release dependencies are not available on crates.io
- stop attempting those impossible uploads
- make failures of every public crate fail the publish workflow instead of being silently ignored
- fix publish workflow shell lint

## Verification
- `actionlint .github/workflows/publish.yml`
- `cargo metadata --no-deps --format-version 1`
- packaged hermes-core, hermes-mal, hermes-server, and hermes-tool with `cargo package --no-verify`
- `git diff --check`