### PR TITLE
fix(docker): include tokenizer workspace crate

### DIFF
--- a/hermes-server/Dockerfile
+++ b/hermes-server/Dockerfile
@@ -22,6 +22,7 @@ COPY hermes-core ./hermes-core
 COPY hermes-llm ./hermes-llm
 COPY hermes-mal ./hermes-mal
 COPY hermes-mal-python ./hermes-mal-python
+COPY hermes-tokenizer ./hermes-tokenizer
 COPY hermes-train ./hermes-train
 COPY hermes-server ./hermes-server
 COPY hermes-tool ./hermes-tool


### PR DESCRIPTION
The v1.8.81 Docker publish failed because the server Docker build copies the workspace manifest but omitted the newly local `hermes-tokenizer` crate. Copy the crate into the builder context so Cargo can load the workspace and build `hermes-server`.