### PR TITLE
docs(bmp): actualize grid memory and compression research

### DIFF
--- a/docs/bmp-grid-compression.md
+++ b/docs/bmp-grid-compression.md
@@ -1,45 +1,64 @@
 # BMP Grid Memory: Compression Research & Roadmap
 
-Status: research (2026-07-10). Phase 1 (per-field `bmp_block_size` in SDL +
-MADV_RANDOM on the grid) implemented; Phase 2 (sparse grid) **benchmarked
-and rejected at current scale** — see measurements; Phase 3 (dim pruning)
-assessed — not recommended.
+Status: research (updated 2026-07-23). Per-field `bmp_block_size`,
+`bmp_grid_bits`, and MADV_RANDOM are implemented. The production schema uses
+`bmp_block_size: 32` and `bmp_grid_bits: 4`. Sparse CSR was benchmarked and
+rejected for the current two-level traversal; see the newer compression
+directions below.
 
 ## Memory anatomy of a BMP segment (V15)
 
 Everything is mmap-backed (page cache, not heap), but resident-set pressure
-is real on memory-bound deployments. Per field, per segment:
+is real on memory-bound deployments. Counts below are per field and use the
+current production settings: 105,879 dimensions, 32 vectors per block, a
+64-block superblock, and a dense 4-bit block grid. The cardinality is sparse
+**vectors/ordinals**, not logical documents; a multi-valued field can therefore
+be many times larger than its document count.
 
-| section        | bytes                          | 18M docs, 105879 dims, block 64 |
-| -------------- | ------------------------------ | ------------------------------- |
-| block grid (D) | `dims × ceil(num_blocks / 2)`  | **≈ 14.9 GB**                   |
-| sb_grid (E)    | `dims × ceil(num_blocks / 64)` | ≈ 465 MB                        |
-| doc maps (F+G) | `6 × num_virtual_docs`         | ≈ 108 MB                        |
-| block data (B) | `2 × postings + headers`       | ≈ 6-8 GB (data, not overhead)   |
+`num_blocks = ceil(num_vectors / 32)`. Sizes are decimal GB/TB, matching disk
+tools; binary sizes are included where useful.
+
+| section          | exact V15 bytes | 18M vectors | 100M vectors | 1B vectors |
+| ---------------- | ---------------: | ----------: | -----------: | ---------: |
+| block grid (D)   | `dims × ceil(num_blocks / 2)` | 29.78 GB (27.73 GiB) | 165.44 GB (154.07 GiB) | **1.654 TB (1.504 TiB)** |
+| sb_grid (E)      | `dims × ceil(num_blocks / 64)` | 0.931 GB (0.867 GiB) | 5.170 GB (4.815 GiB) | 51.70 GB (48.15 GiB) |
+| doc maps (F+G)   | `6 × num_virtual_docs` | 0.108 GB | 0.600 GB | 6.000 GB |
+| block starts (A) | `8 × (num_blocks + 1)` | 4.50 MB | 25.00 MB | 250.00 MB |
+| block data (B)   | `2P + 8T + 8N` | workload-dependent | workload-dependent | workload-dependent |
+
+Thus a single 1B-vector BMP field needs about **1.706 TB** for the two grids
+alone at block size 32/4-bit, before postings, document maps, segment metadata,
+temporary merge output, or a second BMP field. Segment boundaries add a small
+amount of row-padding overhead. Two 1B-vector fields need about **3.412 TB**
+for Sections D and E alone.
+
+In the block-data formula, `P` is the posting count, `T` is the number of
+non-zero `(block, dimension)` pairs, and `N` is the number of non-empty blocks.
+The blob also has at most seven alignment bytes and a 72-byte footer. These
+small fixed sections do not change the conclusion: the block grid dominates.
 
 The **dense block grid dominates**: every one of `dims` vocabulary rows gets
 a 4-bit cell in _every_ block, even though a typical SPLADE block touches
-only a small fraction of the vocabulary. Measured coherence
-`d = total_postings / total_terms ≈ 2-3` at block 64 implies the average
-non-zero density of the grid is `total_terms / (dims × num_blocks)` — for
-the production corpus roughly **3-4% non-zero**. The dense grid stores the
-other ~96% as zero nibbles.
+only a small fraction of the vocabulary. The exact non-zero density is
+`total_terms / (dims × num_blocks)` using the V15 footer counters. Smaller
+blocks reduce that density while increasing the number of dense cells.
 
-## Phase 1 (shipped): per-field `bmp_block_size` + grid MADV_RANDOM
+## Shipped controls: block size, grid width, and paging
 
-Grid bytes scale as `1/block_size`. Moving a field from 64 → 256:
+Grid bytes scale approximately as `1/block_size`. Moving a field from the
+current block size 32 to 256 would:
 
-- grid: 14.9 GB → **3.7 GB** (4×), sb_grid: 465 MB → 116 MB (18M docs);
-  at 50M docs: 41 GB → **10 GB**.
-- pruning granularity coarsens: a block is now 256 docs, so a superblock
-  covers 16k docs. The BMP paper (Mallia, Suel & Tonellotto, SIGIR 2024)
-  favors b=8-32 for in-RAM MS MARCO-scale corpora; at 100k-dim vocabularies
-  and 10M+ doc segments the grid does not fit that regime — coarser blocks
-  are the correct trade (see also docs/budgeted-reorder.md research notes).
-- Block size is **per field, uniform across all segments** (default 64) —
-  set it in SDL at index creation; there is deliberately no auto-escalation
-  and no mixed-block-size support (block-copy merge and blockwise reorder
-  move blocks verbatim and validate uniformity loudly).
+- At 18M vectors: grid 29.78 GB → **3.72 GB** and sb_grid
+  0.931 GB → **0.116 GB** (8×).
+- At 1B vectors: grid 1.654 TB → **206.8 GB** and sb_grid
+  51.70 GB → **6.46 GB** (8×).
+- Pruning granularity would coarsen by the same factor: a block would contain
+  256 vectors and a 64-block superblock 16,384 vectors. This is not a free
+  compression knob. The production choice remains **32** until representative
+  relevance and tail-latency tests justify a larger value.
+- Block size is per field and uniform across all segments. There is deliberately
+  no auto-escalation or mixed-block-size support: block-copy merge and blockwise
+  reorder move blocks verbatim and validate uniformity.
 - The block grid is now `MADV_RANDOM`: queries at production scale read 32
   bytes per (query dim, surviving superblock) at effectively random offsets,
   and default kernel readahead amplified each probe into 128 KB of page
@@ -51,37 +70,53 @@ SDL:
 
 ```sdl
 field embedding: sparse_vector<u32> [indexed<format: bmp, dims: 105879,
-    max_weight: 5.0, bmp_block_size: 256>]
+    max_weight: 5.0, bmp_block_size: 32, bmp_grid_bits: 4>]
 ```
 
-## Phase 2 (benchmarked, rejected at current scale): sparse (CSR) block grid
+## What “compression” means in the original BMP paper
 
-### Idea
+The [SIGIR 2024 BMP paper](https://arxiv.org/pdf/2405.01117) evaluates two
+representations of each dimension's block-max row:
 
-Store, per dim, only the blocks where the dim actually occurs:
-`row(t) = [(block_id, impact_u4), ...]` grouped into superblock runs. The
-entry count is exactly `total_terms` — already a footer stat.
+- **BMP-Dense** stores every 8-bit maximum, including zeros.
+- **BMP-Sparse**, called “compressed” in Table 1, zero-suppresses each row:
+  only non-zero `(offset, maximum)` pairs are kept. The
+  [reference implementation](https://github.com/pisa-engine/BMP) partitions a
+  row into groups of 256 blocks and stores those pairs inside each group.
+  Query evaluation scans the pairs and scatters them into a dense accumulator.
 
-### Why everyone else keeps the grid dense
+This is not entropy compression of the whole index, posting compression, or
+Hermes's 4-bit packing. On MS MARCO with block size 8, the paper reports the
+block-max structure shrinking from 30 GB dense to 5.5 GB compressed; at block
+size 256 it reports 0.9 GB dense versus 1.2 GB compressed, so sparse storage
+can even lose once rows become sufficiently dense.
 
-Block upper bounds stored sparsely are not exotic — that is exactly what
-DAAT block-max engines (BMW/MaxScore) do, per posting list. BMP's specific
-contribution (Mallia, Suel & Tonellotto, SIGIR 2024) was to **densify**
-those bounds into a dims×blocks matrix so block-at-a-time scoring becomes a
-contiguous packed-row sweep. Sparsifying the grid un-does the thing that
-makes BMP fast. At larger scales the field
-does not sparsify the grid either — it abandons exhaustive grids for
-approximate per-list summaries (Seismic: Bruch, Nardini, Rulli & Venturini,
-SIGIR 2024; journal version arXiv:2509.24815 — assessed in
-docs/seismic-research.md).
+Hermes does **not** store BMP-Sparse in production. It currently has:
 
-### Measured (microbenchmark, aarch64 NEON, warm cache)
+- a dense block grid with independently addressable 4-bit cells (or optional
+  2-bit cells), using ceil quantization so the bounds remain rank-safe;
+- an exact dense 8-bit superblock grid;
+- BP document ordering, which improves bound tightness and zero density;
+- two-level superblock pruning and `MADV_RANDOM` on the block grid.
 
-`grid_bench` in `segment/reader/bmp.rs` — Zipf(1.0) over 100k dims, 120
-nnz/doc, 2M docs, 16-dim queries, 30% surviving superblocks, real SIMD
-kernel as the dense-layout throughput baseline vs binary-search + scalar
-scatter for CSR sb-runs
-(correctness cross-checked entry-exact between layouts):
+Hermes therefore has score-width compression, but not the original paper's
+zero-suppression. It has only a CSR research benchmark of that design.
+
+## Why the original sparse grid is wrong for the current executor
+
+The [2025 SP paper](https://arxiv.org/html/2504.17045) introduced two-level
+superblock traversal but left both grids uncompressed. Its
+[2026 LSP follow-up](https://arxiv.org/html/2602.02883) directly tests
+compression with this access pattern. It finds the original BMP-Sparse up to
+**76× slower** because surviving superblocks cause random block-group access,
+rather than BMP's original sequential full-row scan.
+
+Hermes's local CSR experiment reaches the same conclusion. `grid_bench` in
+`segment/reader/bmp.rs` uses Zipf(1.0) over 100k dimensions, 120 terms/vector,
+2M vectors, 16-dimension queries, 30% surviving superblocks, and the real SIMD
+dense kernel versus binary-search plus scalar scatter for CSR superblock runs.
+
+Correctness is cross-checked entry-exact between layouts:
 
 ```
 cargo test --release -p hermes-core --features native --lib -- \
@@ -107,13 +142,53 @@ Note also that the dense grid is mmap-backed: rows of dims that queries
 never touch are never faulted in, so the _resident_ dense grid is already
 concentrated on head-dim rows — the same rows CSR must keep hot.
 
-**Verdict: not worth it at 100k-dim vocabularies with block 256.** Revisit
-only if (a) vocab grows ≫100k (density falls, memory ratio improves), or
-(b) profiling shows the deployment truly page-thrashes on grid rows — and
-then benchmark against the cheaper alternative below first. x86 AVX2 not
-yet measured (aarch64 only); re-run the bench before any decision.
+**Verdict:** do not implement the original BMP-Sparse representation for
+Hermes's two-level executor. The benchmark is aarch64-only, but the independent
+published result is stronger evidence than expecting x86 SIMD to reverse the
+random-access penalty.
 
-### 2-bit grid impacts — MEASURED, IMPLEMENTED (`bmp_grid_bits: 2`)
+## Best next grid experiment: SIMDBP-256*
+
+The 2026 LSP follow-up proposes a better representation for exactly this access
+pattern:
+
+1. Partition each dimension's block and superblock maxima into independently
+   decodable groups of 256 integers.
+2. Bit-pack each group at its local maximum width, so an all-zero group needs
+   no payload bits and low-valued groups use fewer bits.
+3. Put the group-width selectors at the front of each row so a randomly chosen
+   group can be located and decoded without walking earlier payload groups.
+4. Decode 256 values into `u16` lanes, allowing twice as many values per SIMD
+   instruction as the conventional `u32` SIMDBP decoder.
+
+The paper reports that `SIMDBP-256*` is up to 1.5× faster than conventional
+SIMDBP-256 for random group access. On MS MARCO at block size 32, its Table 7
+reports 8.0 GB for dense 8-bit block/superblock maxima, 4.2 GB for BMP-Sparse,
+3.7 GB for 8-bit SIMDBP-256*, and **1.5 GB for SIMDBP-256* with 4-bit
+maxima**. Unlike BMP-Sparse, its safe-search latency stays near the dense
+representation.
+
+Those ratios cannot be applied directly to Hermes: its block grid is already
+4-bit, its superblock grid is 8-bit, and its BP ordering and density differ.
+The remaining opportunity is the zero/low-width compression inside each
+256-cell group, plus converting the superblock grid to ceil-quantized 4-bit.
+The latter alone halves Section E but saves only about 3% of current total grid
+bytes because a superblock spans 64 blocks.
+
+A Hermes prototype must retain the current rank-safe semantics: calculate the
+exact u8 maximum, ceil it to the stored lattice, and losslessly bit-pack that
+ceiling. It must be evaluated on production-shaped, x86 data for:
+
+- bytes per block and superblock maximum, including selectors/offsets;
+- hot and cold p50/p99 latency, page faults, and decoded groups;
+- exact top-k parity with the current 4-bit dense grid;
+- build/reorder/streaming-merge throughput and peak memory.
+
+This is a higher-priority experiment than increasing `bmp_block_size`: it can
+remove zero and low-width storage without coarsening the 32-vector pruning
+unit. It is not implemented yet.
+
+## Existing dense-grid option: 2-bit block maxima
 
 Halve the dense grid (dims × blocks / 4) by quantizing block UBs to 2 bits
 (ceil-quantized, recall-safe like `quantize_u8_to_u4_ceil`). Same layout and
@@ -132,8 +207,9 @@ only loosen, exactness is structural):
 
 Why so cheap: the exact u8 `sb_grid` prunes first and shields the block
 grid — coarse block bounds only act inside surviving superblocks. **2-bit
-grid ≈ free** (grid 10 GB → 5 GB at 50M docs / block 64; combine with
-`bmp_block_size: 256` for 2.5 GB).
+grid ≈ free** in this experiment. At the current block size 32, it changes the
+100M-vector grid from 165.44 GB to 82.72 GB, and the 1B-vector grid from
+1.654 TB to 827.18 GB.
 
 **Implemented**: SDL `indexed<bmp_grid_bits: 2>` (default 4; per field,
 uniform across segments — merge/blockwise validate loudly). The V15 blob
@@ -145,7 +221,7 @@ superblocks. Exactness is pinned by
 `test_bmp_grid_bits_2_exact_parity_and_roundtrip` (identical top-k vs a
 4-bit index over the same corpus, through block-copy merge and BP reorder).
 
-### Exact integer bounds (implemented 2026-07-15)
+## Exact integer bounds (implemented 2026-07-15)
 
 Document scores use a bounded `u32` accumulator. Block and superblock bounds
 now accumulate the same `u16 query × u8 ceiling-impact` integer units and apply
@@ -156,7 +232,7 @@ the common 4-bit path uses exact NEON/SSE integer accumulation (2-bit remains
 unrolled scalar). The legacy float SIMD kernel remains only as the dense-layout
 research benchmark.
 
-### 4-bit posting weights — MEASURED, REJECTED
+## 4-bit posting weights: measured and rejected
 
 Snapping posting impacts to the u4 lattice (u8 multiples of 17; emulated at
 build time so quantization applies to both scores and grid maxes) costs
@@ -167,7 +243,7 @@ NOT 50%, because a BMP posting is 2 bytes `(local_slot: u8, impact: u8)`
 and only the impact half shrinks: packed, 2 B → 1.5 B per posting. Bad
 trade — weights stay 8-bit.
 
-## Phase 3 (assessed, not recommended): dropping grid rows for rare dims
+## Dropping rare-dimension rows: assessed and rejected
 
 Term-centric static pruning (Carmel et al., SIGIR 2001 lineage) suggests
 dropping upper-bound rows for rare dims and treating their UB
@@ -176,6 +252,25 @@ inflates every block bound for queries containing rare dims — exactly the
 discriminative dims BMP prunes best with — and with CSR rejected the
 "row costs bf_t entries" argument is moot: under the dense grid rare-dim
 rows are mmap pages that queries rarely fault in anyway.
+
+## Orthogonal follow-ups
+
+The 2026 paper
+[Forward Index Compression for Learned Sparse Retrieval](https://arxiv.org/html/2602.05445)
+introduces DotVByte, which fuses component-gap decoding, query-value gathers,
+and dot-product accumulation. This targets a document-oriented forward index,
+not the block/superblock maximum grids. Hermes V15 instead stores a block-local
+inverted Section B, so DotVByte is not a drop-in grid fix. Its fused-decode
+approach is worth revisiting only if Section B becomes the measured bottleneck
+after the grids are addressed.
+
+[Seismic](https://arxiv.org/abs/2404.18812) and
+[SeismicWave](https://arxiv.org/abs/2408.04443) avoid an exhaustive BMP grid
+through statically pruned inverted lists, compact block summaries, and (for
+SeismicWave) a proximity graph. They are approximate retrieval designs with
+different build, update, and quality trade-offs, not lossless compression for
+the current BMP executor. They should be compared as separate algorithms
+rather than mixed into the V15 format.
 
 ## SSD-friendliness / paging behavior
 
@@ -193,11 +288,16 @@ bounded and misses are served as clean 4 KB NVMe refaults:
   what keeps the number of grid probes small in the first place.
 - The block grid is deliberately never pinned (data-sized).
 
-## Rollout
+## Recommendation
 
-1. ✅ Phase 1 — rebuild large indexes with `bmp_block_size: 256` in SDL
-   (4× on grid + 4× on sb_grid); MADV_RANDOM ships with the binary and
-   needs no rebuild.
-2. If still memory-bound after 256: benchmark 2-bit grid impacts (skip
-   ratios on production data), and re-run `bench_grid_dense_vs_csr` on the
-   production arch before reconsidering CSR.
+1. Keep the production baseline at block size 32 and 4-bit block maxima. The
+   LSP results also favor small blocks for pruning; increasing the block size
+   trades latency/quality for a fixed size reduction.
+2. Prototype random-access SIMDBP-256* for both maximum grids, retaining
+   Hermes's ceil-quantized exact bounds. Measure it on production-shaped x86
+   segments before changing V15.
+3. Benchmark the already-implemented 2-bit dense block grid on production
+   queries as a separate, immediately available 2× Section D option.
+4. Do not implement original BMP-Sparse/CSR for two-level traversal.
+5. Treat DotVByte/Seismic as orthogonal Section-B or algorithm changes, not as
+   answers to the dense-grid problem.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -363,16 +363,20 @@ The BMP (block-max pruning) format takes additional `indexed<...>` options:
 
 ```
 field emb: sparse_vector<u32> [indexed<format: bmp, dims: 105879, max_weight: 5.0,
-    bmp_block_size: 256>, reorder]
+    bmp_block_size: 32, bmp_grid_bits: 4>, reorder]
 ```
 
-- `bmp_block_size` (power of two, max 256; default 64) — docs per BMP
+- `bmp_block_size` (power of two, max 256; default 32) — vectors per BMP
   block, uniform across every segment of the field. The dense 4-bit grid
   is `dims × num_blocks / 2` bytes, so grid memory scales as
-  1/block_size; smaller blocks give finer pruning granularity. Large
-  corpora (10M+ docs at 100k-dim vocabularies) should set 256 — at 50M
-  docs the grid is ~41 GB at block 64 vs ~10 GB at 256. See
-  `docs/bmp-grid-compression.md`.
+  1/block_size; smaller blocks give finer pruning granularity. Multi-valued
+  fields count each ordinal as a vector. Do not increase the block size solely
+  from document count; benchmark relevance and tail latency first.
+- `bmp_grid_bits` (2 or 4; default 4) — bits per block-grid upper bound.
+  Two-bit bounds are ceil-quantized and remain rank-safe, but are looser.
+
+See `docs/bmp-grid-compression.md` for exact current sizes and compression
+research.
 
 ### Quantization and Pruning
 

--- a/hermes-core/src/dsl/sdl/sdl.pest
+++ b/hermes-core/src/dsl/sdl/sdl.pest
@@ -158,9 +158,9 @@ quantization_kwarg = { "quantization" ~ ":" ~ quantization_spec }
 weight_threshold_kwarg = { "weight_threshold" ~ ":" ~ weight_threshold_spec }
 block_size_kwarg = { "block_size" ~ ":" ~ block_size_spec }
 block_size_spec = @{ ASCII_DIGIT+ }
-// BMP block size (docs per block, power of two, max 256; default 64).
+// BMP block size (vectors per block, power of two, max 256; default 32).
 // Uniform across all segments of the field. Grid memory scales as
-// 1/bmp_block_size — large corpora should set 256 (docs/bmp-grid-compression.md).
+// 1/bmp_block_size; larger values coarsen pruning (docs/bmp-grid-compression.md).
 bmp_block_size_kwarg = { "bmp_block_size" ~ ":" ~ block_size_spec }
 // Bits per BMP block-grid cell: 4 (default) or 2. 2 halves grid memory at
 // ~zero pruning cost (bounds are ceil-quantized — exactness is unchanged).


### PR DESCRIPTION
## Summary
- recalculate V15 BMP memory at the production block-size 32 / 4-bit grid for 18M, 100M, and 1B vectors
- distinguish vectors/ordinals from logical documents and document every V15 section formula
- correct the original BMP paper compression description (zero-suppressed BMP-Sparse)
- assess the 2025 SP paper and 2026 LSP/SIMDBP-256* and forward-index follow-ups
- keep block size 32 as the production recommendation and fix stale schema/default comments

## Validation
- `cargo test -p hermes-core sparse_vector_bmp --lib`
- `cargo fmt --all --check`
- `git diff --check`