### PR TITLE
Optimize BMP compression and LSP search

### DIFF
--- a/docs/block-level-reorder.md
+++ b/docs/block-level-reorder.md
@@ -17,16 +17,16 @@ all.
 Treat each existing block as one entity whose "terms" are its header dim
 list (no posting decode needed):
 
-- BP over `num_blocks` entities (~64× fewer than records) down to
-  `min_partition = superblock_size` — within a superblock, block order is
-  irrelevant to pruning (the executor sorts local blocks by UB at query
-  time), so only superblock _assignment_ matters.
+- BP over `num_blocks` entities (~32× fewer than vectors with the production
+  block size) down to `min_partition = superblock_size` — within a
+  superblock, block order is irrelevant to pruning (the executor sorts local
+  blocks by UB at query time), so only superblock _assignment_ matters.
 - The rewrite is a **permuted block copy**: block bytes verbatim in the new
-  order, `block_data_starts` recomputed, grid rows re-permuted nibble-wise
-  (row-at-a-time streaming, same cost class as the merge's grid pass),
-  `sb_grid` recomputed in the same pass, doc maps copied per 64-entry block
-  chunk (doc-id offsets patched for multi-source). No record unpacking, no
-  per-block hashmaps, no padding changes.
+  order, `block_data_starts` recomputed, compressed grid groups regenerated
+  from exact maxima retained in block headers, `sb_grid` recomputed in the
+  same bounded pass, and document maps copied per block chunk (doc-id offsets
+  patched for multi-source). No record unpacking, no per-block hashmaps, no
+  padding changes.
 
 The row-major grid rewrite is bounded independently of field size: each row
 is spilled and consumed in order instead of retaining `dimensions ×
@@ -81,10 +81,10 @@ Two estimator details:
   ordering signal — and on id-heavy corpora (a unique dim per record) they
   compress the bounds enough to fake "no headroom" and mask real headroom
   in the informative dims.
-- **Large segments are stride-sampled** (cap: 8192 blocks ≈ 512k docs at
-  block_size 64). All aggregates come from the sampled sub-population, so
-  the estimator stays consistent at both extremes; the decision log reports
-  scanned/total blocks.
+- **Large segments are stride-sampled** (cap: 8192 blocks ≈ 262k vectors at
+  the production block size 32). All aggregates come from the sampled
+  sub-population, so the estimator stays consistent at both extremes; the
+  decision log reports scanned/total blocks.
 
 Threshold: `BLOCKWISE_NORM_COHERENCE_THRESHOLD = 0.5`. Every `Auto`
 decision logs `norm`, `d`, `d_rand`, `d_max`, blocks scanned, scan time,
@@ -107,9 +107,10 @@ rules keep them consistent:
   resolves `Records` whenever any source is unconverged.
 - **Depth caps are converted to block units for blockwise BP.**
   `BpBudget::min_partition_docs` is in docs; blockwise BP entities are
-  blocks. Unconverted, the optimizer's large-segment cap (4096 docs) reads
-  as 4096 _blocks_ and stops blockwise BP above superblock depth as a
-  silent no-op. 4096 docs / 64 = 64 blocks = exactly the superblock target.
+  blocks. Unconverted, the optimizer's default large-segment cap (256
+  vectors) would read as 256 _blocks_ and stop blockwise BP above the desired
+  depth as a silent no-op. With the production defaults, 256 / 32 = 8 blocks,
+  exactly one LSP superblock.
 - **Partial record-level output legitimately reads `norm ≈ 0`.** Budgeted
   passes (`min_partition_docs` above block size) leave intra-block order
   random, so Auto keeps routing such segments to record-level until a
@@ -134,8 +135,8 @@ Where Auto applies:
 
 |                  | record-level                    | block-level                           |
 | ---------------- | ------------------------------- | ------------------------------------- |
-| BP entities      | num_records                     | num_blocks (÷64)                      |
-| BP depth target  | block (64 docs)                 | superblock (64 blocks)                |
+| BP entities      | num_records                     | num_blocks (÷32 by default)           |
+| BP depth target  | block (32 vectors by default)   | LSP superblock (8 blocks)             |
 | rewrite          | scatter every record            | permuted memcpy + grid nibble permute |
 | improves         | block UBs + superblock locality | superblock locality only              |
 | interior padding | compacted                       | preserved                             |

--- a/docs/bmp-grid-compression.md
+++ b/docs/bmp-grid-compression.md
@@ -1,303 +1,267 @@
-# BMP Grid Memory: Compression Research & Roadmap
+# BMP LSP/0 and Maximum-Grid Compression
 
-Status: research (updated 2026-07-23). Per-field `bmp_block_size`,
-`bmp_grid_bits`, and MADV_RANDOM are implemented. The production schema uses
-`bmp_block_size: 32` and `bmp_grid_bits: 4`. Sparse CSR was benchmarked and
-rejected for the current two-level traversal; see the newer compression
-directions below.
+Status: implemented in the BMP V17 format (2026-07-23).
 
-## Memory anatomy of a BMP segment (V15)
-
-Everything is mmap-backed (page cache, not heap), but resident-set pressure
-is real on memory-bound deployments. Counts below are per field and use the
-current production settings: 105,879 dimensions, 32 vectors per block, a
-64-block superblock, and a dense 4-bit block grid. The cardinality is sparse
-**vectors/ordinals**, not logical documents; a multi-valued field can therefore
-be many times larger than its document count.
-
-`num_blocks = ceil(num_vectors / 32)`. Sizes are decimal GB/TB, matching disk
-tools; binary sizes are included where useful.
-
-| section          | exact V15 bytes | 18M vectors | 100M vectors | 1B vectors |
-| ---------------- | ---------------: | ----------: | -----------: | ---------: |
-| block grid (D)   | `dims × ceil(num_blocks / 2)` | 29.78 GB (27.73 GiB) | 165.44 GB (154.07 GiB) | **1.654 TB (1.504 TiB)** |
-| sb_grid (E)      | `dims × ceil(num_blocks / 64)` | 0.931 GB (0.867 GiB) | 5.170 GB (4.815 GiB) | 51.70 GB (48.15 GiB) |
-| doc maps (F+G)   | `6 × num_virtual_docs` | 0.108 GB | 0.600 GB | 6.000 GB |
-| block starts (A) | `8 × (num_blocks + 1)` | 4.50 MB | 25.00 MB | 250.00 MB |
-| block data (B)   | `2P + 8T + 8N` | workload-dependent | workload-dependent | workload-dependent |
-
-Thus a single 1B-vector BMP field needs about **1.706 TB** for the two grids
-alone at block size 32/4-bit, before postings, document maps, segment metadata,
-temporary merge output, or a second BMP field. Segment boundaries add a small
-amount of row-padding overhead. Two 1B-vector fields need about **3.412 TB**
-for Sections D and E alone.
-
-In the block-data formula, `P` is the posting count, `T` is the number of
-non-zero `(block, dimension)` pairs, and `N` is the number of non-empty blocks.
-The blob also has at most seven alignment bytes and a 72-byte footer. These
-small fixed sections do not change the conclusion: the block grid dominates.
-
-The **dense block grid dominates**: every one of `dims` vocabulary rows gets
-a 4-bit cell in _every_ block, even though a typical SPLADE block touches
-only a small fraction of the vocabulary. The exact non-zero density is
-`total_terms / (dims × num_blocks)` using the V15 footer counters. Smaller
-blocks reduce that density while increasing the number of dense cells.
-
-## Shipped controls: block size, grid width, and paging
-
-Grid bytes scale approximately as `1/block_size`. Moving a field from the
-current block size 32 to 256 would:
-
-- At 18M vectors: grid 29.78 GB → **3.72 GB** and sb_grid
-  0.931 GB → **0.116 GB** (8×).
-- At 1B vectors: grid 1.654 TB → **206.8 GB** and sb_grid
-  51.70 GB → **6.46 GB** (8×).
-- Pruning granularity would coarsen by the same factor: a block would contain
-  256 vectors and a 64-block superblock 16,384 vectors. This is not a free
-  compression knob. The production choice remains **32** until representative
-  relevance and tail-latency tests justify a larger value.
-- Block size is per field and uniform across all segments. There is deliberately
-  no auto-escalation or mixed-block-size support: block-copy merge and blockwise
-  reorder move blocks verbatim and validate uniformity.
-- The block grid is now `MADV_RANDOM`: queries at production scale read 32
-  bytes per (query dim, surviving superblock) at effectively random offsets,
-  and default kernel readahead amplified each probe into 128 KB of page
-  cache (~4000×) — marching the entire data-sized grid into memory and
-  OOMing cgroup-limited deployments. With MADV_RANDOM only the touched 4 KB
-  pages fault in, and they stay cleanly reclaimable.
-
-SDL:
+The production field shape is:
 
 ```sdl
-field embedding: sparse_vector<u32> [indexed<format: bmp, dims: 105879,
-    max_weight: 5.0, bmp_block_size: 32, bmp_grid_bits: 4>]
+field embedding: sparse_vector<u32> [indexed<
+    format: bmp,
+    dims: 105879,
+    max_weight: 5.0,
+    bmp_block_size: 32,
+    bmp_grid_bits: 4,
+    query<pruning: 0.33>
+>]
 ```
 
-## What “compression” means in the original BMP paper
+V17 is the only supported BMP representation. There is no compatibility
+reader or migration path; rebuild the index after upgrading.
 
-The [SIGIR 2024 BMP paper](https://arxiv.org/pdf/2405.01117) evaluates two
-representations of each dimension's block-max row:
+## Space anatomy
 
-- **BMP-Dense** stores every 8-bit maximum, including zeros.
-- **BMP-Sparse**, called “compressed” in Table 1, zero-suppresses each row:
-  only non-zero `(offset, maximum)` pairs are kept. The
-  [reference implementation](https://github.com/pisa-engine/BMP) partitions a
-  row into groups of 256 blocks and stores those pairs inside each group.
-  Query evaluation scans the pairs and scatters them into a dense accumulator.
+Let `n` be stored vectors/ordinals, `d` the vocabulary size, `b = 32` vectors
+per block, and `c = 8` blocks per superblock. Multi-valued fields count every
+ordinal, not only logical documents.
 
-This is not entropy compression of the whole index, posting compression, or
-Hermes's 4-bit packing. On MS MARCO with block size 8, the paper reports the
-block-max structure shrinking from 30 GB dense to 5.5 GB compressed; at block
-size 256 it reports 0.9 GB dense versus 1.2 GB compressed, so sparse storage
-can even lose once rows become sufficiently dense.
+Before local bit packing, the two maximum grids would occupy:
 
-Hermes does **not** store BMP-Sparse in production. It currently has:
-
-- a dense block grid with independently addressable 4-bit cells (or optional
-  2-bit cells), using ceil quantization so the bounds remain rank-safe;
-- an exact dense 8-bit superblock grid;
-- BP document ordering, which improves bound tightness and zero density;
-- two-level superblock pruning and `MADV_RANDOM` on the block grid.
-
-Hermes therefore has score-width compression, but not the original paper's
-zero-suppression. It has only a CSR research benchmark of that design.
-
-## Why the original sparse grid is wrong for the current executor
-
-The [2025 SP paper](https://arxiv.org/html/2504.17045) introduced two-level
-superblock traversal but left both grids uncompressed. Its
-[2026 LSP follow-up](https://arxiv.org/html/2602.02883) directly tests
-compression with this access pattern. It finds the original BMP-Sparse up to
-**76× slower** because surviving superblocks cause random block-group access,
-rather than BMP's original sequential full-row scan.
-
-Hermes's local CSR experiment reaches the same conclusion. `grid_bench` in
-`segment/reader/bmp.rs` uses Zipf(1.0) over 100k dimensions, 120 terms/vector,
-2M vectors, 16-dimension queries, 30% surviving superblocks, and the real SIMD
-dense kernel versus binary-search plus scalar scatter for CSR superblock runs.
-
-Correctness is cross-checked entry-exact between layouts:
-
-```
-cargo test --release -p hermes-core --features native --lib -- \
-  --ignored bench_grid_dense_vs_csr --nocapture
+```text
+blocks      = ceil(n / b)
+superblocks = ceil(blocks / c)
+D bytes     = d × ceil(blocks / 2)       # ceil-u4 block maxima
+E bytes     = d × ceil(superblocks / 2)  # ceil-u4 superblock maxima
 ```
 
-| config    | density | grid memory: dense → CSR | block-UB compute: dense → CSR | probes hitting |
-| --------- | ------- | ------------------------ | ----------------------------- | -------------- |
-| block 64  | 3.5%    | 1562 → 227 MB (**6.9×**) | 12 → 59 ns/probe (**5.1×**)   | 94%            |
-| block 256 | 10.4%   | 391 → 137 MB (**2.9×**)  | 11 → 72 ns/probe (**6.3×**)   | 99%            |
+For `d = 105,879`:
 
-Two hypotheses failed:
+| vectors | blocks | superblocks | dense D | dense E | dense D + E |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 18M | 562,500 | 70,313 | 29.78 GB | 3.72 GB | **33.50 GB** |
+| 100M | 3,125,000 | 390,625 | 165.44 GB | 20.68 GB | **186.12 GB** |
+| 1B | 31,250,000 | 3,906,250 | 1.654 TB | 206.79 GB | **1.861 TB** |
 
-1. **"Sparse rows skip absent dims"** — real query dims are Zipf-head dims,
-   present in nearly every superblock (94-99% probe hit rate). The skip
-   advantage barely exists; every hit pays a binary search plus a scalar
-   scatter instead of one 32-byte SIMD sweep.
-2. **The memory win shrinks exactly where large fields are going**: at
-   block 256 density triples, so CSR yields only 2.9× — for a 6.3×
-   hot-loop regression.
+Those are dense-reference sizes, not the V17 on-disk sizes. V17 omits
+all-zero payload groups and uses each group’s actual local width. The encoded
+size depends on term density and BP ordering, so projections captured for the
+old 64-block/exact-u8 hierarchy are not valid for V17. The segment load log’s
+separate D/E byte counts are authoritative after a rebuild.
 
-Note also that the dense grid is mmap-backed: rows of dims that queries
-never touch are never faulted in, so the _resident_ dense grid is already
-concentrated on head-dim rows — the same rows CSR must keep hot.
+The other persistent sections are:
 
-**Verdict:** do not implement the original BMP-Sparse representation for
-Hermes's two-level executor. The benchmark is aarch64-only, but the independent
-published result is stronger evidence than expecting x86 SIMD to reverse the
-random-access penalty.
+```text
+T = total non-empty (block, dimension) pairs
+P = total document-term postings
+B = total blocks
+N = padded vector/ordinal count
 
-## Best next grid experiment: SIMDBP-256*
+Section B, Flat-Inv payload = 8 × non-empty_blocks + 9T + 2P
+Section A, block offsets    = 8 × (B + 1)
+Sections F+G, document map  = 6N
+```
 
-The 2026 LSP follow-up proposes a better representation for exactly this access
-pattern:
+The `9T` term-header component is four bytes for the dimension, four bytes for
+its posting start, and one byte for its exact block maximum. The final posting
+start contributes the other four bytes per non-empty block. Retaining the
+exact maximum costs `T` bytes, but lets a D2 BP/reorder regenerate a tight
+ceil-u4 E grid without rereading `2P` posting bytes. Empty blocks have no
+Section B payload.
 
-1. Partition each dimension's block and superblock maxima into independently
-   decodable groups of 256 integers.
-2. Bit-pack each group at its local maximum width, so an all-zero group needs
-   no payload bits and low-valued groups use fewer bits.
-3. Put the group-width selectors at the front of each row so a randomly chosen
-   group can be located and decoded without walking earlier payload groups.
-4. Decode 256 values into `u16` lanes, allowing twice as many values per SIMD
-   instruction as the conventional `u32` SIMDBP decoder.
+## V17 grid representation
 
-The paper reports that `SIMDBP-256*` is up to 1.5× faster than conventional
-SIMDBP-256 for random group access. On MS MARCO at block size 32, its Table 7
-reports 8.0 GB for dense 8-bit block/superblock maxima, 4.2 GB for BMP-Sparse,
-3.7 GB for 8-bit SIMDBP-256*, and **1.5 GB for SIMDBP-256* with 4-bit
-maxima**. Unlike BMP-Sparse, its safe-search latency stays near the dense
-representation.
+D and E are independent dimension-major grids partitioned into 256-cell
+groups. Each exact block-header maximum is ceiling-quantized before projection:
 
-Those ratios cannot be applied directly to Hermes: its block grid is already
-4-bit, its superblock grid is 8-bit, and its BP ordering and density differ.
-The remaining opportunity is the zero/low-width compression inside each
-256-cell group, plus converting the superblock grid to ceil-quantized 4-bit.
-The latter alone halves Section E but saves only about 3% of current total grid
-bytes because a superblock spans 64 blocks.
+```text
+u4 = ceil(exact_u8 / 17)
+u2 = ceil(exact_u8 / 85)  # D only, when bmp_grid_bits = 2
+```
 
-A Hermes prototype must retain the current rank-safe semantics: calculate the
-exact u8 maximum, ceil it to the stored lattice, and losslessly bit-pack that
-ceiling. It must be evaluated on production-shaped, x86 data for:
+E always uses ceil-u4. Taking the maximum of ceiling-quantized block values is
+equivalent to ceiling-quantizing their exact maximum. Query-time multiplication
+by 17 (or 85 for u2 D) makes every decoded cell an upper bound, never a rounded
+down estimate.
 
-- bytes per block and superblock maximum, including selectors/offsets;
-- hot and cold p50/p99 latency, page faults, and decoded groups;
-- exact top-k parity with the current 4-bit dense grid;
-- build/reorder/streaming-merge throughput and peak memory.
+A 256-cell group is encoded at its smallest sufficient bit width:
 
-This is a higher-priority experiment than increasing `bmp_block_size`: it can
-remove zero and low-width storage without coarsening the 32-vector pruning
-unit. It is not implemented yet.
+- D has local width `0..=bmp_grid_bits`.
+- E has local width `0..=4`.
+- An all-zero group has width zero and no payload.
+- A group payload is exactly `width × 32` bytes.
 
-## Existing dense-grid option: 2-bit block maxima
+Rows use checkpointed selectors:
 
-Halve the dense grid (dims × blocks / 4) by quantizing block UBs to 2 bits
-(ceil-quantized, recall-safe like `quantize_u8_to_u4_ceil`). Same layout and
-probe pattern, with no format fork beyond a footer flag.
+```text
+row_offsets: u64[dims + 1]
 
-Measured (`bench_aggressive_quantization`, 400k docs / 256 topics /
-BP-reordered, exact k=10; grid lattices ceil-rounded on the stored file so
-the REAL executor runs both ways; top-k asserted bit-identical — bounds
-only loosen, exactness is structural):
+for each row:
+    repeated every 32 groups:
+        payload_checkpoint: u32  # offset in 32-byte units
+        widths: packed-u4[1..=32]
+    group payloads
+```
 
-| grid            | topical queries (blocks/q) | background-only queries (blocks/q) |
-| --------------- | -------------------------- | ---------------------------------- |
-| 4-bit (shipped) | 25.7                       | 6057                               |
-| 3-bit (9 lvl)   | 25.8 (+0.4%)               | 6122 (+1.1%)                       |
-| 2-bit (4 lvl)   | 25.8 (+0.4%)               | 6188 (+2.2%)                       |
+The final selector record stores only live nibbles. One checkpoint plus at
+most 31 width additions locates any group without walking the row. For
+`C` cells and `G = ceil(C / 256)` groups:
 
-Why so cheap: the exact u8 `sb_grid` prunes first and shields the block
-grid — coarse block bounds only act inside surviving superblocks. **2-bit
-grid ≈ free** in this experiment. At the current block size 32, it changes the
-100M-vector grid from 165.44 GB to 82.72 GB, and the 1B-vector grid from
-1.654 TB to 827.18 GB.
+```text
+row_header  = ceil(G / 2) + 4 × ceil(G / 32)
+row_payload = 32 × sum(local_group_widths)
+section     = 8 × (dims + 1) + sum(row_header + row_payload)
+```
 
-**Implemented**: SDL `indexed<bmp_grid_bits: 2>` (default 4; per field,
-uniform across segments — merge/blockwise validate loudly). The V15 blob
-footer carries the cell width (2 or 4); older segments must be rebuilt.
-2-bit currently uses an unrolled scalar
-accumulate/mask kernel (4 cells/byte); SIMD u2 variants are a follow-up if
-profiling asks for them — the block grid is probed only inside surviving
-superblocks. Exactness is pinned by
-`test_bmp_grid_bits_2_exact_parity_and_roundtrip` (identical top-k vs a
-4-bit index over the same corpus, through block-copy merge and BP reorder).
+Codec groups do not pad the logical BMP block or superblock counts.
 
-## Exact integer bounds (implemented 2026-07-15)
+## LSP/0 execution
 
-Document scores use a bounded `u32` accumulator. Block and superblock bounds
-now accumulate the same `u16 query × u8 ceiling-impact` integer units and apply
-the common dequantizer once. The former term-by-term f32 sum could round below
-the document score (reproducible with 64 dimensions), making exact-mode pruning
-unsafe at a heap-threshold tie. Packed rows are still swept byte-at-a-time, but
-the common 4-bit path uses exact NEON/SSE integer accumulation (2-bit remains
-unrolled scalar). The legacy float SIMD kernel remains only as the dense-layout
-research benchmark.
+V17 implements LSP/0 as a query-level operation:
 
-## 4-bit posting weights: measured and rejected
+1. Keep the strongest query dimensions for candidate generation
+   (`beta = 0.33` by default for BMP).
+2. Sweep E for those dimensions and compute SBMax for every physical segment.
+3. Select one global top-`gamma` set across the entire index, then partition
+   the selected superblock IDs back to their segments.
+4. Visit selected superblocks in non-increasing SBMax order while
+   `SBMax >= theta`.
+5. Within a selected superblock, decode D once per candidate dimension, order
+   its eight blocks by BlockMax, and apply `heap_factor` only at this level.
+6. Score documents in visited blocks with the bounded full query, including
+   dimensions removed from candidate generation.
 
-Snapping posting impacts to the u4 lattice (u8 multiples of 17; emulated at
-build time so quantization applies to both scores and grid maxes) costs
-real quality: **recall@10 vs the 8-bit index = 95.1%** on the same corpus,
-matching the classical 3-5% loss for sub-8-bit impact quantization
-(Anh & Moffat lineage). The saving is only ~25% of the postings section —
-NOT 50%, because a BMP posting is 2 bytes `(local_slot: u8, impact: u8)`
-and only the impact half shrinks: packed, 2 B → 1.5 B per posting. Bad
-trade — weights stay 8-bit.
+The global selection is important: 50 immutable segments still visit at most
+`gamma` superblocks in total, not `50 × gamma`.
 
-## Dropping rare-dimension rows: assessed and rejected
+Automatic gamma follows the paper’s zero-shot depths:
 
-Term-centric static pruning (Carmel et al., SIGIR 2001 lineage) suggests
-dropping upper-bound rows for rare dims and treating their UB
-conservatively (global max weight for all blocks). But a conservative UB
-inflates every block bound for queries containing rare dims — exactly the
-discriminative dims BMP prunes best with — and with CSR rejected the
-"row costs bf_t entries" argument is moot: under the dense grid rare-dim
-rows are mmap pages that queries rarely fault in anyway.
+| requested candidate depth | gamma |
+| ---: | ---: |
+| `1..=10` | 250 |
+| `11..=100` | 500 |
+| `101..=1000` | 1,000 |
+| `> 1000` | `max(2000, depth)` |
 
-## Orthogonal follow-ups
+Set query `lsp_gamma: 0` for exhaustive traversal, or a positive value for an
+explicit cap. `heap_factor: 1.0` and ceiling bounds are rank-safe when query
+pruning is disabled; finite gamma and beta below 1.0 are intentional
+candidate-generation approximations. Full-query scoring preserves relevance
+within the visited candidate set.
 
-The 2026 paper
-[Forward Index Compression for Learned Sparse Retrieval](https://arxiv.org/html/2602.05445)
-introduces DotVByte, which fuses component-gap decoding, query-value gathers,
-and dot-product accumulation. This targets a document-oriented forward index,
-not the block/superblock maximum grids. Hermes V15 instead stores a block-local
-inverted Section B, so DotVByte is not a drop-in grid fix. Its fused-decode
-approach is worth revisiting only if Section B becomes the measured bottleneck
-after the grids are addressed.
+Candidate bounds and their corresponding score contributions share the same
+integer arithmetic: query-u16 times ceiling maximum accumulates in u32 and is
+converted to f32 once with the document scorer’s dequantizer. This prevents a
+floating-point rounding difference from lowering an unpruned bound.
 
-[Seismic](https://arxiv.org/abs/2404.18812) and
-[SeismicWave](https://arxiv.org/abs/2408.04443) avoid an exhaustive BMP grid
-through statically pruned inverted lists, compact block summaries, and (for
-SeismicWave) a proximity graph. They are approximate retrieval designs with
-different build, update, and quality trade-offs, not lossless compression for
-the current BMP executor. They should be compared as separate algorithms
-rather than mixed into the V15 format.
+## Build, merge, and BP reorder
 
-## SSD-friendliness / paging behavior
+Initial build and BP/reorder write grids from sorted
+`(dimension, block, exact_u8_maximum)` entries. Exact maxima are retained in
+each block header, so both D and E can be regenerated without scanning or
+reserializing postings.
 
-The grid is mmap-backed; "SSD-friendly" means the resident set stays
-bounded and misses are served as clean 4 KB NVMe refaults:
+Ordinary merge remains a streaming block-copy operation:
 
-- **MADV_RANDOM on the grid** (shipped): kills readahead amplification —
-  per query the grid working set is `query_dims × surviving_superblocks ×
-4 KB` instead of ×128 KB. Pages are clean and reclaimable; under memory
-  pressure the kernel evicts them and cold queries pay ~20-50 µs NVMe
-  refaults per page instead of the pod OOMing.
-- **sb_grid stays readahead-friendly and pinnable** (priority 4 in the pin
-  budget): it is swept contiguously per query dim and is 64× smaller than
-  the grid — keeping it resident preserves superblock pruning, which is
-  what keeps the number of grid probes small in the first place.
-- The block grid is deliberately never pinned (data-sized).
+- Section B block payloads are copied byte-for-byte.
+- Aligned D groups are copied byte-for-byte.
+- A shifted D boundary is decoded/repacked with one bounded 256-cell buffer.
+- E values are remapped to destination superblocks. If a source superblock
+  straddles a destination boundary, its ceiling bound is max-propagated to
+  both destinations. The bound may be temporarily loose but cannot be unsafe.
+- Document maps are chunked copies with document-ID offset patching.
 
-## Recommendation
+A later BP pass rebuilds tight E values from exact block headers. Reordering
+changes block coordinates first and then projects exact maxima into
+`floor(new_block / 8)`, so ceil quantization composes correctly with any
+permutation.
 
-1. Keep the production baseline at block size 32 and 4-bit block maxima. The
-   LSP results also favor small blocks for pruning; increasing the block size
-   trades latency/quality for a fixed size reduction.
-2. Prototype random-access SIMDBP-256* for both maximum grids, retaining
-   Hermes's ceil-quantized exact bounds. Measure it on production-shaped x86
-   segments before changing V15.
-3. Benchmark the already-implemented 2-bit dense block grid on production
-   queries as a separate, immediately available 2× Section D option.
-4. Do not implement original BMP-Sparse/CSR for two-level traversal.
-5. Treat DotVByte/Seismic as orthogonal Section-B or algorithm changes, not as
-   answers to the dense-grid problem.
+## CPU and paging behavior
+
+The production codec and hot loops are Rust:
+
+- x86_64 uses BMI2 for variable-width unpacking and SSE4.1 for u4/u8 bound
+  accumulation, including the eight-block LSP unit;
+- AArch64 uses bounded unpacking and NEON for the same D/E accumulation paths;
+- other targets use a result-identical scalar fallback.
+
+All large sections remain mmap-backed. E and the compact offset/selector
+structures are eligible for priority pinning because every BMP query uses
+them. D payload and block payload remain pageable. D receives random-access
+advice; E receives sequential advice.
+
+## Match to the LSP paper
+
+V17 follows the core design in
+[Carlson et al., “Efficiency Optimizations for Superblock-based Sparse Retrieval”](https://arxiv.org/html/2602.02883v1):
+
+- 256 independently decodable maximum cells per compressed group;
+- random group access rather than BMP-Sparse’s binary-search/scatter path;
+- four-bit ceiling maxima at both hierarchy levels;
+- a superblock footprint no larger than 256 vectors (`b = 32`, `c = 8`);
+- beta query pruning, strict SBMax top-gamma selection, safe
+  `SBMax >= theta`, block-level eta/`heap_factor`, and full-query scoring of
+  visited candidates.
+
+Hermes’s codec is equivalent in access granularity and bounds but is not the
+paper implementation’s wire format. Its selector checkpoints are interleaved
+every 32 groups rather than stored as one long selector prefix, which bounds
+random lookup work on very long 1B-scale rows.
+
+The paper reports its best latency around block sizes 4–16. Hermes keeps the
+requested block size 32 and compensates with eight-block superblocks; this
+satisfies the paper’s `b × c <= 256` recommendation but is a deliberate
+space/build-time tradeoff rather than a claim that 32 is the paper optimum.
+
+## Flat-Inv versus the paper’s Fwd layout
+
+Hermes does **not** use the paper’s document-major Fwd payload for persistent
+BMP scoring. Section B is a block-local Flat-Inv layout:
+
+```text
+sorted term IDs
+term offsets
+(local_slot: u8, impact: u8) postings
+```
+
+The paper finds Fwd faster for small blocks, including `b = 32`, but its
+Compact-Inv format explicitly assumes a vocabulary that fits two-byte term
+IDs. Hermes production fields use roughly 105,879 dimensions, so a direct
+Hermes Fwd layout requires four-byte IDs. At minimum, separate u32 term IDs
+and u8 weights cost `5P` bytes plus document offsets, while current Section B
+costs `2P + 9T + block headers`. Which representation is smaller therefore
+depends on the measured `T/P` ratio; vocabulary size alone does not settle it.
+Ignoring the small offset/header terms, Fwd becomes smaller only when
+`T/P > 1/3`; repeated dimensions within a 32-vector block push that ratio
+down and favor Flat-Inv.
+Flat-Inv also lets the scorer fetch only postings for query-present terms,
+whereas Fwd streams every term in every candidate document.
+
+At `b = 32` the paper reports a material Fwd latency advantage on its SPLADE
+workload, so this is a legitimate optimization candidate, not a rejected
+design. It should first be implemented as a production-shaped benchmark using
+Hermes's u32 vocabulary and candidate distribution. A format replacement is
+justified only if it wins both hot/cold latency and total Section B bytes on
+that benchmark.
+
+“Forward indexes” elsewhere in Hermes are temporary BP/reorder structures
+used to compute a document or block permutation. They are memory-budgeted,
+discarded after the pass, and are not the on-disk query payload discussed by
+the paper.
+
+## Validation
+
+The test suite pins:
+
+- every local width round trip and malformed metadata rejection;
+- SSE4.1/NEON/scalar-equivalent u4 and u8 accumulation tails;
+- exact BMP-versus-MaxScore top-k parity in exhaustive mode;
+- u2-versus-u4 rank-safe parity;
+- a single global gamma across multiple segments;
+- non-aligned D merge and overlapping E-bound propagation;
+- record and blockwise BP reorder;
+- E regeneration from exact block-header maxima;
+- bounded external-run construction.
+
+After a production rebuild, record D/E encoded bytes, hot and cold
+p50/p95/p99, page faults, global selected/visited superblocks, blocks visited,
+and recall against `lsp_gamma: 0`. The new hierarchy should be judged from
+those measurements rather than the obsolete V16 projections.

--- a/docs/budgeted-reorder.md
+++ b/docs/budgeted-reorder.md
@@ -20,10 +20,12 @@ converge to full-BP quality.
 `BpBudget` (threaded through every reorder path):
 
 - `min_partition_docs: Option<usize>` — depth cap; stop bisection at
-  partitions of this size. **4096 (= superblock 64 blocks × 64 docs) keeps
-  nearly all of the superblock-pruning win at ~⅓ less depth** — the
-  remaining levels only sharpen intra-superblock block ordering. A depth cap
-  is a chosen target: the pass reports `converged = true`.
+  partitions of this size. **256 (= the default LSP superblock, 8 blocks ×
+  32 vectors) reaches the hierarchy's coarse-pruning unit**; remaining
+  levels only sharpen intra-superblock block ordering. The graph routine
+  completes that chosen target normally; segment metadata deliberately
+  records a depth-capped optimizer pass as `bp_converged = false` so the
+  deepening ladder can later reach full block depth.
 - `time_budget: Option<Duration>` — wall-clock deadline, checked between
   refinement passes and before each recursion (atomic flag across the rayon
   fan-out). Hitting it ends the pass cleanly with `converged = false`.
@@ -39,7 +41,7 @@ cold-IO writer, so at least they no longer evict the cache.
 
 - Segments `< --optimizer-large-segment-docs` (default 5M): full-depth BP.
 - Larger: budgeted pass — depth capped at
-  `--optimizer-partial-min-partition-docs` (default 4096) and wall-clock
+  `--optimizer-partial-min-partition-docs` (default 256) and wall-clock
   capped at `--optimizer-time-budget-secs` (default 600).
 - Unconverged segments (deadline fired) are revisited alongside fresh work,
   with at most one deepening pass active globally. After it completes, the

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -363,20 +363,31 @@ The BMP (block-max pruning) format takes additional `indexed<...>` options:
 
 ```
 field emb: sparse_vector<u32> [indexed<format: bmp, dims: 105879, max_weight: 5.0,
-    bmp_block_size: 32, bmp_grid_bits: 4>, reorder]
+    bmp_block_size: 32, bmp_grid_bits: 4,
+    query<pruning: 0.33, lsp_gamma: 1000>>, reorder]
 ```
 
 - `bmp_block_size` (power of two, max 256; default 32) — vectors per BMP
-  block, uniform across every segment of the field. The dense 4-bit grid
-  is `dims × num_blocks / 2` bytes, so grid memory scales as
-  1/block_size; smaller blocks give finer pruning granularity. Multi-valued
-  fields count each ordinal as a vector. Do not increase the block size solely
-  from document count; benchmark relevance and tail latency first.
+  block, uniform across every segment of the field. Larger blocks reduce the
+  number of locally bit-packed maximum cells but also coarsen pruning.
+  Multi-valued fields count each ordinal as a vector. Do not increase the block
+  size solely from document count; benchmark relevance and tail latency first.
 - `bmp_grid_bits` (2 or 4; default 4) — bits per block-grid upper bound.
-  Two-bit bounds are ceil-quantized and remain rank-safe, but are looser.
+  Two-bit bounds are ceil-quantized and remain rank-safe, but are looser. They
+  cap compressed D payload widths at two bits; the exact saving is
+  workload-dependent.
+- `query<pruning: 0.33>` — retain the highest-weight third of query
+  dimensions for BMP candidate generation, matching the LSP/0 zero-shot beta.
+  Visited documents are still scored with the bounded full query. The BMP
+  preset and server fallback use 0.33; use 1.0 for unpruned candidate
+  generation.
+- `query<lsp_gamma: N>` — cap traversal to the global top-N superblocks across
+  all physical segments. When omitted, Hermes derives gamma from candidate
+  depth (250/500/1000 for depths 10/100/1000). Set zero for exhaustive
+  traversal.
 
-See `docs/bmp-grid-compression.md` for exact current sizes and compression
-research.
+See `docs/bmp-grid-compression.md` for current size formulas, LSP/0 behavior,
+merge/reorder invariants, and the Flat-Inv versus Fwd design choice.
 
 ### Quantization and Pruning
 

--- a/docs/seismic-research.md
+++ b/docs/seismic-research.md
@@ -38,14 +38,16 @@ An _approximate_ sparse index that abandons the document-space grid entirely:
 
 ## Why this matters for Hermes at 1B scale
 
-BMP's grid is O(dims × docs / 2b) — the structure that forces block-size
-compromises and dominates memory (~15 GB per 18M-doc segment today, ~410 GB
-at 1B even with b=64). Seismic's memory is O(kept postings): λ caps every
-list, so the index grows with _vocabulary_, not corpus × dims. That is the
-structurally right shape for 1B vectors. The trade: approximate-only (no
-rank-safe mode), parameter-sensitive, and per-list clustering makes
-incremental merging awkward (blocks must be re-clustered per list — a
-rebuild-style operation like our reorder, not a byte-stack merge).
+BMP's maximum grids are O(dims × vectors / block_size) before V17's local
+bit packing. At 1B vectors, `dims=105879`, `b=32`, and eight blocks per
+superblock, the dense D+E reference is 1.861 TB; actual V17 size is
+data-dependent because zero groups disappear and every 256-cell group uses
+its local width. Seismic's memory is O(kept postings): λ caps every list, so
+the index grows with _vocabulary_, not corpus × dims. That is a structurally
+attractive shape for 1B vectors. The trade: approximate-only (no rank-safe
+mode), parameter-sensitive, and per-list clustering makes incremental
+merging awkward (blocks must be re-clustered per list — a rebuild-style
+operation like our reorder, not a byte-stack merge).
 
 ## Fit with existing Hermes machinery
 
@@ -57,7 +59,7 @@ Most building blocks already exist:
 | α-mass summaries                | `doc_mass` logic (same cropping, applied to a max-vector) |
 | u8 quantization                 | `WeightQuantization::UInt8` + max_weight scale            |
 | shallow k-means                 | shared deterministic k-means++/Lloyd trainer             |
-| forward index for exact scoring | BMP block data is already a forward index                 |
+| forward index for exact scoring | BMP has the same values in block-local Flat-Inv form; a Seismic scorer would need a persistent document-major Fwd layout or an equivalent exact-vector store |
 | heap_factor pruning             | same knob/semantics as BMP/MaxScore                       |
 | kNN graph (Wave)                | could reuse the global dense IVF HNSW topology            |
 
@@ -65,16 +67,17 @@ Sketch: a third `SparseFormat::Seismic` with per-list blocked-cluster layout
 
 - summary section; merge = concat lists then recluster (or block-stack with
   summary rebuild as the cheap path); query executor mirrors the paper's
-  coordinate-at-a-time loop. Estimated scope: comparable to the BMP V13
+  coordinate-at-a-time loop. Estimated scope: comparable to the BMP
   implementation (format + builder + merger + executor + tests).
 
 ## Recommendation
 
-Not a replacement for BMP today — BMP + superblocks + BP reorder is
-rank-safe, merge-friendly, and now well-instrumented. Seismic becomes the
-right tool when (a) corpus per segment pushes the grid past what block-size
-inflation can absorb (≳100M docs/segment territory), or (b) strictly
-approximate retrieval with sub-ms budgets is acceptable product-wide.
+Not a replacement for BMP today — BMP + superblocks + BP reorder supports an
+exhaustive rank-safe mode, remains merge-friendly, and is well-instrumented.
+Seismic becomes the right tool when (a) corpus per segment pushes the grid
+past what local compression and the chosen block size can absorb, or (b)
+strictly approximate retrieval with sub-ms budgets is acceptable
+product-wide.
 Suggested path: prototype behind `format: seismic` on one production-shaped
 segment, compare against BMP at equal recall using the new
 `hermes_bmp_*`/latency metrics before committing to the format.

--- a/hermes-core/src/dsl/sdl/mod.rs
+++ b/hermes-core/src/dsl/sdl/mod.rs
@@ -277,6 +277,7 @@ struct IndexConfig {
     query_max_dims: Option<usize>,
     query_pruning: Option<f32>,
     query_min_query_dims: Option<usize>,
+    query_lsp_gamma: Option<usize>,
     // BMP fixed dims (vocabulary size) and max weight scale
     dims: Option<u32>,
     max_weight: Option<f32>,
@@ -478,10 +479,11 @@ fn parse_single_index_config_param(config: &mut IndexConfig, p: pest::iterators:
             if let Some(n) = p.into_inner().next() {
                 config.bmp_grid_bits = Some(n.as_str().parse().unwrap_or_else(|_| {
                     log::warn!(
-                        "Invalid bmp_grid_bits value '{}', using default 4",
-                        n.as_str()
+                        "Invalid bmp_grid_bits value '{}', using default {}",
+                        n.as_str(),
+                        SparseVectorConfig::DEFAULT_BMP_GRID_BITS,
                     );
-                    4
+                    SparseVectorConfig::DEFAULT_BMP_GRID_BITS
                 }));
             }
         }
@@ -642,6 +644,18 @@ fn parse_query_config_block(config: &mut IndexConfig, pair: pest::iterators::Pai
                                                 t.as_str()
                                             );
                                             4
+                                        }));
+                                }
+                            }
+                            Rule::query_lsp_gamma_kwarg => {
+                                if let Some(value) = p.into_inner().next() {
+                                    config.query_lsp_gamma =
+                                        Some(value.as_str().parse().unwrap_or_else(|_| {
+                                            log::warn!(
+                                                "Invalid query lsp_gamma '{}', using 0",
+                                                value.as_str()
+                                            );
+                                            0
                                         }));
                                 }
                             }
@@ -896,10 +910,11 @@ fn apply_index_config_to_sparse_vector(config: &mut SparseVectorConfig, idx_cfg:
             config.bmp_grid_bits = bits;
         } else {
             log::warn!(
-                "bmp_grid_bits {} unsupported (must be 2 or 4), using 4",
-                bits
+                "bmp_grid_bits {} unsupported (must be 2 or 4), using {}",
+                bits,
+                SparseVectorConfig::DEFAULT_BMP_GRID_BITS,
             );
-            config.bmp_grid_bits = 4;
+            config.bmp_grid_bits = SparseVectorConfig::DEFAULT_BMP_GRID_BITS;
         }
     }
     if let Some(p) = idx_cfg.pruning {
@@ -940,6 +955,7 @@ fn apply_index_config_to_sparse_vector(config: &mut SparseVectorConfig, idx_cfg:
         || idx_cfg.query_max_dims.is_some()
         || idx_cfg.query_pruning.is_some()
         || idx_cfg.query_min_query_dims.is_some()
+        || idx_cfg.query_lsp_gamma.is_some()
     {
         let query_config = config
             .query_config
@@ -961,6 +977,9 @@ fn apply_index_config_to_sparse_vector(config: &mut SparseVectorConfig, idx_cfg:
         }
         if let Some(m) = idx_cfg.query_min_query_dims {
             query_config.min_query_dims = m;
+        }
+        if let Some(gamma) = idx_cfg.query_lsp_gamma {
+            query_config.lsp_gamma = Some(gamma);
         }
     }
 }
@@ -1631,10 +1650,16 @@ mod tests {
         assert_eq!(config1.bmp_grid_bits, 2);
         // Default stays 4
         let config2 = indexes[0].fields[1].sparse_vector_config.as_ref().unwrap();
-        assert_eq!(config2.bmp_grid_bits, 4);
+        assert_eq!(
+            config2.bmp_grid_bits,
+            SparseVectorConfig::DEFAULT_BMP_GRID_BITS
+        );
         // Unsupported width falls back to 4 with a warning
         let config3 = indexes[0].fields[2].sparse_vector_config.as_ref().unwrap();
-        assert_eq!(config3.bmp_grid_bits, 4);
+        assert_eq!(
+            config3.bmp_grid_bits,
+            SparseVectorConfig::DEFAULT_BMP_GRID_BITS
+        );
     }
 
     #[test]
@@ -2249,7 +2274,7 @@ mod tests {
     fn test_sparse_vector_query_config_pruning_params() {
         let sdl = r#"
             index documents {
-                field embedding: sparse_vector<u16> [indexed<quantization: uint8, query<weighting: idf, weight_threshold: 0.03, max_dims: 25, pruning: 0.2>>]
+                field embedding: sparse_vector<u16> [indexed<quantization: uint8, query<weighting: idf, weight_threshold: 0.03, max_dims: 25, pruning: 0.2, lsp_gamma: 500>>]
             }
         "#;
 
@@ -2261,6 +2286,7 @@ mod tests {
         assert!((qc.weight_threshold - 0.03).abs() < 0.001);
         assert_eq!(qc.max_query_dims, Some(25));
         assert!((qc.pruning.unwrap() - 0.2).abs() < 0.001);
+        assert_eq!(qc.lsp_gamma, Some(500));
 
         // Verify schema roundtrip
         let schema = indexes[0].to_schema();
@@ -2271,6 +2297,7 @@ mod tests {
         assert!((rqc.weight_threshold - 0.03).abs() < 0.001);
         assert_eq!(rqc.max_query_dims, Some(25));
         assert!((rqc.pruning.unwrap() - 0.2).abs() < 0.001);
+        assert_eq!(rqc.lsp_gamma, Some(500));
     }
 
     #[test]

--- a/hermes-core/src/dsl/sdl/sdl.pest
+++ b/hermes-core/src/dsl/sdl/sdl.pest
@@ -159,11 +159,11 @@ weight_threshold_kwarg = { "weight_threshold" ~ ":" ~ weight_threshold_spec }
 block_size_kwarg = { "block_size" ~ ":" ~ block_size_spec }
 block_size_spec = @{ ASCII_DIGIT+ }
 // BMP block size (vectors per block, power of two, max 256; default 32).
-// Uniform across all segments of the field. Grid memory scales as
-// 1/bmp_block_size; larger values coarsen pruning (docs/bmp-grid-compression.md).
+// Uniform across all segments of the field. Larger values reduce compressed
+// grid cells but coarsen pruning (docs/bmp-grid-compression.md).
 bmp_block_size_kwarg = { "bmp_block_size" ~ ":" ~ block_size_spec }
-// Bits per BMP block-grid cell: 4 (default) or 2. 2 halves grid memory at
-// ~zero pruning cost (bounds are ceil-quantized — exactness is unchanged).
+// Bits per BMP block-grid cell: 4 (default) or 2. Two caps local D payload
+// widths at two bits (bounds are ceil-quantized — exactness is unchanged).
 bmp_grid_bits_kwarg = { "bmp_grid_bits" ~ ":" ~ bits_spec }
 pruning_kwarg = { "pruning" ~ ":" ~ pruning_spec }
 pruning_spec = @{ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
@@ -193,7 +193,7 @@ path_chars = @{ (!("\"" ) ~ ANY)* }
 // Example: query<tokenizer: "model/name", weighting: idf>
 query_config_block = { "query" ~ "<" ~ query_config_params ~ ">" }
 query_config_params = { query_config_param ~ ("," ~ query_config_param)* }
-query_config_param = { query_tokenizer_kwarg | query_weighting_kwarg | query_weight_threshold_kwarg | query_max_dims_kwarg | query_pruning_kwarg | query_min_query_dims_kwarg }
+query_config_param = { query_tokenizer_kwarg | query_weighting_kwarg | query_weight_threshold_kwarg | query_max_dims_kwarg | query_pruning_kwarg | query_min_query_dims_kwarg | query_lsp_gamma_kwarg }
 query_tokenizer_kwarg = { "tokenizer" ~ ":" ~ tokenizer_path }
 query_weighting_kwarg = { "weighting" ~ ":" ~ weighting_spec }
 tokenizer_path = { "\"" ~ path_chars ~ "\"" }
@@ -202,6 +202,8 @@ query_weight_threshold_kwarg = { "weight_threshold" ~ ":" ~ weight_threshold_spe
 query_max_dims_kwarg = { "max_dims" ~ ":" ~ nprobe_spec }
 query_pruning_kwarg = { "pruning" ~ ":" ~ pruning_spec }
 query_min_query_dims_kwarg = { "min_query_dims" ~ ":" ~ min_terms_spec }
+// LSP/0 top-superblock guarantee. 0 means exhaustive SBMax traversal.
+query_lsp_gamma_kwarg = { "lsp_gamma" ~ ":" ~ nprobe_spec }
 
 // Identifier (field names, index names, tokenizer names)
 identifier = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_")* }

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -570,6 +570,113 @@ impl<D: Directory + 'static> Searcher<D> {
         self.search_internal(query, limit, 0, true).await
     }
 
+    /// Build the paper's single query-level top-γ superblock set, then project
+    /// it back onto segment-local plans.
+    ///
+    /// Treating every immutable segment as an independent LSP index would
+    /// multiply work by the segment count. The prepass retains one global γ
+    /// while preserving Hermes's streaming segment architecture.
+    fn prepare_global_lsp(
+        &self,
+        query: &dyn crate::query::Query,
+        retrieval_depth: usize,
+        parallel: bool,
+    ) -> Result<Vec<Option<std::sync::Arc<crate::query::bmp::LspSegmentPlan>>>> {
+        let empty = || vec![None; self.segments.len()];
+        if retrieval_depth == 0 {
+            return Ok(empty());
+        }
+        let crate::query::QueryDecomposition::SparseTerms(infos) = query.decompose() else {
+            return Ok(empty());
+        };
+        let Some(first) = infos.first() else {
+            return Ok(empty());
+        };
+        if infos
+            .iter()
+            .any(|info| info.field != first.field || info.lsp_gamma != first.lsp_gamma)
+        {
+            return Ok(empty());
+        }
+        let gamma = first
+            .lsp_gamma
+            .unwrap_or_else(|| crate::query::bmp::recommended_lsp_gamma(retrieval_depth));
+        if gamma == 0 {
+            return Ok(empty());
+        }
+        let field = first.field;
+        let candidate_terms: Vec<(u32, f32)> = infos
+            .iter()
+            .filter(|info| info.candidate)
+            .map(|info| (info.dim_id, info.weight))
+            .collect();
+        if candidate_terms.is_empty() {
+            return Ok(empty());
+        }
+        let scoring_terms: Vec<(u32, f32)> = infos
+            .iter()
+            .map(|info| (info.dim_id, info.weight))
+            .collect();
+        let prepare = |segment: &std::sync::Arc<crate::segment::SegmentReader>| {
+            segment
+                .bmp_index(field)
+                .map(|bmp| {
+                    crate::query::bmp::prepare_lsp_superblock_ubs(
+                        bmp,
+                        &candidate_terms,
+                        &scoring_terms,
+                    )
+                })
+                .transpose()
+        };
+
+        #[cfg(feature = "sync")]
+        let bounds: Vec<Option<Vec<f32>>> = if parallel {
+            use rayon::prelude::*;
+            self.search_pool.install(|| {
+                self.segments
+                    .par_iter()
+                    .map(prepare)
+                    .collect::<Result<Vec<_>>>()
+            })?
+        } else {
+            self.segments
+                .iter()
+                .map(prepare)
+                .collect::<Result<Vec<_>>>()?
+        };
+        #[cfg(not(feature = "sync"))]
+        let bounds: Vec<Option<Vec<f32>>> = {
+            let _ = parallel;
+            self.segments
+                .iter()
+                .map(prepare)
+                .collect::<Result<Vec<_>>>()?
+        };
+
+        let mut selected = select_global_lsp_superblocks(&bounds, gamma);
+
+        let mut plans = Vec::with_capacity(self.segments.len());
+        for (segment, segment_bounds) in bounds.into_iter().enumerate() {
+            let Some(segment_bounds) = segment_bounds else {
+                plans.push(None);
+                continue;
+            };
+            selected[segment].sort_unstable_by(|&left, &right| {
+                segment_bounds[right as usize]
+                    .total_cmp(&segment_bounds[left as usize])
+                    .then_with(|| left.cmp(&right))
+            });
+            plans.push(Some(std::sync::Arc::new(
+                crate::query::bmp::LspSegmentPlan {
+                    sb_ubs: segment_bounds,
+                    sb_order: std::mem::take(&mut selected[segment]),
+                },
+            )));
+        }
+        Ok(plans)
+    }
+
     /// Internal search implementation
     async fn search_internal(
         &self,
@@ -602,28 +709,32 @@ impl<D: Directory + 'static> Searcher<D> {
         // Cross-segment top-k floor (see search_internal_sync). Concurrent
         // segments share it via an atomic; ordering is best-effort.
         let shared = crate::query::SharedThreshold::new();
-        let searches = futures::stream::iter(self.segments.iter().cloned().map(|segment| {
-            let sid = segment.meta().id;
-            let shared = shared.clone();
-            async move {
-                let (mut results, segment_seen) = crate::query::search_segment_shared(
-                    segment.as_ref(),
-                    query,
-                    fetch_limit,
-                    collect_positions,
-                    shared.clone(),
-                )
-                .await?;
-                if fetch_limit > 0 && results.len() >= fetch_limit {
-                    shared.raise(results[fetch_limit - 1].score);
+        let lsp_plans = self.prepare_global_lsp(query, fetch_limit, false)?;
+        let searches = futures::stream::iter(self.segments.iter().cloned().zip(lsp_plans).map(
+            |(segment, lsp_plan)| {
+                let sid = segment.meta().id;
+                let shared = shared.clone();
+                async move {
+                    let (mut results, segment_seen) = crate::query::search_segment_shared_planned(
+                        segment.as_ref(),
+                        query,
+                        fetch_limit,
+                        collect_positions,
+                        shared.clone(),
+                        lsp_plan,
+                    )
+                    .await?;
+                    if fetch_limit > 0 && results.len() >= fetch_limit {
+                        shared.raise(results[fetch_limit - 1].score);
+                    }
+                    // Stamp segment_id on each result
+                    for r in &mut results {
+                        r.segment_id = sid;
+                    }
+                    Ok::<_, crate::error::Error>((results, segment_seen))
                 }
-                // Stamp segment_id on each result
-                for r in &mut results {
-                    r.segment_id = sid;
-                }
-                Ok::<_, crate::error::Error>((results, segment_seen))
-            }
-        }))
+            },
+        ))
         .buffer_unordered(MAX_ASYNC_SEGMENT_SEARCHES);
         futures::pin_mut!(searches);
 
@@ -669,21 +780,25 @@ impl<D: Directory + 'static> Searcher<D> {
     ) -> Result<(Vec<crate::query::SearchResult>, u32)> {
         use rayon::prelude::*;
 
+        let lsp_plans = self.prepare_global_lsp(query, fetch_limit, true)?;
         // Cross-segment top-k floor: each segment seeds its pruning from the
         // running global k-th score and raises it once it fills its own heap.
         let shared = crate::query::SharedThreshold::new();
         let (merged, total_seen) = self.search_pool.install(|| {
             self.segments
                 .par_iter()
-                .map(|segment| {
+                .zip(lsp_plans.par_iter())
+                .map(|(segment, lsp_plan)| {
                     let sid = segment.meta().id;
-                    let (mut results, segment_seen) = crate::query::search_segment_shared_sync(
-                        segment.as_ref(),
-                        query,
-                        fetch_limit,
-                        collect_positions,
-                        shared.clone(),
-                    )?;
+                    let (mut results, segment_seen) =
+                        crate::query::search_segment_shared_sync_planned(
+                            segment.as_ref(),
+                            query,
+                            fetch_limit,
+                            collect_positions,
+                            shared.clone(),
+                            lsp_plan.clone(),
+                        )?;
                     if fetch_limit > 0 && results.len() >= fetch_limit {
                         shared.raise(results[fetch_limit - 1].score);
                     }
@@ -721,20 +836,24 @@ impl<D: Directory + 'static> Searcher<D> {
 
         let fetch_limit = checked_search_window(limit, offset)?;
 
+        let lsp_plans = self.prepare_global_lsp(query, fetch_limit, true)?;
         // Cross-segment top-k floor (see search_internal_sync).
         let shared = crate::query::SharedThreshold::new();
         let (merged, total_seen) = self.search_pool.install(|| {
             self.segments
                 .par_iter()
-                .map(|segment| {
+                .zip(lsp_plans.par_iter())
+                .map(|(segment, lsp_plan)| {
                     let sid = segment.meta().id;
-                    let (mut results, segment_seen) = crate::query::search_segment_shared_sync(
-                        segment.as_ref(),
-                        query,
-                        fetch_limit,
-                        false,
-                        shared.clone(),
-                    )?;
+                    let (mut results, segment_seen) =
+                        crate::query::search_segment_shared_sync_planned(
+                            segment.as_ref(),
+                            query,
+                            fetch_limit,
+                            false,
+                            shared.clone(),
+                            lsp_plan.clone(),
+                        )?;
                     if fetch_limit > 0 && results.len() >= fetch_limit {
                         shared.raise(results[fetch_limit - 1].score);
                     }
@@ -1008,6 +1127,39 @@ impl<D: Directory + 'static> Searcher<D> {
     }
 }
 
+/// Select one query-level top-γ set without allocating one tuple per
+/// superblock. Prepared BMP bounds are finite and non-negative, so their f32
+/// bit patterns have the same order as their numeric values.
+fn select_global_lsp_superblocks(bounds: &[Option<Vec<f32>>], gamma: usize) -> Vec<Vec<u32>> {
+    let mut top =
+        std::collections::BinaryHeap::<std::cmp::Reverse<(u32, usize, u32)>>::with_capacity(
+            gamma.min(65_536),
+        );
+    for (segment, segment_bounds) in bounds.iter().enumerate() {
+        let Some(segment_bounds) = segment_bounds else {
+            continue;
+        };
+        for (superblock, &bound) in segment_bounds.iter().enumerate() {
+            if bound <= 0.0 {
+                continue;
+            }
+            let candidate = (bound.to_bits(), segment, superblock as u32);
+            if top.len() < gamma {
+                top.push(std::cmp::Reverse(candidate));
+            } else if top.peek().is_some_and(|minimum| candidate > minimum.0) {
+                top.pop();
+                top.push(std::cmp::Reverse(candidate));
+            }
+        }
+    }
+
+    let mut selected = vec![Vec::<u32>::new(); bounds.len()];
+    for std::cmp::Reverse((_, segment, superblock)) in top {
+        selected[segment].push(superblock);
+    }
+    selected
+}
+
 /// Merge two canonically sorted batches while moving (not cloning) hits.
 /// Reductions use this eagerly, so retained cross-segment results stay O(k)
 /// instead of O(number_of_segments × k).
@@ -1144,7 +1296,9 @@ mod load_segments_tests {
 
 #[cfg(test)]
 mod search_window_tests {
-    use super::{apply_result_offset, checked_search_window, merge_two_ranked};
+    use super::{
+        apply_result_offset, checked_search_window, merge_two_ranked, select_global_lsp_superblocks,
+    };
     use crate::query::SearchResult;
 
     fn result(segment_id: u128, doc_id: u32, score: f32) -> SearchResult {
@@ -1186,6 +1340,25 @@ mod search_window_tests {
             page.iter().map(|result| result.doc_id).collect::<Vec<_>>(),
             vec![2, 3, 4]
         );
+    }
+
+    #[test]
+    fn lsp_gamma_is_global_not_per_segment() {
+        let bounds = vec![
+            Some(vec![9.0, 1.0, 8.0]),
+            Some(vec![7.0, 6.0, 0.0]),
+            None,
+            Some(vec![5.0, 4.0]),
+        ];
+        let mut selected = select_global_lsp_superblocks(&bounds, 4);
+        for segment in &mut selected {
+            segment.sort_unstable();
+        }
+        assert_eq!(selected.iter().map(Vec::len).sum::<usize>(), 4);
+        assert_eq!(selected[0], vec![0, 2]);
+        assert_eq!(selected[1], vec![0, 1]);
+        assert!(selected[2].is_empty());
+        assert!(selected[3].is_empty());
     }
 }
 

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -116,6 +116,67 @@ async fn test_bmp_needle_in_haystack() {
     assert_eq!(results.len(), 0);
 }
 
+/// LSP follows the paper's query-pruning split: the pruned terms select
+/// superblocks/blocks, but every visited document is scored with the bounded
+/// full query. Otherwise candidate pruning silently changes final scores and
+/// can reverse the ranking even inside the same selected block.
+#[tokio::test]
+async fn test_bmp_pruned_candidate_query_scores_with_full_query() {
+    let mut schema_builder = SchemaBuilder::default();
+    let title = schema_builder.add_text_field("title", true, true);
+    let sparse = schema_builder.add_sparse_vector_field_with_config(
+        "sparse",
+        true,
+        true,
+        SparseVectorConfig {
+            format: SparseFormat::Bmp,
+            weight_quantization: WeightQuantization::UInt8,
+            bmp_block_size: 32,
+            dims: Some(2),
+            max_weight: Some(5.0),
+            ..SparseVectorConfig::default()
+        },
+    );
+    let schema = schema_builder.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    let mut candidate_winner = Document::new();
+    candidate_winner.add_text(title, "candidate-only winner");
+    candidate_winner.add_sparse_vector(sparse, vec![(0, 1.0)]);
+    writer.add_document(candidate_winner).unwrap();
+
+    let mut full_query_winner = Document::new();
+    full_query_winner.add_text(title, "full-query winner");
+    full_query_winner.add_sparse_vector(sparse, vec![(0, 0.9), (1, 5.0)]);
+    writer.add_document(full_query_winner).unwrap();
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let query = SparseVectorQuery::new(sparse, vec![(0, 1.0), (1, 0.9)])
+        .with_min_query_dims(0)
+        .with_pruning(0.5)
+        .with_lsp_gamma(0);
+    assert_eq!(query.pruned_dims(), &[(0, 1.0)]);
+
+    let results = searcher.search(&query, 1).await.unwrap();
+    assert_eq!(results.len(), 1);
+    let document = searcher
+        .doc(results[0].segment_id, results[0].doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        document.get_first(title).unwrap().as_text(),
+        Some("full-query winner")
+    );
+}
+
 /// A live global BMP floor may change traversal work, never the exact top-k.
 /// This also exercises physical single-value detection on many small segments:
 /// each segment should collect `k`, not the sparse query's default `2k`.
@@ -893,6 +954,12 @@ async fn test_bmp_merge_correctness() {
         segments.len() >= 5,
         "Should have >= 5 segments before merge"
     );
+    assert!(
+        segments
+            .iter()
+            .all(|segment| segment.bmp_indexes()[&sparse.0].num_blocks == 2),
+        "100 vectors at block size 64 must use two blocks, without codec-group padding"
+    );
 
     // Force merge
     let mut writer = IndexWriter::open(dir.clone(), config.clone())
@@ -901,7 +968,11 @@ async fn test_bmp_merge_correctness() {
     writer.force_merge().await.unwrap();
 
     let index = Index::open(dir.clone(), config.clone()).await.unwrap();
-    assert_eq!(index.segment_readers().await.unwrap().len(), 1);
+    let merged_segments = index.segment_readers().await.unwrap();
+    assert_eq!(merged_segments.len(), 1);
+    let merged_bmp = &merged_segments[0].bmp_indexes()[&sparse.0];
+    assert_eq!(merged_bmp.num_blocks, (NUM_SEGS * 2) as u32);
+    assert_eq!(merged_bmp.num_virtual_docs, (NUM_SEGS * 2 * 64) as u32);
     assert_eq!(
         index.num_docs().await.unwrap() as usize,
         DOCS_PER_SEG * NUM_SEGS
@@ -957,6 +1028,76 @@ async fn test_bmp_merge_correctness() {
         DOCS_PER_SEG * NUM_SEGS,
         results.len()
     );
+}
+
+/// A source-row group can straddle two output groups when segment block
+/// counts are not 256-aligned. The shifted output group must use the width of
+/// the cells it actually receives, not the maximum width of the whole source
+/// group; otherwise repeated block-copy merges gradually inflate Section D.
+#[tokio::test]
+async fn test_bmp_merge_repacked_group_uses_exact_local_width() {
+    let mut schema_builder = SchemaBuilder::default();
+    let sparse = schema_builder.add_sparse_vector_field_with_config(
+        "sparse",
+        true,
+        true,
+        SparseVectorConfig {
+            bmp_block_size: 1,
+            dims: Some(2),
+            max_weight: Some(5.0),
+            ..bmp_config()
+        },
+    );
+    let schema = schema_builder.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    // One block shifts the following 256-block source by one output cell.
+    let mut prefix = Document::new();
+    prefix.add_sparse_vector(sparse, vec![(1, 1.0)]);
+    writer.add_document(prefix).unwrap();
+    writer.commit().await.unwrap();
+
+    // The source group needs width four because of local block zero, but its
+    // final cell needs only width one.
+    for block in 0..256 {
+        let mut document = Document::new();
+        document.add_sparse_vector(sparse, vec![(0, if block == 0 { 5.0 } else { 0.1 })]);
+        writer.add_document(document).unwrap();
+    }
+    writer.commit().await.unwrap();
+    writer.force_merge().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir, config).await.unwrap();
+    let segments = index.segment_readers().await.unwrap();
+    assert_eq!(segments.len(), 1);
+    let bmp = &segments[0].bmp_indexes()[&sparse.0];
+    assert_eq!(bmp.num_blocks, 257);
+    let grid = bmp.block_grid();
+    assert_eq!(grid.groups(), 2);
+    assert_eq!(grid.group(0, 0).unwrap().width(), 4);
+    assert_eq!(grid.group(0, 1).unwrap().width(), 1);
+
+    let mut decoded = [0u8; crate::segment::bmp_grid::GRID_GROUP_CELLS];
+    grid.group(0, 1).unwrap().decode(0, 1, &mut decoded);
+    assert_eq!(decoded[0], 1);
+
+    // Source 2 starts at output block 1. Its first source superblock therefore
+    // overlaps output superblocks 0 and 1. The pure-copy merge must propagate
+    // its ceil-u4 maximum to both destinations; recomputing only from source
+    // superblock IDs would underestimate output SB 1 and make LSP pruning
+    // unsafe.
+    let superblock_grid = bmp.superblock_grid();
+    assert_eq!(superblock_grid.max_width(), 4);
+    superblock_grid
+        .group(0, 0)
+        .unwrap()
+        .decode(0, 2, &mut decoded);
+    assert_eq!(&decoded[..2], &[15, 15]);
 }
 
 /// BMP merge large: stress test with many blocks and multi-segment merge.
@@ -2174,8 +2315,8 @@ fn bmp_schema_with_config(
     (sb.build(), title, sparse)
 }
 
-/// Block size 256 (the default) must work end-to-end: build, block-copy
-/// merge, BP reorder, and exact search.
+/// The maximum block size 256 must work end-to-end: build, block-copy merge,
+/// BP reorder, and exact search.
 #[tokio::test]
 async fn test_bmp_block_size_256_build_merge_reorder_search() {
     let (schema, _title, sparse) = bmp_schema_with_config(SparseVectorConfig {
@@ -2412,7 +2553,7 @@ async fn test_deepening_pass_on_unconverged_segment_forces_record_level() {
 
 /// Alignment of the depth budget with blockwise BP: `min_partition_docs` is
 /// in DOC units, but blockwise BP entities are BLOCKS — the cap must be
-/// converted (4096 docs = 64 blocks = exactly superblock depth), or the
+/// converted (4096 docs = 64 blocks for this test's 64-vector blocks), or the
 /// optimizer's large-segment cap silently stops blockwise BP above
 /// superblock granularity and the pass becomes an identity no-op.
 #[tokio::test]
@@ -2465,7 +2606,7 @@ async fn test_blockwise_budget_depth_cap_scales_to_block_units() {
     );
     assert_ne!(
         ids_before, ids_after,
-        "a 4096-doc depth cap = superblock depth for blockwise BP — the pass must actually permute blocks"
+        "a document-unit depth cap must be converted to blocks, so the pass actually permutes blocks"
     );
     // Ladder semantics: a pass with a depth floor above block granularity is
     // recorded UNCONVERGED so the optimizer's deepening ladder revisits it
@@ -3051,7 +3192,7 @@ async fn test_bmp_grid_bits_2_exact_parity_and_roundtrip() {
         assert_eq!(readers.len(), 1);
         let bmp = readers[0].bmp_indexes().get(&sparse.0).unwrap();
         assert_eq!(bmp.grid_bits(), grid_bits, "footer must carry grid_bits");
-        grid_sizes.push(bmp.packed_row_size());
+        grid_sizes.push(bmp.block_grid().encoded_bytes());
 
         let reader = index.reader().await.unwrap();
         let searcher = reader.searcher().await.unwrap();
@@ -3083,16 +3224,15 @@ async fn test_bmp_grid_bits_2_exact_parity_and_roundtrip() {
             assert!((a - b).abs() < 1e-3, "score mismatch {a} vs {b}");
         }
     }
-    // 2-bit grid rows are half the 4-bit rows
-    assert_eq!(grid_sizes[1], grid_sizes[0].div_ceil(2));
+    // Selector/checkpoint metadata is shared, so the complete compressed
+    // section is not exactly half-sized; the narrower payload must still win.
+    assert!(grid_sizes[1] < grid_sizes[0]);
 }
 
-/// Regression: blockwise reorder used to write the superblock grid in
-/// GRID-CELL scale (0-15) instead of u8 impact scale (0-255), deflating
-/// superblock UBs ~17× — unsafe pruning (silent recall loss) once the heap
-/// fills. Pin the structural invariant directly: the sb_grid's maximum
-/// value must survive a blockwise pass (builder writes u8 impacts; the
-/// needle dims here have impact ≈51, which the bug collapses to cell 3).
+/// Regression: the superblock grid is ceiling-quantized directly from exact
+/// block-header impacts. A BP/reorder pass must reproduce that same scale,
+/// neither omitting the query-time ×17 multiplier nor quantizing an already
+/// quantized cell a second time.
 #[tokio::test]
 async fn test_blockwise_reorder_preserves_sb_grid_scale() {
     let (schema, _title, sparse) = bmp_schema();
@@ -3109,13 +3249,25 @@ async fn test_blockwise_reorder_preserves_sb_grid_scale() {
         let index = Index::open(dir, config).await.unwrap();
         let readers = index.segment_readers().await.unwrap();
         let bmp = readers[0].bmp_indexes().get(&sparse.0).unwrap();
-        bmp.sb_grid_slice().iter().copied().max().unwrap_or(0)
+        let grid = bmp.superblock_grid();
+        let mut decoded = [0u8; crate::segment::bmp_grid::GRID_GROUP_CELLS];
+        let mut maximum = 0u8;
+        for dimension in 0..grid.dims() {
+            for group_id in 0..grid.groups() {
+                let group = grid.group(dimension, group_id).unwrap();
+                if group.width() == 0 {
+                    continue;
+                }
+                let start = group_id * crate::segment::bmp_grid::GRID_GROUP_CELLS;
+                let count = crate::segment::bmp_grid::GRID_GROUP_CELLS.min(grid.cells() - start);
+                group.decode(0, count, &mut decoded);
+                maximum = maximum.max(decoded[..count].iter().copied().max().unwrap_or(0));
+            }
+        }
+        maximum
     };
     let before = sb_max(dir.clone(), config.clone()).await;
-    assert!(
-        before > 15,
-        "test setup: builder sb_grid must carry u8 impacts (got max {before})"
-    );
+    assert_eq!(before, 3, "test setup: ceil(impact 51 / 17)");
 
     // Blockwise pass (Auto picks Blocks for this corpus — pinned elsewhere)
     let mut writer = IndexWriter::open(dir.clone(), config.clone())
@@ -3127,8 +3279,7 @@ async fn test_blockwise_reorder_preserves_sb_grid_scale() {
     let after = sb_max(dir.clone(), config.clone()).await;
     assert_eq!(
         after, before,
-        "blockwise reorder must preserve sb_grid impact scale (0-255) — \
-         cell-scale values (≤15) deflate superblock UBs ~17× (unsafe pruning)"
+        "blockwise reorder must rebuild the same ceil-u4 bound from exact block headers"
     );
 }
 
@@ -3277,7 +3428,7 @@ async fn bench_forward_index_build() {
 /// posting prefix sums at build time (bmp_block_size=256 × ~300-dim docs
 /// hits this in production), silently corrupting the block; the reader's
 /// `end - start` then underflowed into a wild posting slice — SIGSEGV in
-/// the BP forward-index build (optimizer-bp threads). V14 and later store
+/// the BP forward-index build (optimizer-bp threads). The current format stores
 /// num_terms and prefix sums as u32.
 #[tokio::test]
 async fn test_bmp_block_posting_overflow_256() {

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -14,7 +14,7 @@
 //!
 //! ## Three-level pruning hierarchy
 //!
-//! 1. **LSP/0 gamma cap**: Hard limit on superblock visits (prevents tail waste)
+//! 1. **LSP/0 top-γ**: Visit only the highest-SBMax superblocks
 //! 2. **Superblock UBs** (~1.2K entries at 1M×5): cheap to compute, prune 25-75%
 //! 3. **Block UBs** (only for surviving superblocks): L1-cache friendly per-SB
 //!
@@ -24,10 +24,10 @@
 //! only flat contiguous arrays — no file I/O, no parsing, no heap allocation
 //! in the hot path.
 //!
-//! - **LSP/0 gamma cap**: Hard limit on superblock visits for predictable latency
+//! - **LSP/0 top-γ**: strict SBMax order with safe superblock-level pruning
 //! - **Integer scoring**: u32 accumulators with u16 quantized query weights (~20% faster)
 //! - **Superblock pruning**: Skip entire groups of blocks via coarse UBs
-//! - **L1 cache locality**: SaaT loop keeps c=64 blocks' grid data in L1
+//! - **L1 cache locality**: SaaT loop keeps eight blocks' grid data in registers/L1
 //! - **Integer-consistent UBs**: bounds and document scores share exact accumulator units
 //! - **Pre-scaled weights**: `weight * scale` computed once, not per-block
 //! - **Bitmask skip**: Register-level mask check replaces grid DRAM lookups
@@ -38,10 +38,11 @@
 //! - **Early termination**: stop when superblock/block UB < top-k threshold
 
 use super::scoring::{ScoreCollector, ScoredDoc, SharedThreshold};
-use crate::segment::{
-    BMP_SUPERBLOCK_SIZE, BmpIndex, accumulate_grid_u32, block_term_postings, compute_block_masks,
-    find_dim_in_block_data,
+use crate::segment::bmp_grid::{
+    CompressedGrid, GRID_GROUP_CELLS, LSP_SUPERBLOCK_GRID_BITS, accumulate_packed_u4,
+    accumulate_u8, block_grid_scale,
 };
+use crate::segment::{BMP_SUPERBLOCK_SIZE, BmpIndex, block_term_postings, find_dim_in_block_data};
 
 // dim_id is used directly as grid row index. No dim_idx indirection.
 
@@ -81,29 +82,27 @@ fn prefetch_read<T>(ptr: *const T) {
 ///
 /// Two-level hierarchy:
 /// - **Superblock-level**: sized to num_superblocks, for SB ordering + early termination
-/// - **Local block-level**: sized to BMP_SUPERBLOCK_SIZE (64), for per-SB block computation
+/// - **Local block-level**: sized to BMP_SUPERBLOCK_SIZE (8), for per-SB block computation
 /// - **Accumulator**: u32 sized to bmp_block_size, reused per block (integer scoring)
 #[derive(Default)]
 struct BmpScratch {
     // Superblock-level (reused across queries, sized to num_superblocks)
     sb_ubs: Vec<f32>,
+    sb_ub_units: Vec<u32>,
     sb_order: Vec<u32>,
-    sb_priorities: Vec<f32>,
-    sb_suffix_max: Vec<f32>,
     // Block-level (reused per superblock, sized to BMP_SUPERBLOCK_SIZE)
     local_block_ubs: Vec<f32>,
     local_block_ub_units: Vec<u32>,
-    local_block_masks: Vec<u64>,
+    query_presence: Vec<u64>,
     local_block_order: Vec<u32>,
     // Two-phase block scoring: phase1 block UBs (sized to BMP_SUPERBLOCK_SIZE)
     phase1_local_block_ubs: Vec<f32>,
     phase1_local_block_ub_units: Vec<u32>,
     // Per-slot accumulator (sized to block_size) — u32 for integer scoring
     acc: Vec<u32>,
-    // Compact grid buffers: query-relevant dim rows copied contiguously for L1 locality.
-    // Resized per query to num_query_dims × row_size. Typical: 20 dims → ~16KB total.
-    compact_sb_grid: Vec<u8>,
-    compact_grid: Vec<u8>,
+    // One decoded random-access group. D uses at most eight values per visit; E
+    // uses the full 256-cell group.
+    decoded_grid_group: Vec<u8>,
 }
 
 impl BmpScratch {
@@ -112,24 +111,17 @@ impl BmpScratch {
         if self.sb_ubs.len() < num_superblocks {
             self.sb_ubs.resize(num_superblocks, 0.0);
         }
+        if self.sb_ub_units.len() < num_superblocks {
+            self.sb_ub_units.resize(num_superblocks, 0);
+        }
         if self.sb_order.capacity() < num_superblocks {
             self.sb_order.reserve(num_superblocks - self.sb_order.len());
-        }
-        if self.sb_priorities.len() < num_superblocks {
-            self.sb_priorities.resize(num_superblocks, 0.0);
-        }
-        // suffix_max needs num_superblocks + 1 for sentinel
-        if self.sb_suffix_max.len() < num_superblocks + 1 {
-            self.sb_suffix_max.resize(num_superblocks + 1, 0.0);
         }
         if self.local_block_ubs.len() < sb_size {
             self.local_block_ubs.resize(sb_size, 0.0);
         }
         if self.local_block_ub_units.len() < sb_size {
             self.local_block_ub_units.resize(sb_size, 0);
-        }
-        if self.local_block_masks.len() < sb_size {
-            self.local_block_masks.resize(sb_size, 0u64);
         }
         if self.local_block_order.len() < sb_size {
             self.local_block_order.resize(sb_size, 0);
@@ -146,6 +138,9 @@ impl BmpScratch {
         let safe_acc_size = block_size.max(256);
         if self.acc.len() < safe_acc_size {
             self.acc.resize(safe_acc_size, 0);
+        }
+        if self.decoded_grid_group.len() < GRID_GROUP_CELLS {
+            self.decoded_grid_group.resize(GRID_GROUP_CELLS, 0);
         }
     }
 }
@@ -167,6 +162,170 @@ pub(crate) struct BmpThreshold<'a> {
     pub publish: bool,
 }
 
+struct BmpQueryWeights {
+    query_by_dim_u16: Vec<(u32, u16)>,
+    candidate_grid_weights: Vec<BmpGridWeight>,
+    candidate_mask: u64,
+    dequant: f32,
+}
+
+#[derive(Clone, Copy)]
+struct BmpGridWeight {
+    dimension: usize,
+    weight: u16,
+    query_index: usize,
+}
+
+/// Globally selected LSP/0 superblocks for one segment.
+///
+/// The multi-segment searcher computes all segment SBMax values first and
+/// partitions the single query-level top-γ set into these segment plans. This
+/// prevents a 50-segment index from silently turning γ into `50 × γ`.
+#[derive(Debug)]
+pub(crate) struct LspSegmentPlan {
+    pub(crate) sb_ubs: Vec<f32>,
+    pub(crate) sb_order: Vec<u32>,
+}
+
+/// Robust zero-shot γ schedule reported for LSP/0.
+///
+/// The paper evaluates 250 for k=10, 500 for k=100, and 1000 for k=1000.
+/// Beyond the evaluated range we avoid inventing a sublinear cap: γ grows
+/// with the requested depth and is never smaller than 2000.
+pub(crate) const fn recommended_lsp_gamma(retrieval_depth: usize) -> usize {
+    match retrieval_depth {
+        0..=10 => 250,
+        11..=100 => 500,
+        101..=1000 => 1000,
+        _ => {
+            if retrieval_depth < 2000 {
+                2000
+            } else {
+                retrieval_depth
+            }
+        }
+    }
+}
+
+fn prepare_bmp_query(
+    index: &BmpIndex,
+    candidate_terms: &[(u32, f32)],
+    scoring_terms: &[(u32, f32)],
+) -> crate::Result<Option<BmpQueryWeights>> {
+    let dims = index.dims();
+    let mut query_info: Vec<(u32, f32)> = scoring_terms
+        .iter()
+        .filter_map(|&(dimension, weight)| {
+            (dimension < dims && weight.is_finite() && weight != 0.0)
+                .then_some((dimension, weight.abs()))
+        })
+        .collect();
+    if query_info.is_empty() {
+        return Ok(None);
+    }
+    if query_info.len() > crate::query::MAX_QUERY_TERMS {
+        return Err(crate::Error::Query(format!(
+            "BMP query has {} resolved dimensions; maximum is {}",
+            query_info.len(),
+            crate::query::MAX_QUERY_TERMS
+        )));
+    }
+    query_info.sort_unstable_by_key(|&(dimension, _)| dimension);
+
+    let max_query_weight = query_info
+        .iter()
+        .map(|&(_, weight)| weight)
+        .fold(0.0f32, f32::max);
+    let accumulator_denominator = 255u64.saturating_mul(query_info.len() as u64);
+    let max_quantized_weight = ((u32::MAX as u64) / accumulator_denominator).min(16_383);
+    if max_quantized_weight == 0 {
+        return Err(crate::Error::Query(format!(
+            "BMP query has too many resolved dimensions ({})",
+            query_info.len()
+        )));
+    }
+    let quant_scale = max_quantized_weight as f32 / max_query_weight;
+    let dequant =
+        (max_query_weight / max_quantized_weight as f32) * (index.max_weight_scale / 255.0);
+    if !dequant.is_finite() {
+        return Err(crate::Error::Query(
+            "BMP query score scale exceeds the finite f32 range".into(),
+        ));
+    }
+
+    let query_by_dim_u16: Vec<(u32, u16)> = query_info
+        .iter()
+        .map(|&(dimension, weight)| {
+            (
+                dimension,
+                (weight * quant_scale)
+                    .round()
+                    .clamp(0.0, max_quantized_weight as f32) as u16,
+            )
+        })
+        .collect();
+    let mut candidate_dimensions: Vec<u32> = candidate_terms
+        .iter()
+        .filter_map(|&(dimension, weight)| {
+            (dimension < dims && weight.is_finite() && weight != 0.0).then_some(dimension)
+        })
+        .collect();
+    candidate_dimensions.sort_unstable();
+    candidate_dimensions.dedup();
+    let mut candidate_mask = 0u64;
+    let mut candidate_grid_weights = Vec::with_capacity(candidate_dimensions.len());
+    let mut candidate_index = 0usize;
+    for (query_index, &(dimension, weight)) in query_by_dim_u16.iter().enumerate() {
+        while candidate_dimensions
+            .get(candidate_index)
+            .is_some_and(|&candidate| candidate < dimension)
+        {
+            candidate_index += 1;
+        }
+        if candidate_dimensions.get(candidate_index) == Some(&dimension) {
+            candidate_mask |= 1u64 << query_index;
+            candidate_grid_weights.push(BmpGridWeight {
+                dimension: dimension as usize,
+                weight,
+                query_index,
+            });
+        }
+    }
+    if candidate_grid_weights.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(BmpQueryWeights {
+        query_by_dim_u16,
+        candidate_grid_weights,
+        candidate_mask,
+        dequant,
+    }))
+}
+
+/// Compute one segment's SBMax vector for the global LSP/0 selection pass.
+pub(crate) fn prepare_lsp_superblock_ubs(
+    index: &BmpIndex,
+    candidate_terms: &[(u32, f32)],
+    scoring_terms: &[(u32, f32)],
+) -> crate::Result<Vec<f32>> {
+    let Some(weights) = prepare_bmp_query(index, candidate_terms, scoring_terms)? else {
+        return Ok(vec![0.0; index.num_superblocks as usize]);
+    };
+    let count = index.num_superblocks as usize;
+    let mut units = vec![0u32; count];
+    let mut bounds = vec![0.0f32; count];
+    let mut decoded = [0u8; GRID_GROUP_CELLS];
+    compute_sb_ubs_int(
+        index.superblock_grid(),
+        &weights.candidate_grid_weights,
+        weights.dequant,
+        &mut units,
+        &mut bounds,
+        &mut decoded,
+    )?;
+    Ok(bounds)
+}
+
 /// Execute a BMP query against the given index.
 ///
 /// Returns top-k results sorted by score descending.
@@ -174,7 +333,7 @@ pub(crate) struct BmpThreshold<'a> {
 /// (doc_id, ordinal) pairs at collection time. The caller's `combine_ordinal_results`
 /// handles multi-ordinal grouping via the configured combiner.
 ///
-/// Uses superblock pruning: computes coarse UBs over groups of 64 blocks,
+/// Uses LSP/0 pruning: computes coarse UBs over groups of eight blocks,
 /// prunes entire superblocks, then scores only surviving blocks.
 ///
 /// `heap_factor` controls approximate retrieval (BMP alpha parameter):
@@ -182,9 +341,9 @@ pub(crate) struct BmpThreshold<'a> {
 /// - **0.8**: prune when `UB * 0.8 < threshold` → ~20% more aggressive
 /// - **0.6**: prune when `UB * 0.6 < threshold` → ~40% more aggressive
 ///
-/// `max_superblocks` (LSP/0 gamma cap): hard limit on superblock visits.
-/// - **0**: unlimited (default, existing behavior)
-/// - **>0**: stop after visiting this many superblocks
+/// `lsp_gamma` is the paper's γ: the maximum number of highest-SBMax
+/// superblocks selected for block traversal. Zero means exhaustive top-down
+/// traversal while retaining the same safe superblock stopping condition.
 ///
 /// Based on Mallia et al. (SIGIR 2024) and Carlson et al. (arXiv 2602.02883).
 #[allow(dead_code)]
@@ -195,16 +354,18 @@ pub fn execute_bmp(
     query_terms: &[(u32, f32)],
     k: usize,
     heap_factor: f32,
-    max_superblocks: usize,
+    lsp_gamma: usize,
 ) -> crate::Result<Vec<ScoredDoc>> {
     execute_bmp_inner(
         index,
         index_label,
         field_label,
         query_terms,
+        query_terms,
         k,
         heap_factor,
-        max_superblocks,
+        lsp_gamma,
+        None,
         None,
         BmpThreshold::default(),
     )
@@ -216,20 +377,24 @@ pub(crate) fn execute_bmp_with_threshold(
     index: &BmpIndex,
     index_label: &str,
     field_label: &str,
-    query_terms: &[(u32, f32)],
+    candidate_terms: &[(u32, f32)],
+    scoring_terms: &[(u32, f32)],
     k: usize,
     heap_factor: f32,
-    max_superblocks: usize,
+    lsp_gamma: usize,
+    lsp_plan: Option<&LspSegmentPlan>,
     threshold: BmpThreshold<'_>,
 ) -> crate::Result<Vec<ScoredDoc>> {
     execute_bmp_inner(
         index,
         index_label,
         field_label,
-        query_terms,
+        candidate_terms,
+        scoring_terms,
         k,
         heap_factor,
-        max_superblocks,
+        lsp_gamma,
+        lsp_plan,
         None,
         threshold,
     )
@@ -249,7 +414,7 @@ pub fn execute_bmp_filtered(
     query_terms: &[(u32, f32)],
     k: usize,
     heap_factor: f32,
-    max_superblocks: usize,
+    lsp_gamma: usize,
     predicate: &dyn Fn(crate::DocId) -> bool,
 ) -> crate::Result<Vec<ScoredDoc>> {
     execute_bmp_inner(
@@ -257,9 +422,11 @@ pub fn execute_bmp_filtered(
         index_label,
         field_label,
         query_terms,
+        query_terms,
         k,
         heap_factor,
-        max_superblocks,
+        lsp_gamma,
+        None,
         Some(predicate),
         BmpThreshold::default(),
     )
@@ -271,10 +438,12 @@ pub(crate) fn execute_bmp_filtered_with_threshold(
     index: &BmpIndex,
     index_label: &str,
     field_label: &str,
-    query_terms: &[(u32, f32)],
+    candidate_terms: &[(u32, f32)],
+    scoring_terms: &[(u32, f32)],
     k: usize,
     heap_factor: f32,
-    max_superblocks: usize,
+    lsp_gamma: usize,
+    lsp_plan: Option<&LspSegmentPlan>,
     predicate: &dyn Fn(crate::DocId) -> bool,
     threshold: BmpThreshold<'_>,
 ) -> crate::Result<Vec<ScoredDoc>> {
@@ -282,10 +451,12 @@ pub(crate) fn execute_bmp_filtered_with_threshold(
         index,
         index_label,
         field_label,
-        query_terms,
+        candidate_terms,
+        scoring_terms,
         k,
         heap_factor,
-        max_superblocks,
+        lsp_gamma,
+        lsp_plan,
         Some(predicate),
         threshold,
     )
@@ -296,14 +467,16 @@ fn execute_bmp_inner(
     index: &BmpIndex,
     index_label: &str,
     field_label: &str,
-    query_terms: &[(u32, f32)],
+    candidate_terms: &[(u32, f32)],
+    scoring_terms: &[(u32, f32)],
     k: usize,
     heap_factor: f32,
-    max_superblocks: usize,
+    lsp_gamma: usize,
+    lsp_plan: Option<&LspSegmentPlan>,
     predicate: Option<&dyn Fn(crate::DocId) -> bool>,
     threshold_source: BmpThreshold<'_>,
 ) -> crate::Result<Vec<ScoredDoc>> {
-    if query_terms.is_empty() || index.num_blocks == 0 || k == 0 {
+    if candidate_terms.is_empty() || scoring_terms.is_empty() || index.num_blocks == 0 || k == 0 {
         return Ok(Vec::new());
     }
 
@@ -311,95 +484,20 @@ fn execute_bmp_inner(
     // UB * alpha < threshold → prune when UB < threshold / alpha
     // alpha < 1.0 means more aggressive pruning (approximate but faster)
     let alpha = heap_factor.clamp(0.01, 1.0);
-    let scale = index.max_weight_scale / 255.0;
     let num_blocks = index.num_blocks as usize;
     let block_size = index.bmp_block_size as usize;
     let num_superblocks_total = index.num_superblocks as usize;
 
     // ── Phase 1: Resolve query dimensions and quantize weights ────────
-    // dim_id is used directly as grid row index (no dim_idx indirection).
-    // Build combined info, sort by dim_id, then split into resolved + query_by_dim_u16.
-    // Both arrays MUST have the same ordering so mask bit `q` corresponds to the
-    // same dimension in both compute_block_masks (uses resolved) and
-    // score_block_bsearch_int (uses query_by_dim_u16).
-    let dims = index.dims();
-    let mut query_info: Vec<(u32, usize, f32)> = Vec::with_capacity(query_terms.len());
-
-    for &(dim_id, weight) in query_terms {
-        // dim_id IS the grid row index — just check bounds
-        if dim_id < dims && weight.is_finite() && weight != 0.0 {
-            // BMP stores absolute document impacts. Upper bounds and integer
-            // scoring must use the same absolute query weight; keeping the
-            // sign only in the grid path could under-estimate a block and
-            // prune a result that the scorer later treated as positive.
-            query_info.push((dim_id, dim_id as usize, weight.abs()));
-        }
-    }
-
-    if query_info.is_empty() {
+    let Some(prepared_query) = prepare_bmp_query(index, candidate_terms, scoring_terms)? else {
         return Ok(Vec::new());
-    }
-
-    // Block masks and the two-phase scorer use one u64 bit per query term.
-    // SparseVectorQuery enforces this already; reject oversized direct calls
-    // rather than silently producing an incomplete mask.
-    if query_info.len() > crate::query::MAX_QUERY_TERMS {
-        return Err(crate::Error::Query(format!(
-            "BMP query has {} resolved dimensions; maximum is {}",
-            query_info.len(),
-            crate::query::MAX_QUERY_TERMS
-        )));
-    }
-
-    // Sort by dim_id for binary search within blocks (blocks store dim_id directly).
-    query_info.sort_unstable_by_key(|&(dim_id, _, _)| dim_id);
-
-    // Integer scoring: adapt the quantizer to query width so the documented
-    // u32 accumulator bound remains true for queries wider than 1024 dims.
-    let max_query_weight = query_info.iter().map(|q| q.2).fold(0.0f32, f32::max);
-    let accumulator_denominator = 255u64.saturating_mul(query_info.len() as u64);
-    let max_quantized_weight = ((u32::MAX as u64) / accumulator_denominator).min(16_383);
-    if max_quantized_weight == 0 {
-        return Err(crate::Error::Query(format!(
-            "BMP query has too many resolved dimensions ({})",
-            query_info.len()
-        )));
-    }
-    let (quant_scale, dequant) = if max_query_weight > 0.0 {
-        (
-            max_quantized_weight as f32 / max_query_weight,
-            (max_query_weight / max_quantized_weight as f32) * scale,
-        )
-    } else {
-        (0.0, 0.0)
     };
-    // query_by_dim_u16 stores (dim_id, weight) — matches per-block dim_ids
-    let query_by_dim_u16: Vec<(u32, u16)> = query_info
-        .iter()
-        .map(|&(dim_id, _, w)| {
-            (
-                dim_id,
-                (w.abs() * quant_scale)
-                    .round()
-                    .clamp(0.0, max_quantized_weight as f32) as u16,
-            )
-        })
-        .collect();
-    if !dequant.is_finite() {
-        return Err(crate::Error::Query(
-            "BMP query score scale exceeds the finite f32 range".into(),
-        ));
-    }
-
-    // Block and superblock bounds use the exact integer-scoring weight
-    // (quantized query × common dequantizer), not the original f32 weight.
-    // Otherwise rounding a query weight upward could make a scored document
-    // slightly exceed its block bound and be pruned incorrectly.
-    let resolved: Vec<(usize, f32)> = query_info
-        .iter()
-        .zip(&query_by_dim_u16)
-        .map(|(&(.., grid_index, _), &(_, weight))| (grid_index, weight as f32 * dequant))
-        .collect();
+    let BmpQueryWeights {
+        query_by_dim_u16,
+        candidate_grid_weights,
+        candidate_mask,
+        dequant,
+    } = prepared_query;
 
     // ── Two-phase lazy block scoring setup ────────────────────────────
     // For queries with >5 dims, score only the top-3 heaviest dims first (phase1).
@@ -407,7 +505,8 @@ fn execute_bmp_inner(
     // For ≤5 dims: full scoring directly (zero overhead).
     const PHASE1_DIMS: usize = 3;
     const MIN_DIMS_FOR_TWO_PHASE: usize = 6;
-    let two_phase_active = (MIN_DIMS_FOR_TWO_PHASE..=64).contains(&query_by_dim_u16.len());
+    let two_phase_active = candidate_mask.count_ones() as usize == query_by_dim_u16.len()
+        && (MIN_DIMS_FOR_TWO_PHASE..=64).contains(&query_by_dim_u16.len());
     // phase1_mask: bitmask of which query dim indices are in phase1
     let phase1_mask: u64 = if two_phase_active {
         let mut weight_indices: Vec<(u16, usize)> = query_by_dim_u16
@@ -422,15 +521,6 @@ fn execute_bmp_inner(
     } else {
         u64::MAX
     };
-    // phase1 grid dims for UB computation (indices into grid_dims/resolved)
-    let phase1_grid_indices: Vec<usize> = if two_phase_active {
-        (0..query_by_dim_u16.len())
-            .filter(|&i| phase1_mask & (1u64 << i) != 0)
-            .collect()
-    } else {
-        Vec::new()
-    };
-
     // The planner has already applied the configured ordinal over-fetch factor
     // to `k`.  Do not derive another factor from num_virtual_docs: that ratio
     // includes block-alignment padding and used to multiply the heap depth a
@@ -439,7 +529,7 @@ fn execute_bmp_inner(
 
     let t_start = std::time::Instant::now();
 
-    let result = BMP_SCRATCH.with(|cell| {
+    let result = BMP_SCRATCH.with(|cell| -> crate::Result<Vec<ScoredDoc>> {
         let scratch = &mut *cell.borrow_mut();
 
         // ── Superblock-at-a-time scoring ─────────────────────────────
@@ -449,114 +539,61 @@ fn execute_bmp_inner(
             block_size,
         );
 
-        let prs = index.packed_row_size();
-
-        // ── Grid access strategy ─────────────────────────────────────
-        // For small segments: copy query-relevant grid rows into compact
-        // buffers that fit L1 cache (~16KB for 20 dims × 750 blocks).
-        // For large segments: use mmap-backed grid directly (zero alloc)
-        // to avoid multi-MB thread-local scratch that never shrinks.
-        const COMPACT_GRID_MAX: usize = 128 * 1024; // 128KB — fits L2 comfortably
-        let compact_sb_size = resolved.len().saturating_mul(num_superblocks_total);
-        let compact_grid_size = resolved.len().saturating_mul(prs);
-        let use_compact = compact_sb_size.saturating_add(compact_grid_size) <= COMPACT_GRID_MAX;
-
-        // grid_dims: (dim_index_into_grid, weight) — local for compact, global for direct
-        let grid_dims: Vec<(usize, f32)>;
-        // sb_int_weights: (dim_index_into_sb_grid, u16_weight) — for integer-consistent SB UBs
-        let sb_int_weights: Vec<(usize, u16)>;
-        let sb_grid_slice: &[u8];
-        let grid_slice: &[u8];
-
-        if use_compact {
-            let dim_indices: Vec<usize> = resolved.iter().map(|&(idx, _)| idx).collect();
-            index.extract_compact_grids(
-                &dim_indices,
-                &mut scratch.compact_sb_grid,
-                &mut scratch.compact_grid,
-            );
-            grid_dims = (0..resolved.len()).map(|i| (i, resolved[i].1)).collect();
-            sb_int_weights = (0..resolved.len())
-                .map(|i| (i, query_by_dim_u16[i].1))
-                .collect();
-            sb_grid_slice = &scratch.compact_sb_grid;
-            grid_slice = &scratch.compact_grid;
-        } else {
-            // Direct mmap access — zero allocation. Grid layout uses global dim indices.
-            grid_dims = resolved.clone();
-            sb_int_weights = resolved
-                .iter()
-                .enumerate()
-                .map(|(i, &(idx, _))| (idx, query_by_dim_u16[i].1))
-                .collect();
-            sb_grid_slice = index.sb_grid_slice();
-            grid_slice = index.grid_slice();
-            // Shrink oversized compact buffers from previous queries
-            if scratch.compact_grid.capacity() > COMPACT_GRID_MAX {
-                scratch.compact_sb_grid = Vec::new();
-                scratch.compact_grid = Vec::new();
+        let (sb_ubs, sb_order, superblock_visit_limit) = if let Some(plan) = lsp_plan {
+            if plan.sb_ubs.len() != num_superblocks_total {
+                return Err(crate::Error::Internal(format!(
+                    "global LSP/0 plan has {} bounds for {} superblocks",
+                    plan.sb_ubs.len(),
+                    num_superblocks_total
+                )));
             }
-        }
-
-        let phase1_int_weights: Vec<(usize, u16)> = if two_phase_active {
-            phase1_grid_indices
+            if plan
+                .sb_order
                 .iter()
-                .map(|&index| sb_int_weights[index])
-                .collect()
+                .any(|&superblock| superblock as usize >= num_superblocks_total)
+            {
+                return Err(crate::Error::Internal(
+                    "global LSP/0 plan contains an invalid superblock id".into(),
+                ));
+            }
+            (
+                plan.sb_ubs.as_slice(),
+                plan.sb_order.as_slice(),
+                plan.sb_order.len(),
+            )
         } else {
-            Vec::new()
+            // Single-segment/direct execution computes its own SBMax order.
+            compute_sb_ubs_int(
+                index.superblock_grid(),
+                &candidate_grid_weights,
+                dequant,
+                &mut scratch.sb_ub_units,
+                &mut scratch.sb_ubs,
+                &mut scratch.decoded_grid_group,
+            )?;
+            // LSP/0 requires strict non-increasing SBMax order. A secondary
+            // coverage heuristic would change membership in top-γ.
+            sort_sb_desc_into(
+                &scratch.sb_ubs[..num_superblocks_total],
+                &mut scratch.sb_order,
+            );
+            let visit_limit = if lsp_gamma == 0 {
+                scratch.sb_order.len()
+            } else {
+                lsp_gamma.min(scratch.sb_order.len())
+            };
+            (
+                &scratch.sb_ubs[..num_superblocks_total],
+                scratch.sb_order.as_slice(),
+                visit_limit,
+            )
         };
 
-        // Phase 2: Compute SUPERBLOCK UBs using integer weights (matching scoring path)
-        compute_sb_ubs_int(
-            sb_grid_slice,
-            num_superblocks_total,
-            &sb_int_weights,
-            dequant,
-            &mut scratch.sb_ubs,
-        );
-
-        // Coverage-biased SB ordering: boost SBs with higher query-dim coverage.
-        // Count how many query dims are active in each SB (non-zero sb_grid value).
-        let nqd = sb_int_weights.len();
-        for sb in 0..num_superblocks_total {
-            let base_ub = scratch.sb_ubs[sb];
-            if base_ub == 0.0 {
-                scratch.sb_priorities[sb] = 0.0;
-                continue;
-            }
-            let mut coverage = 0u32;
-            for &(local_idx, _) in &sb_int_weights {
-                if sb_grid_slice[local_idx * num_superblocks_total + sb] > 0 {
-                    coverage += 1;
-                }
-            }
-            // Boost: high-coverage SBs get +5% priority boost (breaks ties, doesn't
-            // significantly reorder SBs with very different UBs).
-            let cf = coverage as f32 / nqd as f32;
-            scratch.sb_priorities[sb] = base_ub * (1.0 + cf * 0.05);
+        if sb_order.is_empty() {
+            return Ok(Vec::new());
         }
 
-        sort_sb_desc_into(
-            &scratch.sb_priorities[..num_superblocks_total],
-            &mut scratch.sb_order,
-        );
-
-        if scratch.sb_order.is_empty() {
-            return Vec::new();
-        }
-
-        // Pre-compute suffix-max of ACTUAL UBs for safe early termination.
-        // Because coverage-biased ordering is non-monotonic in UB, we can't `break`
-        // on a single low-UB SB. Instead we `break` when the max UB of ALL remaining
-        // SBs < threshold — guaranteed correct while retaining canonical ties.
-        compute_suffix_max_ubs(
-            &scratch.sb_ubs,
-            &scratch.sb_order,
-            &mut scratch.sb_suffix_max,
-        );
-
-        // Phase 3: Score superblocks in priority-descending order
+        // Phase 3: score the selected superblocks in SBMax-descending order.
         let mut blocks_scored = 0u32;
         let mut docmap_lookups = 0u32;
         let mut sbs_scored = 0u32;
@@ -568,33 +605,27 @@ fn execute_bmp_inner(
             .max(threshold_source.initial);
         collector.seed_threshold(initial_threshold);
 
-        for (idx, &sb_id) in scratch.sb_order.iter().enumerate() {
+        for (idx, &sb_id) in sb_order.iter().take(superblock_visit_limit).enumerate() {
             if let Some(shared) = threshold_source.shared {
                 collector.seed_threshold(shared.get());
             }
-            // LSP/0: hard cap on superblock visits
-            if max_superblocks > 0 && idx >= max_superblocks {
-                break;
-            }
+            let sb_ub = sb_ubs[sb_id as usize];
 
-            // Safe early termination: max UB of ALL remaining SBs < threshold
-            if collector.len() >= collector_k
-                && scratch.sb_suffix_max[idx] * alpha < collector.threshold()
-            {
+            // LSP/0's superblock condition is SBMax >= theta. Eta/alpha is
+            // deliberately NOT applied here; it belongs only to block
+            // pruning. With an unpruned query this is rank-safe; candidate
+            // query pruning is the paper's intentional approximation while
+            // final document scores still use the full query.
+            let threshold = collector.threshold();
+            if threshold > 0.0 && sb_ub < threshold {
                 break;
-            }
-
-            // Individual SB skip (continue, not break — ordering is non-monotonic in UB)
-            let sb_ub = scratch.sb_ubs[sb_id as usize];
-            if collector.len() >= collector_k && sb_ub * alpha < collector.threshold() {
-                continue;
             }
 
             let block_start = sb_id as usize * BMP_SUPERBLOCK_SIZE as usize;
             let block_end = (block_start + BMP_SUPERBLOCK_SIZE as usize).min(num_blocks);
             let count = block_end - block_start;
 
-            // Level 1: Warm block_data_starts for this superblock (~520 bytes, 8-9 cache lines).
+            // Warm one cache line of block offsets for this eight-block superblock.
             // Ensures block_data_ptr() never stalls on offset lookups during scoring.
             // Range includes the sentinel at block_end (needed by block_data_range).
             {
@@ -605,42 +636,28 @@ fn execute_bmp_inner(
                 }
             }
 
-            // Compute block UBs + masks from grid
-            compute_block_ubs_int(
-                grid_slice,
+            // Decode every candidate-generation dimension once for this
+            // eight-block range. The same pass accumulates full/phase-one
+            // candidate bounds and produces a block-presence bitset. Final
+            // payload scoring below still evaluates all bounded query terms.
+            let blocks_with_query_terms = compute_block_ubs_and_presence(
+                index.block_grid(),
                 index.grid_bits(),
-                prs,
-                &sb_int_weights,
+                &candidate_grid_weights,
+                query_by_dim_u16.len(),
+                phase1_mask,
                 block_start,
-                block_end,
-                dequant,
+                count,
                 &mut scratch.local_block_ub_units,
+                &mut scratch.phase1_local_block_ub_units,
                 &mut scratch.local_block_ubs,
-            );
-            compute_block_masks(
-                grid_slice,
-                index.grid_bits(),
-                prs,
-                &grid_dims,
-                block_start,
-                block_end - block_start,
-                &mut scratch.local_block_masks,
-            );
-
-            // Two-phase: compute phase1 block UBs (only top-3 dims)
-            if two_phase_active {
-                compute_block_ubs_int(
-                    grid_slice,
-                    index.grid_bits(),
-                    prs,
-                    &phase1_int_weights,
-                    block_start,
-                    block_end,
-                    dequant,
-                    &mut scratch.phase1_local_block_ub_units,
-                    &mut scratch.phase1_local_block_ubs,
-                );
-            }
+                &mut scratch.phase1_local_block_ubs,
+                &mut scratch.query_presence,
+                &mut scratch.decoded_grid_group,
+                dequant,
+            )?;
+            #[cfg(not(feature = "native"))]
+            let _ = blocks_with_query_terms;
 
             sort_local_blocks_desc(
                 &scratch.local_block_ubs[..count],
@@ -667,7 +684,7 @@ fn execute_bmp_inner(
                     if heap_full && scratch.local_block_ubs[li] * alpha < thr {
                         break;
                     }
-                    if scratch.local_block_masks[li] == 0 {
+                    if blocks_with_query_terms & (1u64 << li) == 0 {
                         continue;
                     }
                     let (s, e) = index.block_data_range((block_start + li) as u32);
@@ -685,8 +702,9 @@ fn execute_bmp_inner(
                 count,
                 &scratch.local_block_order,
                 &scratch.local_block_ubs,
-                &scratch.local_block_masks,
+                &scratch.query_presence,
                 &query_by_dim_u16,
+                candidate_mask,
                 dequant,
                 alpha,
                 collector_k,
@@ -713,7 +731,9 @@ fn execute_bmp_inner(
             // Cross-superblock lookahead: prefetch next superblock's block_data_starts.
             // Gives offsets time to arrive during pruning check + UB/mask computation.
             // Range includes the sentinel at next_end (needed by block_data_range).
-            if let Some(&next_sb) = scratch.sb_order.get(idx + 1) {
+            if idx + 1 < superblock_visit_limit
+                && let Some(&next_sb) = sb_order.get(idx + 1)
+            {
                 let next_start = next_sb as usize * BMP_SUPERBLOCK_SIZE as usize;
                 let next_end = (next_start + BMP_SUPERBLOCK_SIZE as usize).min(num_blocks);
                 let bds_base = index.block_data_starts_ptr(0);
@@ -740,12 +760,15 @@ fn execute_bmp_inner(
         );
         if elapsed_ms > 500.0 {
             log::warn!(
-                "slow BMP: {:.1}ms, sbs={}/{}, blocks={}/{}, k={}, returned={}, seed={:.4}, threshold={:.4}, alpha={:.2}",
+                "slow BMP: {:.1}ms, sbs={}/{}, gamma={}, blocks={}/{}, dims={}/{}, k={}, returned={}, seed={:.4}, threshold={:.4}, eta={:.2}",
                 elapsed_ms,
                 sbs_scored,
                 num_superblocks_total,
+                superblock_visit_limit,
                 blocks_scored,
                 num_blocks,
+                candidate_mask.count_ones(),
+                query_by_dim_u16.len(),
                 collector_k,
                 returned,
                 initial_threshold,
@@ -754,12 +777,15 @@ fn execute_bmp_inner(
             );
         } else {
             log::debug!(
-                "BMP execute: {:.1}ms, sbs={}/{}, blocks={}/{}, k={}, returned={}, seed={:.4}, threshold={:.4}, alpha={:.2}",
+                "BMP execute: {:.1}ms, sbs={}/{}, gamma={}, blocks={}/{}, dims={}/{}, k={}, returned={}, seed={:.4}, threshold={:.4}, eta={:.2}",
                 elapsed_ms,
                 sbs_scored,
                 num_superblocks_total,
+                superblock_visit_limit,
                 blocks_scored,
                 num_blocks,
+                candidate_mask.count_ones(),
+                query_by_dim_u16.len(),
                 collector_k,
                 returned,
                 initial_threshold,
@@ -768,8 +794,8 @@ fn execute_bmp_inner(
             );
         }
 
-        collector_to_results(collector)
-    });
+        Ok(collector_to_results(collector))
+    })?;
 
     Ok(result)
 }
@@ -810,7 +836,7 @@ fn zero_touched_acc(acc: &mut [u32], touched: &[u64; 4]) {
 
 /// Score a block using integer arithmetic (u32 accumulators, u16 weights).
 ///
-/// Uses **bitmask skip**: checks `block_mask & (1 << q) != 0` before binary search.
+/// Uses one per-query-dimension block-presence bitset before binary search.
 /// Accumulates `w_u16 * impact_u8` into u32 — eliminates u8→f32 conversion per posting.
 ///
 /// Blocks store u32 dim_id directly. Binary search on dim_id (always 4 bytes).
@@ -831,15 +857,22 @@ fn score_block_bsearch_int(
     ps_ptr: *const u8,
     post_ptr: *const u8,
     query_by_dim_u16: &[(u32, u16)],
-    block_mask: u64,
+    query_mask: u64,
+    candidate_mask: u64,
+    query_presence: &[u64],
+    local_block: usize,
     acc: &mut [u32],
     touched: &mut [u64; 4],
     block_size: usize,
     total_block_postings: u32,
 ) {
     for (q, &(dim_id, w)) in query_by_dim_u16.iter().enumerate() {
-        // Bitmask skip: if this query dim has zero max in this block, skip
-        if q < 64 && block_mask & (1u64 << q) == 0 {
+        // The fused grid decoder produces one block-presence bitset per query
+        // dimension. Avoid transposing those bits into 64 per-block masks.
+        let query_bit = 1u64 << q;
+        if query_mask & query_bit == 0
+            || candidate_mask & query_bit != 0 && query_presence[q] & (1u64 << local_block) == 0
+        {
             continue;
         }
         // find_dim_in_block_data always uses u32 dim_ids
@@ -865,7 +898,8 @@ fn score_block_bsearch_int(
 /// Score blocks within a single superblock using integer scoring.
 ///
 /// `block_start` is the global block ID of the first block in this superblock.
-/// `local_order`, `local_ubs`, `local_masks` are indexed by local offset (0..count).
+/// `local_order` and `local_ubs` are indexed by local offset (0..count);
+/// `query_presence` stores one local-block bitset per query dimension.
 ///
 /// **Two-phase lazy scoring**: When `phase1_mask != u64::MAX` and `phase1_local_ubs`
 /// is `Some`, scores only phase1 dims first. If the best possible score from phase1 +
@@ -880,8 +914,9 @@ fn score_superblock_blocks(
     count: usize,
     local_order: &[u32],
     local_ubs: &[f32],
-    local_masks: &[u64],
+    query_presence: &[u64],
     query_by_dim_u16: &[(u32, u16)],
+    candidate_mask: u64,
     dequant: f32,
     alpha: f32,
     k: usize,
@@ -935,9 +970,8 @@ fn score_superblock_blocks(
             }
         }
 
-        let (num_terms, dim_ptr, ps_ptr, post_ptr, total_block_postings) =
+        let (num_terms, dim_ptr, ps_ptr, _, post_ptr, total_block_postings) =
             index.parse_block(block_id);
-        let mask = local_masks[local_idx as usize];
         let mut touched = [0u64; 4];
         if num_terms > 0 {
             if two_phase && collector.len() >= k {
@@ -948,7 +982,10 @@ fn score_superblock_blocks(
                     ps_ptr,
                     post_ptr,
                     query_by_dim_u16,
-                    mask & phase1_mask,
+                    phase1_mask,
+                    candidate_mask,
+                    query_presence,
+                    local_idx as usize,
                     acc,
                     &mut touched,
                     block_size,
@@ -975,7 +1012,10 @@ fn score_superblock_blocks(
                     ps_ptr,
                     post_ptr,
                     query_by_dim_u16,
-                    mask & !phase1_mask,
+                    !phase1_mask,
+                    candidate_mask,
+                    query_presence,
+                    local_idx as usize,
                     acc,
                     &mut touched,
                     block_size,
@@ -989,7 +1029,10 @@ fn score_superblock_blocks(
                     ps_ptr,
                     post_ptr,
                     query_by_dim_u16,
-                    mask,
+                    u64::MAX,
+                    candidate_mask,
+                    query_presence,
+                    local_idx as usize,
                     acc,
                     &mut touched,
                     block_size,
@@ -1056,7 +1099,7 @@ fn score_superblock_blocks(
 
 /// Sort local block indices by their UBs in descending order.
 ///
-/// For c=64 blocks, a simple sort on non-zero UB indices is optimal.
+/// For eight blocks, a simple sort on non-zero UB indices is optimal.
 /// Reuses `out` Vec to avoid allocation.
 fn sort_local_blocks_desc(local_ubs: &[f32], out: &mut Vec<u32>) {
     out.clear();
@@ -1067,12 +1110,12 @@ fn sort_local_blocks_desc(local_ubs: &[f32], out: &mut Vec<u32>) {
     }
     out.sort_unstable_by(|&a, &b| {
         local_ubs[b as usize]
-            .partial_cmp(&local_ubs[a as usize])
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .total_cmp(&local_ubs[a as usize])
+            .then_with(|| a.cmp(&b))
     });
 }
 
-/// Sort superblock IDs by values (priorities or UBs) in descending order, into `out`.
+/// Sort superblock IDs by SBMax in descending order, into `out`.
 ///
 /// For ~2K superblocks, comparison sort takes ~30μs — negligible vs BMP query time.
 /// Reuses `out` Vec to avoid allocation.
@@ -1085,26 +1128,9 @@ fn sort_sb_desc_into(values: &[f32], out: &mut Vec<u32>) {
     }
     out.sort_unstable_by(|&a, &b| {
         values[b as usize]
-            .partial_cmp(&values[a as usize])
-            .unwrap_or(std::cmp::Ordering::Equal)
+            .total_cmp(&values[a as usize])
+            .then_with(|| a.cmp(&b))
     });
-}
-
-/// Pre-compute suffix-max of actual UBs over the sorted SB order.
-///
-/// `suffix_max[i]` = max UB among all SBs at positions `i..order.len()`.
-/// This enables safe early termination with non-monotonic ordering:
-/// if `suffix_max[i] * alpha < threshold`, ALL remaining SBs can be skipped.
-///
-/// O(num_superblocks) pre-computation, then O(1) check per SB in the loop.
-fn compute_suffix_max_ubs(sb_ubs: &[f32], order: &[u32], out: &mut [f32]) {
-    let n = order.len();
-    // Sentinel: suffix_max[n] = 0.0 (no remaining SBs)
-    out[n] = 0.0;
-    for i in (0..n).rev() {
-        let ub = sb_ubs[order[i] as usize];
-        out[i] = ub.max(out[i + 1]);
-    }
 }
 
 fn collector_to_results(collector: ScoreCollector) -> Vec<ScoredDoc> {
@@ -1119,10 +1145,6 @@ fn collector_to_results(collector: ScoreCollector) -> Vec<ScoredDoc> {
         .collect()
 }
 
-// ============================================================================
-// Compact grid helpers: operate on query-local contiguous grid buffers
-// ============================================================================
-
 /// Compute superblock UBs using integer weights for consistency with integer scoring.
 ///
 /// Uses the same u16 query weights and dequantization factor as `score_block_bsearch_int`,
@@ -1130,71 +1152,180 @@ fn collector_to_results(collector: ScoreCollector) -> Vec<ScoredDoc> {
 /// a subtle correctness issue where f32-weighted UBs can be slightly LOWER than
 /// integer-scored thresholds due to u16 quantization rounding.
 ///
-/// `compact_sb_grid` layout: `compact_sb_grid[local_dim * nsb + sb_id]`
-/// `int_weights[i] = (local_dim_index, u16_weight)` — parallel to `compact_dims`.
 #[inline]
 fn compute_sb_ubs_int(
-    compact_sb_grid: &[u8],
-    nsb: usize,
-    int_weights: &[(usize, u16)],
-    dequant: f32,
-    out: &mut [f32],
-) {
-    debug_assert!(out.len() >= nsb);
-    // Accumulate as u32 to match integer scoring path exactly
-    for sb in 0..nsb {
-        let mut acc: u32 = 0;
-        for &(local_idx, w) in int_weights {
-            let val = compact_sb_grid[local_idx * nsb + sb];
-            acc += w as u32 * val as u32;
-        }
-        out[sb] = acc as f32 * dequant;
-    }
-}
-
-/// Compute block UBs in the same integer units as document scoring.
-///
-/// Grid cells are ceiling-quantized upper bounds. Accumulating `u16 × u8` in
-/// `u32`, then applying the common dequantizer once, preserves the monotonic
-/// relationship `block_ub >= document_score` under f32 conversion. Summing
-/// already-dequantized f32 terms can round downward (measurably even at 64
-/// dimensions) and made exact-mode pruning unsafe near the heap threshold.
-#[inline]
-#[allow(clippy::too_many_arguments)]
-fn compute_block_ubs_int(
-    compact_grid: &[u8],
-    grid_bits: u8,
-    prs: usize,
-    int_weights: &[(usize, u16)],
-    block_start: usize,
-    block_end: usize,
+    grid: &CompressedGrid,
+    int_weights: &[BmpGridWeight],
     dequant: f32,
     units: &mut [u32],
     out: &mut [f32],
-) {
-    let count = block_end - block_start;
+    decoded: &mut [u8],
+) -> crate::Result<()> {
+    let nsb = grid.cells();
+    debug_assert!(out.len() >= nsb);
+    debug_assert!(units.len() >= nsb);
+    debug_assert!(decoded.len() >= GRID_GROUP_CELLS);
+    units[..nsb].fill(0);
+
+    // E is always consumed as a complete row. Walk its selectors and payload
+    // once without allocating descriptors or paying a checkpoint-prefix
+    // lookup for every group.
+    let cell_scale = block_grid_scale(LSP_SUPERBLOCK_GRID_BITS);
+    for &BmpGridWeight {
+        dimension, weight, ..
+    } in int_weights
+    {
+        grid.try_for_each_row_group(dimension, |group_id, group| {
+            let start = group_id * GRID_GROUP_CELLS;
+            let count = GRID_GROUP_CELLS.min(nsb - start);
+            if group.width() == 0 {
+                return Ok(());
+            }
+            group.decode(0, count, decoded);
+            accumulate_u8(
+                decoded,
+                count,
+                cell_scale * u32::from(weight),
+                &mut units[start..start + count],
+            );
+            Ok(())
+        })?;
+    }
+    for (bound, &integer_units) in out[..nsb].iter_mut().zip(&units[..nsb]) {
+        *bound = integer_units as f32 * dequant;
+    }
+    Ok(())
+}
+
+/// Decode one eight-block superblock and compute every grid-derived value in one
+/// pass: full bounds, phase-one bounds, and per-query-dimension presence.
+///
+/// Grid cells are ceiling-quantized upper bounds. Accumulating `u16 × u8` in
+/// `u32`, then applying the common dequantizer once, preserves
+/// `block_ub >= candidate-query document score` under f32 conversion.
+/// Summing already-dequantized terms can round downward and made unpruned
+/// exact-mode pruning unsafe near the heap threshold.
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn compute_block_ubs_and_presence(
+    grid: &CompressedGrid,
+    grid_bits: u8,
+    int_weights: &[BmpGridWeight],
+    query_term_count: usize,
+    phase1_mask: u64,
+    block_start: usize,
+    count: usize,
+    units: &mut [u32],
+    phase1_units: &mut [u32],
+    out: &mut [f32],
+    phase1_out: &mut [f32],
+    query_presence: &mut Vec<u64>,
+    decoded: &mut [u8],
+    dequant: f32,
+) -> crate::Result<u64> {
     debug_assert!(units.len() >= count);
+    debug_assert!(phase1_units.len() >= count);
     debug_assert!(out.len() >= count);
+    debug_assert!(phase1_out.len() >= count);
+    debug_assert!(decoded.len() >= count);
+    debug_assert!(count <= BMP_SUPERBLOCK_SIZE as usize);
+    let group_id = block_start / GRID_GROUP_CELLS;
+    let within = block_start % GRID_GROUP_CELLS;
+    if within + count > GRID_GROUP_CELLS {
+        return Err(crate::Error::Corruption(
+            "BMP superblock crosses a compressed-grid group boundary".into(),
+        ));
+    }
+
     units[..count].fill(0);
-    for &(local_idx, weight) in int_weights {
-        let row = &compact_grid[local_idx * prs..(local_idx + 1) * prs];
-        accumulate_grid_u32(
-            row,
-            grid_bits,
-            block_start,
+    phase1_units[..count].fill(0);
+    if query_presence.len() < query_term_count {
+        query_presence.resize(query_term_count, 0);
+    }
+    query_presence[..query_term_count].fill(0);
+
+    let cell_scale = crate::segment::bmp_grid::block_grid_scale(grid_bits);
+    let use_phase1 = phase1_mask != u64::MAX;
+    let mut blocks_with_query_terms = 0u64;
+    for &BmpGridWeight {
+        dimension,
+        weight,
+        query_index,
+    } in int_weights
+    {
+        let group = grid.group(dimension, group_id)?;
+        if group.width() == 0 {
+            continue;
+        }
+        group.decode_u4_packed(within, count, decoded);
+        let multiplier = cell_scale * u32::from(weight);
+        let phase1 = (use_phase1 && phase1_mask & (1u64 << query_index) != 0)
+            .then_some(&mut phase1_units[..count]);
+        let presence = accumulate_packed_u4(
+            &decoded[..count.div_ceil(2)],
             count,
-            u32::from(weight),
+            multiplier,
             &mut units[..count],
+            phase1,
         );
+        query_presence[query_index] = presence;
+        blocks_with_query_terms |= presence;
     }
     for (bound, &integer_units) in out[..count].iter_mut().zip(&units[..count]) {
         *bound = integer_units as f32 * dequant;
     }
+    if use_phase1 {
+        for (bound, &integer_units) in phase1_out[..count].iter_mut().zip(&phase1_units[..count]) {
+            *bound = integer_units as f32 * dequant;
+        }
+    }
+    Ok(blocks_with_query_terms)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::compute_block_ubs_int;
+    use std::io::Write;
+
+    use super::{
+        BmpGridWeight, compute_block_ubs_and_presence, recommended_lsp_gamma, sort_sb_desc_into,
+    };
+    use crate::directories::OwnedBytes;
+    use crate::segment::BMP_SUPERBLOCK_SIZE;
+    use crate::segment::bmp_grid::{
+        CompressedGrid, CompressedGridLayout, GRID_GROUP_CELLS, bit_width, pack_group,
+    };
+
+    fn test_grid(rows: &[Vec<u8>], cells: usize) -> CompressedGrid {
+        let layout = CompressedGridLayout::new(rows.len(), cells);
+        let widths_by_row: Vec<Vec<u8>> = rows
+            .iter()
+            .map(|row| {
+                row.chunks(GRID_GROUP_CELLS)
+                    .map(|group| bit_width(group.iter().copied().max().unwrap_or(0)))
+                    .collect()
+            })
+            .collect();
+        let row_sizes: Vec<u64> = widths_by_row
+            .iter()
+            .map(|widths| layout.row_bytes(widths).unwrap())
+            .collect();
+        let mut bytes = Vec::new();
+        layout.write_row_offsets(&row_sizes, &mut bytes).unwrap();
+        let mut values = [0u8; GRID_GROUP_CELLS];
+        let mut packed = [0u8; GRID_GROUP_CELLS];
+        for (row, widths) in rows.iter().zip(&widths_by_row) {
+            layout.write_row_header(widths, 4, &mut bytes).unwrap();
+            for (group, &width) in widths.iter().enumerate() {
+                values.fill(0);
+                let start = group * GRID_GROUP_CELLS;
+                let count = GRID_GROUP_CELLS.min(cells - start);
+                values[..count].copy_from_slice(&row[start..start + count]);
+                let len = pack_group(&values, width, &mut packed).unwrap();
+                bytes.write_all(&packed[..len]).unwrap();
+            }
+        }
+        CompressedGrid::parse(OwnedBytes::new(bytes), rows.len(), cells, 4, "test grid").unwrap()
+    }
 
     #[test]
     fn integer_block_bound_cannot_round_below_integer_score() {
@@ -1202,24 +1333,40 @@ mod tests {
         // common targets. The block bound and document score now convert the
         // same integer units exactly once.
         let dimensions = 64usize;
-        let grid = vec![0x0f; dimensions]; // one 4-bit cell (= 255) per row
-        let weights: Vec<(usize, u16)> =
-            (0..dimensions).map(|dimension| (dimension, 160)).collect();
+        let rows = vec![vec![15]; dimensions]; // one 4-bit cell (= 255) per row
+        let grid = test_grid(&rows, 1);
+        let weights: Vec<BmpGridWeight> = (0..dimensions)
+            .map(|dimension| BmpGridWeight {
+                dimension,
+                weight: 160,
+                query_index: dimension,
+            })
+            .collect();
         let dequant = 0.123_456_7f32;
         let mut units = [0u32; 1];
         let mut bounds = [0.0f32; 1];
 
-        compute_block_ubs_int(
+        let mut phase1_units = [0u32; 1];
+        let mut phase1_bounds = [0.0f32; 1];
+        let mut presence = Vec::new();
+        let mut decoded = [0u8; GRID_GROUP_CELLS];
+        compute_block_ubs_and_presence(
             &grid,
             4,
-            1,
             &weights,
+            dimensions,
+            u64::MAX,
             0,
             1,
-            dequant,
             &mut units,
+            &mut phase1_units,
             &mut bounds,
-        );
+            &mut phase1_bounds,
+            &mut presence,
+            &mut decoded,
+            dequant,
+        )
+        .unwrap();
 
         let score_units = 160u32 * 255 * dimensions as u32;
         let score = score_units as f32 * dequant;
@@ -1230,31 +1377,65 @@ mod tests {
     #[test]
     fn packed_integer_bound_kernel_matches_every_4bit_cell() {
         let blocks = 64usize;
-        let grid: Vec<u8> = (0..blocks / 2)
-            .map(|pair| {
-                let low = (pair * 2 % 16) as u8;
-                let high = ((pair * 2 + 1) % 16) as u8;
-                low | (high << 4)
-            })
-            .collect();
-        let mut units = [0u32; 64];
-        let mut bounds = [0.0f32; 64];
-
-        compute_block_ubs_int(
-            &grid,
-            4,
-            grid.len(),
-            &[(0, 123)],
-            0,
+        let grid = test_grid(
+            &[(0..blocks).map(|block| (block % 16) as u8).collect()],
             blocks,
-            1.0,
-            &mut units,
-            &mut bounds,
         );
+        for block_start in (0..blocks).step_by(BMP_SUPERBLOCK_SIZE as usize) {
+            let mut units = [0u32; BMP_SUPERBLOCK_SIZE as usize];
+            let mut phase1_units = [0u32; BMP_SUPERBLOCK_SIZE as usize];
+            let mut bounds = [0.0f32; BMP_SUPERBLOCK_SIZE as usize];
+            let mut phase1_bounds = [0.0f32; BMP_SUPERBLOCK_SIZE as usize];
+            let mut presence = Vec::new();
+            let mut decoded = [0u8; GRID_GROUP_CELLS];
 
-        for block in 0..blocks {
-            assert_eq!(units[block], (block % 16) as u32 * 17 * 123);
-            assert_eq!(bounds[block], units[block] as f32);
+            compute_block_ubs_and_presence(
+                &grid,
+                4,
+                &[BmpGridWeight {
+                    dimension: 0,
+                    weight: 123,
+                    query_index: 0,
+                }],
+                1,
+                u64::MAX,
+                block_start,
+                BMP_SUPERBLOCK_SIZE as usize,
+                &mut units,
+                &mut phase1_units,
+                &mut bounds,
+                &mut phase1_bounds,
+                &mut presence,
+                &mut decoded,
+                1.0,
+            )
+            .unwrap();
+
+            for local in 0..BMP_SUPERBLOCK_SIZE as usize {
+                let block = block_start + local;
+                assert_eq!(units[local], (block % 16) as u32 * 17 * 123);
+                assert_eq!(bounds[local], units[local] as f32);
+            }
         }
+    }
+
+    #[test]
+    fn lsp_zero_shot_gamma_schedule_is_depth_aware() {
+        assert_eq!(recommended_lsp_gamma(0), 250);
+        assert_eq!(recommended_lsp_gamma(10), 250);
+        assert_eq!(recommended_lsp_gamma(11), 500);
+        assert_eq!(recommended_lsp_gamma(100), 500);
+        assert_eq!(recommended_lsp_gamma(101), 1000);
+        assert_eq!(recommended_lsp_gamma(1000), 1000);
+        assert_eq!(recommended_lsp_gamma(1001), 2000);
+        assert_eq!(recommended_lsp_gamma(4800), 4800);
+    }
+
+    #[test]
+    fn lsp_orders_strictly_by_superblock_maximum() {
+        let bounds = [4.0, 9.0, 9.0, 1.0, 7.0];
+        let mut order = Vec::new();
+        sort_sb_desc_into(&bounds, &mut order);
+        assert_eq!(order, vec![1, 2, 4, 0, 3]);
     }
 }

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -426,10 +426,17 @@ macro_rules! boolean_plan {
             } else {
                 limit
             };
+            let mut should_options = scorer_options.without_threshold();
+            if should_is_sparse {
+                // The outer decomposition built this plan from the complete
+                // sparse SHOULD expression. Filters cannot increase scores,
+                // so retain global γ even when a verifier prevents predicate
+                // push-down. Thresholds still belong to the outer score space
+                // and remain cleared.
+                should_options.lsp_plan = scorer_options.lsp_plan.clone();
+            }
             let should_scorer = if should.len() == 1 {
-                should[0].$scorer_fn(
-                    reader, should_limit, scorer_options.without_threshold()
-                ) $(. $aw)* ?
+                should[0].$scorer_fn(reader, should_limit, should_options) $(. $aw)* ?
             } else {
                 let sub = BooleanQuery {
                     must: Vec::new(),
@@ -437,9 +444,7 @@ macro_rules! boolean_plan {
                     must_not: Vec::new(),
                     global_stats: global_stats.cloned(),
                 };
-                sub.$scorer_fn(
-                    reader, should_limit, scorer_options.without_threshold()
-                ) $(. $aw)* ?
+                sub.$scorer_fn(reader, should_limit, should_options) $(. $aw)* ?
             };
 
             let use_predicated =
@@ -564,6 +569,20 @@ impl Query for BooleanQuery {
             get_postings_sync,
             execute_sync
         )
+    }
+
+    fn decompose(&self) -> super::QueryDecomposition {
+        // LSP/0 selection depends only on the sparse scoring clauses. Pure
+        // filters may remove documents but cannot increase their score, so a
+        // query-global superblock plan remains valid and must be shared across
+        // segments for filtered sparse queries too. A scoring MUST clause can
+        // change final ordering, therefore keep that shape opaque.
+        if self.should.is_empty() || self.must.iter().any(|query| !query.is_filter()) {
+            return super::QueryDecomposition::Opaque;
+        }
+        extract_all_sparse_infos(&self.should)
+            .map(super::QueryDecomposition::SparseTerms)
+            .unwrap_or(super::QueryDecomposition::Opaque)
     }
 
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<super::DocBitset> {

--- a/hermes-core/src/query/collector.rs
+++ b/hermes-core/src/query/collector.rs
@@ -586,6 +586,7 @@ pub async fn collect_segment_with_limit_seeded<C: Collector>(
         collect_positions: collector.needs_positions(),
         initial_threshold,
         shared_threshold: None,
+        lsp_plan: None,
     };
     let mut scorer = query.scorer_with_options(reader, limit, options).await?;
     drive_scorer(scorer.as_mut(), collector);
@@ -661,6 +662,7 @@ pub fn collect_segment_with_limit_seeded_sync<C: Collector>(
         collect_positions: collector.needs_positions(),
         initial_threshold,
         shared_threshold: None,
+        lsp_plan: None,
     };
     let mut scorer = query.scorer_sync_with_options(reader, limit, options)?;
     drive_scorer(scorer.as_mut(), collector);
@@ -706,6 +708,26 @@ pub fn search_segment_shared_sync(
     collect_positions: bool,
     shared_threshold: super::SharedThreshold,
 ) -> Result<(Vec<SearchResult>, u32)> {
+    search_segment_shared_sync_planned(
+        reader,
+        query,
+        limit,
+        collect_positions,
+        shared_threshold,
+        None,
+    )
+}
+
+/// Per-segment search with a live threshold and a query-global LSP/0 plan.
+#[cfg(feature = "sync")]
+pub(crate) fn search_segment_shared_sync_planned(
+    reader: &SegmentReader,
+    query: &dyn Query,
+    limit: usize,
+    collect_positions: bool,
+    shared_threshold: super::SharedThreshold,
+    lsp_plan: Option<std::sync::Arc<super::bmp::LspSegmentPlan>>,
+) -> Result<(Vec<SearchResult>, u32)> {
     let segment_limit = limit.min(reader.num_docs() as usize);
     let mut collector = if collect_positions {
         TopKCollector::with_positions(segment_limit)
@@ -716,6 +738,7 @@ pub fn search_segment_shared_sync(
         collect_positions,
         initial_threshold: shared_threshold.get(),
         shared_threshold: Some(shared_threshold),
+        lsp_plan,
     };
     let mut scorer = query.scorer_sync_with_options(reader, segment_limit, options)?;
     drive_scorer(scorer.as_mut(), &mut collector);
@@ -755,6 +778,26 @@ pub async fn search_segment_shared(
     collect_positions: bool,
     shared_threshold: super::SharedThreshold,
 ) -> Result<(Vec<SearchResult>, u32)> {
+    search_segment_shared_planned(
+        reader,
+        query,
+        limit,
+        collect_positions,
+        shared_threshold,
+        None,
+    )
+    .await
+}
+
+/// Async per-segment search with a query-global LSP/0 plan.
+pub(crate) async fn search_segment_shared_planned(
+    reader: &SegmentReader,
+    query: &dyn Query,
+    limit: usize,
+    collect_positions: bool,
+    shared_threshold: super::SharedThreshold,
+    lsp_plan: Option<std::sync::Arc<super::bmp::LspSegmentPlan>>,
+) -> Result<(Vec<SearchResult>, u32)> {
     let segment_limit = limit.min(reader.num_docs() as usize);
     let mut collector = if collect_positions {
         TopKCollector::with_positions(segment_limit)
@@ -765,6 +808,7 @@ pub async fn search_segment_shared(
         collect_positions,
         initial_threshold: shared_threshold.get(),
         shared_threshold: Some(shared_threshold),
+        lsp_plan,
     };
     let mut scorer = query
         .scorer_with_options(reader, segment_limit, options)

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -241,7 +241,7 @@ pub(crate) fn build_sparse_maxscore_executor<'a>(
     let si = reader.sparse_index(field)?;
     let query_terms: Vec<(u32, f32)> = infos
         .iter()
-        .filter(|info| si.has_dimension(info.dim_id))
+        .filter(|info| info.candidate && si.has_dimension(info.dim_id))
         .map(|info| (info.dim_id, info.weight))
         .collect();
     if query_terms.is_empty() {
@@ -275,34 +275,7 @@ pub(crate) fn build_sparse_bmp_results(
     limit: usize,
     options: &super::ScorerOptions,
 ) -> Option<(Vec<ScoredDoc>, SparseTermQueryInfo)> {
-    let field = infos[0].field;
-    let bmp = reader.bmp_index(field)?;
-    let query_terms: Vec<(u32, f32)> = infos
-        .iter()
-        .map(|info| (info.dim_id, info.weight))
-        .collect();
-    if query_terms.is_empty() {
-        return None;
-    }
-    let executor_limit = bmp_executor_limit(limit, infos[0].over_fetch_factor, bmp);
-    let max_sb = infos[0].max_superblocks;
-    let field_label = reader.schema().get_field_name(field).unwrap_or("?");
-    match super::bmp::execute_bmp_with_threshold(
-        bmp,
-        reader.schema().index_label(),
-        field_label,
-        &query_terms,
-        executor_limit,
-        infos[0].heap_factor,
-        max_sb,
-        bmp_threshold(options, infos[0].combiner, bmp.is_single_valued()),
-    ) {
-        Ok(results) => Some((results, infos[0])),
-        Err(e) => {
-            log::warn!("BMP execution failed for field {}: {}", field.0, e);
-            None
-        }
-    }
+    build_sparse_bmp_results_inner(infos, reader, limit, None, options)
 }
 
 /// Build a sparse BMP executor with a document predicate filter.
@@ -316,32 +289,69 @@ pub(crate) fn build_sparse_bmp_results_filtered(
     predicate: &dyn Fn(crate::DocId) -> bool,
     options: &super::ScorerOptions,
 ) -> Option<(Vec<ScoredDoc>, SparseTermQueryInfo)> {
-    let field = infos[0].field;
+    build_sparse_bmp_results_inner(infos, reader, limit, Some(predicate), options)
+}
+
+fn build_sparse_bmp_results_inner(
+    infos: &[SparseTermQueryInfo],
+    reader: &SegmentReader,
+    limit: usize,
+    predicate: Option<&dyn Fn(crate::DocId) -> bool>,
+    options: &super::ScorerOptions,
+) -> Option<(Vec<ScoredDoc>, SparseTermQueryInfo)> {
+    let info = *infos.first()?;
+    let field = info.field;
     let bmp = reader.bmp_index(field)?;
-    let query_terms: Vec<(u32, f32)> = infos
+    let candidate_terms: Vec<(u32, f32)> = infos
+        .iter()
+        .filter(|info| info.candidate)
+        .map(|info| (info.dim_id, info.weight))
+        .collect();
+    if candidate_terms.is_empty() {
+        return None;
+    }
+    let scoring_terms: Vec<(u32, f32)> = infos
         .iter()
         .map(|info| (info.dim_id, info.weight))
         .collect();
-    if query_terms.is_empty() {
-        return None;
-    }
-    let executor_limit = bmp_executor_limit(limit, infos[0].over_fetch_factor, bmp);
-    let max_sb = infos[0].max_superblocks;
+    let executor_limit = bmp_executor_limit(limit, info.over_fetch_factor, bmp);
+    let lsp_gamma = info
+        .lsp_gamma
+        .unwrap_or_else(|| super::bmp::recommended_lsp_gamma(executor_limit));
     let field_label = reader.schema().get_field_name(field).unwrap_or("?");
-    match super::bmp::execute_bmp_filtered_with_threshold(
-        bmp,
-        reader.schema().index_label(),
-        field_label,
-        &query_terms,
-        executor_limit,
-        infos[0].heap_factor,
-        max_sb,
-        predicate,
-        bmp_threshold(options, infos[0].combiner, bmp.is_single_valued()),
-    ) {
-        Ok(results) => Some((results, infos[0])),
+    let threshold = bmp_threshold(options, info.combiner, bmp.is_single_valued());
+    let result = if let Some(predicate) = predicate {
+        super::bmp::execute_bmp_filtered_with_threshold(
+            bmp,
+            reader.schema().index_label(),
+            field_label,
+            &candidate_terms,
+            &scoring_terms,
+            executor_limit,
+            info.heap_factor,
+            lsp_gamma,
+            options.lsp_plan.as_deref(),
+            predicate,
+            threshold,
+        )
+    } else {
+        super::bmp::execute_bmp_with_threshold(
+            bmp,
+            reader.schema().index_label(),
+            field_label,
+            &candidate_terms,
+            &scoring_terms,
+            executor_limit,
+            info.heap_factor,
+            lsp_gamma,
+            options.lsp_plan.as_deref(),
+            threshold,
+        )
+    };
+    match result {
+        Ok(results) => Some((results, info)),
         Err(e) => {
-            log::warn!("BMP filtered execution failed for field {}: {}", field.0, e);
+            log::warn!("BMP execution failed for field {}: {}", field.0, e);
             None
         }
     }
@@ -668,6 +678,7 @@ mod tests {
             collect_positions: false,
             initial_threshold: 5.0,
             shared_threshold: Some(shared),
+            lsp_plan: None,
         };
 
         let single_sum = bmp_threshold(&options, MultiValueCombiner::Sum, true);

--- a/hermes-core/src/query/traits.rs
+++ b/hermes-core/src/query/traits.rs
@@ -47,6 +47,8 @@ pub struct ScorerOptions {
     /// it during traversal so concurrently searched segments benefit as soon
     /// as another segment establishes a stronger global floor.
     pub shared_threshold: Option<super::scoring::SharedThreshold>,
+    /// Query-global LSP/0 selection projected onto this segment.
+    pub(crate) lsp_plan: Option<std::sync::Arc<super::bmp::LspSegmentPlan>>,
 }
 
 impl ScorerOptions {
@@ -55,6 +57,7 @@ impl ScorerOptions {
             collect_positions: true,
             initial_threshold: 0.0,
             shared_threshold: None,
+            lsp_plan: None,
         }
     }
 
@@ -66,6 +69,7 @@ impl ScorerOptions {
             collect_positions: self.collect_positions,
             initial_threshold: 0.0,
             shared_threshold: None,
+            lsp_plan: None,
         }
     }
 }
@@ -195,6 +199,10 @@ pub struct SparseTermQueryInfo {
     pub dim_id: u32,
     /// Query weight for this dimension
     pub weight: f32,
+    /// Whether this term participates in candidate generation. BMP/LSP uses
+    /// the pruned subset for maximum-grid traversal, then scores candidates
+    /// with every term retained in this decomposition.
+    pub candidate: bool,
     /// MaxScore heap factor (1.0 = exact, lower = approximate)
     pub heap_factor: f32,
     /// Multi-value combiner for ordinal deduplication
@@ -202,8 +210,8 @@ pub struct SparseTermQueryInfo {
     /// Multiplier on executor limit to compensate for ordinal deduplication
     /// (1.0 = exact, 2.0 = fetch 2x then combine down)
     pub over_fetch_factor: f32,
-    /// Maximum superblocks to visit (LSP/0 gamma cap). 0 = unlimited.
-    pub max_superblocks: usize,
+    /// LSP/0 γ. None is depth-derived; Some(0) is exhaustive.
+    pub lsp_gamma: Option<usize>,
 }
 
 /// Decomposition of a query for MaxScore optimization.

--- a/hermes-core/src/query/vector/sparse.rs
+++ b/hermes-core/src/query/vector/sparse.rs
@@ -23,14 +23,17 @@ pub struct SparseVectorQuery {
     /// Controls MaxScore pruning aggressiveness in block-max scoring
     pub heap_factor: f32,
     /// Minimum abs(weight) for query dimensions (0.0 = no filtering)
-    /// Dimensions below this threshold are dropped before search.
+    /// Dimensions below this threshold are dropped from candidate generation.
+    /// BMP still uses the bounded full query when scoring visited candidates.
     pub weight_threshold: f32,
-    /// Maximum number of query dimensions to process (None = all)
-    /// Keeps only the top-k dimensions by abs(weight).
+    /// Maximum candidate-generation dimensions (None = implementation cap).
+    /// Keeps only the top-k dimensions by abs(weight); BMP final scoring uses
+    /// up to `MAX_QUERY_TERMS` dimensions from the full query.
     pub max_query_dims: Option<usize>,
     /// Fraction of query dimensions to keep (0.0-1.0), same semantics as
     /// indexing-time `pruning`: sort by abs(weight) descending,
-    /// keep top fraction. None or 1.0 = no pruning.
+    /// keep top fraction. BMP applies it to candidate generation and scores
+    /// visited candidates with the bounded full query. None or 1.0 = no pruning.
     pub pruning: Option<f32>,
     /// Minimum number of query dimensions before pruning and weight_threshold
     /// filtering are applied. Protects short queries from losing signal.
@@ -38,8 +41,8 @@ pub struct SparseVectorQuery {
     pub min_query_dims: usize,
     /// Multiplier on executor limit for ordinal deduplication (1.0 = no over-fetch)
     pub over_fetch_factor: f32,
-    /// Maximum superblocks to visit (LSP/0 gamma cap). 0 = unlimited.
-    pub max_superblocks: usize,
+    /// LSP/0 γ. None is depth-derived; Some(0) is exhaustive.
+    pub lsp_gamma: Option<usize>,
     /// Cached pruned vector; None = use `vector` as-is (no pruning applied)
     pruned: Option<Vec<(u32, f32)>>,
 }
@@ -76,7 +79,7 @@ impl SparseVectorQuery {
             pruning: None,
             min_query_dims: 4,
             over_fetch_factor: DEFAULT_SPARSE_OVER_FETCH_FACTOR,
-            max_superblocks: 0,
+            lsp_gamma: None,
             pruned: None,
         };
         q.pruned = Some(q.compute_pruned_vector());
@@ -186,6 +189,13 @@ impl SparseVectorQuery {
         self
     }
 
+    /// Select at most the top-γ superblocks by SBMax using LSP/0.
+    /// Zero retains exhaustive SBMax-ordered traversal.
+    pub fn with_lsp_gamma(mut self, gamma: usize) -> Self {
+        self.lsp_gamma = Some(gamma);
+        self
+    }
+
     /// Apply weight_threshold, pruning, and max_query_dims, returning the pruned vector.
     fn compute_pruned_vector(&self) -> Vec<(u32, f32)> {
         let original_len = self.vector.len();
@@ -211,11 +221,7 @@ impl SparseVectorQuery {
             && fraction < 1.0
             && v.len() > self.min_query_dims
         {
-            v.sort_unstable_by(|a, b| {
-                b.1.abs()
-                    .partial_cmp(&a.1.abs())
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
+            v.sort_unstable_by(|a, b| b.1.abs().total_cmp(&a.1.abs()).then_with(|| a.0.cmp(&b.0)));
             sorted_by_weight = true;
             let keep = ((v.len() as f64 * fraction as f64).ceil() as usize).max(1);
             v.truncate(keep);
@@ -232,9 +238,7 @@ impl SparseVectorQuery {
         if v.len() > max_dims {
             if !sorted_by_weight {
                 v.sort_unstable_by(|a, b| {
-                    b.1.abs()
-                        .partial_cmp(&a.1.abs())
-                        .unwrap_or(std::cmp::Ordering::Equal)
+                    b.1.abs().total_cmp(&a.1.abs()).then_with(|| a.0.cmp(&b.0))
                 });
             }
             v.truncate(max_dims);
@@ -422,18 +426,37 @@ impl SparseVectorQuery {
 }
 
 impl SparseVectorQuery {
-    /// Build SparseTermQueryInfo decomposition for MaxScore execution.
+    /// Build a bounded full-query decomposition and mark the pruned terms used
+    /// for candidate generation. LSP/BMP scores visited documents with the
+    /// full list; MaxScore continues to consume only marked candidate terms.
     fn sparse_infos(&self) -> Vec<crate::query::SparseTermQueryInfo> {
-        self.pruned_dims()
+        let candidate_dims: rustc_hash::FxHashSet<u32> = self
+            .pruned_dims()
             .iter()
-            .map(|&(dim_id, weight)| crate::query::SparseTermQueryInfo {
+            .map(|&(dimension, _)| dimension)
+            .collect();
+        let mut scoring_dims = self.vector.clone();
+        if scoring_dims.len() > crate::query::MAX_QUERY_TERMS {
+            scoring_dims.sort_unstable_by(|left, right| {
+                right
+                    .1
+                    .abs()
+                    .total_cmp(&left.1.abs())
+                    .then_with(|| left.0.cmp(&right.0))
+            });
+            scoring_dims.truncate(crate::query::MAX_QUERY_TERMS);
+        }
+        scoring_dims
+            .into_iter()
+            .map(|(dim_id, weight)| crate::query::SparseTermQueryInfo {
                 field: self.field,
                 dim_id,
                 weight,
+                candidate: candidate_dims.contains(&dim_id),
                 heap_factor: self.heap_factor,
                 combiner: self.combiner,
                 over_fetch_factor: self.over_fetch_factor,
-                max_superblocks: self.max_superblocks,
+                lsp_gamma: self.lsp_gamma,
             })
             .collect()
     }
@@ -653,10 +676,11 @@ impl SparseTermQuery {
             field: self.field,
             dim_id: self.dim_id,
             weight: self.weight,
+            candidate: true,
             heap_factor: self.heap_factor,
             combiner: self.combiner,
             over_fetch_factor: self.over_fetch_factor,
-            max_superblocks: 0,
+            lsp_gamma: None,
         }];
         if let Some((raw, info)) =
             crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, options)
@@ -769,10 +793,11 @@ impl Query for SparseTermQuery {
             field: self.field,
             dim_id: self.dim_id,
             weight: self.weight,
+            candidate: true,
             heap_factor: self.heap_factor,
             combiner: self.combiner,
             over_fetch_factor: self.over_fetch_factor,
-            max_superblocks: 0,
+            lsp_gamma: None,
         }])
     }
 }
@@ -861,6 +886,31 @@ mod tests {
         assert_eq!(query.pruned_dims().len(), crate::query::MAX_QUERY_TERMS);
         // Pruning retains the dimensions with the largest absolute weights.
         assert!(query.pruned_dims().iter().all(|(dim, _)| *dim >= 36));
+    }
+
+    #[test]
+    fn decomposition_keeps_full_scores_and_marks_pruned_candidates() {
+        let query = SparseVectorQuery::new(Field(0), vec![(3, 1.0), (7, 0.8), (11, 0.2)])
+            .with_min_query_dims(0)
+            .with_pruning(0.34);
+        let infos = query.sparse_infos();
+
+        assert_eq!(infos.len(), 3);
+        assert_eq!(
+            infos
+                .iter()
+                .filter(|info| info.candidate)
+                .map(|info| info.dim_id)
+                .collect::<Vec<_>>(),
+            vec![3, 7]
+        );
+        assert_eq!(
+            infos
+                .iter()
+                .map(|info| (info.dim_id, info.weight))
+                .collect::<Vec<_>>(),
+            vec![(3, 1.0), (7, 0.8), (11, 0.2)]
+        );
     }
 
     #[test]

--- a/hermes-core/src/segment/bmp_grid.rs
+++ b/hermes-core/src/segment/bmp_grid.rs
@@ -1,0 +1,1559 @@
+//! Random-access bit-packed BMP maximum grids.
+//!
+//! Every dimension is stored as independently decodable groups of 256 cells.
+//! A row header contains one compact metadata record per 32 groups:
+//!
+//! ```text
+//! checkpoint: u32-LE       // payload offset in 32-byte units
+//! widths:     packed-u4    // local bit width for each 256-cell group
+//! ```
+//!
+//! The payload for a group is exactly `width * 32` bytes. Thus one metadata
+//! record and a bounded sum of at most 31 width nibbles locate any group
+//! without walking earlier payload. All-zero groups have width zero and no
+//! payload. Row offsets are a small, separately pinnable `u64` table.
+
+use std::io::Write;
+
+use crate::directories::OwnedBytes;
+
+pub(crate) const GRID_GROUP_CELLS: usize = 256;
+/// LSP/0 uses four-bit maximum weights at both pruning levels.
+pub(crate) const LSP_SUPERBLOCK_GRID_BITS: u8 = 4;
+const META_GROUPS: usize = 32;
+const META_SELECTOR_BYTES: usize = META_GROUPS / 2;
+const META_RECORD_BYTES: usize = 4 + META_SELECTOR_BYTES;
+const PAYLOAD_UNIT_BYTES: usize = GRID_GROUP_CELLS / 8;
+
+#[inline]
+fn selector_bytes(groups: usize) -> usize {
+    groups.div_ceil(2)
+}
+
+#[inline]
+fn selector_width(selectors: &[u8], group: usize) -> u8 {
+    let byte = selectors[group / 2];
+    if group.is_multiple_of(2) {
+        byte & 0x0f
+    } else {
+        byte >> 4
+    }
+}
+
+/// Dequantization multiplier for a block-grid cell.
+#[inline]
+pub(crate) fn block_grid_scale(grid_bits: u8) -> u32 {
+    match grid_bits {
+        2 => 85,
+        _ => 17,
+    }
+}
+
+/// Ceiling-quantize an exact u8 maximum without underestimating it.
+#[inline]
+pub(crate) fn quantize_block_maximum(value: u8, grid_bits: u8) -> u8 {
+    if value == 0 {
+        return 0;
+    }
+    match grid_bits {
+        2 => (u16::from(value) * 3).div_ceil(255) as u8,
+        _ => (u16::from(value) * 15).div_ceil(255) as u8,
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CompressedGridLayout {
+    dims: usize,
+    cells: usize,
+    groups: usize,
+}
+
+impl CompressedGridLayout {
+    pub(crate) fn new(dims: usize, cells: usize) -> Self {
+        let groups = cells.div_ceil(GRID_GROUP_CELLS);
+        Self {
+            dims,
+            cells,
+            groups,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn dims(self) -> usize {
+        self.dims
+    }
+
+    #[inline]
+    pub(crate) fn cells(self) -> usize {
+        self.cells
+    }
+
+    #[inline]
+    pub(crate) fn groups(self) -> usize {
+        self.groups
+    }
+
+    #[inline]
+    pub(crate) fn row_header_bytes(self) -> usize {
+        let complete = self.groups / META_GROUPS;
+        let remainder = self.groups % META_GROUPS;
+        complete * META_RECORD_BYTES
+            + usize::from(remainder != 0) * (std::mem::size_of::<u32>() + selector_bytes(remainder))
+    }
+
+    pub(crate) fn row_bytes(self, widths: &[u8]) -> crate::Result<u64> {
+        if widths.len() != self.groups {
+            return Err(crate::Error::Internal(format!(
+                "BMP compressed-grid width count {} != expected {}",
+                widths.len(),
+                self.groups
+            )));
+        }
+        let payload_units = widths.iter().try_fold(0u64, |total, &width| {
+            total.checked_add(u64::from(width)).ok_or_else(|| {
+                crate::Error::Internal("BMP compressed-grid row size overflows u64".into())
+            })
+        })?;
+        let payload_bytes = payload_units
+            .checked_mul(PAYLOAD_UNIT_BYTES as u64)
+            .ok_or_else(|| {
+                crate::Error::Internal("BMP compressed-grid row size overflows u64".into())
+            })?;
+        (self.row_header_bytes() as u64)
+            .checked_add(payload_bytes)
+            .ok_or_else(|| {
+                crate::Error::Internal("BMP compressed-grid row size overflows u64".into())
+            })
+    }
+
+    /// Write the row-offset table. Offsets are relative to the first row byte.
+    pub(crate) fn write_row_offsets(
+        self,
+        row_sizes: &[u64],
+        writer: &mut dyn Write,
+    ) -> std::io::Result<u64> {
+        debug_assert_eq!(row_sizes.len(), self.dims);
+        let mut offset = 0u64;
+        writer.write_all(&offset.to_le_bytes())?;
+        for &row_size in row_sizes {
+            offset = offset.checked_add(row_size).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "BMP compressed-grid section exceeds u64",
+                )
+            })?;
+            writer.write_all(&offset.to_le_bytes())?;
+        }
+        Ok((row_sizes.len() as u64 + 1) * 8)
+    }
+
+    /// Write the fixed-size metadata header for one row.
+    pub(crate) fn write_row_header(
+        self,
+        widths: &[u8],
+        max_width: u8,
+        writer: &mut dyn Write,
+    ) -> std::io::Result<()> {
+        if widths.len() != self.groups {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "invalid BMP compressed-grid width count",
+            ));
+        }
+        let mut payload_units = 0u32;
+        for chunk in widths.chunks(META_GROUPS) {
+            writer.write_all(&payload_units.to_le_bytes())?;
+            let mut packed_selectors = [0u8; META_SELECTOR_BYTES];
+            for (index, &width) in chunk.iter().enumerate() {
+                if width > max_width {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("BMP compressed-grid width {width} exceeds maximum {max_width}"),
+                    ));
+                }
+                payload_units = payload_units.checked_add(u32::from(width)).ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "BMP compressed-grid row payload exceeds u32 units",
+                    )
+                })?;
+                packed_selectors[index / 2] |= width << ((index % 2) * 4);
+            }
+            writer.write_all(&packed_selectors[..selector_bytes(chunk.len())])?;
+        }
+        Ok(())
+    }
+}
+
+/// One independently addressable 256-cell payload.
+#[derive(Clone, Copy)]
+pub(crate) struct PackedGridGroup<'a> {
+    width: u8,
+    bytes: &'a [u8],
+}
+
+impl<'a> PackedGridGroup<'a> {
+    #[inline]
+    pub(crate) fn width(self) -> u8 {
+        self.width
+    }
+
+    #[inline]
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
+    pub(crate) fn bytes(self) -> &'a [u8] {
+        self.bytes
+    }
+
+    /// Decode a range within this group into one byte per value.
+    pub(crate) fn decode(self, start: usize, count: usize, output: &mut [u8]) {
+        debug_assert!(start + count <= GRID_GROUP_CELLS);
+        debug_assert!(output.len() >= count);
+        if self.width == 0 {
+            output[..count].fill(0);
+            return;
+        }
+        if self.width == 8 {
+            output[..count].copy_from_slice(&self.bytes[start..start + count]);
+            return;
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("bmi2") && (start * usize::from(self.width)).is_multiple_of(8) {
+            // SAFETY: BMI2 was detected at runtime. Each complete chunk reads
+            // exactly `width` payload bytes and writes eight output bytes.
+            unsafe {
+                decode_u8_bmi2(self.bytes, start, count, self.width, output);
+            }
+            return;
+        }
+
+        let width = usize::from(self.width);
+        let mask = (1u64 << width) - 1;
+        let aligned_values = if (start * width).is_multiple_of(8) {
+            count / 8 * 8
+        } else {
+            0
+        };
+        if aligned_values != 0 {
+            let source_start = start * width / 8;
+            for chunk in 0..aligned_values / 8 {
+                let packed = load_packed_eight(self.bytes, source_start + chunk * width, width);
+                unpack_eight_u8(packed, width, mask, &mut output[chunk * 8..chunk * 8 + 8]);
+            }
+        }
+        for (index, value) in output[aligned_values..count].iter_mut().enumerate() {
+            let index = aligned_values + index;
+            let bit = (start + index) * width;
+            let byte = bit / 8;
+            let shift = bit % 8;
+            let low = u16::from(self.bytes[byte]);
+            let high = self
+                .bytes
+                .get(byte + 1)
+                .copied()
+                .map(u16::from)
+                .unwrap_or(0);
+            *value = (((low | (high << 8)) >> shift) & mask as u16) as u8;
+        }
+    }
+
+    /// Decode a u2/u4 block-grid range into ordinary packed-u4 bytes.
+    ///
+    /// BMP visits eight-cell ranges aligned inside a 256-cell group. Width four
+    /// is a direct copy; x86 BMI2 expands widths one through three eight cells
+    /// at a time. A bounded eight-cell unpacker handles AArch64 and the
+    /// portable fallback without per-cell division.
+    pub(crate) fn decode_u4_packed(self, start: usize, count: usize, output: &mut [u8]) {
+        debug_assert!(self.width <= 4);
+        debug_assert!(start + count <= GRID_GROUP_CELLS);
+        let output_len = count.div_ceil(2);
+        debug_assert!(output.len() >= output_len);
+        output[..output_len].fill(0);
+        if self.width == 0 || count == 0 {
+            return;
+        }
+        if self.width == 4 && start.is_multiple_of(2) {
+            output[..output_len].copy_from_slice(&self.bytes[start / 2..start / 2 + output_len]);
+            return;
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        if is_x86_feature_detected!("bmi2")
+            && (start * usize::from(self.width)).is_multiple_of(8)
+            && count.is_multiple_of(8)
+        {
+            // SAFETY: BMI2 was detected at runtime. The format guarantees a
+            // width*32-byte payload, and each eight-cell chunk consumes
+            // exactly `width` bytes and emits four bytes.
+            unsafe {
+                decode_u4_packed_bmi2(self.bytes, start, count, self.width, output);
+            }
+            return;
+        }
+
+        let width = usize::from(self.width);
+        let mask = (1u64 << width) - 1;
+        let aligned_values = if (start * width).is_multiple_of(8) {
+            count / 8 * 8
+        } else {
+            0
+        };
+        if aligned_values != 0 {
+            let source_start = start * width / 8;
+            for chunk in 0..aligned_values / 8 {
+                let packed = load_packed_eight(self.bytes, source_start + chunk * width, width);
+                let nibbles = pack_eight_u4(packed, width, mask).to_le_bytes();
+                output[chunk * 4..chunk * 4 + 4].copy_from_slice(&nibbles);
+            }
+        }
+        for index in aligned_values..count {
+            let bit = (start + index) * width;
+            let byte = bit / 8;
+            let shift = bit % 8;
+            let low = u16::from(self.bytes[byte]);
+            let high = self
+                .bytes
+                .get(byte + 1)
+                .copied()
+                .map(u16::from)
+                .unwrap_or(0);
+            let value = (((low | high << 8) >> shift) & mask as u16) as u8;
+            if index.is_multiple_of(2) {
+                output[index / 2] |= value;
+            } else {
+                output[index / 2] |= value << 4;
+            }
+        }
+    }
+}
+
+/// Load the packed representation of eight consecutive cells.
+///
+/// Eight width-`w` values occupy exactly `w` bytes, so this never reads past
+/// the final chunk. Chunking removes division, modulus, and cross-byte loads
+/// from the AArch64/portable per-cell loop.
+#[inline(always)]
+fn load_packed_eight(payload: &[u8], source: usize, width: usize) -> u64 {
+    debug_assert!((1..=7).contains(&width));
+    debug_assert!(source + width <= payload.len());
+    let mut packed = 0u64;
+    // SAFETY: callers request complete eight-cell chunks and `group()`
+    // validates the width-sized payload.
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            payload.as_ptr().add(source),
+            (&mut packed as *mut u64).cast::<u8>(),
+            width,
+        );
+    }
+    u64::from_le(packed)
+}
+
+#[inline(always)]
+fn unpack_eight_u8(packed: u64, width: usize, mask: u64, output: &mut [u8]) {
+    debug_assert!(output.len() >= 8);
+    output[0] = (packed & mask) as u8;
+    output[1] = (packed >> width & mask) as u8;
+    output[2] = (packed >> (width * 2) & mask) as u8;
+    output[3] = (packed >> (width * 3) & mask) as u8;
+    output[4] = (packed >> (width * 4) & mask) as u8;
+    output[5] = (packed >> (width * 5) & mask) as u8;
+    output[6] = (packed >> (width * 6) & mask) as u8;
+    output[7] = (packed >> (width * 7) & mask) as u8;
+}
+
+#[inline(always)]
+fn pack_eight_u4(packed: u64, width: usize, mask: u64) -> u32 {
+    (packed & mask) as u32
+        | ((packed >> width & mask) as u32) << 4
+        | ((packed >> (width * 2) & mask) as u32) << 8
+        | ((packed >> (width * 3) & mask) as u32) << 12
+        | ((packed >> (width * 4) & mask) as u32) << 16
+        | ((packed >> (width * 5) & mask) as u32) << 20
+        | ((packed >> (width * 6) & mask) as u32) << 24
+        | ((packed >> (width * 7) & mask) as u32) << 28
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn decode_u8_bmi2(payload: &[u8], start: usize, count: usize, width: u8, output: &mut [u8]) {
+    use std::arch::x86_64::_pdep_u64;
+
+    let deposit_mask = u64::MAX / 255 * ((1u64 << width) - 1);
+    let source_start = start * usize::from(width) / 8;
+    let chunks = count / 8;
+    for chunk in 0..chunks {
+        let source = source_start + chunk * usize::from(width);
+        let mut packed = 0u64;
+        std::ptr::copy_nonoverlapping(
+            payload.as_ptr().add(source),
+            (&mut packed as *mut u64).cast::<u8>(),
+            usize::from(width),
+        );
+        let unpacked = _pdep_u64(packed, deposit_mask).to_le_bytes();
+        let destination = chunk * 8;
+        output
+            .get_unchecked_mut(destination..destination + 8)
+            .copy_from_slice(&unpacked);
+    }
+
+    let width_usize = usize::from(width);
+    let value_mask = (1u16 << width) - 1;
+    for index in chunks * 8..count {
+        let bit = (start + index) * width_usize;
+        let byte = bit / 8;
+        let shift = bit % 8;
+        let low = u16::from(*payload.get_unchecked(byte));
+        let high = payload.get(byte + 1).copied().map(u16::from).unwrap_or(0);
+        *output.get_unchecked_mut(index) = (((low | high << 8) >> shift) & value_mask) as u8;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn decode_u4_packed_bmi2(
+    payload: &[u8],
+    start: usize,
+    count: usize,
+    width: u8,
+    output: &mut [u8],
+) {
+    use std::arch::x86_64::_pdep_u32;
+
+    let deposit_mask = match width {
+        1 => 0x1111_1111,
+        2 => 0x3333_3333,
+        3 => 0x7777_7777,
+        _ => unreachable!(),
+    };
+    let source_start = start * usize::from(width) / 8;
+    for chunk in 0..count / 8 {
+        let source = source_start + chunk * usize::from(width);
+        let packed = match width {
+            1 => u32::from(*payload.get_unchecked(source)),
+            2 => u32::from(u16::from_le_bytes([
+                *payload.get_unchecked(source),
+                *payload.get_unchecked(source + 1),
+            ])),
+            3 => {
+                u32::from(*payload.get_unchecked(source))
+                    | u32::from(*payload.get_unchecked(source + 1)) << 8
+                    | u32::from(*payload.get_unchecked(source + 2)) << 16
+            }
+            _ => unreachable!(),
+        };
+        let unpacked = _pdep_u32(packed, deposit_mask).to_le_bytes();
+        let destination = chunk * 4;
+        output
+            .get_unchecked_mut(destination..destination + 4)
+            .copy_from_slice(&unpacked);
+    }
+}
+
+/// Accumulate one packed-u4 range and return its non-zero-cell bitset.
+///
+/// The optional secondary accumulator is updated in the same SIMD pass for
+/// BMP's phase-one dimensions. This is the only production u4 accumulation
+/// kernel: compressed widths 1–3 are normalized by `decode_u4_packed`, and a
+/// width-4 group uses the same representation directly.
+#[inline]
+pub(crate) fn accumulate_packed_u4(
+    packed: &[u8],
+    count: usize,
+    multiplier: u32,
+    output: &mut [u32],
+    mut secondary: Option<&mut [u32]>,
+) -> u64 {
+    debug_assert!(count <= 64);
+    debug_assert!(packed.len() >= count.div_ceil(2));
+    debug_assert!(output.len() >= count);
+    debug_assert!(
+        secondary
+            .as_ref()
+            .is_none_or(|values| values.len() >= count)
+    );
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        // AArch64 mandates NEON.
+        let secondary_ptr = secondary.as_mut().map(|values| values.as_mut_ptr());
+        // SAFETY: all pointers cover `count` elements and AArch64 has NEON.
+        unsafe {
+            accumulate_packed_u4_neon(
+                packed,
+                count,
+                multiplier,
+                output.as_mut_ptr(),
+                secondary_ptr,
+            )
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    if is_x86_feature_detected!("sse4.1") {
+        let secondary_ptr = secondary.as_mut().map(|values| values.as_mut_ptr());
+        // SAFETY: runtime detection proves SSE4.1 support; pointers cover
+        // `count` elements.
+        return unsafe {
+            accumulate_packed_u4_sse41(
+                packed,
+                count,
+                multiplier,
+                output.as_mut_ptr(),
+                secondary_ptr,
+            )
+        };
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let mut presence = 0u64;
+        for index in 0..count {
+            let byte = packed[index / 2];
+            let value = if index.is_multiple_of(2) {
+                byte & 0x0f
+            } else {
+                byte >> 4
+            };
+            if value == 0 {
+                continue;
+            }
+            presence |= 1u64 << index;
+            let contribution = u32::from(value) * multiplier;
+            output[index] += contribution;
+            if let Some(values) = secondary.as_deref_mut() {
+                values[index] += contribution;
+            }
+        }
+        presence
+    }
+}
+
+/// Add decoded grid cells to integer bounds.
+#[inline]
+pub(crate) fn accumulate_u8(values: &[u8], count: usize, multiplier: u32, output: &mut [u32]) {
+    debug_assert!(values.len() >= count);
+    debug_assert!(output.len() >= count);
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        // SAFETY: AArch64 mandates NEON and all slices cover `count`.
+        unsafe {
+            accumulate_u8_neon(values.as_ptr(), count, multiplier, output.as_mut_ptr());
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    if is_x86_feature_detected!("sse4.1") {
+        // SAFETY: runtime detection proves SSE4.1 support and all slices cover
+        // `count`.
+        unsafe {
+            accumulate_u8_sse41(values.as_ptr(), count, multiplier, output.as_mut_ptr());
+        }
+        return;
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    for index in 0..count {
+        let value = values[index];
+        output[index] += u32::from(value) * multiplier;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "sse4.1")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn accumulate_u8_sse41(values: *const u8, count: usize, multiplier: u32, output: *mut u32) {
+    use std::arch::x86_64::*;
+
+    let zero = _mm_setzero_si128();
+    let multiplier_vector = _mm_set1_epi32(multiplier as i32);
+    let chunks = count / 16;
+    for chunk in 0..chunks {
+        let offset = chunk * 16;
+        let bytes = _mm_loadu_si128(values.add(offset) as *const __m128i);
+        let low = _mm_unpacklo_epi8(bytes, zero);
+        let high = _mm_unpackhi_epi8(bytes, zero);
+        let vectors = [
+            _mm_unpacklo_epi16(low, zero),
+            _mm_unpackhi_epi16(low, zero),
+            _mm_unpacklo_epi16(high, zero),
+            _mm_unpackhi_epi16(high, zero),
+        ];
+        for (vector, decoded) in vectors.into_iter().enumerate() {
+            let destination = output.add(offset + vector * 4) as *mut __m128i;
+            let contribution = _mm_mullo_epi32(decoded, multiplier_vector);
+            _mm_storeu_si128(
+                destination,
+                _mm_add_epi32(_mm_loadu_si128(destination), contribution),
+            );
+        }
+    }
+    for index in chunks * 16..count {
+        let value = *values.add(index);
+        *output.add(index) += u32::from(value) * multiplier;
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn accumulate_u8_neon(values: *const u8, count: usize, multiplier: u32, output: *mut u32) {
+    use std::arch::aarch64::*;
+
+    let chunks = count / 16;
+    for chunk in 0..chunks {
+        let offset = chunk * 16;
+        let bytes = vld1q_u8(values.add(offset));
+        let low = vmovl_u8(vget_low_u8(bytes));
+        let high = vmovl_u8(vget_high_u8(bytes));
+        let vectors = [
+            vmovl_u16(vget_low_u16(low)),
+            vmovl_u16(vget_high_u16(low)),
+            vmovl_u16(vget_low_u16(high)),
+            vmovl_u16(vget_high_u16(high)),
+        ];
+        for (vector, decoded) in vectors.into_iter().enumerate() {
+            let destination = output.add(offset + vector * 4);
+            vst1q_u32(
+                destination,
+                vmlaq_n_u32(vld1q_u32(destination), decoded, multiplier),
+            );
+        }
+    }
+    for index in chunks * 16..count {
+        let value = *values.add(index);
+        *output.add(index) += u32::from(value) * multiplier;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn spread_16_bits(mut value: u32) -> u32 {
+    value = (value | value << 8) & 0x00ff_00ff;
+    value = (value | value << 4) & 0x0f0f_0f0f;
+    value = (value | value << 2) & 0x3333_3333;
+    (value | value << 1) & 0x5555_5555
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "sse4.1")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn accumulate_packed_u4_sse41(
+    packed: &[u8],
+    count: usize,
+    multiplier: u32,
+    output: *mut u32,
+    secondary: Option<*mut u32>,
+) -> u64 {
+    use std::arch::x86_64::*;
+
+    let nibble_mask = _mm_set1_epi8(0x0f);
+    let zero = _mm_setzero_si128();
+    let multiplier_vector = _mm_set1_epi32(multiplier as i32);
+    let chunks = count / 32;
+    let mut presence = 0u64;
+
+    for chunk in 0..chunks {
+        let bytes = _mm_loadu_si128(packed.as_ptr().add(chunk * 16) as *const __m128i);
+        let low = _mm_and_si128(bytes, nibble_mask);
+        let high = _mm_and_si128(_mm_srli_epi16::<4>(bytes), nibble_mask);
+        let low_mask = _mm_movemask_epi8(_mm_cmpgt_epi8(low, zero)) as u32;
+        let high_mask = _mm_movemask_epi8(_mm_cmpgt_epi8(high, zero)) as u32;
+        let chunk_presence = spread_16_bits(low_mask) | spread_16_bits(high_mask) << 1;
+        presence |= u64::from(chunk_presence) << (chunk * 32);
+
+        let first = _mm_unpacklo_epi8(low, high);
+        let second = _mm_unpackhi_epi8(low, high);
+        let first_low = _mm_unpacklo_epi8(first, zero);
+        let first_high = _mm_unpackhi_epi8(first, zero);
+        let second_low = _mm_unpacklo_epi8(second, zero);
+        let second_high = _mm_unpackhi_epi8(second, zero);
+        let vectors = [
+            _mm_unpacklo_epi16(first_low, zero),
+            _mm_unpackhi_epi16(first_low, zero),
+            _mm_unpacklo_epi16(first_high, zero),
+            _mm_unpackhi_epi16(first_high, zero),
+            _mm_unpacklo_epi16(second_low, zero),
+            _mm_unpackhi_epi16(second_low, zero),
+            _mm_unpacklo_epi16(second_high, zero),
+            _mm_unpackhi_epi16(second_high, zero),
+        ];
+        for (vector, values) in vectors.into_iter().enumerate() {
+            let offset = chunk * 32 + vector * 4;
+            let contribution = _mm_mullo_epi32(values, multiplier_vector);
+            let destination = output.add(offset) as *mut __m128i;
+            _mm_storeu_si128(
+                destination,
+                _mm_add_epi32(_mm_loadu_si128(destination), contribution),
+            );
+            if let Some(secondary) = secondary {
+                let destination = secondary.add(offset) as *mut __m128i;
+                _mm_storeu_si128(
+                    destination,
+                    _mm_add_epi32(_mm_loadu_si128(destination), contribution),
+                );
+            }
+        }
+    }
+
+    // LSP uses eight blocks per superblock. Handle that common tail with two
+    // vector accumulations instead of falling back to eight scalar updates.
+    let mut base = chunks * 32;
+    while base + 8 <= count {
+        let packed_word = (packed.as_ptr().add(base / 2) as *const u32).read_unaligned();
+        let bytes = _mm_cvtsi32_si128(packed_word as i32);
+        let low = _mm_and_si128(bytes, nibble_mask);
+        let high = _mm_and_si128(_mm_srli_epi16::<4>(bytes), nibble_mask);
+        let interleaved = _mm_unpacklo_epi8(low, high);
+        let widened = _mm_cvtepu8_epi16(interleaved);
+        let vectors = [
+            _mm_cvtepu16_epi32(widened),
+            _mm_cvtepu16_epi32(_mm_srli_si128::<8>(widened)),
+        ];
+        for (vector, values) in vectors.into_iter().enumerate() {
+            let offset = base + vector * 4;
+            let contribution = _mm_mullo_epi32(values, multiplier_vector);
+            let destination = output.add(offset) as *mut __m128i;
+            _mm_storeu_si128(
+                destination,
+                _mm_add_epi32(_mm_loadu_si128(destination), contribution),
+            );
+            if let Some(secondary) = secondary {
+                let destination = secondary.add(offset) as *mut __m128i;
+                _mm_storeu_si128(
+                    destination,
+                    _mm_add_epi32(_mm_loadu_si128(destination), contribution),
+                );
+            }
+        }
+        for local_byte in 0..4 {
+            let byte = *packed.get_unchecked(base / 2 + local_byte);
+            let pair = u64::from(byte & 0x0f != 0) | (u64::from(byte >> 4 != 0) << 1);
+            presence |= pair << (base + local_byte * 2);
+        }
+        base += 8;
+    }
+    for index in base..count {
+        let byte = *packed.get_unchecked(index / 2);
+        let value = if index.is_multiple_of(2) {
+            byte & 0x0f
+        } else {
+            byte >> 4
+        };
+        if value == 0 {
+            continue;
+        }
+        presence |= 1u64 << index;
+        let contribution = u32::from(value) * multiplier;
+        *output.add(index) += contribution;
+        if let Some(secondary) = secondary {
+            *secondary.add(index) += contribution;
+        }
+    }
+    presence
+}
+
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn accumulate_packed_u4_neon(
+    packed: &[u8],
+    count: usize,
+    multiplier: u32,
+    output: *mut u32,
+    secondary: Option<*mut u32>,
+) -> u64 {
+    use std::arch::aarch64::*;
+
+    let nibble_mask = vdupq_n_u8(0x0f);
+    let chunks = count / 32;
+    let mut presence = 0u64;
+    for chunk in 0..chunks {
+        let bytes = vld1q_u8(packed.as_ptr().add(chunk * 16));
+        let low = vandq_u8(bytes, nibble_mask);
+        let high = vshrq_n_u8::<4>(bytes);
+        let first = vzip1q_u8(low, high);
+        let second = vzip2q_u8(low, high);
+        let first_low = vmovl_u8(vget_low_u8(first));
+        let first_high = vmovl_u8(vget_high_u8(first));
+        let second_low = vmovl_u8(vget_low_u8(second));
+        let second_high = vmovl_u8(vget_high_u8(second));
+        let vectors = [
+            vmovl_u16(vget_low_u16(first_low)),
+            vmovl_u16(vget_high_u16(first_low)),
+            vmovl_u16(vget_low_u16(first_high)),
+            vmovl_u16(vget_high_u16(first_high)),
+            vmovl_u16(vget_low_u16(second_low)),
+            vmovl_u16(vget_high_u16(second_low)),
+            vmovl_u16(vget_low_u16(second_high)),
+            vmovl_u16(vget_high_u16(second_high)),
+        ];
+        for (vector, values) in vectors.into_iter().enumerate() {
+            let offset = chunk * 32 + vector * 4;
+            let destination = output.add(offset);
+            vst1q_u32(
+                destination,
+                vmlaq_n_u32(vld1q_u32(destination), values, multiplier),
+            );
+            if let Some(secondary) = secondary {
+                let destination = secondary.add(offset);
+                vst1q_u32(
+                    destination,
+                    vmlaq_n_u32(vld1q_u32(destination), values, multiplier),
+                );
+            }
+        }
+
+        // Presence is consumed as one u64 per query dimension. Extract both
+        // nibble flags per byte in one pass; this avoids a NEON-to-GPR
+        // reduction and rereading each packed byte.
+        for local_byte in 0..16 {
+            let byte = *packed.get_unchecked(chunk * 16 + local_byte);
+            let pair = u64::from(byte & 0x0f != 0) | (u64::from(byte >> 4 != 0) << 1);
+            presence |= pair << (chunk * 32 + local_byte * 2);
+        }
+    }
+
+    // LSP uses eight blocks per superblock. A four-byte unaligned read is
+    // sufficient for eight nibbles, and keeps the load in bounds even for the
+    // final partial compressed-grid group.
+    let mut base = chunks * 32;
+    while base + 8 <= count {
+        let packed_word = (packed.as_ptr().add(base / 2) as *const u32).read_unaligned();
+        let bytes = vreinterpret_u8_u32(vdup_n_u32(packed_word));
+        let low = vand_u8(bytes, vdup_n_u8(0x0f));
+        let high = vshr_n_u8::<4>(bytes);
+        let interleaved = vzip1_u8(low, high);
+        let widened = vmovl_u8(interleaved);
+        let vectors = [
+            vmovl_u16(vget_low_u16(widened)),
+            vmovl_u16(vget_high_u16(widened)),
+        ];
+        for (vector, values) in vectors.into_iter().enumerate() {
+            let offset = base + vector * 4;
+            let destination = output.add(offset);
+            vst1q_u32(
+                destination,
+                vmlaq_n_u32(vld1q_u32(destination), values, multiplier),
+            );
+            if let Some(secondary) = secondary {
+                let destination = secondary.add(offset);
+                vst1q_u32(
+                    destination,
+                    vmlaq_n_u32(vld1q_u32(destination), values, multiplier),
+                );
+            }
+        }
+        for local_byte in 0..4 {
+            let byte = *packed.get_unchecked(base / 2 + local_byte);
+            let pair = u64::from(byte & 0x0f != 0) | (u64::from(byte >> 4 != 0) << 1);
+            presence |= pair << (base + local_byte * 2);
+        }
+        base += 8;
+    }
+    for index in base..count {
+        let byte = *packed.get_unchecked(index / 2);
+        let value = if index.is_multiple_of(2) {
+            byte & 0x0f
+        } else {
+            byte >> 4
+        };
+        if value == 0 {
+            continue;
+        }
+        presence |= 1u64 << index;
+        let contribution = u32::from(value) * multiplier;
+        *output.add(index) += contribution;
+        if let Some(secondary) = secondary {
+            *secondary.add(index) += contribution;
+        }
+    }
+    presence
+}
+
+/// Mmap-backed compressed grid section.
+#[derive(Clone)]
+pub(crate) struct CompressedGrid {
+    row_offsets: OwnedBytes,
+    rows: OwnedBytes,
+    layout: CompressedGridLayout,
+    max_width: u8,
+}
+
+impl CompressedGrid {
+    pub(crate) fn empty() -> Self {
+        Self {
+            row_offsets: OwnedBytes::empty(),
+            rows: OwnedBytes::empty(),
+            layout: CompressedGridLayout::new(0, 0),
+            max_width: 0,
+        }
+    }
+
+    pub(crate) fn parse(
+        section: OwnedBytes,
+        dims: usize,
+        cells: usize,
+        max_width: u8,
+        label: &str,
+    ) -> crate::Result<Self> {
+        let layout = CompressedGridLayout::new(dims, cells);
+        let table_bytes = dims
+            .checked_add(1)
+            .and_then(|count| count.checked_mul(8))
+            .ok_or_else(|| {
+                crate::Error::Corruption(format!("{label} row-offset table overflows usize"))
+            })?;
+        if section.len() < table_bytes {
+            return Err(crate::Error::Corruption(format!(
+                "{label} is {} bytes, shorter than its {}-byte row-offset table",
+                section.len(),
+                table_bytes
+            )));
+        }
+        let row_offsets = section.slice(0..table_bytes);
+        let rows = section.slice(table_bytes..section.len());
+
+        let offsets = row_offsets.as_slice();
+        let mut previous = 0u64;
+        for row in 0..=dims {
+            let offset = row * 8;
+            let current = u64::from_le_bytes(offsets[offset..offset + 8].try_into().unwrap());
+            if current < previous || current > rows.len() as u64 {
+                return Err(crate::Error::Corruption(format!(
+                    "invalid {label} row offset {row}: {current} (previous={previous}, rows={})",
+                    rows.len()
+                )));
+            }
+            if row == 0 && current != 0 {
+                return Err(crate::Error::Corruption(format!(
+                    "{label} first row offset is {current}, expected 0"
+                )));
+            }
+            if row > 0 && current - previous < layout.row_header_bytes() as u64 {
+                return Err(crate::Error::Corruption(format!(
+                    "{label} row {} is shorter than its {}-byte metadata header",
+                    row - 1,
+                    layout.row_header_bytes()
+                )));
+            }
+            previous = current;
+        }
+        if previous != rows.len() as u64 {
+            return Err(crate::Error::Corruption(format!(
+                "{label} rows end at {previous}, section contains {} bytes",
+                rows.len()
+            )));
+        }
+
+        Ok(Self {
+            row_offsets,
+            rows,
+            layout,
+            max_width,
+        })
+    }
+
+    #[inline]
+    pub(crate) fn cells(&self) -> usize {
+        self.layout.cells()
+    }
+
+    #[inline]
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
+    pub(crate) fn groups(&self) -> usize {
+        self.layout.groups()
+    }
+
+    #[inline]
+    pub(crate) fn dims(&self) -> usize {
+        self.layout.dims()
+    }
+
+    #[inline]
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
+    pub(crate) fn max_width(&self) -> u8 {
+        self.max_width
+    }
+
+    #[inline]
+    fn row_range(&self, dimension: usize) -> crate::Result<(usize, usize)> {
+        if dimension >= self.layout.dims() {
+            return Err(crate::Error::Corruption(format!(
+                "BMP compressed-grid dimension {dimension} exceeds {}",
+                self.layout.dims()
+            )));
+        }
+        let offsets = self.row_offsets.as_slice();
+        let start_offset = dimension * 8;
+        let start = u64::from_le_bytes(offsets[start_offset..start_offset + 8].try_into().unwrap());
+        let end = u64::from_le_bytes(
+            offsets[start_offset + 8..start_offset + 16]
+                .try_into()
+                .unwrap(),
+        );
+        Ok((start as usize, end as usize))
+    }
+
+    pub(crate) fn group(
+        &self,
+        dimension: usize,
+        group: usize,
+    ) -> crate::Result<PackedGridGroup<'_>> {
+        if group >= self.layout.groups() {
+            return Err(crate::Error::Corruption(format!(
+                "BMP compressed-grid group {group} exceeds {}",
+                self.layout.groups()
+            )));
+        }
+        let (row_start, row_end) = self.row_range(dimension)?;
+        let chunk = group / META_GROUPS;
+        let within = group % META_GROUPS;
+        let record_start = row_start + chunk * META_RECORD_BYTES;
+        let selectors = META_GROUPS.min(self.layout.groups() - chunk * META_GROUPS);
+        let record_end = record_start + std::mem::size_of::<u32>() + selector_bytes(selectors);
+        if record_end > row_end {
+            return Err(crate::Error::Corruption(
+                "BMP compressed-grid metadata extends beyond row".into(),
+            ));
+        }
+        let rows = self.rows.as_slice();
+        let record = &rows[record_start..record_end];
+        let checkpoint = u32::from_le_bytes(record[..4].try_into().unwrap()) as usize;
+        if chunk == 0 && checkpoint != 0 {
+            return Err(crate::Error::Corruption(format!(
+                "BMP compressed-grid first checkpoint is {checkpoint}, expected 0"
+            )));
+        }
+        let selectors = &record[4..];
+        let width = selector_width(selectors, within);
+        if width > self.max_width {
+            return Err(crate::Error::Corruption(format!(
+                "BMP compressed-grid width {width} exceeds {}",
+                self.max_width
+            )));
+        }
+        let mut preceding = 0usize;
+        for &packed in &selectors[..within / 2] {
+            let low = packed & 0x0f;
+            let high = packed >> 4;
+            if low > self.max_width || high > self.max_width {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP compressed-grid selector {packed:#04x} exceeds width {}",
+                    self.max_width
+                )));
+            }
+            preceding += usize::from(low + high);
+        }
+        if !within.is_multiple_of(2) {
+            let value = selectors[within / 2] & 0x0f;
+            if value > self.max_width {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP compressed-grid width {value} exceeds {}",
+                    self.max_width
+                )));
+            }
+            preceding += usize::from(value);
+        }
+        let payload_units = checkpoint.checked_add(preceding).ok_or_else(|| {
+            crate::Error::Corruption("BMP compressed-grid payload offset overflows usize".into())
+        })?;
+        let payload_byte_offset =
+            payload_units
+                .checked_mul(PAYLOAD_UNIT_BYTES)
+                .ok_or_else(|| {
+                    crate::Error::Corruption(
+                        "BMP compressed-grid payload byte offset overflows usize".into(),
+                    )
+                })?;
+        let payload_start = row_start
+            .checked_add(self.layout.row_header_bytes())
+            .and_then(|base| base.checked_add(payload_byte_offset))
+            .ok_or_else(|| {
+                crate::Error::Corruption(
+                    "BMP compressed-grid payload offset overflows usize".into(),
+                )
+            })?;
+        let payload_len = usize::from(width)
+            .checked_mul(PAYLOAD_UNIT_BYTES)
+            .ok_or_else(|| {
+                crate::Error::Corruption(
+                    "BMP compressed-grid payload length overflows usize".into(),
+                )
+            })?;
+        let payload_end = payload_start.checked_add(payload_len).ok_or_else(|| {
+            crate::Error::Corruption("BMP compressed-grid payload end overflows usize".into())
+        })?;
+        if payload_end > row_end {
+            return Err(crate::Error::Corruption(format!(
+                "BMP compressed-grid payload {payload_start}..{payload_end} exceeds row end {row_end}"
+            )));
+        }
+        Ok(PackedGridGroup {
+            width,
+            bytes: &rows[payload_start..payload_end],
+        })
+    }
+
+    /// Visit every group in one row using a single sequential metadata pass.
+    ///
+    /// Full-row scans should use this rather than random `group()` calls:
+    /// it advances one payload cursor, avoids repeated checkpoint-prefix
+    /// sums, performs no allocation, and validates the complete row.
+    pub(crate) fn try_for_each_row_group<'a>(
+        &'a self,
+        dimension: usize,
+        mut visitor: impl FnMut(usize, PackedGridGroup<'a>) -> crate::Result<()>,
+    ) -> crate::Result<()> {
+        let (row_start, row_end) = self.row_range(dimension)?;
+        let rows = self.rows.as_slice();
+        let header_end = row_start
+            .checked_add(self.layout.row_header_bytes())
+            .ok_or_else(|| {
+                crate::Error::Corruption("BMP compressed-grid row header overflows usize".into())
+            })?;
+        if header_end > row_end {
+            return Err(crate::Error::Corruption(
+                "BMP compressed-grid metadata extends beyond row".into(),
+            ));
+        }
+        let mut payload = header_end;
+        for group in 0..self.layout.groups() {
+            let record = group / META_GROUPS;
+            let within = group % META_GROUPS;
+            if within == 0 {
+                let record_start = row_start + record * META_RECORD_BYTES;
+                let checkpoint =
+                    u32::from_le_bytes(rows[record_start..record_start + 4].try_into().unwrap())
+                        as usize;
+                let expected = (payload - header_end) / PAYLOAD_UNIT_BYTES;
+                if checkpoint != expected {
+                    return Err(crate::Error::Corruption(format!(
+                        "BMP compressed-grid checkpoint {checkpoint} != expected {expected}"
+                    )));
+                }
+            }
+            let selector = row_start + record * META_RECORD_BYTES + 4 + within / 2;
+            if selector >= header_end {
+                return Err(crate::Error::Corruption(
+                    "BMP compressed-grid selector extends beyond row header".into(),
+                ));
+            }
+            let selector = rows[selector];
+            let width = if within.is_multiple_of(2) {
+                selector & 0x0f
+            } else {
+                selector >> 4
+            };
+            if width > self.max_width {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP compressed-grid width {width} exceeds {}",
+                    self.max_width
+                )));
+            }
+            let payload_end = payload
+                .checked_add(usize::from(width) * PAYLOAD_UNIT_BYTES)
+                .ok_or_else(|| {
+                    crate::Error::Corruption(
+                        "BMP compressed-grid row payload overflows usize".into(),
+                    )
+                })?;
+            if payload_end > row_end {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP compressed-grid payload {payload}..{payload_end} exceeds row end {row_end}"
+                )));
+            }
+            visitor(
+                group,
+                PackedGridGroup {
+                    width,
+                    bytes: &rows[payload..payload_end],
+                },
+            )?;
+            payload = payload_end;
+        }
+        if payload != row_end {
+            return Err(crate::Error::Corruption(format!(
+                "BMP compressed-grid row payload ends at {payload}, expected {row_end}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Append a row's group descriptors for merge paths that combine several
+    /// source rows.
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
+    pub(crate) fn append_row_groups<'a>(
+        &'a self,
+        dimension: usize,
+        output: &mut Vec<PackedGridGroup<'a>>,
+    ) -> crate::Result<()> {
+        output.reserve(self.layout.groups());
+        self.try_for_each_row_group(dimension, |_, group| {
+            output.push(group);
+            Ok(())
+        })
+    }
+
+    pub(crate) fn encoded_bytes(&self) -> usize {
+        self.row_offsets.len() + self.rows.len()
+    }
+
+    #[cfg(feature = "native")]
+    pub(crate) fn madvise_rows(&self, advice: i32) {
+        self.rows.madvise(advice);
+    }
+
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_offsets(
+        &mut self,
+        label: &'static str,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        crate::segment::pin::pin_section(&mut self.row_offsets, label, mode, remaining, report);
+    }
+
+    #[cfg(feature = "native")]
+    pub(crate) fn pin_all(
+        &mut self,
+        offsets_label: &'static str,
+        rows_label: &'static str,
+        mode: crate::segment::pin::PinMode,
+        remaining: &mut u64,
+        report: &mut crate::segment::pin::PinReport,
+    ) {
+        self.pin_offsets(offsets_label, mode, remaining, report);
+        crate::segment::pin::pin_section(&mut self.rows, rows_label, mode, remaining, report);
+    }
+}
+
+#[inline]
+pub(crate) fn bit_width(value: u8) -> u8 {
+    (u8::BITS - value.leading_zeros()) as u8
+}
+
+/// Pack exactly 256 values using the supplied local width.
+///
+/// Callers zero-pad the unused tail of the last logical group. The returned
+/// payload always occupies `width * 32` bytes.
+pub(crate) fn pack_group(
+    values: &[u8; GRID_GROUP_CELLS],
+    width: u8,
+    output: &mut [u8; GRID_GROUP_CELLS],
+) -> crate::Result<usize> {
+    if width > 8 {
+        return Err(crate::Error::Internal(format!(
+            "BMP compressed-grid width {width} exceeds 8"
+        )));
+    }
+    let output_len = usize::from(width) * PAYLOAD_UNIT_BYTES;
+    output[..output_len].fill(0);
+    if width == 0 {
+        return Ok(0);
+    }
+    if width == 8 {
+        output.copy_from_slice(values);
+        return Ok(GRID_GROUP_CELLS);
+    }
+    let mask = (1u16 << width) - 1;
+    if u16::from(values.iter().copied().max().unwrap_or(0)) > mask {
+        return Err(crate::Error::Internal(format!(
+            "BMP compressed-grid value does not fit width {width}"
+        )));
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    if is_x86_feature_detected!("bmi2") {
+        // SAFETY: BMI2 was detected at runtime; input and output are fixed
+        // 256-byte group buffers.
+        unsafe {
+            pack_group_bmi2(values, width, output);
+        }
+        return Ok(output_len);
+    }
+
+    let width = usize::from(width);
+    for (chunk, values) in values.chunks_exact(8).enumerate() {
+        let mut packed = 0u64;
+        for (index, &value) in values.iter().enumerate() {
+            packed |= u64::from(value) << (index * width);
+        }
+        let bytes = packed.to_le_bytes();
+        let destination = chunk * width;
+        output[destination..destination + width].copy_from_slice(&bytes[..width]);
+    }
+    Ok(output_len)
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn pack_group_bmi2(
+    values: &[u8; GRID_GROUP_CELLS],
+    width: u8,
+    output: &mut [u8; GRID_GROUP_CELLS],
+) {
+    use std::arch::x86_64::_pext_u64;
+
+    let extract_mask = u64::MAX / 255 * ((1u64 << width) - 1);
+    for chunk in 0..GRID_GROUP_CELLS / 8 {
+        let source = u64::from_le((values.as_ptr().add(chunk * 8) as *const u64).read_unaligned());
+        let packed = _pext_u64(source, extract_mask).to_le_bytes();
+        let destination = chunk * usize::from(width);
+        output
+            .get_unchecked_mut(destination..destination + usize::from(width))
+            .copy_from_slice(&packed[..usize::from(width)]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded_section(widths_by_row: &[Vec<u8>], values_by_row: &[Vec<u8>]) -> Vec<u8> {
+        let dims = widths_by_row.len();
+        let cells = values_by_row[0].len();
+        let layout = CompressedGridLayout::new(dims, cells);
+        let row_sizes: Vec<u64> = widths_by_row
+            .iter()
+            .map(|widths| layout.row_bytes(widths).unwrap())
+            .collect();
+        let mut bytes = Vec::new();
+        layout.write_row_offsets(&row_sizes, &mut bytes).unwrap();
+        let mut packed = [0u8; GRID_GROUP_CELLS];
+        let mut group_values = [0u8; GRID_GROUP_CELLS];
+        for (widths, values) in widths_by_row.iter().zip(values_by_row) {
+            layout.write_row_header(widths, 8, &mut bytes).unwrap();
+            for (group, &width) in widths.iter().enumerate() {
+                group_values.fill(0);
+                let start = group * GRID_GROUP_CELLS;
+                let count = GRID_GROUP_CELLS.min(cells - start);
+                group_values[..count].copy_from_slice(&values[start..start + count]);
+                let len = pack_group(&group_values, width, &mut packed).unwrap();
+                bytes.extend_from_slice(&packed[..len]);
+            }
+        }
+        bytes
+    }
+
+    #[test]
+    fn every_width_round_trips_with_random_group_access() {
+        let cells = GRID_GROUP_CELLS * 9 + 17;
+        let mut values_by_row = Vec::new();
+        let mut widths_by_row = Vec::new();
+        for row in 0..9u8 {
+            let width = row;
+            let mask = if width == 0 { 0 } else { (1u16 << width) - 1 };
+            let values: Vec<u8> = (0..cells)
+                .map(|index| ((index * 37 + usize::from(row)) as u16 & mask) as u8)
+                .collect();
+            values_by_row.push(values);
+            widths_by_row.push(vec![width; cells.div_ceil(GRID_GROUP_CELLS)]);
+        }
+        let bytes = encoded_section(&widths_by_row, &values_by_row);
+        let grid = CompressedGrid::parse(OwnedBytes::new(bytes), 9, cells, 8, "test grid").unwrap();
+        let mut decoded = [0u8; GRID_GROUP_CELLS];
+        for (row, expected_row) in values_by_row.iter().enumerate() {
+            for group in (0..grid.groups()).rev() {
+                let count = GRID_GROUP_CELLS.min(cells - group * GRID_GROUP_CELLS);
+                grid.group(row, group)
+                    .unwrap()
+                    .decode(0, count, &mut decoded);
+                assert_eq!(
+                    &decoded[..count],
+                    &expected_row[group * GRID_GROUP_CELLS..group * GRID_GROUP_CELLS + count]
+                );
+                if count > 8 {
+                    let range_start = 3;
+                    let range_len = count - 7;
+                    grid.group(row, group)
+                        .unwrap()
+                        .decode(range_start, range_len, &mut decoded);
+                    assert_eq!(
+                        &decoded[..range_len],
+                        &expected_row[group * GRID_GROUP_CELLS + range_start
+                            ..group * GRID_GROUP_CELLS + range_start + range_len]
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn final_metadata_record_has_no_unused_selector_padding() {
+        assert_eq!(META_RECORD_BYTES, 20);
+        let one_group = CompressedGridLayout::new(1, GRID_GROUP_CELLS);
+        assert_eq!(one_group.row_header_bytes(), 5);
+        let thirty_two_groups = CompressedGridLayout::new(1, GRID_GROUP_CELLS * META_GROUPS);
+        assert_eq!(thirty_two_groups.row_header_bytes(), 20);
+        let thirty_three_groups =
+            CompressedGridLayout::new(1, GRID_GROUP_CELLS * (META_GROUPS + 1));
+        assert_eq!(thirty_three_groups.row_header_bytes(), 25);
+    }
+
+    #[test]
+    fn malformed_width_is_rejected_on_access() {
+        let layout = CompressedGridLayout::new(1, GRID_GROUP_CELLS);
+        let mut bytes = Vec::new();
+        layout.write_row_offsets(&[5], &mut bytes).unwrap();
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.push(9);
+        let grid = CompressedGrid::parse(OwnedBytes::new(bytes), 1, 256, 8, "test").unwrap();
+        assert!(matches!(grid.group(0, 0), Err(crate::Error::Corruption(_))));
+    }
+
+    #[test]
+    fn malformed_checkpoint_is_rejected_on_access() {
+        let cells = GRID_GROUP_CELLS * (META_GROUPS + 1);
+        let layout = CompressedGridLayout::new(1, cells);
+        let widths = vec![0u8; layout.groups()];
+        let row_size = layout.row_bytes(&widths).unwrap();
+        let mut bytes = Vec::new();
+        layout.write_row_offsets(&[row_size], &mut bytes).unwrap();
+        layout.write_row_header(&widths, 4, &mut bytes).unwrap();
+        let second_record = 16 + META_RECORD_BYTES;
+        bytes[second_record..second_record + 4].copy_from_slice(&1u32.to_le_bytes());
+        let grid = CompressedGrid::parse(OwnedBytes::new(bytes), 1, cells, 4, "test").unwrap();
+        assert!(matches!(
+            grid.group(0, META_GROUPS),
+            Err(crate::Error::Corruption(_))
+        ));
+    }
+
+    #[test]
+    fn every_block_width_decodes_to_packed_u4_at_each_superblock_offset() {
+        let mut values = [0u8; GRID_GROUP_CELLS];
+        let mut encoded = [0u8; GRID_GROUP_CELLS];
+        let mut decoded = [0u8; 32];
+        for width in 0..=4u8 {
+            let mask = if width == 0 { 0 } else { (1u8 << width) - 1 };
+            for (index, value) in values.iter_mut().enumerate() {
+                *value = (index as u8).wrapping_mul(13) & mask;
+            }
+            let len = pack_group(&values, width, &mut encoded).unwrap();
+            let group = PackedGridGroup {
+                width,
+                bytes: &encoded[..len],
+            };
+            for start in [0, 64, 128, 192] {
+                group.decode_u4_packed(start, 64, &mut decoded);
+                for index in 0..64 {
+                    let byte = decoded[index / 2];
+                    let actual = if index.is_multiple_of(2) {
+                        byte & 0x0f
+                    } else {
+                        byte >> 4
+                    };
+                    assert_eq!(
+                        actual,
+                        values[start + index],
+                        "width={width}, index={index}"
+                    );
+                }
+            }
+            group.decode_u4_packed(3, 59, &mut decoded);
+            for index in 0..59 {
+                let byte = decoded[index / 2];
+                let actual = if index.is_multiple_of(2) {
+                    byte & 0x0f
+                } else {
+                    byte >> 4
+                };
+                assert_eq!(
+                    actual,
+                    values[3 + index],
+                    "unaligned width={width}, index={index}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fused_u4_accumulator_returns_presence_and_updates_both_outputs() {
+        let values: Vec<u8> = (0..64)
+            .map(|index| {
+                if index % 7 == 0 {
+                    0
+                } else {
+                    (index % 16) as u8
+                }
+            })
+            .collect();
+        let mut packed = [0u8; 32];
+        for (index, &value) in values.iter().enumerate() {
+            if index.is_multiple_of(2) {
+                packed[index / 2] = value;
+            } else {
+                packed[index / 2] |= value << 4;
+            }
+        }
+        let mut primary = [0u32; 64];
+        let mut secondary = [11u32; 64];
+        let presence = accumulate_packed_u4(
+            &packed,
+            values.len(),
+            37,
+            &mut primary,
+            Some(&mut secondary),
+        );
+        for (index, &value) in values.iter().enumerate() {
+            assert_eq!(primary[index], u32::from(value) * 37);
+            assert_eq!(secondary[index], 11 + u32::from(value) * 37);
+            assert_eq!((presence >> index) & 1, u64::from(value != 0));
+        }
+    }
+
+    #[test]
+    fn fused_u4_accumulator_handles_lsp_and_partial_tails() {
+        for count in [1usize, 7, 8, 9, 15, 16, 24, 31, 32, 33, 63, 64] {
+            let values: Vec<u8> = (0..count)
+                .map(|index| ((index * 11 + 3) % 16) as u8)
+                .collect();
+            let mut packed = [0u8; 32];
+            for (index, &value) in values.iter().enumerate() {
+                if index.is_multiple_of(2) {
+                    packed[index / 2] = value;
+                } else {
+                    packed[index / 2] |= value << 4;
+                }
+            }
+            let mut primary = [5u32; 64];
+            let mut secondary = [17u32; 64];
+            let presence = accumulate_packed_u4(
+                &packed[..count.div_ceil(2)],
+                count,
+                29,
+                &mut primary[..count],
+                Some(&mut secondary[..count]),
+            );
+            for (index, &value) in values.iter().enumerate() {
+                assert_eq!(primary[index], 5 + u32::from(value) * 29);
+                assert_eq!(secondary[index], 17 + u32::from(value) * 29);
+                assert_eq!((presence >> index) & 1, u64::from(value != 0));
+            }
+        }
+    }
+
+    #[test]
+    fn u8_accumulator_handles_high_bit_values() {
+        let values: Vec<u8> = (0..257)
+            .map(|index| match index % 5 {
+                0 => 0,
+                1 => 1,
+                2 => 127,
+                3 => 128,
+                _ => 255,
+            })
+            .collect();
+        let mut output = vec![9u32; values.len()];
+        accumulate_u8(&values, values.len(), 41, &mut output);
+        for (index, &value) in values.iter().enumerate() {
+            assert_eq!(output[index], 9 + u32::from(value) * 41);
+        }
+    }
+}

--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -1,4 +1,4 @@
-//! BMP (Block-Max Pruning) index builder for sparse vectors — **V15 format**.
+//! BMP (Block-Max Pruning) index builder for sparse vectors — **V17 format**.
 //!
 //! Builds a block-at-a-time (BAAT) index using **compact virtual coordinates**:
 //! sequential IDs are assigned to unique `(doc_id, ordinal)` pairs. A lookup
@@ -18,21 +18,14 @@
 //!
 //! Peak memory: `input + grid_entries + O(num_blocks) block_data_starts`.
 //!
-//! ## V13 changes from V12
-//!
-//! - **Recursive Graph Bisection (BP)** replaces SimHash for document ordering
-//! - **Section H removed**: no per-block SimHash (BP needs no stored metadata)
-//! - **64-byte footer** (was 72): `block_simhash_offset` field removed
-//! - V12 segments are incompatible — must rebuild
-//!
-//! ## BMP V15 Blob Layout (data-first, block-interleaved)
+//! ## BMP V17 Blob Layout (data-first, block-interleaved)
 //!
 //! ```text
 //! Section B:  block_data         [per-block interleaved data]   variable-length
 //!             padding            [0-7 bytes to 8-byte boundary]
 //! Section A:  block_data_starts  [u64-LE × (num_blocks + 1)]   byte offsets into Section B
-//! Section D:  grid_packed4       [u8 × (dims × packed_row_size)]  ← indexed by dim_id directly
-//! Section E:  sb_grid            [u8 × (dims × num_superblocks)]  ← indexed by dim_id directly
+//! Section D:  compressed block grid       [random-access 256-cell groups]
+//! Section E:  compressed superblock grid  [ceil-u4, random-access 256-cell groups]
 //! Section F:  doc_map_ids        [u32-LE × num_virtual_docs]
 //! Section G:  doc_map_ordinals   [u16-LE × num_virtual_docs]
 //!
@@ -40,9 +33,10 @@
 //!   num_terms: u32                                    offset 0
 //!   term_dim_ids: [u32-LE × num_terms]                offset 4
 //!   posting_starts: [u32-LE × (num_terms + 1)]        relative cumulative counts
+//!   term_max_impacts: [u8 × num_terms]                exact per-block maxima
 //!   postings: [(u8, u8) × total_block_postings]       BmpPosting pairs
 //!
-//! BMP V15 Footer (72 bytes):
+//! BMP V17 Footer (72 bytes):
 //!   total_terms: u64              //  0- 7  (stats only)
 //!   total_postings: u64           //  8-15  (stats only)
 //!   grid_offset: u64              // 16-23  (byte offset of Section D)
@@ -55,7 +49,7 @@
 //!   doc_map_offset: u64           // 52-59  (byte offset of Section F)
 //!   num_real_docs: u32            // 60-63  (actual vector count before padding)
 //!   grid_bits: u32                // 64-67  (2 or 4)
-//!   magic: u32                    // 68-71  (BMP5 = 0x35504D42)
+//!   magic: u32                    // 68-71  (BMP7 = 0x37504D42)
 //! ```
 
 use std::cmp::Reverse;
@@ -93,10 +87,14 @@ impl VidLookup {
 }
 
 use crate::DocId;
+use crate::segment::bmp_grid::{
+    CompressedGridLayout, GRID_GROUP_CELLS, LSP_SUPERBLOCK_GRID_BITS, bit_width, pack_group,
+    quantize_block_maximum,
+};
 use crate::segment::format::{BMP_BLOB_FOOTER_SIZE, BMP_BLOB_MAGIC};
 use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
 
-/// Build a BMP V15 blob from per-dimension postings.
+/// Build a BMP V17 blob from per-dimension postings.
 ///
 /// **Takes ownership** of the postings HashMap. All per-dim Vecs are moved
 /// out of the HashMap into `dim_vecs` before the K-way merge starts, and
@@ -196,7 +194,7 @@ pub(crate) fn build_bmp_blob(
     if num_real_docs > u32::MAX as usize {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            "BMP real document count exceeds the V15 u32 format limit",
+            "BMP real document count exceeds the V17 u32 format limit",
         ));
     }
 
@@ -206,9 +204,11 @@ pub(crate) fn build_bmp_blob(
     // Safety: local_slot is u8, so block_size must not exceed 256
     let effective_block_size = bmp_block_size.clamp(1, 256);
 
-    // Pad num_virtual_docs to block_size alignment
-    let num_virtual_docs = num_real_docs
-        .div_ceil(effective_block_size as usize)
+    // Pad only the final document block. Compressed-grid groups are
+    // independently decodable, so merge can repack the at-most-two groups
+    // crossing each source boundary while copying aligned interiors verbatim.
+    let num_blocks = num_real_docs.div_ceil(effective_block_size as usize);
+    let num_virtual_docs = num_blocks
         .checked_mul(effective_block_size as usize)
         .ok_or_else(|| {
             std::io::Error::new(
@@ -219,10 +219,9 @@ pub(crate) fn build_bmp_blob(
     if num_virtual_docs > u32::MAX as usize {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            "BMP padded document count exceeds the V15 u32 format limit",
+            "BMP padded document count exceeds the V17 u32 format limit",
         ));
     }
-    let num_blocks = num_virtual_docs / effective_block_size as usize;
 
     let mut dim_ids: Vec<u32> = postings.keys().copied().collect();
     dim_ids.sort_unstable();
@@ -313,6 +312,7 @@ pub(crate) fn build_bmp_blob(
     let mut blk_buf: Vec<u8> = Vec::with_capacity(4096);
     let mut blk_dim_ids: Vec<u32> = Vec::new();
     let mut blk_posting_counts: Vec<u32> = Vec::new();
+    let mut blk_max_impacts: Vec<u8> = Vec::new();
     let mut blk_postings: Vec<u8> = Vec::new();
 
     while let Some(&Reverse((block_id, _, _))) = heap.peek() {
@@ -327,6 +327,7 @@ pub(crate) fn build_bmp_blob(
         // Clear per-block scratch
         blk_dim_ids.clear();
         blk_posting_counts.clear();
+        blk_max_impacts.clear();
         blk_postings.clear();
 
         // Process all dims with postings in this block
@@ -380,6 +381,7 @@ pub(crate) fn build_bmp_blob(
             }
 
             blk_posting_counts.push(term_posting_count);
+            blk_max_impacts.push(max_impact);
             total_postings = total_postings.saturating_add(u64::from(term_posting_count));
             total_terms = total_terms.saturating_add(1);
 
@@ -419,7 +421,7 @@ pub(crate) fn build_bmp_blob(
             let nt_u32 = u32::try_from(nt).map_err(|_| {
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
-                    "BMP block term count exceeds the V15 u32 format limit",
+                    "BMP block term count exceeds the V17 u32 format limit",
                 )
             })?;
             blk_buf.extend_from_slice(&nt_u32.to_le_bytes());
@@ -430,8 +432,8 @@ pub(crate) fn build_bmp_blob(
             }
 
             // posting_starts [u32 × (nt + 1)] — relative cumulative.
-            // u32, not u16: a 256-doc block of ~300-dim docs exceeds 65,535
-            // postings, and the old u16 sums wrapped silently (V13 → V14).
+            // A 256-vector block with hundreds of dimensions can exceed
+            // 65,535 postings, so both counts and prefixes are u32.
             let mut cum: u32 = 0;
             for &count in &blk_posting_counts {
                 blk_buf.extend_from_slice(&cum.to_le_bytes());
@@ -443,6 +445,11 @@ pub(crate) fn build_bmp_blob(
                 })?;
             }
             blk_buf.extend_from_slice(&cum.to_le_bytes());
+
+            // Exact per-term block maxima. The compressed D grid keeps its
+            // existing ceil-u4 semantics; these exact values let reorder
+            // rebuild tight ceil-u4 superblock maxima without rescanning postings.
+            blk_buf.extend_from_slice(&blk_max_impacts);
 
             // postings [(u8, u8) × total_block_postings]
             blk_buf.extend_from_slice(&blk_postings);
@@ -463,7 +470,7 @@ pub(crate) fn build_bmp_blob(
     grid_entries.sort_unstable();
 
     log::info!(
-        "[bmp_build] V15 vectors={} padded={} blocks={} dims={} \
+        "[bmp_build] V17 vectors={} padded={} blocks={} dims={} \
          terms={} postings={} grid_entries={}",
         num_real_docs,
         num_virtual_docs,
@@ -526,7 +533,7 @@ pub(crate) fn build_bmp_blob(
 
     drop(vid_pairs); // Free after last use (~6 bytes × num_real_docs)
 
-    // BMP V15 footer.
+    // BMP V17 footer.
     write_bmp_footer(
         writer,
         total_terms,
@@ -547,7 +554,7 @@ pub(crate) fn build_bmp_blob(
     Ok(bytes_written)
 }
 
-/// Write the BMP V15 footer.
+/// Write the BMP V17 footer.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn write_bmp_footer(
     writer: &mut dyn Write,
@@ -604,76 +611,164 @@ pub(crate) fn write_u64_slice_le(writer: &mut dyn Write, data: &[u64]) -> std::i
     Ok(data.len() as u64 * 8)
 }
 
-/// Bytes per grid row for `num_blocks` cells at `bits` per cell (2 or 4).
-#[inline]
-pub(crate) fn grid_packed_row_size(num_blocks: usize, grid_bits: u8) -> usize {
-    match grid_bits {
-        2 => num_blocks.div_ceil(4),
-        _ => num_blocks.div_ceil(2),
-    }
+#[derive(Clone, Copy)]
+enum GridProjection {
+    Block { bits: u8 },
+    Superblock,
 }
 
-/// Dequantization multiplier for a grid cell: `cell × scale` recovers a safe
-/// (ceil-quantized) u8 upper bound. 4-bit → 17 (15×17=255); 2-bit → 85.
-#[inline]
-pub(crate) fn grid_dequant_scale(grid_bits: u8) -> u32 {
-    match grid_bits {
-        2 => 85,
-        _ => 17,
+impl GridProjection {
+    #[inline]
+    fn cells(self, num_blocks: usize) -> usize {
+        match self {
+            Self::Block { .. } => num_blocks,
+            Self::Superblock => num_blocks.div_ceil(BMP_SUPERBLOCK_SIZE as usize),
+        }
     }
-}
 
-/// Ceiling quantize u8 to a `bits`-wide grid cell. Guarantees
-/// `cell × grid_dequant_scale(bits) >= original` (bounds never underestimate).
-#[inline]
-pub(crate) fn grid_quantize_ceil(val: u8, grid_bits: u8) -> u8 {
-    if val == 0 {
-        return 0;
+    #[inline]
+    fn max_width(self) -> u8 {
+        match self {
+            Self::Block { bits } => bits,
+            Self::Superblock => LSP_SUPERBLOCK_GRID_BITS,
+        }
     }
-    match grid_bits {
-        2 => (val as u16 * 3).div_ceil(255) as u8,
-        _ => (val as u16 * 15).div_ceil(255) as u8,
-    }
-}
 
-/// OR a quantized cell into a packed grid row at cell index `idx`.
-#[inline]
-pub(crate) fn grid_set_cell(row: &mut [u8], idx: usize, cell: u8, grid_bits: u8) {
-    match grid_bits {
-        2 => row[idx / 4] |= cell << ((idx % 4) * 2),
-        _ => {
-            if idx.is_multiple_of(2) {
-                row[idx / 2] |= cell;
-            } else {
-                row[idx / 2] |= cell << 4;
-            }
+    #[inline]
+    fn project(self, block: u32, impact: u8) -> (usize, u8) {
+        match self {
+            Self::Block { bits } => (block as usize, quantize_block_maximum(impact, bits)),
+            Self::Superblock => (
+                block as usize / BMP_SUPERBLOCK_SIZE as usize,
+                quantize_block_maximum(impact, LSP_SUPERBLOCK_GRID_BITS),
+            ),
         }
     }
 }
 
-/// Read a cell from a packed grid row at cell index `idx`.
-#[inline]
-pub(crate) fn grid_get_cell(row: &[u8], idx: usize, grid_bits: u8) -> u8 {
-    match grid_bits {
-        2 => (row[idx / 4] >> ((idx % 4) * 2)) & 0x03,
-        _ => {
-            if idx.is_multiple_of(2) {
-                row[idx / 2] & 0x0F
-            } else {
-                row[idx / 2] >> 4
-            }
+fn fill_row_widths(
+    entries: &[(u32, u32, u8)],
+    projection: GridProjection,
+    widths: &mut [u8],
+    cells: usize,
+) -> std::io::Result<()> {
+    widths.fill(0);
+    for &(_, block, impact) in entries {
+        let (cell, value) = projection.project(block, impact);
+        if cell >= cells {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("BMP grid cell {cell} exceeds configured cell count {cells}"),
+            ));
         }
+        let group = cell / GRID_GROUP_CELLS;
+        widths[group] = widths[group].max(bit_width(value));
     }
+    Ok(())
 }
 
-/// Stream-write 4-bit packed grid (Section D) and 8-bit superblock grid (Section E).
+fn write_compressed_row_payload(
+    entries: &[(u32, u32, u8)],
+    projection: GridProjection,
+    widths: &[u8],
+    cells: usize,
+    writer: &mut dyn Write,
+) -> std::io::Result<()> {
+    let mut values = [0u8; GRID_GROUP_CELLS];
+    let mut packed = [0u8; GRID_GROUP_CELLS];
+    let mut entry = 0usize;
+    for (group, &width) in widths.iter().enumerate() {
+        values.fill(0);
+        while entry < entries.len() {
+            let (_, block, impact) = entries[entry];
+            let (cell, value) = projection.project(block, impact);
+            let entry_group = cell / GRID_GROUP_CELLS;
+            if entry_group > group {
+                break;
+            }
+            if entry_group < group || cell >= cells {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "BMP grid entries are not sorted by block within a dimension",
+                ));
+            }
+            let slot = &mut values[cell % GRID_GROUP_CELLS];
+            *slot = (*slot).max(value);
+            entry += 1;
+        }
+        let payload_len = pack_group(&values, width, &mut packed)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        writer.write_all(&packed[..payload_len])?;
+    }
+    if entry != entries.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "BMP grid row contains entries beyond the final group",
+        ));
+    }
+    Ok(())
+}
+
+fn write_compressed_grid_section(
+    grid_entries: &[(u32, u32, u8)],
+    num_dims: usize,
+    num_blocks: usize,
+    projection: GridProjection,
+    writer: &mut dyn Write,
+) -> std::io::Result<u64> {
+    let cells = projection.cells(num_blocks);
+    let layout = CompressedGridLayout::new(num_dims, cells);
+    let mut widths = vec![0u8; layout.groups()];
+    let mut row_sizes = Vec::with_capacity(num_dims);
+
+    let mut entry = 0usize;
+    for dim in 0..num_dims as u32 {
+        let start = entry;
+        while entry < grid_entries.len() && grid_entries[entry].0 == dim {
+            entry += 1;
+        }
+        fill_row_widths(&grid_entries[start..entry], projection, &mut widths, cells)?;
+        row_sizes.push(
+            layout
+                .row_bytes(&widths)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?,
+        );
+    }
+    if entry != grid_entries.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "BMP grid entry dim_id {} exceeds configured dims={num_dims}",
+                grid_entries[entry].0
+            ),
+        ));
+    }
+
+    let table_bytes = layout.write_row_offsets(&row_sizes, writer)?;
+    entry = 0;
+    for dim in 0..num_dims as u32 {
+        let start = entry;
+        while entry < grid_entries.len() && grid_entries[entry].0 == dim {
+            entry += 1;
+        }
+        let row_entries = &grid_entries[start..entry];
+        fill_row_widths(row_entries, projection, &mut widths, cells)?;
+        layout.write_row_header(&widths, projection.max_width(), writer)?;
+        write_compressed_row_payload(row_entries, projection, &widths, cells, writer)?;
+    }
+    Ok(table_bytes + row_sizes.into_iter().sum::<u64>())
+}
+
+/// Stream-write compressed ceil-quantized block (D) and LSP/0 superblock (E)
+/// grids. Both levels use four bits by default; an explicitly configured
+/// two-bit block grid does not reduce the four-bit superblock grid.
 ///
 /// `grid_entries` sorted by `(dim_id, block_id)`. `num_dims` is the fixed
 /// vocabulary size (dims), so the grid has `num_dims` rows.
 /// Each entry is `(dim_id, block_id, max_impact_u8)`.
 ///
-/// Memory: O(packed_row_size + num_superblocks) — one row buffer each.
-/// Returns `(packed_grid_bytes, sb_grid_bytes)`.
+/// Memory is bounded by one selector row plus two 256-byte group buffers.
+/// Returns `(block_grid_bytes, superblock_grid_bytes)`.
 pub(crate) fn stream_write_grids(
     grid_entries: &[(u32, u32, u8)],
     num_dims: usize,
@@ -681,58 +776,21 @@ pub(crate) fn stream_write_grids(
     grid_bits: u8,
     writer: &mut dyn Write,
 ) -> std::io::Result<(u64, u64)> {
-    let packed_row_size = grid_packed_row_size(num_blocks, grid_bits);
-    let num_superblocks = num_blocks.div_ceil(BMP_SUPERBLOCK_SIZE as usize);
-
-    let mut row_buf = vec![0u8; packed_row_size];
-    let mut sb_row = vec![0u8; num_superblocks];
-
-    // Section D: packed 4-bit grid, one dim row at a time
-    let mut gi = 0;
-    for dim_id in 0..num_dims as u32 {
-        row_buf.fill(0);
-        while gi < grid_entries.len() && grid_entries[gi].0 == dim_id {
-            let b = grid_entries[gi].1 as usize;
-            let cell = grid_quantize_ceil(grid_entries[gi].2, grid_bits);
-            grid_set_cell(&mut row_buf, b, cell, grid_bits);
-            gi += 1;
-        }
-        writer.write_all(&row_buf)?;
-    }
-    let packed_bytes = (num_dims * packed_row_size) as u64;
-
-    // Entries with dim_id >= num_dims sort past the cursor and have no grid
-    // row: they would be dropped silently, leaving those dimensions
-    // unsearchable. The segment builder rejects them at add/build time, so
-    // leftovers here mean a legacy blob or a caller bug — say so loudly.
-    if gi < grid_entries.len() {
-        log::warn!(
-            "[bmp] {} grid entries with dim_id >= dims={} dropped from the block-max grid \
-             (first dim_id={}); these dimensions are unsearchable — raise `dims` in the \
-             field's sparse_vector config and rebuild",
-            grid_entries.len() - gi,
-            num_dims,
-            grid_entries[gi].0,
-        );
-    }
-
-    // Section E: 8-bit superblock grid, one dim row at a time
-    gi = 0;
-    for dim_id in 0..num_dims as u32 {
-        sb_row.fill(0);
-        while gi < grid_entries.len() && grid_entries[gi].0 == dim_id {
-            let b = grid_entries[gi].1 as usize;
-            let sb = b / BMP_SUPERBLOCK_SIZE as usize;
-            if grid_entries[gi].2 > sb_row[sb] {
-                sb_row[sb] = grid_entries[gi].2;
-            }
-            gi += 1;
-        }
-        writer.write_all(&sb_row)?;
-    }
-    let sb_bytes = (num_dims * num_superblocks) as u64;
-
-    Ok((packed_bytes, sb_bytes))
+    let block_bytes = write_compressed_grid_section(
+        grid_entries,
+        num_dims,
+        num_blocks,
+        GridProjection::Block { bits: grid_bits },
+        writer,
+    )?;
+    let superblock_bytes = write_compressed_grid_section(
+        grid_entries,
+        num_dims,
+        num_blocks,
+        GridProjection::Superblock,
+        writer,
+    )?;
+    Ok((block_bytes, superblock_bytes))
 }
 
 /// Size of a single grid entry on disk: dim_id(4) + block_id(4) + impact(1) = 9 bytes.
@@ -765,16 +823,16 @@ impl GridRunReader {
     ) -> std::io::Result<Option<(u32, u32, u8)>> {
         use std::io::Read;
         let mut buf = [0u8; GRID_ENTRY_DISK_SIZE];
-        match reader.read_exact(&mut buf) {
-            Ok(()) => {
-                let dim_id = u32::from_le_bytes(buf[0..4].try_into().unwrap());
-                let block_id = u32::from_le_bytes(buf[4..8].try_into().unwrap());
-                let impact = buf[8];
-                Ok(Some((dim_id, block_id, impact)))
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => Ok(None),
-            Err(e) => Err(e),
+        // EOF is valid only between complete records. `read_exact` alone
+        // cannot distinguish an empty read from a truncated 1..8-byte tail.
+        if reader.read(&mut buf[..1])? == 0 {
+            return Ok(None);
         }
+        reader.read_exact(&mut buf[1..])?;
+        let dim_id = u32::from_le_bytes(buf[0..4].try_into().unwrap());
+        let block_id = u32::from_le_bytes(buf[4..8].try_into().unwrap());
+        let impact = buf[8];
+        Ok(Some((dim_id, block_id, impact)))
     }
 
     /// Advance to the next entry.
@@ -814,15 +872,196 @@ pub(crate) fn write_grid_run(
     Ok(())
 }
 
-/// Stream-write grids from multiple sorted run files (external merge sort).
+#[cfg(feature = "native")]
+fn visit_merged_dimension(
+    run_readers: &mut [GridRunReader],
+    dimension: u32,
+    mut visitor: impl FnMut(u32, u8) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    let mut heap: BinaryHeap<Reverse<(u32, u8, usize)>> =
+        BinaryHeap::with_capacity(run_readers.len());
+    for (run, reader) in run_readers.iter().enumerate() {
+        if let Some((dim, block, impact)) = reader.current
+            && dim == dimension
+        {
+            heap.push(Reverse((block, impact, run)));
+        }
+    }
+    while let Some(Reverse((block, impact, run))) = heap.pop() {
+        visitor(block, impact)?;
+        let reader = &mut run_readers[run];
+        reader.advance()?;
+        if let Some((dim, next_block, next_impact)) = reader.current
+            && dim == dimension
+        {
+            heap.push(Reverse((next_block, next_impact, run)));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "native")]
+struct ProjectedRowEncoder {
+    projection: GridProjection,
+    cells: usize,
+    widths: Vec<u8>,
+    payload: Vec<u8>,
+    values: [u8; GRID_GROUP_CELLS],
+    packed: [u8; GRID_GROUP_CELLS],
+    current_group: Option<usize>,
+    previous_cell: Option<usize>,
+}
+
+#[cfg(feature = "native")]
+impl ProjectedRowEncoder {
+    fn new(
+        projection: GridProjection,
+        cells: usize,
+        groups: usize,
+        payload_capacity: usize,
+    ) -> Self {
+        Self {
+            projection,
+            cells,
+            widths: vec![0; groups],
+            payload: Vec::with_capacity(payload_capacity),
+            values: [0; GRID_GROUP_CELLS],
+            packed: [0; GRID_GROUP_CELLS],
+            current_group: None,
+            previous_cell: None,
+        }
+    }
+
+    fn push(&mut self, block: u32, impact: u8) -> std::io::Result<()> {
+        let (cell, value) = self.projection.project(block, impact);
+        if cell >= self.cells {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "BMP grid cell {cell} exceeds configured cell count {}",
+                    self.cells
+                ),
+            ));
+        }
+        if self.previous_cell.is_some_and(|previous| cell < previous) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "BMP external grid runs are not sorted by block",
+            ));
+        }
+        let group = cell / GRID_GROUP_CELLS;
+        if self.current_group != Some(group) {
+            self.finish_current_group()?;
+            self.values.fill(0);
+            self.current_group = Some(group);
+        }
+        let slot = &mut self.values[cell % GRID_GROUP_CELLS];
+        *slot = (*slot).max(value);
+        self.previous_cell = Some(cell);
+        Ok(())
+    }
+
+    fn finish_current_group(&mut self) -> std::io::Result<()> {
+        let Some(group) = self.current_group else {
+            return Ok(());
+        };
+        let maximum = self.values.iter().copied().max().unwrap_or(0);
+        let width = bit_width(maximum);
+        self.widths[group] = width;
+        let payload_len = pack_group(&self.values, width, &mut self.packed)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        self.payload.extend_from_slice(&self.packed[..payload_len]);
+        Ok(())
+    }
+
+    fn finish(mut self) -> std::io::Result<(Vec<u8>, Vec<u8>)> {
+        self.finish_current_group()?;
+        Ok((self.widths, self.payload))
+    }
+}
+
+#[cfg(feature = "native")]
+fn write_compressed_grid_section_merged(
+    run_readers: &mut [GridRunReader],
+    num_dims: usize,
+    num_blocks: usize,
+    projection: GridProjection,
+    writer: &mut dyn Write,
+) -> std::io::Result<u64> {
+    let cells = projection.cells(num_blocks);
+    let layout = CompressedGridLayout::new(num_dims, cells);
+    let mut widths = vec![0u8; layout.groups()];
+    let mut row_sizes = Vec::with_capacity(num_dims);
+
+    for dim in 0..num_dims as u32 {
+        widths.fill(0);
+        visit_merged_dimension(run_readers, dim, |block, impact| {
+            let (cell, value) = projection.project(block, impact);
+            if cell >= cells {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("BMP grid cell {cell} exceeds configured cell count {cells}"),
+                ));
+            }
+            let group = cell / GRID_GROUP_CELLS;
+            widths[group] = widths[group].max(bit_width(value));
+            Ok(())
+        })?;
+        row_sizes.push(
+            layout
+                .row_bytes(&widths)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?,
+        );
+    }
+    for reader in run_readers.iter() {
+        if let Some((dimension, _, _)) = reader.current {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("BMP grid run dimension {dimension} exceeds configured dims={num_dims}"),
+            ));
+        }
+    }
+
+    for reader in run_readers.iter_mut() {
+        reader.reset()?;
+    }
+    let table_bytes = layout.write_row_offsets(&row_sizes, writer)?;
+    for (dim, &expected_row_size) in (0..num_dims as u32).zip(&row_sizes) {
+        let expected_row_size = usize::try_from(expected_row_size).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "BMP compressed-grid row exceeds addressable memory",
+            )
+        })?;
+        let payload_capacity = expected_row_size
+            .checked_sub(layout.row_header_bytes())
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "BMP compressed-grid row is shorter than its header",
+                )
+            })?;
+        let mut row =
+            ProjectedRowEncoder::new(projection, cells, layout.groups(), payload_capacity);
+        visit_merged_dimension(run_readers, dim, |block, impact| row.push(block, impact))?;
+        let (widths, payload) = row.finish()?;
+        if payload.len() != payload_capacity {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "BMP compressed-grid row size changed between sizing and encoding",
+            ));
+        }
+        layout.write_row_header(&widths, projection.max_width(), writer)?;
+        writer.write_all(&payload)?;
+    }
+    Ok(table_bytes + row_sizes.into_iter().sum::<u64>())
+}
+
+/// Stream-write compressed grids from multiple sorted run files.
 ///
-/// Two-pass approach: first pass writes Section D (packed 4-bit grid),
-/// then resets all readers and second pass writes Section E (superblock grid).
-///
-/// Within each run, entries are sorted by `(dim_id, block_id)`, so for each dim
-/// we drain matching entries from all readers. No heap needed.
-///
-/// Returns `(packed_grid_bytes, sb_grid_bytes)`.
+/// Each section uses one sizing pass and one encoding pass. Encoding buffers at
+/// most one already-compressed row, so peak memory is bounded even when a head
+/// dimension occurs in every block.
 #[cfg(feature = "native")]
 pub(crate) fn stream_write_grids_merged(
     run_readers: &mut [GridRunReader],
@@ -831,69 +1070,24 @@ pub(crate) fn stream_write_grids_merged(
     grid_bits: u8,
     writer: &mut dyn Write,
 ) -> std::io::Result<(u64, u64)> {
-    let packed_row_size = grid_packed_row_size(num_blocks, grid_bits);
-    let num_superblocks = num_blocks.div_ceil(BMP_SUPERBLOCK_SIZE as usize);
-
-    let mut row_buf = vec![0u8; packed_row_size];
-    let mut sb_row = vec![0u8; num_superblocks];
-
-    // Pass 1: Section D — packed 4-bit grid, one dim row at a time
-    for dim_id in 0..num_dims as u32 {
-        row_buf.fill(0);
-        for reader in run_readers.iter_mut() {
-            while let Some((d, block_id, impact)) = reader.current {
-                if d != dim_id {
-                    break;
-                }
-                let b = block_id as usize;
-                let cell = grid_quantize_ceil(impact, grid_bits);
-                grid_set_cell(&mut row_buf, b, cell, grid_bits);
-                reader.advance()?;
-            }
-        }
-        writer.write_all(&row_buf)?;
-    }
-    let packed_bytes = (num_dims * packed_row_size) as u64;
-
-    // Same silent-drop hazard as `stream_write_grids`: any entry still
-    // pending after the dim sweep has dim_id >= dims and no grid row.
-    for reader in run_readers.iter() {
-        if let Some((dim_id, _, _)) = reader.current {
-            log::warn!(
-                "[bmp] grid run contains entries with dim_id >= dims={num_dims} \
-                 (first dim_id={dim_id}) that were dropped from the block-max grid; \
-                 these dimensions are unsearchable — raise `dims` in the field's \
-                 sparse_vector config and rebuild",
-            );
-            break;
-        }
-    }
-
-    // Reset all readers for pass 2
+    let block_bytes = write_compressed_grid_section_merged(
+        run_readers,
+        num_dims,
+        num_blocks,
+        GridProjection::Block { bits: grid_bits },
+        writer,
+    )?;
     for reader in run_readers.iter_mut() {
         reader.reset()?;
     }
-
-    // Pass 2: Section E — 8-bit superblock grid, one dim row at a time
-    for dim_id in 0..num_dims as u32 {
-        sb_row.fill(0);
-        for reader in run_readers.iter_mut() {
-            while let Some((d, block_id, impact)) = reader.current {
-                if d != dim_id {
-                    break;
-                }
-                let sb = block_id as usize / BMP_SUPERBLOCK_SIZE as usize;
-                if impact > sb_row[sb] {
-                    sb_row[sb] = impact;
-                }
-                reader.advance()?;
-            }
-        }
-        writer.write_all(&sb_row)?;
-    }
-    let sb_bytes = (num_dims * num_superblocks) as u64;
-
-    Ok((packed_bytes, sb_bytes))
+    let superblock_bytes = write_compressed_grid_section_merged(
+        run_readers,
+        num_dims,
+        num_blocks,
+        GridProjection::Superblock,
+        writer,
+    )?;
+    Ok((block_bytes, superblock_bytes))
 }
 
 /// Quantize a weight to u8 (0-255) given the global max scale.
@@ -1039,6 +1233,20 @@ mod tests {
         let fb = &buf[footer_start..];
         let scale = f32::from_le_bytes(fb[48..52].try_into().unwrap());
         assert!((scale - 5.0).abs() < 0.001, "scale={}, expected 5.0", scale);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn grid_run_reader_rejects_a_truncated_final_record() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("grid-run");
+        std::fs::write(&path, [0u8; GRID_ENTRY_DISK_SIZE + 1]).unwrap();
+
+        let mut reader = GridRunReader::open(&path).unwrap();
+        let error = reader
+            .advance()
+            .expect_err("a partial grid record must not be treated as clean EOF");
+        assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
     }
 
     #[test]

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -336,7 +336,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         let bmp = bmps[job.src as usize];
         let (v2r, _) = &vid_maps[job.src as usize];
         let block_size = bmp.bmp_block_size as usize;
-        for (dim_id, postings) in bmp.iter_block_terms(job.block_id) {
+        for (dim_id, _, postings) in bmp.iter_block_terms(job.block_id) {
             let mut n = 0usize;
             for p in postings {
                 let vid = job.block_id as usize * block_size + p.local_slot as usize;
@@ -488,7 +488,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         let bmp = bmps[job.src as usize];
         let (v2r, _) = &vid_maps[job.src as usize];
         let block_size = bmp.bmp_block_size as usize;
-        for (dim_id, postings) in bmp.iter_block_terms(job.block_id) {
+        for (dim_id, _, postings) in bmp.iter_block_terms(job.block_id) {
             if term_remap.get(dim_id as usize).copied().unwrap_or(u32::MAX) == u32::MAX {
                 continue;
             }
@@ -535,7 +535,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         assert!(job.real_len as usize <= 256, "BMP block exceeds 256 docs");
         let mut cursor = [0u32; 256];
         let base = offsets[global_real_start] as usize;
-        for (dim_id, postings) in bmp.iter_block_terms(job.block_id) {
+        for (dim_id, _, postings) in bmp.iter_block_terms(job.block_id) {
             let compact = term_remap.get(dim_id as usize).copied().unwrap_or(u32::MAX);
             if compact == u32::MAX {
                 continue;
@@ -643,7 +643,7 @@ pub(crate) fn build_forward_index_from_blocks(
         .map(|_| std::sync::atomic::AtomicU32::new(0))
         .collect();
     let count_block_bf = |&(src, block_id): &(u32, u32)| {
-        for (dim_id, _) in bmps[src as usize].iter_block_terms(block_id) {
+        for (dim_id, _, _) in bmps[src as usize].iter_block_terms(block_id) {
             if let Some(count) = dim_bf.get(dim_id as usize) {
                 count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
@@ -757,7 +757,7 @@ pub(crate) fn build_forward_index_from_blocks(
     let count_remapped = |&(src, block_id): &(u32, u32)| -> u32 {
         bmps[src as usize]
             .iter_block_terms(block_id)
-            .filter(|(dim_id, _)| {
+            .filter(|(dim_id, _, _)| {
                 term_remap
                     .get(*dim_id as usize)
                     .copied()
@@ -778,7 +778,7 @@ pub(crate) fn build_forward_index_from_blocks(
     let mut terms = vec![0u32; total];
     let fill_block = |&(src, block_id): &(u32, u32), out: &mut [u32]| {
         let mut n = 0usize;
-        for (dim_id, _) in bmps[src as usize].iter_block_terms(block_id) {
+        for (dim_id, _, _) in bmps[src as usize].iter_block_terms(block_id) {
             let compact = term_remap.get(dim_id as usize).copied().unwrap_or(u32::MAX);
             if compact != u32::MAX {
                 out[n] = compact;

--- a/hermes-core/src/segment/builder/sparse.rs
+++ b/hermes-core/src/segment/builder/sparse.rs
@@ -112,7 +112,9 @@ pub(super) fn build_sparse_streaming(
                 let bmp_block_size = sparse_config
                     .map(|config| config.bmp_block_size)
                     .unwrap_or(crate::structures::SparseVectorConfig::DEFAULT_BMP_BLOCK_SIZE);
-                let grid_bits = sparse_config.map(|c| c.bmp_grid_bits).unwrap_or(4);
+                let grid_bits = sparse_config
+                    .map(|c| c.bmp_grid_bits)
+                    .unwrap_or(crate::structures::SparseVectorConfig::DEFAULT_BMP_GRID_BITS);
                 let dims = sparse_config.and_then(|c| c.dims).unwrap_or(105879); // default SPLADE vocab
                 let max_weight = sparse_config.and_then(|c| c.max_weight).unwrap_or(5.0); // default SPLADE max
 

--- a/hermes-core/src/segment/format.rs
+++ b/hermes-core/src/segment/format.rs
@@ -91,29 +91,16 @@ pub fn read_dense_toc(
 /// Field header: field_id(4) + quant(1) + num_dims(4) + total_vectors(4) = 13B
 pub const SPARSE_FOOTER_MAGIC: u32 = 0x34525053;
 
-/// Magic number for the current BMP V15 blob footer ("BMP5" in LE).
+/// Magic number for the current BMP V17 blob footer ("BMP7" in LE).
 ///
-/// V15 changes from V14:
-/// - **u64 total_terms and total_postings** footer statistics (were u32 and
-///   saturated on billion-scale indexes).
-/// - **72-byte footer** (was 64) to accommodate the wider statistics.
-///
-/// V14 changed from V13:
-/// - **u32 num_terms and u32 posting prefix sums** per block (were u16):
-///   blocks with >65,535 postings (bmp_block_size 256 × ~300-dim docs)
-///   silently wrapped the u16 prefix sums, corrupting the block and
-///   producing wild posting slices at read time. No compatibility shim —
-///   V13 and older segments must be rebuilt.
-///
-/// V13 changes from V12:
-/// - **Recursive Graph Bisection (BP)** replaces SimHash for document ordering
-/// - **Section H removed**: no per-block SimHash (BP needs no stored metadata)
-/// - **64-byte footer** (was 72): `block_simhash_offset` field removed.
-///
-/// Only V15 is accepted; older indexes must be rebuilt.
-pub const BMP_BLOB_MAGIC: u32 = 0x35504D42;
+/// V17 uses LSP/0's 256-vector superblocks and ceil-u4 maximum weights at both
+/// pruning levels. It retains independently addressable, locally bit-packed
+/// 256-cell groups and exact per-term block-header maxima.
+/// This is the only accepted BMP representation; indexes are rebuilt on format
+/// changes rather than carrying compatibility parsers.
+pub const BMP_BLOB_MAGIC: u32 = 0x37504D42;
 
-/// Current BMP V15 blob footer size.
+/// Current BMP V17 blob footer size.
 pub const BMP_BLOB_FOOTER_SIZE: usize = 72;
 
 /// V3 footer size: skip_offset(8) + toc_offset(8) + num_fields(4) + magic(4) = 24

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -98,14 +98,17 @@ impl SegmentMerger {
                         .try_fold(0u32, |total, vectors| total.checked_add(vectors))
                         .ok_or_else(|| {
                             crate::Error::Internal(
-                                "merged BMP vector count exceeds the V15 u32 format limit".into(),
+                                "merged BMP vector count exceeds the V17 u32 format limit".into(),
                             )
                         })?;
                     let bmp_block_size = sparse_config
                         .as_ref()
                         .map(|c| c.bmp_block_size)
-                        .unwrap_or(64);
-                    let grid_bits = sparse_config.as_ref().map(|c| c.bmp_grid_bits).unwrap_or(4);
+                        .unwrap_or(crate::structures::SparseVectorConfig::DEFAULT_BMP_BLOCK_SIZE);
+                    let grid_bits = sparse_config
+                        .as_ref()
+                        .map(|c| c.bmp_grid_bits)
+                        .unwrap_or(crate::structures::SparseVectorConfig::DEFAULT_BMP_GRID_BITS);
                     let dims = sparse_config
                         .as_ref()
                         .and_then(|c| c.dims)
@@ -572,20 +575,23 @@ fn validate_sparse_merge_source(dim_id: u32, source_index: usize, raw: &DimRawDa
     Ok(())
 }
 
-/// Merge BMP fields with **streaming block-copy V15 format**.
+/// Merge BMP fields with **streaming block-copy V17 format**.
 ///
-/// V15 block-copy merge: all segments share the same `dims`, `bmp_block_size`,
+/// V17 block-copy merge: all segments share the same `dims`, `bmp_block_size`,
 /// and `max_weight_scale`, so blocks are self-contained and can be copied directly.
 ///
 /// Phases:
 /// 1. Stream Section B (block data) — sequential chunked copy
 /// 2. Write padding + Section A (block_data_starts) — recomputed on-the-fly
-/// 3. Stream Section D (packed_grid) — one row at a time
-/// 4. Write Section E (sb_grid) — one row at a time
+/// 3. Stream Section D — payload groups already aligned in output coordinates
+///    are copied byte-for-byte; shifted groups use a bounded decode/repack
+/// 4. Stream Section E — ceil-u4 values decoded/repacked into the output
+///    superblock coordinate system
 /// 5. Stream Section F+G (doc_map) — bulk copy with offset patching
-/// 6. Write the V15 footer
+/// 6. Write the V17 footer
 ///
-/// Peak memory: row_buf (~4 MB) + sb_row (~120 KB) + id_buf (256 KB) + tiny Vecs.
+/// Peak memory is one row's group descriptors/selectors, one superblock row,
+/// and fixed-size copy/decode buffers; it does not scale with postings.
 #[allow(clippy::too_many_arguments)]
 fn merge_bmp_field(
     bmp_indexes: &[Option<&BmpIndex>],
@@ -601,8 +607,6 @@ fn merge_bmp_field(
     field_tocs: &mut Vec<SparseFieldToc>,
 ) -> Result<()> {
     use crate::segment::builder::bmp::write_bmp_footer;
-    use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
-
     let effective_block_size = bmp_block_size.clamp(1, 256);
 
     // Pre-build source list: (&BmpIndex, doc_offset). Filters out None segments.
@@ -652,14 +656,14 @@ fn merge_bmp_field(
             .checked_add(bmp.num_blocks)
             .ok_or_else(|| {
                 crate::Error::Internal(
-                    "merged BMP block count exceeds the V15 u32 format limit".into(),
+                    "merged BMP block count exceeds the V17 u32 format limit".into(),
                 )
             })?;
         num_real_docs_total = num_real_docs_total
             .checked_add(bmp.num_real_docs())
             .ok_or_else(|| {
                 crate::Error::Internal(
-                    "merged BMP real-document count exceeds the V15 u32 format limit".into(),
+                    "merged BMP real-document count exceeds the V17 u32 format limit".into(),
                 )
             })?;
     }
@@ -674,12 +678,9 @@ fn merge_bmp_field(
         .filter(|&count| count <= u32::MAX as usize)
         .ok_or_else(|| {
             crate::Error::Internal(
-                "merged BMP virtual-document count exceeds the V15 u32 format limit".into(),
+                "merged BMP virtual-document count exceeds the V17 u32 format limit".into(),
             )
         })?;
-    let packed_row_size = crate::segment::builder::bmp::grid_packed_row_size(num_blocks, grid_bits);
-    let num_superblocks = num_blocks.div_ceil(BMP_SUPERBLOCK_SIZE as usize);
-
     // Pre-compute aggregate stats (needed for footer, independent of block order)
     let mut total_terms: u64 = 0;
     let mut total_postings: u64 = 0;
@@ -687,20 +688,8 @@ fn merge_bmp_field(
         total_terms = total_terms.saturating_add(bmp.total_terms());
         total_postings = total_postings.saturating_add(bmp.total_postings());
     }
-    // Pre-compute per-source block offsets (first global block id for each source)
-    let mut block_offsets: Vec<u32> = Vec::with_capacity(sources.len());
-    {
-        let mut cumulative: u32 = 0;
-        for &(bmp, _) in &sources {
-            block_offsets.push(cumulative);
-            cumulative = cumulative.checked_add(bmp.num_blocks).ok_or_else(|| {
-                crate::Error::Internal("merged BMP block offset exceeds u32::MAX".into())
-            })?;
-        }
-    }
-
     log::debug!(
-        "[merge_bmp_v14] field {}: dims={}, {} sources, {} total_blocks, \
+        "[merge_bmp_v17] field {}: dims={}, {} sources, {} total_blocks, \
          block_size={}, max_weight_scale={:.4}",
         field_id,
         dims,
@@ -765,66 +754,19 @@ fn merge_bmp_field(
         .write_all(&cumulative_bytes.to_le_bytes())
         .map_err(crate::Error::Io)?;
 
-    // ── Phase 3: Stream Section D (packed_grid) — one row at a time
+    // ── Phase 3: Stream Section D. Groups already aligned in output
+    // coordinates are copied byte-for-byte; shifted output groups use a
+    // bounded 256-cell decode/repack.
     let grid_offset = writer.offset() - blob_start;
-    let mut row_buf = vec![0u8; packed_row_size];
+    let block_grid_bytes =
+        write_merged_block_grid(&sources, dims as usize, num_blocks, grid_bits, writer)?;
 
-    for dim_id in 0..dims {
-        row_buf.fill(0);
-        for (src_idx, &(bmp, _)) in sources.iter().enumerate() {
-            let col_offset = block_offsets[src_idx] as usize;
-            let src_prs = bmp.packed_row_size();
-            let src_num_blocks = bmp.num_blocks as usize;
-            let src_row_start = dim_id as usize * src_prs;
-            let src_row_end = src_row_start + src_prs;
-            let src_grid = bmp.grid_slice();
-            if src_row_end > src_grid.len() {
-                continue;
-            }
-            let src_row = &src_grid[src_row_start..src_row_end];
-            copy_cells(src_row, src_num_blocks, &mut row_buf, col_offset, grid_bits);
-        }
-        writer.write_all(&row_buf).map_err(crate::Error::Io)?;
-    }
-    drop(row_buf);
-
-    // ── Phase 4: Stream Section E (sb_grid) — one row at a time ─
+    // ── Phase 4: Stream Section E. Source superblock coordinates restart at
+    // every segment, so this ceil-u4 section is remapped by
+    // source block offsets and repacked.
     let sb_grid_offset = writer.offset() - blob_start;
-    let mut sb_row = vec![0u8; num_superblocks];
-    let sb_size = BMP_SUPERBLOCK_SIZE as usize;
-
-    for dim_id in 0..dims {
-        sb_row.fill(0);
-        for (src_idx, &(bmp, _)) in sources.iter().enumerate() {
-            let col_offset = block_offsets[src_idx] as usize;
-            let src_num_blocks = bmp.num_blocks as usize;
-            let src_num_sbs = bmp.num_superblocks as usize;
-            let src_sb_grid = bmp.sb_grid_slice();
-            let src_sb_row_start = dim_id as usize * src_num_sbs;
-            let src_sb_row_end = src_sb_row_start + src_num_sbs;
-            if src_sb_row_end > src_sb_grid.len() {
-                continue;
-            }
-            let src_sb_row = &src_sb_grid[src_sb_row_start..src_sb_row_end];
-
-            for (sb_src, &val) in src_sb_row.iter().enumerate() {
-                if val == 0 {
-                    continue;
-                }
-                let first_block = col_offset + sb_src * sb_size;
-                let last_block = (first_block + sb_size).min(col_offset + src_num_blocks) - 1;
-                let first_out_sb = first_block / sb_size;
-                let last_out_sb = last_block / sb_size;
-                for slot in &mut sb_row[first_out_sb..=last_out_sb] {
-                    if val > *slot {
-                        *slot = val;
-                    }
-                }
-            }
-        }
-        writer.write_all(&sb_row).map_err(crate::Error::Io)?;
-    }
-    drop(sb_row);
+    debug_assert_eq!(sb_grid_offset, grid_offset + block_grid_bytes);
+    write_merged_superblock_grid(&sources, dims as usize, num_blocks, writer)?;
 
     // Release grid pages
     #[cfg(feature = "native")]
@@ -881,7 +823,7 @@ fn merge_bmp_field(
         }
     }
 
-    // ── Phase 6: Write V15 footer ───────────────────────────────────────
+    // ── Phase 6: Write V17 footer ───────────────────────────────────────
     write_bmp_footer(
         writer,
         total_terms,
@@ -984,20 +926,355 @@ fn push_bmp_field_toc(
     });
 }
 
-/// Copy 4-bit nibbles from a source grid row to a destination row at a column offset.
-///
-/// Hot inner loop for grid merge (~8 KB per row).
-/// Source nibbles are packed: low nibble = even block, high nibble = odd block.
-#[inline]
-fn copy_cells(src_row: &[u8], src_blocks: usize, dst_row: &mut [u8], offset: usize, grid_bits: u8) {
-    use crate::segment::builder::bmp::{grid_get_cell, grid_set_cell};
-    for b in 0..src_blocks {
-        let val = grid_get_cell(src_row, b, grid_bits);
-        if val == 0 {
-            continue;
-        }
-        grid_set_cell(dst_row, offset + b, val, grid_bits);
+enum MergedBlockGroup<'a> {
+    Borrowed(crate::segment::bmp_grid::PackedGridGroup<'a>),
+    Repacked { width: u8 },
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_merged_block_group<'a>(
+    output_group: usize,
+    num_blocks: usize,
+    source_bases: &[usize],
+    source_group_bases: &[usize],
+    row_groups: &[crate::segment::bmp_grid::PackedGridGroup<'a>],
+    source_cursor: &mut usize,
+    values: &mut [u8; crate::segment::bmp_grid::GRID_GROUP_CELLS],
+) -> Result<MergedBlockGroup<'a>> {
+    use crate::segment::bmp_grid::{GRID_GROUP_CELLS, bit_width};
+
+    let output_start = output_group * GRID_GROUP_CELLS;
+    let output_end = (output_start + GRID_GROUP_CELLS).min(num_blocks);
+    while source_bases
+        .get(*source_cursor + 1)
+        .is_some_and(|&end| end <= output_start)
+    {
+        *source_cursor += 1;
     }
+    let source_end = source_bases.get(*source_cursor + 1).ok_or_else(|| {
+        crate::Error::Corruption("BMP merge block-grid source range is incomplete".into())
+    })?;
+    let local_start = output_start
+        .checked_sub(source_bases[*source_cursor])
+        .ok_or_else(|| {
+            crate::Error::Corruption("BMP merge block-grid source ranges overlap".into())
+        })?;
+
+    // The common large-segment case: this output group is exactly one
+    // complete source group. Preserve its payload byte-for-byte.
+    if output_end - output_start == GRID_GROUP_CELLS
+        && output_end <= *source_end
+        && local_start.is_multiple_of(GRID_GROUP_CELLS)
+    {
+        let group_index = source_group_bases[*source_cursor] + local_start / GRID_GROUP_CELLS;
+        let group = row_groups.get(group_index).copied().ok_or_else(|| {
+            crate::Error::Corruption("BMP merge block-grid group is missing".into())
+        })?;
+        return Ok(MergedBlockGroup::Borrowed(group));
+    }
+
+    values.fill(0);
+    let mut global = output_start;
+    let mut current_source = *source_cursor;
+    while global < output_end {
+        while source_bases
+            .get(current_source + 1)
+            .is_some_and(|&end| end <= global)
+        {
+            current_source += 1;
+        }
+        let current_end = *source_bases.get(current_source + 1).ok_or_else(|| {
+            crate::Error::Corruption("BMP merge block-grid source range is incomplete".into())
+        })?;
+        let local = global
+            .checked_sub(source_bases[current_source])
+            .ok_or_else(|| {
+                crate::Error::Corruption("BMP merge block-grid source ranges overlap".into())
+            })?;
+        let source_group = local / GRID_GROUP_CELLS;
+        let within = local % GRID_GROUP_CELLS;
+        let count = (GRID_GROUP_CELLS - within)
+            .min(output_end - global)
+            .min(current_end - global);
+        let destination = global - output_start;
+        let group_index = source_group_bases[current_source] + source_group;
+        row_groups
+            .get(group_index)
+            .copied()
+            .ok_or_else(|| {
+                crate::Error::Corruption("BMP merge block-grid group is missing".into())
+            })?
+            .decode(within, count, &mut values[destination..destination + count]);
+        global += count;
+    }
+    Ok(MergedBlockGroup::Repacked {
+        width: bit_width(values.iter().copied().max().unwrap_or(0)),
+    })
+}
+
+fn write_merged_block_grid<'a>(
+    sources: &[(&'a BmpIndex, u32)],
+    dims: usize,
+    num_blocks: usize,
+    grid_bits: u8,
+    writer: &mut dyn Write,
+) -> Result<u64> {
+    use crate::segment::bmp_grid::{CompressedGridLayout, GRID_GROUP_CELLS, pack_group};
+
+    let layout = CompressedGridLayout::new(dims, num_blocks);
+    let mut source_bases = Vec::with_capacity(sources.len() + 1);
+    let mut source_group_bases = Vec::with_capacity(sources.len() + 1);
+    source_bases.push(0usize);
+    source_group_bases.push(0usize);
+    for &(bmp, _) in sources {
+        let next = source_bases
+            .last()
+            .copied()
+            .unwrap_or(0)
+            .checked_add(bmp.num_blocks as usize)
+            .ok_or_else(|| {
+                crate::Error::Internal("merged BMP block-grid offset overflows usize".into())
+            })?;
+        source_bases.push(next);
+        source_group_bases.push(
+            source_group_bases
+                .last()
+                .copied()
+                .unwrap_or(0)
+                .checked_add(bmp.block_grid().groups())
+                .ok_or_else(|| {
+                    crate::Error::Internal(
+                        "merged BMP block-grid group offset overflows usize".into(),
+                    )
+                })?,
+        );
+    }
+    if source_bases.last().copied() != Some(num_blocks) {
+        return Err(crate::Error::Internal(
+            "merged BMP block-grid source lengths disagree with output".into(),
+        ));
+    }
+
+    let mut widths = vec![0u8; layout.groups()];
+    let mut row_sizes = Vec::with_capacity(dims);
+    let mut row_groups: Vec<crate::segment::bmp_grid::PackedGridGroup<'a>> =
+        Vec::with_capacity(*source_group_bases.last().unwrap_or(&0));
+
+    let load_row = |dimension: usize,
+                    groups: &mut Vec<crate::segment::bmp_grid::PackedGridGroup<'a>>|
+     -> Result<()> {
+        groups.clear();
+        for &(bmp, _) in sources {
+            let grid = bmp.block_grid();
+            if grid.dims() != dims || grid.max_width() != grid_bits {
+                return Err(crate::Error::Corruption(
+                    "BMP merge block-grid metadata disagrees with the field schema".into(),
+                ));
+            }
+            grid.append_row_groups(dimension, groups)?;
+        }
+        if groups.len() != *source_group_bases.last().unwrap_or(&0) {
+            return Err(crate::Error::Corruption(
+                "BMP merge block-grid row has an inconsistent group count".into(),
+            ));
+        }
+        Ok(())
+    };
+    let mut group_values = [0u8; GRID_GROUP_CELLS];
+    let collect_widths = |widths: &mut [u8],
+                          groups: &[crate::segment::bmp_grid::PackedGridGroup<'a>],
+                          values: &mut [u8; GRID_GROUP_CELLS]|
+     -> Result<()> {
+        widths.fill(0);
+        let mut source = 0usize;
+        for (output_group, output_width) in widths.iter_mut().enumerate() {
+            *output_width = match prepare_merged_block_group(
+                output_group,
+                num_blocks,
+                &source_bases,
+                &source_group_bases,
+                groups,
+                &mut source,
+                values,
+            )? {
+                MergedBlockGroup::Borrowed(group) => group.width(),
+                MergedBlockGroup::Repacked { width } => width,
+            };
+        }
+        Ok(())
+    };
+
+    for dimension in 0..dims {
+        load_row(dimension, &mut row_groups)?;
+        collect_widths(&mut widths, &row_groups, &mut group_values)?;
+        row_sizes.push(layout.row_bytes(&widths)?);
+    }
+    let table_bytes = layout
+        .write_row_offsets(&row_sizes, writer)
+        .map_err(crate::Error::Io)?;
+
+    for dimension in 0..dims {
+        load_row(dimension, &mut row_groups)?;
+        collect_widths(&mut widths, &row_groups, &mut group_values)?;
+        layout
+            .write_row_header(&widths, grid_bits, writer)
+            .map_err(crate::Error::Io)?;
+
+        let mut packed = [0u8; GRID_GROUP_CELLS];
+        let mut source = 0usize;
+        for (output_group, &width) in widths.iter().enumerate() {
+            match prepare_merged_block_group(
+                output_group,
+                num_blocks,
+                &source_bases,
+                &source_group_bases,
+                &row_groups,
+                &mut source,
+                &mut group_values,
+            )? {
+                MergedBlockGroup::Borrowed(group) => {
+                    if group.width() != width {
+                        return Err(crate::Error::Corruption(
+                            "BMP merge block-grid sizing changed during encoding".into(),
+                        ));
+                    }
+                    writer.write_all(group.bytes()).map_err(crate::Error::Io)?;
+                }
+                MergedBlockGroup::Repacked {
+                    width: actual_width,
+                } => {
+                    if actual_width != width {
+                        return Err(crate::Error::Corruption(
+                            "BMP merge block-grid sizing changed during encoding".into(),
+                        ));
+                    }
+                    let payload_len = pack_group(&group_values, width, &mut packed)?;
+                    writer
+                        .write_all(&packed[..payload_len])
+                        .map_err(crate::Error::Io)?;
+                }
+            }
+        }
+    }
+    Ok(table_bytes + row_sizes.into_iter().sum::<u64>())
+}
+
+fn write_merged_superblock_grid<'a>(
+    sources: &[(&'a BmpIndex, u32)],
+    dims: usize,
+    num_blocks: usize,
+    writer: &mut dyn Write,
+) -> Result<u64> {
+    use crate::segment::bmp_grid::{CompressedGridLayout, GRID_GROUP_CELLS, pack_group};
+
+    let mut source_block_bases = Vec::with_capacity(sources.len() + 1);
+    source_block_bases.push(0usize);
+    for &(bmp, _) in sources {
+        let next = source_block_bases
+            .last()
+            .copied()
+            .unwrap_or(0)
+            .checked_add(bmp.num_blocks as usize)
+            .ok_or_else(|| {
+                crate::Error::Internal("merged BMP superblock block offset overflows usize".into())
+            })?;
+        source_block_bases.push(next);
+    }
+    if source_block_bases.last().copied() != Some(num_blocks) {
+        return Err(crate::Error::Internal(
+            "merged BMP superblock source lengths disagree with output".into(),
+        ));
+    }
+    let cells = num_blocks.div_ceil(crate::segment::BMP_SUPERBLOCK_SIZE as usize);
+    let layout = CompressedGridLayout::new(dims, cells);
+    let mut widths = vec![0u8; layout.groups()];
+    let mut row_sizes = Vec::with_capacity(dims);
+    let mut row = vec![0u8; cells];
+    let mut decoded = [0u8; GRID_GROUP_CELLS];
+    let mut source_groups: Vec<crate::segment::bmp_grid::PackedGridGroup<'a>> = Vec::new();
+
+    let fill_row = |dimension: usize,
+                    row: &mut [u8],
+                    decoded: &mut [u8; GRID_GROUP_CELLS],
+                    source_groups: &mut Vec<crate::segment::bmp_grid::PackedGridGroup<'a>>|
+     -> Result<()> {
+        const SB: usize = crate::segment::BMP_SUPERBLOCK_SIZE as usize;
+        row.fill(0);
+        for (source, &(bmp, _)) in sources.iter().enumerate() {
+            let grid = bmp.superblock_grid();
+            let source_blocks = bmp.num_blocks as usize;
+            source_groups.clear();
+            grid.append_row_groups(dimension, source_groups)?;
+            for (source_group, group) in source_groups.iter().copied().enumerate() {
+                let source_cell_start = source_group * GRID_GROUP_CELLS;
+                let count = GRID_GROUP_CELLS.min(grid.cells() - source_cell_start);
+                if group.width() == 0 {
+                    continue;
+                }
+                group.decode(0, count, decoded);
+                for (within, &value) in decoded[..count].iter().enumerate() {
+                    if value == 0 {
+                        continue;
+                    }
+                    let source_sb = source_cell_start + within;
+                    let local_block_start = source_sb * SB;
+                    if local_block_start >= source_blocks {
+                        break;
+                    }
+                    let local_block_end = (local_block_start + SB).min(source_blocks);
+                    let global_block_start = source_block_bases[source] + local_block_start;
+                    let global_block_end = source_block_bases[source] + local_block_end;
+                    let first_output_sb = global_block_start / SB;
+                    let last_output_sb = (global_block_end - 1) / SB;
+                    for slot in &mut row[first_output_sb..=last_output_sb] {
+                        *slot = (*slot).max(value);
+                    }
+                }
+            }
+        }
+        Ok(())
+    };
+    let collect_widths = |row: &[u8], widths: &mut [u8]| {
+        widths.fill(0);
+        for (group, values) in row.chunks(GRID_GROUP_CELLS).enumerate() {
+            widths[group] =
+                crate::segment::bmp_grid::bit_width(values.iter().copied().max().unwrap_or(0));
+        }
+    };
+
+    for dimension in 0..dims {
+        fill_row(dimension, &mut row, &mut decoded, &mut source_groups)?;
+        collect_widths(&row, &mut widths);
+        row_sizes.push(layout.row_bytes(&widths)?);
+    }
+    let table_bytes = layout
+        .write_row_offsets(&row_sizes, writer)
+        .map_err(crate::Error::Io)?;
+
+    let mut values = [0u8; GRID_GROUP_CELLS];
+    let mut packed = [0u8; GRID_GROUP_CELLS];
+    for dimension in 0..dims {
+        fill_row(dimension, &mut row, &mut decoded, &mut source_groups)?;
+        collect_widths(&row, &mut widths);
+        layout
+            .write_row_header(
+                &widths,
+                crate::segment::bmp_grid::LSP_SUPERBLOCK_GRID_BITS,
+                writer,
+            )
+            .map_err(crate::Error::Io)?;
+        for (output_group, &width) in widths.iter().enumerate() {
+            values.fill(0);
+            let start = output_group * GRID_GROUP_CELLS;
+            let count = GRID_GROUP_CELLS.min(cells - start);
+            values[..count].copy_from_slice(&row[start..start + count]);
+            let payload_len = pack_group(&values, width, &mut packed)?;
+            writer
+                .write_all(&packed[..payload_len])
+                .map_err(crate::Error::Io)?;
+        }
+    }
+    Ok(table_bytes + row_sizes.into_iter().sum::<u64>())
 }
 
 #[cfg(test)]

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod ann_build;
 mod ann_disk;
+pub(crate) mod bmp_grid;
 #[cfg(any(feature = "native", feature = "wasm"))]
 mod builder;
 pub(crate) mod format;
@@ -28,9 +29,7 @@ pub(crate) use merger::block_in_place_if_multithread;
 pub use merger::{MergeStats, SegmentMerger, delete_segment};
 pub(crate) use reader::BmpIndex;
 pub(crate) use reader::bmp::BMP_SUPERBLOCK_SIZE;
-pub(crate) use reader::bmp::{
-    accumulate_grid_u32, block_term_postings, compute_block_masks, find_dim_in_block_data,
-};
+pub(crate) use reader::bmp::{block_term_postings, find_dim_in_block_data};
 pub(crate) use reader::combine_ordinal_results;
 #[cfg(feature = "native")]
 pub mod pin;

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -1,6 +1,6 @@
-//! BMP (Block-Max Pruning) index reader for sparse vectors — **V15 zero-copy**.
+//! BMP (Block-Max Pruning) index reader for sparse vectors — **V17 zero-copy**.
 //!
-//! V15 uses fixed `dims` (vocabulary size) and dim_id directly in per-block data.
+//! V17 uses fixed `dims` (vocabulary size) and dim_id directly in per-block data.
 //! Grid is indexed by dim_id as row index (no Section C dim_ids array).
 //! Data-first layout: block data (Section B) appears before block_data_starts
 //! (Section A). The reader derives the Section A offset from
@@ -20,18 +20,17 @@
 //! Based on Mallia, Suel & Tonellotto (SIGIR 2024).
 
 use crate::directories::{FileHandle, OwnedBytes};
+use crate::segment::bmp_grid::CompressedGrid;
 
-/// Number of BMP blocks grouped into one superblock for hierarchical pruning.
+/// Number of BMP blocks grouped into one LSP/0 superblock.
 ///
-/// Based on Carlson et al. (SIGIR 2025): "Dynamic Superblock Pruning for Fast
-/// Learned Sparse Retrieval". Superblocks precompute per-superblock upper bounds,
-/// enabling entire groups of blocks to be pruned before computing block-level UBs.
-///
-/// At 1M×5 ordinals (78K blocks), this reduces UB computation from 78K entries
-/// to ~1.2K superblock entries, pruning 25-75% of blocks before detailed scoring.
-pub const BMP_SUPERBLOCK_SIZE: u32 = 64;
+/// Carlson et al. recommend `block_size × blocks_per_superblock <= 256`.
+/// Hermes keeps the requested 32-vector blocks, so eight blocks form one
+/// 256-vector superblock. Eight divides the 256-cell compressed-grid group,
+/// ensuring a selected superblock never crosses a codec group.
+pub const BMP_SUPERBLOCK_SIZE: u32 = 8;
 
-/// A single posting in the BMP forward index: (local_slot, impact).
+/// A single posting in BMP's block-local flat inverted index.
 ///
 /// Exactly 2 bytes: `[local_slot: u8, impact: u8]`.
 #[derive(Clone, Copy)]
@@ -73,9 +72,9 @@ unsafe fn read_u64_unchecked(base: *const u8, idx: usize) -> u64 {
     }
 }
 
-/// BMP V15 index for a single sparse field — fully zero-copy mmap-backed.
+/// BMP V17 index for a single sparse field — fully zero-copy mmap-backed.
 ///
-/// V15 format with Recursive Graph Bisection (BP) document ordering.
+/// V17 format with Recursive Graph Bisection (BP) document ordering.
 ///
 /// All data sections are `OwnedBytes` slices into the same underlying mmap Arc.
 /// No heap allocation — the superblock grid is persisted on disk and loaded as
@@ -102,15 +101,12 @@ pub struct BmpIndex {
     dims: u32,
     total_terms: u64,
     total_postings: u64,
-    /// Packed row size for 4-bit grid: `(num_blocks + 1) / 2`
-    packed_row_size: u32,
     /// Bits per block-grid cell (4 or 2); dequant scale is 17 or 85.
     grid_bits: u8,
     /// Actual vector count before padding
     num_real_docs: u32,
     /// True when every stored vector is ordinal zero. This is derived from
-    /// the physical document map rather than the schema so legacy segments
-    /// whose `multi` flag was inaccurate still get correct query planning.
+    /// the physical document map rather than trusting schema declarations.
     single_valued: bool,
 
     // ── Zero-copy OwnedBytes sections (keeps backing store alive) ────
@@ -118,10 +114,11 @@ pub struct BmpIndex {
     block_data_starts_bytes: OwnedBytes,
     /// Section B: interleaved per-block data (all scoring data contiguous per block)
     block_data_bytes: OwnedBytes,
-    /// 4-bit packed block grid: `grid[dim_id * packed_row_size + block_id/2]`
-    grid_bytes: OwnedBytes,
-    /// sb_grid[dim_id * num_superblocks + sb_id] = max impact across all blocks in superblock
-    sb_grid_bytes: OwnedBytes,
+    /// Locally bit-packed block maxima. Stored values retain their configured
+    /// ceil-u4/u2 semantics exactly.
+    block_grid: CompressedGrid,
+    /// Locally bit-packed ceil-u4 superblock maxima.
+    superblock_grid: CompressedGrid,
     /// Number of superblocks
     pub num_superblocks: u32,
     /// doc_map_ids[virtual_id] = original doc_id — zero-copy OwnedBytes
@@ -147,12 +144,12 @@ pub struct BmpIndex {
 // inherits Send+Sync automatically through its fields.
 
 impl BmpIndex {
-    /// Parse a BMP V15 blob from the given file handle.
+    /// Parse a BMP V17 blob from the given file handle.
     ///
     /// Reads the footer, then acquires the entire blob as a single
     /// `OwnedBytes` and slices it into zero-copy sections.
     ///
-    /// V15 data-first layout: Section B (per-block interleaved data) first,
+    /// V17 data-first layout: Section B (per-block interleaved data) first,
     /// then Section A (block_data_starts with u64 entries), grids, doc_map.
     pub fn parse(
         handle: FileHandle,
@@ -165,7 +162,7 @@ impl BmpIndex {
 
         if blob_len < BMP_BLOB_FOOTER_SIZE as u64 {
             return Err(crate::Error::Corruption(
-                "BMP blob too small for V15 footer".into(),
+                "BMP blob too small for V17 footer".into(),
             ));
         }
 
@@ -195,7 +192,7 @@ impl BmpIndex {
 
         if magic != BMP_BLOB_MAGIC {
             return Err(crate::Error::Corruption(format!(
-                "Invalid BMP blob magic: {:#x} (expected BMP5 {:#x}); rebuild \
+                "Invalid BMP blob magic: {:#x} (expected BMP7 {:#x}); rebuild \
                  the index with this version.",
                 magic, BMP_BLOB_MAGIC
             )));
@@ -228,14 +225,13 @@ impl BmpIndex {
                 dims,
                 total_terms: 0,
                 total_postings: 0,
-                packed_row_size: 0,
                 grid_bits,
                 num_real_docs,
                 single_valued: true,
                 block_data_starts_bytes: OwnedBytes::empty(),
                 block_data_bytes: OwnedBytes::empty(),
-                grid_bytes: OwnedBytes::empty(),
-                sb_grid_bytes: OwnedBytes::empty(),
+                block_grid: CompressedGrid::empty(),
+                superblock_grid: CompressedGrid::empty(),
                 num_superblocks: 0,
                 doc_map_ids_bytes: OwnedBytes::empty(),
                 doc_map_ordinals_bytes: OwnedBytes::empty(),
@@ -310,42 +306,27 @@ impl BmpIndex {
         // Section A: block_data_starts [bds_start..grid_offset)
         let block_data_starts_bytes = blob.slice(bds_start..grid_start);
 
-        // Sections D+E: grid, sb_grid, doc_map
-        let packed_row_size =
-            crate::segment::builder::bmp::grid_packed_row_size(num_blocks as usize, grid_bits)
-                as u32;
-        let grid_size = (dims as usize)
-            .checked_mul(packed_row_size as usize)
-            .ok_or_else(|| crate::Error::Corruption("BMP grid size overflows usize".into()))?;
-        let grid_end = grid_start.checked_add(grid_size).ok_or_else(|| {
-            crate::Error::Corruption("BMP grid end offset overflows usize".into())
-        })?;
-
+        // Sections D+E: compressed ceil-u4 block and superblock grids, then
+        // document maps. Their byte lengths are carried
+        // by the footer's section offsets; each grid validates its own row
+        // table before exposing random group access.
         let num_superblocks = num_blocks.div_ceil(BMP_SUPERBLOCK_SIZE);
         let sb_grid_start = usize::try_from(sb_grid_offset).map_err(|_| {
             crate::Error::Corruption("BMP superblock-grid offset is too large".into())
         })?;
-        if sb_grid_start != grid_end {
+        if sb_grid_start < grid_start || sb_grid_start > data_len_usize {
             return Err(crate::Error::Corruption(format!(
-                "BMP section order mismatch: superblock grid starts at {}, expected {}",
-                sb_grid_start, grid_end
+                "BMP section order mismatch: block grid starts at {}, superblock grid at {}, data ends at {}",
+                grid_start, sb_grid_start, data_len_usize
             )));
         }
-        let sb_grid_size = (dims as usize)
-            .checked_mul(num_superblocks as usize)
-            .ok_or_else(|| {
-                crate::Error::Corruption("BMP superblock-grid size overflows usize".into())
-            })?;
-        let sb_grid_end = sb_grid_start.checked_add(sb_grid_size).ok_or_else(|| {
-            crate::Error::Corruption("BMP superblock-grid end overflows usize".into())
-        })?;
 
         let dm_start = usize::try_from(doc_map_offset)
             .map_err(|_| crate::Error::Corruption("BMP document-map offset is too large".into()))?;
-        if dm_start != sb_grid_end {
+        if dm_start < sb_grid_start || dm_start > data_len_usize {
             return Err(crate::Error::Corruption(format!(
-                "BMP section order mismatch: document map starts at {}, expected {}",
-                dm_start, sb_grid_end
+                "BMP section order mismatch: superblock grid starts at {}, document map at {}, data ends at {}",
+                sb_grid_start, dm_start, data_len_usize
             )));
         }
         let dm_ids_len = (num_virtual_docs as usize).checked_mul(4).ok_or_else(|| {
@@ -368,8 +349,20 @@ impl BmpIndex {
         }
 
         // Slice into sections (all zero-copy — just offset adjustments on same Arc)
-        let grid_bytes = blob.slice(grid_start..grid_end);
-        let sb_grid_bytes = blob.slice(sb_grid_start..sb_grid_end);
+        let block_grid = CompressedGrid::parse(
+            blob.slice(grid_start..sb_grid_start),
+            dims as usize,
+            num_blocks as usize,
+            grid_bits,
+            "BMP block grid",
+        )?;
+        let superblock_grid = CompressedGrid::parse(
+            blob.slice(sb_grid_start..dm_start),
+            dims as usize,
+            num_superblocks as usize,
+            4,
+            "BMP superblock grid",
+        )?;
         let doc_map_ids_bytes = blob.slice(dm_start..dm_ids_end);
         let doc_map_ordinals_bytes = blob.slice(dm_ids_end..dm_ords_end);
         let single_valued = doc_map_ordinals_bytes
@@ -404,14 +397,10 @@ impl BmpIndex {
         // scattered. Default kernel readahead pulls in 128KB per fault around
         // each touched location, which evicts hot pages under memory pressure.
         //
-        // The grid especially: at production scale queries take the direct
-        // (non-compact) path and read 32 bytes per (query dim, surviving
-        // superblock) at UB-priority — i.e. effectively random — offsets
-        // within each ~100KB+ row. Default readahead amplifies each 32-byte
-        // probe into 128KB of page cache (~4000×), marching the entire
-        // data-sized grid into memory and OOMing cgroup-limited deployments.
-        // The compact path (whole-row copies) only runs when a query's rows
-        // total ≤128KB, where losing readahead costs a couple of pages.
+        // The block grid especially: queries read one eight-cell range per
+        // (query dim, surviving superblock) at UB-priority, i.e. effectively
+        // random offsets. Default readahead can amplify each tiny probe into
+        // 128KB of page cache and march a data-sized grid into memory.
         //
         // sb_grid keeps default readahead: its rows are swept contiguously
         // per query dim, and it is pinnable (priority 4).
@@ -420,13 +409,14 @@ impl BmpIndex {
             block_data_bytes.madvise(libc::MADV_RANDOM);
             doc_map_ids_bytes.madvise(libc::MADV_RANDOM);
             doc_map_ordinals_bytes.madvise(libc::MADV_RANDOM);
-            grid_bytes.madvise(libc::MADV_RANDOM);
+            block_grid.madvise_rows(libc::MADV_RANDOM);
+            superblock_grid.madvise_rows(libc::MADV_SEQUENTIAL);
         }
 
         log::debug!(
-            "BMP V15 index loaded: num_blocks={}, num_superblocks={}, dims={}, bmp_block_size={}, \
+            "BMP V17 index loaded: num_blocks={}, num_superblocks={}, dims={}, bmp_block_size={}, \
              num_virtual_docs={}, num_real_docs={}, max_weight_scale={:.4}, postings={}, \
-             packed_row_size={}, single_valued={}, block_data={}B, doc_map={}B",
+             block_grid={}B, superblock_grid={}B, single_valued={}, block_data={}B, doc_map={}B",
             num_blocks,
             num_superblocks,
             dims,
@@ -435,7 +425,8 @@ impl BmpIndex {
             num_real_docs,
             max_weight_scale,
             total_postings,
-            packed_row_size,
+            block_grid.encoded_bytes(),
+            superblock_grid.encoded_bytes(),
             single_valued,
             bds_start,
             num_virtual_docs as usize * 6,
@@ -450,14 +441,13 @@ impl BmpIndex {
             dims,
             total_terms,
             total_postings,
-            packed_row_size,
             grid_bits,
             num_real_docs,
             single_valued,
             block_data_starts_bytes,
             block_data_bytes,
-            grid_bytes,
-            sb_grid_bytes,
+            block_grid,
+            superblock_grid,
             num_superblocks,
             doc_map_ids_bytes,
             doc_map_ordinals_bytes,
@@ -467,7 +457,7 @@ impl BmpIndex {
         })
     }
 
-    /// Read the entire raw V15 blob (including footer) from the source file.
+    /// Read the entire raw V17 blob (including footer) from the source file.
     ///
     /// Used by reorder paths (native-only) to copy a field byte-identically
     /// when its `reorder` schema attribute is unset.
@@ -540,6 +530,8 @@ impl BmpIndex {
             remaining,
             report,
         );
+        self.block_grid
+            .pin_offsets("bmp block_grid row_offsets", mode, remaining, report);
     }
 
     /// Pin the virtual-doc → (doc_id, ordinal) maps (priority 3: every
@@ -568,7 +560,8 @@ impl BmpIndex {
     }
 
     /// Pin the superblock grid (priority 4: every query dim reads a row).
-    /// The 4-bit block grid is deliberately never pinned (data-sized).
+    /// The compressed block-grid payload is deliberately never pinned
+    /// (data-sized); its small row-offset table is priority 1 above.
     #[cfg(feature = "native")]
     pub(crate) fn pin_sb_grid(
         &mut self,
@@ -576,9 +569,9 @@ impl BmpIndex {
         remaining: &mut u64,
         report: &mut crate::segment::pin::PinReport,
     ) {
-        crate::segment::pin::pin_section(
-            &mut self.sb_grid_bytes,
-            "bmp sb_grid",
+        self.superblock_grid.pin_all(
+            "bmp sb_grid row_offsets",
+            "bmp sb_grid rows",
             mode,
             remaining,
             report,
@@ -613,22 +606,48 @@ impl BmpIndex {
     }
 
     /// Parse a block header: returns
-    /// (num_terms, dim_ptr, ps_ptr, post_ptr, total_block_postings).
+    /// (num_terms, dim_ptr, ps_ptr, max_ptr, post_ptr, total_block_postings).
     /// All pointers are within block_data_bytes — guaranteed contiguous.
     ///
     /// Always 4-byte (u32) dim IDs.
     ///
     /// Returns zero terms and null section pointers for empty blocks.
     #[inline(always)]
-    pub(crate) fn parse_block(&self, block_id: u32) -> (u32, *const u8, *const u8, *const u8, u32) {
+    pub(crate) fn parse_block(
+        &self,
+        block_id: u32,
+    ) -> (u32, *const u8, *const u8, *const u8, *const u8, u32) {
         if block_id >= self.num_blocks {
-            return (0, std::ptr::null(), std::ptr::null(), std::ptr::null(), 0);
+            return (
+                0,
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+            );
         }
         let (start, end) = self.block_data_range(block_id);
         if start == end {
-            return (0, std::ptr::null(), std::ptr::null(), std::ptr::null(), 0);
+            return (
+                0,
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+            );
         }
-        let invalid = || (0, std::ptr::null(), std::ptr::null(), std::ptr::null(), 0);
+        let invalid = || {
+            (
+                0,
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+            )
+        };
         let Ok(block_len) = usize::try_from(end - start) else {
             return invalid();
         };
@@ -643,7 +662,7 @@ impl BmpIndex {
         };
         let num_terms = unsafe { u32::from_le((base as *const u32).read_unaligned()) };
         let Some(header_len) = (num_terms as usize)
-            .checked_mul(8)
+            .checked_mul(9)
             .and_then(|bytes| bytes.checked_add(8))
         else {
             return invalid();
@@ -658,8 +677,8 @@ impl BmpIndex {
         let dim_ptr = unsafe { base.add(4) };
         // Always u32 dim IDs (4 bytes each)
         let ps_ptr = unsafe { dim_ptr.add(num_terms as usize * 4) };
-        // u32 prefix sums (V14): u16 wrapped past 65,535 postings per block
-        let post_ptr = unsafe { ps_ptr.add((num_terms as usize + 1) * 4) };
+        let max_ptr = unsafe { ps_ptr.add((num_terms as usize + 1) * 4) };
+        let post_ptr = unsafe { max_ptr.add(num_terms as usize) };
         let first = unsafe { u32::from_le((ps_ptr as *const u32).read_unaligned()) };
         let last = unsafe {
             u32::from_le((ps_ptr.add(num_terms as usize * 4) as *const u32).read_unaligned())
@@ -671,6 +690,7 @@ impl BmpIndex {
             num_terms,
             dim_ptr,
             ps_ptr,
+            max_ptr,
             post_ptr,
             total_block_postings_u32,
         )
@@ -693,10 +713,12 @@ impl BmpIndex {
     ///
     /// Reads u32 dim_id directly from block data (no dim_idx→dim_id lookup).
     pub fn iter_block_terms(&self, block_id: u32) -> BlockTermIter<'_> {
-        let (num_terms, dim_ptr, ps_ptr, post_ptr, total_postings) = self.parse_block(block_id);
+        let (num_terms, dim_ptr, ps_ptr, max_ptr, post_ptr, total_postings) =
+            self.parse_block(block_id);
         BlockTermIter {
             dim_ptr,
             ps_ptr,
+            max_ptr,
             post_ptr,
             num_terms,
             total_postings,
@@ -742,50 +764,10 @@ impl BmpIndex {
         std::mem::size_of::<Self>()
             + self.block_data_starts_bytes.len()
             + self.block_data_bytes.len()
-            + self.grid_bytes.len()
-            + self.sb_grid_bytes.len()
+            + self.block_grid.encoded_bytes()
+            + self.superblock_grid.encoded_bytes()
             + self.doc_map_ids_bytes.len()
             + self.doc_map_ordinals_bytes.len()
-    }
-
-    /// Extract compact grid data for query-relevant dims into caller-provided buffers.
-    ///
-    /// `dim_indices` are dim_id values (used directly as grid row indices).
-    ///
-    /// Copies only the rows corresponding to `dim_indices`, creating a contiguous
-    /// layout that fits in L1/L2 cache. For ~20 query dims with 1500 blocks:
-    /// sb_grid ~480B + grid ~15KB = ~16KB — comfortably in L1 (32-64KB).
-    ///
-    /// After extraction, local dim index `i` maps to `compact_sb_grid[i * nsb..]`
-    /// and `compact_grid[i * prs..]`.
-    pub(crate) fn extract_compact_grids(
-        &self,
-        dim_indices: &[usize],
-        compact_sb_grid: &mut Vec<u8>,
-        compact_grid: &mut Vec<u8>,
-    ) {
-        let nsb = self.num_superblocks as usize;
-        let prs = self.packed_row_size as usize;
-        let nqd = dim_indices.len();
-
-        compact_sb_grid.resize(nqd * nsb, 0);
-        compact_grid.resize(nqd * prs, 0);
-
-        let sb_grid = self.sb_grid_bytes.as_slice();
-        let grid = self.grid_bytes.as_slice();
-
-        for (local, &dim_idx) in dim_indices.iter().enumerate() {
-            compact_sb_grid[local * nsb..(local + 1) * nsb]
-                .copy_from_slice(&sb_grid[dim_idx * nsb..(dim_idx + 1) * nsb]);
-            compact_grid[local * prs..(local + 1) * prs]
-                .copy_from_slice(&grid[dim_idx * prs..(dim_idx + 1) * prs]);
-        }
-    }
-
-    /// Packed row size (bytes per dim row in 4-bit grid).
-    #[inline]
-    pub fn packed_row_size(&self) -> usize {
-        self.packed_row_size as usize
     }
 
     /// Bits per block-grid cell (4 or 2).
@@ -793,17 +775,49 @@ impl BmpIndex {
         self.grid_bits
     }
 
-    /// Direct access to mmap-backed superblock grid (zero-copy, zero allocation).
-    /// Used for large segments where compact grid extraction would be too expensive.
+    /// Direct random-group access to the compressed block grid.
     #[inline]
-    pub(crate) fn sb_grid_slice(&self) -> &[u8] {
-        self.sb_grid_bytes.as_slice()
+    pub(crate) fn block_grid(&self) -> &CompressedGrid {
+        &self.block_grid
     }
 
-    /// Direct access to mmap-backed block grid (zero-copy, zero allocation).
+    /// Direct random-group access to the compressed ceil-u4 superblock grid.
     #[inline]
-    pub fn grid_slice(&self) -> &[u8] {
-        self.grid_bytes.as_slice()
+    pub(crate) fn superblock_grid(&self) -> &CompressedGrid {
+        &self.superblock_grid
+    }
+
+    /// Visit independently decoded chunks of one block-grid row.
+    ///
+    /// This is intended for diagnostics such as the CLI heatmap. `None`
+    /// represents an all-zero chunk and avoids materializing it; non-zero
+    /// values are valid only for the duration of the callback.
+    pub fn for_each_block_grid_chunk(
+        &self,
+        dimension: u32,
+        mut visitor: impl FnMut(usize, usize, Option<&[u8]>),
+    ) -> crate::Result<()> {
+        let dimension = dimension as usize;
+        if dimension >= self.block_grid.dims() {
+            return Err(crate::Error::Query(format!(
+                "BMP block-grid dimension {dimension} exceeds {}",
+                self.block_grid.dims()
+            )));
+        }
+        let mut decoded = [0u8; crate::segment::bmp_grid::GRID_GROUP_CELLS];
+        self.block_grid
+            .try_for_each_row_group(dimension, |group_id, group| {
+                let start = group_id * crate::segment::bmp_grid::GRID_GROUP_CELLS;
+                let count =
+                    crate::segment::bmp_grid::GRID_GROUP_CELLS.min(self.block_grid.cells() - start);
+                if group.width() == 0 {
+                    visitor(start, count, None);
+                } else {
+                    group.decode(0, count, &mut decoded);
+                    visitor(start, count, Some(&decoded[..count]));
+                }
+                Ok(())
+            })
     }
 
     // ── Streaming merge accessors (block-copy) ────────────────────────
@@ -849,8 +863,8 @@ impl BmpIndex {
     pub fn madvise_sequential(&self) {
         Self::madvise_owned(&self.block_data_bytes, libc::MADV_SEQUENTIAL);
         Self::madvise_owned(&self.block_data_starts_bytes, libc::MADV_SEQUENTIAL);
-        Self::madvise_owned(&self.grid_bytes, libc::MADV_SEQUENTIAL);
-        Self::madvise_owned(&self.sb_grid_bytes, libc::MADV_SEQUENTIAL);
+        self.block_grid.madvise_rows(libc::MADV_SEQUENTIAL);
+        self.superblock_grid.madvise_rows(libc::MADV_SEQUENTIAL);
         Self::madvise_owned(&self.doc_map_ids_bytes, libc::MADV_SEQUENTIAL);
         Self::madvise_owned(&self.doc_map_ordinals_bytes, libc::MADV_SEQUENTIAL);
     }
@@ -868,8 +882,8 @@ impl BmpIndex {
     #[cfg(feature = "native")]
     pub fn madvise_random_query(&self) {
         Self::madvise_owned(&self.block_data_bytes, libc::MADV_RANDOM);
-        Self::madvise_owned(&self.grid_bytes, libc::MADV_RANDOM);
-        Self::madvise_owned(&self.sb_grid_bytes, libc::MADV_RANDOM);
+        self.block_grid.madvise_rows(libc::MADV_RANDOM);
+        self.superblock_grid.madvise_rows(libc::MADV_SEQUENTIAL);
         Self::madvise_owned(&self.doc_map_ids_bytes, libc::MADV_RANDOM);
         Self::madvise_owned(&self.doc_map_ordinals_bytes, libc::MADV_RANDOM);
     }
@@ -877,8 +891,8 @@ impl BmpIndex {
     /// Release grid pages after Phase 3+4 complete.
     #[cfg(feature = "native")]
     pub fn madvise_dontneed_grids(&self) {
-        Self::madvise_owned(&self.grid_bytes, libc::MADV_DONTNEED);
-        Self::madvise_owned(&self.sb_grid_bytes, libc::MADV_DONTNEED);
+        self.block_grid.madvise_rows(libc::MADV_DONTNEED);
+        self.superblock_grid.madvise_rows(libc::MADV_DONTNEED);
     }
 
     /// Release document-map pages faulted by a full reorder scan. They remain
@@ -948,6 +962,7 @@ impl Drop for BmpScanPageGuard<'_> {
 pub struct BlockTermIter<'a> {
     dim_ptr: *const u8,
     ps_ptr: *const u8,
+    max_ptr: *const u8,
     post_ptr: *const u8,
     num_terms: u32,
     total_postings: u32,
@@ -962,7 +977,7 @@ unsafe impl<'a> Send for BlockTermIter<'a> {}
 unsafe impl<'a> Sync for BlockTermIter<'a> {}
 
 impl<'a> Iterator for BlockTermIter<'a> {
-    type Item = (u32, &'a [BmpPosting]);
+    type Item = (u32, u8, &'a [BmpPosting]);
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -974,11 +989,12 @@ impl<'a> Iterator for BlockTermIter<'a> {
 
         // Read u32 dim_id directly from block data
         let dim_id = unsafe { read_u32_unchecked(self.dim_ptr, i as usize) };
+        let max_impact = unsafe { *self.max_ptr.add(i as usize) };
 
         // Get postings from block-local ps_ptr/post_ptr
         let postings =
             unsafe { block_term_postings(self.ps_ptr, self.post_ptr, i, self.total_postings) };
-        Some((dim_id, postings))
+        Some((dim_id, max_impact, postings))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -1045,8 +1061,7 @@ pub(crate) unsafe fn block_term_postings<'a>(
     let start = u32::from_le((start_p as *const u32).read_unaligned()) as usize;
     let end = u32::from_le((end_p as *const u32).read_unaligned()) as usize;
     // Prefix sums are cumulative — a non-monotonic pair means the block is
-    // corrupt. Never build a wild slice from it (`end - start` underflow on
-    // wrapped V13 data was a production SIGSEGV).
+    // corrupt. Never build a wild slice from it (`end - start` can underflow).
     if end <= start || end > total_block_postings as usize {
         return &[];
     }
@@ -1054,741 +1069,6 @@ pub(crate) unsafe fn block_term_postings<'a>(
     // SAFETY: BmpPosting is #[repr(C)] with align=1 (two u8 fields).
     let ptr = post_ptr.add(start * 2) as *const BmpPosting;
     std::slice::from_raw_parts(ptr, count)
-}
-
-// ============================================================================
-// SIMD-accelerated helpers for BMP scoring
-// ============================================================================
-// Packed grid accumulation
-// ============================================================================
-
-/// Add one packed grid row to exact integer block-bound accumulators.
-///
-/// The query quantizer proves that the sum over all rows fits `u32`. Keeping
-/// this loop in integer units makes the final f32 conversion monotonic with
-/// document scoring. Rows are unpacked a byte at a time to avoid per-cell
-/// division and repeated packed-byte loads.
-#[inline]
-pub(crate) fn accumulate_grid_u32(
-    packed: &[u8],
-    grid_bits: u8,
-    elem_offset: usize,
-    count: usize,
-    weight: u32,
-    out: &mut [u32],
-) {
-    debug_assert!(out.len() >= count);
-    if grid_bits == 2 {
-        let scaled_weight = weight * 85;
-        let mut index = 0usize;
-        while index < count && !(elem_offset + index).is_multiple_of(4) {
-            let absolute = elem_offset + index;
-            let cell =
-                (unsafe { *packed.get_unchecked(absolute / 4) } >> ((absolute % 4) * 2)) & 0x03;
-            unsafe { *out.get_unchecked_mut(index) += u32::from(cell) * scaled_weight };
-            index += 1;
-        }
-        while index + 4 <= count {
-            let byte = unsafe { *packed.get_unchecked((elem_offset + index) / 4) };
-            unsafe {
-                *out.get_unchecked_mut(index) += u32::from(byte & 0x03) * scaled_weight;
-                *out.get_unchecked_mut(index + 1) += u32::from((byte >> 2) & 0x03) * scaled_weight;
-                *out.get_unchecked_mut(index + 2) += u32::from((byte >> 4) & 0x03) * scaled_weight;
-                *out.get_unchecked_mut(index + 3) += u32::from(byte >> 6) * scaled_weight;
-            }
-            index += 4;
-        }
-        while index < count {
-            let absolute = elem_offset + index;
-            let cell =
-                (unsafe { *packed.get_unchecked(absolute / 4) } >> ((absolute % 4) * 2)) & 0x03;
-            unsafe { *out.get_unchecked_mut(index) += u32::from(cell) * scaled_weight };
-            index += 1;
-        }
-        return;
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    if elem_offset.is_multiple_of(2) {
-        unsafe { accumulate_u4_u32_neon(packed, elem_offset, count, weight, out) };
-        return;
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    if elem_offset.is_multiple_of(2) && is_x86_feature_detected!("sse4.1") {
-        unsafe { accumulate_u4_u32_sse41(packed, elem_offset, count, weight, out) };
-        return;
-    }
-
-    let scaled_weight = weight * 17;
-    let mut index = 0usize;
-    if !elem_offset.is_multiple_of(2) && count > 0 {
-        let byte = unsafe { *packed.get_unchecked(elem_offset / 2) };
-        unsafe { *out.get_unchecked_mut(0) += u32::from(byte >> 4) * scaled_weight };
-        index = 1;
-    }
-    while index + 2 <= count {
-        let byte = unsafe { *packed.get_unchecked((elem_offset + index) / 2) };
-        unsafe {
-            *out.get_unchecked_mut(index) += u32::from(byte & 0x0f) * scaled_weight;
-            *out.get_unchecked_mut(index + 1) += u32::from(byte >> 4) * scaled_weight;
-        }
-        index += 2;
-    }
-    if index < count {
-        let byte = unsafe { *packed.get_unchecked((elem_offset + index) / 2) };
-        unsafe { *out.get_unchecked_mut(index) += u32::from(byte & 0x0f) * scaled_weight };
-    }
-}
-
-#[cfg(target_arch = "aarch64")]
-#[target_feature(enable = "neon")]
-#[allow(unsafe_op_in_unsafe_fn)]
-unsafe fn accumulate_u4_u32_neon(
-    packed: &[u8],
-    elem_offset: usize,
-    count: usize,
-    weight: u32,
-    out: &mut [u32],
-) {
-    use std::arch::aarch64::*;
-
-    let mask = vdupq_n_u8(0x0f);
-    let scale = vdupq_n_u8(17);
-    let packed_ptr = packed.as_ptr().add(elem_offset / 2);
-    let out_ptr = out.as_mut_ptr();
-    let chunks = count / 32;
-
-    for chunk in 0..chunks {
-        let bytes = vld1q_u8(packed_ptr.add(chunk * 16));
-        let low = vmulq_u8(vandq_u8(bytes, mask), scale);
-        let high = vmulq_u8(vshrq_n_u8::<4>(bytes), scale);
-        let first = vzip1q_u8(low, high);
-        let second = vzip2q_u8(low, high);
-        let output = out_ptr.add(chunk * 32);
-
-        let first_low = vmovl_u8(vget_low_u8(first));
-        let first_high = vmovl_u8(vget_high_u8(first));
-        let second_low = vmovl_u8(vget_low_u8(second));
-        let second_high = vmovl_u8(vget_high_u8(second));
-        let vectors = [
-            vmovl_u16(vget_low_u16(first_low)),
-            vmovl_u16(vget_high_u16(first_low)),
-            vmovl_u16(vget_low_u16(first_high)),
-            vmovl_u16(vget_high_u16(first_high)),
-            vmovl_u16(vget_low_u16(second_low)),
-            vmovl_u16(vget_high_u16(second_low)),
-            vmovl_u16(vget_low_u16(second_high)),
-            vmovl_u16(vget_high_u16(second_high)),
-        ];
-        for (vector_index, values) in vectors.into_iter().enumerate() {
-            let destination = output.add(vector_index * 4);
-            let accumulated = vld1q_u32(destination);
-            vst1q_u32(destination, vmlaq_n_u32(accumulated, values, weight));
-        }
-    }
-
-    let base = chunks * 32;
-    let scaled_weight = weight * 17;
-    for index in base..count {
-        let absolute = elem_offset + index;
-        let byte = *packed.get_unchecked(absolute / 2);
-        let cell = if absolute.is_multiple_of(2) {
-            byte & 0x0f
-        } else {
-            byte >> 4
-        };
-        *out.get_unchecked_mut(index) += u32::from(cell) * scaled_weight;
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "sse4.1")]
-#[allow(unsafe_op_in_unsafe_fn)]
-unsafe fn accumulate_u4_u32_sse41(
-    packed: &[u8],
-    elem_offset: usize,
-    count: usize,
-    weight: u32,
-    out: &mut [u32],
-) {
-    use std::arch::x86_64::*;
-
-    let mask = _mm_set1_epi8(0x0f);
-    let zero = _mm_setzero_si128();
-    let weight_vector = _mm_set1_epi32(weight as i32);
-    let packed_ptr = packed.as_ptr().add(elem_offset / 2);
-    let out_ptr = out.as_mut_ptr();
-    let chunks = count / 32;
-
-    for chunk in 0..chunks {
-        let bytes = _mm_loadu_si128(packed_ptr.add(chunk * 16) as *const __m128i);
-        let low = _mm_and_si128(bytes, mask);
-        let high = _mm_and_si128(_mm_srli_epi16::<4>(bytes), mask);
-        let low = _mm_add_epi8(_mm_slli_epi16::<4>(low), low);
-        let high = _mm_add_epi8(_mm_slli_epi16::<4>(high), high);
-        let first = _mm_unpacklo_epi8(low, high);
-        let second = _mm_unpackhi_epi8(low, high);
-        let output = out_ptr.add(chunk * 32);
-
-        let first_low = _mm_unpacklo_epi8(first, zero);
-        let first_high = _mm_unpackhi_epi8(first, zero);
-        let second_low = _mm_unpacklo_epi8(second, zero);
-        let second_high = _mm_unpackhi_epi8(second, zero);
-        let vectors = [
-            _mm_unpacklo_epi16(first_low, zero),
-            _mm_unpackhi_epi16(first_low, zero),
-            _mm_unpacklo_epi16(first_high, zero),
-            _mm_unpackhi_epi16(first_high, zero),
-            _mm_unpacklo_epi16(second_low, zero),
-            _mm_unpackhi_epi16(second_low, zero),
-            _mm_unpacklo_epi16(second_high, zero),
-            _mm_unpackhi_epi16(second_high, zero),
-        ];
-        for (vector_index, values) in vectors.into_iter().enumerate() {
-            let destination = output.add(vector_index * 4) as *mut __m128i;
-            let accumulated = _mm_loadu_si128(destination);
-            let contribution = _mm_mullo_epi32(values, weight_vector);
-            _mm_storeu_si128(destination, _mm_add_epi32(accumulated, contribution));
-        }
-    }
-
-    let base = chunks * 32;
-    let scaled_weight = weight * 17;
-    for index in base..count {
-        let absolute = elem_offset + index;
-        let byte = *packed.get_unchecked(absolute / 2);
-        let cell = if absolute.is_multiple_of(2) {
-            byte & 0x0f
-        } else {
-            byte >> 4
-        };
-        *out.get_unchecked_mut(index) += u32::from(cell) * scaled_weight;
-    }
-}
-
-/// Legacy f32 SIMD kernel retained only by the grid-layout microbenchmark.
-/// Production pruning accumulates integer bound units in `query::bmp`; f32
-/// term-by-term addition can round below the matching integer document score.
-#[cfg(test)]
-pub(crate) fn accumulate_u4_weighted(
-    packed: &[u8],
-    elem_offset: usize,
-    count: usize,
-    weight: f32,
-    out: &mut [f32],
-) {
-    if count == 0 {
-        return;
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    {
-        if elem_offset.is_multiple_of(2) {
-            unsafe { accumulate_u4_weighted_neon(packed, elem_offset, count, weight, out) };
-            return;
-        }
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    {
-        if elem_offset.is_multiple_of(2) && is_x86_feature_detected!("sse4.1") {
-            unsafe { accumulate_u4_weighted_sse41(packed, elem_offset, count, weight, out) };
-            return;
-        }
-    }
-
-    // Scalar fallback (also used for odd elem_offset)
-    for i in 0..count {
-        let abs_idx = elem_offset + i;
-        let byte_val = unsafe { *packed.get_unchecked(abs_idx / 2) };
-        let val = if abs_idx.is_multiple_of(2) {
-            byte_val & 0x0F
-        } else {
-            byte_val >> 4
-        };
-        unsafe {
-            *out.get_unchecked_mut(i) += (val as u32 * 17) as f32 * weight;
-        }
-    }
-}
-
-#[cfg(all(test, target_arch = "aarch64"))]
-#[target_feature(enable = "neon")]
-#[allow(unsafe_op_in_unsafe_fn)]
-unsafe fn accumulate_u4_weighted_neon(
-    packed: &[u8],
-    elem_offset: usize,
-    count: usize,
-    weight: f32,
-    out: &mut [f32],
-) {
-    use std::arch::aarch64::*;
-
-    debug_assert!(elem_offset.is_multiple_of(2));
-
-    let weight_v = vdupq_n_f32(weight);
-    let mask_lo = vdupq_n_u8(0x0F);
-    let scale17 = vdupq_n_u8(17);
-
-    let byte_offset = elem_offset / 2;
-    let packed_ptr = packed.as_ptr().add(byte_offset);
-    let out_ptr = out.as_mut_ptr();
-
-    let chunks = count / 32;
-    let remainder = count % 32;
-
-    for chunk in 0..chunks {
-        let pb = packed_ptr.add(chunk * 16);
-        let ob = out_ptr.add(chunk * 32);
-
-        let bytes = vld1q_u8(pb);
-
-        let low = vandq_u8(bytes, mask_lo);
-        let high = vshrq_n_u8::<4>(bytes);
-
-        let low_scaled = vmulq_u8(low, scale17);
-        let high_scaled = vmulq_u8(high, scale17);
-
-        let elems_0_15 = vzip1q_u8(low_scaled, high_scaled);
-        let elems_16_31 = vzip2q_u8(low_scaled, high_scaled);
-
-        {
-            let lo8 = vget_low_u8(elems_0_15);
-            let hi8 = vget_high_u8(elems_0_15);
-            let lo16 = vmovl_u8(lo8);
-            let hi16 = vmovl_u8(hi8);
-
-            let u32_0 = vmovl_u16(vget_low_u16(lo16));
-            let f32_0 = vcvtq_f32_u32(u32_0);
-            let acc_0 = vld1q_f32(ob);
-            vst1q_f32(ob, vfmaq_f32(acc_0, f32_0, weight_v));
-
-            let u32_1 = vmovl_u16(vget_high_u16(lo16));
-            let f32_1 = vcvtq_f32_u32(u32_1);
-            let acc_1 = vld1q_f32(ob.add(4));
-            vst1q_f32(ob.add(4), vfmaq_f32(acc_1, f32_1, weight_v));
-
-            let u32_2 = vmovl_u16(vget_low_u16(hi16));
-            let f32_2 = vcvtq_f32_u32(u32_2);
-            let acc_2 = vld1q_f32(ob.add(8));
-            vst1q_f32(ob.add(8), vfmaq_f32(acc_2, f32_2, weight_v));
-
-            let u32_3 = vmovl_u16(vget_high_u16(hi16));
-            let f32_3 = vcvtq_f32_u32(u32_3);
-            let acc_3 = vld1q_f32(ob.add(12));
-            vst1q_f32(ob.add(12), vfmaq_f32(acc_3, f32_3, weight_v));
-        }
-
-        {
-            let lo8 = vget_low_u8(elems_16_31);
-            let hi8 = vget_high_u8(elems_16_31);
-            let lo16 = vmovl_u8(lo8);
-            let hi16 = vmovl_u8(hi8);
-
-            let u32_0 = vmovl_u16(vget_low_u16(lo16));
-            let f32_0 = vcvtq_f32_u32(u32_0);
-            let acc_0 = vld1q_f32(ob.add(16));
-            vst1q_f32(ob.add(16), vfmaq_f32(acc_0, f32_0, weight_v));
-
-            let u32_1 = vmovl_u16(vget_high_u16(lo16));
-            let f32_1 = vcvtq_f32_u32(u32_1);
-            let acc_1 = vld1q_f32(ob.add(20));
-            vst1q_f32(ob.add(20), vfmaq_f32(acc_1, f32_1, weight_v));
-
-            let u32_2 = vmovl_u16(vget_low_u16(hi16));
-            let f32_2 = vcvtq_f32_u32(u32_2);
-            let acc_2 = vld1q_f32(ob.add(24));
-            vst1q_f32(ob.add(24), vfmaq_f32(acc_2, f32_2, weight_v));
-
-            let u32_3 = vmovl_u16(vget_high_u16(hi16));
-            let f32_3 = vcvtq_f32_u32(u32_3);
-            let acc_3 = vld1q_f32(ob.add(28));
-            vst1q_f32(ob.add(28), vfmaq_f32(acc_3, f32_3, weight_v));
-        }
-    }
-
-    let base_elem = chunks * 32;
-    for i in 0..remainder {
-        let abs_idx = elem_offset + base_elem + i;
-        let byte_val = *packed.get_unchecked(abs_idx / 2);
-        let val = if abs_idx.is_multiple_of(2) {
-            byte_val & 0x0F
-        } else {
-            byte_val >> 4
-        };
-        *out.get_unchecked_mut(base_elem + i) += (val as u32 * 17) as f32 * weight;
-    }
-}
-
-#[cfg(all(test, target_arch = "x86_64"))]
-#[target_feature(enable = "sse4.1")]
-#[allow(unsafe_op_in_unsafe_fn)]
-unsafe fn accumulate_u4_weighted_sse41(
-    packed: &[u8],
-    elem_offset: usize,
-    count: usize,
-    weight: f32,
-    out: &mut [f32],
-) {
-    use std::arch::x86_64::*;
-
-    debug_assert!(elem_offset.is_multiple_of(2));
-
-    let weight_v = _mm_set1_ps(weight);
-    let mask_lo = _mm_set1_epi8(0x0F);
-    let zero = _mm_setzero_si128();
-
-    let byte_offset = elem_offset / 2;
-    let packed_ptr = packed.as_ptr().add(byte_offset);
-    let out_ptr = out.as_mut_ptr();
-
-    let chunks = count / 32;
-    let remainder = count % 32;
-
-    for chunk in 0..chunks {
-        let pb = packed_ptr.add(chunk * 16);
-        let ob = out_ptr.add(chunk * 32);
-
-        let bytes = _mm_loadu_si128(pb as *const __m128i);
-
-        let low = _mm_and_si128(bytes, mask_lo);
-        let high = _mm_srli_epi16::<4>(bytes);
-        let high = _mm_and_si128(high, mask_lo);
-
-        let low_scaled = _mm_add_epi8(_mm_slli_epi16::<4>(_mm_and_si128(low, mask_lo)), low);
-        let high_scaled = _mm_add_epi8(_mm_slli_epi16::<4>(_mm_and_si128(high, mask_lo)), high);
-
-        let elems_0_15 = _mm_unpacklo_epi8(low_scaled, high_scaled);
-        let elems_16_31 = _mm_unpackhi_epi8(low_scaled, high_scaled);
-
-        {
-            let lo8 = _mm_unpacklo_epi8(elems_0_15, zero);
-            let hi8 = _mm_unpackhi_epi8(elems_0_15, zero);
-
-            let u32_0 = _mm_unpacklo_epi16(lo8, zero);
-            let f32_0 = _mm_cvtepi32_ps(u32_0);
-            let acc_0 = _mm_loadu_ps(ob);
-            _mm_storeu_ps(ob, _mm_add_ps(acc_0, _mm_mul_ps(f32_0, weight_v)));
-
-            let u32_1 = _mm_unpackhi_epi16(lo8, zero);
-            let f32_1 = _mm_cvtepi32_ps(u32_1);
-            let acc_1 = _mm_loadu_ps(ob.add(4));
-            _mm_storeu_ps(ob.add(4), _mm_add_ps(acc_1, _mm_mul_ps(f32_1, weight_v)));
-
-            let u32_2 = _mm_unpacklo_epi16(hi8, zero);
-            let f32_2 = _mm_cvtepi32_ps(u32_2);
-            let acc_2 = _mm_loadu_ps(ob.add(8));
-            _mm_storeu_ps(ob.add(8), _mm_add_ps(acc_2, _mm_mul_ps(f32_2, weight_v)));
-
-            let u32_3 = _mm_unpackhi_epi16(hi8, zero);
-            let f32_3 = _mm_cvtepi32_ps(u32_3);
-            let acc_3 = _mm_loadu_ps(ob.add(12));
-            _mm_storeu_ps(ob.add(12), _mm_add_ps(acc_3, _mm_mul_ps(f32_3, weight_v)));
-        }
-
-        {
-            let lo8 = _mm_unpacklo_epi8(elems_16_31, zero);
-            let hi8 = _mm_unpackhi_epi8(elems_16_31, zero);
-
-            let u32_0 = _mm_unpacklo_epi16(lo8, zero);
-            let f32_0 = _mm_cvtepi32_ps(u32_0);
-            let acc_0 = _mm_loadu_ps(ob.add(16));
-            _mm_storeu_ps(ob.add(16), _mm_add_ps(acc_0, _mm_mul_ps(f32_0, weight_v)));
-
-            let u32_1 = _mm_unpackhi_epi16(lo8, zero);
-            let f32_1 = _mm_cvtepi32_ps(u32_1);
-            let acc_1 = _mm_loadu_ps(ob.add(20));
-            _mm_storeu_ps(ob.add(20), _mm_add_ps(acc_1, _mm_mul_ps(f32_1, weight_v)));
-
-            let u32_2 = _mm_unpacklo_epi16(hi8, zero);
-            let f32_2 = _mm_cvtepi32_ps(u32_2);
-            let acc_2 = _mm_loadu_ps(ob.add(24));
-            _mm_storeu_ps(ob.add(24), _mm_add_ps(acc_2, _mm_mul_ps(f32_2, weight_v)));
-
-            let u32_3 = _mm_unpackhi_epi16(hi8, zero);
-            let f32_3 = _mm_cvtepi32_ps(u32_3);
-            let acc_3 = _mm_loadu_ps(ob.add(28));
-            _mm_storeu_ps(ob.add(28), _mm_add_ps(acc_3, _mm_mul_ps(f32_3, weight_v)));
-        }
-    }
-
-    let base_elem = chunks * 32;
-    for i in 0..remainder {
-        let abs_idx = elem_offset + base_elem + i;
-        let byte_val = *packed.get_unchecked(abs_idx / 2);
-        let val = if abs_idx.is_multiple_of(2) {
-            byte_val & 0x0F
-        } else {
-            byte_val >> 4
-        };
-        *out.get_unchecked_mut(base_elem + i) += (val as u32 * 17) as f32 * weight;
-    }
-}
-
-// ============================================================================
-// Block mask computation: standalone function with SIMD dispatch
-// ============================================================================
-
-/// Compute per-block query-dim presence masks from 4-bit packed grid data.
-///
-/// Standalone function that works with any grid slice (full index grid or
-/// compact query-local grid). Uses SIMD when available.
-///
-/// `grid` layout: `grid[dim_idx * prs + byte_idx]` where each byte packs
-/// two 4-bit values (low nibble = even block, high nibble = odd block).
-///
-/// `query_dims` entries: `(dim_idx, weight)` where dim_idx indexes into grid rows.
-/// Bits-dispatching mask computation (which query dims are present per block).
-pub(crate) fn compute_block_masks(
-    grid: &[u8],
-    grid_bits: u8,
-    prs: usize,
-    query_dims: &[(usize, f32)],
-    block_start: usize,
-    count: usize,
-    masks: &mut [u64],
-) {
-    // Presence masks have 64 bits. For wider queries, disable this optional
-    // shortcut (all blocks appear present) and let binary search decide per
-    // dimension; shifting by q>=64 used to panic in debug and wrap in release.
-    if query_dims.len() > 64 {
-        masks[..count].fill(u64::MAX);
-        return;
-    }
-    if grid_bits == 2 {
-        compute_block_masks_2bit(grid, prs, query_dims, block_start, count, masks);
-    } else {
-        compute_block_masks_4bit(grid, prs, query_dims, block_start, count, masks);
-    }
-}
-
-/// Scalar 2-bit presence masks.
-pub(crate) fn compute_block_masks_2bit(
-    grid: &[u8],
-    prs: usize,
-    query_dims: &[(usize, f32)],
-    block_start: usize,
-    count: usize,
-    masks: &mut [u64],
-) {
-    debug_assert!(masks.len() >= count);
-    if query_dims.len() > 64 {
-        masks[..count].fill(u64::MAX);
-        return;
-    }
-    masks[..count].fill(0);
-    for (q, &(dim_idx, _)) in query_dims.iter().enumerate() {
-        let row = &grid[dim_idx * prs..(dim_idx + 1) * prs];
-        let bit = 1u64 << q;
-        for b in 0..count {
-            let abs = block_start + b;
-            let cell = (unsafe { *row.get_unchecked(abs / 4) } >> ((abs % 4) * 2)) & 0x03;
-            if cell != 0 {
-                unsafe { *masks.get_unchecked_mut(b) |= bit };
-            }
-        }
-    }
-}
-
-pub(crate) fn compute_block_masks_4bit(
-    grid: &[u8],
-    prs: usize,
-    query_dims: &[(usize, f32)],
-    block_start: usize,
-    count: usize,
-    masks: &mut [u64],
-) {
-    debug_assert!(masks.len() >= count);
-    if query_dims.len() > 64 {
-        masks[..count].fill(u64::MAX);
-        return;
-    }
-    masks[..count].fill(0);
-
-    #[cfg(target_arch = "aarch64")]
-    {
-        if block_start.is_multiple_of(2) {
-            unsafe {
-                compute_block_masks_range_neon(grid, prs, query_dims, block_start, count, masks)
-            };
-            return;
-        }
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    {
-        if block_start.is_multiple_of(2) && is_x86_feature_detected!("sse4.1") {
-            unsafe {
-                compute_block_masks_range_sse41(grid, prs, query_dims, block_start, count, masks)
-            };
-            return;
-        }
-    }
-
-    for (q, &(dim_idx, _)) in query_dims.iter().enumerate() {
-        let row = &grid[dim_idx * prs..(dim_idx + 1) * prs];
-        let bit = 1u64 << q;
-        for b in 0..count {
-            let abs_b = block_start + b;
-            let byte_val = unsafe { *row.get_unchecked(abs_b / 2) };
-            let val = if abs_b.is_multiple_of(2) {
-                byte_val & 0x0F
-            } else {
-                byte_val >> 4
-            };
-            if val > 0 {
-                unsafe { *masks.get_unchecked_mut(b) |= bit };
-            }
-        }
-    }
-}
-
-// ============================================================================
-// Block mask SIMD kernels
-// ============================================================================
-
-#[cfg(target_arch = "aarch64")]
-#[target_feature(enable = "neon")]
-#[allow(unsafe_op_in_unsafe_fn)]
-unsafe fn compute_block_masks_range_neon(
-    grid: &[u8],
-    prs: usize,
-    query_dims: &[(usize, f32)],
-    block_start: usize,
-    count: usize,
-    masks: &mut [u64],
-) {
-    use std::arch::aarch64::*;
-
-    debug_assert!(block_start.is_multiple_of(2));
-    let byte_offset = block_start / 2;
-    let zero = vdupq_n_u8(0);
-    let mask_lo = vdupq_n_u8(0x0F);
-
-    for (q, &(dim_idx, _)) in query_dims.iter().enumerate() {
-        let row_ptr = grid.as_ptr().add(dim_idx * prs + byte_offset);
-        let bit = 1u64 << q;
-
-        let chunks = count / 32;
-        let remainder = count % 32;
-
-        for chunk in 0..chunks {
-            let pb = row_ptr.add(chunk * 16);
-            let base = chunk * 32;
-
-            let bytes = vld1q_u8(pb);
-
-            let low = vandq_u8(bytes, mask_lo);
-            let high = vshrq_n_u8::<4>(bytes);
-
-            let elems_lo = vzip1q_u8(low, high);
-            let elems_hi = vzip2q_u8(low, high);
-
-            let nz_lo = vcgtq_u8(elems_lo, zero);
-            let nz_hi = vcgtq_u8(elems_hi, zero);
-
-            let mut lo_arr = [0u8; 16];
-            let mut hi_arr = [0u8; 16];
-            vst1q_u8(lo_arr.as_mut_ptr(), nz_lo);
-            vst1q_u8(hi_arr.as_mut_ptr(), nz_hi);
-
-            for (i, &v) in lo_arr.iter().enumerate() {
-                if v != 0 {
-                    *masks.get_unchecked_mut(base + i) |= bit;
-                }
-            }
-            for (i, &v) in hi_arr.iter().enumerate() {
-                if v != 0 {
-                    *masks.get_unchecked_mut(base + 16 + i) |= bit;
-                }
-            }
-        }
-
-        let base = chunks * 32;
-        for i in 0..remainder {
-            let abs_b = block_start + base + i;
-            let byte_val = *grid.get_unchecked(dim_idx * prs + abs_b / 2);
-            let val = if abs_b.is_multiple_of(2) {
-                byte_val & 0x0F
-            } else {
-                byte_val >> 4
-            };
-            if val > 0 {
-                *masks.get_unchecked_mut(base + i) |= bit;
-            }
-        }
-    }
-}
-
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "sse4.1")]
-#[allow(unsafe_op_in_unsafe_fn)]
-unsafe fn compute_block_masks_range_sse41(
-    grid: &[u8],
-    prs: usize,
-    query_dims: &[(usize, f32)],
-    block_start: usize,
-    count: usize,
-    masks: &mut [u64],
-) {
-    use std::arch::x86_64::*;
-
-    debug_assert!(block_start.is_multiple_of(2));
-    let byte_offset = block_start / 2;
-    let zero = _mm_setzero_si128();
-    let mask_lo_v = _mm_set1_epi8(0x0F);
-
-    for (q, &(dim_idx, _)) in query_dims.iter().enumerate() {
-        let row_ptr = grid.as_ptr().add(dim_idx * prs + byte_offset);
-        let bit = 1u64 << q;
-
-        let chunks = count / 32;
-        let remainder = count % 32;
-
-        for chunk in 0..chunks {
-            let pb = row_ptr.add(chunk * 16);
-            let base = chunk * 32;
-
-            let bytes = _mm_loadu_si128(pb as *const __m128i);
-
-            let low = _mm_and_si128(bytes, mask_lo_v);
-            let high = _mm_and_si128(_mm_srli_epi16::<4>(bytes), mask_lo_v);
-
-            let elems_lo = _mm_unpacklo_epi8(low, high);
-            let elems_hi = _mm_unpackhi_epi8(low, high);
-
-            let nz_lo = _mm_cmpgt_epi8(elems_lo, zero);
-            let nz_hi = _mm_cmpgt_epi8(elems_hi, zero);
-
-            let mut m = _mm_movemask_epi8(nz_lo) as u32;
-            while m != 0 {
-                let i = m.trailing_zeros() as usize;
-                m &= m - 1;
-                *masks.get_unchecked_mut(base + i) |= bit;
-            }
-            let mut m = _mm_movemask_epi8(nz_hi) as u32;
-            while m != 0 {
-                let i = m.trailing_zeros() as usize;
-                m &= m - 1;
-                *masks.get_unchecked_mut(base + 16 + i) |= bit;
-            }
-        }
-
-        let base = chunks * 32;
-        for i in 0..remainder {
-            let abs_b = block_start + base + i;
-            let byte_val = *grid.get_unchecked(dim_idx * prs + abs_b / 2);
-            let val = if abs_b.is_multiple_of(2) {
-                byte_val & 0x0F
-            } else {
-                byte_val >> 4
-            };
-            if val > 0 {
-                *masks.get_unchecked_mut(base + i) |= bit;
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1849,267 +1129,5 @@ mod safety_tests {
         .unwrap();
         let multi = parse(blob).unwrap();
         assert!(!multi.is_single_valued());
-    }
-}
-
-/// Microbenchmark: dense 4-bit grid (SIMD nibble sweep, the current layout)
-/// vs a CSR superblock-run grid, on Zipfian SPLADE-like block occupancy.
-/// Run: cargo test --release -p hermes-core --features native --lib -- \
-///        --ignored bench_grid_dense_vs_csr --nocapture
-/// See docs/bmp-grid-compression.md for measured results.
-#[cfg(test)]
-mod grid_bench {
-    use super::{accumulate_u4_weighted, compute_block_masks};
-    use std::hint::black_box;
-    use std::time::Instant;
-
-    struct XorShift(u64);
-    impl XorShift {
-        fn next(&mut self) -> u64 {
-            let mut x = self.0;
-            x ^= x << 13;
-            x ^= x >> 7;
-            x ^= x << 17;
-            self.0 = x;
-            x
-        }
-        fn next_f64(&mut self) -> f64 {
-            (self.next() >> 11) as f64 / (1u64 << 53) as f64
-        }
-    }
-
-    #[test]
-    fn wide_query_disables_u64_presence_mask_without_shifting() {
-        let query_dims: Vec<(usize, f32)> = (0..65).map(|dim| (dim, 1.0)).collect();
-        let grid = vec![0x11; query_dims.len()];
-        let mut masks = [0u64; 2];
-        compute_block_masks(&grid, 4, 1, &query_dims, 0, 2, &mut masks);
-        assert_eq!(masks, [u64::MAX; 2]);
-    }
-
-    /// CSR grid: per dim, runs of present superblocks with (slot, nibble)
-    /// entries. Flattened per dim for cache-friendly probing.
-    struct CsrGrid {
-        /// per dim: [start..end) into run_sbs / run_entry_offsets
-        dim_run_offsets: Vec<u32>,
-        /// superblock id of each run
-        run_sbs: Vec<u16>,
-        /// per run: [start..end) into entries
-        run_entry_offsets: Vec<u32>,
-        /// (block_in_sb, nibble)
-        entries: Vec<(u8, u8)>,
-    }
-
-    impl CsrGrid {
-        /// Accumulate dim's contribution to the 64 block UBs of superblock
-        /// `sb` — the CSR replacement for one dense accumulate_u4_weighted
-        /// call. Returns false if the dim has no blocks in this superblock.
-        #[inline]
-        fn accumulate(&self, dim: usize, sb: u16, weight: f32, out: &mut [f32]) -> bool {
-            let rs = self.dim_run_offsets[dim] as usize;
-            let re = self.dim_run_offsets[dim + 1] as usize;
-            let runs = &self.run_sbs[rs..re];
-            match runs.binary_search(&sb) {
-                Ok(pos) => {
-                    let es = self.run_entry_offsets[rs + pos] as usize;
-                    let ee = self.run_entry_offsets[rs + pos + 1] as usize;
-                    for &(slot, nib) in &self.entries[es..ee] {
-                        unsafe {
-                            *out.get_unchecked_mut(slot as usize) +=
-                                (nib as u32 * 17) as f32 * weight;
-                        }
-                    }
-                    true
-                }
-                Err(_) => false,
-            }
-        }
-    }
-
-    fn run_config(num_docs: usize, block_size: usize, dims: usize, nnz_per_doc: usize) {
-        const SB: usize = 64; // blocks per superblock
-        let num_blocks = num_docs.div_ceil(block_size);
-        let num_sbs = num_blocks.div_ceil(SB);
-        let prs = num_blocks.div_ceil(2);
-
-        // Zipf(1.0) over dims: cumulative distribution for binary-search sampling
-        let mut cum = Vec::with_capacity(dims);
-        let mut acc = 0.0f64;
-        for i in 0..dims {
-            acc += 1.0 / (i + 1) as f64;
-            cum.push(acc);
-        }
-        let total = acc;
-
-        // Per-block occupancy: block_size × nnz draws, dedup per block.
-        // (dim, block) → nibble, filling dense + collecting CSR entries.
-        let mut rng = XorShift(0x9E3779B97F4A7C15);
-        let mut dense = vec![0u8; dims * prs];
-        // per-dim collected (block, nibble), built block-major then sorted
-        let mut per_dim: Vec<Vec<(u32, u8)>> = vec![Vec::new(); dims];
-        let mut seen = vec![u32::MAX; dims];
-        let mut total_entries = 0u64;
-        let gen_start = Instant::now();
-        for b in 0..num_blocks {
-            let draws = block_size * nnz_per_doc;
-            for _ in 0..draws {
-                let r = rng.next_f64() * total;
-                let dim = cum.partition_point(|&c| c < r).min(dims - 1);
-                if seen[dim] != b as u32 {
-                    seen[dim] = b as u32;
-                    let nib = (rng.next() % 15 + 1) as u8;
-                    dense[dim * prs + b / 2] |= if b % 2 == 0 { nib } else { nib << 4 };
-                    per_dim[dim].push((b as u32, nib));
-                    total_entries += 1;
-                }
-            }
-        }
-        // Build CSR (per-dim vectors are already block-sorted by construction)
-        let mut csr = CsrGrid {
-            dim_run_offsets: Vec::with_capacity(dims + 1),
-            run_sbs: Vec::new(),
-            run_entry_offsets: Vec::new(),
-            entries: Vec::with_capacity(total_entries as usize),
-        };
-        csr.dim_run_offsets.push(0);
-        for blocks in &per_dim {
-            let mut cur_sb = u32::MAX;
-            for &(b, nib) in blocks {
-                let sb = b as usize / SB;
-                if sb as u32 != cur_sb {
-                    cur_sb = sb as u32;
-                    csr.run_sbs.push(sb as u16);
-                    csr.run_entry_offsets.push(csr.entries.len() as u32);
-                }
-                csr.entries.push(((b as usize % SB) as u8, nib));
-            }
-            csr.dim_run_offsets.push(csr.run_sbs.len() as u32);
-        }
-        csr.run_entry_offsets.push(csr.entries.len() as u32);
-        let num_runs = csr.run_sbs.len() as u64;
-
-        // ── Memory accounting ────────────────────────────────────────────
-        let dense_bytes = dense.len() as u64;
-        // sb-run encoding: 10 bits/entry (6-bit slot + 4-bit nibble) + 3B/run
-        // (u16 sb + u8 count) + 5B/dim row offset
-        let csr_bytes = total_entries * 10 / 8 + num_runs * 3 + dims as u64 * 5;
-        // flat encoding: u16 block delta + 4-bit nibble + 4B/dim offset
-        let flat_bytes = total_entries * 5 / 2 + dims as u64 * 4;
-        let density = total_entries as f64 / (dims as f64 * num_blocks as f64);
-        println!(
-            "\n=== docs={num_docs} block={block_size} dims={dims} blocks={num_blocks} sbs={num_sbs} (gen {:.1}s) ===",
-            gen_start.elapsed().as_secs_f64()
-        );
-        println!(
-            "occupancy: {total_entries} (dim,block) pairs, density {:.2}% | runs {num_runs}",
-            density * 100.0
-        );
-        println!(
-            "memory: dense {:.1} MB | csr sb-run {:.1} MB ({:.1}x) | csr flat {:.1} MB ({:.1}x)",
-            dense_bytes as f64 / 1e6,
-            csr_bytes as f64 / 1e6,
-            dense_bytes as f64 / csr_bytes as f64,
-            flat_bytes as f64 / 1e6,
-            dense_bytes as f64 / flat_bytes as f64,
-        );
-
-        // ── Correctness: identical block UBs from both layouts ──────────
-        let mut out_d = vec![0.0f32; SB];
-        let mut out_c = vec![0.0f32; SB];
-        for probe in 0..200 {
-            let dim = (rng.next() % dims as u64) as usize;
-            let sb = (rng.next() % num_sbs as u64) as usize;
-            let count = SB.min(num_blocks - sb * SB);
-            out_d[..count].fill(0.0);
-            out_c[..count].fill(0.0);
-            accumulate_u4_weighted(
-                &dense[dim * prs..(dim + 1) * prs],
-                sb * SB,
-                count,
-                1.5,
-                &mut out_d[..count],
-            );
-            csr.accumulate(dim, sb as u16, 1.5, &mut out_c[..count]);
-            assert_eq!(out_d, out_c, "layout mismatch at probe {probe}");
-        }
-
-        // ── Timing: Q queries × 16 dims × 30% surviving superblocks ─────
-        const QUERIES: usize = 200;
-        const QDIMS: usize = 16;
-        let surviving = (num_sbs * 3 / 10).max(1);
-        type Query = (Vec<(usize, f32)>, Vec<u16>);
-        let queries: Vec<Query> = (0..QUERIES)
-            .map(|_| {
-                let qdims: Vec<(usize, f32)> = (0..QDIMS)
-                    .map(|_| {
-                        let r = rng.next_f64() * total;
-                        let dim = cum.partition_point(|&c| c < r).min(dims - 1);
-                        (dim, rng.next_f64() as f32 + 0.1)
-                    })
-                    .collect();
-                let sbs: Vec<u16> = (0..surviving)
-                    .map(|_| (rng.next() % num_sbs as u64) as u16)
-                    .collect();
-                (qdims, sbs)
-            })
-            .collect();
-
-        let probes = (QUERIES * QDIMS * surviving) as f64;
-
-        let t = Instant::now();
-        let mut sink = 0.0f32;
-        for (qdims, sbs) in &queries {
-            for &sb in sbs {
-                out_d.fill(0.0);
-                for &(dim, w) in qdims {
-                    let count = SB.min(num_blocks - (sb as usize) * SB);
-                    accumulate_u4_weighted(
-                        &dense[dim * prs..(dim + 1) * prs],
-                        sb as usize * SB,
-                        count,
-                        w,
-                        &mut out_d[..count],
-                    );
-                }
-                sink += out_d[0];
-            }
-        }
-        let dense_t = t.elapsed();
-        black_box(sink);
-
-        let t = Instant::now();
-        let mut sink = 0.0f32;
-        let mut hits = 0u64;
-        for (qdims, sbs) in &queries {
-            for &sb in sbs {
-                out_c.fill(0.0);
-                for &(dim, w) in qdims {
-                    if csr.accumulate(dim, sb, w, &mut out_c) {
-                        hits += 1;
-                    }
-                }
-                sink += out_c[0];
-            }
-        }
-        let csr_t = t.elapsed();
-        black_box(sink);
-
-        println!(
-            "block-UB compute: dense {:.0} ns/probe ({:.2} ms/query) | csr {:.0} ns/probe ({:.2} ms/query, {:.0}% probes hit) | csr/dense {:.2}x",
-            dense_t.as_nanos() as f64 / probes,
-            dense_t.as_secs_f64() * 1000.0 / QUERIES as f64,
-            csr_t.as_nanos() as f64 / probes,
-            csr_t.as_secs_f64() * 1000.0 / QUERIES as f64,
-            hits as f64 / probes * 100.0,
-            csr_t.as_secs_f64() / dense_t.as_secs_f64(),
-        );
-    }
-
-    #[test]
-    #[ignore = "microbenchmark — run manually in release"]
-    fn bench_grid_dense_vs_csr() {
-        // SPLADE-like: 100k vocab, 120 nnz/doc, Zipf(1.0)
-        run_config(2_000_000, 64, 100_000, 120);
-        run_config(2_000_000, 256, 100_000, 120);
     }
 }

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -8,7 +8,7 @@
 //! reordering is optional; when enabled, both paths share the same bounded
 //! CPU pool and whole-pass concurrency gate.
 
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -95,6 +95,48 @@ impl Drop for GridRunFiles {
     }
 }
 
+type BmpGridEntry = (u32, u32, u8);
+const MAX_GRID_RUN_ENTRIES: usize = 16 * 1024 * 1024;
+
+fn spill_grid_entries(
+    entries: &mut Vec<BmpGridEntry>,
+    runs: &mut GridRunFiles,
+    field_id: u32,
+) -> Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    entries.sort_unstable();
+    let path = runs.allocate();
+    crate::segment::builder::bmp::write_grid_run(entries, &path).map_err(crate::Error::Io)?;
+    entries.clear();
+    log::debug!(
+        "[reorder_bmp] field {}: spilled grid run {} to disk",
+        field_id,
+        runs.len(),
+    );
+    Ok(())
+}
+
+fn extend_grid_entries_bounded(
+    entries: &mut Vec<BmpGridEntry>,
+    mut additional: &[BmpGridEntry],
+    limit: usize,
+    runs: &mut GridRunFiles,
+    field_id: u32,
+) -> Result<()> {
+    debug_assert!(limit > 0);
+    while !additional.is_empty() {
+        if entries.len() >= limit {
+            spill_grid_entries(entries, runs, field_id)?;
+        }
+        let count = (limit - entries.len()).min(additional.len());
+        entries.extend_from_slice(&additional[..count]);
+        additional = &additional[count..];
+    }
+    Ok(())
+}
+
 /// Reorder granularity (see docs/block-level-reorder.md).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum BpGranularity {
@@ -121,9 +163,10 @@ pub enum BpGranularity {
 pub const BLOCKWISE_NORM_COHERENCE_THRESHOLD: f32 = 0.5;
 
 /// Scan cap for the coherence decision: above this many blocks the scan
-/// samples every k-th block instead of all of them. 8192 blocks (~512k
-/// docs at block_size 64) is statistically ample for a 0.5 threshold and
-/// bounds the decision cost on multi-million-doc segments.
+/// samples every k-th block instead of all of them. 8192 blocks (~262k
+/// vectors at the production block size 32) is statistically ample for a
+/// 0.5 threshold and bounds the decision cost on multi-million-vector
+/// segments.
 const MAX_COHERENCE_SCAN_BLOCKS: usize = 8192;
 
 /// Coherence statistics driving the `Auto` granularity decision.
@@ -188,7 +231,7 @@ fn block_coherence(
         for block_id in 0..bmp.num_blocks {
             if global_block.is_multiple_of(stride) {
                 scanned_blocks += 1;
-                for (dim_id, posts) in bmp.iter_block_terms(block_id) {
+                for (dim_id, _, posts) in bmp.iter_block_terms(block_id) {
                     let e = df.entry(dim_id).or_insert((0, 0));
                     e.0 += posts.len() as u64;
                     e.1 += 1;
@@ -615,13 +658,16 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                 let effective_block_size = sparse_config
                     .as_ref()
                     .map(|c| c.bmp_block_size)
-                    .unwrap_or(64)
+                    .unwrap_or(crate::structures::SparseVectorConfig::DEFAULT_BMP_BLOCK_SIZE)
                     .clamp(1, 256) as usize;
                 let dims = sparse_config
                     .as_ref()
                     .and_then(|c| c.dims)
                     .unwrap_or_else(|| bmp_idx.dims());
-                let grid_bits = sparse_config.as_ref().map(|c| c.bmp_grid_bits).unwrap_or(4);
+                let grid_bits = sparse_config
+                    .as_ref()
+                    .map(|c| c.bmp_grid_bits)
+                    .unwrap_or(crate::structures::SparseVectorConfig::DEFAULT_BMP_GRID_BITS);
                 let max_weight_scale = sparse_config
                     .as_ref()
                     .and_then(|c| c.max_weight)
@@ -734,7 +780,9 @@ fn reorder_bmp_field_blockwise(
     mut field_tocs: Vec<SparseFieldToc>,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
 ) -> Result<(OffsetWriter, Vec<SparseFieldToc>, bool)> {
-    use crate::segment::builder::bmp::write_bmp_footer;
+    use crate::segment::builder::bmp::{
+        GridRunReader, stream_write_grids, stream_write_grids_merged, write_bmp_footer,
+    };
     use crate::segment::builder::graph_bisection::{
         build_forward_index_from_blocks, graph_bisection,
     };
@@ -756,7 +804,7 @@ fn reorder_bmp_field_blockwise(
     }
     if num_blocks_total > u32::MAX as usize {
         return Err(crate::Error::Internal(
-            "reordered BMP block count exceeds the V15 u32 format limit".into(),
+            "reordered BMP block count exceeds the V17 u32 format limit".into(),
         ));
     }
     let num_virtual_docs = num_blocks_total
@@ -764,7 +812,7 @@ fn reorder_bmp_field_blockwise(
         .filter(|&count| count <= u32::MAX as usize)
         .ok_or_else(|| {
             crate::Error::Internal(
-                "reordered BMP virtual-document count exceeds the V15 u32 format limit".into(),
+                "reordered BMP virtual-document count exceeds the V17 u32 format limit".into(),
             )
         })?;
 
@@ -850,7 +898,24 @@ fn reorder_bmp_field_blockwise(
         total_terms = total_terms.saturating_add(b.total_terms());
         total_postings = total_postings.saturating_add(b.total_postings());
     }
-    for &(src, lb) in &permuted_blocks {
+    let persistent_bytes = permuted_blocks
+        .capacity()
+        .saturating_mul(std::mem::size_of::<(u32, u32)>())
+        .saturating_add(
+            block_data_starts
+                .capacity()
+                .saturating_mul(std::mem::size_of::<u64>()),
+        );
+    let grid_budget = memory_budget
+        .saturating_sub(persistent_bytes)
+        .saturating_div(2)
+        .clamp(1024 * 1024, 512 * 1024 * 1024);
+    let grid_run_entries =
+        (grid_budget / std::mem::size_of::<BmpGridEntry>()).clamp(1, MAX_GRID_RUN_ENTRIES);
+    let mut grid_entries = Vec::with_capacity(grid_run_entries);
+    let mut run_files = GridRunFiles::new(field_id);
+
+    for (new_block, &(src, lb)) in permuted_blocks.iter().enumerate() {
         let bmp = bmp_refs[src as usize];
         let start = bmp.block_data_start(lb) as usize;
         let end = if lb + 1 < bmp.num_blocks {
@@ -862,6 +927,12 @@ fn reorder_bmp_field_blockwise(
         let bytes = &bmp.block_data_slice()[start..end];
         writer.write_all(bytes).map_err(crate::Error::Io)?;
         cumulative += bytes.len() as u64;
+        for (dimension, max_impact, _) in bmp.iter_block_terms(lb) {
+            if grid_entries.len() == grid_run_entries {
+                spill_grid_entries(&mut grid_entries, &mut run_files, field_id)?;
+            }
+            grid_entries.push((dimension, new_block as u32, max_impact));
+        }
     }
     block_data_starts.push(cumulative);
 
@@ -880,71 +951,42 @@ fn reorder_bmp_field_blockwise(
     }
     drop(block_data_starts);
 
-    // Sections D + E: permuted grid rows + recomputed sb_grid, streamed per dim
+    // Sections D + E: exact maxima from the copied blocks, compressed in one
+    // bounded external-sort pass. Block payloads above remained byte-identical.
     let grid_offset = writer.offset() - blob_start;
-    let packed_row_size =
-        crate::segment::builder::bmp::grid_packed_row_size(num_blocks_total, grid_bits);
-    let num_superblocks = num_blocks_total.div_ceil(sb);
-    let mut out_row = vec![0u8; packed_row_size];
-    let mut sb_row = vec![0u8; num_superblocks];
-    // Section E follows every Section D row on disk. Keeping all E rows until
-    // then was O(dims × superblocks) RAM (tens of GB at production scale).
-    // Spill E linearly while computing D; the RAII owner removes partial files
-    // on every exit path.
-    let mut sb_spill_files = GridRunFiles::new(field_id);
-    let sb_spill_path = sb_spill_files.allocate();
-    let sb_spill = std::fs::File::create(&sb_spill_path).map_err(crate::Error::Io)?;
-    let mut sb_spill_writer = std::io::BufWriter::with_capacity(4 * 1024 * 1024, sb_spill);
-    let dequant = crate::segment::builder::bmp::grid_dequant_scale(grid_bits);
-
-    for dim in 0..dims as usize {
-        out_row.fill(0);
-        sb_row.fill(0);
-        for (new_pos, &(src, lb)) in permuted_blocks.iter().enumerate() {
-            let bmp = bmp_refs[src as usize];
-            let prs = bmp.packed_row_size();
-            let row = &bmp.grid_slice()[dim * prs..dim * prs + prs];
-            let cell = crate::segment::builder::bmp::grid_get_cell(row, lb as usize, grid_bits);
-            if cell == 0 {
-                continue;
-            }
-            crate::segment::builder::bmp::grid_set_cell(&mut out_row, new_pos, cell, grid_bits);
-            // sb_grid stores u8 impact scale (0-255) everywhere else (builder,
-            // block-copy merge). Dequantize the cell to its safe u8 upper
-            // bound — writing the raw cell here deflated superblock UBs ~17×
-            // after blockwise passes (unsafe pruning once heaps fill).
-            let ub = (cell as u32 * dequant).min(255) as u8;
-            let slot = &mut sb_row[new_pos / sb];
-            if ub > *slot {
-                *slot = ub;
-            }
+    let (block_grid_bytes, _) = if run_files.is_empty() {
+        grid_entries.sort_unstable();
+        let result = stream_write_grids(
+            &grid_entries,
+            dims as usize,
+            num_blocks_total,
+            grid_bits,
+            &mut writer,
+        )
+        .map_err(crate::Error::Io)?;
+        drop(grid_entries);
+        result
+    } else {
+        if !grid_entries.is_empty() {
+            spill_grid_entries(&mut grid_entries, &mut run_files, field_id)?;
         }
-        writer.write_all(&out_row).map_err(crate::Error::Io)?;
-        sb_spill_writer
-            .write_all(&sb_row)
-            .map_err(crate::Error::Io)?;
-    }
-    drop(out_row);
-    drop(sb_row);
-    sb_spill_writer.flush().map_err(crate::Error::Io)?;
-    drop(sb_spill_writer);
-
-    let sb_grid_offset = writer.offset() - blob_start;
-    let mut sb_spill_reader = std::fs::File::open(&sb_spill_path).map_err(crate::Error::Io)?;
-    let mut copy_buffer = vec![0u8; 4 * 1024 * 1024];
-    loop {
-        let read = sb_spill_reader
-            .read(&mut copy_buffer)
-            .map_err(crate::Error::Io)?;
-        if read == 0 {
-            break;
-        }
-        writer
-            .write_all(&copy_buffer[..read])
-            .map_err(crate::Error::Io)?;
-    }
-    drop(copy_buffer);
-    drop(sb_spill_reader);
+        drop(grid_entries);
+        let mut readers: Vec<GridRunReader> = run_files
+            .iter()
+            .map(|path| GridRunReader::open(path).map_err(crate::Error::Io))
+            .collect::<Result<_>>()?;
+        let result = stream_write_grids_merged(
+            &mut readers,
+            dims as usize,
+            num_blocks_total,
+            grid_bits,
+            &mut writer,
+        )
+        .map_err(crate::Error::Io)?;
+        drop(readers);
+        result
+    };
+    let sb_grid_offset = grid_offset + block_grid_bytes;
 
     // Sections F + G: doc maps copied per block chunk, ids offset-patched
     let doc_map_offset = writer.offset() - blob_start;
@@ -955,7 +997,7 @@ fn reorder_bmp_field_blockwise(
             .checked_add(b.num_real_docs())
             .ok_or_else(|| {
                 crate::Error::Internal(
-                    "reordered BMP real-document count exceeds the V15 u32 format limit".into(),
+                    "reordered BMP real-document count exceeds the V17 u32 format limit".into(),
                 )
             })?;
     }
@@ -1196,7 +1238,6 @@ pub(crate) fn reorder_bmp_field(
     }
     use crate::segment::builder::bmp::{
         GridRunReader, stream_write_grids, stream_write_grids_merged, write_bmp_footer,
-        write_grid_run,
     };
     use crate::segment::builder::graph_bisection::{
         build_forward_index_from_bmps_with_maps, build_vid_maps, graph_bisection,
@@ -1351,7 +1392,7 @@ pub(crate) fn reorder_bmp_field(
     }
     if num_real_docs > u32::MAX as usize {
         return Err(crate::Error::Internal(
-            "reordered BMP real-document count exceeds the V15 u32 format limit".into(),
+            "reordered BMP real-document count exceeds the V17 u32 format limit".into(),
         ));
     }
 
@@ -1464,7 +1505,7 @@ pub(crate) fn reorder_bmp_field(
     let new_num_blocks = num_real_docs.div_ceil(effective_block_size);
     if new_num_blocks > u32::MAX as usize {
         return Err(crate::Error::Internal(
-            "reordered BMP block count exceeds the V15 u32 format limit".into(),
+            "reordered BMP block count exceeds the V17 u32 format limit".into(),
         ));
     }
     let new_num_virtual_docs = new_num_blocks
@@ -1472,7 +1513,7 @@ pub(crate) fn reorder_bmp_field(
         .filter(|&count| count <= u32::MAX as usize)
         .ok_or_else(|| {
             crate::Error::Internal(
-                "reordered BMP virtual-document count exceeds the V15 u32 format limit".into(),
+                "reordered BMP virtual-document count exceeds the V17 u32 format limit".into(),
             )
         })?;
 
@@ -1504,20 +1545,16 @@ pub(crate) fn reorder_bmp_field(
         .saturating_sub(grid_entries_budget)
         .clamp(1024 * 1024, 256 * 1024 * 1024);
 
-    // Grid entries with external merge sort: accumulate in memory up to budget,
-    // spill sorted runs to temp files when exceeded. 12 bytes per entry in memory.
-    const GRID_ENTRY_MEM_SIZE: usize = std::mem::size_of::<(u32, u32, u8)>(); // 12 bytes
-    let max_entries_in_memory = grid_entries_budget / GRID_ENTRY_MEM_SIZE;
-
-    let total_source_terms = bmp_refs.iter().fold(0usize, |total, bmp| {
-        total.saturating_add(bmp.total_terms() as usize)
-    });
-    let est_entries = total_source_terms.min(max_entries_in_memory);
-    let mut grid_entries: Vec<(u32, u32, u8)> = Vec::with_capacity(est_entries);
+    // Grid entries use bounded sorted runs. Reserving the complete run up
+    // front prevents Vec's geometric growth from overshooting the advertised
+    // memory budget just before a spill.
+    let grid_run_entries =
+        (grid_entries_budget / std::mem::size_of::<BmpGridEntry>()).clamp(1, MAX_GRID_RUN_ENTRIES);
+    let mut grid_entries: Vec<BmpGridEntry> = Vec::with_capacity(grid_run_entries);
     let mut run_files = GridRunFiles::new(field_id);
 
     // Encode one output block: gather its records from source blocks and
-    // serialize the V15 block layout. Pure function of `perm` + read-only
+    // serialize the V17 block layout. Pure function of `perm` + read-only
     // sources — output blocks encode independently.
     //
     // Global real ids resolve to a source via `real_base`, then to a
@@ -1526,9 +1563,12 @@ pub(crate) fn reorder_bmp_field(
     // (uniform with the output in practice — merge validates it — but the
     // source footer is the ground truth for parsing source blocks).
     // (serialized block bytes, its (dim, out_block, max_impact) grid entries)
-    type EncodedBlock = (Vec<u8>, Vec<(u32, u32, u8)>);
+    type EncodedBlock = (Vec<u8>, Vec<BmpGridEntry>);
     let encode_block = |out_block: usize| -> Result<EncodedBlock> {
         let new_vid_start = out_block * effective_block_size;
+        if new_vid_start >= num_real_docs {
+            return Ok((Vec::new(), Vec::new()));
+        }
         let new_vid_end = ((out_block + 1) * effective_block_size).min(num_real_docs);
         let slots_count = new_vid_end - new_vid_start;
 
@@ -1559,7 +1599,7 @@ pub(crate) fn reorder_bmp_field(
                 slot_map[old_s as usize] = u16::from(new_s);
             }
 
-            for (dim_id, postings) in sources[src].0.iter_block_terms(old_block as u32) {
+            for (dim_id, _, postings) in sources[src].0.iter_block_terms(old_block as u32) {
                 for p in postings {
                     let new_slot = slot_map[p.local_slot as usize];
                     if new_slot != u16::MAX {
@@ -1593,7 +1633,7 @@ pub(crate) fn reorder_bmp_field(
             blk_buf.extend_from_slice(&dim_id.to_le_bytes());
         }
 
-        // u32 prefix sums (V14): u16 wrapped past 65,535 postings per block
+        // u32 prefix sums: a block/dimension can exceed 65,535 postings.
         let mut cum: u32 = 0;
         for &dim_id in &sorted_dims {
             blk_buf.extend_from_slice(&cum.to_le_bytes());
@@ -1606,14 +1646,23 @@ pub(crate) fn reorder_bmp_field(
         }
         blk_buf.extend_from_slice(&cum.to_le_bytes());
 
+        let max_impacts: Vec<u8> = sorted_dims
+            .iter()
+            .map(|dim_id| {
+                dim_postings[dim_id]
+                    .iter()
+                    .map(|&(_, impact)| impact)
+                    .max()
+                    .unwrap_or(0)
+            })
+            .collect();
+        blk_buf.extend_from_slice(&max_impacts);
+
         let mut grid: Vec<(u32, u32, u8)> = Vec::with_capacity(nt);
-        for &dim_id in &sorted_dims {
-            let posts = &dim_postings[&dim_id];
-            let mut max_impact: u8 = 0;
-            for &(slot, impact) in posts {
+        for (&dim_id, &max_impact) in sorted_dims.iter().zip(&max_impacts) {
+            for &(slot, impact) in &dim_postings[&dim_id] {
                 blk_buf.push(slot);
                 blk_buf.push(impact);
-                max_impact = max_impact.max(impact);
             }
             grid.push((dim_id, out_block as u32, max_impact));
         }
@@ -1677,24 +1726,17 @@ pub(crate) fn reorder_bmp_field(
                 continue;
             }
             total_terms += grid.len() as u64;
-            // layout: 4 (nt) + nt*4 (dims) + (nt+1)*4 (prefix) + postings*2
-            total_postings += ((blk_buf.len() - 8 - grid.len() * 8) / 2) as u64;
-            grid_entries.extend_from_slice(&grid);
+            // layout: 4 + nt*4 dims + (nt+1)*4 prefixes + nt maxima + postings*2
+            total_postings += ((blk_buf.len() - 8 - grid.len() * 9) / 2) as u64;
+            extend_grid_entries_bounded(
+                &mut grid_entries,
+                &grid,
+                grid_run_entries,
+                &mut run_files,
+                field_id,
+            )?;
             writer.write_all(&blk_buf).map_err(crate::Error::Io)?;
             cumulative_bytes += blk_buf.len() as u64;
-        }
-
-        // Spill grid entries to disk when memory budget exceeded
-        if grid_entries.len() >= max_entries_in_memory {
-            grid_entries.sort_unstable();
-            let run_path = run_files.allocate();
-            write_grid_run(&grid_entries, &run_path).map_err(crate::Error::Io)?;
-            grid_entries.clear();
-            log::debug!(
-                "[reorder_bmp] field {}: spilled grid run {} to disk",
-                field_id,
-                run_files.len(),
-            );
         }
     }
     drop(encoded);
@@ -1705,9 +1747,6 @@ pub(crate) fn reorder_bmp_field(
     if total_terms == 0 {
         return Ok((writer, field_tocs, converged));
     }
-
-    // Sort remaining in-memory entries
-    grid_entries.sort_unstable();
 
     // ── Write remaining sections ────────────────────────────────────────
 
@@ -1731,6 +1770,7 @@ pub(crate) fn reorder_bmp_field(
     let grid_offset = writer.offset() - blob_start;
     let (packed_bytes, _sb_bytes) = if run_files.is_empty() {
         // Fast path: all entries fit in memory, use existing function
+        grid_entries.sort_unstable();
         let result = stream_write_grids(
             &grid_entries,
             dims as usize,
@@ -1744,8 +1784,7 @@ pub(crate) fn reorder_bmp_field(
     } else {
         // Flush remaining in-memory entries as the final run if non-empty
         if !grid_entries.is_empty() {
-            let run_path = run_files.allocate();
-            write_grid_run(&grid_entries, &run_path).map_err(crate::Error::Io)?;
+            spill_grid_entries(&mut grid_entries, &mut run_files, field_id)?;
         }
         drop(grid_entries);
 
@@ -1823,7 +1862,7 @@ pub(crate) fn reorder_bmp_field(
             .map_err(crate::Error::Io)?;
     }
 
-    // V15 footer.
+    // V17 footer.
     write_bmp_footer(
         &mut writer,
         total_terms,
@@ -1944,5 +1983,23 @@ mod grid_run_prefix_tests {
             !path.exists(),
             "spill owner must remove files on unwind/drop"
         );
+    }
+
+    #[test]
+    fn grid_entry_spills_never_exceed_the_run_limit() {
+        let mut entries = Vec::with_capacity(3);
+        let mut runs = super::GridRunFiles::new(9);
+        let additional: Vec<super::BmpGridEntry> =
+            (0..8).rev().map(|block| (1, block, 1)).collect();
+
+        super::extend_grid_entries_bounded(&mut entries, &additional, 3, &mut runs, 9).unwrap();
+
+        assert_eq!(runs.len(), 2);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries.capacity(), 3);
+        for path in runs.iter() {
+            // Three 9-byte serialized entries per complete run.
+            assert_eq!(std::fs::metadata(path).unwrap().len(), 27);
+        }
     }
 }

--- a/hermes-core/src/structures/postings/sparse/config.rs
+++ b/hermes-core/src/structures/postings/sparse/config.rs
@@ -167,8 +167,10 @@ pub struct SparseQueryConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_query_dims: Option<usize>,
     /// Fraction of query dimensions to keep (0.0-1.0), same semantics as
-    /// indexing-time `pruning`: sort by abs(weight) descending,
-    /// keep top fraction. None or 1.0 = no pruning.
+    /// indexing-time `pruning`: sort by abs(weight) descending and keep the
+    /// top fraction. BMP uses this subset for candidate generation and the
+    /// bounded full query for final scoring; MaxScore uses the subset for both.
+    /// None or 1.0 = no pruning.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pruning: Option<f32>,
     /// Minimum number of query dimensions before pruning and weight_threshold
@@ -177,10 +179,10 @@ pub struct SparseQueryConfig {
     /// Default: 4. Set to 0 to always apply pruning/filtering.
     #[serde(default = "default_min_terms")]
     pub min_query_dims: usize,
-    /// Maximum number of superblocks to visit (LSP/0 gamma cap).
-    /// 0 = unlimited (default). Only applies to BMP format.
-    #[serde(default)]
-    pub max_superblocks: usize,
+    /// LSP/0 top-superblock guarantee γ. `None` selects the paper-derived
+    /// schedule from retrieval depth; `Some(0)` requests exhaustive traversal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lsp_gamma: Option<usize>,
 }
 
 fn default_heap_factor() -> f32 {
@@ -197,7 +199,7 @@ impl Default for SparseQueryConfig {
             max_query_dims: None,
             pruning: None,
             min_query_dims: 4,
-            max_superblocks: 0,
+            lsp_gamma: None,
         }
     }
 }
@@ -247,28 +249,21 @@ pub struct SparseVectorConfig {
     /// BMP block size: number of consecutive doc_ids per block (must be power
     /// of 2, max 256). Only used when format = Bmp. Uniform across every
     /// segment of the field — set per field in SDL (`bmp_block_size: N`).
-    /// Smaller = better pruning granularity; larger = smaller grid — the
-    /// dense 4-bit grid is `dims × num_blocks / 2` bytes, so grid memory
-    /// scales as 1/block_size. Default 32 favors pruning granularity; increase
-    /// it explicitly only when the block-grid memory tradeoff requires it
+    /// Smaller = better pruning granularity; larger means fewer locally
+    /// bit-packed maximum cells. Default 32 favors pruning granularity;
+    /// increase it only after representative tail-latency testing
     /// (docs/bmp-grid-compression.md).
     #[serde(default = "default_bmp_block_size")]
     pub bmp_block_size: u32,
-    /// Bits per BMP block-grid cell: 4 (default) or 2. The grid is
-    /// `dims × num_blocks × bits/8` bytes, so 2 halves grid memory; measured
-    /// pruning cost is ~free (+0.4-2.2% blocks scored — the exact u8 sb_grid
-    /// prunes first and shields the block grid; docs/bmp-grid-compression.md).
+    /// Bits per BMP block-grid cell: 4 (default) or 2. Two caps compressed D
+    /// payload groups at two bits; the exact space reduction depends on local
+    /// group widths. Measured pruning cost is small (+0.4-2.2% blocks scored;
+    /// the ceil-u4 superblock grid prunes first).
     /// Grid bounds are ceil-quantized, so exact top-k results are unchanged
     /// at any width. Uniform per field across all segments — set in SDL
     /// (`bmp_grid_bits: 2`) at index creation.
     #[serde(default = "default_bmp_grid_bits")]
     pub bmp_grid_bits: u8,
-    /// BMP superblock size: number of consecutive blocks grouped for hierarchical
-    /// pruning (Carlson et al., SIGIR 2025). Must be power of 2.
-    /// Default 64. Set to 0 to disable superblock pruning (flat BMP scoring).
-    /// Only used when format = Bmp.
-    #[serde(default = "default_bmp_superblock_size")]
-    pub bmp_superblock_size: u32,
     /// Static pruning: fraction of postings to keep per inverted list (SEISMIC-style)
     /// Lists are sorted by weight descending and truncated to top fraction.
     ///
@@ -296,7 +291,7 @@ pub struct SparseVectorConfig {
     /// - uniCOIL: 30522
     /// - Custom models: set to vocabulary size
     ///
-    /// If None, BMP builder derives dims from observed data (V10 behavior).
+    /// If None, the BMP builder derives dims from observed data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dims: Option<u32>,
     /// Fixed max weight scale for BMP format.
@@ -305,7 +300,7 @@ pub struct SparseVectorConfig {
     /// (`max_weight_scale = max_weight`), eliminating rescaling during merge.
     ///
     /// For SPLADE models: 5.0 (covers typical weight range 0-5).
-    /// If None, BMP builder derives scale from data (V10 behavior).
+    /// If None, the BMP builder derives scale from data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_weight: Option<f32>,
     /// Minimum number of postings in a dimension before pruning and
@@ -326,11 +321,7 @@ fn default_bmp_block_size() -> u32 {
 }
 
 fn default_bmp_grid_bits() -> u8 {
-    4
-}
-
-fn default_bmp_superblock_size() -> u32 {
-    64
+    SparseVectorConfig::DEFAULT_BMP_GRID_BITS
 }
 
 fn default_min_terms() -> usize {
@@ -347,8 +338,7 @@ impl Default for SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
-            bmp_grid_bits: 4,
-            bmp_superblock_size: 64,
+            bmp_grid_bits: default_bmp_grid_bits(),
             pruning: None,
             query_config: None,
 
@@ -361,6 +351,7 @@ impl Default for SparseVectorConfig {
 
 impl SparseVectorConfig {
     pub const DEFAULT_BMP_BLOCK_SIZE: u32 = 32;
+    pub const DEFAULT_BMP_GRID_BITS: u8 = 4;
 
     /// SPLADE-optimized config with research-validated defaults
     ///
@@ -386,8 +377,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
-            bmp_grid_bits: 4,
-            bmp_superblock_size: 64,
+            bmp_grid_bits: default_bmp_grid_bits(),
             pruning: Some(0.1), // Keep top 10% per dimension
             query_config: Some(SparseQueryConfig {
                 tokenizer: None,
@@ -397,7 +387,7 @@ impl SparseVectorConfig {
                 max_query_dims: Some(20), // Process top 20 query dimensions
                 pruning: Some(0.1),       // Keep top 10% of query dims
                 min_query_dims: 4,
-                max_superblocks: 0,
+                lsp_gamma: None,
             }),
 
             dims: None,
@@ -421,18 +411,17 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
-            bmp_grid_bits: 4,
-            bmp_superblock_size: 64,
+            bmp_grid_bits: default_bmp_grid_bits(),
             pruning: Some(0.1),
             query_config: Some(SparseQueryConfig {
                 tokenizer: None,
                 weighting: QueryWeighting::One,
-                heap_factor: 0.8,
+                heap_factor: 1.0,
                 weight_threshold: 0.01,
-                max_query_dims: Some(20),
-                pruning: Some(0.1),
+                max_query_dims: None,
+                pruning: Some(0.33),
                 min_query_dims: 4,
-                max_superblocks: 0,
+                lsp_gamma: None,
             }),
 
             dims: Some(105879),
@@ -458,8 +447,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
-            bmp_grid_bits: 4,
-            bmp_superblock_size: 64,
+            bmp_grid_bits: default_bmp_grid_bits(),
             pruning: Some(0.15), // Keep top 15% per dimension
             query_config: Some(SparseQueryConfig {
                 tokenizer: None,
@@ -469,7 +457,7 @@ impl SparseVectorConfig {
                 max_query_dims: Some(15), // Fewer query dimensions
                 pruning: Some(0.15),      // Keep top 15% of query dims
                 min_query_dims: 4,
-                max_superblocks: 0,
+                lsp_gamma: None,
             }),
 
             dims: None,
@@ -490,8 +478,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
-            bmp_grid_bits: 4,
-            bmp_superblock_size: 64,
+            bmp_grid_bits: default_bmp_grid_bits(),
             pruning: None,
             query_config: None,
 
@@ -519,8 +506,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
-            bmp_grid_bits: 4,
-            bmp_superblock_size: 64,
+            bmp_grid_bits: default_bmp_grid_bits(),
             pruning: None, // No posting list pruning
             query_config: Some(SparseQueryConfig {
                 tokenizer: None,
@@ -530,7 +516,7 @@ impl SparseVectorConfig {
                 max_query_dims: Some(50), // Process more dimensions
                 pruning: None,            // No fraction-based pruning
                 min_query_dims: 4,
-                max_superblocks: 0,
+                lsp_gamma: None,
             }),
 
             dims: None,
@@ -596,8 +582,7 @@ impl SparseVectorConfig {
             doc_mass: None,
             block_size: 128,
             bmp_block_size: default_bmp_block_size(),
-            bmp_grid_bits: 4,
-            bmp_superblock_size: 64,
+            bmp_grid_bits: default_bmp_grid_bits(),
             pruning: None,
             query_config: None,
 

--- a/hermes-proto/hermes.proto
+++ b/hermes-proto/hermes.proto
@@ -113,6 +113,7 @@ message SparseVectorQuery {
   float weight_threshold = 10;      // Min abs(weight) for query dims (0 = no filtering)
   uint32 max_query_dims = 11;       // Max query dimensions to process (0 = all)
   float pruning = 12;               // Fraction of query dims to keep (0 = no pruning, 0.1 = top 10%)
+  optional uint32 lsp_gamma = 13;   // LSP/0 gamma (unset = depth-derived, 0 = exhaustive)
 }
 
 // Dense vector query for similarity search

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -377,10 +377,12 @@ pub fn convert_query(
                 .with_over_fetch_factor(1.0);
 
             // Apply SDL query_config defaults, then override with per-request values
-            let schema_qc = schema
+            let sparse_config = schema
                 .get_field_entry(field)
-                .and_then(|e| e.sparse_vector_config.as_ref())
-                .and_then(|c| c.query_config.as_ref());
+                .and_then(|entry| entry.sparse_vector_config.as_ref());
+            let schema_qc = sparse_config.and_then(|config| config.query_config.as_ref());
+            let is_bmp = sparse_config
+                .is_some_and(|config| config.format == hermes_core::structures::SparseFormat::Bmp);
 
             // heap_factor: per-request > schema default > 1.0
             if sv_query.heap_factor > 0.0 {
@@ -408,11 +410,22 @@ pub fn convert_query(
                 query = query.with_pruning(sv_query.pruning);
             } else if let Some(Some(p)) = schema_qc.map(|qc| qc.pruning) {
                 query = query.with_pruning(p);
+            } else if is_bmp {
+                // LSP/0's robust zero-shot configuration keeps the top third
+                // of query terms by absolute weight.
+                query = query.with_pruning(0.33);
             }
 
             // min_query_dims: schema default (no per-request override)
             if let Some(qc) = schema_qc {
                 query = query.with_min_query_dims(qc.min_query_dims);
+            }
+
+            // LSP/0 gamma: per-request > schema default > depth-derived.
+            if let Some(gamma) = sv_query.lsp_gamma {
+                query = query.with_lsp_gamma(gamma as usize);
+            } else if let Some(gamma) = schema_qc.and_then(|config| config.lsp_gamma) {
+                query = query.with_lsp_gamma(gamma);
             }
 
             Ok(Box::new(query))
@@ -816,6 +829,9 @@ pub fn schema_to_sdl(schema: &Schema) -> String {
                     }
                     if qc.min_query_dims != 4 {
                         qparams.push(format!("min_query_dims: {}", qc.min_query_dims));
+                    }
+                    if let Some(gamma) = qc.lsp_gamma {
+                        qparams.push(format!("lsp_gamma: {gamma}"));
                     }
                     if !qparams.is_empty() {
                         idx_params.push(format!("query<{}>", qparams.join(", ")));

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -108,9 +108,9 @@ struct Args {
     #[arg(long, default_value = "600")]
     optimizer_time_budget_secs: u64,
 
-    /// Depth cap for large-segment BP: stop at partitions of this many docs
-    /// (4096 = superblock granularity, keeps most of the pruning win)
-    #[arg(long, default_value = "4096")]
+    /// Depth cap for large-segment BP: stop at partitions of this many vectors
+    /// (256 = one default 32-vector × 8-block LSP superblock)
+    #[arg(long, default_value = "256")]
     optimizer_partial_min_partition_docs: usize,
 
     /// Cooldown in seconds between deepening passes on budget-truncated segments

--- a/hermes-server/src/optimizer.rs
+++ b/hermes-server/src/optimizer.rs
@@ -33,8 +33,7 @@ pub struct OptimizerConfig {
     /// Wall-clock budget per BP pass on large segments.
     pub time_budget: Duration,
     /// Depth cap for large segments: stop bisection at partitions of this
-    /// many docs. 4096 = superblock granularity (64 blocks × 64 docs), which
-    /// keeps most of the superblock-pruning win at ~⅓ less depth.
+    /// many vectors. 256 is one default LSP superblock (8 × 32 vectors).
     pub partial_min_partition_docs: usize,
     /// Minimum wait between follow-up passes on a segment whose previous
     /// pass hit its wall-clock budget (`bp_converged == false`). Each

--- a/hermes-tool/src/index_ops.rs
+++ b/hermes-tool/src/index_ops.rs
@@ -406,8 +406,6 @@ pub async fn heatmap_bmp_grid(
 
     let dims = bmp.dims() as usize;
     let num_blocks = bmp.num_blocks as usize;
-    let packed_row_size = bmp.packed_row_size();
-    let grid = bmp.grid_slice();
 
     // Get terminal size
     let (term_cols, term_rows) = terminal_size();
@@ -427,17 +425,20 @@ pub async fn heatmap_bmp_grid(
 
     for d in 0..dims {
         let row = (d / dim_bin_size).min(actual_rows - 1);
-        let row_base = d * packed_row_size;
-        for b in 0..num_blocks {
-            let col = (b / block_bin_size).min(actual_cols - 1);
-            let byte = grid[row_base + b / 2];
-            let val = if b % 2 == 0 { byte & 0x0F } else { byte >> 4 };
-            if val > 0 {
-                nonzero_cells += 1;
+        bmp.for_each_block_grid_chunk(d as u32, |start, count, values| {
+            total_cells += count as u64;
+            let Some(values) = values else {
+                return;
+            };
+            for (within, &value) in values.iter().enumerate() {
+                let block = start + within;
+                let col = (block / block_bin_size).min(actual_cols - 1);
+                if value > 0 {
+                    nonzero_cells += 1;
+                }
+                heatmap[row][col] = heatmap[row][col].max(value);
             }
-            total_cells += 1;
-            heatmap[row][col] = heatmap[row][col].max(val);
-        }
+        })?;
     }
 
     let sparsity = if total_cells > 0 {


### PR DESCRIPTION
## Summary
- replace legacy BMP grid storage with grouped ceil-quantized BMP7 grids and safe streaming merge/reorder handling
- add query-global LSP/0 candidate scheduling, full-query scoring, and shared sparse planner behavior
- optimize x86_64 and AArch64 grid decoding, reduce hot-path allocation, and tighten corruption checks
- update format, sizing, forward-index, and operational documentation

## Validation
- cargo test -p hermes-core --features native (863 passed, 6 ignored)
- cargo clippy --workspace --all-targets --features native -- -D warnings
- cargo check -p hermes-core --target x86_64-apple-darwin --features native
- cargo test -p hermes-core --target x86_64-apple-darwin --features native segment::bmp_grid::tests (8 passed)
- cargo check -p hermes-wasm --target wasm32-unknown-unknown
- cargo fmt --all -- --check
- git diff --check