### PR TITLE
Harden BMP planning and exact pruning

### DIFF
--- a/hermes-core/src/directories/cold_io.rs
+++ b/hermes-core/src/directories/cold_io.rs
@@ -184,8 +184,8 @@ impl StreamingWriter for ColdStreamingWriter {
         self.maybe_drop(true);
         crate::observe::cold_write(&self.label, self.written as usize);
         log::debug!(
-            "[cold_io] wrote {:.1} MB with page cache dropped behind the cursor",
-            self.written as f64 / (1024.0 * 1024.0)
+            "[cold_io] wrote {} with page cache dropped behind the cursor",
+            crate::format_bytes(self.written)
         );
         Ok(())
     }

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -422,7 +422,7 @@ impl IndexMetadata {
         built_fields.sort_unstable_by_key(|(field_id, _)| **field_id);
 
         log::debug!(
-            "[trained] loading trained structures, vector_fields={:?}",
+            "[trained] loading trained structures, dense_vector_fields={:?}",
             vector_fields.keys().collect::<Vec<_>>()
         );
 

--- a/hermes-core/src/index/primary_key.rs
+++ b/hermes-core/src/index/primary_key.rs
@@ -96,9 +96,9 @@ impl PrimaryKeyIndex {
 
         let bloom_bytes = bloom.size_bytes();
         log::info!(
-            "[primary_key] bloom filter: {} keys, {:.2} MB",
+            "[primary_key] bloom filter: {} keys, {}",
             total_keys,
-            bloom_bytes as f64 / (1024.0 * 1024.0),
+            crate::format_bytes(bloom_bytes as u64),
         );
 
         Self {
@@ -139,8 +139,8 @@ impl PrimaryKeyIndex {
         }
 
         log::info!(
-            "[primary_key] bloom filter loaded from cache: {:.2} MB{}",
-            bloom.size_bytes() as f64 / (1024.0 * 1024.0),
+            "[primary_key] bloom filter loaded from cache: {}{}",
+            crate::format_bytes(bloom.size_bytes() as u64),
             if added > 0 {
                 format!(
                     ", added {} keys from {} new segment(s)",

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -598,13 +598,33 @@ impl<D: Directory + 'static> Searcher<D> {
         {
             return Ok(empty());
         }
+        let field = first.field;
+        let (total_superblocks, planning_depth) = self
+            .segments
+            .iter()
+            .filter_map(|segment| segment.bmp_index(field))
+            .fold((0usize, retrieval_depth), |(total, depth), bmp| {
+                (
+                    total.saturating_add(bmp.num_superblocks as usize),
+                    depth.max(crate::query::bmp_executor_limit(
+                        retrieval_depth,
+                        first.over_fetch_factor,
+                        bmp,
+                    )),
+                )
+            });
         let gamma = first
             .lsp_gamma
-            .unwrap_or_else(|| crate::query::bmp::recommended_lsp_gamma(retrieval_depth));
+            .unwrap_or_else(|| crate::query::bmp::recommended_lsp_gamma(planning_depth));
         if gamma == 0 {
             return Ok(empty());
         }
-        let field = first.field;
+        if total_superblocks == 0 || gamma >= total_superblocks {
+            // A cap covering the whole index is exhaustive. Let each segment
+            // compute and traverse its local order once instead of building a
+            // query-global heap and retaining an all-superblock plan.
+            return Ok(empty());
+        }
         let candidate_terms: Vec<(u32, f32)> = infos
             .iter()
             .filter(|info| info.candidate)
@@ -667,9 +687,13 @@ impl<D: Directory + 'static> Searcher<D> {
                     .total_cmp(&segment_bounds[left as usize])
                     .then_with(|| left.cmp(&right))
             });
+            let selected_bounds = selected[segment]
+                .iter()
+                .map(|&superblock| segment_bounds[superblock as usize])
+                .collect();
             plans.push(Some(std::sync::Arc::new(
                 crate::query::bmp::LspSegmentPlan {
-                    sb_ubs: segment_bounds,
+                    sb_ubs: selected_bounds,
                     sb_order: std::mem::take(&mut selected[segment]),
                 },
             )));

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -392,26 +392,26 @@ impl<D: Directory + 'static> Searcher<D> {
             let seg_total = stats.total_bytes();
             total_mem += seg_total;
             log::info!(
-                "[searcher] segment {:016x}: docs={}, mem={:.2} MB \
-                 (term_dict={:.2} MB, store={:.2} MB, sparse={:.2} MB, dense={:.2} MB, bloom={:.2} MB)",
+                "[searcher] segment {:016x}: docs={}, estimated_memory={} \
+                 (term_dict={}, store={}, sparse_vectors={}, dense_vectors={}, bloom={})",
                 stats.segment_id,
                 stats.num_docs,
-                seg_total as f64 / (1024.0 * 1024.0),
-                stats.term_dict_cache_bytes as f64 / (1024.0 * 1024.0),
-                stats.store_cache_bytes as f64 / (1024.0 * 1024.0),
-                stats.sparse_index_bytes as f64 / (1024.0 * 1024.0),
-                stats.dense_index_bytes as f64 / (1024.0 * 1024.0),
-                stats.bloom_filter_bytes as f64 / (1024.0 * 1024.0),
+                crate::format_bytes(seg_total as u64),
+                crate::format_bytes(stats.term_dict_cache_bytes as u64),
+                crate::format_bytes(stats.store_cache_bytes as u64),
+                crate::format_bytes(stats.sparse_index_bytes as u64),
+                crate::format_bytes(stats.dense_index_bytes as u64),
+                crate::format_bytes(stats.bloom_filter_bytes as u64),
             );
         }
         // Log process RSS if available (helps diagnose OOM)
-        let rss_mb = process_rss_mb();
+        let rss_bytes = process_rss_bytes();
         log::info!(
-            "[searcher] loaded {} segments: total_docs={}, estimated_mem={:.2} MB, process_rss={:.1} MB",
+            "[searcher] loaded {} segments: total_docs={}, estimated_memory={}, process_rss={}",
             segments.len(),
             total_docs,
-            total_mem as f64 / (1024.0 * 1024.0),
-            rss_mb,
+            crate::format_bytes(total_mem as u64),
+            crate::format_bytes(rss_bytes),
         );
 
         Ok(segments)
@@ -1232,25 +1232,25 @@ fn checked_search_window(limit: usize, offset: usize) -> Result<usize> {
         .ok_or_else(|| crate::Error::Query("search offset + limit overflow".into()))
 }
 
-/// Get current process RSS in MB (best-effort, returns 0.0 on failure)
-fn process_rss_mb() -> f64 {
+/// Get current process RSS in bytes (best-effort, returns zero on failure).
+fn process_rss_bytes() -> u64 {
     #[cfg(target_os = "linux")]
     {
         // Read from /proc/self/status — VmRSS line
         if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
             for line in status.lines() {
                 if let Some(rest) = line.strip_prefix("VmRSS:") {
-                    let kb: f64 = rest
+                    let kib: u64 = rest
                         .trim()
                         .trim_end_matches("kB")
                         .trim()
                         .parse()
-                        .unwrap_or(0.0);
-                    return kb / 1024.0;
+                        .unwrap_or(0);
+                    return kib.saturating_mul(1024);
                 }
             }
         }
-        0.0
+        0
     }
     #[cfg(target_os = "macos")]
     {
@@ -1281,15 +1281,11 @@ fn process_rss_mb() -> f64 {
                 &mut count,
             )
         };
-        if ret == 0 {
-            info.resident_size as f64 / (1024.0 * 1024.0)
-        } else {
-            0.0
-        }
+        if ret == 0 { info.resident_size } else { 0 }
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
-        0.0
+        0
     }
 }
 

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -384,33 +384,58 @@ impl<D: Directory + 'static> Searcher<D> {
 
         let segments: Vec<Arc<SegmentReader>> = loaded.into_iter().map(|(_, seg)| seg).collect();
 
-        // Log searcher loading summary with per-segment memory breakdown
+        // Keep heap, file-backed address space, and pinned residency separate.
+        // Mapped bytes are not necessarily resident; process RSS is the
+        // authoritative whole-process residency measurement.
         let total_docs: u64 = segments.iter().map(|s| s.meta().num_docs as u64).sum();
-        let mut total_mem = 0usize;
+        let mut total_heap = 0usize;
+        let mut total_file_backed = 0u64;
+        let mut total_pinned = 0u64;
+        let mut total_pin_intended = 0u64;
         for seg in &segments {
             let stats = seg.memory_stats();
-            let seg_total = stats.total_bytes();
-            total_mem += seg_total;
+            let heap = stats.estimated_heap_bytes();
+            let file_backed = stats.file_backed_bytes();
+            total_heap = total_heap.saturating_add(heap);
+            total_file_backed = total_file_backed.saturating_add(file_backed);
+            total_pinned = total_pinned.saturating_add(stats.pinned_metadata_bytes);
+            total_pin_intended = total_pin_intended.saturating_add(stats.pin_intended_bytes);
             log::info!(
-                "[searcher] segment {:016x}: docs={}, estimated_memory={} \
-                 (term_dict={}, store={}, sparse_vectors={}, dense_vectors={}, bloom={})",
+                "[searcher] segment {:016x}: docs={}, heap_estimate={} \
+                 (term_cache={}, store_cache={}, sparse_vectors={}, dense_vectors={}), \
+                 file_backed={} (term_bloom={}, sparse_vectors={}, dense_vectors={}), \
+                 pinned_metadata={} of {} eligible \
+                 (sparse_vectors={} of {}, dense_vectors={} of {})",
                 stats.segment_id,
                 stats.num_docs,
-                crate::format_bytes(seg_total as u64),
+                crate::format_bytes(heap as u64),
                 crate::format_bytes(stats.term_dict_cache_bytes as u64),
                 crate::format_bytes(stats.store_cache_bytes as u64),
-                crate::format_bytes(stats.sparse_index_bytes as u64),
-                crate::format_bytes(stats.dense_index_bytes as u64),
-                crate::format_bytes(stats.bloom_filter_bytes as u64),
+                crate::format_bytes(stats.sparse_heap_bytes as u64),
+                crate::format_bytes(stats.dense_heap_bytes as u64),
+                crate::format_bytes(file_backed),
+                crate::format_bytes(stats.term_bloom_file_bytes),
+                crate::format_bytes(stats.sparse_file_backed_bytes),
+                crate::format_bytes(stats.dense_file_backed_bytes),
+                crate::format_bytes(stats.pinned_metadata_bytes),
+                crate::format_bytes(stats.pin_intended_bytes),
+                crate::format_bytes(stats.sparse_pinned_metadata_bytes),
+                crate::format_bytes(stats.sparse_pin_intended_bytes),
+                crate::format_bytes(stats.dense_pinned_metadata_bytes),
+                crate::format_bytes(stats.dense_pin_intended_bytes),
             );
         }
         // Log process RSS if available (helps diagnose OOM)
         let rss_bytes = process_rss_bytes();
         log::info!(
-            "[searcher] loaded {} segments: total_docs={}, estimated_memory={}, process_rss={}",
+            "[searcher] loaded {} segments: total_docs={}, heap_estimate={}, \
+             file_backed={}, pinned_metadata={} of {} eligible, process_rss={}",
             segments.len(),
             total_docs,
-            crate::format_bytes(total_mem as u64),
+            crate::format_bytes(total_heap as u64),
+            crate::format_bytes(total_file_backed),
+            crate::format_bytes(total_pinned),
+            crate::format_bytes(total_pin_intended),
             crate::format_bytes(rss_bytes),
         );
 

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3036,9 +3036,9 @@ async fn bench_aggressive_quantization() {
     let grid_end =
         u64::from_le_bytes(original[bfoot + 24..bfoot + 32].try_into().unwrap()) as usize;
     println!(
-        "\ncorpus: {DOCS} docs, {TOPICS} topics, {} blocks | grid {:.1} MB | k={K}, {QUERIES} queries, exact",
+        "\ncorpus: {DOCS} docs, {TOPICS} topics, {} blocks | grid {} | k={K}, {QUERIES} queries, exact",
         num_blocks,
-        (grid_end - grid_start) as f64 / 1e6
+        crate::format_bytes((grid_end - grid_start) as u64)
     );
 
     let patch = |levels: &[u8]| -> Vec<u8> {

--- a/hermes-core/src/index/tests/pin.rs
+++ b/hermes-core/src/index/tests/pin.rs
@@ -64,9 +64,29 @@ async fn test_pin_metadata_copy_mode_preserves_search() {
         mode: PinMode::Copy,
     });
     let stats = reader.memory_stats();
+    assert!(stats.sparse_file_backed_bytes > 0);
+    assert!(stats.dense_file_backed_bytes > 0);
+    assert!(
+        stats.sparse_file_backed_bytes > stats.sparse_heap_bytes as u64,
+        "BMP corpus bytes must be reported as file-backed, not heap"
+    );
     assert!(
         stats.pinned_metadata_bytes > 0,
         "BMP starts/doc-maps/sb_grid + flat doc_ids should be pinnable"
+    );
+    assert!(stats.sparse_pinned_metadata_bytes > 0);
+    assert!(stats.dense_pinned_metadata_bytes > 0);
+    assert_eq!(
+        stats.pinned_metadata_bytes,
+        stats
+            .sparse_pinned_metadata_bytes
+            .saturating_add(stats.dense_pinned_metadata_bytes)
+    );
+    assert_eq!(
+        stats.pin_intended_bytes,
+        stats
+            .sparse_pin_intended_bytes
+            .saturating_add(stats.dense_pin_intended_bytes)
     );
     assert_eq!(
         stats.pinned_metadata_bytes, stats.pin_intended_bytes,
@@ -102,6 +122,12 @@ async fn test_pin_metadata_budget_exhaustion_reported() {
     });
     let stats = reader.memory_stats();
     assert!(stats.pinned_metadata_bytes <= budget);
+    assert_eq!(
+        stats.pinned_metadata_bytes,
+        stats
+            .sparse_pinned_metadata_bytes
+            .saturating_add(stats.dense_pinned_metadata_bytes)
+    );
     assert!(
         stats.pin_intended_bytes > stats.pinned_metadata_bytes,
         "tiny budget must leave a visible intended-vs-pinned gap"

--- a/hermes-core/src/index/vector_builder.rs
+++ b/hermes-core/src/index/vector_builder.rs
@@ -385,7 +385,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             .await?;
         self.cleanup_unreferenced_vector_artifacts().await;
         log::info!(
-            "Vector generation {:?} complete for {} field(s)",
+            "Dense vector ANN generation {:?} complete for {} field(s)",
             mode,
             target_field_ids.len(),
         );
@@ -437,7 +437,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         }
         if !missing.is_empty() {
             log::info!(
-                "Skipping vector field(s) {missing:?}: the current corpus contains no vectors"
+                "Skipping dense vector field(s) {missing:?}: the current corpus contains no vectors"
             );
         }
         Ok(updates)
@@ -467,7 +467,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let files = match self.directory.list_files(std::path::Path::new("")).await {
             Ok(files) => files,
             Err(error) => {
-                log::warn!("[trained] failed listing abandoned vector artifacts: {error}");
+                log::warn!("[trained] failed listing abandoned dense vector artifacts: {error}");
                 return;
             }
         };
@@ -759,12 +759,12 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         }
         if collected < total {
             log::info!(
-                "Sampled {} / {} vectors for field {} (max {} vectors / {} bytes resident)",
+                "Sampled {} / {} dense vectors for field {} (max {} vectors / {} resident)",
                 collected,
                 total,
                 field.0,
                 self.config.vector_training_max_samples,
-                self.config.vector_training_memory_bytes,
+                crate::format_bytes(self.config.vector_training_memory_bytes as u64),
             );
         }
         Ok(Some(sample))
@@ -790,7 +790,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let num_clusters = effective_field_num_clusters(config, corpus_count, sample_count)?;
 
         log::info!(
-            "Training vector index for field {} with {} sampled / {} total vectors, {} clusters (dim={})",
+            "Training dense vector index for field {} with {} sampled / {} total vectors, {} clusters (dim={})",
             field_id,
             sample_count,
             corpus_count,

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -901,10 +901,10 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
                     if b.num_docs() & 0x3FFF == 0 {
                         log::debug!(
-                            "[indexing] docs={}, memory={:.2} MB, budget={:.2} MB",
+                            "[indexing] docs={}, memory={}, budget={}",
                             b.num_docs(),
-                            builder_memory as f64 / (1024.0 * 1024.0),
-                            state.memory_budget_per_worker as f64 / (1024.0 * 1024.0)
+                            crate::format_bytes(builder_memory as u64),
+                            crate::format_bytes(state.memory_budget_per_worker as u64)
                         );
                     }
 
@@ -919,10 +919,10 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     if builder_memory >= effective_budget && b.num_docs() >= MIN_DOCS_BEFORE_FLUSH {
                         log::info!(
                             "[indexing] memory budget reached, building segment: \
-                             docs={}, memory={:.2} MB, budget={:.2} MB",
+                             docs={}, memory={}, budget={}",
                             b.num_docs(),
-                            builder_memory as f64 / (1024.0 * 1024.0),
-                            state.memory_budget_per_worker as f64 / (1024.0 * 1024.0),
+                            crate::format_bytes(builder_memory as u64),
+                            crate::format_bytes(state.memory_budget_per_worker as u64),
                         );
                         let full_builder = builder.take().unwrap();
                         Self::build_segment_inline(&state, full_builder, &handle);

--- a/hermes-core/src/lib.rs
+++ b/hermes-core/src/lib.rs
@@ -93,6 +93,29 @@ pub type DocId = u32;
 pub type TermFreq = u32;
 pub type Score = f32;
 
+/// Format a byte count with IEC binary units.
+///
+/// All Hermes user-facing size logs use this formatter so a `MiB` always
+/// means 1,048,576 bytes and the precision is consistent across subsystems.
+pub fn format_bytes(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * KIB;
+    const GIB: u64 = 1024 * MIB;
+    const TIB: u64 = 1024 * GIB;
+
+    if bytes >= TIB {
+        format!("{:.2} TiB", bytes as f64 / TIB as f64)
+    } else if bytes >= GIB {
+        format!("{:.2} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{:.2} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.2} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
 /// Default number of indexing threads (cpu / 4, minimum 1).
 /// Centralized so all configs share one definition.
 #[cfg(feature = "native")]
@@ -111,4 +134,20 @@ pub fn default_search_threads() -> usize {
 #[cfg(feature = "native")]
 pub fn default_compression_threads() -> usize {
     (num_cpus::get() / 4).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn format_bytes_uses_iec_units() {
+        assert_eq!(super::format_bytes(0), "0 B");
+        assert_eq!(super::format_bytes(1023), "1023 B");
+        assert_eq!(super::format_bytes(1024), "1.00 KiB");
+        assert_eq!(super::format_bytes(1024 * 1024), "1.00 MiB");
+        assert_eq!(super::format_bytes(3 * 1024 * 1024 * 1024), "3.00 GiB");
+        assert_eq!(
+            super::format_bytes(2 * 1024 * 1024 * 1024 * 1024),
+            "2.00 TiB"
+        );
+    }
 }

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -146,7 +146,7 @@ impl ActiveSegmentOperations {
             return None;
         }
         if !indexing && !vector_update && inner.non_indexing_paused {
-            log::debug!("[segment_lifecycle] deferred operation during vector retraining");
+            log::debug!("[segment_lifecycle] deferred operation during dense vector retraining");
             return None;
         }
         // Check for overlap with any active lifecycle operation.
@@ -1247,7 +1247,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     crate::segment::delete_segment(directory.as_ref(), segment_id).await
                 {
                     log::warn!(
-                        "[segment_cleanup] immediate vector-generation delete failed for {}: {}",
+                        "[segment_cleanup] immediate dense-vector generation delete failed for {}: {}",
                         segment_id.to_hex(),
                         error,
                     );
@@ -2582,7 +2582,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             }
             if !conflicted && !changed {
                 log::info!(
-                    "[vector_rewrite] ANN finalization complete ({} segment(s) rewritten)",
+                    "[dense_vector_rewrite] ANN finalization complete ({} segment(s) rewritten)",
                     rewritten,
                 );
                 return Ok(rewritten);
@@ -2630,7 +2630,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                         Ok(_) => break,
                         Err(error) => {
                             log::error!(
-                                "[vector_rewrite] failed to upgrade newly committed segment {}: {}",
+                                "[dense_vector_rewrite] failed to upgrade newly committed segment {}: {}",
                                 segment_id,
                                 error,
                             );
@@ -2642,12 +2642,14 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         };
         let Ok(runtime) = tokio::runtime::Handle::try_current() else {
             log::warn!(
-                "[vector_rewrite] runtime unavailable; newly committed flat segment upgrade deferred"
+                "[dense_vector_rewrite] runtime unavailable; newly committed flat segment upgrade deferred"
             );
             return;
         };
         if !try_spawn_lifecycle(&self.lifecycle_handles, &runtime, future) {
-            log::warn!("[vector_rewrite] runtime rejected newly committed flat segment upgrade");
+            log::warn!(
+                "[dense_vector_rewrite] runtime rejected newly committed flat segment upgrade"
+            );
         }
     }
 

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -96,7 +96,6 @@ struct BmpScratch {
     query_presence: Vec<u64>,
     local_block_order: Vec<u32>,
     // Two-phase block scoring: phase1 block UBs (sized to BMP_SUPERBLOCK_SIZE)
-    phase1_local_block_ubs: Vec<f32>,
     phase1_local_block_ub_units: Vec<u32>,
     // Per-slot accumulator (sized to block_size) — u32 for integer scoring
     acc: Vec<u32>,
@@ -125,9 +124,6 @@ impl BmpScratch {
         }
         if self.local_block_order.len() < sb_size {
             self.local_block_order.resize(sb_size, 0);
-        }
-        if self.phase1_local_block_ubs.len() < sb_size {
-            self.phase1_local_block_ubs.resize(sb_size, 0.0);
         }
         if self.phase1_local_block_ub_units.len() < sb_size {
             self.phase1_local_block_ub_units.resize(sb_size, 0);
@@ -183,6 +179,8 @@ struct BmpGridWeight {
 /// prevents a 50-segment index from silently turning γ into `50 × γ`.
 #[derive(Debug)]
 pub(crate) struct LspSegmentPlan {
+    /// Upper bounds aligned one-for-one with `sb_order`. Keeping only selected
+    /// values makes plan residency O(gamma), not O(all superblocks).
     pub(crate) sb_ubs: Vec<f32>,
     pub(crate) sb_order: Vec<u32>,
 }
@@ -534,60 +532,70 @@ fn execute_bmp_inner(
 
         // ── Superblock-at-a-time scoring ─────────────────────────────
         scratch.ensure_capacity_sb(
-            num_superblocks_total,
+            if lsp_plan.is_some() {
+                0
+            } else {
+                num_superblocks_total
+            },
             BMP_SUPERBLOCK_SIZE as usize,
             block_size,
         );
 
-        let (sb_ubs, sb_order, superblock_visit_limit) = if let Some(plan) = lsp_plan {
-            if plan.sb_ubs.len() != num_superblocks_total {
-                return Err(crate::Error::Internal(format!(
-                    "global LSP/0 plan has {} bounds for {} superblocks",
-                    plan.sb_ubs.len(),
-                    num_superblocks_total
-                )));
-            }
-            if plan
-                .sb_order
-                .iter()
-                .any(|&superblock| superblock as usize >= num_superblocks_total)
-            {
-                return Err(crate::Error::Internal(
-                    "global LSP/0 plan contains an invalid superblock id".into(),
-                ));
-            }
-            (
-                plan.sb_ubs.as_slice(),
-                plan.sb_order.as_slice(),
-                plan.sb_order.len(),
-            )
-        } else {
-            // Single-segment/direct execution computes its own SBMax order.
-            compute_sb_ubs_int(
-                index.superblock_grid(),
-                &candidate_grid_weights,
-                dequant,
-                &mut scratch.sb_ub_units,
-                &mut scratch.sb_ubs,
-                &mut scratch.decoded_grid_group,
-            )?;
-            // LSP/0 requires strict non-increasing SBMax order. A secondary
-            // coverage heuristic would change membership in top-γ.
-            sort_sb_desc_into(
-                &scratch.sb_ubs[..num_superblocks_total],
-                &mut scratch.sb_order,
-            );
-            let visit_limit = if lsp_gamma == 0 {
-                scratch.sb_order.len()
-            } else {
-                lsp_gamma.min(scratch.sb_order.len())
+        let (sb_ubs, sb_order, superblock_visit_limit, bounds_follow_order) =
+            match lsp_plan {
+                Some(plan) => {
+                    if plan.sb_ubs.len() != plan.sb_order.len() {
+                        return Err(crate::Error::Internal(format!(
+                            "global LSP/0 plan has {} bounds for {} selected superblocks",
+                            plan.sb_ubs.len(),
+                            plan.sb_order.len()
+                        )));
+                    }
+                    if plan
+                        .sb_order
+                        .iter()
+                        .any(|&superblock| superblock as usize >= num_superblocks_total)
+                    {
+                        return Err(crate::Error::Internal(
+                            "global LSP/0 plan contains an invalid superblock id".into(),
+                        ));
+                    }
+                    (
+                        plan.sb_ubs.as_slice(),
+                        plan.sb_order.as_slice(),
+                        plan.sb_order.len(),
+                        true,
+                    )
+                }
+                None => {
+                    // Single-segment/direct execution computes its own SBMax order.
+                    compute_sb_ubs_int(
+                        index.superblock_grid(),
+                        &candidate_grid_weights,
+                        dequant,
+                        &mut scratch.sb_ub_units,
+                        &mut scratch.sb_ubs,
+                        &mut scratch.decoded_grid_group,
+                    )?;
+                    // LSP/0 requires strict non-increasing SBMax order. A secondary
+                    // coverage heuristic would change membership in top-γ.
+                    sort_sb_desc_into(
+                        &scratch.sb_ubs[..num_superblocks_total],
+                        &mut scratch.sb_order,
+                    );
+                    let visit_limit = if lsp_gamma == 0 {
+                        scratch.sb_order.len()
+                    } else {
+                        lsp_gamma.min(scratch.sb_order.len())
+                    };
+                    (
+                        &scratch.sb_ubs[..num_superblocks_total],
+                        scratch.sb_order.as_slice(),
+                        visit_limit,
+                        false,
+                    )
+                }
             };
-            (
-                &scratch.sb_ubs[..num_superblocks_total],
-                scratch.sb_order.as_slice(),
-                visit_limit,
-            )
-        };
 
         if sb_order.is_empty() {
             return Ok(Vec::new());
@@ -609,7 +617,11 @@ fn execute_bmp_inner(
             if let Some(shared) = threshold_source.shared {
                 collector.seed_threshold(shared.get());
             }
-            let sb_ub = sb_ubs[sb_id as usize];
+            let sb_ub = if bounds_follow_order {
+                sb_ubs[idx]
+            } else {
+                sb_ubs[sb_id as usize]
+            };
 
             // LSP/0's superblock condition is SBMax >= theta. Eta/alpha is
             // deliberately NOT applied here; it belongs only to block
@@ -651,7 +663,6 @@ fn execute_bmp_inner(
                 &mut scratch.local_block_ub_units,
                 &mut scratch.phase1_local_block_ub_units,
                 &mut scratch.local_block_ubs,
-                &mut scratch.phase1_local_block_ubs,
                 &mut scratch.query_presence,
                 &mut scratch.decoded_grid_group,
                 dequant,
@@ -702,6 +713,7 @@ fn execute_bmp_inner(
                 count,
                 &scratch.local_block_order,
                 &scratch.local_block_ubs,
+                &scratch.local_block_ub_units,
                 &scratch.query_presence,
                 &query_by_dim_u16,
                 candidate_mask,
@@ -715,7 +727,7 @@ fn execute_bmp_inner(
                 &mut scratch.acc,
                 phase1_mask,
                 if two_phase_active {
-                    Some(&scratch.phase1_local_block_ubs)
+                    Some(&scratch.phase1_local_block_ub_units)
                 } else {
                     None
                 },
@@ -914,6 +926,7 @@ fn score_superblock_blocks(
     count: usize,
     local_order: &[u32],
     local_ubs: &[f32],
+    local_ub_units: &[u32],
     query_presence: &[u64],
     query_by_dim_u16: &[(u32, u16)],
     candidate_mask: u64,
@@ -926,10 +939,10 @@ fn score_superblock_blocks(
     docmap_lookups: &mut u32,
     acc: &mut [u32],
     phase1_mask: u64,
-    phase1_local_ubs: Option<&[f32]>,
+    phase1_local_ub_units: Option<&[u32]>,
 ) {
     let block_size = index.bmp_block_size as usize;
-    let two_phase = phase1_mask != u64::MAX && phase1_local_ubs.is_some();
+    let two_phase = phase1_mask != u64::MAX && phase1_local_ub_units.is_some();
 
     // Level 2: Pre-warm first few blocks' data (eliminates cold-start for first block).
     // block_data_starts offsets are already in cache from superblock-level prefetch.
@@ -992,13 +1005,16 @@ fn score_superblock_blocks(
                     total_block_postings,
                 );
 
-                // Check if phase2 can be skipped:
-                // max_partial_score + remaining_ub < threshold?
-                // remaining_ub = full_block_ub - phase1_block_ub
-                let max_partial = max_touched_acc(acc, &touched) as f32 * dequant;
-                let phase1_ub = phase1_local_ubs.unwrap()[local_idx as usize];
-                let remaining_ub = (ub - phase1_ub).max(0.0);
-                if (max_partial + remaining_ub) * alpha < collector.threshold() {
+                // Keep the subtraction and addition in integer accumulator
+                // units. Subtracting independently rounded f32 bounds can
+                // underestimate the remaining score by one ULP near 2^24.
+                let max_possible_units = two_phase_upper_bound_units(
+                    max_touched_acc(acc, &touched),
+                    local_ub_units[local_idx as usize],
+                    phase1_local_ub_units.unwrap()[local_idx as usize],
+                );
+                let max_possible = max_possible_units as f32 * dequant;
+                if max_possible * alpha < collector.threshold() {
                     // Skip phase2 — zero touched slots and continue
                     zero_touched_acc(acc, &touched);
                     *blocks_scored += 1;
@@ -1091,6 +1107,15 @@ fn score_superblock_blocks(
 
         *blocks_scored += 1;
     }
+}
+
+#[inline(always)]
+fn two_phase_upper_bound_units(
+    max_partial_units: u32,
+    full_bound_units: u32,
+    phase1_bound_units: u32,
+) -> u32 {
+    max_partial_units.saturating_add(full_bound_units.saturating_sub(phase1_bound_units))
 }
 
 // ============================================================================
@@ -1218,7 +1243,6 @@ fn compute_block_ubs_and_presence(
     units: &mut [u32],
     phase1_units: &mut [u32],
     out: &mut [f32],
-    phase1_out: &mut [f32],
     query_presence: &mut Vec<u64>,
     decoded: &mut [u8],
     dequant: f32,
@@ -1226,7 +1250,6 @@ fn compute_block_ubs_and_presence(
     debug_assert!(units.len() >= count);
     debug_assert!(phase1_units.len() >= count);
     debug_assert!(out.len() >= count);
-    debug_assert!(phase1_out.len() >= count);
     debug_assert!(decoded.len() >= count);
     debug_assert!(count <= BMP_SUPERBLOCK_SIZE as usize);
     let group_id = block_start / GRID_GROUP_CELLS;
@@ -1274,11 +1297,6 @@ fn compute_block_ubs_and_presence(
     for (bound, &integer_units) in out[..count].iter_mut().zip(&units[..count]) {
         *bound = integer_units as f32 * dequant;
     }
-    if use_phase1 {
-        for (bound, &integer_units) in phase1_out[..count].iter_mut().zip(&phase1_units[..count]) {
-            *bound = integer_units as f32 * dequant;
-        }
-    }
     Ok(blocks_with_query_terms)
 }
 
@@ -1288,6 +1306,7 @@ mod tests {
 
     use super::{
         BmpGridWeight, compute_block_ubs_and_presence, recommended_lsp_gamma, sort_sb_desc_into,
+        two_phase_upper_bound_units,
     };
     use crate::directories::OwnedBytes;
     use crate::segment::BMP_SUPERBLOCK_SIZE;
@@ -1347,7 +1366,6 @@ mod tests {
         let mut bounds = [0.0f32; 1];
 
         let mut phase1_units = [0u32; 1];
-        let mut phase1_bounds = [0.0f32; 1];
         let mut presence = Vec::new();
         let mut decoded = [0u8; GRID_GROUP_CELLS];
         compute_block_ubs_and_presence(
@@ -1361,7 +1379,6 @@ mod tests {
             &mut units,
             &mut phase1_units,
             &mut bounds,
-            &mut phase1_bounds,
             &mut presence,
             &mut decoded,
             dequant,
@@ -1375,6 +1392,22 @@ mod tests {
     }
 
     #[test]
+    fn two_phase_bound_is_combined_before_f32_rounding() {
+        // Around 2^24, independently converting the full and phase-one
+        // bounds to f32 loses a unit in their difference:
+        // f32(max_partial) + (f32(full) - f32(phase1)) = 16_777_215,
+        // while the integer-domain upper bound is 16_777_216.
+        let max_partial = 16_777_199u32;
+        let full = 16_777_217u32;
+        let phase1 = 16_777_200u32;
+        let rounded_subtraction = max_partial as f32 + (full as f32 - phase1 as f32).max(0.0);
+        let integer_bound = two_phase_upper_bound_units(max_partial, full, phase1) as f32;
+
+        assert!(rounded_subtraction < integer_bound);
+        assert_eq!(integer_bound, 16_777_216.0);
+    }
+
+    #[test]
     fn packed_integer_bound_kernel_matches_every_4bit_cell() {
         let blocks = 64usize;
         let grid = test_grid(
@@ -1385,7 +1418,6 @@ mod tests {
             let mut units = [0u32; BMP_SUPERBLOCK_SIZE as usize];
             let mut phase1_units = [0u32; BMP_SUPERBLOCK_SIZE as usize];
             let mut bounds = [0.0f32; BMP_SUPERBLOCK_SIZE as usize];
-            let mut phase1_bounds = [0.0f32; BMP_SUPERBLOCK_SIZE as usize];
             let mut presence = Vec::new();
             let mut decoded = [0u8; GRID_GROUP_CELLS];
 
@@ -1404,7 +1436,6 @@ mod tests {
                 &mut units,
                 &mut phase1_units,
                 &mut bounds,
-                &mut phase1_bounds,
                 &mut presence,
                 &mut decoded,
                 1.0,

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -226,7 +226,7 @@ macro_rules! boolean_plan {
             // Auto-detect: BMP executor if field has BMP index, else MaxScore
             if let Some(infos) = extract_all_sparse_infos(should) {
                 if let Some((raw, info)) =
-                    build_sparse_bmp_results(&infos, reader, limit, &scorer_options)
+                    build_sparse_bmp_results(&infos, reader, limit, &scorer_options)?
                 {
                     return Ok(combine_sparse_results(raw, info.combiner, info.field, limit));
                 }
@@ -358,7 +358,7 @@ macro_rules! boolean_plan {
                         if let Some((raw, info)) =
                             build_sparse_bmp_results_filtered(
                                 &infos, reader, limit, &bitset_pred, &scorer_options
-                            )
+                            )?
                         {
                             log::debug!(
                                 "BooleanQuery planner: bitset-aware sparse BMP, {} dims, {} matching docs",
@@ -374,7 +374,7 @@ macro_rules! boolean_plan {
                     if let Some((raw, info)) =
                         build_sparse_bmp_results_filtered(
                             &infos, reader, limit, &*combined, &scorer_options
-                        )
+                        )?
                     {
                         log::debug!(
                             "BooleanQuery planner: predicate-aware sparse BMP, {} dims",

--- a/hermes-core/src/query/mod.rs
+++ b/hermes-core/src/query/mod.rs
@@ -27,6 +27,7 @@ mod fusion;
 mod global_stats;
 mod phrase;
 mod planner;
+pub(crate) use planner::bmp_executor_limit;
 mod prefix;
 mod range;
 mod reranker;

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -184,7 +184,7 @@ pub(super) fn bounded_sparse_executor_limit(limit: usize, over_fetch_factor: f32
 /// hit is already a distinct final document. Genuine multi-value segments
 /// retain the configured budget because aggregation can collapse many raw
 /// ordinals into one document.
-fn bmp_executor_limit(
+pub(crate) fn bmp_executor_limit(
     limit: usize,
     over_fetch_factor: f32,
     bmp: &crate::segment::reader::bmp::BmpIndex,
@@ -194,7 +194,6 @@ fn bmp_executor_limit(
         over_fetch_factor,
         bmp.is_single_valued(),
         bmp.num_real_docs() as usize,
-        bmp.num_virtual_docs as usize,
     )
 }
 
@@ -203,12 +202,11 @@ fn bmp_executor_limit_for_counts(
     over_fetch_factor: f32,
     single_valued: bool,
     num_real_docs: usize,
-    num_virtual_docs: usize,
 ) -> usize {
     if single_valued {
         limit.min(num_real_docs)
     } else {
-        bounded_sparse_executor_limit(limit, over_fetch_factor).min(num_virtual_docs)
+        bounded_sparse_executor_limit(limit, over_fetch_factor).min(num_real_docs)
     }
 }
 
@@ -274,7 +272,7 @@ pub(crate) fn build_sparse_bmp_results(
     reader: &SegmentReader,
     limit: usize,
     options: &super::ScorerOptions,
-) -> Option<(Vec<ScoredDoc>, SparseTermQueryInfo)> {
+) -> crate::Result<Option<(Vec<ScoredDoc>, SparseTermQueryInfo)>> {
     build_sparse_bmp_results_inner(infos, reader, limit, None, options)
 }
 
@@ -288,7 +286,7 @@ pub(crate) fn build_sparse_bmp_results_filtered(
     limit: usize,
     predicate: &dyn Fn(crate::DocId) -> bool,
     options: &super::ScorerOptions,
-) -> Option<(Vec<ScoredDoc>, SparseTermQueryInfo)> {
+) -> crate::Result<Option<(Vec<ScoredDoc>, SparseTermQueryInfo)>> {
     build_sparse_bmp_results_inner(infos, reader, limit, Some(predicate), options)
 }
 
@@ -298,17 +296,21 @@ fn build_sparse_bmp_results_inner(
     limit: usize,
     predicate: Option<&dyn Fn(crate::DocId) -> bool>,
     options: &super::ScorerOptions,
-) -> Option<(Vec<ScoredDoc>, SparseTermQueryInfo)> {
-    let info = *infos.first()?;
+) -> crate::Result<Option<(Vec<ScoredDoc>, SparseTermQueryInfo)>> {
+    let Some(&info) = infos.first() else {
+        return Ok(None);
+    };
     let field = info.field;
-    let bmp = reader.bmp_index(field)?;
+    let Some(bmp) = reader.bmp_index(field) else {
+        return Ok(None);
+    };
     let candidate_terms: Vec<(u32, f32)> = infos
         .iter()
         .filter(|info| info.candidate)
         .map(|info| (info.dim_id, info.weight))
         .collect();
     if candidate_terms.is_empty() {
-        return None;
+        return Ok(None);
     }
     let scoring_terms: Vec<(u32, f32)> = infos
         .iter()
@@ -320,7 +322,7 @@ fn build_sparse_bmp_results_inner(
         .unwrap_or_else(|| super::bmp::recommended_lsp_gamma(executor_limit));
     let field_label = reader.schema().get_field_name(field).unwrap_or("?");
     let threshold = bmp_threshold(options, info.combiner, bmp.is_single_valued());
-    let result = if let Some(predicate) = predicate {
+    let results = if let Some(predicate) = predicate {
         super::bmp::execute_bmp_filtered_with_threshold(
             bmp,
             reader.schema().index_label(),
@@ -347,14 +349,8 @@ fn build_sparse_bmp_results_inner(
             options.lsp_plan.as_deref(),
             threshold,
         )
-    };
-    match result {
-        Ok(results) => Some((results, info)),
-        Err(e) => {
-            log::warn!("BMP execution failed for field {}: {}", field.0, e);
-            None
-        }
-    }
+    }?;
+    Ok(Some((results, info)))
 }
 
 /// Combine raw MaxScore results with ordinal deduplication into a scorer.
@@ -660,14 +656,8 @@ mod tests {
     #[test]
     fn bmp_single_value_limit_does_not_overfetch() {
         assert_eq!(bounded_sparse_executor_limit(320, 99.0), 640);
-        assert_eq!(
-            bmp_executor_limit_for_counts(320, 2.0, true, 10_000, 10_048),
-            320
-        );
-        assert_eq!(
-            bmp_executor_limit_for_counts(320, 2.0, false, 10_000, 10_048),
-            640
-        );
+        assert_eq!(bmp_executor_limit_for_counts(320, 2.0, true, 10_000), 320);
+        assert_eq!(bmp_executor_limit_for_counts(320, 2.0, false, 10_000), 640);
     }
 
     #[test]

--- a/hermes-core/src/query/reranker.rs
+++ b/hermes-core/src/query/reranker.rs
@@ -642,7 +642,7 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
 
                     let survivor_vectors = survivor_entries.len();
                     log::debug!(
-                        "[reranker] matryoshka pre-filter: {}/{} dims, {}/{} docs and {}/{} vectors survived",
+            "[dense_vector_rerank] matryoshka pre-filter: {}/{} dims, {}/{} docs and {}/{} vectors survived",
                         trunc_dim,
                         query_dim,
                         survivor_docs.len(),
@@ -706,7 +706,7 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
 
     if total_vectors == 0 {
         log::debug!(
-            "[reranker] field {}: {} candidates, all skipped (no flat vectors)",
+            "[dense_vector_rerank] field {}: {} candidates, all skipped (no flat vectors)",
             field_id,
             candidates.len()
         );
@@ -761,7 +761,7 @@ pub async fn rerank<D: crate::directories::Directory + 'static>(
     }
 
     log::debug!(
-        "[reranker] field {}: {} candidates -> {} results (skipped {}, {} vectors, unit_norm={}, rrf_k={}): read+score={:.1}ms total={:.1}ms",
+        "[dense_vector_rerank] field {}: {} candidates -> {} results (skipped {}, {} vectors, unit_norm={}, rrf_k={}): read+score={:.1}ms total={:.1}ms",
         field_id,
         candidates.len(),
         scored.len(),
@@ -935,7 +935,7 @@ async fn rerank_binary<D: crate::directories::Directory + 'static>(
     }
 
     log::debug!(
-        "[reranker-binary] field {}: {} candidates -> {} results ({} docs scored, {} bytes/vec, rrf_k={}): {:.1}ms",
+        "[dense_vector_binary_rerank] field {}: {} candidates -> {} results ({} docs scored, bytes_per_vector={}, rrf_k={}): {:.1}ms",
         field_id,
         candidates.len(),
         scored.len(),

--- a/hermes-core/src/query/vector/sparse.rs
+++ b/hermes-core/src/query/vector/sparse.rs
@@ -484,7 +484,7 @@ impl Query for SparseVectorQuery {
 
             // Auto-detect: try BMP executor first (coupled to index format)
             if let Some((raw, info)) =
-                crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, &options)
+                crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, &options)?
             {
                 return Ok(crate::query::planner::combine_sparse_results(
                     raw,
@@ -535,7 +535,7 @@ impl Query for SparseVectorQuery {
 
         // Auto-detect: try BMP executor first (coupled to index format)
         if let Some((raw, info)) =
-            crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, &options)
+            crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, &options)?
         {
             return Ok(crate::query::planner::combine_sparse_results(
                 raw,
@@ -683,7 +683,7 @@ impl SparseTermQuery {
             lsp_gamma: None,
         }];
         if let Some((raw, info)) =
-            crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, options)
+            crate::query::planner::build_sparse_bmp_results(&infos, reader, limit, options)?
         {
             return Ok(crate::query::planner::combine_sparse_results(
                 raw,

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -253,8 +253,8 @@ impl AnnDiskIndex {
         &self.header
     }
 
-    pub(crate) fn estimated_memory_bytes(&self) -> usize {
-        self.runs.capacity() * std::mem::size_of::<AnnRun>()
+    pub(crate) fn estimated_heap_bytes(&self) -> usize {
+        std::mem::size_of::<Self>() + self.runs.capacity() * std::mem::size_of::<AnnRun>()
     }
 
     #[cfg(feature = "native")]
@@ -272,6 +272,7 @@ impl AnnDiskIndex {
         report.pinned_bytes += after.pinned_bytes - before.pinned_bytes;
         report.skipped_budget_bytes += after.skipped_budget_bytes - before.skipped_budget_bytes;
         report.failed_bytes += after.failed_bytes - before.failed_bytes;
+        report.heap_copy_bytes += after.heap_copy_bytes - before.heap_copy_bytes;
     }
 
     fn cluster_runs(&self, cluster_id: u32) -> &[AnnRun] {

--- a/hermes-core/src/segment/builder/dense.rs
+++ b/hermes-core/src/segment/builder/dense.rs
@@ -254,11 +254,11 @@ pub(super) fn build_vectors_streaming(
                 };
                 let (index_type, bytes) = blob?;
                 log::info!(
-                    "[segment_build] built ANN(type={}) for field {} ({} vectors, {} bytes)",
+                    "[dense_vector_build] built ANN(type={}) for field {} ({} vectors, {})",
                     index_type,
                     field_id,
                     builder.doc_ids.len(),
-                    bytes.len()
+                    crate::format_bytes(bytes.len() as u64)
                 );
                 Ok(Some((*field_id, index_type, bytes)))
             };
@@ -415,11 +415,11 @@ pub(super) fn build_vectors_streaming(
                     })?;
                 }
                 log::debug!(
-                    "[build_vectors] field {}: binary IVF built ({} vectors, {} clusters, {} bytes)",
+                    "[dense_vector_build] field {}: binary IVF built ({} vectors, {} clusters, {})",
                     field_id,
                     num_vectors,
                     quantizer.num_clusters,
-                    blob_len,
+                    crate::format_bytes(blob_len),
                 );
             }
         }

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -314,9 +314,9 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         max_dims.saturating_mul(std::mem::size_of::<std::sync::atomic::AtomicU32>());
     if frequency_bytes > memory_budget_bytes.saturating_sub(jobs_bytes) {
         log::warn!(
-            "[reorder] memory budget {:.0} MB cannot hold the {:.0} MB dimension-frequency table; using identity order",
-            memory_budget_bytes as f64 / (1024.0 * 1024.0),
-            frequency_bytes as f64 / (1024.0 * 1024.0),
+            "[reorder] memory budget {} cannot hold the {} dimension-frequency table; using identity order",
+            crate::format_bytes(memory_budget_bytes as u64),
+            crate::format_bytes(frequency_bytes as u64),
         );
         return (
             ForwardIndex {
@@ -443,9 +443,9 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         budget_limited |= dropped > 0;
 
         log::warn!(
-            "[reorder] memory budget {:.0} MB: estimated {:.0} MB, dropped {} highest-df dims, keeping {} ({} postings)",
-            memory_budget_bytes as f64 / (1024.0 * 1024.0),
-            estimated_bytes as f64 / (1024.0 * 1024.0),
+            "[reorder] memory budget {}: estimated {}, dropped {} highest-df dims, keeping {} ({} postings)",
+            crate::format_bytes(memory_budget_bytes as u64),
+            crate::format_bytes(estimated_bytes as u64),
             dropped,
             keep_count,
             cum,

--- a/hermes-core/src/segment/builder/mod.rs
+++ b/hermes-core/src/segment/builder/mod.rs
@@ -1425,14 +1425,14 @@ impl SegmentBuilder {
         drop(sparse_vectors);
 
         log::info!(
-            "[segment_build] {} docs: term_dict={}, postings={}, store={}, vectors={}, sparse={}, fast={}",
+            "[segment_build] docs={}: term_dict={}, postings={}, store={}, dense_vectors={}, sparse_vectors={}, fast_fields={}",
             num_docs,
-            super::format_bytes(term_dict_bytes),
-            super::format_bytes(postings_bytes),
-            super::format_bytes(store_bytes),
-            super::format_bytes(vectors_bytes),
-            super::format_bytes(sparse_bytes),
-            super::format_bytes(fast_bytes),
+            crate::format_bytes(term_dict_bytes as u64),
+            crate::format_bytes(postings_bytes as u64),
+            crate::format_bytes(store_bytes as u64),
+            crate::format_bytes(vectors_bytes as u64),
+            crate::format_bytes(sparse_bytes as u64),
+            crate::format_bytes(fast_bytes as u64),
         );
 
         let meta = SegmentMeta {

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -387,8 +387,8 @@ impl SegmentMerger {
         let output_size = writer.offset() as usize;
         super::block_in_place_if_multithread(move || writer.finish())?;
         log::info!(
-            "[merge_vectors] file written: {} ({} entries) in {:.1}s",
-            super::format_bytes(output_size),
+            "[dense_vector_merge] file written: {} ({} fields) in {:.1}s",
+            crate::format_bytes(output_size as u64),
             toc.len(),
             write_start.elapsed().as_secs_f64()
         );
@@ -568,10 +568,10 @@ impl SegmentMerger {
         .map_err(crate::Error::Io)?;
         let data_size = writer.offset() - data_offset;
         log::debug!(
-            "[merge_vectors] field {}: copied {} compatible ANN run source(s), {} bytes",
+            "[dense_vector_merge] field {}: copied {} compatible ANN run source(s), {}",
             field.0,
             sources.len(),
-            data_size,
+            crate::format_bytes(data_size),
         );
         Ok(Some((index_type, data_offset, data_size)))
     }
@@ -652,11 +652,11 @@ impl SegmentMerger {
         let num_clusters = quantizer.num_clusters;
         let index = builder.finish().map_err(crate::Error::Io)?;
         log::debug!(
-            "[merge_vectors] field {}: binary IVF rebuilt ({} vectors, {} clusters, estimated {} bytes)",
+            "[dense_vector_merge] field {}: binary IVF rebuilt ({} vectors, {} clusters, estimated {})",
             field.0,
             vector_count,
             num_clusters,
-            index.estimated_memory_bytes(),
+            crate::format_bytes(index.estimated_memory_bytes() as u64),
         );
         Ok(Some(index))
     }
@@ -725,11 +725,11 @@ impl SegmentMerger {
         }
 
         log::info!(
-            "[merge_vectors] field {} IVF-PQ rebuilt from {} vectors into {} assignments (estimated {}, {:.1}s)",
+            "[dense_vector_merge] field {} IVF-PQ rebuilt from {} vectors into {} assignments (estimated {}, {:.1}s)",
             field.0,
             total_fed,
             index.len(),
-            super::format_bytes(index.estimated_memory_bytes()),
+            crate::format_bytes(index.estimated_memory_bytes() as u64),
             ann_start.elapsed().as_secs_f64()
         );
         Ok(Some((index, centroids.num_clusters)))

--- a/hermes-core/src/segment/merger/fast_fields.rs
+++ b/hermes-core/src/segment/merger/fast_fields.rs
@@ -145,7 +145,7 @@ impl SegmentMerger {
             "[merge] fast-fields: {} columns, {} docs, {} (raw block stacking)",
             toc_entries.len(),
             total_docs,
-            super::format_bytes(total_bytes)
+            crate::format_bytes(total_bytes as u64)
         );
 
         Ok(total_bytes)

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -12,9 +12,9 @@ use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
 
+use super::OffsetWriter;
 use super::reader::SegmentReader;
 use super::types::{FieldStats, SegmentFiles, SegmentId, SegmentMeta};
-use super::{OffsetWriter, format_bytes};
 use crate::Result;
 use crate::directories::{Directory, DirectoryWriter};
 use crate::dsl::Schema;
@@ -66,14 +66,14 @@ impl std::fmt::Display for MergeStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "terms={}, term_dict={}, postings={}, store={}, vectors={}, sparse={}, fast={}",
+            "terms={}, term_dict={}, postings={}, store={}, dense_vectors={}, sparse_vectors={}, fast_fields={}",
             self.terms_processed,
-            format_bytes(self.term_dict_bytes),
-            format_bytes(self.postings_bytes),
-            format_bytes(self.store_bytes),
-            format_bytes(self.vectors_bytes),
-            format_bytes(self.sparse_bytes),
-            format_bytes(self.fast_bytes),
+            crate::format_bytes(self.term_dict_bytes as u64),
+            crate::format_bytes(self.postings_bytes as u64),
+            crate::format_bytes(self.store_bytes as u64),
+            crate::format_bytes(self.vectors_bytes as u64),
+            crate::format_bytes(self.sparse_bytes as u64),
+            crate::format_bytes(self.fast_bytes as u64),
         )
     }
 }
@@ -251,9 +251,9 @@ impl SegmentMerger {
             log::info!(
                 "[merge] postings done: {} terms, term_dict={}, postings={}, positions={}",
                 terms_processed,
-                format_bytes(term_dict_bytes),
-                format_bytes(postings_bytes),
-                format_bytes(positions_bytes as usize),
+                crate::format_bytes(term_dict_bytes as u64),
+                crate::format_bytes(postings_bytes as u64),
+                crate::format_bytes(positions_bytes),
             );
             Ok::<(usize, usize, usize), crate::Error>((
                 terms_processed,

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -292,7 +292,7 @@ impl SegmentMerger {
                 })?;
 
             log::debug!(
-                "[merge] sparse field {}: {} unique dims across {} segments, total_vectors={}",
+                "[sparse_vector_merge] field {}: {} unique dims across {} segments, total_vectors={}",
                 field.0,
                 all_dims.len(),
                 segments.len(),
@@ -500,8 +500,8 @@ impl SegmentMerger {
 
         let total_dims: usize = field_tocs.iter().map(|f| f.dims.len()).sum();
         log::info!(
-            "[merge_sparse] file written: {:.2} MB ({} fields, {} dims, {} skip entries)",
-            output_size as f64 / (1024.0 * 1024.0),
+            "[sparse_vector_merge] file written: {} ({} fields, {} dims, {} skip entries)",
+            crate::format_bytes(output_size as u64),
             field_tocs.len(),
             total_dims,
             skip_count,

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -91,6 +91,15 @@ impl SegmentMerger {
                     .map(|seg| seg.bmp_indexes().get(&field.0))
                     .collect();
                 let has_bmp_data = bmp_indexes.iter().any(|bi| bi.is_some());
+                if segments
+                    .iter()
+                    .any(|segment| segment.sparse_indexes().contains_key(&field.0))
+                {
+                    return Err(crate::Error::Corruption(format!(
+                        "field {} is configured as BMP but a source segment contains MaxScore data; rebuild the index",
+                        field.0
+                    )));
+                }
                 if has_bmp_data {
                     let total_vectors_bmp: u32 = bmp_indexes
                         .iter()
@@ -232,10 +241,18 @@ impl SegmentMerger {
                             &mut field_tocs,
                         )
                     })?;
-                    continue;
                 }
-                // No BMP data — fall through to MaxScore path
-                // (handles legacy segments that used MaxScore format)
+                continue;
+            }
+
+            if segments
+                .iter()
+                .any(|segment| segment.bmp_indexes().contains_key(&field.0))
+            {
+                return Err(crate::Error::Corruption(format!(
+                    "field {} is configured as MaxScore but a source segment contains BMP data; rebuild the index",
+                    field.0
+                )));
             }
 
             // MaxScore format: byte-level block stacking

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -40,20 +40,6 @@ pub use tracker::{SegmentSnapshot, SegmentTracker};
 pub use types::{FieldStats, SegmentFiles, SegmentId, SegmentMeta, TrainedVectorStructures};
 pub use vector_data::{FlatVectorData, LazyFlatVectorData, dequantize_raw};
 
-/// Format byte count as human-readable string
-#[cfg(any(feature = "native", feature = "wasm"))]
-pub(crate) fn format_bytes(bytes: usize) -> String {
-    if bytes >= 1024 * 1024 * 1024 {
-        format!("{:.2} GB", bytes as f64 / (1024.0 * 1024.0 * 1024.0))
-    } else if bytes >= 1024 * 1024 {
-        format!("{:.2} MB", bytes as f64 / (1024.0 * 1024.0))
-    } else if bytes >= 1024 {
-        format!("{:.2} KB", bytes as f64 / 1024.0)
-    } else {
-        format!("{} B", bytes)
-    }
-}
-
 /// Write adapter that tracks bytes written.
 ///
 /// Concrete type so it works with generic `serialize<W: Write>` functions

--- a/hermes-core/src/segment/pin.rs
+++ b/hermes-core/src/segment/pin.rs
@@ -124,8 +124,8 @@ impl Drop for HeapPinGuard {
     fn drop(&mut self) {
         if unsafe { libc::munlock(self.page_start, self.page_len) } != 0 {
             log::warn!(
-                "[pin] munlock failed for {} ANN heap bytes: {}",
-                self.page_len,
+                "[pin] munlock failed for {} of ANN heap: {}",
+                crate::format_bytes(self.page_len as u64),
                 std::io::Error::last_os_error()
             );
         }
@@ -177,10 +177,10 @@ impl HeapPinSet {
             self.report.skipped_budget_bytes =
                 self.report.skipped_budget_bytes.saturating_add(len_u64);
             log::debug!(
-                "[pin] ANN budget exhausted: skipping {} ({} bytes, {} remaining)",
+                "[pin] ANN budget exhausted: skipping {} ({}, {} remaining)",
                 label,
-                len_u64,
-                *remaining
+                crate::format_bytes(len_u64),
+                crate::format_bytes(*remaining)
             );
             return;
         }
@@ -225,9 +225,9 @@ impl HeapPinSet {
         } else {
             self.report.failed_bytes = self.report.failed_bytes.saturating_add(len_u64);
             log::warn!(
-                "[pin] mlock failed for ANN {} ({} bytes): {} — check RLIMIT_MEMLOCK/CAP_IPC_LOCK; continuing unpinned",
+                "[pin] mlock failed for ANN {} ({}): {} — check RLIMIT_MEMLOCK/CAP_IPC_LOCK; continuing unpinned",
                 label,
-                len_u64,
+                crate::format_bytes(len_u64),
                 std::io::Error::last_os_error()
             );
         }
@@ -256,10 +256,10 @@ pub(crate) fn pin_section(
     if len > *remaining {
         report.skipped_budget_bytes += len;
         log::debug!(
-            "[pin] budget exhausted: skipping {} ({} bytes, {} remaining)",
+            "[pin] budget exhausted: skipping {} ({}, {} remaining)",
             label,
-            len,
-            *remaining
+            crate::format_bytes(len),
+            crate::format_bytes(*remaining)
         );
         return;
     }
@@ -272,10 +272,10 @@ pub(crate) fn pin_section(
             } else {
                 report.failed_bytes += len;
                 log::warn!(
-                    "[pin] mlock failed for {} ({} bytes) — check RLIMIT_MEMLOCK; \
+                    "[pin] mlock failed for {} ({}) — check RLIMIT_MEMLOCK; \
                      continuing unpinned",
                     label,
-                    len
+                    crate::format_bytes(len)
                 );
             }
         }

--- a/hermes-core/src/segment/pin.rs
+++ b/hermes-core/src/segment/pin.rs
@@ -104,6 +104,9 @@ pub struct PinReport {
     pub skipped_budget_bytes: u64,
     /// Bytes where mlock failed (RLIMIT_MEMLOCK etc.)
     pub failed_bytes: u64,
+    /// Additional heap allocated by `PinMode::Copy`. Already-heap ANN routing
+    /// structures are resident but do not contribute here.
+    pub heap_copy_bytes: u64,
 }
 
 /// RAII owner for heap pages locked on behalf of one immutable ANN artifact
@@ -283,6 +286,7 @@ pub(crate) fn pin_section(
             *bytes = OwnedBytes::new(bytes.to_vec());
             *remaining -= len;
             report.pinned_bytes += len;
+            report.heap_copy_bytes += len;
         }
     }
 }

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -416,7 +416,7 @@ impl BmpIndex {
         log::debug!(
             "BMP V17 index loaded: num_blocks={}, num_superblocks={}, dims={}, bmp_block_size={}, \
              num_virtual_docs={}, num_real_docs={}, max_weight_scale={:.4}, postings={}, \
-             block_grid={}B, superblock_grid={}B, single_valued={}, block_data={}B, doc_map={}B",
+             block_grid={}, superblock_grid={}, single_valued={}, block_data={}, doc_map={}",
             num_blocks,
             num_superblocks,
             dims,
@@ -425,11 +425,11 @@ impl BmpIndex {
             num_real_docs,
             max_weight_scale,
             total_postings,
-            block_grid.encoded_bytes(),
-            superblock_grid.encoded_bytes(),
+            crate::format_bytes(block_grid.encoded_bytes() as u64),
+            crate::format_bytes(superblock_grid.encoded_bytes() as u64),
             single_valued,
-            bds_start,
-            num_virtual_docs as usize * 6,
+            crate::format_bytes(bds_start as u64),
+            crate::format_bytes(u64::from(num_virtual_docs) * 6),
         );
 
         Ok(Self {

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -756,18 +756,10 @@ impl BmpIndex {
         self.single_valued
     }
 
-    /// Estimated memory usage in bytes (mmap-backed region sizes).
-    ///
-    /// Fully zero-copy: all data is mmap-backed OwnedBytes, but the
-    /// mapped regions still consume RSS when paged in by the OS.
-    pub fn estimated_memory_bytes(&self) -> usize {
+    /// Estimated heap retained by this index. All corpus-sized sections are
+    /// file-backed `OwnedBytes` slices and therefore excluded.
+    pub fn estimated_heap_bytes(&self) -> usize {
         std::mem::size_of::<Self>()
-            + self.block_data_starts_bytes.len()
-            + self.block_data_bytes.len()
-            + self.block_grid.encoded_bytes()
-            + self.superblock_grid.encoded_bytes()
-            + self.doc_map_ids_bytes.len()
-            + self.doc_map_ordinals_bytes.len()
     }
 
     /// Bits per block-grid cell (4 or 2).

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -20,14 +20,20 @@ use crate::dsl::{
 pub struct SparseFileData {
     pub maxscore_indexes: FxHashMap<u32, SparseIndex>,
     pub bmp_indexes: FxHashMap<u32, BmpIndex>,
+    /// Logical size of the retained `.sparse` file handle. With
+    /// `MmapDirectory` this is mapped address space, not resident memory.
+    pub file_backed_bytes: u64,
 }
 
 /// Vectors file loading result
 pub struct VectorsFileData {
     /// Segment-level IVF payloads per field, loaded lazily for search.
     pub indexes: FxHashMap<u32, VectorIndex>,
-    /// Lazy flat vectors per field — doc_ids in memory, vectors via mmap for reranking/merge
+    /// Lazy flat vectors per field — document maps and vectors stay file-backed.
     pub flat_vectors: FxHashMap<u32, LazyFlatVectorData>,
+    /// Logical size of the retained `.vectors` file handle. With
+    /// `MmapDirectory` this is mapped address space, not resident memory.
+    pub file_backed_bytes: u64,
     /// ANN field IDs declared by the validated TOC. Training-only callers use
     /// this without opening corpus-sized ANN payloads.
     #[cfg(feature = "native")]
@@ -296,6 +302,7 @@ async fn load_vectors_file_impl<D: Directory>(
     let empty = || VectorsFileData {
         indexes: FxHashMap::default(),
         flat_vectors: FxHashMap::default(),
+        file_backed_bytes: 0,
         #[cfg(feature = "native")]
         ann_fields: Vec::new(),
     };
@@ -524,6 +531,7 @@ async fn load_vectors_file_impl<D: Directory>(
     Ok(VectorsFileData {
         indexes,
         flat_vectors,
+        file_backed_bytes: file_size,
         #[cfg(feature = "native")]
         ann_fields,
     })
@@ -552,6 +560,7 @@ pub async fn load_sparse_file<D: Directory>(
     let empty = || SparseFileData {
         maxscore_indexes: FxHashMap::default(),
         bmp_indexes: FxHashMap::default(),
+        file_backed_bytes: 0,
     };
 
     let mut maxscore_indexes = FxHashMap::default();
@@ -863,6 +872,7 @@ pub async fn load_sparse_file<D: Directory>(
     Ok(SparseFileData {
         maxscore_indexes,
         bmp_indexes,
+        file_backed_bytes: file_size,
     })
 }
 

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -614,8 +614,8 @@ pub async fn load_sparse_file<D: Directory>(
     }
 
     log::debug!(
-        "Loading sparse: size={} bytes, num_fields={}, skip_offset={}, toc_offset={}",
-        file_size,
+        "Loading sparse vectors: size={}, num_fields={}, skip_offset={}, toc_offset={}",
+        crate::format_bytes(file_size),
         num_fields,
         skip_offset,
         toc_offset,
@@ -722,7 +722,7 @@ pub async fn load_sparse_file<D: Directory>(
             ) {
                 Ok(idx) => {
                     log::debug!(
-                        "Loaded BMP index for field {}: dims={}, num_blocks={}, total_vectors={}",
+                        "Loaded BMP sparse vector index for field {}: dims={}, num_blocks={}, total_vectors={}",
                         field_id,
                         idx.dims(),
                         idx.num_blocks,
@@ -797,11 +797,11 @@ pub async fn load_sparse_file<D: Directory>(
             }
 
             log::debug!(
-                "Loaded sparse index for field {}: num_dims={}, total_vectors={}, skip_bytes={}",
+                "Loaded sparse vector index for field {}: num_dims={}, total_vectors={}, skip={}",
                 field_id,
                 dims.len(),
                 total_vectors,
-                skip_section.len(),
+                crate::format_bytes(skip_section.len() as u64),
             );
 
             maxscore_indexes.insert(

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -23,7 +23,11 @@ const DENSE_SCORE_BATCH: usize = 4_096;
 const BINARY_SCORE_BATCH: usize = 8_192;
 const MAX_VECTOR_SCORE_BATCH_BYTES: usize = 8 * 1024 * 1024;
 
-/// Memory statistics for a single segment
+/// Runtime memory accounting for a single segment.
+///
+/// Heap, file-backed address space, and pinned residency are deliberately
+/// separate: file-backed bytes are not resident merely because they are
+/// mapped, and pinned bytes are a subset rather than an additive allocation.
 #[derive(Debug, Clone, Default)]
 pub struct SegmentMemoryStats {
     /// Segment ID
@@ -34,27 +38,47 @@ pub struct SegmentMemoryStats {
     pub term_dict_cache_bytes: usize,
     /// Document store block cache bytes
     pub store_cache_bytes: usize,
-    /// Sparse vector index bytes (in-memory posting lists)
-    pub sparse_index_bytes: usize,
-    /// Dense vector index bytes (cluster assignments, quantized codes)
-    pub dense_index_bytes: usize,
-    /// Bloom filter bytes
-    pub bloom_filter_bytes: usize,
+    /// Sparse-vector lookup structures retained on the heap.
+    pub sparse_heap_bytes: usize,
+    /// Dense-vector ANN lookup structures retained on the heap.
+    pub dense_heap_bytes: usize,
+    /// File-backed term-dictionary bloom-filter bytes.
+    pub term_bloom_file_bytes: u64,
+    /// Logical `.sparse` file bytes retained by the reader.
+    pub sparse_file_backed_bytes: u64,
+    /// Logical `.vectors` file bytes retained by the reader.
+    pub dense_file_backed_bytes: u64,
     /// Hot metadata bytes actually pinned (mlock/heap-copy) at open
     pub pinned_metadata_bytes: u64,
     /// Hot metadata bytes eligible for pinning (gap vs pinned = budget
     /// exhausted or mlock failures — operator-visible)
     pub pin_intended_bytes: u64,
+    /// Sparse-vector subset of `pinned_metadata_bytes`.
+    pub sparse_pinned_metadata_bytes: u64,
+    /// Sparse-vector bytes eligible for pinning.
+    pub sparse_pin_intended_bytes: u64,
+    /// Dense-vector subset of `pinned_metadata_bytes`.
+    pub dense_pinned_metadata_bytes: u64,
+    /// Dense-vector bytes eligible for pinning.
+    pub dense_pin_intended_bytes: u64,
 }
 
 impl SegmentMemoryStats {
-    /// Total estimated memory for this segment
-    pub fn total_bytes(&self) -> usize {
+    /// Total estimated heap retained by this segment reader.
+    pub fn estimated_heap_bytes(&self) -> usize {
         self.term_dict_cache_bytes
             + self.store_cache_bytes
-            + self.sparse_index_bytes
-            + self.dense_index_bytes
-            + self.bloom_filter_bytes
+            + self.sparse_heap_bytes
+            + self.dense_heap_bytes
+    }
+
+    /// Total logical bytes in the explicitly accounted file-backed sections.
+    ///
+    /// This is mapped address space for `MmapDirectory`, not resident memory.
+    pub fn file_backed_bytes(&self) -> u64 {
+        self.term_bloom_file_bytes
+            .saturating_add(self.sparse_file_backed_bytes)
+            .saturating_add(self.dense_file_backed_bytes)
     }
 }
 
@@ -932,24 +956,28 @@ pub struct SegmentReader {
     schema: Arc<Schema>,
     /// Per-segment ANN payloads.
     vector_indexes: FxHashMap<u32, VectorIndex>,
-    /// Lazy flat vectors per field — for reranking and merge (doc_ids in memory, vectors via mmap)
+    /// Lazy flat vectors per field — document maps and vectors stay file-backed.
     flat_vectors: FxHashMap<u32, LazyFlatVectorData>,
+    /// Logical size of the retained `.vectors` file handle.
+    dense_file_backed_bytes: u64,
     /// One immutable generation of all index-global ANN artifacts.
     trained_vectors: Arc<crate::segment::TrainedVectorStructures>,
     /// Sparse vector indexes per field (MaxScore format)
     sparse_indexes: FxHashMap<u32, SparseIndex>,
     /// BMP sparse vector indexes per field (BMP format)
     bmp_indexes: FxHashMap<u32, BmpIndex>,
+    /// Logical size of the retained `.sparse` file handle.
+    sparse_file_backed_bytes: u64,
     /// Position file handle for phrase queries (lazy loading)
     positions_handle: Option<FileHandle>,
     /// Fast-field columnar readers per field_id
     fast_fields: FxHashMap<u32, crate::structures::fast_field::FastFieldReader>,
-    /// Per-segment MaxScore threshold (f32 stored as AtomicU32 bits).
-    /// Allows per-field MaxScore groups within a single query to share thresholds:
-    /// field A's result seeds field B's pruning on the same segment.
-    /// Hot-metadata pin accounting (see `segment::pin`)
+    /// Dense-vector hot-metadata pin accounting (see `segment::pin`).
     #[cfg(feature = "native")]
-    pin_report: crate::segment::pin::PinReport,
+    dense_pin_report: crate::segment::pin::PinReport,
+    /// Sparse-vector hot-metadata pin accounting (see `segment::pin`).
+    #[cfg(feature = "native")]
+    sparse_pin_report: crate::segment::pin::PinReport,
 }
 
 impl SegmentReader {
@@ -996,6 +1024,7 @@ impl SegmentReader {
 
         // Load dense vector indexes from unified .vectors file
         let vectors_data = loader::load_vectors_file(dir, &files, &schema, meta.num_docs).await?;
+        let dense_file_backed_bytes = vectors_data.file_backed_bytes;
         let vector_indexes = vectors_data.indexes;
         let flat_vectors = vectors_data.flat_vectors;
 
@@ -1012,6 +1041,7 @@ impl SegmentReader {
 
         // Load sparse vector indexes from .sparse file (MaxScore + BMP)
         let sparse_data = loader::load_sparse_file(dir, &files, meta.num_docs, &schema).await?;
+        let sparse_file_backed_bytes = sparse_data.file_backed_bytes;
         let sparse_indexes = sparse_data.maxscore_indexes;
         let bmp_indexes = sparse_data.bmp_indexes;
 
@@ -1065,13 +1095,17 @@ impl SegmentReader {
             schema,
             vector_indexes,
             flat_vectors,
+            dense_file_backed_bytes,
             trained_vectors: Arc::new(crate::segment::TrainedVectorStructures::default()),
             sparse_indexes,
             bmp_indexes,
+            sparse_file_backed_bytes,
             positions_handle,
             fast_fields,
             #[cfg(feature = "native")]
-            pin_report: Default::default(),
+            dense_pin_report: Default::default(),
+            #[cfg(feature = "native")]
+            sparse_pin_report: Default::default(),
         };
 
         // Pin hot metadata per the process-wide policy (no-op when disabled)
@@ -1098,32 +1132,50 @@ impl SegmentReader {
             return;
         }
         let mut remaining = policy.budget_bytes;
-        let mut report = PinReport::default();
+        let mut dense_report = PinReport::default();
+        let mut sparse_report = PinReport::default();
 
         // Priority 1: compact ANN lookup directories
         for index in self.vector_indexes.values_mut() {
-            index.pin_lookup_directory(policy.mode, &mut remaining, &mut report);
+            index.pin_lookup_directory(policy.mode, &mut remaining, &mut dense_report);
         }
         // Priority 2: BMP block-offset tables
         for bmp in self.bmp_indexes.values_mut() {
-            bmp.pin_block_starts(policy.mode, &mut remaining, &mut report);
+            bmp.pin_block_starts(policy.mode, &mut remaining, &mut sparse_report);
         }
         // Priority 3: sparse skip sections
         for sparse in self.sparse_indexes.values_mut() {
-            sparse.pin_skip_section(policy.mode, &mut remaining, &mut report);
+            sparse.pin_skip_section(policy.mode, &mut remaining, &mut sparse_report);
         }
         // Priority 4: doc-id maps
         for flat in self.flat_vectors.values_mut() {
-            flat.pin_doc_ids(policy.mode, &mut remaining, &mut report);
+            flat.pin_doc_ids(policy.mode, &mut remaining, &mut dense_report);
         }
         for bmp in self.bmp_indexes.values_mut() {
-            bmp.pin_doc_maps(policy.mode, &mut remaining, &mut report);
+            bmp.pin_doc_maps(policy.mode, &mut remaining, &mut sparse_report);
         }
         // Priority 5: BMP superblock grids
         for bmp in self.bmp_indexes.values_mut() {
-            bmp.pin_sb_grid(policy.mode, &mut remaining, &mut report);
+            bmp.pin_sb_grid(policy.mode, &mut remaining, &mut sparse_report);
         }
 
+        let report = PinReport {
+            intended_bytes: dense_report
+                .intended_bytes
+                .saturating_add(sparse_report.intended_bytes),
+            pinned_bytes: dense_report
+                .pinned_bytes
+                .saturating_add(sparse_report.pinned_bytes),
+            skipped_budget_bytes: dense_report
+                .skipped_budget_bytes
+                .saturating_add(sparse_report.skipped_budget_bytes),
+            failed_bytes: dense_report
+                .failed_bytes
+                .saturating_add(sparse_report.failed_bytes),
+            heap_copy_bytes: dense_report
+                .heap_copy_bytes
+                .saturating_add(sparse_report.heap_copy_bytes),
+        };
         if report.skipped_budget_bytes > 0 || report.failed_bytes > 0 {
             log::warn!(
                 "[pin] segment {:016x}: pinned {}/{} (budget skipped {}, mlock failed {}) — \
@@ -1142,7 +1194,8 @@ impl SegmentReader {
                 policy.mode,
             );
         }
-        self.pin_report = report;
+        self.dense_pin_report = dense_report;
+        self.sparse_pin_report = sparse_report;
     }
 
     // NOTE: cross-group MaxScore threshold seeding is query-execution-local
@@ -1215,7 +1268,7 @@ impl SegmentReader {
         self.term_dict.stats()
     }
 
-    /// Estimate memory usage of this segment reader
+    /// Account for heap, file-backed, and pinned bytes separately.
     pub fn memory_stats(&self) -> SegmentMemoryStats {
         let term_dict_stats = self.term_dict.stats();
 
@@ -1225,42 +1278,82 @@ impl SegmentReader {
         let term_dict_cache_bytes = self.term_dict.cached_bytes();
         let store_cache_bytes = self.store.cached_bytes();
 
-        // Sparse index: SoA dim table + OwnedBytes skip section + BMP grids
-        let sparse_index_bytes: usize = self
+        // Sparse heap: SoA dimension tables and small reader objects. Posting
+        // payloads, BMP grids, and document maps remain file-backed.
+        let sparse_heap_bytes: usize = self
             .sparse_indexes
             .values()
-            .map(|s| s.estimated_memory_bytes())
+            .map(|s| s.estimated_heap_bytes())
             .sum::<usize>()
             + self
                 .bmp_indexes
                 .values()
-                .map(|b| b.estimated_memory_bytes())
+                .map(|b| b.estimated_heap_bytes())
                 .sum::<usize>();
 
-        // Dense corpus columns are memory-mapped; only compact ANN run
-        // directories and other lookup structures count as heap memory here.
-        let dense_index_bytes: usize = self
+        // Dense corpus columns are file-backed. Only compact ANN run
+        // directories and flat-reader objects count as heap here.
+        let dense_heap_bytes: usize = self
             .vector_indexes
             .values()
-            .map(|v| v.estimated_memory_bytes())
-            .sum();
+            .map(|v| v.estimated_heap_bytes())
+            .sum::<usize>()
+            + self
+                .flat_vectors
+                .values()
+                .map(LazyFlatVectorData::estimated_heap_bytes)
+                .sum::<usize>();
 
         #[cfg(feature = "native")]
-        let (pinned_metadata_bytes, pin_intended_bytes) =
-            (self.pin_report.pinned_bytes, self.pin_report.intended_bytes);
+        let (sparse_heap_bytes, dense_heap_bytes) = (
+            sparse_heap_bytes.saturating_add(
+                usize::try_from(self.sparse_pin_report.heap_copy_bytes).unwrap_or(usize::MAX),
+            ),
+            dense_heap_bytes.saturating_add(
+                usize::try_from(self.dense_pin_report.heap_copy_bytes).unwrap_or(usize::MAX),
+            ),
+        );
+
+        #[cfg(feature = "native")]
+        let (
+            sparse_pinned_metadata_bytes,
+            sparse_pin_intended_bytes,
+            dense_pinned_metadata_bytes,
+            dense_pin_intended_bytes,
+        ) = (
+            self.sparse_pin_report.pinned_bytes,
+            self.sparse_pin_report.intended_bytes,
+            self.dense_pin_report.pinned_bytes,
+            self.dense_pin_report.intended_bytes,
+        );
         #[cfg(not(feature = "native"))]
-        let (pinned_metadata_bytes, pin_intended_bytes) = (0u64, 0u64);
+        let (
+            sparse_pinned_metadata_bytes,
+            sparse_pin_intended_bytes,
+            dense_pinned_metadata_bytes,
+            dense_pin_intended_bytes,
+        ) = (0u64, 0u64, 0u64, 0u64);
+
+        let pinned_metadata_bytes =
+            sparse_pinned_metadata_bytes.saturating_add(dense_pinned_metadata_bytes);
+        let pin_intended_bytes = sparse_pin_intended_bytes.saturating_add(dense_pin_intended_bytes);
 
         SegmentMemoryStats {
             segment_id: self.meta.id,
             num_docs: self.meta.num_docs,
             term_dict_cache_bytes,
             store_cache_bytes,
-            sparse_index_bytes,
-            dense_index_bytes,
-            bloom_filter_bytes: term_dict_stats.bloom_filter_size,
+            sparse_heap_bytes,
+            dense_heap_bytes,
+            term_bloom_file_bytes: term_dict_stats.bloom_filter_size as u64,
+            sparse_file_backed_bytes: self.sparse_file_backed_bytes,
+            dense_file_backed_bytes: self.dense_file_backed_bytes,
             pinned_metadata_bytes,
             pin_intended_bytes,
+            sparse_pinned_metadata_bytes,
+            sparse_pin_intended_bytes,
+            dense_pinned_metadata_bytes,
+            dense_pin_intended_bytes,
         }
     }
 

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -1029,17 +1029,17 @@ impl SegmentReader {
             )];
             if !vector_indexes.is_empty() || !flat_vectors.is_empty() {
                 parts.push(format!(
-                    "dense: {} ann + {} flat fields",
+                    "dense vectors: {} ANN + {} flat fields",
                     vector_indexes.len(),
                     flat_vectors.len()
                 ));
             }
             for (field_id, idx) in &sparse_indexes {
                 parts.push(format!(
-                    "sparse field {}: {} dims, ~{:.1} KB",
+                    "sparse vector field {}: {} dims, ~{}",
                     field_id,
                     idx.num_dimensions(),
-                    idx.num_dimensions() as f64 * 24.0 / 1024.0
+                    crate::format_bytes(idx.num_dimensions() as u64 * 24)
                 ));
             }
             for (field_id, idx) in &bmp_indexes {
@@ -1126,18 +1126,19 @@ impl SegmentReader {
 
         if report.skipped_budget_bytes > 0 || report.failed_bytes > 0 {
             log::warn!(
-                "[pin] segment {:016x}: pinned {}/{} bytes (budget skipped {}, mlock failed {}) —                  raise HERMES_PIN_METADATA_BUDGET_MB or RLIMIT_MEMLOCK for full coverage",
+                "[pin] segment {:016x}: pinned {}/{} (budget skipped {}, mlock failed {}) — \
+                 raise HERMES_PIN_METADATA_BUDGET_MB or RLIMIT_MEMLOCK for full coverage",
                 self.meta.id,
-                report.pinned_bytes,
-                report.intended_bytes,
-                report.skipped_budget_bytes,
-                report.failed_bytes,
+                crate::format_bytes(report.pinned_bytes),
+                crate::format_bytes(report.intended_bytes),
+                crate::format_bytes(report.skipped_budget_bytes),
+                crate::format_bytes(report.failed_bytes),
             );
         } else if report.pinned_bytes > 0 {
             log::info!(
-                "[pin] segment {:016x}: pinned {} bytes of hot metadata ({:?})",
+                "[pin] segment {:016x}: pinned {} of hot metadata ({:?})",
                 self.meta.id,
-                report.pinned_bytes,
+                crate::format_bytes(report.pinned_bytes),
                 policy.mode,
             );
         }
@@ -1438,7 +1439,11 @@ impl SegmentReader {
                             doc.add_binary_dense_vector(Field(field_id), raw);
                         }
                         Err(e) => {
-                            log::warn!("Failed to hydrate binary vector field {}: {}", field_id, e);
+                            log::warn!(
+                                "Failed to hydrate binary dense vector field {}: {}",
+                                field_id,
+                                e
+                            );
                         }
                     }
                 } else {
@@ -1447,7 +1452,7 @@ impl SegmentReader {
                             doc.add_dense_vector(Field(field_id), vec);
                         }
                         Err(e) => {
-                            log::warn!("Failed to hydrate vector field {}: {}", field_id, e);
+                            log::warn!("Failed to hydrate dense vector field {}: {}", field_id, e);
                         }
                     }
                 }
@@ -1921,7 +1926,7 @@ impl SegmentReader {
             // Combine every value of a document before document-level top-k;
             // vector-level top-k loses documents on multi-valued fields.
             log::debug!(
-                "[search_dense] field {}: brute-force on {} vectors (dim={}, quant={:?})",
+                "[dense_vector_search] field {}: brute-force on {} vectors (dim={}, quant={:?})",
                 field.0,
                 lazy_flat.num_vectors,
                 lazy_flat.dim,
@@ -1979,7 +1984,7 @@ impl SegmentReader {
             );
         }
         log::debug!(
-            "[search_dense] field {}: L1 returned {} candidates in {:.1}ms",
+            "[dense_vector_search] field {}: L1 returned {} candidates in {:.1}ms",
             field.0,
             flat_results.as_ref().map_or(results.len(), Vec::len),
             l1_elapsed.as_secs_f64() * 1000.0
@@ -2016,7 +2021,7 @@ impl SegmentReader {
                 stats.vector_count,
             );
             log::debug!(
-                "[search_dense] field {}: rerank {} vectors (dim={}, quant={:?}, {}B/vec): resolve={:.1}ms read={:.1}ms score={:.1}ms",
+                "[dense_vector_search] field {}: rerank {} vectors (dim={}, quant={:?}, bytes_per_vector={}): resolve={:.1}ms read={:.1}ms score={:.1}ms",
                 field.0,
                 stats.vector_count,
                 lazy_flat.dim,
@@ -2028,7 +2033,7 @@ impl SegmentReader {
             );
 
             log::debug!(
-                "[search_dense] field {}: rerank total={:.1}ms",
+                "[dense_vector_search] field {}: rerank total={:.1}ms",
                 field.0,
                 t_rerank.elapsed().as_secs_f64() * 1000.0
             );

--- a/hermes-core/src/segment/reader/types.rs
+++ b/hermes-core/src/segment/reader/types.rs
@@ -39,8 +39,8 @@ impl MmapAnnIndex {
         })
     }
 
-    pub fn estimated_memory_bytes(&self) -> usize {
-        self.index.estimated_memory_bytes()
+    pub fn estimated_heap_bytes(&self) -> usize {
+        self.index.estimated_heap_bytes()
     }
 
     pub(crate) fn get(&self) -> &crate::segment::ann_disk::AnnDiskIndex {
@@ -59,11 +59,12 @@ impl MmapAnnIndex {
 }
 
 impl VectorIndex {
-    /// Estimate memory usage of this vector index
-    pub fn estimated_memory_bytes(&self) -> usize {
+    /// Estimate heap retained by this vector index. Corpus-sized ANN columns
+    /// remain file-backed and are not included.
+    pub fn estimated_heap_bytes(&self) -> usize {
         match self {
-            VectorIndex::IvfPq(lazy) => lazy.estimated_memory_bytes(),
-            VectorIndex::BinaryIvf(lazy) => lazy.estimated_memory_bytes(),
+            VectorIndex::IvfPq(lazy) => lazy.estimated_heap_bytes(),
+            VectorIndex::BinaryIvf(lazy) => lazy.estimated_heap_bytes(),
         }
     }
 
@@ -193,9 +194,9 @@ impl DimensionTable {
     }
 
     /// Estimated heap memory in bytes (6 Vecs × capacity × element_size)
-    pub fn estimated_memory_bytes(&self) -> usize {
+    pub fn estimated_heap_bytes(&self) -> usize {
         let n = self.dim_ids.capacity();
-        n * (4 + 8 + 4 + 4 + 4 + 4) // u32×4 + u64×1 + f32×1 = 28 bytes per entry
+        std::mem::size_of::<Self>() + n * (4 + 8 + 4 + 4 + 4 + 4) // u32×4 + u64×1 + f32×1 = 28 bytes per entry
     }
 }
 
@@ -544,16 +545,10 @@ impl SparseIndex {
         dim_ids.iter().map(|&d| self.idf(d)).collect()
     }
 
-    /// Estimated memory usage in bytes
-    ///
-    /// - DimensionTable: SoA arrays (6 × ndims × 4 bytes)
-    /// - Skip section: OwnedBytes (Arc overhead only; data is mmap-backed)
-    /// - Handle: LazyFileHandle overhead
-    pub fn estimated_memory_bytes(&self) -> usize {
-        let dim_table = self.dims.estimated_memory_bytes();
-        // OwnedBytes: just Arc + range (no heap copy for mmap)
-        let skip_overhead = std::mem::size_of::<OwnedBytes>() + self.skip_bytes.len();
-        dim_table + skip_overhead
+    /// Estimated heap retained by this index. The skip section and posting
+    /// blocks are file-backed and therefore excluded.
+    pub fn estimated_heap_bytes(&self) -> usize {
+        std::mem::size_of::<Self>() + self.dims.estimated_heap_bytes()
     }
 
     /// Whether the handle supports synchronous reads (mmap/RAM-backed).

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -413,7 +413,7 @@ pub async fn rewrite_vector_segment<D: Directory + DirectoryWriter>(
     let dst_files = SegmentFiles::new(output_id.0);
 
     log::info!(
-        "[vector_rewrite] finalizing segment {} → {} ({} docs)",
+        "[dense_vector_rewrite] finalizing segment {} → {} ({} docs)",
         source_id.to_hex(),
         output_id.to_hex(),
         num_docs,
@@ -1074,10 +1074,10 @@ fn reorder_bmp_field_blockwise(
     });
 
     log::info!(
-        "[reorder_bmp] field {}: blockwise reorder done — {} blocks, {:.2} MB",
+        "[reorder_bmp] field {}: blockwise reorder done — {} blocks, {}",
         field_id,
         num_blocks_total,
-        blob_len as f64 / (1024.0 * 1024.0),
+        crate::format_bytes(blob_len),
     );
 
     Ok((writer, field_tocs, converged))
@@ -1334,10 +1334,10 @@ pub(crate) fn reorder_bmp_field(
     const MIN_RECORD_WORKSPACE: usize = 16 * 1024 * 1024;
     if record_fixed_peak > memory_budget.saturating_sub(MIN_RECORD_WORKSPACE) {
         log::warn!(
-            "[reorder_bmp] field {}: record maps need {:.0} MB of the {:.0} MB total budget; falling back to blockwise order",
+            "[reorder_bmp] field {}: record maps need {} of the {} total budget; falling back to blockwise order",
             field_id,
-            record_fixed_peak as f64 / (1024.0 * 1024.0),
-            memory_budget as f64 / (1024.0 * 1024.0),
+            crate::format_bytes(record_fixed_peak as u64),
+            crate::format_bytes(memory_budget as u64),
         );
         let (writer, field_tocs, _) = reorder_bmp_field_blockwise(
             sources,
@@ -1903,12 +1903,12 @@ pub(crate) fn reorder_bmp_field(
     });
 
     log::info!(
-        "[reorder_bmp] field {}: done — {} blocks, {} terms, {} postings, {:.2} MB",
+        "[reorder_bmp] field {}: done — {} blocks, {} terms, {} postings, {}",
         field_id,
         new_num_blocks,
         total_terms,
         total_postings,
-        blob_len as f64 / (1024.0 * 1024.0),
+        crate::format_bytes(blob_len),
     );
 
     Ok((writer, field_tocs, converged))

--- a/hermes-core/src/segment/types.rs
+++ b/hermes-core/src/segment/types.rs
@@ -112,17 +112,17 @@ impl TrainedVectorStructures {
         let report = pins.report();
         if report.skipped_budget_bytes > 0 || report.failed_bytes > 0 {
             log::warn!(
-                "[pin] ANN generation: resident {}/{} bytes ({:?}); budget skipped {}, mlock failed {}",
-                report.pinned_bytes,
-                report.intended_bytes,
+                "[pin] ANN generation: resident {}/{} ({:?}); budget skipped {}, mlock failed {}",
+                crate::format_bytes(report.pinned_bytes),
+                crate::format_bytes(report.intended_bytes),
                 policy.mode,
-                report.skipped_budget_bytes,
-                report.failed_bytes,
+                crate::format_bytes(report.skipped_budget_bytes),
+                crate::format_bytes(report.failed_bytes),
             );
         } else if report.pinned_bytes > 0 {
             log::info!(
-                "[pin] ANN generation: pinned {} bytes of routing structures ({:?})",
-                report.pinned_bytes,
+                "[pin] ANN generation: pinned {} of routing structures ({:?})",
+                crate::format_bytes(report.pinned_bytes),
                 policy.mode,
             );
         }

--- a/hermes-core/src/segment/vector_data.rs
+++ b/hermes-core/src/segment/vector_data.rs
@@ -1066,9 +1066,9 @@ impl LazyFlatVectorData {
         &self.handle
     }
 
-    /// Estimated memory usage — doc_ids are mmap-backed (only Arc overhead).
-    pub fn estimated_memory_bytes(&self) -> usize {
-        size_of::<Self>() + size_of::<OwnedBytes>()
+    /// Estimated heap usage — document IDs and vectors are file-backed.
+    pub fn estimated_heap_bytes(&self) -> usize {
+        size_of::<Self>()
     }
 }
 

--- a/hermes-proto/hermes.proto
+++ b/hermes-proto/hermes.proto
@@ -330,7 +330,9 @@ message IndexingBufferStats {
   uint32 unique_terms = 8;
 }
 
-// Segment reader memory (search structures)
+// Segment-reader heap memory (search structures and decompressed caches).
+// File-backed mappings and pinned residency are intentionally excluded:
+// mapped file extent is not equivalent to resident memory.
 message SegmentReaderStats {
   uint64 total_bytes = 1;
   uint64 term_dict_cache_bytes = 2;

--- a/hermes-server/src/search_service.rs
+++ b/hermes-server/src/search_service.rs
@@ -1007,8 +1007,8 @@ impl SearchService for SearchServiceImpl {
             let stats = segment.memory_stats();
             total_term_dict_cache += stats.term_dict_cache_bytes as u64;
             total_store_cache += stats.store_cache_bytes as u64;
-            total_sparse_index += stats.sparse_index_bytes as u64;
-            total_dense_index += stats.dense_index_bytes as u64;
+            total_sparse_index += stats.sparse_heap_bytes as u64;
+            total_dense_index += stats.dense_heap_bytes as u64;
         }
 
         let segment_reader_stats = SegmentReaderStats {

--- a/hermes-tool/src/index_ops.rs
+++ b/hermes-tool/src/index_ops.rs
@@ -565,8 +565,8 @@ pub async fn warmup_cache(index_path: PathBuf, cache_size: usize) -> Result<()> 
     use hermes_core::{DirectoryWriter, SLICE_CACHE_FILENAME, SliceCachingDirectory};
 
     info!(
-        "Opening index with slice caching (max {} bytes)...",
-        cache_size
+        "Opening index with slice caching (max {})...",
+        hermes_core::format_bytes(cache_size as u64)
     );
 
     let dir = FsDirectory::new(&index_path);
@@ -583,8 +583,10 @@ pub async fn warmup_cache(index_path: PathBuf, cache_size: usize) -> Result<()> 
 
     let stats = index.directory().stats();
     info!(
-        "Cache populated: {} bytes in {} slices across {} files",
-        stats.total_bytes, stats.total_slices, stats.files_cached
+        "Cache populated: {} in {} slices across {} files",
+        hermes_core::format_bytes(stats.total_bytes as u64),
+        stats.total_slices,
+        stats.files_cached
     );
 
     // Serialize cache data
@@ -595,8 +597,9 @@ pub async fn warmup_cache(index_path: PathBuf, cache_size: usize) -> Result<()> 
     let cache_file_size = std::fs::metadata(&cache_file).map(|m| m.len()).unwrap_or(0);
 
     info!(
-        "Slice cache saved to {:?} ({} bytes)",
-        cache_file, cache_file_size
+        "Slice cache saved to {:?} ({})",
+        cache_file,
+        hermes_core::format_bytes(cache_file_size)
     );
 
     Ok(())

--- a/hermes-tool/src/main.rs
+++ b/hermes-tool/src/main.rs
@@ -69,9 +69,9 @@ fn release_memory_to_os() {
     // Log current memory stats
     if let (Ok(allocated), Ok(resident)) = (stats::allocated::read(), stats::resident::read()) {
         tracing::debug!(
-            "Memory: allocated={:.1} MB, resident={:.1} MB",
-            allocated as f64 / (1024.0 * 1024.0),
-            resident as f64 / (1024.0 * 1024.0)
+            "Memory: allocated={}, resident={}",
+            hermes_core::format_bytes(allocated as u64),
+            hermes_core::format_bytes(resident as u64)
         );
     }
 }

--- a/hermes-wasm/src/remote_index.rs
+++ b/hermes-wasm/src/remote_index.rs
@@ -261,14 +261,14 @@ impl RemoteIndex {
             if let Some(directory) = &self.directory {
                 let stats = directory.inner().http_stats();
                 log::debug!(
-                    "=== SEARCH END: {} requests, {} bytes ===",
+                    "=== SEARCH END: {} requests, {} ===",
                     stats.total_requests,
-                    stats.total_bytes
+                    hermes_core::format_bytes(stats.total_bytes)
                 );
                 for op in &stats.operations {
                     log::debug!(
-                        "  HTTP: {} bytes, {}ms, range={:?}, url={}",
-                        op.bytes,
+                        "  HTTP: {}, {}ms, range={:?}, url={}",
+                        hermes_core::format_bytes(op.bytes),
                         op.duration_ms,
                         op.range,
                         op.url


### PR DESCRIPTION
Post-publish correctness and performance audit for the BMP/LSP release.

- combine two-phase bounds in integer score units before f32 conversion, preventing one-ULP underestimation in exact mode
- retain only selected global LSP bounds and skip the global heap when gamma is exhaustive
- derive default global gamma from the larger final-document and multi-value candidate depths
- propagate BMP execution errors instead of silently returning empty results
- bound multi-value collectors by real vectors, not padded virtual slots
- reject mixed BMP/MaxScore merge inputs instead of keeping a legacy fallback

Validation:
- cargo test -p hermes-core --features native: 864 passed, 6 ignored; all integration and doctests passed
- cargo clippy --workspace --all-targets --features native -- -D warnings
- cargo check -p hermes-wasm --target wasm32-unknown-unknown
- cargo check -p hermes-core --features native --target x86_64-apple-darwin
- native ARM64 targeted BMP, merge, and planner tests