### PR TITLE
feat(core): TurboQuant training-free dense ANN (index_type: tq)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -268,19 +268,27 @@ field embedding: dense_vector<DIM, uint8> [indexed]       # scalar quantized, 4Ã
 
 ### Index Types and Routing
 
-Float fields have one production ANN format: corpus-trained global IVF-PQ.
-Every segment shares the index's centroid router and residual-PQ codebook;
-segments store only mmap-backed cluster runs and PQ codes. Ordinary segment
-merges copy those immutable run columns byte-for-byte and rewrite only their
-compact document-base directory. `flat` remains available for exact
-brute-force search and as the accumulation format before ANN build.
+Float fields have two ANN formats. `ivf_pq` is the corpus-trained global
+IVF-PQ: every segment shares the index's centroid router and residual-PQ
+codebook; segments store only mmap-backed cluster runs and PQ codes. `tq`
+(TurboQuant, `docs/turboquant-quantization.md`) is training-free: each segment
+carries a 4-bit compressed payload built at commit with no global artifacts,
+scanned exhaustively with SIMD lookup tables and exact-reranked. Ordinary
+segment merges copy both formats' immutable run columns byte-for-byte and
+rewrite only their compact document-base directory. `flat` remains available
+for exact brute-force search and as the accumulation format before an
+`ivf_pq` build.
 
 ```
 field e: dense_vector<768, f16> [indexed]                                      # global IVF-PQ
 field e: dense_vector<768, f16> [indexed<ivf_pq, routing: hnsw, nprobe: 64>]
+field e: dense_vector<768, f16> [indexed<tq>]                                  # training-free TQ
 field e: dense_vector<768, f16> [indexed<flat>]                                # exact full scan
 field e: dense_vector<768> [stored]                                            # stored, not indexed
 ```
+
+`tq` ignores `num_clusters`, `nprobe`, `routing`, and `soar` (it scans every
+code) and warns when they are set; `rerank_factor` applies unchanged.
 
 When `num_clusters` is omitted, training chooses a corpus-sized leaf count
 using an 8Ã—sqrt(N) target bounded by sample quality and artifact memory. Routing

--- a/docs/turboquant-quantization.md
+++ b/docs/turboquant-quantization.md
@@ -8,7 +8,7 @@ IVF-PQ requires corpus-trained global artifacts (coarse centroids + OPQ-PQ
 codebook). Until `build_vector_index()` runs, dense queries brute-force the
 flat vectors; every trained generation adds version gates, and OPQ training is
 disabled on WASM. TurboQuant (Zandieh, Daliri et al., arXiv 2504.19874; see
-also mayflower/pg_turboquant, MIT) is a _data-oblivious_ quantizer: its
+also mayflower/pg_turboquant, MIT) is a **data-oblivious** quantizer: its
 codebook is derived analytically from the geometry of the unit sphere, so a
 segment can carry a compressed ANN payload from its very first build with
 **zero training** and no cross-segment compatibility surface beyond fixed

--- a/docs/turboquant-quantization.md
+++ b/docs/turboquant-quantization.md
@@ -1,0 +1,145 @@
+# TurboQuant (TQ) — training-free dense ANN codec
+
+Status: implemented (v1, `AnnKind::TqFlat`).
+
+## Motivation
+
+IVF-PQ requires corpus-trained global artifacts (coarse centroids + OPQ-PQ
+codebook). Until `build_vector_index()` runs, dense queries brute-force the
+flat vectors; every trained generation adds version gates, and OPQ training is
+disabled on WASM. TurboQuant (Zandieh, Daliri et al., arXiv 2504.19874; see
+also mayflower/pg_turboquant, MIT) is a _data-oblivious_ quantizer: its
+codebook is derived analytically from the geometry of the unit sphere, so a
+segment can carry a compressed ANN payload from its very first build with
+**zero training** and no cross-segment compatibility surface beyond fixed
+constants.
+
+`index_type: tq` is a per-segment compressed _flat_ scan: every code is
+scored (no IVF pruning), so candidate recall is limited only by estimator
+error at the `fetch_k` boundary, and the existing exact re-rank restores
+full-precision ordering. It replaces the brute-force fallback lane, not
+IVF-PQ: at large N, IVF-PQ scans `nprobe/num_clusters` of the corpus while TQ
+scans all of it (at 1/8 the bytes of f32).
+
+## Codec (bits = 4 per padded dimension, fixed in v1)
+
+Encode, per vector `x` (always the L2-normalized vector; cosine and unit-norm
+dot coincide after normalization, exact re-rank applies the field's metric):
+
+1. Zero-pad to `P = dim.next_power_of_two()`, apply seeded rotation
+   `R1` = sign flips → normalized FWHT → permutation (orthonormal; seed is a
+   codec constant).
+2. Stage 1: per-coordinate 3-bit code into the analytic codebook `C[8]` —
+   Lloyd-Max levels for the marginal density of a unit-sphere coordinate in
+   `R^P`, `f(t) ∝ (1 − t²)^((P−3)/2)` on `[−1, 1]`. Depends only on `P`.
+3. Residual `r = R1·x − C[codes]`, `gamma = ‖r‖₂` (stored f32).
+4. QJL sketch: 1 sign bit per coordinate of `R2·r` (`R2` an independent
+   seeded rotation).
+5. Nibble per coordinate: `(code << 1) | sign` → `P/2` bytes per vector.
+
+Score estimate for query `q` (normalized, rotated once per query):
+
+```
+q1 = R1·q,  q2 = R2·q1
+est(q, x) = Σᵢ q1[i]·C[code[i]]  +  gamma · sqrt(π/2)/sqrt(P) · Σᵢ ±q2[i]
+```
+
+The second term is the QJL unbiased correction of the inner product lost to
+stage-1 quantization (sign `±` from the stored bit). Unbiasedness is pinned by
+a statistical test, not assumed.
+
+## Segment payload and scoring
+
+TQ reuses the run-based ANN container (`segment/ann_disk.rs`) with
+`AnnKind::TqFlat = 3`, TOC discriminant `TQ_FLAT_TYPE = 7`, one logical
+cluster (`num_clusters = 1`, routing `Flat`). Runs keep explicit doc-ID and
+ordinal columns, so the normal merge stays a byte-for-byte column copy.
+
+The codes column is laid out for FastScan-style LUT16 scoring (pg_turboquant /
+Faiss FastScan pattern): groups of 16 vectors ("lanes") per block:
+
+```
+block = [gamma: 16 × f32] [nibbles: P dims × 8 bytes]
+```
+
+Nibbles are dimension-major; for dim `i`, byte `j` holds lane `j` (low nibble)
+and lane `j + 8` (high nibble). The final block of a run is zero-padded;
+padded lanes are never read back (lane index ≥ run count).
+
+Query time builds two 16-entry LUTs per dimension (stage-1 term and QJL term,
+the latter with the `sqrt(π/2)/sqrt(P)` constant folded in), quantized to i8
+with one global scale each. Kernels score 16 lanes per dimension with in-
+register table lookups (`vqtbl1q_u8` on NEON, `_mm_shuffle_epi8` on
+x86_64/SSSE3+), accumulate i16 in chunks of ≤ 128 dims, widen to i32, and
+finish per lane as `base_sum·s_base + gamma·qjl_sum·s_qjl`. A scalar fallback
+(f32 LUTs, no i8 quantization) ships alongside and is the WASM path; a test
+pins SIMD ≈ scalar agreement.
+
+`code_size` in the ANN header is the logical `P/2` bytes/vector; the container
+validates the block-padded column length for `TqFlat` specifically.
+
+## Compatibility and gates
+
+There are no trained artifacts. `quantizer_version` carries a deterministic
+FNV-1a fingerprint of `(codec version, bits, dim, P, R1/R2 seeds)`;
+`codebook_version = 0`. Merge (`headers_compatible`) and query-time validation
+compare that fingerprint, so any future change to seeds, bit width, or level
+derivation bumps `TQ_CODEC_VERSION` and refuses to mix loudly. Merge under
+`AnnWriteMode::Rebuild` (vector-generation rewrites) still byte-copies TQ
+payloads — they are generation-independent.
+
+## Schema surface
+
+```sdl
+field embedding: dense_vector<768> [indexed<tq>]
+```
+
+`VectorIndexType::Tq`. `nprobe` is meaningless for TQ (no probing) and is
+warned about at parse time; `soar`/`num_clusters` likewise. `rerank_factor`
+works unchanged. `build_vector_index()` skips TQ fields (nothing to train).
+
+## Cost model (768-dim example)
+
+| lane     | bytes/vector                     | trained artifacts        |
+| -------- | -------------------------------- | ------------------------ |
+| flat f32 | 3072                             | none                     |
+| IVF-PQ   | 96 codes + assignment            | centroids + OPQ codebook |
+| TQ       | 512 nibbles + 4 gamma (P = 1024) | none                     |
+
+Non-power-of-two dims pay FWHT padding (768 → 1024, +33%). A structured
+non-pow2 transform (Kac walk / block butterfly) is possible follow-up work.
+
+## Benchmark
+
+`hermes-core/src/index/tests/tq_bench.rs` (ignored test; run in release):
+clustered synthetic unit-norm corpus, queries perturbed from corpus points,
+ground truth = the flat index's exact cosine top-10.
+
+Measured 2026-07-23, aarch64 (Apple Silicon, NEON kernels), 100k docs ×
+768 dims, 256 corpus clusters, 100 queries, k=10, `nprobe: 64` over 1,024
+trained leaves, `rerank_factor: 2.0`, mmap directory, page cache warmed:
+
+| method       | build (s) | train (s) | .vectors (MB) | p50 (ms) | p95 (ms)  | recall@10 |
+| ------------ | --------- | --------- | ------------- | -------- | --------- | --------- |
+| flat (exact) | 0.5       | —         | 293.5         | 18.50    | 94.47     | 1.000     |
+| **tq**       | 1.4       | **0**     | 343.3         | **9.33** | **11.33** | **0.959** |
+| ivf_pq       | 0.5       | 466.9     | 303.4         | 31.16    | 43.14     | 0.786     |
+
+At this scale TQ dominates: ~2× faster than exact at p50 with 0.96 recall and
+zero training, while IVF-PQ pays ~8 minutes of training and lands at 0.786
+recall at nprobe 64 (its per-query cost here is dominated by building 64 ADC
+tables per query). The caveat is asymptotic: TQ scans every code (O(N) per
+query, ~9 ms per 100k docs at 768 dims on this machine), while IVF-PQ scans
+`nprobe/num_clusters` of the corpus — at millions of vectors per segment the
+trained lane wins latency. TQ therefore replaces the brute-force lane and
+small-to-medium segments, not the billion-scale trained path. x86_64
+SSSE3/AVX2 kernels are correctness-pinned against the scalar reference in
+unit tests; perf numbers on x86 should be captured before quoting them.
+
+## Explicit non-goals in v1
+
+- No IVF-routed TQ leaves (would reuse trained coarse centroids; follow-up).
+- No configurable bit width (4 = 3+1 fixed; header carries it for evolution).
+- No WASM in-browser TQ _encoding_ (WASM reads native-built payloads;
+  `LocalIndex` encode support is a follow-up).
+- No L2 metric (dense scoring in Hermes is cosine/dot; unchanged).

--- a/hermes-core/src/dsl/schema.rs
+++ b/hermes-core/src/dsl/schema.rs
@@ -110,10 +110,15 @@ impl PositionMode {
 pub enum VectorIndexType {
     /// Flat - brute-force search over raw vectors (accumulating state)
     Flat,
-    /// Global IVF with residual product quantization. This is the sole float
-    /// ANN format; Flat remains the accumulation/exact-scan representation.
+    /// Global IVF with residual product quantization. This is the trained
+    /// float ANN format; Flat remains the accumulation/exact-scan
+    /// representation.
     #[default]
     IvfPq,
+    /// TurboQuant: training-free per-segment compressed flat scan
+    /// (`docs/turboquant-quantization.md`). Available from the first segment
+    /// build with no global artifacts.
+    Tq,
 }
 
 /// How an IVF coarse codebook is searched.
@@ -280,6 +285,20 @@ impl DenseVectorConfig {
             quantization: DenseVectorQuantization::F32,
             num_clusters: None,
             ivf_routing: IvfRoutingMode::Auto,
+            nprobe: 0,
+            unit_norm: true,
+            soar: None,
+        }
+    }
+
+    /// Create TurboQuant configuration: training-free compressed flat scan.
+    pub fn tq(dim: usize) -> Self {
+        Self {
+            dim,
+            index_type: VectorIndexType::Tq,
+            quantization: DenseVectorQuantization::F32,
+            num_clusters: None,
+            ivf_routing: IvfRoutingMode::Flat,
             nprobe: 0,
             unit_norm: true,
             soar: None,

--- a/hermes-core/src/dsl/sdl/mod.rs
+++ b/hermes-core/src/dsl/sdl/mod.rs
@@ -379,6 +379,7 @@ fn parse_single_index_config_param(config: &mut IndexConfig, p: pest::iterators:
             }
             "ivf" => config.binary_index_type = Some(super::schema::BinaryIndexType::Ivf),
             "ivf_pq" => config.index_type = Some(VectorIndexType::IvfPq),
+            "tq" => config.index_type = Some(VectorIndexType::Tq),
             _ => {}
         },
         Rule::index_type_kwarg => {
@@ -391,6 +392,7 @@ fn parse_single_index_config_param(config: &mut IndexConfig, p: pest::iterators:
                     }
                     "ivf" => config.binary_index_type = Some(super::schema::BinaryIndexType::Ivf),
                     "ivf_pq" => config.index_type = Some(VectorIndexType::IvfPq),
+                    "tq" => config.index_type = Some(VectorIndexType::Tq),
                     _ => {}
                 }
             }
@@ -823,6 +825,29 @@ fn apply_index_config_to_dense_vector(config: &mut DenseVectorConfig, idx_cfg: I
         config.index_type = index_type;
     }
 
+    // TQ scans every code (no probing, no clusters, no routing); accepting
+    // these knobs silently would misrepresent how the field is searched.
+    if config.index_type == super::schema::VectorIndexType::Tq {
+        for (option, present) in [
+            ("num_clusters", idx_cfg.num_clusters.is_some()),
+            ("nprobe", idx_cfg.nprobe.is_some()),
+            ("routing", idx_cfg.ivf_routing.is_some()),
+        ] {
+            if present {
+                log::warn!(
+                    "'{option}' has no effect on the 'tq' index (training-free full \
+                     scan); ignoring"
+                );
+            }
+        }
+        // Canonicalize to the same shape as DenseVectorConfig::tq() so every
+        // construction path yields an identical config for a `tq` field.
+        config.num_clusters = None;
+        config.nprobe = 0;
+        config.ivf_routing = super::schema::IvfRoutingMode::Flat;
+        return apply_soar_to_dense_vector(config, idx_cfg);
+    }
+
     // Apply num_clusters for IVF-based indexes
     if idx_cfg.num_clusters.is_some() {
         config.num_clusters = idx_cfg.num_clusters;
@@ -836,7 +861,11 @@ fn apply_index_config_to_dense_vector(config: &mut DenseVectorConfig, idx_cfg: I
         config.ivf_routing = routing;
     }
 
-    // Apply SOAR spilling if specified (IVF-based indexes only)
+    apply_soar_to_dense_vector(config, idx_cfg);
+}
+
+/// Apply SOAR spilling if specified (IVF-based indexes only)
+fn apply_soar_to_dense_vector(config: &mut DenseVectorConfig, idx_cfg: IndexConfig) {
     if idx_cfg.soar.is_some() {
         if config.uses_ivf() {
             config.soar = idx_cfg.soar;

--- a/hermes-core/src/dsl/sdl/sdl.pest
+++ b/hermes-core/src/dsl/sdl/sdl.pest
@@ -148,7 +148,7 @@ index_config_param = { index_type_kwarg | num_clusters_kwarg | nprobe_kwarg | ro
 //   token_position - only token position within text for phrase queries
 positions_kwarg = { "positions" | "ordinal" | "token_position" }
 index_type_kwarg = { "index" ~ ":" ~ index_type_spec }
-index_type_spec = { "flat" | "ivf_pq" | "ivf" }
+index_type_spec = { "flat" | "ivf_pq" | "ivf" | "tq" }
 num_clusters_kwarg = { "num_clusters" ~ ":" ~ num_clusters_spec }
 num_clusters_spec = @{ ASCII_DIGIT+ }
 nprobe_kwarg = { "nprobe" ~ ":" ~ nprobe_spec }

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -6,6 +6,7 @@ mod pin;
 mod primary_key;
 mod range;
 mod search;
+mod tq_bench;
 mod vector;
 
 #[cfg(feature = "sync")]

--- a/hermes-core/src/index/tests/tq_bench.rs
+++ b/hermes-core/src/index/tests/tq_bench.rs
@@ -1,0 +1,271 @@
+//! TQ vs IVF-PQ vs flat brute-force benchmark (docs/turboquant-quantization.md).
+//!
+//! Run in release mode; results are meaningless in debug builds:
+//! ```bash
+//! cargo test --release -p hermes-core --features native \
+//!     tq_ivf_pq_flat_benchmark -- --ignored --nocapture
+//! ```
+//!
+//! Clustered unit-norm corpus, queries perturbed from corpus points. Ground
+//! truth is the flat index's own exact cosine top-k. Reports recall@k after
+//! re-rank, p50/p95 end-to-end query latency, .vectors bytes, and build/train
+//! wall time per method.
+
+use crate::directories::MmapDirectory;
+use crate::dsl::{DenseVectorConfig, Document, SchemaBuilder};
+use crate::index::{Index, IndexConfig, IndexWriter};
+use crate::query::DenseVectorQuery;
+
+const DIM: usize = 768; // pads to 1024 for TQ: the unfavorable case
+const DOCS: usize = 100_000;
+const CLUSTERS: usize = 256;
+const QUERIES: usize = 100;
+const K: usize = 10;
+const IVF_NUM_CLUSTERS: usize = 1_024;
+const NPROBE: usize = 64;
+
+fn splitmix(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+fn gaussian_unit(dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed;
+    let mut values: Vec<f32> = (0..dim)
+        .map(|_| {
+            let a = (splitmix(&mut state) >> 11) as f64 / (1u64 << 53) as f64;
+            let b = (splitmix(&mut state) >> 11) as f64 / (1u64 << 53) as f64;
+            ((-2.0 * (1.0 - a).max(f64::MIN_POSITIVE).ln()).sqrt()
+                * (2.0 * std::f64::consts::PI * b).cos()) as f32
+        })
+        .collect();
+    let norm = values.iter().map(|v| v * v).sum::<f32>().sqrt();
+    values.iter_mut().for_each(|v| *v /= norm);
+    values
+}
+
+fn normalize(mut values: Vec<f32>) -> Vec<f32> {
+    let norm = values.iter().map(|v| v * v).sum::<f32>().sqrt();
+    values.iter_mut().for_each(|v| *v /= norm);
+    values
+}
+
+fn build_corpus() -> (Vec<Vec<f32>>, Vec<Vec<f32>>) {
+    let centers: Vec<Vec<f32>> = (0..CLUSTERS)
+        .map(|c| gaussian_unit(DIM, 1_000 + c as u64))
+        .collect();
+    let corpus: Vec<Vec<f32>> = (0..DOCS)
+        .map(|i| {
+            let center = &centers[i % CLUSTERS];
+            let noise = gaussian_unit(DIM, 50_000 + i as u64);
+            normalize(
+                center
+                    .iter()
+                    .zip(&noise)
+                    .map(|(c, n)| c + 0.6 * n)
+                    .collect(),
+            )
+        })
+        .collect();
+    let queries: Vec<Vec<f32>> = (0..QUERIES)
+        .map(|q| {
+            let base = &corpus[(q * 977) % DOCS];
+            let noise = gaussian_unit(DIM, 900_000 + q as u64);
+            normalize(base.iter().zip(&noise).map(|(v, n)| v + 0.3 * n).collect())
+        })
+        .collect();
+    (corpus, queries)
+}
+
+struct MethodReport {
+    label: &'static str,
+    build_secs: f64,
+    train_secs: f64,
+    vectors_bytes: u64,
+    ann_kind: String,
+    p50_ms: f64,
+    p95_ms: f64,
+    results: Vec<Vec<u32>>,
+}
+
+async fn run_method(
+    label: &'static str,
+    config: DenseVectorConfig,
+    corpus: &[Vec<f32>],
+    queries: &[Vec<f32>],
+) -> MethodReport {
+    let temp = tempfile::tempdir().expect("bench tempdir");
+    let dir = MmapDirectory::new(temp.path());
+    let mut sb = SchemaBuilder::default();
+    let embedding = sb.add_dense_vector_field_with_config("embedding", true, false, config);
+    let schema = sb.build();
+
+    let build_start = std::time::Instant::now();
+    let index_config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, index_config.clone())
+        .await
+        .expect("create writer");
+    for vector in corpus {
+        // add_document is non-blocking; QueueFull is explicit backpressure.
+        loop {
+            let mut doc = Document::new();
+            doc.add_dense_vector(embedding, vector.clone());
+            match writer.add_document(doc) {
+                Ok(()) => break,
+                Err(crate::Error::QueueFull) => {
+                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                }
+                Err(error) => panic!("add document: {error:?}"),
+            }
+        }
+    }
+    writer.commit().await.expect("commit");
+    drop(writer);
+    let build_secs = build_start.elapsed().as_secs_f64();
+
+    let train_start = std::time::Instant::now();
+    let train_secs = if label == "ivf_pq" {
+        let writer = IndexWriter::open(dir.clone(), index_config.clone())
+            .await
+            .expect("reopen writer for training");
+        writer.build_vector_index().await.expect("train IVF-PQ");
+        drop(writer);
+        train_start.elapsed().as_secs_f64()
+    } else {
+        0.0
+    };
+
+    // Reopen so trained generations and rewritten segments are what serve.
+    let index = Index::open(dir, index_config).await.expect("reopen index");
+    let segments = index.segment_readers().await.expect("segments");
+    let ann_kind = segments
+        .iter()
+        .filter_map(|segment| segment.vector_indexes().get(&embedding.0))
+        .map(|ann| match ann {
+            crate::segment::VectorIndex::IvfPq(_) => "ivf_pq",
+            crate::segment::VectorIndex::BinaryIvf(_) => "binary_ivf",
+            crate::segment::VectorIndex::Tq { .. } => "tq_flat",
+        })
+        .next()
+        .unwrap_or("none")
+        .to_string();
+    let vectors_bytes: u64 = {
+        let mut total = 0u64;
+        for entry in std::fs::read_dir(temp.path()).expect("read bench dir") {
+            let entry = entry.expect("dir entry");
+            if entry.path().extension().is_some_and(|ext| ext == "vectors") {
+                total += entry.metadata().expect("metadata").len();
+            }
+        }
+        total
+    };
+
+    let reader = index.reader().await.expect("reader");
+    let searcher = reader.searcher().await.expect("searcher");
+    // Warm the page cache so latency measures compute, not first-touch I/O.
+    for query in queries.iter().take(10) {
+        let warm = DenseVectorQuery::new(embedding, query.clone()).with_nprobe(NPROBE);
+        searcher.search(&warm, K).await.expect("warm query");
+    }
+
+    let mut latencies = Vec::with_capacity(queries.len());
+    let mut results = Vec::with_capacity(queries.len());
+    for query in queries {
+        let dense = DenseVectorQuery::new(embedding, query.clone()).with_nprobe(NPROBE);
+        let started = std::time::Instant::now();
+        let hits = searcher.search(&dense, K).await.expect("query");
+        latencies.push(started.elapsed().as_secs_f64() * 1_000.0);
+        results.push(hits.iter().map(|hit| hit.doc_id).collect::<Vec<u32>>());
+    }
+    latencies.sort_by(|a, b| a.total_cmp(b));
+    let p50_ms = latencies[latencies.len() / 2];
+    let p95_ms = latencies[(latencies.len() * 95) / 100];
+
+    MethodReport {
+        label,
+        build_secs,
+        train_secs,
+        vectors_bytes,
+        ann_kind,
+        p50_ms,
+        p95_ms,
+        results,
+    }
+}
+
+fn recall(reference: &[Vec<u32>], candidate: &[Vec<u32>]) -> f64 {
+    let mut hits = 0usize;
+    let mut total = 0usize;
+    for (truth, got) in reference.iter().zip(candidate) {
+        let truth: std::collections::HashSet<u32> = truth.iter().copied().collect();
+        hits += got.iter().filter(|doc| truth.contains(doc)).count();
+        total += truth.len();
+    }
+    hits as f64 / total as f64
+}
+
+/// Ignored benchmark; see the module docs for the release-mode invocation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
+async fn tq_ivf_pq_flat_benchmark() {
+    let arch = std::env::consts::ARCH;
+    println!(
+        "\n=== TQ benchmark: {DOCS} docs, dim {DIM}, {CLUSTERS} clusters, \
+         {QUERIES} queries, k={K}, nprobe={NPROBE}, arch={arch} ===",
+    );
+    let corpus_start = std::time::Instant::now();
+    let (corpus, queries) = build_corpus();
+    println!(
+        "corpus generated in {:.1}s",
+        corpus_start.elapsed().as_secs_f64()
+    );
+
+    let flat = run_method("flat", DenseVectorConfig::flat(DIM), &corpus, &queries).await;
+    let tq = run_method("tq", DenseVectorConfig::tq(DIM), &corpus, &queries).await;
+    let ivf_pq = run_method(
+        "ivf_pq",
+        DenseVectorConfig {
+            num_clusters: Some(IVF_NUM_CLUSTERS),
+            ..DenseVectorConfig::with_ivf_pq(DIM, Some(IVF_NUM_CLUSTERS), NPROBE)
+        },
+        &corpus,
+        &queries,
+    )
+    .await;
+
+    assert_eq!(flat.ann_kind, "none", "flat must not build an ANN payload");
+    assert_eq!(
+        tq.ann_kind, "tq_flat",
+        "tq must build its payload at commit"
+    );
+    assert_eq!(
+        ivf_pq.ann_kind, "ivf_pq",
+        "ivf_pq must be trained and built"
+    );
+
+    println!(
+        "\n{:<8} {:>10} {:>10} {:>12} {:>9} {:>9} {:>9}",
+        "method", "build(s)", "train(s)", "vectors(MB)", "p50(ms)", "p95(ms)", "recall@10"
+    );
+    for report in [&flat, &tq, &ivf_pq] {
+        println!(
+            "{:<8} {:>10.1} {:>10.1} {:>12.1} {:>9.2} {:>9.2} {:>9.3}",
+            report.label,
+            report.build_secs,
+            report.train_secs,
+            report.vectors_bytes as f64 / (1024.0 * 1024.0),
+            report.p50_ms,
+            report.p95_ms,
+            recall(&flat.results, &report.results),
+        );
+    }
+    let flat_bytes = flat.vectors_bytes as f64;
+    println!(
+        "\nANN payload overhead vs flat storage: tq +{:.1} MB, ivf_pq +{:.1} MB",
+        (tq.vectors_bytes as f64 - flat_bytes) / (1024.0 * 1024.0),
+        (ivf_pq.vectors_bytes as f64 - flat_bytes) / (1024.0 * 1024.0),
+    );
+}

--- a/hermes-core/src/index/tests/vector.rs
+++ b/hermes-core/src/index/tests/vector.rs
@@ -1402,3 +1402,321 @@ async fn test_binary_ivf_multi_value_exact_scores_async_path() {
 async fn test_binary_ivf_multi_value_exact_scores_sync_path() {
     binary_ivf_multi_value_exact_scores().await;
 }
+
+/// TurboQuant end-to-end: the payload is built at commit with no training,
+/// searched via the estimated-similarity scan, and exact-reranked.
+/// Pins recall vs brute force and the needle ranking on the async path.
+#[tokio::test]
+async fn test_tq_dense_search_end_to_end() {
+    use crate::dsl::DenseVectorConfig;
+    use crate::query::DenseVectorQuery;
+
+    let dim = 48; // pads to 64
+    let doc_count = 400usize;
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    let embedding =
+        sb.add_dense_vector_field_with_config("embedding", true, true, DenseVectorConfig::tq(dim));
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+
+    // Hash-based coordinates: sin-of-linear-index aliases badly (distinct
+    // seeds can produce near-identical vectors), which breaks ranking tests.
+    let unit_vector = |seed: usize| -> Vec<f32> {
+        let mut values: Vec<f32> = (0..dim)
+            .map(|d| {
+                let mut state = (seed as u64)
+                    .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                    .wrapping_add(d as u64);
+                state ^= state >> 33;
+                state = state.wrapping_mul(0xFF51_AFD7_ED55_8CCD);
+                state ^= state >> 33;
+                ((state >> 40) as f32 / (1u64 << 24) as f32) - 0.5
+            })
+            .collect();
+        let norm = values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        values.iter_mut().for_each(|v| *v /= norm);
+        values
+    };
+    // 20 clusters of 10 near-duplicates plus 200 background docs. Cluster
+    // members sit at cosine ~0.9 to their center while background stays near
+    // zero, so exact top-10 for a center query is its own cluster — the
+    // separation a 4-bit estimator must preserve.
+    let normalize = |mut values: Vec<f32>| -> Vec<f32> {
+        let norm = values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        values.iter_mut().for_each(|v| *v /= norm);
+        values
+    };
+    let clusters = 20usize;
+    let members = 10usize;
+    let mut doc_vectors: Vec<(String, Vec<f32>)> = Vec::new();
+    for cluster in 0..clusters {
+        let center = unit_vector(cluster);
+        for member in 0..members {
+            let noise = unit_vector(10_000 + cluster * members + member);
+            let vector = normalize(
+                center
+                    .iter()
+                    .zip(&noise)
+                    .map(|(c, n)| c + 0.35 * n)
+                    .collect(),
+            );
+            doc_vectors.push((format!("cluster {cluster} member {member}"), vector));
+        }
+    }
+    for background in 0..(doc_count - clusters * members) {
+        doc_vectors.push((format!("bg {background}"), unit_vector(50_000 + background)));
+    }
+    for (doc_title, vector) in &doc_vectors {
+        let mut doc = Document::new();
+        doc.add_text(title, doc_title.clone());
+        doc.add_dense_vector(embedding, vector.clone());
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    // The TQ payload must exist without any build_vector_index() call.
+    let segments = index.segment_readers().await.unwrap();
+    assert_eq!(segments.len(), 1);
+    assert!(
+        matches!(
+            segments[0].vector_indexes().get(&embedding.0),
+            Some(crate::segment::VectorIndex::Tq { .. })
+        ),
+        "TQ segment payload must be built at commit with no training"
+    );
+
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    // Exact-duplicate queries must rank their document first (post re-rank),
+    // including against nine near-duplicates from the same cluster.
+    for target in [0usize, 137, 399] {
+        let (target_title, target_vector) = &doc_vectors[target];
+        let query = DenseVectorQuery::new(embedding, target_vector.clone());
+        let results = searcher.search(&query, 5).await.unwrap();
+        let top = searcher
+            .doc(results[0].segment_id, results[0].doc_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            top.get_first(title).unwrap().as_text().unwrap(),
+            target_title.as_str(),
+            "duplicate query must rank its own document first"
+        );
+        assert!(
+            results[0].score > 0.999,
+            "exact re-rank must restore the true cosine, got {}",
+            results[0].score
+        );
+    }
+
+    // Recall@10 vs exact cosine for every cluster-center query.
+    let k = 10;
+    let mut recall_hits = 0usize;
+    let mut recall_total = 0usize;
+    for cluster in 0..clusters {
+        let query_vector = unit_vector(cluster);
+        let mut exact: Vec<(usize, f32)> = doc_vectors
+            .iter()
+            .enumerate()
+            .map(|(index, (_, vector))| {
+                let dot: f32 = vector.iter().zip(&query_vector).map(|(a, b)| a * b).sum();
+                (index, dot)
+            })
+            .collect();
+        exact.sort_by(|a, b| b.1.total_cmp(&a.1));
+        let expected: std::collections::HashSet<&str> = exact[..k]
+            .iter()
+            .map(|(index, _)| doc_vectors[*index].0.as_str())
+            .collect();
+
+        let query = DenseVectorQuery::new(embedding, query_vector);
+        let results = searcher.search(&query, k).await.unwrap();
+        for result in &results {
+            let doc = searcher
+                .doc(result.segment_id, result.doc_id)
+                .await
+                .unwrap()
+                .unwrap();
+            let doc_title = doc.get_first(title).unwrap().as_text().unwrap().to_string();
+            recall_hits += usize::from(expected.contains(doc_title.as_str()));
+        }
+        recall_total += k;
+    }
+    let recall = recall_hits as f32 / recall_total as f32;
+    assert!(
+        recall >= 0.9,
+        "TQ recall@{k} vs exact cosine must stay high with 2x re-rank, got {recall}"
+    );
+}
+
+/// TQ on the sync scorer path (multi-thread runtime), mirroring
+/// test_binary_dense_search_multi_thread_runtime.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_tq_dense_search_multi_thread_runtime() {
+    use crate::dsl::DenseVectorConfig;
+    use crate::query::DenseVectorQuery;
+
+    let dim = 24; // pads to 32
+    let mut sb = SchemaBuilder::default();
+    let embedding =
+        sb.add_dense_vector_field_with_config("embedding", true, true, DenseVectorConfig::tq(dim));
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+
+    let needle: Vec<f32> = {
+        let mut v = vec![1.0f32; dim];
+        let norm = (dim as f32).sqrt();
+        v.iter_mut().for_each(|x| *x /= norm);
+        v
+    };
+    let mut doc = Document::new();
+    doc.add_dense_vector(embedding, needle.clone());
+    writer.add_document(doc).unwrap();
+    for i in 0..40 {
+        let mut doc = Document::new();
+        let mut v: Vec<f32> = (0..dim)
+            .map(|d| (((i * 13 + d * 7) as f32) * 1.3).sin())
+            .collect();
+        let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        v.iter_mut().for_each(|x| *x /= norm);
+        doc.add_dense_vector(embedding, v);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let results = searcher
+        .search(&DenseVectorQuery::new(embedding, needle), 5)
+        .await
+        .expect("TQ search must work on multi-thread runtime (sync scorer path)");
+    assert!(!results.is_empty());
+    assert!(
+        results[0].score > 0.999,
+        "needle must be an exact match after re-rank, got {}",
+        results[0].score
+    );
+}
+
+/// TQ payloads across a merge: the merged segment keeps a TQ payload
+/// (pure byte-copy path) and search results survive doc-base remapping.
+#[tokio::test]
+async fn test_tq_dense_multi_segment_merge_preserves_payload() {
+    use crate::dsl::DenseVectorConfig;
+    use crate::query::DenseVectorQuery;
+
+    let dim = 24;
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    let embedding =
+        sb.add_dense_vector_field_with_config("embedding", true, true, DenseVectorConfig::tq(dim));
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+
+    let unit_vector = |seed: usize| -> Vec<f32> {
+        let mut values: Vec<f32> = (0..dim)
+            .map(|d| (((seed * 29 + d * 11) as f32) * 0.9).cos())
+            .collect();
+        let norm = values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        values.iter_mut().for_each(|v| *v /= norm);
+        values
+    };
+
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+    for i in 0..30 {
+        let mut doc = Document::new();
+        doc.add_text(title, format!("seg1 doc {}", i));
+        doc.add_dense_vector(embedding, unit_vector(i));
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    for i in 0..30 {
+        let mut doc = Document::new();
+        doc.add_text(title, format!("seg2 doc {}", i));
+        doc.add_dense_vector(embedding, unit_vector(1_000 + i));
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    assert_eq!(index.segment_readers().await.unwrap().len(), 2);
+
+    async fn top_result(
+        searcher: &crate::index::Searcher<RamDirectory>,
+        embedding: crate::dsl::Field,
+        title: crate::dsl::Field,
+        query_vector: Vec<f32>,
+    ) -> (String, f32) {
+        let query = DenseVectorQuery::new(embedding, query_vector);
+        let results = searcher.search(&query, 3).await.unwrap();
+        let doc = searcher
+            .doc(results[0].segment_id, results[0].doc_id)
+            .await
+            .unwrap()
+            .unwrap();
+        (
+            doc.get_first(title).unwrap().as_text().unwrap().to_string(),
+            results[0].score,
+        )
+    }
+
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let (pre_first, pre_first_score) =
+        top_result(&searcher, embedding, title, unit_vector(7)).await;
+    let (pre_second, pre_second_score) =
+        top_result(&searcher, embedding, title, unit_vector(1_012)).await;
+    assert_eq!(pre_first, "seg1 doc 7");
+    assert_eq!(pre_second, "seg2 doc 12");
+
+    let mut writer = IndexWriter::open(dir.clone(), config.clone())
+        .await
+        .unwrap();
+    writer.force_merge().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir, config).await.unwrap();
+    let segments = index.segment_readers().await.unwrap();
+    assert_eq!(segments.len(), 1);
+    assert!(
+        matches!(
+            segments[0].vector_indexes().get(&embedding.0),
+            Some(crate::segment::VectorIndex::Tq { .. })
+        ),
+        "merged segment must keep its TQ payload (byte-copy merge)"
+    );
+
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let (post_first, post_first_score) =
+        top_result(&searcher, embedding, title, unit_vector(7)).await;
+    let (post_second, post_second_score) =
+        top_result(&searcher, embedding, title, unit_vector(1_012)).await;
+    assert_eq!(post_first, "seg1 doc 7", "doc bases must survive the merge");
+    assert_eq!(post_second, "seg2 doc 12");
+    assert!((post_first_score - pre_first_score).abs() < 1e-5);
+    assert!((post_second_score - pre_second_score).abs() < 1e-5);
+}

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -2286,6 +2286,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 ))
             })?;
             let current = match entry.field_type {
+                // TQ payloads carry no trained generation, so an existing one
+                // is always current; a tq field must never be staged for a
+                // vector-generation rewrite.
+                crate::dsl::FieldType::DenseVector
+                    if entry.dense_vector_config.as_ref().is_some_and(|config| {
+                        config.index_type == crate::dsl::VectorIndexType::Tq
+                    }) =>
+                {
+                    matches!(ann, Some(crate::segment::VectorIndex::Tq { .. }))
+                }
                 crate::dsl::FieldType::DenseVector => {
                     matches!(ann, Some(crate::segment::VectorIndex::IvfPq(_)))
                 }

--- a/hermes-core/src/query/vector/dense.rs
+++ b/hermes-core/src/query/vector/dense.rs
@@ -2,7 +2,7 @@
 
 use crate::dsl::Field;
 use crate::segment::SegmentReader;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use super::VectorResultScorer;
 use super::combiner::MultiValueCombiner;
@@ -33,10 +33,10 @@ pub struct DenseVectorQuery {
     pub rerank_factor: f32,
     /// How to combine scores for multi-valued documents
     pub combiner: MultiValueCombiner,
-    /// One global-quantizer route, shared by all segment scorers spawned for
-    /// this query. The cache is versioned, so a query reused after an index
-    /// generation change recomputes safely.
-    probe_cache: Arc<Mutex<Option<Arc<crate::structures::IvfPqQueryPlan>>>>,
+    /// Query-global dense plans (IVF-PQ probe route / TQ LUTs), shared by all
+    /// segment scorers spawned for this query. The caches are versioned, so a
+    /// query reused after an index generation change recomputes safely.
+    plan_cache: Arc<crate::segment::DensePlanCache>,
 }
 
 impl std::fmt::Display for DenseVectorQuery {
@@ -61,7 +61,7 @@ impl DenseVectorQuery {
             nprobe: 64,
             rerank_factor: DEFAULT_DENSE_RERANK_FACTOR,
             combiner: MultiValueCombiner::Max,
-            probe_cache: Arc::new(Mutex::new(None)),
+            plan_cache: Arc::new(Default::default()),
         }
     }
 
@@ -97,7 +97,7 @@ impl Query for DenseVectorQuery {
         let nprobe = self.nprobe;
         let rerank_factor = self.rerank_factor;
         let combiner = self.combiner;
-        let probe_cache = Arc::clone(&self.probe_cache);
+        let plan_cache = Arc::clone(&self.plan_cache);
         Box::pin(async move {
             let results = reader
                 .search_dense_vector_with_probe_cache(
@@ -107,7 +107,7 @@ impl Query for DenseVectorQuery {
                     nprobe,
                     rerank_factor,
                     combiner,
-                    &probe_cache,
+                    &plan_cache,
                 )
                 .await?;
 
@@ -128,7 +128,7 @@ impl Query for DenseVectorQuery {
             self.nprobe,
             self.rerank_factor,
             self.combiner,
-            &self.probe_cache,
+            &self.plan_cache,
         )?;
         Ok(Box::new(VectorResultScorer::new(results, self.field.0)) as Box<dyn Scorer>)
     }

--- a/hermes-core/src/segment/ann_build.rs
+++ b/hermes-core/src/segment/ann_build.rs
@@ -8,6 +8,8 @@ pub const IVF_PQ_TYPE: u8 = 2;
 pub const FLAT_TYPE: u8 = 4;
 /// Binary IVF payload backed by an index-level global quantizer.
 pub const BINARY_IVF_TYPE: u8 = 6;
+/// TurboQuant flat payload; training-free, no global artifacts.
+pub const TQ_FLAT_TYPE: u8 = 7;
 
 // --- Native-only builder/serialization functions ---
 
@@ -31,6 +33,25 @@ pub fn new_ivf_pq(
 pub fn serialize_ivf_pq(index: IVFPQIndex, num_clusters: u32) -> crate::Result<Vec<u8>> {
     let mut bytes = Vec::new();
     crate::segment::ann_disk::write_built_ivf_pq(&index, num_clusters, &mut bytes)
+        .map_err(crate::Error::Io)?;
+    Ok(bytes)
+}
+
+/// Encode one segment's vectors with the training-free TurboQuant codec.
+#[cfg(feature = "native")]
+pub fn build_tq_flat(
+    dim: usize,
+    doc_id_ordinals: &[(u32, u16)],
+    vectors: &[f32],
+) -> crate::Result<Vec<u8>> {
+    let codec = std::sync::Arc::new(crate::structures::TqCodec::new(dim));
+    let mut builder = crate::structures::TqFlatBuilder::new(codec);
+    builder
+        .add_batch(doc_id_ordinals, vectors)
+        .map_err(|error| crate::Error::Internal(format!("TQ encode failed: {error}")))?;
+    builder.finish();
+    let mut bytes = Vec::new();
+    crate::segment::ann_disk::write_built_tq_flat(&builder, &mut bytes)
         .map_err(crate::Error::Io)?;
     Ok(bytes)
 }

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -40,6 +40,8 @@ const BINARY_SCORE_BATCH: usize = 8_192;
 pub(crate) enum AnnKind {
     IvfPq = 1,
     BinaryIvf = 2,
+    /// TurboQuant flat scan: single logical cluster, block-packed codes.
+    TqFlat = 3,
 }
 
 impl AnnKind {
@@ -47,7 +49,24 @@ impl AnnKind {
         match value {
             1 => Ok(Self::IvfPq),
             2 => Ok(Self::BinaryIvf),
+            3 => Ok(Self::TqFlat),
             _ => Err(invalid_data(format!("unknown ANN kind {value}"))),
+        }
+    }
+}
+
+/// Codes-column byte length for one run. TQ packs vectors into 16-lane
+/// blocks (gammas + dimension-major nibbles), so its column is block-padded
+/// rather than `count * code_size`.
+fn expected_codes_column_len(kind: AnnKind, count: usize, code_size: usize) -> io::Result<usize> {
+    match kind {
+        AnnKind::IvfPq | AnnKind::BinaryIvf => count
+            .checked_mul(code_size)
+            .ok_or_else(|| invalid_data("ANN code column size overflows usize")),
+        // Single source of truth for the block-packed layout lives in tq.rs.
+        AnnKind::TqFlat => {
+            crate::structures::vector::quantization::tq_codes_column_len_checked(count, code_size)
+                .ok_or_else(|| invalid_data("TQ code column size overflows usize"))
         }
     }
 }
@@ -191,9 +210,7 @@ impl AnnDiskIndex {
             let ordinals_len = count
                 .checked_mul(std::mem::size_of::<u16>())
                 .ok_or_else(|| invalid_data("ANN ordinal column size overflows usize"))?;
-            let expected_codes_len = count
-                .checked_mul(code_size)
-                .ok_or_else(|| invalid_data("ANN code column size overflows usize"))?;
+            let expected_codes_len = expected_codes_column_len(kind, count, code_size)?;
             let doc_ids_end = doc_ids_offset
                 .checked_add(doc_ids_len)
                 .ok_or_else(|| invalid_data("ANN doc-ID range overflows usize"))?;
@@ -300,6 +317,44 @@ impl AnnDiskIndex {
                         run_doc_id(bytes, run, index)?,
                         read_u16(bytes, run.ordinals.start + index * 2),
                         distance,
+                    );
+                }
+            }
+        }
+        Ok(collector.into_sorted_results())
+    }
+
+    /// Score every TQ block against the query plan and keep the top `k`
+    /// distinct documents by estimated similarity.
+    pub(crate) fn search_tq_distinct(
+        &self,
+        k: usize,
+        plan: &crate::structures::TqQueryPlan,
+    ) -> io::Result<Vec<(u32, u16, f32)>> {
+        use crate::structures::vector::quantization::{TQ_BLOCK_LANES, tq_block_bytes};
+
+        if plan.padded_dim() != self.header.code_size * 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TQ query plan does not match the payload dimension",
+            ));
+        }
+        let block_bytes = tq_block_bytes(self.header.code_size);
+        let bytes = self.raw.as_slice();
+        let mut collector = BoundedAnnCollector::<true, true>::new(k);
+        let mut scores = [0.0f32; TQ_BLOCK_LANES];
+        for run in &self.runs {
+            let codes = &bytes[run.codes.clone()];
+            for (block_index, block) in codes.chunks_exact(block_bytes).enumerate() {
+                crate::structures::vector::quantization::tq_score_block(plan, block, &mut scores);
+                let lane_base = block_index * TQ_BLOCK_LANES;
+                let lanes = TQ_BLOCK_LANES.min(run.count.saturating_sub(lane_base));
+                for (lane, &score) in scores.iter().enumerate().take(lanes) {
+                    let index = lane_base + lane;
+                    collector.insert(
+                        run_doc_id(bytes, run, index)?,
+                        read_u16(bytes, run.ordinals.start + index * 2),
+                        score,
                     );
                 }
             }
@@ -436,6 +491,35 @@ pub(crate) fn write_built_binary_ivf(
     )
 }
 
+/// Serialize a populated TQ builder as a single-run payload.
+#[cfg(feature = "native")]
+pub(crate) fn write_built_tq_flat(
+    builder: &crate::structures::TqFlatBuilder,
+    writer: &mut (impl Write + ?Sized),
+) -> io::Result<u64> {
+    let codec = builder.codec();
+    let runs = [BuildRun {
+        cluster_id: 0,
+        doc_ids: &builder.doc_ids,
+        ordinals: &builder.ordinals,
+        codes: &builder.codes,
+    }];
+    write_built_runs(
+        AnnDiskHeader {
+            kind: AnnKind::TqFlat,
+            routing: IvfRoutingMode::Flat,
+            dim: codec.dim(),
+            code_size: codec.code_size(),
+            num_clusters: 1,
+            quantizer_version: codec.fingerprint(),
+            codebook_version: 0,
+            vector_count: builder.len(),
+        },
+        &runs,
+        writer,
+    )
+}
+
 #[cfg(feature = "native")]
 struct BuildRun<'a> {
     cluster_id: u32,
@@ -478,10 +562,7 @@ fn write_built_runs(
             || run.cluster_id >= header.num_clusters
             || previous_cluster.is_some_and(|cluster| cluster >= run.cluster_id)
             || run.ordinals.len() != count
-            || run.codes.len()
-                != count
-                    .checked_mul(header.code_size)
-                    .ok_or_else(|| invalid_data("ANN build code column size overflows usize"))?
+            || run.codes.len() != expected_codes_column_len(header.kind, count, header.code_size)?
         {
             return Err(invalid_data("ANN build run columns are inconsistent"));
         }
@@ -798,6 +879,12 @@ fn validate_header(header: &AnnDiskHeader) -> io::Result<()> {
             && (header.codebook_version != 0
                 || !header.dim.is_multiple_of(8)
                 || header.code_size != header.dim.div_ceil(8)))
+        || (header.kind == AnnKind::TqFlat
+            && (header.codebook_version != 0
+                || header.num_clusters != 1
+                || header.routing != IvfRoutingMode::Flat
+                || header.code_size * 2
+                    != crate::structures::vector::quantization::tq_padded_dim(header.dim)))
     {
         return Err(invalid_data("ANN header contains invalid metadata"));
     }
@@ -961,6 +1048,102 @@ mod tests {
             .collect();
         docs.sort_unstable();
         assert_eq!(docs, [0, 1, 2, 3, 4, 5]);
+    }
+
+    fn build_tq_payload(dim: usize, count: usize, seed: u64) -> (Vec<u8>, Vec<Vec<f32>>) {
+        let codec = std::sync::Arc::new(crate::structures::TqCodec::new(dim));
+        let mut builder = crate::structures::TqFlatBuilder::new(std::sync::Arc::clone(&codec));
+        let mut state = seed;
+        let mut vectors = Vec::new();
+        let mut flat = Vec::new();
+        for _ in 0..count {
+            let vector: Vec<f32> = (0..dim)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
+                    ((state >> 33) as f32 / (1u64 << 31) as f32) - 0.5
+                })
+                .collect();
+            flat.extend_from_slice(&vector);
+            vectors.push(vector);
+        }
+        let labels: Vec<(u32, u16)> = (0..count).map(|index| (index as u32, 0)).collect();
+        builder.add_batch(&labels, &flat).unwrap();
+        builder.finish();
+        let mut bytes = Vec::new();
+        write_built_tq_flat(&builder, &mut bytes).unwrap();
+        (bytes, vectors)
+    }
+
+    #[test]
+    fn tq_payload_roundtrip_search_and_pure_copy_merge() {
+        let dim = 20; // pads to 32; exercises padding + partial final block
+        let count = 21;
+        let (bytes, vectors) = build_tq_payload(dim, count, 42);
+        let index = AnnDiskIndex::open(
+            OwnedBytes::new(bytes.clone()),
+            AnnKind::TqFlat,
+            count as u32,
+        )
+        .unwrap();
+        assert_eq!(index.header().vector_count, count);
+
+        // The stored estimate must rank an exact-duplicate query's own row first.
+        let codec = crate::structures::TqCodec::new(dim);
+        for target in [0usize, 7, 20] {
+            let plan = crate::structures::TqQueryPlan::build(&codec, &vectors[target]);
+            let results = index.search_tq_distinct(3, &plan).unwrap();
+            assert_eq!(
+                results[0].0, target as u32,
+                "query duplicating vector {target} must rank it first: {results:?}"
+            );
+        }
+
+        // Ordinary merge must not decode or rewrite the corpus columns.
+        let (second_bytes, _) = build_tq_payload(dim, 5, 77);
+        let second =
+            AnnDiskIndex::open(OwnedBytes::new(second_bytes.clone()), AnnKind::TqFlat, 5).unwrap();
+        let mut merged_bytes = Vec::new();
+        write_merged_ann(&[(&index, 0), (&second, count as u32)], &mut merged_bytes).unwrap();
+        let merged = AnnDiskIndex::open(
+            OwnedBytes::new(merged_bytes.clone()),
+            AnnKind::TqFlat,
+            count as u32 + 5,
+        )
+        .unwrap();
+        let mut expected_payload = bytes[ANN_HEADER_SIZE..payload_end(&index)].to_vec();
+        expected_payload.extend_from_slice(&second_bytes[ANN_HEADER_SIZE..payload_end(&second)]);
+        assert_eq!(
+            &merged_bytes[ANN_HEADER_SIZE..payload_end(&merged)],
+            expected_payload.as_slice(),
+            "TQ merge must be a pure byte copy of the source columns",
+        );
+        let plan = crate::structures::TqQueryPlan::build(&codec, &vectors[7]);
+        let results = merged.search_tq_distinct(1, &plan).unwrap();
+        assert_eq!(results[0].0, 7, "merged payload must keep doc bases");
+    }
+
+    #[test]
+    fn open_rejects_tq_payload_with_inconsistent_geometry() {
+        let (bytes, _) = build_tq_payload(20, 4, 9);
+        // code_size (header bytes 12..16) is P/2 = 16 for dim 20; corrupt to 15.
+        let mut corrupted = bytes.clone();
+        corrupted[12..16].copy_from_slice(&15u32.to_le_bytes());
+        assert!(
+            AnnDiskIndex::open(OwnedBytes::new(corrupted), AnnKind::TqFlat, 4).is_err(),
+            "TQ header with code_size != padded_dim/2 must be refused"
+        );
+
+        // A truncated codes column (not block-padded) must also be refused.
+        let (short_bytes, _) = build_tq_payload(20, 4, 9);
+        let mut wrong_kind = short_bytes.clone();
+        wrong_kind[4] = AnnKind::IvfPq as u8;
+        assert!(
+            AnnDiskIndex::open(OwnedBytes::new(wrong_kind), AnnKind::IvfPq, 4).is_err(),
+            "TQ block-padded columns must not validate under another kind"
+        );
+        assert!(AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::TqFlat, 4).is_ok());
     }
 
     #[test]

--- a/hermes-core/src/segment/builder/dense.rs
+++ b/hermes-core/src/segment/builder/dense.rs
@@ -206,9 +206,10 @@ pub(super) fn build_vectors_streaming(
     let mut toc: Vec<DenseVectorTocEntry> = Vec::with_capacity(toc_capacity);
     let mut current_offset = 0u64;
 
-    // Pre-build ANN indexes across fields (native only — requires trained structures).
+    // Pre-build ANN indexes across fields (native only). IVF-PQ requires
+    // trained global structures; TQ is training-free and always builds.
     #[cfg(feature = "native")]
-    let ann_blobs: Vec<(u32, u8, Vec<u8>)> = if let Some(trained) = trained {
+    let ann_blobs: Vec<(u32, u8, Vec<u8>)> = {
         let ann_blob_fn = |(field_id, builder): &(u32, DenseVectorBuilder)|
          -> Result<Option<(u32, u8, Vec<u8>)>> {
                 let Some(config) = schema
@@ -220,12 +221,17 @@ pub(super) fn build_vectors_streaming(
 
                 let dim = builder.dim;
                 let blob = match config.index_type {
-                    VectorIndexType::IvfPq
-                        if trained.centroids.contains_key(field_id)
-                            && trained.codebooks.contains_key(field_id) =>
-                    {
-                        let centroids = &trained.centroids[field_id];
-                        let codebook = &trained.codebooks[field_id];
+                    VectorIndexType::IvfPq => {
+                        // Untrained IVF-PQ fields stay flat until a global
+                        // generation exists.
+                        let Some((centroids, codebook)) = trained.and_then(|trained| {
+                            Some((
+                                trained.centroids.get(field_id)?,
+                                trained.codebooks.get(field_id)?,
+                            ))
+                        }) else {
+                            return Ok(None);
+                        };
                         let mut index = super::super::ann_build::new_ivf_pq(
                             dim,
                             config.ivf_routing,
@@ -250,6 +256,12 @@ pub(super) fn build_vectors_streaming(
                         )
                             .map(|b| (super::super::ann_build::IVF_PQ_TYPE, b))
                     }
+                    VectorIndexType::Tq => super::super::ann_build::build_tq_flat(
+                        dim,
+                        &builder.doc_ids,
+                        &builder.vectors,
+                    )
+                    .map(|b| (super::super::ann_build::TQ_FLAT_TYPE, b)),
                     _ => return Ok(None),
                 };
                 let (index_type, bytes) = blob?;
@@ -270,8 +282,6 @@ pub(super) fn build_vectors_streaming(
             .into_iter()
             .flatten()
             .collect()
-    } else {
-        Vec::new()
     };
     // WASM: no ANN index building (requires trained structures from SegmentManager)
     #[cfg(not(feature = "native"))]

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -281,59 +281,72 @@ impl SegmentMerger {
             let config = entry.dense_vector_config.as_ref();
 
             // ── ANN entry (written first, index_type != FLAT_TYPE) ───────
-            let ann_entry = match ann_mode {
-                AnnWriteMode::Copy => {
-                    self.copy_ann_runs(field, entry, segments, &doc_offs, trained, &mut writer)?
-                }
-                AnnWriteMode::Rebuild if entry.field_type == FieldType::BinaryDenseVector => {
-                    if let Some(index) = self
-                        .rebuild_binary_ivf(field, entry, segments, &doc_offs, trained)
-                        .await?
-                    {
-                        let data_offset = writer.offset();
-                        let routing = entry
-                            .binary_dense_vector_config
-                            .as_ref()
-                            .expect("binary field configuration validated")
-                            .ivf_routing;
-                        super::block_in_place_if_multithread(|| {
-                            crate::segment::ann_disk::write_built_binary_ivf(
-                                &index,
-                                routing,
-                                &mut writer,
-                            )
-                        })
-                        .map_err(crate::Error::Io)?;
-                        Some((
-                            crate::segment::ann_build::BINARY_IVF_TYPE,
-                            data_offset,
-                            writer.offset() - data_offset,
-                        ))
-                    } else {
-                        None
+            let tq_config = config.filter(|config| {
+                entry.field_type == FieldType::DenseVector
+                    && config.index_type == VectorIndexType::Tq
+            });
+            let ann_entry = if let Some(tq_config) = tq_config {
+                // TQ payloads carry no trained generation: every merge mode
+                // byte-copies compatible runs; only sources without a payload
+                // (pre-TQ builds or a schema switch to `tq`) are upgraded by
+                // re-encoding from their flat vectors.
+                self.write_tq_entry(field, tq_config, segments, &doc_offs, &mut writer)
+                    .await?
+            } else {
+                match ann_mode {
+                    AnnWriteMode::Copy => {
+                        self.copy_ann_runs(field, entry, segments, &doc_offs, trained, &mut writer)?
                     }
-                }
-                AnnWriteMode::Rebuild => {
-                    if let Some((index, num_clusters)) = self
-                        .rebuild_float_ivf(field, config, segments, &doc_offs, trained)
-                        .await?
-                    {
-                        let data_offset = writer.offset();
-                        super::block_in_place_if_multithread(|| {
-                            crate::segment::ann_disk::write_built_ivf_pq(
-                                &index,
-                                num_clusters,
-                                &mut writer,
-                            )
-                        })
-                        .map_err(crate::Error::Io)?;
-                        Some((
-                            crate::segment::ann_build::IVF_PQ_TYPE,
-                            data_offset,
-                            writer.offset() - data_offset,
-                        ))
-                    } else {
-                        None
+                    AnnWriteMode::Rebuild if entry.field_type == FieldType::BinaryDenseVector => {
+                        if let Some(index) = self
+                            .rebuild_binary_ivf(field, entry, segments, &doc_offs, trained)
+                            .await?
+                        {
+                            let data_offset = writer.offset();
+                            let routing = entry
+                                .binary_dense_vector_config
+                                .as_ref()
+                                .expect("binary field configuration validated")
+                                .ivf_routing;
+                            super::block_in_place_if_multithread(|| {
+                                crate::segment::ann_disk::write_built_binary_ivf(
+                                    &index,
+                                    routing,
+                                    &mut writer,
+                                )
+                            })
+                            .map_err(crate::Error::Io)?;
+                            Some((
+                                crate::segment::ann_build::BINARY_IVF_TYPE,
+                                data_offset,
+                                writer.offset() - data_offset,
+                            ))
+                        } else {
+                            None
+                        }
+                    }
+                    AnnWriteMode::Rebuild => {
+                        if let Some((index, num_clusters)) = self
+                            .rebuild_float_ivf(field, config, segments, &doc_offs, trained)
+                            .await?
+                        {
+                            let data_offset = writer.offset();
+                            super::block_in_place_if_multithread(|| {
+                                crate::segment::ann_disk::write_built_ivf_pq(
+                                    &index,
+                                    num_clusters,
+                                    &mut writer,
+                                )
+                            })
+                            .map_err(crate::Error::Io)?;
+                            Some((
+                                crate::segment::ann_build::IVF_PQ_TYPE,
+                                data_offset,
+                                writer.offset() - data_offset,
+                            ))
+                        } else {
+                            None
+                        }
                     }
                 }
             };
@@ -574,6 +587,151 @@ impl SegmentMerger {
             crate::format_bytes(data_size),
         );
         Ok(Some((index_type, data_offset, data_size)))
+    }
+
+    /// Write the merged TQ payload for one field.
+    ///
+    /// The normal path is the same pure byte-copy as every other ANN merge:
+    /// TQ payloads have no trained generation, so compatibility is only the
+    /// codec fingerprint. Sources without a payload (segments built before
+    /// the field used `tq`) are upgraded by re-encoding from flat storage —
+    /// loudly, and only for this field.
+    async fn write_tq_entry(
+        &self,
+        field: crate::dsl::Field,
+        config: &crate::dsl::DenseVectorConfig,
+        segments: &[SegmentReader],
+        doc_offs: &[u32],
+        writer: &mut OffsetWriter,
+    ) -> Result<Option<(u8, u64, u64)>> {
+        let expected_fingerprint =
+            crate::structures::vector::quantization::tq_expected_fingerprint(config.dim);
+        let mut sources = Vec::new();
+        let mut segments_with_vectors = 0usize;
+        let mut missing_payloads = 0usize;
+        for (segment_index, segment) in segments.iter().enumerate() {
+            let Some(flat) = segment.flat_vectors().get(&field.0) else {
+                continue;
+            };
+            segments_with_vectors += 1;
+            match segment.vector_indexes().get(&field.0) {
+                Some(crate::segment::VectorIndex::Tq { index, .. }) => {
+                    let header = index.get().header();
+                    if header.dim != config.dim
+                        || header.quantizer_version != expected_fingerprint
+                        || header.vector_count != flat.num_vectors
+                    {
+                        return Err(crate::Error::Corruption(format!(
+                            "merge source {:032x} field {} carries an incompatible TQ payload \
+                             (dim {} fingerprint {:#x} count {}, expected dim {} fingerprint \
+                             {:#x} count {})",
+                            segment.meta().id,
+                            field.0,
+                            header.dim,
+                            header.quantizer_version,
+                            header.vector_count,
+                            config.dim,
+                            expected_fingerprint,
+                            flat.num_vectors,
+                        )));
+                    }
+                    sources.push((index.get(), doc_offs[segment_index]));
+                }
+                Some(_) => {
+                    return Err(crate::Error::Corruption(format!(
+                        "merge source {:032x} field {} has a non-TQ ANN payload for a tq field",
+                        segment.meta().id,
+                        field.0,
+                    )));
+                }
+                None => missing_payloads += 1,
+            }
+        }
+        if segments_with_vectors == 0 {
+            return Ok(None);
+        }
+
+        if missing_payloads == 0 {
+            let data_offset = writer.offset();
+            super::block_in_place_if_multithread(|| {
+                crate::segment::ann_disk::write_merged_ann(&sources, writer)
+            })
+            .map_err(crate::Error::Io)?;
+            let data_size = writer.offset() - data_offset;
+            log::debug!(
+                "[merge_vectors] field {}: copied {} compatible TQ run source(s), {} bytes",
+                field.0,
+                sources.len(),
+                data_size,
+            );
+            return Ok(Some((
+                crate::segment::ann_build::TQ_FLAT_TYPE,
+                data_offset,
+                data_size,
+            )));
+        }
+
+        log::info!(
+            "[merge_vectors] field {}: {}/{} TQ source(s) have no payload; re-encoding from \
+             flat vectors (training-free)",
+            field.0,
+            missing_payloads,
+            segments_with_vectors,
+        );
+        drop(sources);
+        let codec = std::sync::Arc::new(crate::structures::TqCodec::new(config.dim));
+        let mut builder = crate::structures::TqFlatBuilder::new(codec);
+        let encode_start = std::time::Instant::now();
+        for (segment_index, segment) in segments.iter().enumerate() {
+            feed_segment(
+                segment,
+                field,
+                doc_offs[segment_index],
+                |labels, vectors| {
+                    super::block_in_place_if_multithread(|| {
+                        let mut add = || builder.add_batch(labels, vectors);
+                        if let Some(pool) = &self.background_pool {
+                            pool.install(add)
+                        } else {
+                            add()
+                        }
+                    })
+                    .map_err(|error| {
+                        crate::Error::Internal(format!(
+                            "TQ re-encode failed for field {}: {error}",
+                            field.0,
+                        ))
+                    })
+                },
+            )
+            .await?;
+        }
+        if builder.is_empty() {
+            log::warn!(
+                "[merge_vectors] field {}: TQ re-encode found no vectors in any source; \
+                 the merged segment will carry no TQ payload and fall back to exact scan",
+                field.0,
+            );
+            return Ok(None);
+        }
+        builder.finish();
+        let vector_count = builder.len();
+        let data_offset = writer.offset();
+        super::block_in_place_if_multithread(|| {
+            crate::segment::ann_disk::write_built_tq_flat(&builder, writer)
+        })
+        .map_err(crate::Error::Io)?;
+        log::info!(
+            "[merge_vectors] field {}: TQ re-encoded {} vectors in {:.1}s",
+            field.0,
+            vector_count,
+            encode_start.elapsed().as_secs_f64(),
+        );
+        Ok(Some((
+            crate::segment::ann_build::TQ_FLAT_TYPE,
+            data_offset,
+            writer.offset() - data_offset,
+        )))
     }
 
     /// Rebuild the binary IVF index for a vector-generation rewrite.

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -33,7 +33,7 @@ pub(crate) use reader::bmp::{block_term_postings, find_dim_in_block_data};
 pub(crate) use reader::combine_ordinal_results;
 #[cfg(feature = "native")]
 pub mod pin;
-pub use reader::{SegmentReader, SparseIndex, VectorIndex, VectorSearchResult};
+pub use reader::{DensePlanCache, SegmentReader, SparseIndex, VectorIndex, VectorSearchResult};
 pub use store::*;
 #[cfg(feature = "native")]
 pub use tracker::{SegmentSnapshot, SegmentTracker};

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -159,6 +159,13 @@ fn validate_ann_schema(schema: &Schema, field_id: u32, index_type: u8) -> Result
                     .as_ref()
                     .is_some_and(|config| config.index_type == BinaryIndexType::Ivf)
         }
+        ann_build::TQ_FLAT_TYPE => {
+            field.field_type == FieldType::DenseVector
+                && field
+                    .dense_vector_config
+                    .as_ref()
+                    .is_some_and(|config| config.index_type == VectorIndexType::Tq)
+        }
         _ => false,
     };
 
@@ -201,7 +208,7 @@ fn is_ann_vector_type(index_type: u8) -> bool {
 
     matches!(
         index_type,
-        ann_build::IVF_PQ_TYPE | ann_build::BINARY_IVF_TYPE
+        ann_build::IVF_PQ_TYPE | ann_build::BINARY_IVF_TYPE | ann_build::TQ_FLAT_TYPE
     )
 }
 
@@ -375,7 +382,7 @@ async fn load_vectors_file_impl<D: Directory>(
     for entry in &entries {
         let inserted = match entry.index_type {
             ann_build::FLAT_TYPE => flat_toc_fields.insert(entry.field_id),
-            ann_build::IVF_PQ_TYPE | ann_build::BINARY_IVF_TYPE => {
+            ann_build::IVF_PQ_TYPE | ann_build::BINARY_IVF_TYPE | ann_build::TQ_FLAT_TYPE => {
                 ann_toc_fields.insert(entry.field_id)
             }
             _ => continue,
@@ -475,7 +482,7 @@ async fn load_vectors_file_impl<D: Directory>(
                     )));
                 }
             }
-            ann_build::IVF_PQ_TYPE | ann_build::BINARY_IVF_TYPE => {
+            ann_build::IVF_PQ_TYPE | ann_build::BINARY_IVF_TYPE | ann_build::TQ_FLAT_TYPE => {
                 validate_ann_schema(schema, field_id, index_type)?;
                 if !load_ann {
                     continue;
@@ -508,6 +515,39 @@ async fn load_vectors_file_impl<D: Directory>(
                             ))
                         })?,
                     )),
+                    ann_build::TQ_FLAT_TYPE => {
+                        let index = super::types::MmapAnnIndex::open(
+                            data,
+                            crate::segment::ann_disk::AnnKind::TqFlat,
+                            total_docs,
+                        )
+                        .map_err(|error| {
+                            crate::Error::Corruption(format!(
+                                "invalid TQ payload for field {field_id}: {error}"
+                            ))
+                        })?;
+                        let dim = schema
+                            .get_field_entry(Field(field_id))
+                            .and_then(|entry| entry.dense_vector_config.as_ref())
+                            .map(|config| config.dim)
+                            .expect("validated as a TQ dense field above");
+                        let header = index.get().header();
+                        let expected =
+                            crate::structures::vector::quantization::tq_expected_fingerprint(dim);
+                        if header.dim != dim || header.quantizer_version != expected {
+                            return Err(crate::Error::Corruption(format!(
+                                "TQ payload for field {field_id} was built with an \
+                                 incompatible codec (dim {} fingerprint {:#x}, schema \
+                                 expects dim {dim} fingerprint {expected:#x}); rebuild \
+                                 the segment",
+                                header.dim, header.quantizer_version,
+                            )));
+                        }
+                        VectorIndex::Tq {
+                            index: Arc::new(index),
+                            codec: Arc::new(crate::structures::TqCodec::new(dim)),
+                        }
+                    }
                     _ => {
                         return Err(crate::Error::Corruption(format!(
                             "unknown vector index type {index_type} for field {field_id}"

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -835,6 +835,76 @@ fn validate_ivf_pq_ann(
     Ok(())
 }
 
+/// Per-query dense plan caches, shared by every segment scorer the query
+/// spawns. Both members are query-global: the IVF-PQ probe route and ADC
+/// tables depend only on the query and index-level artifacts, and the TQ
+/// LUTs depend only on the query and the schema dimension.
+#[derive(Debug, Default)]
+pub struct DensePlanCache {
+    pub(crate) ivf_pq: std::sync::Mutex<Option<std::sync::Arc<crate::structures::IvfPqQueryPlan>>>,
+    pub(crate) tq: std::sync::Mutex<Option<std::sync::Arc<crate::structures::TqQueryPlan>>>,
+}
+
+/// Search one segment's TQ payload, reusing the per-query plan across
+/// segments: the codec is a pure function of the schema dimension, so the
+/// LUTs are identical for every segment of the field (mirrors the IVF-PQ
+/// `probe_cache` hot-path rule — no repeated per-segment plan allocation).
+fn search_tq_segment(
+    index: &crate::segment::ann_disk::AnnDiskIndex,
+    codec: &crate::structures::TqCodec,
+    query: &[f32],
+    fetch_k: usize,
+    field: Field,
+    dim: usize,
+    plan_cache: Option<&std::sync::Mutex<Option<std::sync::Arc<crate::structures::TqQueryPlan>>>>,
+) -> Result<Vec<RawVectorCandidate>> {
+    validate_tq_ann(index, codec, dim, field)?;
+    let plan = match plan_cache {
+        Some(cache) => {
+            let mut cached = cache
+                .lock()
+                .map_err(|_| Error::Internal("TQ plan cache is poisoned".into()))?;
+            match cached.as_ref() {
+                Some(plan) if plan.fingerprint() == codec.fingerprint() => {
+                    std::sync::Arc::clone(plan)
+                }
+                _ => {
+                    let plan =
+                        std::sync::Arc::new(crate::structures::TqQueryPlan::build(codec, query));
+                    *cached = Some(std::sync::Arc::clone(&plan));
+                    plan
+                }
+            }
+        }
+        None => std::sync::Arc::new(crate::structures::TqQueryPlan::build(codec, query)),
+    };
+    index.search_tq_distinct(fetch_k, &plan).map_err(|error| {
+        Error::Corruption(format!("invalid TQ payload for field {}: {error}", field.0))
+    })
+}
+
+fn validate_tq_ann(
+    index: &crate::segment::ann_disk::AnnDiskIndex,
+    codec: &crate::structures::TqCodec,
+    dim: usize,
+    field: Field,
+) -> Result<()> {
+    let header = index.header();
+    if header.dim != dim
+        || codec.dim() != dim
+        || header.code_size != codec.code_size()
+        || header.quantizer_version != codec.fingerprint()
+        || header.codebook_version != 0
+        || header.num_clusters != 1
+    {
+        return Err(Error::Corruption(format!(
+            "TQ payload for field {} does not match the codec derived from schema dimension {dim}",
+            field.0,
+        )));
+    }
+    Ok(())
+}
+
 fn validate_binary_ann(
     index: &crate::segment::ann_disk::AnnDiskIndex,
     quantizer: &crate::structures::BinaryCoarseQuantizer,
@@ -1891,7 +1961,7 @@ impl SegmentReader {
         nprobe: usize,
         rerank_factor: f32,
         combiner: crate::query::MultiValueCombiner,
-        probe_cache: &std::sync::Mutex<Option<std::sync::Arc<crate::structures::IvfPqQueryPlan>>>,
+        plan_cache: &DensePlanCache,
     ) -> Result<Vec<VectorSearchResult>> {
         self.search_dense_vector_impl(
             field,
@@ -1900,7 +1970,7 @@ impl SegmentReader {
             nprobe,
             rerank_factor,
             combiner,
-            Some(probe_cache),
+            Some(plan_cache),
         )
         .await
     }
@@ -1914,9 +1984,7 @@ impl SegmentReader {
         nprobe: usize,
         rerank_factor: f32,
         combiner: crate::query::MultiValueCombiner,
-        probe_cache: Option<
-            &std::sync::Mutex<Option<std::sync::Arc<crate::structures::IvfPqQueryPlan>>>,
-        >,
+        plan_cache: Option<&DensePlanCache>,
     ) -> Result<Vec<VectorSearchResult>> {
         let params =
             self.validate_dense_search_request(field, query, nprobe, rerank_factor, combiner)?;
@@ -1991,7 +2059,7 @@ impl SegmentReader {
                         query,
                         params.nprobe,
                         routing,
-                        probe_cache,
+                        plan_cache.map(|cache| &cache.ivf_pq),
                     )?;
                     let flat = lazy_flat.expect("ANN/flat pairing validated above");
                     index
@@ -2008,6 +2076,19 @@ impl SegmentReader {
                         .into_iter()
                         .map(|(doc_id, ordinal, dist)| (doc_id, ordinal, 1.0 / (1.0 + dist)))
                         .collect()
+                }
+                VectorIndex::Tq { index: lazy, codec } => {
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    // Estimated similarities feed the shared exact re-rank.
+                    search_tq_segment(
+                        lazy.get(),
+                        codec,
+                        query,
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        field,
+                        params.dim,
+                        plan_cache.map(|cache| &cache.tq),
+                    )?
                 }
                 VectorIndex::BinaryIvf(_) => {
                     // Binary IVF serves Hamming queries only (BinaryDenseVectorQuery)
@@ -2066,6 +2147,7 @@ impl SegmentReader {
             let kind = match ann_index {
                 Some(VectorIndex::IvfPq(_)) => "ivf_pq",
                 Some(VectorIndex::BinaryIvf(_)) => "binary_ivf",
+                Some(VectorIndex::Tq { .. }) => "tq_flat",
                 None => "flat",
             };
             crate::observe::dense_l1(
@@ -2535,7 +2617,7 @@ impl SegmentReader {
         nprobe: usize,
         rerank_factor: f32,
         combiner: crate::query::MultiValueCombiner,
-        probe_cache: &std::sync::Mutex<Option<std::sync::Arc<crate::structures::IvfPqQueryPlan>>>,
+        plan_cache: &DensePlanCache,
     ) -> Result<Vec<VectorSearchResult>> {
         self.search_dense_vector_sync_impl(
             field,
@@ -2544,7 +2626,7 @@ impl SegmentReader {
             nprobe,
             rerank_factor,
             combiner,
-            Some(probe_cache),
+            Some(plan_cache),
         )
     }
 
@@ -2558,9 +2640,7 @@ impl SegmentReader {
         nprobe: usize,
         rerank_factor: f32,
         combiner: crate::query::MultiValueCombiner,
-        probe_cache: Option<
-            &std::sync::Mutex<Option<std::sync::Arc<crate::structures::IvfPqQueryPlan>>>,
-        >,
+        plan_cache: Option<&DensePlanCache>,
     ) -> Result<Vec<VectorSearchResult>> {
         let params =
             self.validate_dense_search_request(field, query, nprobe, rerank_factor, combiner)?;
@@ -2631,7 +2711,7 @@ impl SegmentReader {
                         query,
                         params.nprobe,
                         routing,
-                        probe_cache,
+                        plan_cache.map(|cache| &cache.ivf_pq),
                     )?;
                     let flat = lazy_flat.expect("ANN/flat pairing validated above");
                     index
@@ -2648,6 +2728,18 @@ impl SegmentReader {
                         .into_iter()
                         .map(|(doc_id, ordinal, dist)| (doc_id, ordinal, 1.0 / (1.0 + dist)))
                         .collect()
+                }
+                VectorIndex::Tq { index: lazy, codec } => {
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    search_tq_segment(
+                        lazy.get(),
+                        codec,
+                        query,
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        field,
+                        params.dim,
+                        plan_cache.map(|cache| &cache.tq),
+                    )?
                 }
                 VectorIndex::BinaryIvf(_) => {
                     // Binary IVF serves Hamming queries only (BinaryDenseVectorQuery)

--- a/hermes-core/src/segment/reader/types.rs
+++ b/hermes-core/src/segment/reader/types.rs
@@ -20,6 +20,11 @@ pub enum VectorIndex {
     IvfPq(Arc<MmapAnnIndex>),
     /// Binary IVF (Hamming) payload.
     BinaryIvf(Arc<MmapAnnIndex>),
+    /// TurboQuant flat payload with its derived (training-free) codec.
+    Tq {
+        index: Arc<MmapAnnIndex>,
+        codec: Arc<crate::structures::TqCodec>,
+    },
 }
 
 /// Thin public wrapper around the shared mmap ANN representation. Its internals
@@ -65,6 +70,9 @@ impl VectorIndex {
         match self {
             VectorIndex::IvfPq(lazy) => lazy.estimated_heap_bytes(),
             VectorIndex::BinaryIvf(lazy) => lazy.estimated_heap_bytes(),
+            VectorIndex::Tq { index, codec } => {
+                index.estimated_heap_bytes() + codec.estimated_memory_bytes()
+            }
         }
     }
 
@@ -76,7 +84,7 @@ impl VectorIndex {
         report: &mut crate::segment::pin::PinReport,
     ) {
         let index = match self {
-            Self::IvfPq(index) | Self::BinaryIvf(index) => index,
+            Self::IvfPq(index) | Self::BinaryIvf(index) | Self::Tq { index, .. } => index,
         };
         if let Some(index) = Arc::get_mut(index) {
             index.pin_lookup_directory(mode, remaining, report);

--- a/hermes-core/src/structures/mod.rs
+++ b/hermes-core/src/structures/mod.rs
@@ -120,6 +120,8 @@ pub use postings::{
 };
 
 // Re-export vector
+#[cfg(feature = "native")]
+pub use vector::TqFlatBuilder;
 pub use vector::{
     BinaryCoarseQuantizer,
     BinaryIvfConfig,
@@ -138,6 +140,8 @@ pub use vector::{
     PQCodebook,
     PQConfig,
     SoarConfig,
+    TqCodec,
+    TqQueryPlan,
 };
 
 // Re-export simd

--- a/hermes-core/src/structures/vector/mod.rs
+++ b/hermes-core/src/structures/vector/mod.rs
@@ -31,7 +31,9 @@ pub mod quantization;
 pub use ivf::{CoarseCentroids, CoarseConfig, IvfProbePlan, MultiAssignment, SoarConfig};
 
 // Quantization
-pub use quantization::{DistanceTable, PQCodebook, PQConfig};
+#[cfg(feature = "native")]
+pub use quantization::TqFlatBuilder;
+pub use quantization::{DistanceTable, PQCodebook, PQConfig, TqCodec, TqQueryPlan};
 
 // Indexes
 pub use index::{

--- a/hermes-core/src/structures/vector/quantization/mod.rs
+++ b/hermes-core/src/structures/vector/quantization/mod.rs
@@ -1,7 +1,16 @@
 //! Vector quantization for IVF indexes
 //!
-//! Residual Product Quantization with OPQ is the production float codec.
+//! Residual Product Quantization with OPQ is the trained float codec;
+//! TurboQuant (`tq`) is the training-free per-segment codec.
 //!
 mod pq;
+mod tq;
 
 pub use pq::{DistanceTable, PQCodebook, PQConfig};
+#[cfg(feature = "native")]
+pub use tq::TqFlatBuilder;
+pub use tq::{
+    TQ_BLOCK_LANES, TQ_CODEC_VERSION, TqCodec, TqEncodeScratch, TqQueryPlan, tq_block_bytes,
+    tq_codes_column_len, tq_codes_column_len_checked, tq_expected_fingerprint, tq_pack_block,
+    tq_padded_dim, tq_score_block,
+};

--- a/hermes-core/src/structures/vector/quantization/tq.rs
+++ b/hermes-core/src/structures/vector/quantization/tq.rs
@@ -1,0 +1,1147 @@
+//! TurboQuant (TQ): training-free dense-vector codec.
+//!
+//! Design: `docs/turboquant-quantization.md`. Per padded coordinate the codec
+//! stores a 3-bit scalar code (analytic Lloyd-Max levels for the unit-sphere
+//! coordinate density) plus a 1-bit QJL sign of the rotated stage-1 residual;
+//! a per-vector f32 `gamma = ‖residual‖₂` makes the inner-product estimator
+//! unbiased. Everything is derived from `(dim, codec constants)` — no trained
+//! artifacts and no cross-segment generations.
+//!
+//! References: Zandieh, Daliri et al., "TurboQuant: Online Vector
+//! Quantization with Near-optimal Distortion Rate" (arXiv 2504.19874);
+//! layout and LUT16 scoring follow the FastScan pattern (Faiss,
+//! mayflower/pg_turboquant, both MIT).
+
+/// Bumping this refuses to mix payloads across incompatible codec revisions.
+pub const TQ_CODEC_VERSION: u32 = 1;
+/// Bits per padded coordinate: 3-bit stage-1 code + 1-bit QJL sign.
+pub const TQ_BITS: u32 = 4;
+/// Vectors per scoring block; one lane per vector.
+pub const TQ_BLOCK_LANES: usize = 16;
+/// Smallest supported padded dimension. Below this the coordinate density
+/// exponent `(P-3)/2` degenerates and LUT rows would not fill a SIMD lane.
+pub const TQ_MIN_PADDED_DIM: usize = 8;
+
+const TQ_STAGE1_LEVELS: usize = 8;
+const TQ_STAGE1_SEED: u64 = 0x7154_5354_4147_4531; // "qTSTAGE1"
+const TQ_QJL_SEED: u64 = 0x7154_514a_4c53_4b31; // "qTQJLSK1"
+const TQ_LLOYD_GRID: usize = 8192;
+const TQ_LLOYD_MAX_ITERATIONS: usize = 64;
+const TQ_LLOYD_TOLERANCE: f64 = 1e-9;
+/// i16 lane accumulators are widened to i32 at least every this many
+/// dimensions: 128 * 127 = 16256 stays far from i16 saturation.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+const TQ_ACCUMULATE_CHUNK_DIMS: usize = 128;
+
+/// Padded (power-of-two, ≥ [`TQ_MIN_PADDED_DIM`]) dimension for an input
+/// dimension. Cheap; usable for header validation without building a codec.
+#[inline]
+pub fn tq_padded_dim(dim: usize) -> usize {
+    dim.next_power_of_two().max(TQ_MIN_PADDED_DIM)
+}
+
+/// Fingerprint every payload built for `dim` must carry (no codebook build).
+#[inline]
+pub fn tq_expected_fingerprint(dim: usize) -> u64 {
+    tq_fingerprint(dim, tq_padded_dim(dim))
+}
+
+/// Bytes of one scoring block: 16 f32 gammas + 16 packed nibble rows.
+#[inline]
+pub const fn tq_block_bytes(code_size: usize) -> usize {
+    TQ_BLOCK_LANES * (size_of::<f32>() + code_size)
+}
+
+/// Total codes-column bytes for `count` vectors (final block zero-padded).
+#[inline]
+pub const fn tq_codes_column_len(count: usize, code_size: usize) -> usize {
+    count.div_ceil(TQ_BLOCK_LANES) * tq_block_bytes(code_size)
+}
+
+/// Overflow-checked [`tq_codes_column_len`] for untrusted header values.
+#[inline]
+pub fn tq_codes_column_len_checked(count: usize, code_size: usize) -> Option<usize> {
+    count
+        .div_ceil(TQ_BLOCK_LANES)
+        .checked_mul(tq_block_bytes(code_size))
+}
+
+#[inline]
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    z ^ (z >> 31)
+}
+
+/// Seeded structured rotation: sign flips → normalized FWHT → permutation.
+/// Orthonormal on `R^padded_dim`; inputs shorter than `padded_dim` are
+/// zero-padded, which embeds them isometrically.
+#[derive(Debug, Clone)]
+pub struct TqRotation {
+    input_dim: usize,
+    padded_dim: usize,
+    /// +1.0 / -1.0 per padded coordinate.
+    signs: Vec<f32>,
+    /// `output[i] = fwht(signs * input)[perm[i]]`.
+    perm: Vec<u32>,
+}
+
+impl TqRotation {
+    pub fn new(input_dim: usize, seed: u64) -> Self {
+        let padded_dim = tq_padded_dim(input_dim);
+        let mut state = seed;
+        let signs = (0..padded_dim)
+            .map(|_| {
+                if splitmix64(&mut state) & 1 == 1 {
+                    1.0
+                } else {
+                    -1.0
+                }
+            })
+            .collect();
+        let mut perm: Vec<u32> = (0..padded_dim as u32).collect();
+        for i in (1..padded_dim).rev() {
+            let j = (splitmix64(&mut state) % (i as u64 + 1)) as usize;
+            perm.swap(i, j);
+        }
+        Self {
+            input_dim,
+            padded_dim,
+            signs,
+            perm,
+        }
+    }
+
+    #[inline]
+    pub fn padded_dim(&self) -> usize {
+        self.padded_dim
+    }
+
+    /// Rotate `input` (length `input_dim`, or `padded_dim` for already-padded
+    /// residuals) into `output` (length `padded_dim`). `scratch` is reused
+    /// across calls to keep encoding allocation-free.
+    pub fn apply(&self, input: &[f32], scratch: &mut Vec<f32>, output: &mut [f32]) {
+        debug_assert!(input.len() == self.input_dim || input.len() == self.padded_dim);
+        debug_assert_eq!(output.len(), self.padded_dim);
+        scratch.clear();
+        scratch.extend(
+            self.signs
+                .iter()
+                .enumerate()
+                .map(|(index, sign)| input.get(index).copied().unwrap_or(0.0) * sign),
+        );
+        fwht_normalized(scratch);
+        for (slot, &source) in output.iter_mut().zip(&self.perm) {
+            *slot = scratch[source as usize];
+        }
+    }
+}
+
+/// In-place normalized fast Walsh-Hadamard transform (`len` a power of two).
+fn fwht_normalized(values: &mut [f32]) {
+    let len = values.len();
+    debug_assert!(len.is_power_of_two());
+    let mut step = 1;
+    while step < len {
+        let mut base = 0;
+        while base < len {
+            for offset in base..base + step {
+                let left = values[offset];
+                let right = values[offset + step];
+                values[offset] = left + right;
+                values[offset + step] = left - right;
+            }
+            base += step * 2;
+        }
+        step *= 2;
+    }
+    let scale = 1.0 / (len as f32).sqrt();
+    for value in values.iter_mut() {
+        *value *= scale;
+    }
+}
+
+/// Analytic 3-bit Lloyd-Max codebook for the marginal density of one
+/// coordinate of a uniform unit vector in `R^padded_dim`:
+/// `f(t) ∝ (1 - t²)^((padded_dim - 3) / 2)` on `[-1, 1]`.
+#[derive(Debug, Clone)]
+pub struct TqCodebook {
+    levels: [f32; TQ_STAGE1_LEVELS],
+    /// Decision boundaries between adjacent levels (midpoints).
+    boundaries: [f32; TQ_STAGE1_LEVELS - 1],
+}
+
+impl TqCodebook {
+    pub fn analytic(padded_dim: usize) -> Self {
+        assert!(
+            padded_dim >= TQ_MIN_PADDED_DIM,
+            "TQ codebook requires padded_dim >= {TQ_MIN_PADDED_DIM}, got {padded_dim}"
+        );
+        let exponent = (padded_dim as f64 - 3.0) / 2.0;
+        let cell = 2.0 / TQ_LLOYD_GRID as f64;
+        // Grid midpoints and their density weights over [-1, 1].
+        // Heap-allocated: two [f64; 8192] frames (~128 KiB) would risk stack
+        // overflow on constrained runtimes (WASM readers, worker threads).
+        let mut weights = vec![0.0f64; TQ_LLOYD_GRID];
+        let mut positions = vec![0.0f64; TQ_LLOYD_GRID];
+        for index in 0..TQ_LLOYD_GRID {
+            let t = -1.0 + (index as f64 + 0.5) * cell;
+            positions[index] = t;
+            let log_density = exponent * (1.0 - t * t).max(f64::MIN_POSITIVE).ln();
+            weights[index] = log_density.exp();
+        }
+
+        // Initialize boundaries at equal-mass quantiles.
+        let total_mass: f64 = weights.iter().sum();
+        let mut levels = [0.0f64; TQ_STAGE1_LEVELS];
+        let mut boundaries = [0.0f64; TQ_STAGE1_LEVELS - 1];
+        let mut accumulated = 0.0f64;
+        let mut next_boundary = 0usize;
+        for index in 0..TQ_LLOYD_GRID {
+            accumulated += weights[index];
+            while next_boundary < TQ_STAGE1_LEVELS - 1
+                && accumulated
+                    >= total_mass * (next_boundary as f64 + 1.0) / TQ_STAGE1_LEVELS as f64
+            {
+                boundaries[next_boundary] = positions[index];
+                next_boundary += 1;
+            }
+        }
+
+        // Lloyd-Max: centroids are density-weighted means of their cell,
+        // boundaries are midpoints of adjacent centroids.
+        for _ in 0..TQ_LLOYD_MAX_ITERATIONS {
+            let mut mass = [0.0f64; TQ_STAGE1_LEVELS];
+            let mut moment = [0.0f64; TQ_STAGE1_LEVELS];
+            let mut bucket = 0usize;
+            for index in 0..TQ_LLOYD_GRID {
+                let t = positions[index];
+                while bucket < TQ_STAGE1_LEVELS - 1 && t > boundaries[bucket] {
+                    bucket += 1;
+                }
+                mass[bucket] += weights[index];
+                moment[bucket] += weights[index] * t;
+            }
+            let mut shift = 0.0f64;
+            for level in 0..TQ_STAGE1_LEVELS {
+                if mass[level] > 0.0 {
+                    let updated = moment[level] / mass[level];
+                    shift = shift.max((updated - levels[level]).abs());
+                    levels[level] = updated;
+                }
+            }
+            for boundary in 0..TQ_STAGE1_LEVELS - 1 {
+                boundaries[boundary] = 0.5 * (levels[boundary] + levels[boundary + 1]);
+            }
+            if shift < TQ_LLOYD_TOLERANCE {
+                break;
+            }
+        }
+
+        // The density is even, so the optimal codebook is exactly symmetric;
+        // grid discretization leaves ~1e-4 asymmetry. Symmetrize so the
+        // central decision boundary is exactly zero.
+        for index in 0..TQ_STAGE1_LEVELS / 2 {
+            let magnitude = 0.5 * (levels[TQ_STAGE1_LEVELS - 1 - index] - levels[index]);
+            levels[index] = -magnitude;
+            levels[TQ_STAGE1_LEVELS - 1 - index] = magnitude;
+        }
+        for boundary in 0..TQ_STAGE1_LEVELS - 1 {
+            boundaries[boundary] = 0.5 * (levels[boundary] + levels[boundary + 1]);
+        }
+
+        Self {
+            levels: levels.map(|level| level as f32),
+            boundaries: boundaries.map(|boundary| boundary as f32),
+        }
+    }
+
+    /// 3-bit code of the nearest level.
+    #[inline]
+    pub fn encode_coordinate(&self, value: f32) -> u8 {
+        let mut code = 0u8;
+        for &boundary in &self.boundaries {
+            code += u8::from(value > boundary);
+        }
+        code
+    }
+}
+
+/// Complete TQ codec for one field dimension. Cheap to build (sub-millisecond)
+/// and immutable; share via `Arc` per open segment.
+#[derive(Debug, Clone)]
+pub struct TqCodec {
+    dim: usize,
+    padded_dim: usize,
+    stage1_rotation: TqRotation,
+    qjl_rotation: TqRotation,
+    codebook: TqCodebook,
+    /// `sqrt(π/2) / sqrt(padded_dim)`: QJL correction for an orthonormal sketch.
+    qjl_scale: f32,
+    fingerprint: u64,
+}
+
+impl TqCodec {
+    pub fn new(dim: usize) -> Self {
+        assert!(dim > 0, "TQ codec requires a non-zero dimension");
+        let stage1_rotation = TqRotation::new(dim, TQ_STAGE1_SEED);
+        let padded_dim = stage1_rotation.padded_dim();
+        let qjl_rotation = TqRotation::new(padded_dim, TQ_QJL_SEED);
+        debug_assert_eq!(qjl_rotation.padded_dim(), padded_dim);
+        let codebook = TqCodebook::analytic(padded_dim);
+        let qjl_scale = (std::f64::consts::PI / 2.0).sqrt() as f32 / (padded_dim as f32).sqrt();
+        let fingerprint = tq_fingerprint(dim, padded_dim);
+        Self {
+            dim,
+            padded_dim,
+            stage1_rotation,
+            qjl_rotation,
+            codebook,
+            qjl_scale,
+            fingerprint,
+        }
+    }
+
+    #[inline]
+    pub fn dim(&self) -> usize {
+        self.dim
+    }
+
+    #[inline]
+    pub fn padded_dim(&self) -> usize {
+        self.padded_dim
+    }
+
+    /// Logical bytes per vector (two 4-bit coordinates per byte).
+    #[inline]
+    pub fn code_size(&self) -> usize {
+        self.padded_dim / 2
+    }
+
+    /// Deterministic compatibility fingerprint carried as `quantizer_version`.
+    #[inline]
+    pub fn fingerprint(&self) -> u64 {
+        self.fingerprint
+    }
+
+    /// Heap footprint: two rotations (signs f32 + perm u32 per padded coord)
+    /// plus the fixed-size codebook.
+    pub fn estimated_memory_bytes(&self) -> usize {
+        2 * self.padded_dim * (size_of::<f32>() + size_of::<u32>()) + size_of::<TqCodebook>()
+    }
+
+    /// Encode one vector into `nibbles` (one 0..=15 value per padded
+    /// coordinate) and return `gamma`. The vector is normalized internally;
+    /// zero vectors encode as all-zero nibbles with `gamma = 0`.
+    pub fn encode_into(
+        &self,
+        vector: &[f32],
+        nibbles: &mut [u8],
+        scratch: &mut TqEncodeScratch,
+    ) -> f32 {
+        assert_eq!(vector.len(), self.dim, "TQ encode dimension mismatch");
+        assert_eq!(nibbles.len(), self.padded_dim, "TQ nibble buffer mismatch");
+        let norm = crate::structures::simd::dot_product_f32(vector, vector, vector.len()).sqrt();
+        if !norm.is_finite() || norm <= 0.0 {
+            nibbles.fill(0);
+            return 0.0;
+        }
+        scratch.normalized.clear();
+        scratch
+            .normalized
+            .extend(vector.iter().map(|value| value / norm));
+
+        scratch.rotated.resize(self.padded_dim, 0.0);
+        let (normalized, rotated, fwht) =
+            (&scratch.normalized, &mut scratch.rotated, &mut scratch.fwht);
+        self.stage1_rotation.apply(normalized, fwht, rotated);
+
+        // Stage-1 codes and residual (in stage-1 rotated space).
+        scratch.residual.resize(self.padded_dim, 0.0);
+        let mut residual_norm_sq = 0.0f32;
+        for ((&value, nibble), residual_slot) in scratch
+            .rotated
+            .iter()
+            .zip(nibbles.iter_mut())
+            .zip(scratch.residual.iter_mut())
+        {
+            let code = self.codebook.encode_coordinate(value);
+            *nibble = code << 1;
+            let residual = value - self.codebook.levels[code as usize];
+            *residual_slot = residual;
+            residual_norm_sq += residual * residual;
+        }
+
+        // QJL sign bits of the rotated residual.
+        scratch.rotated_residual.resize(self.padded_dim, 0.0);
+        let (residual, rotated_residual, fwht) = (
+            &scratch.residual,
+            &mut scratch.rotated_residual,
+            &mut scratch.fwht,
+        );
+        self.qjl_rotation.apply(residual, fwht, rotated_residual);
+        for (nibble, &rotated) in nibbles.iter_mut().zip(scratch.rotated_residual.iter()) {
+            *nibble |= u8::from(rotated >= 0.0);
+        }
+        residual_norm_sq.sqrt()
+    }
+}
+
+/// Reusable per-thread encode buffers (hot-path allocation hygiene).
+#[derive(Debug, Default)]
+pub struct TqEncodeScratch {
+    normalized: Vec<f32>,
+    rotated: Vec<f32>,
+    residual: Vec<f32>,
+    rotated_residual: Vec<f32>,
+    fwht: Vec<f32>,
+}
+
+fn tq_fingerprint(dim: usize, padded_dim: usize) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64; // FNV-1a offset basis
+    let mut mix = |bytes: &[u8]| {
+        for &byte in bytes {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    };
+    mix(b"hermes-tq");
+    mix(&TQ_CODEC_VERSION.to_le_bytes());
+    mix(&TQ_BITS.to_le_bytes());
+    mix(&(dim as u64).to_le_bytes());
+    mix(&(padded_dim as u64).to_le_bytes());
+    mix(&TQ_STAGE1_SEED.to_le_bytes());
+    mix(&TQ_QJL_SEED.to_le_bytes());
+    if hash == 0 { 1 } else { hash }
+}
+
+// ---------------------------------------------------------------------------
+// Query plan and block scoring
+// ---------------------------------------------------------------------------
+
+/// Per-query LUTs: `padded_dim × 16` i8 tables (globally-scaled
+/// quantizations) for the block kernels. The intermediate f32 tables are
+/// dropped after quantization — they are not read on the search path.
+pub struct TqQueryPlan {
+    padded_dim: usize,
+    fingerprint: u64,
+    base_lut_i8: Vec<i8>,
+    qjl_lut_i8: Vec<i8>,
+    base_dequant: f32,
+    qjl_dequant: f32,
+    /// Full-precision tables, retained for the reference estimator in tests.
+    #[cfg(test)]
+    reference_luts: (Vec<f32>, Vec<f32>),
+}
+
+impl std::fmt::Debug for TqQueryPlan {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TqQueryPlan")
+            .field("padded_dim", &self.padded_dim)
+            .field("fingerprint", &self.fingerprint)
+            .finish()
+    }
+}
+
+impl TqQueryPlan {
+    pub fn build(codec: &TqCodec, query: &[f32]) -> Self {
+        assert_eq!(query.len(), codec.dim, "TQ query dimension mismatch");
+        let padded_dim = codec.padded_dim;
+        let norm = crate::structures::simd::dot_product_f32(query, query, query.len()).sqrt();
+        let inverse_norm = if norm.is_finite() && norm > 0.0 {
+            1.0 / norm
+        } else {
+            0.0
+        };
+        let normalized: Vec<f32> = query.iter().map(|value| value * inverse_norm).collect();
+        let mut fwht = Vec::with_capacity(padded_dim);
+        let mut rotated = vec![0.0f32; padded_dim];
+        codec
+            .stage1_rotation
+            .apply(&normalized, &mut fwht, &mut rotated);
+        let mut qjl_rotated = vec![0.0f32; padded_dim];
+        codec
+            .qjl_rotation
+            .apply(&rotated, &mut fwht, &mut qjl_rotated);
+
+        let mut base_lut = vec![0.0f32; padded_dim * 16];
+        let mut qjl_lut = vec![0.0f32; padded_dim * 16];
+        for dim in 0..padded_dim {
+            for nibble in 0..16 {
+                let level = codec.codebook.levels[nibble >> 1];
+                let sign = if nibble & 1 == 1 { 1.0 } else { -1.0 };
+                base_lut[dim * 16 + nibble] = rotated[dim] * level;
+                qjl_lut[dim * 16 + nibble] = sign * codec.qjl_scale * qjl_rotated[dim];
+            }
+        }
+        let (base_lut_i8, base_dequant) = quantize_lut(&base_lut);
+        let (qjl_lut_i8, qjl_dequant) = quantize_lut(&qjl_lut);
+        Self {
+            padded_dim,
+            fingerprint: codec.fingerprint,
+            base_lut_i8,
+            qjl_lut_i8,
+            base_dequant,
+            qjl_dequant,
+            #[cfg(test)]
+            reference_luts: (base_lut, qjl_lut),
+        }
+    }
+
+    #[inline]
+    pub fn padded_dim(&self) -> usize {
+        self.padded_dim
+    }
+
+    #[inline]
+    pub fn fingerprint(&self) -> u64 {
+        self.fingerprint
+    }
+
+    /// Reference f32 estimator over one unpacked nibble row (test oracle for
+    /// the quantized block path).
+    #[cfg(test)]
+    pub(crate) fn estimate_row(&self, nibbles: &[u8], gamma: f32) -> f32 {
+        debug_assert_eq!(nibbles.len(), self.padded_dim);
+        let (base_lut, qjl_lut) = &self.reference_luts;
+        let mut base = 0.0f32;
+        let mut qjl = 0.0f32;
+        for (dim, &nibble) in nibbles.iter().enumerate() {
+            base += base_lut[dim * 16 + nibble as usize];
+            qjl += qjl_lut[dim * 16 + nibble as usize];
+        }
+        base + gamma * qjl
+    }
+}
+
+fn quantize_lut(values: &[f32]) -> (Vec<i8>, f32) {
+    let max_abs = values
+        .iter()
+        .fold(0.0f32, |acc, &value| acc.max(value.abs()));
+    if !max_abs.is_finite() || max_abs <= 0.0 {
+        return (vec![0i8; values.len()], 0.0);
+    }
+    let quantize_scale = 127.0 / max_abs;
+    let quantized = values
+        .iter()
+        .map(|&value| (value * quantize_scale).round().clamp(-127.0, 127.0) as i8)
+        .collect();
+    (quantized, max_abs / 127.0)
+}
+
+/// Score one block (16 lanes) into `scores`. `block` is
+/// `[16 × f32 gamma][padded_dim × 8 packed nibbles]`; lanes past the run's
+/// vector count hold zero padding and must be ignored by the caller.
+pub fn tq_score_block(plan: &TqQueryPlan, block: &[u8], scores: &mut [f32; TQ_BLOCK_LANES]) {
+    debug_assert_eq!(block.len(), tq_block_bytes(plan.padded_dim / 2));
+    let (gamma_bytes, nibble_bytes) = block.split_at(TQ_BLOCK_LANES * size_of::<f32>());
+    let mut base = [0i32; TQ_BLOCK_LANES];
+    let mut qjl = [0i32; TQ_BLOCK_LANES];
+    lut16::accumulate_block(
+        &plan.base_lut_i8,
+        &plan.qjl_lut_i8,
+        nibble_bytes,
+        plan.padded_dim,
+        &mut base,
+        &mut qjl,
+    );
+    for lane in 0..TQ_BLOCK_LANES {
+        let gamma = f32::from_le_bytes(
+            gamma_bytes[lane * 4..lane * 4 + 4]
+                .try_into()
+                .expect("gamma slice is 4 bytes"),
+        );
+        scores[lane] =
+            base[lane] as f32 * plan.base_dequant + gamma * qjl[lane] as f32 * plan.qjl_dequant;
+    }
+}
+
+/// Pack up to 16 nibble rows (+ gammas) into one block. Missing lanes are
+/// zero-filled. `rows` are `padded_dim`-length 0..=15 values.
+pub fn tq_pack_block(rows: &[&[u8]], gammas: &[f32], padded_dim: usize, output: &mut Vec<u8>) {
+    assert!(rows.len() <= TQ_BLOCK_LANES && rows.len() == gammas.len());
+    for lane in 0..TQ_BLOCK_LANES {
+        let gamma = gammas.get(lane).copied().unwrap_or(0.0);
+        output.extend_from_slice(&gamma.to_le_bytes());
+    }
+    for dim in 0..padded_dim {
+        for byte_index in 0..TQ_BLOCK_LANES / 2 {
+            let low = rows.get(byte_index).map_or(0, |row| row[dim] & 0x0F);
+            let high = rows
+                .get(byte_index + TQ_BLOCK_LANES / 2)
+                .map_or(0, |row| row[dim] & 0x0F);
+            output.push(low | (high << 4));
+        }
+    }
+}
+
+mod lut16 {
+    use super::{TQ_ACCUMULATE_CHUNK_DIMS, TQ_BLOCK_LANES};
+
+    /// Accumulate both LUT sums for 16 lanes over all dimensions.
+    /// `nibble_bytes` is dimension-major: 8 bytes per dimension, byte `j`
+    /// holding lane `j` (low nibble) and lane `j + 8` (high nibble).
+    pub(super) fn accumulate_block(
+        base_lut: &[i8],
+        qjl_lut: &[i8],
+        nibble_bytes: &[u8],
+        padded_dim: usize,
+        base: &mut [i32; TQ_BLOCK_LANES],
+        qjl: &mut [i32; TQ_BLOCK_LANES],
+    ) {
+        #[cfg(target_arch = "aarch64")]
+        {
+            // NEON is baseline on aarch64.
+            unsafe { accumulate_block_neon(base_lut, qjl_lut, nibble_bytes, padded_dim, base, qjl) }
+            return;
+        }
+        #[cfg(target_arch = "x86_64")]
+        {
+            if std::arch::is_x86_feature_detected!("ssse3") {
+                unsafe {
+                    accumulate_block_ssse3(base_lut, qjl_lut, nibble_bytes, padded_dim, base, qjl)
+                }
+                return;
+            }
+        }
+        #[allow(unreachable_code)]
+        accumulate_block_scalar(base_lut, qjl_lut, nibble_bytes, padded_dim, base, qjl);
+    }
+
+    /// Scalar fallback mirroring the SIMD integer arithmetic exactly
+    /// (i8 lookups, i32 sums), so all paths agree bit-for-bit.
+    pub(super) fn accumulate_block_scalar(
+        base_lut: &[i8],
+        qjl_lut: &[i8],
+        nibble_bytes: &[u8],
+        padded_dim: usize,
+        base: &mut [i32; TQ_BLOCK_LANES],
+        qjl: &mut [i32; TQ_BLOCK_LANES],
+    ) {
+        for dim in 0..padded_dim {
+            let row = &nibble_bytes[dim * 8..dim * 8 + 8];
+            let base_table = &base_lut[dim * 16..dim * 16 + 16];
+            let qjl_table = &qjl_lut[dim * 16..dim * 16 + 16];
+            for (lane, &byte) in row.iter().enumerate() {
+                let low = (byte & 0x0F) as usize;
+                let high = (byte >> 4) as usize;
+                base[lane] += i32::from(base_table[low]);
+                base[lane + 8] += i32::from(base_table[high]);
+                qjl[lane] += i32::from(qjl_table[low]);
+                qjl[lane + 8] += i32::from(qjl_table[high]);
+            }
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[target_feature(enable = "neon")]
+    unsafe fn accumulate_block_neon(
+        base_lut: &[i8],
+        qjl_lut: &[i8],
+        nibble_bytes: &[u8],
+        padded_dim: usize,
+        base: &mut [i32; TQ_BLOCK_LANES],
+        qjl: &mut [i32; TQ_BLOCK_LANES],
+    ) {
+        use std::arch::aarch64::*;
+        unsafe {
+            let mask = vdup_n_u8(0x0F);
+            let mut base_lo_i32 = [vdupq_n_s32(0); 4];
+            let mut qjl_lo_i32 = [vdupq_n_s32(0); 4];
+            let mut dim = 0;
+            while dim < padded_dim {
+                let chunk_end = (dim + TQ_ACCUMULATE_CHUNK_DIMS).min(padded_dim);
+                let mut base_acc = [vdupq_n_s16(0); 2];
+                let mut qjl_acc = [vdupq_n_s16(0); 2];
+                while dim < chunk_end {
+                    let row = vld1_u8(nibble_bytes.as_ptr().add(dim * 8));
+                    let low = vand_u8(row, mask);
+                    let high = vshr_n_u8::<4>(row);
+                    let lanes = vcombine_u8(low, high);
+                    let base_table = vld1q_s8(base_lut.as_ptr().add(dim * 16));
+                    let qjl_table = vld1q_s8(qjl_lut.as_ptr().add(dim * 16));
+                    let base_values =
+                        vreinterpretq_s8_u8(vqtbl1q_u8(vreinterpretq_u8_s8(base_table), lanes));
+                    let qjl_values =
+                        vreinterpretq_s8_u8(vqtbl1q_u8(vreinterpretq_u8_s8(qjl_table), lanes));
+                    base_acc[0] = vaddw_s8(base_acc[0], vget_low_s8(base_values));
+                    base_acc[1] = vaddw_s8(base_acc[1], vget_high_s8(base_values));
+                    qjl_acc[0] = vaddw_s8(qjl_acc[0], vget_low_s8(qjl_values));
+                    qjl_acc[1] = vaddw_s8(qjl_acc[1], vget_high_s8(qjl_values));
+                    dim += 1;
+                }
+                for half in 0..2 {
+                    base_lo_i32[half * 2] =
+                        vaddw_s16(base_lo_i32[half * 2], vget_low_s16(base_acc[half]));
+                    base_lo_i32[half * 2 + 1] =
+                        vaddw_s16(base_lo_i32[half * 2 + 1], vget_high_s16(base_acc[half]));
+                    qjl_lo_i32[half * 2] =
+                        vaddw_s16(qjl_lo_i32[half * 2], vget_low_s16(qjl_acc[half]));
+                    qjl_lo_i32[half * 2 + 1] =
+                        vaddw_s16(qjl_lo_i32[half * 2 + 1], vget_high_s16(qjl_acc[half]));
+                }
+            }
+            for quarter in 0..4 {
+                vst1q_s32(base.as_mut_ptr().add(quarter * 4), base_lo_i32[quarter]);
+                vst1q_s32(qjl.as_mut_ptr().add(quarter * 4), qjl_lo_i32[quarter]);
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[target_feature(enable = "ssse3")]
+    unsafe fn accumulate_block_ssse3(
+        base_lut: &[i8],
+        qjl_lut: &[i8],
+        nibble_bytes: &[u8],
+        padded_dim: usize,
+        base: &mut [i32; TQ_BLOCK_LANES],
+        qjl: &mut [i32; TQ_BLOCK_LANES],
+    ) {
+        use std::arch::x86_64::*;
+        unsafe {
+            let mask = _mm_set1_epi8(0x0F);
+            let zero = _mm_setzero_si128();
+            let mut base_i32 = [zero; 4];
+            let mut qjl_i32 = [zero; 4];
+            let mut dim = 0;
+            while dim < padded_dim {
+                let chunk_end = (dim + TQ_ACCUMULATE_CHUNK_DIMS).min(padded_dim);
+                let mut base_acc = [zero; 2];
+                let mut qjl_acc = [zero; 2];
+                while dim < chunk_end {
+                    let row = _mm_loadl_epi64(nibble_bytes.as_ptr().add(dim * 8).cast());
+                    let low = _mm_and_si128(row, mask);
+                    let high = _mm_and_si128(_mm_srli_epi16(row, 4), mask);
+                    let lanes = _mm_unpacklo_epi64(low, high);
+                    let base_table = _mm_loadu_si128(base_lut.as_ptr().add(dim * 16).cast());
+                    let qjl_table = _mm_loadu_si128(qjl_lut.as_ptr().add(dim * 16).cast());
+                    let base_values = _mm_shuffle_epi8(base_table, lanes);
+                    let qjl_values = _mm_shuffle_epi8(qjl_table, lanes);
+                    // Sign-extend i8 → i16 without SSE4.1: compare-based sign mask.
+                    let base_sign = _mm_cmpgt_epi8(zero, base_values);
+                    let qjl_sign = _mm_cmpgt_epi8(zero, qjl_values);
+                    base_acc[0] =
+                        _mm_add_epi16(base_acc[0], _mm_unpacklo_epi8(base_values, base_sign));
+                    base_acc[1] =
+                        _mm_add_epi16(base_acc[1], _mm_unpackhi_epi8(base_values, base_sign));
+                    qjl_acc[0] = _mm_add_epi16(qjl_acc[0], _mm_unpacklo_epi8(qjl_values, qjl_sign));
+                    qjl_acc[1] = _mm_add_epi16(qjl_acc[1], _mm_unpackhi_epi8(qjl_values, qjl_sign));
+                    dim += 1;
+                }
+                for half in 0..2 {
+                    let base_sign = _mm_cmpgt_epi16(zero, base_acc[half]);
+                    let qjl_sign = _mm_cmpgt_epi16(zero, qjl_acc[half]);
+                    base_i32[half * 2] = _mm_add_epi32(
+                        base_i32[half * 2],
+                        _mm_unpacklo_epi16(base_acc[half], base_sign),
+                    );
+                    base_i32[half * 2 + 1] = _mm_add_epi32(
+                        base_i32[half * 2 + 1],
+                        _mm_unpackhi_epi16(base_acc[half], base_sign),
+                    );
+                    qjl_i32[half * 2] = _mm_add_epi32(
+                        qjl_i32[half * 2],
+                        _mm_unpacklo_epi16(qjl_acc[half], qjl_sign),
+                    );
+                    qjl_i32[half * 2 + 1] = _mm_add_epi32(
+                        qjl_i32[half * 2 + 1],
+                        _mm_unpackhi_epi16(qjl_acc[half], qjl_sign),
+                    );
+                }
+            }
+            for quarter in 0..4 {
+                _mm_storeu_si128(base.as_mut_ptr().add(quarter * 4).cast(), base_i32[quarter]);
+                _mm_storeu_si128(qjl.as_mut_ptr().add(quarter * 4).cast(), qjl_i32[quarter]);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Segment build support
+// ---------------------------------------------------------------------------
+
+/// Streaming builder for one segment's TQ payload: doc/ordinal columns plus a
+/// block-packed codes column ready for `ann_disk` serialization.
+#[cfg(feature = "native")]
+pub struct TqFlatBuilder {
+    codec: std::sync::Arc<TqCodec>,
+    pub doc_ids: Vec<u32>,
+    pub ordinals: Vec<u16>,
+    pub codes: Vec<u8>,
+    pending_rows: Vec<Vec<u8>>,
+    pending_gammas: Vec<f32>,
+}
+
+#[cfg(feature = "native")]
+impl TqFlatBuilder {
+    pub fn new(codec: std::sync::Arc<TqCodec>) -> Self {
+        Self {
+            codec,
+            doc_ids: Vec::new(),
+            ordinals: Vec::new(),
+            codes: Vec::new(),
+            pending_rows: Vec::with_capacity(TQ_BLOCK_LANES),
+            pending_gammas: Vec::with_capacity(TQ_BLOCK_LANES),
+        }
+    }
+
+    #[inline]
+    pub fn codec(&self) -> &TqCodec {
+        &self.codec
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.doc_ids.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.doc_ids.is_empty()
+    }
+
+    /// Encode one contiguous `(labels, vectors)` batch in parallel while
+    /// preserving input order (lane order must match the doc-ID column).
+    pub fn add_batch(
+        &mut self,
+        labels: &[(u32, u16)],
+        vectors: &[f32],
+    ) -> Result<(), &'static str> {
+        use rayon::prelude::*;
+
+        let dim = self.codec.dim();
+        let expected = labels
+            .len()
+            .checked_mul(dim)
+            .ok_or("TQ input size overflow")?;
+        if vectors.len() != expected {
+            return Err("TQ vector and label matrices are inconsistent");
+        }
+        let padded_dim = self.codec.padded_dim();
+        let codec = std::sync::Arc::clone(&self.codec);
+        let rows: Vec<(Vec<u8>, f32)> = vectors
+            .par_chunks_exact(dim)
+            .map_init(TqEncodeScratch::default, |scratch, vector| {
+                let mut nibbles = vec![0u8; padded_dim];
+                let gamma = codec.encode_into(vector, &mut nibbles, scratch);
+                (nibbles, gamma)
+            })
+            .collect();
+        for (&(doc_id, ordinal), (nibbles, gamma)) in labels.iter().zip(rows) {
+            self.doc_ids.push(doc_id);
+            self.ordinals.push(ordinal);
+            self.pending_rows.push(nibbles);
+            self.pending_gammas.push(gamma);
+            if self.pending_rows.len() == TQ_BLOCK_LANES {
+                self.flush_block();
+            }
+        }
+        Ok(())
+    }
+
+    fn flush_block(&mut self) {
+        let rows: Vec<&[u8]> = self.pending_rows.iter().map(Vec::as_slice).collect();
+        tq_pack_block(
+            &rows,
+            &self.pending_gammas,
+            self.codec.padded_dim(),
+            &mut self.codes,
+        );
+        self.pending_rows.clear();
+        self.pending_gammas.clear();
+    }
+
+    /// Flush the trailing partial block (zero-padded lanes).
+    pub fn finish(&mut self) {
+        if !self.pending_rows.is_empty() {
+            self.flush_block();
+        }
+        debug_assert_eq!(
+            self.codes.len(),
+            tq_codes_column_len(self.doc_ids.len(), self.codec.code_size())
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seeded_unit_vector(dim: usize, seed: u64) -> Vec<f32> {
+        // Box-Muller from splitmix64 for an isotropic direction.
+        let mut state = seed;
+        let mut values: Vec<f32> = (0..dim)
+            .map(|_| {
+                let a = (splitmix64(&mut state) >> 11) as f64 / (1u64 << 53) as f64;
+                let b = (splitmix64(&mut state) >> 11) as f64 / (1u64 << 53) as f64;
+                let gaussian = (-2.0 * (1.0 - a).max(f64::MIN_POSITIVE).ln()).sqrt()
+                    * (2.0 * std::f64::consts::PI * b).cos();
+                gaussian as f32
+            })
+            .collect();
+        let norm = values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        values.iter_mut().for_each(|v| *v /= norm);
+        values
+    }
+
+    #[test]
+    fn rotation_is_orthonormal_and_deterministic() {
+        let rotation = TqRotation::new(100, 42);
+        assert_eq!(rotation.padded_dim(), 128);
+        let input = seeded_unit_vector(100, 7);
+        let mut fwht = Vec::new();
+        let mut output = vec![0.0f32; 128];
+        rotation.apply(&input, &mut fwht, &mut output);
+        let norm: f32 = output.iter().map(|v| v * v).sum();
+        assert!(
+            (norm - 1.0).abs() < 1e-5,
+            "rotation must preserve norm, got {norm}"
+        );
+
+        let mut second = vec![0.0f32; 128];
+        TqRotation::new(100, 42).apply(&input, &mut fwht, &mut second);
+        assert_eq!(output, second, "rotation must be deterministic");
+
+        // Distinct inputs keep their inner product (isometry).
+        let other = seeded_unit_vector(100, 8);
+        let mut other_rotated = vec![0.0f32; 128];
+        rotation.apply(&other, &mut fwht, &mut other_rotated);
+        let dot_before: f32 = input.iter().zip(&other).map(|(a, b)| a * b).sum();
+        let dot_after: f32 = output.iter().zip(&other_rotated).map(|(a, b)| a * b).sum();
+        assert!(
+            (dot_before - dot_after).abs() < 1e-4,
+            "rotation must preserve inner products: {dot_before} vs {dot_after}"
+        );
+    }
+
+    #[test]
+    fn analytic_codebook_is_symmetric_and_monotonic() {
+        for padded_dim in [8, 128, 1024] {
+            let codebook = TqCodebook::analytic(padded_dim);
+            let levels = &codebook.levels;
+            for pair in levels.windows(2) {
+                assert!(pair[0] < pair[1], "levels must be strictly increasing");
+            }
+            for index in 0..TQ_STAGE1_LEVELS / 2 {
+                assert_eq!(
+                    levels[index],
+                    -levels[TQ_STAGE1_LEVELS - 1 - index],
+                    "levels must be exactly symmetric for P={padded_dim}: {levels:?}"
+                );
+            }
+            assert!(levels[TQ_STAGE1_LEVELS - 1] < 1.0);
+            // Coordinates concentrate near ±1/sqrt(P); the top level must be
+            // on that scale, not at the interval edge.
+            let scale = 1.0 / (padded_dim as f32).sqrt();
+            assert!(
+                levels[TQ_STAGE1_LEVELS - 1] < 6.0 * scale,
+                "top level {} is implausibly large for P={padded_dim}",
+                levels[TQ_STAGE1_LEVELS - 1]
+            );
+        }
+    }
+
+    #[test]
+    fn encode_coordinate_matches_nearest_level() {
+        let codebook = TqCodebook::analytic(256);
+        for step in -1000i32..=1000 {
+            let value = step as f32 / 1000.0;
+            let code = codebook.encode_coordinate(value) as usize;
+            let nearest = codebook
+                .levels
+                .iter()
+                .enumerate()
+                .min_by(|a, b| (a.1 - value).abs().total_cmp(&(b.1 - value).abs()))
+                .unwrap()
+                .0;
+            assert_eq!(
+                code, nearest,
+                "value {value} coded {code}, nearest {nearest}"
+            );
+        }
+    }
+
+    #[test]
+    fn estimator_is_unbiased_and_tight() {
+        let dim = 96;
+        let codec = TqCodec::new(dim);
+        let mut scratch = TqEncodeScratch::default();
+        let mut nibbles = vec![0u8; codec.padded_dim()];
+
+        let pairs = 512;
+        let mut signed_error_sum = 0.0f64;
+        let mut squared_error_sum = 0.0f64;
+        let mut stage1_signed_error_sum = 0.0f64;
+        for pair in 0..pairs {
+            let vector = seeded_unit_vector(dim, 1000 + pair);
+            let query = seeded_unit_vector(dim, 900_000 + pair);
+            let gamma = codec.encode_into(&vector, &mut nibbles, &mut scratch);
+            let plan = TqQueryPlan::build(&codec, &query);
+            let estimate = plan.estimate_row(&nibbles, gamma);
+            let stage1_only = plan.estimate_row(&nibbles, 0.0);
+            let truth: f32 = vector.iter().zip(&query).map(|(a, b)| a * b).sum();
+            signed_error_sum += f64::from(estimate - truth);
+            squared_error_sum += f64::from(estimate - truth).powi(2);
+            stage1_signed_error_sum += f64::from(stage1_only - truth);
+        }
+        let mean_error = signed_error_sum / pairs as f64;
+        let rmse = (squared_error_sum / pairs as f64).sqrt();
+        let stage1_mean_error = stage1_signed_error_sum / pairs as f64;
+        assert!(
+            mean_error.abs() < 3e-3,
+            "QJL-corrected estimator must be unbiased: mean error {mean_error}"
+        );
+        assert!(rmse < 0.05, "estimator RMSE too large: {rmse}");
+        assert!(
+            mean_error.abs() <= stage1_mean_error.abs() + 1e-4,
+            "QJL correction must not increase bias: {mean_error} vs stage-1 {stage1_mean_error}"
+        );
+    }
+
+    #[test]
+    fn block_scoring_matches_row_estimates() {
+        let dim = 100; // padded to 128; exercises zero-padding
+        let codec = TqCodec::new(dim);
+        let mut scratch = TqEncodeScratch::default();
+        let query = seeded_unit_vector(dim, 3);
+        let plan = TqQueryPlan::build(&codec, &query);
+
+        let lanes = 13; // deliberately partial block
+        let mut rows = Vec::new();
+        let mut gammas = Vec::new();
+        for lane in 0..lanes {
+            let vector = seeded_unit_vector(dim, 50 + lane as u64);
+            let mut nibbles = vec![0u8; codec.padded_dim()];
+            let gamma = codec.encode_into(&vector, &mut nibbles, &mut scratch);
+            rows.push(nibbles);
+            gammas.push(gamma);
+        }
+        let row_refs: Vec<&[u8]> = rows.iter().map(Vec::as_slice).collect();
+        let mut block = Vec::new();
+        tq_pack_block(&row_refs, &gammas, codec.padded_dim(), &mut block);
+        assert_eq!(block.len(), tq_block_bytes(codec.code_size()));
+
+        let mut scores = [0.0f32; TQ_BLOCK_LANES];
+        tq_score_block(&plan, &block, &mut scores);
+        for lane in 0..lanes {
+            let expected = plan.estimate_row(&rows[lane], gammas[lane]);
+            // The block path uses i8 LUTs; agreement is approximate.
+            assert!(
+                (scores[lane] - expected).abs() < 0.02,
+                "lane {lane}: block score {} vs row estimate {expected}",
+                scores[lane]
+            );
+        }
+    }
+
+    #[test]
+    fn simd_accumulation_matches_scalar_reference_exactly() {
+        let padded_dim = 192; // not a multiple of the widen chunk
+        let mut state = 99u64;
+        let mut base_lut = vec![0i8; padded_dim * 16];
+        let mut qjl_lut = vec![0i8; padded_dim * 16];
+        for value in base_lut.iter_mut().chain(qjl_lut.iter_mut()) {
+            *value = (splitmix64(&mut state) as i32 % 255 - 127) as i8;
+        }
+        let mut nibble_bytes = vec![0u8; padded_dim * 8];
+        for byte in nibble_bytes.iter_mut() {
+            *byte = splitmix64(&mut state) as u8;
+        }
+
+        let mut base_reference = [0i32; TQ_BLOCK_LANES];
+        let mut qjl_reference = [0i32; TQ_BLOCK_LANES];
+        lut16::accumulate_block_scalar(
+            &base_lut,
+            &qjl_lut,
+            &nibble_bytes,
+            padded_dim,
+            &mut base_reference,
+            &mut qjl_reference,
+        );
+        let mut base_dispatch = [0i32; TQ_BLOCK_LANES];
+        let mut qjl_dispatch = [0i32; TQ_BLOCK_LANES];
+        lut16::accumulate_block(
+            &base_lut,
+            &qjl_lut,
+            &nibble_bytes,
+            padded_dim,
+            &mut base_dispatch,
+            &mut qjl_dispatch,
+        );
+        assert_eq!(
+            base_reference, base_dispatch,
+            "base sums must match exactly"
+        );
+        assert_eq!(qjl_reference, qjl_dispatch, "qjl sums must match exactly");
+    }
+
+    #[test]
+    fn fingerprint_pins_codec_constants() {
+        let codec = TqCodec::new(768);
+        assert_eq!(codec.padded_dim(), 1024);
+        assert_eq!(codec.code_size(), 512);
+        assert_ne!(codec.fingerprint(), 0);
+        assert_eq!(codec.fingerprint(), TqCodec::new(768).fingerprint());
+        assert_ne!(codec.fingerprint(), TqCodec::new(769).fingerprint());
+        // Golden value: the fingerprint is persisted as quantizer_version in
+        // every TQ segment. Any change to the hash, seeds, or codec constants
+        // MUST bump TQ_CODEC_VERSION — never silently re-derive.
+        assert_eq!(
+            codec.fingerprint(),
+            GOLDEN_FINGERPRINT_768,
+            "TQ fingerprint for dim 768 changed; existing segments would be \
+             rejected. Bump TQ_CODEC_VERSION deliberately instead."
+        );
+    }
+
+    const GOLDEN_FINGERPRINT_768: u64 = 4674713535241508736;
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn builder_packs_blocks_in_input_order() {
+        let dim = 32;
+        let codec = std::sync::Arc::new(TqCodec::new(dim));
+        let mut builder = TqFlatBuilder::new(std::sync::Arc::clone(&codec));
+        let count = 37; // two full blocks + partial
+        let labels: Vec<(u32, u16)> = (0..count).map(|i| (i as u32, (i % 3) as u16)).collect();
+        let mut vectors = Vec::new();
+        for i in 0..count {
+            vectors.extend(seeded_unit_vector(dim, 7_000 + i as u64));
+        }
+        builder.add_batch(&labels, &vectors).unwrap();
+        builder.finish();
+        assert_eq!(builder.doc_ids.len(), count);
+        assert_eq!(
+            builder.codes.len(),
+            tq_codes_column_len(count, codec.code_size())
+        );
+
+        // Every lane must score identically to encoding the row directly.
+        let query = seeded_unit_vector(dim, 1);
+        let plan = TqQueryPlan::build(&codec, &query);
+        let block_bytes = tq_block_bytes(codec.code_size());
+        let mut scratch = TqEncodeScratch::default();
+        let mut scores = [0.0f32; TQ_BLOCK_LANES];
+        for index in 0..count {
+            let block = &builder.codes[(index / TQ_BLOCK_LANES) * block_bytes..][..block_bytes];
+            tq_score_block(&plan, block, &mut scores);
+            let mut nibbles = vec![0u8; codec.padded_dim()];
+            let gamma = codec.encode_into(
+                &vectors[index * dim..(index + 1) * dim],
+                &mut nibbles,
+                &mut scratch,
+            );
+            let expected = plan.estimate_row(&nibbles, gamma);
+            assert!(
+                (scores[index % TQ_BLOCK_LANES] - expected).abs() < 0.02,
+                "vector {index} scored {} expected {expected}",
+                scores[index % TQ_BLOCK_LANES]
+            );
+        }
+    }
+}

--- a/hermes-core/src/structures/vector/quantization/tq.rs
+++ b/hermes-core/src/structures/vector/quantization/tq.rs
@@ -579,7 +579,9 @@ pub fn tq_pack_block(rows: &[&[u8]], gammas: &[f32], padded_dim: usize, output: 
 }
 
 mod lut16 {
-    use super::{TQ_ACCUMULATE_CHUNK_DIMS, TQ_BLOCK_LANES};
+    #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+    use super::TQ_ACCUMULATE_CHUNK_DIMS;
+    use super::TQ_BLOCK_LANES;
 
     /// Accumulate both LUT sums for 16 lanes over all dimensions.
     /// `nibble_bytes` is dimension-major: 8 bytes per dimension, byte `j`

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -727,32 +727,37 @@ pub fn schema_to_sdl(schema: &Schema) -> String {
                 let idx_name = match cfg.index_type {
                     VectorIndexType::Flat => "flat",
                     VectorIndexType::IvfPq => "ivf_pq",
+                    VectorIndexType::Tq => "tq",
                 };
                 idx_params.push(idx_name.to_string());
-                if let Some(nc) = cfg.num_clusters {
-                    idx_params.push(format!("num_clusters: {}", nc));
-                }
-                if cfg.nprobe != 64 {
-                    idx_params.push(format!("nprobe: {}", cfg.nprobe));
-                }
-                if cfg.ivf_routing != IvfRoutingMode::Auto {
-                    let routing = match cfg.ivf_routing {
-                        IvfRoutingMode::Auto => unreachable!(),
-                        IvfRoutingMode::Flat => "flat",
-                        IvfRoutingMode::TwoLevel => "two_level",
-                        IvfRoutingMode::Hnsw => "hnsw",
-                    };
-                    idx_params.push(format!("routing: {routing}"));
-                }
-                if let Some(soar) = &cfg.soar {
-                    let mode = if soar.selective {
-                        "selective"
-                    } else if soar.num_secondary > 1 {
-                        "aggressive"
-                    } else {
-                        "full"
-                    };
-                    idx_params.push(format!("soar: {mode}"));
+                // TQ scans every code: IVF knobs do not apply and re-parsing
+                // them would warn.
+                if cfg.index_type != VectorIndexType::Tq {
+                    if let Some(nc) = cfg.num_clusters {
+                        idx_params.push(format!("num_clusters: {}", nc));
+                    }
+                    if cfg.nprobe != 64 {
+                        idx_params.push(format!("nprobe: {}", cfg.nprobe));
+                    }
+                    if cfg.ivf_routing != IvfRoutingMode::Auto {
+                        let routing = match cfg.ivf_routing {
+                            IvfRoutingMode::Auto => unreachable!(),
+                            IvfRoutingMode::Flat => "flat",
+                            IvfRoutingMode::TwoLevel => "two_level",
+                            IvfRoutingMode::Hnsw => "hnsw",
+                        };
+                        idx_params.push(format!("routing: {routing}"));
+                    }
+                    if let Some(soar) = &cfg.soar {
+                        let mode = if soar.selective {
+                            "selective"
+                        } else if soar.num_secondary > 1 {
+                            "aggressive"
+                        } else {
+                            "full"
+                        };
+                        idx_params.push(format!("soar: {mode}"));
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Adds a **training-free 4-bit dense ANN lane** based on TurboQuant (arXiv 2504.19874; layout/LUT16 scoring after Faiss FastScan and mayflower/pg_turboquant, both MIT). Design doc: `docs/turboquant-quantization.md`.

- **Codec** (`structures/vector/quantization/tq.rs`): seeded Hadamard rotation (FWHT + sign flips + permutation), analytic 3-bit Lloyd-Max codebook for the unit-sphere coordinate density (no training data, exactly symmetrized), 1-bit QJL residual sign + per-vector `gamma` giving an **unbiased inner-product estimator** (pinned by a statistical test, not assumed).
- **LUT16 kernels**: NEON `TBL` + x86 SSSE3 `PSHUFB`, dual i8 LUTs, i16 accumulation in 128-dim chunks widened to i32; scalar fallback pinned **bit-exact** against SIMD. WASM reads payloads via the scalar path.
- **Segment integration**: `AnnKind::TqFlat` in the run-based ANN container (16-lane block-packed codes column, kind-aware validation), payload built unconditionally at commit (**no global artifacts, no `build_vector_index()`**), pure byte-copy merge with a loud re-encode upgrade for sources lacking a payload, compatibility gated by a deterministic codec fingerprint in `quantizer_version` (golden-value pinned).
- **Query**: estimated-similarity scan feeding the existing exact re-rank on async and sync paths; per-query plan shared across segments via `DensePlanCache` (extends the IVF-PQ `probe_cache` pattern).
- **SDL**: `field e: dense_vector<768> [indexed<tq>]`; inapplicable IVF knobs warn loudly and the config canonicalizes to `DenseVectorConfig::tq()`.

## Benchmark

aarch64 (Apple Silicon, NEON), 100k docs × 768 dims, k=10, nprobe 64/1024, rerank 2.0, warmed mmap. Reproduce: `cargo test --release -p hermes-core --features native tq_ivf_pq_flat_benchmark -- --ignored --nocapture`

| method | build (s) | train (s) | .vectors (MB) | p50 (ms) | p95 (ms) | recall@10 |
|---|---|---|---|---|---|---|
| flat (exact) | 0.5 | — | 293.5 | 18.50 | 94.47 | 1.000 |
| **tq** | 1.4 | **0** | 343.3 | **9.33** | **11.33** | **0.959** |
| ivf_pq | 0.5 | 466.9 | 303.4 | 31.16 | 43.14 | 0.786 |

TQ is a compressed **full scan** (O(N)/query): it replaces the brute-force lane and small/medium segments; IVF-PQ remains the sub-linear trained lane at scale. x86 kernels are correctness-pinned vs the scalar reference; x86 perf numbers pending before quoting them anywhere.

## Review pass

8-angle review executed; 10 confirmed/plausible findings all fixed in this branch (loader TOC gates for the new kind, cross-segment plan cache + test-only LUT removal, latent `segment_needs_vector_rewrite` misclassification, heap-allocated codebook grid, SDL config canonicalization, observable empty-payload drop, single source of truth for the block layout, guard/unwrap decoupling, honest codec memory accounting). Deferred as follow-ups: per-kind merge strategy generalization, per-dim codec memoization at segment open, partial byte-copy on mixed-payload upgrades.

## Follow-up (next PR)

**IVF-TQ**: TQ residual codec inside the trained IVF router — sub-linear scan with a training-free leaf codec; its query plan needs one shared LUT per query instead of nprobe ADC tables.

## Testing

- 876 lib tests + integration tests green; clippy `-D warnings` clean; fmt clean; WASM feature build clean.
- New: codec math tests (unbiasedness, symmetry, rotation isometry, SIMD==scalar exact), format roundtrip + pure-copy merge byte-equality, corruption refusal, e2e search/recall/multi-thread/merge tests.
- Note: `hermes-llm --all-features` fails to compile on main already (pre-existing, verified via stash) — unrelated to this PR.