### PR TITLE
feat(core): IVF-TQ — trained IVF router with TurboQuant residual leaves (index_type: ivf_tq)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -283,12 +283,15 @@ for exact brute-force search and as the accumulation format before an
 field e: dense_vector<768, f16> [indexed]                                      # global IVF-PQ
 field e: dense_vector<768, f16> [indexed<ivf_pq, routing: hnsw, nprobe: 64>]
 field e: dense_vector<768, f16> [indexed<tq>]                                  # training-free TQ
+field e: dense_vector<768, f16> [indexed<ivf_tq, nprobe: 64>]                  # trained router, TQ leaves
 field e: dense_vector<768, f16> [indexed<flat>]                                # exact full scan
 field e: dense_vector<768> [stored]                                            # stored, not indexed
 ```
 
 `tq` ignores `num_clusters`, `nprobe`, `routing`, and `soar` (it scans every
 code) and warns when they are set; `rerank_factor` applies unchanged.
+`ivf_tq` combines the trained coarse router (all IVF knobs apply) with the
+training-free TQ leaf codec — only centroids are trained, never a codebook.
 
 When `num_clusters` is omitted, training chooses a corpus-sized leaf count
 using an 8×sqrt(N) target bounded by sample quality and artifact memory. Routing

--- a/docs/turboquant-quantization.md
+++ b/docs/turboquant-quantization.md
@@ -1,6 +1,6 @@
 # TurboQuant (TQ) — training-free dense ANN codec
 
-Status: implemented (v1, `AnnKind::TqFlat`).
+Status: implemented (v1 `AnnKind::TqFlat`, v1.1 adds `AnnKind::IvfTq`).
 
 ## Motivation
 
@@ -117,28 +117,59 @@ ground truth = the flat index's exact cosine top-10.
 
 Measured 2026-07-23, aarch64 (Apple Silicon, NEON kernels), 100k docs ×
 768 dims, 256 corpus clusters, 100 queries, k=10, `nprobe: 64` over 1,024
-trained leaves, `rerank_factor: 2.0`, mmap directory, page cache warmed:
+trained leaves, `rerank_factor: 2.0`, mmap directory, page cache warmed
+(single idle-machine run; compare rows within the table, not across runs):
 
-| method       | build (s) | train (s) | .vectors (MB) | p50 (ms) | p95 (ms)  | recall@10 |
-| ------------ | --------- | --------- | ------------- | -------- | --------- | --------- |
-| flat (exact) | 0.5       | —         | 293.5         | 18.50    | 94.47     | 1.000     |
-| **tq**       | 1.4       | **0**     | 343.3         | **9.33** | **11.33** | **0.959** |
-| ivf_pq       | 0.5       | 466.9     | 303.4         | 31.16    | 43.14     | 0.786     |
+| method       | build (s) | train (s) | .vectors (MB) | p50 (ms) | p95 (ms) | recall@10 |
+| ------------ | --------- | --------- | ------------- | -------- | -------- | --------- |
+| flat (exact) | 0.4       | —         | 293.5         | 4.85     | 5.51     | 1.000     |
+| **tq**       | 0.7       | **0**     | 343.3         | **3.27** | **3.50** | 0.959     |
+| ivf_pq       | 0.8       | 212.2     | 303.4         | 8.54     | 12.29    | 0.786     |
+| **ivf_tq**   | 0.4       | 143.3     | 351.3         | 3.33     | 5.81     | **0.997** |
 
-At this scale TQ dominates: ~2× faster than exact at p50 with 0.96 recall and
-zero training, while IVF-PQ pays ~8 minutes of training and lands at 0.786
-recall at nprobe 64 (its per-query cost here is dominated by building 64 ADC
-tables per query). The caveat is asymptotic: TQ scans every code (O(N) per
-query, ~9 ms per 100k docs at 768 dims on this machine), while IVF-PQ scans
-`nprobe/num_clusters` of the corpus — at millions of vectors per segment the
-trained lane wins latency. TQ therefore replaces the brute-force lane and
-small-to-medium segments, not the billion-scale trained path. x86_64
-SSSE3/AVX2 kernels are correctness-pinned against the scalar reference in
-unit tests; perf numbers on x86 should be captured before quoting them.
+Two headline results. First, training-free `tq` beats exact scan by ~1.5× at
+p50 with 0.96 recall and zero training. Second, at the same probe budget
+`ivf_tq` beats `ivf_pq` on every axis: +0.21 recall@10 (0.997 vs 0.786 — the
+4-bit residual estimate keeps the true top-10 alive inside the probed set
+where 1-bit/dim PQ loses them), 2.6× lower p50 (no per-cluster ADC table
+builds, which dominate IVF-PQ's query cost at nprobe 64), and ~33% less
+training time (no PQ/OPQ stage). The asymptotic caveat applies to `tq` only:
+it scans every code (O(N)/query), so at millions of vectors per segment the
+probed lanes (`ivf_tq`, `ivf_pq`) win latency; `tq` remains the
+zero-training lane for small/medium segments and the pre-training state.
+x86_64 SSSE3/AVX2 kernels are correctness-pinned against the scalar
+reference in unit tests; perf numbers on x86 should be captured before
+quoting them.
+
+## IVF-TQ (`index_type: ivf_tq`)
+
+Sub-linear probing with the training-free leaf codec: the trained global
+coarse router (same `build_vector_index()` machinery, HNSW/SOAR supported)
+plus TQ codes of the centroid residual `r = x − c` per leaf. Residual norms
+carry ranking information, so each vector stores `scale = ‖r‖` next to
+`gamma`, and the leaf estimate is
+
+```
+⟨q̂, x⟩ = ⟨q̂, c⟩ + scale · est⟨q̂, r̂⟩
+```
+
+Because residuals are encoded in absolute rotated space (not per-cluster
+tables), the whole query needs **one** LUT set plus one `⟨q̂,c⟩` scalar per
+probed cluster — plan build is `O(P·16 + nprobe·dim)` instead of IVF-PQ's
+`nprobe` ADC tables (which dominated its measured per-query cost). Blocks are
+`[16 scales][16 gammas][nibbles]`; runs are per-leaf, merges byte-copy.
+On disk `quantizer_version` is the trained centroid generation and
+`codebook_version` carries the codec fingerprint; only centroids are stored
+as trained artifacts (`codebook_file` must be absent).
+
+```sdl
+field e: dense_vector<768, f16> [indexed<ivf_tq, num_clusters: 1024, nprobe: 64>]
+```
+
+`num_clusters`, `nprobe`, `routing`, and `soar` all apply (unlike `tq`).
 
 ## Explicit non-goals in v1
 
-- No IVF-routed TQ leaves (would reuse trained coarse centroids; follow-up).
 - No configurable bit width (4 = 3+1 fixed; header carries it for evolution).
 - No WASM in-browser TQ _encoding_ (WASM reads native-built payloads;
   `LocalIndex` encode support is a follow-up).

--- a/hermes-core/src/dsl/schema.rs
+++ b/hermes-core/src/dsl/schema.rs
@@ -119,6 +119,10 @@ pub enum VectorIndexType {
     /// (`docs/turboquant-quantization.md`). Available from the first segment
     /// build with no global artifacts.
     Tq,
+    /// Trained global IVF router with TurboQuant-coded centroid residuals:
+    /// sub-linear probing like IVF-PQ, but the leaf codec needs no trained
+    /// codebook (only coarse centroids).
+    IvfTq,
 }
 
 /// How an IVF coarse codebook is searched.
@@ -305,6 +309,20 @@ impl DenseVectorConfig {
         }
     }
 
+    /// Create IVF-TQ configuration: trained coarse router, TurboQuant leaves.
+    pub fn ivf_tq(dim: usize, num_clusters: Option<usize>, nprobe: usize) -> Self {
+        Self {
+            dim,
+            index_type: VectorIndexType::IvfTq,
+            quantization: DenseVectorQuantization::F32,
+            num_clusters,
+            ivf_routing: IvfRoutingMode::Auto,
+            nprobe,
+            unit_norm: true,
+            soar: None,
+        }
+    }
+
     /// Set storage quantization
     pub fn with_quantization(mut self, quantization: DenseVectorQuantization) -> Self {
         self.quantization = quantization;
@@ -336,7 +354,10 @@ impl DenseVectorConfig {
 
     /// Check if this config uses IVF
     pub fn uses_ivf(&self) -> bool {
-        self.index_type == VectorIndexType::IvfPq
+        matches!(
+            self.index_type,
+            VectorIndexType::IvfPq | VectorIndexType::IvfTq
+        )
     }
 
     /// Check if this config is flat (brute-force)

--- a/hermes-core/src/dsl/sdl/mod.rs
+++ b/hermes-core/src/dsl/sdl/mod.rs
@@ -379,6 +379,7 @@ fn parse_single_index_config_param(config: &mut IndexConfig, p: pest::iterators:
             }
             "ivf" => config.binary_index_type = Some(super::schema::BinaryIndexType::Ivf),
             "ivf_pq" => config.index_type = Some(VectorIndexType::IvfPq),
+            "ivf_tq" => config.index_type = Some(VectorIndexType::IvfTq),
             "tq" => config.index_type = Some(VectorIndexType::Tq),
             _ => {}
         },
@@ -392,6 +393,7 @@ fn parse_single_index_config_param(config: &mut IndexConfig, p: pest::iterators:
                     }
                     "ivf" => config.binary_index_type = Some(super::schema::BinaryIndexType::Ivf),
                     "ivf_pq" => config.index_type = Some(VectorIndexType::IvfPq),
+                    "ivf_tq" => config.index_type = Some(VectorIndexType::IvfTq),
                     "tq" => config.index_type = Some(VectorIndexType::Tq),
                     _ => {}
                 }

--- a/hermes-core/src/dsl/sdl/sdl.pest
+++ b/hermes-core/src/dsl/sdl/sdl.pest
@@ -148,7 +148,7 @@ index_config_param = { index_type_kwarg | num_clusters_kwarg | nprobe_kwarg | ro
 //   token_position - only token position within text for phrase queries
 positions_kwarg = { "positions" | "ordinal" | "token_position" }
 index_type_kwarg = { "index" ~ ":" ~ index_type_spec }
-index_type_spec = { "flat" | "ivf_pq" | "ivf" | "tq" }
+index_type_spec = { "flat" | "ivf_pq" | "ivf_tq" | "ivf" | "tq" }
 num_clusters_kwarg = { "num_clusters" ~ ":" ~ num_clusters_spec }
 num_clusters_spec = @{ ASCII_DIGIT+ }
 nprobe_kwarg = { "nprobe" ~ ":" ~ nprobe_spec }

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -457,7 +457,9 @@ impl IndexMetadata {
                 ))
             })?;
             match field_meta.index_type {
-                VectorFieldIndexType::Float(index_type @ VectorIndexType::IvfPq) => {
+                VectorFieldIndexType::Float(
+                    index_type @ (VectorIndexType::IvfPq | VectorIndexType::IvfTq),
+                ) => {
                     let entry = schema
                         .get_field_entry(crate::dsl::Field(*field_id))
                         .ok_or_else(|| {
@@ -507,25 +509,34 @@ impl IndexMetadata {
                                 "invalid trained centroid routing for field {field_id}: {error}"
                             ))
                         })?;
-                    let codebook_file = field_meta.codebook_file.as_deref().ok_or_else(|| {
-                        Error::Corruption(format!(
-                            "trained float IVF-PQ field {field_id} has no codebook_file"
-                        ))
-                    })?;
-                    let codebook: crate::structures::PQCodebook =
-                        load_trained_artifact(dir, *field_id, "codebook", codebook_file).await?;
-                    codebook.validate().map_err(|error| {
-                        Error::Corruption(format!(
-                            "invalid trained codebook for field {field_id}: {error}"
-                        ))
-                    })?;
-                    if codebook.config.dim != expected_dim {
+                    if index_type == VectorIndexType::IvfPq {
+                        let codebook_file =
+                            field_meta.codebook_file.as_deref().ok_or_else(|| {
+                                Error::Corruption(format!(
+                                    "trained float IVF-PQ field {field_id} has no codebook_file"
+                                ))
+                            })?;
+                        let codebook: crate::structures::PQCodebook =
+                            load_trained_artifact(dir, *field_id, "codebook", codebook_file)
+                                .await?;
+                        codebook.validate().map_err(|error| {
+                            Error::Corruption(format!(
+                                "invalid trained codebook for field {field_id}: {error}"
+                            ))
+                        })?;
+                        if codebook.config.dim != expected_dim {
+                            return Err(Error::Corruption(format!(
+                                "trained codebook for field {field_id} has dimension {}, expected {expected_dim}",
+                                codebook.config.dim
+                            )));
+                        }
+                        codebooks.insert(*field_id, Arc::new(codebook));
+                    } else if field_meta.codebook_file.is_some() {
+                        // IVF-TQ's leaf codec is derived, never trained.
                         return Err(Error::Corruption(format!(
-                            "trained codebook for field {field_id} has dimension {}, expected {expected_dim}",
-                            codebook.config.dim
+                            "trained IVF-TQ field {field_id} unexpectedly references a codebook file"
                         )));
                     }
-                    codebooks.insert(*field_id, Arc::new(codebook));
                     centroids.insert(*field_id, Arc::new(c));
                 }
                 VectorFieldIndexType::Binary(BinaryIndexType::Ivf) => {

--- a/hermes-core/src/index/tests/tq_bench.rs
+++ b/hermes-core/src/index/tests/tq_bench.rs
@@ -127,7 +127,7 @@ async fn run_method(
     let build_secs = build_start.elapsed().as_secs_f64();
 
     let train_start = std::time::Instant::now();
-    let train_secs = if label == "ivf_pq" {
+    let train_secs = if label == "ivf_pq" || label == "ivf_tq" {
         let writer = IndexWriter::open(dir.clone(), index_config.clone())
             .await
             .expect("reopen writer for training");
@@ -148,6 +148,7 @@ async fn run_method(
             crate::segment::VectorIndex::IvfPq(_) => "ivf_pq",
             crate::segment::VectorIndex::BinaryIvf(_) => "binary_ivf",
             crate::segment::VectorIndex::Tq { .. } => "tq_flat",
+            crate::segment::VectorIndex::IvfTq { .. } => "ivf_tq",
         })
         .next()
         .unwrap_or("none")
@@ -235,6 +236,13 @@ async fn tq_ivf_pq_flat_benchmark() {
         &queries,
     )
     .await;
+    let ivf_tq = run_method(
+        "ivf_tq",
+        DenseVectorConfig::ivf_tq(DIM, Some(IVF_NUM_CLUSTERS), NPROBE),
+        &corpus,
+        &queries,
+    )
+    .await;
 
     assert_eq!(flat.ann_kind, "none", "flat must not build an ANN payload");
     assert_eq!(
@@ -245,12 +253,16 @@ async fn tq_ivf_pq_flat_benchmark() {
         ivf_pq.ann_kind, "ivf_pq",
         "ivf_pq must be trained and built"
     );
+    assert_eq!(
+        ivf_tq.ann_kind, "ivf_tq",
+        "ivf_tq must be trained and built"
+    );
 
     println!(
         "\n{:<8} {:>10} {:>10} {:>12} {:>9} {:>9} {:>9}",
         "method", "build(s)", "train(s)", "vectors(MB)", "p50(ms)", "p95(ms)", "recall@10"
     );
-    for report in [&flat, &tq, &ivf_pq] {
+    for report in [&flat, &tq, &ivf_pq, &ivf_tq] {
         println!(
             "{:<8} {:>10.1} {:>10.1} {:>12.1} {:>9.2} {:>9.2} {:>9.3}",
             report.label,
@@ -264,8 +276,9 @@ async fn tq_ivf_pq_flat_benchmark() {
     }
     let flat_bytes = flat.vectors_bytes as f64;
     println!(
-        "\nANN payload overhead vs flat storage: tq +{:.1} MB, ivf_pq +{:.1} MB",
+        "\nANN payload overhead vs flat storage: tq +{:.1} MB, ivf_pq +{:.1} MB, ivf_tq +{:.1} MB",
         (tq.vectors_bytes as f64 - flat_bytes) / (1024.0 * 1024.0),
         (ivf_pq.vectors_bytes as f64 - flat_bytes) / (1024.0 * 1024.0),
+        (ivf_tq.vectors_bytes as f64 - flat_bytes) / (1024.0 * 1024.0),
     );
 }

--- a/hermes-core/src/index/tests/vector.rs
+++ b/hermes-core/src/index/tests/vector.rs
@@ -1720,3 +1720,195 @@ async fn test_tq_dense_multi_segment_merge_preserves_payload() {
     assert!((post_first_score - pre_first_score).abs() < 1e-5);
     assert!((post_second_score - pre_second_score).abs() < 1e-5);
 }
+
+/// IVF-TQ end-to-end: coarse centroids trained via build_vector_index (no
+/// codebook), segments rebuilt into the generation, probed search feeding
+/// exact re-rank, and payload survival across a merge.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ivf_tq_end_to_end_with_merge() {
+    use crate::dsl::DenseVectorConfig;
+    use crate::query::DenseVectorQuery;
+
+    let dim = 32;
+    let clusters = 12usize;
+    let members = 20usize;
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    let embedding = sb.add_dense_vector_field_with_config(
+        "embedding",
+        true,
+        true,
+        DenseVectorConfig::ivf_tq(dim, Some(8), 8),
+    );
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+
+    let unit_vector = |seed: usize| -> Vec<f32> {
+        let mut values: Vec<f32> = (0..dim)
+            .map(|d| {
+                let mut state = (seed as u64)
+                    .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+                    .wrapping_add(d as u64);
+                state ^= state >> 33;
+                state = state.wrapping_mul(0xFF51_AFD7_ED55_8CCD);
+                state ^= state >> 33;
+                ((state >> 40) as f32 / (1u64 << 24) as f32) - 0.5
+            })
+            .collect();
+        let norm = values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        values.iter_mut().for_each(|v| *v /= norm);
+        values
+    };
+    let normalize = |mut values: Vec<f32>| -> Vec<f32> {
+        let norm = values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        values.iter_mut().for_each(|v| *v /= norm);
+        values
+    };
+
+    // Clustered corpus split across two segments.
+    let mut doc_vectors: Vec<(String, Vec<f32>)> = Vec::new();
+    for cluster in 0..clusters {
+        let center = unit_vector(cluster);
+        for member in 0..members {
+            let noise = unit_vector(90_000 + cluster * members + member);
+            let vector = normalize(
+                center
+                    .iter()
+                    .zip(&noise)
+                    .map(|(c, n)| c + 0.35 * n)
+                    .collect(),
+            );
+            doc_vectors.push((format!("cluster {cluster} member {member}"), vector));
+        }
+    }
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+    let half = doc_vectors.len() / 2;
+    for (doc_title, vector) in &doc_vectors[..half] {
+        let mut doc = Document::new();
+        doc.add_text(title, doc_title.clone());
+        doc.add_dense_vector(embedding, vector.clone());
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    for (doc_title, vector) in &doc_vectors[half..] {
+        let mut doc = Document::new();
+        doc.add_text(title, doc_title.clone());
+        doc.add_dense_vector(embedding, vector.clone());
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    // Train coarse centroids and rebuild both segments into the generation.
+    writer.build_vector_index().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let segments = index.segment_readers().await.unwrap();
+    assert!(!segments.is_empty());
+    for segment in &segments {
+        assert!(
+            matches!(
+                segment.vector_indexes().get(&embedding.0),
+                Some(crate::segment::VectorIndex::IvfTq { .. })
+            ),
+            "every segment must carry an IVF-TQ payload after training"
+        );
+    }
+
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    // Duplicate queries must rank their own document first after re-rank.
+    for target in [3usize, half + 7, doc_vectors.len() - 1] {
+        let (target_title, target_vector) = &doc_vectors[target];
+        let query = DenseVectorQuery::new(embedding, target_vector.clone()).with_nprobe(8);
+        let results = searcher.search(&query, 5).await.unwrap();
+        let top = searcher
+            .doc(results[0].segment_id, results[0].doc_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            top.get_first(title).unwrap().as_text().unwrap(),
+            target_title.as_str(),
+            "duplicate query must rank its own document first"
+        );
+        assert!(results[0].score > 0.999);
+    }
+
+    // Recall@10 vs exact cosine for cluster-center queries with full probing.
+    let k = 10;
+    let mut hits = 0usize;
+    let mut total = 0usize;
+    for cluster in 0..clusters {
+        let query_vector = unit_vector(cluster);
+        let mut exact: Vec<(usize, f32)> = doc_vectors
+            .iter()
+            .enumerate()
+            .map(|(index, (_, vector))| {
+                let dot: f32 = vector.iter().zip(&query_vector).map(|(a, b)| a * b).sum();
+                (index, dot)
+            })
+            .collect();
+        exact.sort_by(|a, b| b.1.total_cmp(&a.1));
+        let expected: std::collections::HashSet<&str> = exact[..k]
+            .iter()
+            .map(|(index, _)| doc_vectors[*index].0.as_str())
+            .collect();
+        let query = DenseVectorQuery::new(embedding, query_vector).with_nprobe(8);
+        let results = searcher.search(&query, k).await.unwrap();
+        for result in &results {
+            let doc = searcher
+                .doc(result.segment_id, result.doc_id)
+                .await
+                .unwrap()
+                .unwrap();
+            hits +=
+                usize::from(expected.contains(doc.get_first(title).unwrap().as_text().unwrap()));
+        }
+        total += k;
+    }
+    let recall = hits as f32 / total as f32;
+    assert!(
+        recall >= 0.9,
+        "IVF-TQ recall@{k} with full probing must stay high, got {recall}"
+    );
+
+    // Merge: payloads byte-copy and results survive doc-base remapping.
+    let mut writer = IndexWriter::open(dir.clone(), config.clone())
+        .await
+        .unwrap();
+    writer.force_merge().await.unwrap();
+    drop(writer);
+    let index = Index::open(dir, config).await.unwrap();
+    let segments = index.segment_readers().await.unwrap();
+    assert_eq!(segments.len(), 1);
+    assert!(
+        matches!(
+            segments[0].vector_indexes().get(&embedding.0),
+            Some(crate::segment::VectorIndex::IvfTq { .. })
+        ),
+        "merged segment must keep its IVF-TQ payload (byte-copy merge)"
+    );
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let (target_title, target_vector) = &doc_vectors[half + 7];
+    let query = DenseVectorQuery::new(embedding, target_vector.clone()).with_nprobe(8);
+    let results = searcher.search(&query, 3).await.unwrap();
+    let top = searcher
+        .doc(results[0].segment_id, results[0].doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        top.get_first(title).unwrap().as_text().unwrap(),
+        target_title.as_str(),
+        "doc bases must survive the merge"
+    );
+}

--- a/hermes-core/src/index/vector_builder.rs
+++ b/hermes-core/src/index/vector_builder.rs
@@ -47,6 +47,9 @@ enum TrainedFieldArtifacts {
         codebook: crate::structures::PQCodebook,
         pq_sample_count: usize,
     },
+    /// IVF-TQ: only the coarse router is trained; the TQ leaf codec is
+    /// derived from the dimension.
+    FloatCentroids(crate::structures::CoarseCentroids),
     Binary(crate::structures::BinaryCoarseQuantizer),
 }
 
@@ -822,6 +825,19 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     pq_sample_count,
                 }
             }
+            (IvfFieldConfig::Float(config), TrainingSample::Float(vectors))
+                if config.index_type == VectorIndexType::IvfTq =>
+            {
+                let mut coarse_config = crate::structures::CoarseConfig::new(dim, num_clusters)
+                    .with_routing(config.ivf_routing);
+                if let Some(soar) = config.soar.clone() {
+                    coarse_config = coarse_config.with_soar(soar);
+                }
+                TrainedFieldArtifacts::FloatCentroids(crate::structures::CoarseCentroids::train(
+                    &coarse_config,
+                    vectors,
+                ))
+            }
             (IvfFieldConfig::Binary(config), TrainingSample::Binary(codes)) => {
                 let mut binary_config = crate::structures::BinaryIvfConfig::new(dim, num_clusters);
                 binary_config.max_train_samples = sample_count;
@@ -844,6 +860,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
         let actual_num_clusters = match &artifacts {
             TrainedFieldArtifacts::Float { centroids, .. } => centroids.num_clusters as usize,
+            TrainedFieldArtifacts::FloatCentroids(centroids) => centroids.num_clusters as usize,
             TrainedFieldArtifacts::Binary(quantizer) => quantizer.num_clusters as usize,
         };
         Ok(TrainedFieldModel {
@@ -882,6 +899,15 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     update.field_id,
                     centroids.num_clusters,
                     pq_sample_count,
+                );
+            }
+            TrainedFieldArtifacts::FloatCentroids(centroids) => {
+                self.save_trained_artifact(&centroids, &update.centroids_file)
+                    .await?;
+                log::info!(
+                    "Saved IVF-TQ coarse artifact for field {} ({} clusters; leaf codec is derived)",
+                    update.field_id,
+                    centroids.num_clusters,
                 );
             }
             TrainedFieldArtifacts::Binary(quantizer) => {

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -2296,6 +2296,13 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 {
                     matches!(ann, Some(crate::segment::VectorIndex::Tq { .. }))
                 }
+                crate::dsl::FieldType::DenseVector
+                    if entry.dense_vector_config.as_ref().is_some_and(|config| {
+                        config.index_type == crate::dsl::VectorIndexType::IvfTq
+                    }) =>
+                {
+                    matches!(ann, Some(crate::segment::VectorIndex::IvfTq { .. }))
+                }
                 crate::dsl::FieldType::DenseVector => {
                     matches!(ann, Some(crate::segment::VectorIndex::IvfPq(_)))
                 }

--- a/hermes-core/src/segment/ann_build.rs
+++ b/hermes-core/src/segment/ann_build.rs
@@ -10,6 +10,8 @@ pub const FLAT_TYPE: u8 = 4;
 pub const BINARY_IVF_TYPE: u8 = 6;
 /// TurboQuant flat payload; training-free, no global artifacts.
 pub const TQ_FLAT_TYPE: u8 = 7;
+/// IVF-TQ payload: trained coarse router, TurboQuant residual leaves.
+pub const IVF_TQ_TYPE: u8 = 8;
 
 // --- Native-only builder/serialization functions ---
 
@@ -33,6 +35,27 @@ pub fn new_ivf_pq(
 pub fn serialize_ivf_pq(index: IVFPQIndex, num_clusters: u32) -> crate::Result<Vec<u8>> {
     let mut bytes = Vec::new();
     crate::segment::ann_disk::write_built_ivf_pq(&index, num_clusters, &mut bytes)
+        .map_err(crate::Error::Io)?;
+    Ok(bytes)
+}
+
+/// Encode one segment's vectors into IVF-TQ leaves against the trained
+/// global coarse centroids.
+#[cfg(feature = "native")]
+pub fn build_ivf_tq(
+    dim: usize,
+    routing: crate::dsl::IvfRoutingMode,
+    centroids: &CoarseCentroids,
+    doc_id_ordinals: &[(u32, u16)],
+    vectors: &[f32],
+) -> crate::Result<Vec<u8>> {
+    let codec = std::sync::Arc::new(crate::structures::TqCodec::new(dim));
+    let mut index = crate::structures::IvfTqIndex::new(dim, routing, centroids.version, codec);
+    index
+        .add_vectors_parallel(centroids, doc_id_ordinals, vectors)
+        .map_err(|error| crate::Error::Internal(format!("IVF-TQ encode failed: {error}")))?;
+    let mut bytes = Vec::new();
+    crate::segment::ann_disk::write_built_ivf_tq(&index, centroids.num_clusters, &mut bytes)
         .map_err(crate::Error::Io)?;
     Ok(bytes)
 }

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -42,6 +42,8 @@ pub(crate) enum AnnKind {
     BinaryIvf = 2,
     /// TurboQuant flat scan: single logical cluster, block-packed codes.
     TqFlat = 3,
+    /// Trained IVF router with TurboQuant-coded centroid residuals.
+    IvfTq = 4,
 }
 
 impl AnnKind {
@@ -50,6 +52,7 @@ impl AnnKind {
             1 => Ok(Self::IvfPq),
             2 => Ok(Self::BinaryIvf),
             3 => Ok(Self::TqFlat),
+            4 => Ok(Self::IvfTq),
             _ => Err(invalid_data(format!("unknown ANN kind {value}"))),
         }
     }
@@ -63,11 +66,15 @@ fn expected_codes_column_len(kind: AnnKind, count: usize, code_size: usize) -> i
         AnnKind::IvfPq | AnnKind::BinaryIvf => count
             .checked_mul(code_size)
             .ok_or_else(|| invalid_data("ANN code column size overflows usize")),
-        // Single source of truth for the block-packed layout lives in tq.rs.
+        // Single source of truth for the block-packed layouts lives in tq.rs.
         AnnKind::TqFlat => {
             crate::structures::vector::quantization::tq_codes_column_len_checked(count, code_size)
                 .ok_or_else(|| invalid_data("TQ code column size overflows usize"))
         }
+        AnnKind::IvfTq => crate::structures::vector::quantization::tq_ivf_codes_column_len_checked(
+            count, code_size,
+        )
+        .ok_or_else(|| invalid_data("IVF-TQ code column size overflows usize")),
     }
 }
 
@@ -362,6 +369,49 @@ impl AnnDiskIndex {
         Ok(collector.into_sorted_results())
     }
 
+    /// Score the probed IVF-TQ leaves and keep the top `k` distinct
+    /// documents by estimated similarity (`⟨q̂,c⟩ + scale·⟨q̂,r̂⟩`).
+    pub(crate) fn search_ivf_tq_distinct(
+        &self,
+        k: usize,
+        plan: &crate::structures::TqIvfQueryPlan,
+    ) -> io::Result<Vec<(u32, u16, f32)>> {
+        use crate::structures::vector::quantization::{
+            TQ_BLOCK_LANES, tq_ivf_block_bytes, tq_score_ivf_block,
+        };
+
+        let tq_plan = plan.tq_plan();
+        if tq_plan.padded_dim() != self.header.code_size * 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "IVF-TQ query plan does not match the payload dimension",
+            ));
+        }
+        let block_bytes = tq_ivf_block_bytes(self.header.code_size);
+        let bytes = self.raw.as_slice();
+        let mut collector = BoundedAnnCollector::<true, true>::new(k);
+        let mut scores = [0.0f32; TQ_BLOCK_LANES];
+        for (cluster_id, cluster_dot) in plan.cluster_dots() {
+            for run in self.cluster_runs(cluster_id) {
+                let codes = &bytes[run.codes.clone()];
+                for (block_index, block) in codes.chunks_exact(block_bytes).enumerate() {
+                    tq_score_ivf_block(tq_plan, block, cluster_dot, &mut scores);
+                    let lane_base = block_index * TQ_BLOCK_LANES;
+                    let lanes = TQ_BLOCK_LANES.min(run.count.saturating_sub(lane_base));
+                    for (lane, &score) in scores.iter().enumerate().take(lanes) {
+                        let index = lane_base + lane;
+                        collector.insert(
+                            run_doc_id(bytes, run, index)?,
+                            read_u16(bytes, run.ordinals.start + index * 2),
+                            score,
+                        );
+                    }
+                }
+            }
+        }
+        Ok(collector.into_sorted_results())
+    }
+
     pub(crate) fn search_binary_clusters<const BY_DOCUMENT: bool>(
         &self,
         query: &[u8],
@@ -484,6 +534,78 @@ pub(crate) fn write_built_binary_ivf(
             num_clusters: index.num_clusters,
             quantizer_version: index.quantizer_version,
             codebook_version: 0,
+            vector_count: index.len(),
+        },
+        &runs,
+        writer,
+    )
+}
+
+/// Serialize a populated IVF-TQ build: one run per non-empty leaf, codes
+/// block-packed per run (scales + gammas + dimension-major nibbles).
+#[cfg(feature = "native")]
+pub(crate) fn write_built_ivf_tq(
+    index: &crate::structures::IvfTqIndex,
+    num_clusters: u32,
+    writer: &mut (impl Write + ?Sized),
+) -> io::Result<u64> {
+    use crate::structures::vector::quantization::{TQ_BLOCK_LANES, tq_pack_ivf_block};
+
+    let codec = index.codec();
+    let padded_dim = codec.padded_dim();
+    let mut clusters: Vec<_> = index.clusters.iter().collect();
+    clusters.sort_unstable_by_key(|(cluster_id, _)| **cluster_id);
+    let packed: Vec<(u32, Vec<u8>)> = clusters
+        .iter()
+        .map(|&(&cluster_id, cluster)| {
+            let mut codes = Vec::with_capacity(
+                crate::structures::vector::quantization::tq_ivf_codes_column_len_checked(
+                    cluster.doc_ids.len(),
+                    codec.code_size(),
+                )
+                .unwrap_or_default(),
+            );
+            for block_start in (0..cluster.doc_ids.len()).step_by(TQ_BLOCK_LANES) {
+                let lanes = TQ_BLOCK_LANES.min(cluster.doc_ids.len() - block_start);
+                let rows: Vec<&[u8]> = (0..lanes)
+                    .map(|lane| {
+                        let row = block_start + lane;
+                        &cluster.rows[row * padded_dim..(row + 1) * padded_dim]
+                    })
+                    .collect();
+                tq_pack_ivf_block(
+                    &rows,
+                    &cluster.scales[block_start..block_start + lanes],
+                    &cluster.gammas[block_start..block_start + lanes],
+                    padded_dim,
+                    &mut codes,
+                );
+            }
+            (cluster_id, codes)
+        })
+        .collect();
+    let runs: Vec<_> = clusters
+        .iter()
+        .zip(&packed)
+        .map(|(&(&cluster_id, cluster), (packed_id, codes))| {
+            debug_assert_eq!(cluster_id, *packed_id);
+            BuildRun {
+                cluster_id,
+                doc_ids: &cluster.doc_ids,
+                ordinals: &cluster.ordinals,
+                codes,
+            }
+        })
+        .collect();
+    write_built_runs(
+        AnnDiskHeader {
+            kind: AnnKind::IvfTq,
+            routing: index.routing,
+            dim: index.dim,
+            code_size: codec.code_size(),
+            num_clusters,
+            quantizer_version: index.centroids_version,
+            codebook_version: codec.fingerprint(),
             vector_count: index.len(),
         },
         &runs,
@@ -883,6 +1005,12 @@ fn validate_header(header: &AnnDiskHeader) -> io::Result<()> {
             && (header.codebook_version != 0
                 || header.num_clusters != 1
                 || header.routing != IvfRoutingMode::Flat
+                || header.code_size * 2
+                    != crate::structures::vector::quantization::tq_padded_dim(header.dim)))
+        // IVF-TQ: quantizer_version is the trained centroid generation and
+        // codebook_version carries the (nonzero) TQ codec fingerprint.
+        || (header.kind == AnnKind::IvfTq
+            && (header.codebook_version == 0
                 || header.code_size * 2
                     != crate::structures::vector::quantization::tq_padded_dim(header.dim)))
     {

--- a/hermes-core/src/segment/builder/dense.rs
+++ b/hermes-core/src/segment/builder/dense.rs
@@ -262,6 +262,23 @@ pub(super) fn build_vectors_streaming(
                         &builder.vectors,
                     )
                     .map(|b| (super::super::ann_build::TQ_FLAT_TYPE, b)),
+                    VectorIndexType::IvfTq => {
+                        // Only the coarse router is trained; segments stay
+                        // flat until a generation exists (same as IVF-PQ).
+                        let Some(centroids) =
+                            trained.and_then(|trained| trained.centroids.get(field_id))
+                        else {
+                            return Ok(None);
+                        };
+                        super::super::ann_build::build_ivf_tq(
+                            dim,
+                            config.ivf_routing,
+                            centroids,
+                            &builder.doc_ids,
+                            &builder.vectors,
+                        )
+                        .map(|b| (super::super::ann_build::IVF_TQ_TYPE, b))
+                    }
                     _ => return Ok(None),
                 };
                 let (index_type, bytes) = blob?;

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -344,6 +344,24 @@ impl SegmentMerger {
                                 data_offset,
                                 writer.offset() - data_offset,
                             ))
+                        } else if let Some((index, num_clusters)) = self
+                            .rebuild_ivf_tq(field, config, segments, &doc_offs, trained)
+                            .await?
+                        {
+                            let data_offset = writer.offset();
+                            super::block_in_place_if_multithread(|| {
+                                crate::segment::ann_disk::write_built_ivf_tq(
+                                    &index,
+                                    num_clusters,
+                                    &mut writer,
+                                )
+                            })
+                            .map_err(crate::Error::Io)?;
+                            Some((
+                                crate::segment::ann_build::IVF_TQ_TYPE,
+                                data_offset,
+                                writer.offset() - data_offset,
+                            ))
                         } else {
                             None
                         }
@@ -431,6 +449,15 @@ impl SegmentMerger {
             }
             return Ok(None);
         };
+
+        if entry.field_type == FieldType::DenseVector
+            && let Some(config) = entry
+                .dense_vector_config
+                .as_ref()
+                .filter(|config| config.index_type == VectorIndexType::IvfTq)
+        {
+            return self.copy_ivf_tq_runs(field, config, segments, doc_offs, Some(trained), writer);
+        }
 
         let mut sources = Vec::new();
         let index_type = match entry.field_type {
@@ -732,6 +759,169 @@ impl SegmentMerger {
             data_offset,
             writer.offset() - data_offset,
         )))
+    }
+
+    /// Byte-copy compatible IVF-TQ run columns (the ordinary merge path for
+    /// `ivf_tq` fields). Generation compatibility is the trained centroid
+    /// version plus the derived codec fingerprint.
+    fn copy_ivf_tq_runs(
+        &self,
+        field: crate::dsl::Field,
+        config: &crate::dsl::DenseVectorConfig,
+        segments: &[SegmentReader],
+        doc_offs: &[u32],
+        trained: Option<&TrainedVectorStructures>,
+        writer: &mut OffsetWriter,
+    ) -> Result<Option<(u8, u64, u64)>> {
+        let has_source_ann = segments
+            .iter()
+            .any(|segment| segment.vector_indexes().contains_key(&field.0));
+        let Some(centroids) = trained.and_then(|trained| trained.centroids.get(&field.0)) else {
+            if has_source_ann {
+                return Err(crate::Error::Corruption(format!(
+                    "IVF-TQ field {} has payloads but no global centroids",
+                    field.0,
+                )));
+            }
+            return Ok(None);
+        };
+        let expected_fingerprint =
+            crate::structures::vector::quantization::tq_expected_fingerprint(config.dim);
+        let max_assignments = centroids
+            .soar_config
+            .as_ref()
+            .map_or(1, |soar| 1usize.saturating_add(soar.num_secondary));
+        let mut sources = Vec::new();
+        for (segment_index, segment) in segments.iter().enumerate() {
+            let Some(flat) = segment.flat_vectors().get(&field.0) else {
+                continue;
+            };
+            let Some(crate::segment::VectorIndex::IvfTq { index, .. }) =
+                segment.vector_indexes().get(&field.0)
+            else {
+                return Err(crate::Error::Corruption(format!(
+                    "ordinary merge source {:032x} field {} is missing its IVF-TQ payload",
+                    segment.meta().id,
+                    field.0,
+                )));
+            };
+            let disk = index.get();
+            let header = disk.header();
+            let max_vectors = flat
+                .num_vectors
+                .checked_mul(max_assignments)
+                .ok_or_else(|| {
+                    crate::Error::Corruption(format!(
+                        "IVF-TQ assignment count overflows for field {}",
+                        field.0,
+                    ))
+                })?;
+            if header.dim != config.dim
+                || header.num_clusters != centroids.num_clusters
+                || header.quantizer_version != centroids.version
+                || header.codebook_version != expected_fingerprint
+                || header.routing != config.ivf_routing
+                || !(flat.num_vectors..=max_vectors).contains(&header.vector_count)
+            {
+                return Err(crate::Error::Corruption(format!(
+                    "ordinary merge source {:032x} field {} uses an incompatible IVF-TQ generation",
+                    segment.meta().id,
+                    field.0,
+                )));
+            }
+            sources.push((disk, doc_offs[segment_index]));
+        }
+        if sources.is_empty() {
+            return Ok(None);
+        }
+        let data_offset = writer.offset();
+        super::block_in_place_if_multithread(|| {
+            crate::segment::ann_disk::write_merged_ann(&sources, writer)
+        })
+        .map_err(crate::Error::Io)?;
+        let data_size = writer.offset() - data_offset;
+        log::debug!(
+            "[merge_vectors] field {}: copied {} compatible IVF-TQ run source(s), {} bytes",
+            field.0,
+            sources.len(),
+            data_size,
+        );
+        Ok(Some((
+            crate::segment::ann_build::IVF_TQ_TYPE,
+            data_offset,
+            data_size,
+        )))
+    }
+
+    /// Rebuild the IVF-TQ index for a vector-generation rewrite: re-assign
+    /// every flat vector against the supplied centroid generation and
+    /// re-encode residuals with the derived codec.
+    async fn rebuild_ivf_tq(
+        &self,
+        field: crate::dsl::Field,
+        config: Option<&crate::dsl::DenseVectorConfig>,
+        segments: &[SegmentReader],
+        doc_offs: &[u32],
+        trained: Option<&TrainedVectorStructures>,
+    ) -> Result<Option<(crate::structures::IvfTqIndex, u32)>> {
+        let Some(config) = config.filter(|config| config.index_type == VectorIndexType::IvfTq)
+        else {
+            return Ok(None);
+        };
+        let Some(centroids) = trained.and_then(|trained| trained.centroids.get(&field.0)) else {
+            return Ok(None);
+        };
+
+        let codec = std::sync::Arc::new(crate::structures::TqCodec::new(config.dim));
+        let mut index = crate::structures::IvfTqIndex::new(
+            config.dim,
+            config.ivf_routing,
+            centroids.version,
+            codec,
+        );
+        let mut total_fed = 0usize;
+        let ann_start = std::time::Instant::now();
+        for (segment_index, segment) in segments.iter().enumerate() {
+            let fed = feed_segment(
+                segment,
+                field,
+                doc_offs[segment_index],
+                |labels, vectors| {
+                    super::block_in_place_if_multithread(|| {
+                        let mut add = || index.add_vectors_parallel(centroids, labels, vectors);
+                        if let Some(pool) = &self.background_pool {
+                            pool.install(add)
+                        } else {
+                            add()
+                        }
+                    })
+                    .map_err(|error| {
+                        crate::Error::Internal(format!(
+                            "parallel IVF-TQ rebuild failed for field {}: {error}",
+                            field.0,
+                        ))
+                    })
+                },
+            )
+            .await?;
+            total_fed = total_fed.checked_add(fed).ok_or_else(|| {
+                crate::Error::Corruption(format!(
+                    "IVF-TQ rebuild vector count overflows for field {}",
+                    field.0,
+                ))
+            })?;
+        }
+        if total_fed == 0 {
+            return Ok(None);
+        }
+        log::info!(
+            "[merge_vectors] field {} IVF-TQ rebuilt from {} vectors into {} assignments ({:.1}s)",
+            field.0,
+            total_fed,
+            index.len(),
+            ann_start.elapsed().as_secs_f64()
+        );
+        Ok(Some((index, centroids.num_clusters)))
     }
 
     /// Rebuild the binary IVF index for a vector-generation rewrite.

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -166,6 +166,13 @@ fn validate_ann_schema(schema: &Schema, field_id: u32, index_type: u8) -> Result
                     .as_ref()
                     .is_some_and(|config| config.index_type == VectorIndexType::Tq)
         }
+        ann_build::IVF_TQ_TYPE => {
+            field.field_type == FieldType::DenseVector
+                && field
+                    .dense_vector_config
+                    .as_ref()
+                    .is_some_and(|config| config.index_type == VectorIndexType::IvfTq)
+        }
         _ => false,
     };
 
@@ -208,7 +215,10 @@ fn is_ann_vector_type(index_type: u8) -> bool {
 
     matches!(
         index_type,
-        ann_build::IVF_PQ_TYPE | ann_build::BINARY_IVF_TYPE | ann_build::TQ_FLAT_TYPE
+        ann_build::IVF_PQ_TYPE
+            | ann_build::BINARY_IVF_TYPE
+            | ann_build::TQ_FLAT_TYPE
+            | ann_build::IVF_TQ_TYPE
     )
 }
 
@@ -382,9 +392,10 @@ async fn load_vectors_file_impl<D: Directory>(
     for entry in &entries {
         let inserted = match entry.index_type {
             ann_build::FLAT_TYPE => flat_toc_fields.insert(entry.field_id),
-            ann_build::IVF_PQ_TYPE | ann_build::BINARY_IVF_TYPE | ann_build::TQ_FLAT_TYPE => {
-                ann_toc_fields.insert(entry.field_id)
-            }
+            ann_build::IVF_PQ_TYPE
+            | ann_build::BINARY_IVF_TYPE
+            | ann_build::TQ_FLAT_TYPE
+            | ann_build::IVF_TQ_TYPE => ann_toc_fields.insert(entry.field_id),
             _ => continue,
         };
         if !inserted {
@@ -482,7 +493,10 @@ async fn load_vectors_file_impl<D: Directory>(
                     )));
                 }
             }
-            ann_build::IVF_PQ_TYPE | ann_build::BINARY_IVF_TYPE | ann_build::TQ_FLAT_TYPE => {
+            ann_build::IVF_PQ_TYPE
+            | ann_build::BINARY_IVF_TYPE
+            | ann_build::TQ_FLAT_TYPE
+            | ann_build::IVF_TQ_TYPE => {
                 validate_ann_schema(schema, field_id, index_type)?;
                 if !load_ann {
                     continue;
@@ -544,6 +558,39 @@ async fn load_vectors_file_impl<D: Directory>(
                             )));
                         }
                         VectorIndex::Tq {
+                            index: Arc::new(index),
+                            codec: Arc::new(crate::structures::TqCodec::new(dim)),
+                        }
+                    }
+                    ann_build::IVF_TQ_TYPE => {
+                        let index = super::types::MmapAnnIndex::open(
+                            data,
+                            crate::segment::ann_disk::AnnKind::IvfTq,
+                            total_docs,
+                        )
+                        .map_err(|error| {
+                            crate::Error::Corruption(format!(
+                                "invalid IVF-TQ payload for field {field_id}: {error}"
+                            ))
+                        })?;
+                        let dim = schema
+                            .get_field_entry(Field(field_id))
+                            .and_then(|entry| entry.dense_vector_config.as_ref())
+                            .map(|config| config.dim)
+                            .expect("validated as an IVF-TQ dense field above");
+                        let header = index.get().header();
+                        let expected =
+                            crate::structures::vector::quantization::tq_expected_fingerprint(dim);
+                        if header.dim != dim || header.codebook_version != expected {
+                            return Err(crate::Error::Corruption(format!(
+                                "IVF-TQ payload for field {field_id} was built with an \
+                                 incompatible codec (dim {} fingerprint {:#x}, schema \
+                                 expects dim {dim} fingerprint {expected:#x}); rebuild \
+                                 the segment",
+                                header.dim, header.codebook_version,
+                            )));
+                        }
+                        VectorIndex::IvfTq {
                             index: Arc::new(index),
                             codec: Arc::new(crate::structures::TqCodec::new(dim)),
                         }

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -843,6 +843,7 @@ fn validate_ivf_pq_ann(
 pub struct DensePlanCache {
     pub(crate) ivf_pq: std::sync::Mutex<Option<std::sync::Arc<crate::structures::IvfPqQueryPlan>>>,
     pub(crate) tq: std::sync::Mutex<Option<std::sync::Arc<crate::structures::TqQueryPlan>>>,
+    pub(crate) ivf_tq: std::sync::Mutex<Option<std::sync::Arc<crate::structures::TqIvfQueryPlan>>>,
 }
 
 /// Search one segment's TQ payload, reusing the per-query plan across
@@ -899,6 +900,96 @@ fn validate_tq_ann(
     {
         return Err(Error::Corruption(format!(
             "TQ payload for field {} does not match the codec derived from schema dimension {dim}",
+            field.0,
+        )));
+    }
+    Ok(())
+}
+
+/// Search one segment's IVF-TQ payload. The probe route, the `⟨q̂,c⟩`
+/// scalars, and the TQ LUTs are all query-global, so the plan is cached and
+/// shared across every segment of the field (same rule as `float_query_plan`).
+#[allow(clippy::too_many_arguments)]
+fn search_ivf_tq_segment(
+    index: &crate::segment::ann_disk::AnnDiskIndex,
+    centroids: &CoarseCentroids,
+    codec: &crate::structures::TqCodec,
+    query: &[f32],
+    fetch_k: usize,
+    field: Field,
+    nprobe: usize,
+    routing: crate::dsl::IvfRoutingMode,
+    plan_cache: Option<
+        &std::sync::Mutex<Option<std::sync::Arc<crate::structures::TqIvfQueryPlan>>>,
+    >,
+) -> Result<Vec<RawVectorCandidate>> {
+    let effective_nprobe = nprobe.clamp(1, centroids.num_clusters as usize);
+    let request_fingerprint = crate::structures::vector::ivf::routing::float_probe_fingerprint(
+        query,
+        effective_nprobe,
+        routing,
+    );
+    let build = || {
+        std::sync::Arc::new(crate::structures::TqIvfQueryPlan::build(
+            centroids,
+            codec,
+            query,
+            effective_nprobe,
+            routing,
+        ))
+    };
+    let plan = match plan_cache {
+        Some(cache) => {
+            let mut cached = cache
+                .lock()
+                .map_err(|_| Error::Internal("IVF-TQ plan cache is poisoned".into()))?;
+            match cached.as_ref() {
+                Some(plan)
+                    if plan.quantizer_version == centroids.version
+                        && plan.fingerprint == codec.fingerprint()
+                        && plan.request_fingerprint == request_fingerprint
+                        && plan.cluster_ids.len() == effective_nprobe =>
+                {
+                    std::sync::Arc::clone(plan)
+                }
+                _ => {
+                    let plan = build();
+                    *cached = Some(std::sync::Arc::clone(&plan));
+                    plan
+                }
+            }
+        }
+        None => build(),
+    };
+    index
+        .search_ivf_tq_distinct(fetch_k, &plan)
+        .map_err(|error| {
+            Error::Corruption(format!(
+                "invalid IVF-TQ payload for field {}: {error}",
+                field.0
+            ))
+        })
+}
+
+fn validate_ivf_tq_ann(
+    index: &crate::segment::ann_disk::AnnDiskIndex,
+    centroids: &CoarseCentroids,
+    codec: &crate::structures::TqCodec,
+    dim: usize,
+    routing: crate::dsl::IvfRoutingMode,
+    field: Field,
+) -> Result<()> {
+    let header = index.header();
+    if header.dim != dim
+        || codec.dim() != dim
+        || header.code_size != codec.code_size()
+        || header.num_clusters != centroids.num_clusters
+        || header.quantizer_version != centroids.version
+        || header.codebook_version != codec.fingerprint()
+        || header.routing != routing
+    {
+        return Err(Error::Corruption(format!(
+            "IVF-TQ payload for field {} does not match its quantizer/codec generation",
             field.0,
         )));
     }
@@ -2090,6 +2181,40 @@ impl SegmentReader {
                         plan_cache.map(|cache| &cache.tq),
                     )?
                 }
+                VectorIndex::IvfTq { index: lazy, codec } => {
+                    let index = lazy.get();
+                    let centroids =
+                        self.trained_vectors
+                            .centroids
+                            .get(&field.0)
+                            .ok_or_else(|| {
+                                Error::Schema(format!(
+                                    "IVF-TQ index requires coarse centroids for field {}",
+                                    field.0
+                                ))
+                            })?;
+                    validate_coarse_centroids(centroids, params.dim)?;
+                    let routing = self
+                        .schema
+                        .get_field_entry(field)
+                        .and_then(|entry| entry.dense_vector_config.as_ref())
+                        .map_or(crate::dsl::IvfRoutingMode::Auto, |config| {
+                            config.ivf_routing
+                        });
+                    validate_ivf_tq_ann(index, centroids, codec, params.dim, routing, field)?;
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    search_ivf_tq_segment(
+                        index,
+                        centroids,
+                        codec,
+                        query,
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        field,
+                        params.nprobe,
+                        routing,
+                        plan_cache.map(|cache| &cache.ivf_tq),
+                    )?
+                }
                 VectorIndex::BinaryIvf(_) => {
                     // Binary IVF serves Hamming queries only (BinaryDenseVectorQuery)
                     Vec::new()
@@ -2148,6 +2273,7 @@ impl SegmentReader {
                 Some(VectorIndex::IvfPq(_)) => "ivf_pq",
                 Some(VectorIndex::BinaryIvf(_)) => "binary_ivf",
                 Some(VectorIndex::Tq { .. }) => "tq_flat",
+                Some(VectorIndex::IvfTq { .. }) => "ivf_tq",
                 None => "flat",
             };
             crate::observe::dense_l1(
@@ -2739,6 +2865,40 @@ impl SegmentReader {
                         field,
                         params.dim,
                         plan_cache.map(|cache| &cache.tq),
+                    )?
+                }
+                VectorIndex::IvfTq { index: lazy, codec } => {
+                    let index = lazy.get();
+                    let centroids =
+                        self.trained_vectors
+                            .centroids
+                            .get(&field.0)
+                            .ok_or_else(|| {
+                                Error::Schema(format!(
+                                    "IVF-TQ index requires coarse centroids for field {}",
+                                    field.0
+                                ))
+                            })?;
+                    validate_coarse_centroids(centroids, params.dim)?;
+                    let routing = self
+                        .schema
+                        .get_field_entry(field)
+                        .and_then(|entry| entry.dense_vector_config.as_ref())
+                        .map_or(crate::dsl::IvfRoutingMode::Auto, |config| {
+                            config.ivf_routing
+                        });
+                    validate_ivf_tq_ann(index, centroids, codec, params.dim, routing, field)?;
+                    let flat = lazy_flat.expect("ANN/flat pairing validated above");
+                    search_ivf_tq_segment(
+                        index,
+                        centroids,
+                        codec,
+                        query,
+                        fetch_k.min(flat.num_docs_with_vectors()),
+                        field,
+                        params.nprobe,
+                        routing,
+                        plan_cache.map(|cache| &cache.ivf_tq),
                     )?
                 }
                 VectorIndex::BinaryIvf(_) => {

--- a/hermes-core/src/segment/reader/types.rs
+++ b/hermes-core/src/segment/reader/types.rs
@@ -25,6 +25,11 @@ pub enum VectorIndex {
         index: Arc<MmapAnnIndex>,
         codec: Arc<crate::structures::TqCodec>,
     },
+    /// IVF-TQ payload: trained coarse router, TurboQuant residual leaves.
+    IvfTq {
+        index: Arc<MmapAnnIndex>,
+        codec: Arc<crate::structures::TqCodec>,
+    },
 }
 
 /// Thin public wrapper around the shared mmap ANN representation. Its internals
@@ -70,7 +75,7 @@ impl VectorIndex {
         match self {
             VectorIndex::IvfPq(lazy) => lazy.estimated_heap_bytes(),
             VectorIndex::BinaryIvf(lazy) => lazy.estimated_heap_bytes(),
-            VectorIndex::Tq { index, codec } => {
+            VectorIndex::Tq { index, codec } | VectorIndex::IvfTq { index, codec } => {
                 index.estimated_heap_bytes() + codec.estimated_memory_bytes()
             }
         }
@@ -84,7 +89,10 @@ impl VectorIndex {
         report: &mut crate::segment::pin::PinReport,
     ) {
         let index = match self {
-            Self::IvfPq(index) | Self::BinaryIvf(index) | Self::Tq { index, .. } => index,
+            Self::IvfPq(index)
+            | Self::BinaryIvf(index)
+            | Self::Tq { index, .. }
+            | Self::IvfTq { index, .. } => index,
         };
         if let Some(index) = Arc::get_mut(index) {
             index.pin_lookup_directory(mode, remaining, report);

--- a/hermes-core/src/structures/mod.rs
+++ b/hermes-core/src/structures/mod.rs
@@ -136,11 +136,14 @@ pub use vector::{
     IVFPQIndex,
     IvfPqQueryPlan,
     IvfProbePlan,
+    IvfTqIndex,
     MultiAssignment,
     PQCodebook,
     PQConfig,
     SoarConfig,
     TqCodec,
+    TqIvfEncodeScratch,
+    TqIvfQueryPlan,
     TqQueryPlan,
 };
 

--- a/hermes-core/src/structures/vector/index/ivf_tq.rs
+++ b/hermes-core/src/structures/vector/index/ivf_tq.rs
@@ -1,0 +1,407 @@
+//! IVF-TQ: inverted-file search with TurboQuant-coded centroid residuals.
+//!
+//! Two-level index (design: `docs/turboquant-quantization.md`):
+//! - Level 1: the trained global coarse quantizer (same router as IVF-PQ).
+//! - Level 2: per-leaf TQ codes of `vector − centroid` residuals plus a
+//!   per-vector residual scale, so `⟨q̂, x⟩ = ⟨q̂, c⟩ + scale · ⟨q̂, r̂⟩`.
+//!
+//! Unlike IVF-PQ, the leaf codec is training-free and the residual estimate
+//! uses one query-wide LUT: probed clusters differ only by the scalar
+//! `⟨q̂, c⟩`, so plan build is O(P·16 + nprobe·dim) instead of nprobe ADC
+//! tables. Segment persistence and pure-copy merging live in
+//! `segment::ann_disk`; this type is build-only.
+
+use crate::dsl::IvfRoutingMode;
+use crate::structures::vector::ivf::{CoarseCentroids, IvfProbePlan};
+use crate::structures::vector::quantization::{TqCodec, TqEncodeScratch, TqQueryPlan};
+
+/// Struct-of-arrays payload for one non-empty IVF-TQ leaf. `rows` holds one
+/// unpacked nibble value (0..=15) per padded coordinate per vector; blocks
+/// are packed lazily at serialization time.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct TqCluster {
+    pub(crate) doc_ids: Vec<u32>,
+    pub(crate) ordinals: Vec<u16>,
+    pub(crate) scales: Vec<f32>,
+    pub(crate) gammas: Vec<f32>,
+    pub(crate) rows: Vec<u8>,
+}
+
+impl TqCluster {
+    #[cfg(feature = "native")]
+    fn append_owned(&mut self, mut source: Self) {
+        self.doc_ids.append(&mut source.doc_ids);
+        self.ordinals.append(&mut source.ordinals);
+        self.scales.append(&mut source.scales);
+        self.gammas.append(&mut source.gammas);
+        self.rows.append(&mut source.rows);
+    }
+}
+
+/// Query-global IVF-TQ work shared by every segment: one probe route, one
+/// set of TQ LUTs, and one `⟨q̂, centroid⟩` scalar per probed cluster.
+pub struct TqIvfQueryPlan {
+    pub quantizer_version: u64,
+    /// TQ codec fingerprint (carried as `codebook_version` on disk).
+    pub fingerprint: u64,
+    pub request_fingerprint: u64,
+    pub cluster_ids: std::sync::Arc<[u32]>,
+    cluster_dots: Vec<f32>,
+    tq: TqQueryPlan,
+}
+
+impl std::fmt::Debug for TqIvfQueryPlan {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TqIvfQueryPlan")
+            .field("quantizer_version", &self.quantizer_version)
+            .field("fingerprint", &self.fingerprint)
+            .field("cluster_count", &self.cluster_ids.len())
+            .finish()
+    }
+}
+
+impl TqIvfQueryPlan {
+    pub fn build(
+        coarse_centroids: &CoarseCentroids,
+        codec: &TqCodec,
+        query: &[f32],
+        nprobe: usize,
+        routing: IvfRoutingMode,
+    ) -> Self {
+        let route: IvfProbePlan = coarse_centroids.probe(query, nprobe, routing);
+        let norm = crate::structures::simd::dot_product_f32(query, query, query.len()).sqrt();
+        let inverse_norm = if norm.is_finite() && norm > 0.0 {
+            1.0 / norm
+        } else {
+            0.0
+        };
+        let cluster_dots = route
+            .cluster_ids
+            .iter()
+            .map(|&cluster_id| {
+                let centroid = coarse_centroids.get_centroid(cluster_id);
+                crate::structures::simd::dot_product_f32(query, centroid, query.len())
+                    * inverse_norm
+            })
+            .collect();
+        Self {
+            quantizer_version: route.quantizer_version,
+            fingerprint: codec.fingerprint(),
+            request_fingerprint: route.request_fingerprint,
+            cluster_ids: route.cluster_ids,
+            cluster_dots,
+            tq: TqQueryPlan::build(codec, query),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn tq_plan(&self) -> &TqQueryPlan {
+        &self.tq
+    }
+
+    pub(crate) fn cluster_dots(&self) -> impl Iterator<Item = (u32, f32)> + '_ {
+        self.cluster_ids
+            .iter()
+            .copied()
+            .zip(self.cluster_dots.iter().copied())
+    }
+}
+
+/// IVF-TQ build payload for a single segment.
+#[derive(Debug, Clone)]
+pub struct IvfTqIndex {
+    pub dim: usize,
+    pub routing: IvfRoutingMode,
+    /// Version of coarse centroids used (for merge compatibility).
+    pub centroids_version: u64,
+    codec: std::sync::Arc<TqCodec>,
+    pub(crate) clusters: rustc_hash::FxHashMap<u32, TqCluster>,
+    len: usize,
+}
+
+impl IvfTqIndex {
+    pub fn new(
+        dim: usize,
+        routing: IvfRoutingMode,
+        centroids_version: u64,
+        codec: std::sync::Arc<TqCodec>,
+    ) -> Self {
+        assert_eq!(codec.dim(), dim, "IVF-TQ codec/config dimension mismatch");
+        Self {
+            dim,
+            routing,
+            centroids_version,
+            codec,
+            clusters: rustc_hash::FxHashMap::default(),
+            len: 0,
+        }
+    }
+
+    #[inline]
+    pub fn codec(&self) -> &TqCodec {
+        &self.codec
+    }
+
+    /// Add a single vector: assign to the trained router (with SOAR when
+    /// configured) and TQ-encode the residual against every assigned leaf.
+    pub fn add_vector(
+        &mut self,
+        coarse_centroids: &CoarseCentroids,
+        doc_id: u32,
+        ordinal: u16,
+        vector: &[f32],
+        scratch: &mut TqIvfEncodeScratch,
+    ) {
+        let assignment = coarse_centroids.assign_with_routing(vector, self.routing);
+        self.add_to_cluster(
+            coarse_centroids,
+            assignment.primary_cluster,
+            doc_id,
+            ordinal,
+            vector,
+            scratch,
+        );
+        for &cluster_id in &assignment.secondary_clusters {
+            self.add_to_cluster(
+                coarse_centroids,
+                cluster_id,
+                doc_id,
+                ordinal,
+                vector,
+                scratch,
+            );
+        }
+    }
+
+    fn add_to_cluster(
+        &mut self,
+        coarse_centroids: &CoarseCentroids,
+        cluster_id: u32,
+        doc_id: u32,
+        ordinal: u16,
+        vector: &[f32],
+        scratch: &mut TqIvfEncodeScratch,
+    ) {
+        let centroid = coarse_centroids.get_centroid(cluster_id);
+        scratch.residual.clear();
+        scratch.residual.extend(
+            vector
+                .iter()
+                .zip(centroid)
+                .map(|(value, center)| value - center),
+        );
+        scratch.nibbles.resize(self.codec.padded_dim(), 0);
+        let (scale, gamma) = self.codec.encode_residual_into(
+            &scratch.residual,
+            &mut scratch.nibbles,
+            &mut scratch.tq,
+        );
+
+        let cluster = self.clusters.entry(cluster_id).or_default();
+        cluster.doc_ids.push(doc_id);
+        cluster.ordinals.push(ordinal);
+        cluster.scales.push(scale);
+        cluster.gammas.push(gamma);
+        cluster.rows.extend_from_slice(&scratch.nibbles);
+        self.len += 1;
+    }
+
+    /// Add one contiguous vector batch in parallel while preserving input
+    /// order inside every leaf (mirrors `IVFPQIndex::add_vectors_parallel`).
+    #[cfg(feature = "native")]
+    pub fn add_vectors_parallel(
+        &mut self,
+        coarse_centroids: &CoarseCentroids,
+        doc_id_ordinals: &[(u32, u16)],
+        vectors: &[f32],
+    ) -> Result<(), &'static str> {
+        use rayon::prelude::*;
+
+        let vector_count = doc_id_ordinals.len();
+        let expected = vector_count
+            .checked_mul(self.dim)
+            .ok_or("IVF-TQ input size overflow")?;
+        if vectors.len() != expected {
+            return Err("IVF-TQ vector and label matrices are inconsistent");
+        }
+        if vector_count == 0 {
+            return Ok(());
+        }
+
+        let target_tasks = rayon::current_num_threads().saturating_mul(4).max(1);
+        let chunk_vectors = vector_count.div_ceil(target_tasks).max(64);
+        let dim = self.dim;
+        let routing = self.routing;
+        let centroids_version = self.centroids_version;
+        let codec = std::sync::Arc::clone(&self.codec);
+        let partials: Vec<Self> = doc_id_ordinals
+            .par_chunks(chunk_vectors)
+            .enumerate()
+            .map(|(chunk_index, labels)| {
+                let first = chunk_index * chunk_vectors;
+                let chunk = &vectors[first * dim..(first + labels.len()) * dim];
+                let mut partial = Self::new(
+                    dim,
+                    routing,
+                    centroids_version,
+                    std::sync::Arc::clone(&codec),
+                );
+                let mut scratch = TqIvfEncodeScratch::default();
+                for (&(doc_id, ordinal), vector) in labels.iter().zip(chunk.chunks_exact(dim)) {
+                    partial.add_vector(coarse_centroids, doc_id, ordinal, vector, &mut scratch);
+                }
+                partial
+            })
+            .collect();
+
+        for partial in partials {
+            self.append_owned(partial)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "native")]
+    fn append_owned(&mut self, mut other: Self) -> Result<(), &'static str> {
+        if self.centroids_version != other.centroids_version
+            || self.dim != other.dim
+            || self.codec.fingerprint() != other.codec.fingerprint()
+        {
+            return Err("Cannot merge IVF-TQ payloads from different generations");
+        }
+        let other_len = other.len;
+        for (cluster_id, source) in other.clusters.drain() {
+            match self.clusters.entry(cluster_id) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.get_mut().append_owned(source);
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(source);
+                }
+            }
+        }
+        self.len = self
+            .len
+            .checked_add(other_len)
+            .ok_or("IVF-TQ vector count overflow during parallel build")?;
+        Ok(())
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn estimated_memory_bytes(&self) -> usize {
+        self.clusters
+            .values()
+            .map(|cluster| {
+                cluster.rows.len()
+                    + cluster.doc_ids.len() * size_of::<u32>()
+                    + cluster.ordinals.len() * size_of::<u16>()
+                    + (cluster.scales.len() + cluster.gammas.len()) * size_of::<f32>()
+            })
+            .sum()
+    }
+}
+
+/// Reusable per-thread IVF-TQ encode buffers.
+#[derive(Debug, Default)]
+pub struct TqIvfEncodeScratch {
+    residual: Vec<f32>,
+    nibbles: Vec<u8>,
+    tq: TqEncodeScratch,
+}
+
+#[cfg(all(test, feature = "native"))]
+mod tests {
+    use super::*;
+    use crate::structures::vector::ivf::CoarseConfig;
+    use crate::structures::vector::quantization::{
+        TQ_BLOCK_LANES, tq_pack_ivf_block, tq_score_ivf_block,
+    };
+
+    fn seeded_unit_vector(dim: usize, seed: u64) -> Vec<f32> {
+        let mut state = seed;
+        let mut next = move || {
+            state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+            let mut z = state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+            z ^ (z >> 31)
+        };
+        let mut values: Vec<f32> = (0..dim)
+            .map(|_| ((next() >> 40) as f32 / (1u64 << 24) as f32) - 0.5)
+            .collect();
+        let norm = values.iter().map(|v| v * v).sum::<f32>().sqrt();
+        values.iter_mut().for_each(|v| *v /= norm);
+        values
+    }
+
+    /// The scaled residual estimator must approximate the true inner product
+    /// of the raw (unnormalized-residual) decomposition.
+    #[test]
+    fn scaled_residual_estimator_tracks_true_dot() {
+        let dim = 64;
+        let codec = std::sync::Arc::new(TqCodec::new(dim));
+        let vectors: Vec<Vec<f32>> = (0..64).map(|i| seeded_unit_vector(dim, 100 + i)).collect();
+        let centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 4), &vectors);
+
+        let mut index = IvfTqIndex::new(
+            dim,
+            IvfRoutingMode::Flat,
+            centroids.version,
+            std::sync::Arc::clone(&codec),
+        );
+        let mut scratch = TqIvfEncodeScratch::default();
+        for (i, vector) in vectors.iter().enumerate() {
+            index.add_vector(&centroids, i as u32, 0, vector, &mut scratch);
+        }
+        assert_eq!(index.len(), vectors.len());
+
+        let query = seeded_unit_vector(dim, 7);
+        let plan = TqIvfQueryPlan::build(&centroids, &codec, &query, 4, IvfRoutingMode::Flat);
+
+        let mut checked = 0usize;
+        let mut squared_error = 0.0f64;
+        for (cluster_id, cluster_dot) in plan.cluster_dots() {
+            let Some(cluster) = index.clusters.get(&cluster_id) else {
+                continue;
+            };
+            let padded = codec.padded_dim();
+            for block_start in (0..cluster.doc_ids.len()).step_by(TQ_BLOCK_LANES) {
+                let lanes = TQ_BLOCK_LANES.min(cluster.doc_ids.len() - block_start);
+                let rows: Vec<&[u8]> = (0..lanes)
+                    .map(|lane| {
+                        &cluster.rows
+                            [(block_start + lane) * padded..(block_start + lane + 1) * padded]
+                    })
+                    .collect();
+                let mut block = Vec::new();
+                tq_pack_ivf_block(
+                    &rows,
+                    &cluster.scales[block_start..block_start + lanes],
+                    &cluster.gammas[block_start..block_start + lanes],
+                    padded,
+                    &mut block,
+                );
+                let mut scores = [0.0f32; TQ_BLOCK_LANES];
+                tq_score_ivf_block(plan.tq_plan(), &block, cluster_dot, &mut scores);
+                for (lane, &score) in scores.iter().enumerate().take(lanes) {
+                    let doc = cluster.doc_ids[block_start + lane] as usize;
+                    let truth: f32 = vectors[doc].iter().zip(&query).map(|(a, b)| a * b).sum();
+                    squared_error += f64::from(score - truth).powi(2);
+                    checked += 1;
+                }
+            }
+        }
+        assert!(checked >= vectors.len(), "every vector must be scored");
+        let rmse = (squared_error / checked as f64).sqrt();
+        assert!(rmse < 0.08, "IVF-TQ estimator RMSE too large: {rmse}");
+    }
+}

--- a/hermes-core/src/structures/vector/index/mod.rs
+++ b/hermes-core/src/structures/vector/index/mod.rs
@@ -5,11 +5,13 @@
 
 mod binary_ivf;
 mod ivf_pq;
+mod ivf_tq;
 
 #[cfg(feature = "native")]
 pub(crate) use binary_ivf::BinaryIvfBuilder;
 pub use binary_ivf::{BinaryCoarseQuantizer, BinaryIvfConfig, BinaryIvfIndex};
 pub use ivf_pq::{IVFPQConfig, IVFPQIndex, IvfPqQueryPlan};
+pub use ivf_tq::{IvfTqIndex, TqIvfEncodeScratch, TqIvfQueryPlan};
 
 #[derive(Clone, Copy)]
 struct RankedEntry {

--- a/hermes-core/src/structures/vector/mod.rs
+++ b/hermes-core/src/structures/vector/mod.rs
@@ -37,5 +37,6 @@ pub use quantization::{DistanceTable, PQCodebook, PQConfig, TqCodec, TqQueryPlan
 
 // Indexes
 pub use index::{
-    BinaryCoarseQuantizer, BinaryIvfConfig, BinaryIvfIndex, IVFPQConfig, IVFPQIndex, IvfPqQueryPlan,
+    BinaryCoarseQuantizer, BinaryIvfConfig, BinaryIvfIndex, IVFPQConfig, IVFPQIndex,
+    IvfPqQueryPlan, IvfTqIndex, TqIvfEncodeScratch, TqIvfQueryPlan,
 };

--- a/hermes-core/src/structures/vector/quantization/mod.rs
+++ b/hermes-core/src/structures/vector/quantization/mod.rs
@@ -11,6 +11,7 @@ pub use pq::{DistanceTable, PQCodebook, PQConfig};
 pub use tq::TqFlatBuilder;
 pub use tq::{
     TQ_BLOCK_LANES, TQ_CODEC_VERSION, TqCodec, TqEncodeScratch, TqQueryPlan, tq_block_bytes,
-    tq_codes_column_len, tq_codes_column_len_checked, tq_expected_fingerprint, tq_pack_block,
-    tq_padded_dim, tq_score_block,
+    tq_codes_column_len, tq_codes_column_len_checked, tq_expected_fingerprint, tq_ivf_block_bytes,
+    tq_ivf_codes_column_len_checked, tq_pack_block, tq_pack_ivf_block, tq_padded_dim,
+    tq_score_block, tq_score_ivf_block,
 };

--- a/hermes-core/src/structures/vector/quantization/tq.rs
+++ b/hermes-core/src/structures/vector/quantization/tq.rs
@@ -66,6 +66,21 @@ pub fn tq_codes_column_len_checked(count: usize, code_size: usize) -> Option<usi
         .checked_mul(tq_block_bytes(code_size))
 }
 
+/// Bytes of one IVF-TQ scoring block: 16 f32 residual scales + 16 f32 gammas
+/// + 16 packed nibble rows.
+#[inline]
+pub const fn tq_ivf_block_bytes(code_size: usize) -> usize {
+    TQ_BLOCK_LANES * (2 * size_of::<f32>() + code_size)
+}
+
+/// Overflow-checked IVF-TQ codes-column length for untrusted header values.
+#[inline]
+pub fn tq_ivf_codes_column_len_checked(count: usize, code_size: usize) -> Option<usize> {
+    count
+        .div_ceil(TQ_BLOCK_LANES)
+        .checked_mul(tq_ivf_block_bytes(code_size))
+}
+
 #[inline]
 fn splitmix64(state: &mut u64) -> u64 {
     *state = state.wrapping_add(0x9e37_79b9_7f4a_7c15);
@@ -341,12 +356,26 @@ impl TqCodec {
         nibbles: &mut [u8],
         scratch: &mut TqEncodeScratch,
     ) -> f32 {
+        self.encode_residual_into(vector, nibbles, scratch).1
+    }
+
+    /// Encode one (possibly non-unit) vector as `scale · unit_direction` and
+    /// return `(scale = ‖vector‖₂, gamma)`. IVF leaves store centroid
+    /// residuals, whose norms carry ranking information; `scale` restores it
+    /// at score time. Zero vectors encode as all-zero nibbles with
+    /// `scale = gamma = 0`.
+    pub fn encode_residual_into(
+        &self,
+        vector: &[f32],
+        nibbles: &mut [u8],
+        scratch: &mut TqEncodeScratch,
+    ) -> (f32, f32) {
         assert_eq!(vector.len(), self.dim, "TQ encode dimension mismatch");
         assert_eq!(nibbles.len(), self.padded_dim, "TQ nibble buffer mismatch");
         let norm = crate::structures::simd::dot_product_f32(vector, vector, vector.len()).sqrt();
         if !norm.is_finite() || norm <= 0.0 {
             nibbles.fill(0);
-            return 0.0;
+            return (0.0, 0.0);
         }
         scratch.normalized.clear();
         scratch
@@ -385,7 +414,7 @@ impl TqCodec {
         for (nibble, &rotated) in nibbles.iter_mut().zip(scratch.rotated_residual.iter()) {
             *nibble |= u8::from(rotated >= 0.0);
         }
-        residual_norm_sq.sqrt()
+        (norm, residual_norm_sq.sqrt())
     }
 }
 
@@ -567,6 +596,31 @@ pub fn tq_pack_block(rows: &[&[u8]], gammas: &[f32], padded_dim: usize, output: 
         let gamma = gammas.get(lane).copied().unwrap_or(0.0);
         output.extend_from_slice(&gamma.to_le_bytes());
     }
+    pack_nibble_rows(rows, padded_dim, output);
+}
+
+/// Pack an IVF-TQ block: per-lane residual scales, gammas, then nibbles.
+pub fn tq_pack_ivf_block(
+    rows: &[&[u8]],
+    scales: &[f32],
+    gammas: &[f32],
+    padded_dim: usize,
+    output: &mut Vec<u8>,
+) {
+    assert!(rows.len() <= TQ_BLOCK_LANES && rows.len() == gammas.len());
+    assert_eq!(scales.len(), gammas.len());
+    for lane in 0..TQ_BLOCK_LANES {
+        let scale = scales.get(lane).copied().unwrap_or(0.0);
+        output.extend_from_slice(&scale.to_le_bytes());
+    }
+    for lane in 0..TQ_BLOCK_LANES {
+        let gamma = gammas.get(lane).copied().unwrap_or(0.0);
+        output.extend_from_slice(&gamma.to_le_bytes());
+    }
+    pack_nibble_rows(rows, padded_dim, output);
+}
+
+fn pack_nibble_rows(rows: &[&[u8]], padded_dim: usize, output: &mut Vec<u8>) {
     for dim in 0..padded_dim {
         for byte_index in 0..TQ_BLOCK_LANES / 2 {
             let low = rows.get(byte_index).map_or(0, |row| row[dim] & 0x0F);
@@ -575,6 +629,47 @@ pub fn tq_pack_block(rows: &[&[u8]], gammas: &[f32], padded_dim: usize, output: 
                 .map_or(0, |row| row[dim] & 0x0F);
             output.push(low | (high << 4));
         }
+    }
+}
+
+/// Score one IVF-TQ block: `score[lane] = cluster_dot + scale · (base +
+/// gamma · qjl)`, where `cluster_dot = ⟨normalized query, centroid⟩` is the
+/// probed cluster's shared contribution and `scale = ‖residual‖`.
+pub fn tq_score_ivf_block(
+    plan: &TqQueryPlan,
+    block: &[u8],
+    cluster_dot: f32,
+    scores: &mut [f32; TQ_BLOCK_LANES],
+) {
+    debug_assert_eq!(block.len(), tq_ivf_block_bytes(plan.padded_dim() / 2));
+    let lane_f32 = TQ_BLOCK_LANES * size_of::<f32>();
+    let (scale_bytes, rest) = block.split_at(lane_f32);
+    let (gamma_bytes, nibble_bytes) = rest.split_at(lane_f32);
+    let mut base = [0i32; TQ_BLOCK_LANES];
+    let mut qjl = [0i32; TQ_BLOCK_LANES];
+    lut16::accumulate_block(
+        &plan.base_lut_i8,
+        &plan.qjl_lut_i8,
+        nibble_bytes,
+        plan.padded_dim,
+        &mut base,
+        &mut qjl,
+    );
+    for lane in 0..TQ_BLOCK_LANES {
+        let scale = f32::from_le_bytes(
+            scale_bytes[lane * 4..lane * 4 + 4]
+                .try_into()
+                .expect("scale slice is 4 bytes"),
+        );
+        let gamma = f32::from_le_bytes(
+            gamma_bytes[lane * 4..lane * 4 + 4]
+                .try_into()
+                .expect("gamma slice is 4 bytes"),
+        );
+        scores[lane] = cluster_dot
+            + scale
+                * (base[lane] as f32 * plan.base_dequant
+                    + gamma * qjl[lane] as f32 * plan.qjl_dequant);
     }
 }
 

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -728,6 +728,7 @@ pub fn schema_to_sdl(schema: &Schema) -> String {
                     VectorIndexType::Flat => "flat",
                     VectorIndexType::IvfPq => "ivf_pq",
                     VectorIndexType::Tq => "tq",
+                    VectorIndexType::IvfTq => "ivf_tq",
                 };
                 idx_params.push(idx_name.to_string());
                 // TQ scans every code: IVF knobs do not apply and re-parsing


### PR DESCRIPTION
## Summary

Follow-up to #102: combines the **trained global coarse router** (same `build_vector_index()` machinery as IVF-PQ, HNSW routing and SOAR supported) with the **training-free TQ leaf codec** — sub-linear probing without a trained codebook.

- **Leaves** store TQ codes of the centroid residual `r = x − c` plus a per-vector `scale = ‖r‖`; leaf estimate is `⟨q̂,c⟩ + scale·est⟨q̂,r̂⟩`. Residuals live in absolute rotated space, so one query builds **one LUT set** plus one `⟨q̂,c⟩` scalar per probed cluster — no per-cluster ADC tables (the dominant IVF-PQ query cost at nprobe 64).
- **Format**: `AnnKind::IvfTq` (TOC 8), per-leaf runs, blocks `[16 scales][16 gammas][dim-major nibbles]`, ordinary merges byte-copy. Gates: `quantizer_version` = centroid generation, `codebook_version` = codec fingerprint; `codebook_file` must be absent (fail loud).
- **Training**: `uses_ivf()` includes `IvfTq`; the trainer fits coarse centroids only (no PQ/OPQ stage → ~33% less training time). Vector-generation rewrites re-encode via the standard rebuild path.
- **Query**: probed scan feeding the shared exact re-rank on async + sync paths; per-query plan cached across segments (`DensePlanCache.ivf_tq`).
- **SDL**: `indexed<ivf_tq, num_clusters: N, nprobe: K, routing: ...>` — all IVF knobs apply (unlike `tq`).

## Benchmark

Same harness/run (single idle-machine run — compare rows within the table), aarch64 Apple Silicon/NEON, 100k docs × 768 dims, k=10, nprobe 64/1024, rerank 2.0, warmed mmap:

| method | build (s) | train (s) | .vectors (MB) | p50 (ms) | p95 (ms) | recall@10 |
|---|---|---|---|---|---|---|
| flat (exact) | 0.4 | — | 293.5 | 4.85 | 5.51 | 1.000 |
| tq | 0.7 | 0 | 343.3 | 3.27 | 3.50 | 0.959 |
| ivf_pq | 0.8 | 212.2 | 303.4 | 8.54 | 12.29 | 0.786 |
| **ivf_tq** | 0.4 | 143.3 | 351.3 | **3.33** | 5.81 | **0.997** |

At the same probe budget IVF-TQ beats IVF-PQ on every axis: **+0.21 recall@10** (the 4-bit residual estimate keeps the true top-10 alive inside the probed set where 1-bit/dim PQ loses them), **2.6× lower p50**, **~33% less training time**. Space trade: ~5× larger codes than PQ (4 bits/dim + 8B scale/gamma vs ~1 bit/dim).

## Testing

- New: scaled-residual estimator unit test (RMSE vs true dot), `test_ivf_tq_end_to_end_with_merge` (train → probed search on async+sync paths → recall ≥0.9 → byte-copy merge survival).
- 880 lib tests + integration green; clippy `-D warnings` clean; fmt clean; wasm32-unknown-unknown target check clean; benchmark row asserted (`ann_kind == "ivf_tq"`).

Design doc updated: `docs/turboquant-quantization.md` (§ IVF-TQ), `docs/schema.md`.