### PR TITLE
perf(core): streamline BP and large force merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,20 +158,27 @@ Python client:
 from hermes_client_python import HermesClient
 
 async with HermesClient("localhost:50051") as client:
-    await client.create_index("articles", '''
+    await client.create_index(
+        "articles",
+        """
         index articles {
             field title: text<en_stem> [indexed, stored]
             field body: text [indexed, stored]
         }
-    ''')
+    """,
+    )
 
-    await client.index_documents("articles", [
-        {"title": "Hybrid Search", "body": "Combining BM25 with vectors"},
-    ])
+    await client.index_documents(
+        "articles",
+        [
+            {"title": "Hybrid Search", "body": "Combining BM25 with vectors"},
+        ],
+    )
     await client.commit("articles")
 
-    results = await client.search("articles",
-        query={"match": {"field": "title", "text": "hybrid"}})
+    results = await client.search(
+        "articles", query={"match": {"field": "title", "text": "hybrid"}}
+    )
     for hit in results.hits:
         print(hit.score, hit.address)
 ```

--- a/hermes-client-python/README.md
+++ b/hermes-client-python/README.md
@@ -14,22 +14,29 @@ pip install hermes-client-python
 import asyncio
 from hermes_client_python import HermesClient
 
+
 async def main():
     async with HermesClient("localhost:50051") as client:
         # Create index with SDL schema
-        await client.create_index("articles", '''
+        await client.create_index(
+            "articles",
+            """
             index articles {
                 field title: text [indexed, stored]
                 field body: text [indexed, stored]
                 field score: f64 [stored]
             }
-        ''')
+        """,
+        )
 
         # Index documents
-        await client.index_documents("articles", [
-            {"title": "Hello World", "body": "First article", "score": 1.5},
-            {"title": "Goodbye World", "body": "Last article", "score": 2.0},
-        ])
+        await client.index_documents(
+            "articles",
+            [
+                {"title": "Hello World", "body": "First article", "score": 1.5},
+                {"title": "Goodbye World", "body": "Last article", "score": 2.0},
+            ],
+        )
 
         # Commit changes
         await client.commit("articles")
@@ -45,6 +52,7 @@ async def main():
 
         # Delete index
         await client.delete_index("articles")
+
 
 asyncio.run(main())
 ```
@@ -75,22 +83,28 @@ await client.close()
 
 ```python
 # Create index with SDL schema
-await client.create_index("myindex", '''
+await client.create_index(
+    "myindex",
+    """
     index myindex {
         field title: text [indexed, stored]
         field body: text [indexed, stored]
     }
-''')
+""",
+)
 
 # Create index with JSON schema
-await client.create_index("myindex", '''
+await client.create_index(
+    "myindex",
+    """
 {
     "fields": [
         {"name": "title", "type": "text", "indexed": true, "stored": true},
         {"name": "body", "type": "text", "indexed": true, "stored": true}
     ]
 }
-''')
+""",
+)
 
 # Get index info
 info = await client.get_index_info("myindex")
@@ -104,18 +118,23 @@ await client.delete_index("myindex")
 
 ```python
 # Index multiple documents (batch)
-indexed, errors = await client.index_documents("myindex", [
-    {"title": "Doc 1", "body": "Content 1"},
-    {"title": "Doc 2", "body": "Content 2"},
-])
+indexed, errors = await client.index_documents(
+    "myindex",
+    [
+        {"title": "Doc 1", "body": "Content 1"},
+        {"title": "Doc 2", "body": "Content 2"},
+    ],
+)
 
 # Index single document
 await client.index_document("myindex", {"title": "Doc", "body": "Content"})
+
 
 # Stream documents (for large datasets)
 async def doc_generator():
     for i in range(10000):
         yield {"title": f"Doc {i}", "body": f"Content {i}"}
+
 
 count = await client.index_documents_stream("myindex", doc_generator())
 
@@ -133,20 +152,21 @@ num_segments = await client.force_merge("myindex")
 results = await client.search("myindex", term=("title", "hello"), limit=10)
 
 # Boolean query
-results = await client.search("myindex", boolean={
-    "must": [("title", "hello")],
-    "should": [("body", "world")],
-    "must_not": [("title", "spam")],
-})
+results = await client.search(
+    "myindex",
+    boolean={
+        "must": [("title", "hello")],
+        "should": [("body", "world")],
+        "must_not": [("title", "spam")],
+    },
+)
 
 # With pagination
 results = await client.search("myindex", term=("title", "hello"), limit=10, offset=20)
 
 # With field loading
 results = await client.search(
-    "myindex",
-    term=("title", "hello"),
-    fields_to_load=["title", "body"]
+    "myindex", term=("title", "hello"), fields_to_load=["title", "body"]
 )
 
 # Access results

--- a/hermes-core/src/directories/directory.rs
+++ b/hermes-core/src/directories/directory.rs
@@ -526,6 +526,16 @@ pub trait Directory: Send + Sync + 'static {
     /// forward to their inner directory. Default: no-op (directories that
     /// emit no Directory-layer metrics, e.g. RamDirectory).
     fn set_index_label(&self, _label: &str) {}
+
+    /// Resolve a directory-relative file to a native filesystem path.
+    ///
+    /// Local backends expose this so large, short-lived merge scratch files
+    /// can live beside the index instead of silently spilling to the
+    /// container's root filesystem. Remote and in-memory backends return
+    /// `None`.
+    fn local_path(&self, _path: &Path) -> Option<PathBuf> {
+        None
+    }
 }
 
 /// Async directory trait for reading index files (WASM version - no Send requirement)
@@ -553,6 +563,11 @@ pub trait Directory: 'static {
     /// Attach the owning index's name for Directory-layer metric labels.
     /// No-op default; metrics are native-only but the label is harmless.
     fn set_index_label(&self, _label: &str) {}
+
+    /// WASM backends do not expose a native filesystem path.
+    fn local_path(&self, _path: &Path) -> Option<PathBuf> {
+        None
+    }
 }
 
 /// A writer for incrementally writing data to a directory file.
@@ -969,6 +984,10 @@ impl Directory for FsDirectory {
     fn set_index_label(&self, label: &str) {
         self.label.set(label);
     }
+
+    fn local_path(&self, path: &Path) -> Option<PathBuf> {
+        Some(self.resolve(path))
+    }
 }
 
 #[cfg(feature = "native")]
@@ -1121,6 +1140,10 @@ impl<D: Directory> Directory for CachingDirectory<D> {
 
     fn set_index_label(&self, label: &str) {
         self.inner.set_index_label(label);
+    }
+
+    fn local_path(&self, path: &Path) -> Option<PathBuf> {
+        self.inner.local_path(path)
     }
 }
 

--- a/hermes-core/src/directories/mmap.rs
+++ b/hermes-core/src/directories/mmap.rs
@@ -132,6 +132,10 @@ impl Directory for MmapDirectory {
     fn set_index_label(&self, label: &str) {
         self.label.set(label);
     }
+
+    fn local_path(&self, path: &Path) -> Option<PathBuf> {
+        Some(self.resolve(path))
+    }
 }
 
 #[async_trait]

--- a/hermes-core/src/directories/slice_cache.rs
+++ b/hermes-core/src/directories/slice_cache.rs
@@ -731,6 +731,10 @@ impl<D: Directory> Directory for SliceCachingDirectory<D> {
         ))
     }
 
+    fn local_path(&self, path: &Path) -> Option<PathBuf> {
+        self.inner.local_path(path)
+    }
+
     fn set_index_label(&self, label: &str) {
         self.label.set(label);
         self.inner.set_index_label(label);

--- a/hermes-core/src/index/primary_key.rs
+++ b/hermes-core/src/index/primary_key.rs
@@ -114,42 +114,18 @@ impl PrimaryKeyIndex {
 
     /// Create from a pre-loaded bloom filter (loaded from `pk_bloom.bin`).
     ///
-    /// Skips dictionary iteration entirely when the persisted bloom covers
-    /// all current segments. `pk_data` contains data for ALL current segments.
-    /// If `new_data` is non-empty, their keys are inserted into the bloom
-    /// before returning (incremental update). `new_data` is a borrowed slice
-    /// pointing to the subset of segments not covered by the persisted bloom.
+    /// Skips dictionary iteration because the caller has already extended the
+    /// persisted bloom with any segments it did not cover. `pk_data` contains
+    /// data for all current segments.
     pub fn from_persisted(
         field: Field,
-        mut bloom: BloomFilter,
+        bloom: BloomFilter,
         pk_data: Vec<PkSegmentData>,
-        new_data: &[PkSegmentData],
         snapshot: SegmentSnapshot,
     ) -> Self {
-        let mut added = 0usize;
-        for data in new_data {
-            if let Some(ff) = data.fast_fields.get(&field.0)
-                && let Some(dict) = ff.text_dict()
-            {
-                for key in dict.iter() {
-                    bloom.insert(key.as_bytes());
-                    added += 1;
-                }
-            }
-        }
-
         log::info!(
-            "[primary_key] bloom filter loaded from cache: {}{}",
+            "[primary_key] bloom filter loaded from cache: {}",
             crate::format_bytes(bloom.size_bytes() as u64),
-            if added > 0 {
-                format!(
-                    ", added {} keys from {} new segment(s)",
-                    added,
-                    new_data.len()
-                )
-            } else {
-                String::new()
-            },
         );
 
         Self {
@@ -163,9 +139,15 @@ impl PrimaryKeyIndex {
         }
     }
 
-    /// Serialize the bloom filter for persistence to `pk_bloom.bin`.
-    pub fn bloom_to_bytes(&self) -> Vec<u8> {
-        self.state.lock().bloom.to_bytes()
+    /// Stream the complete primary-key cache without a corpus-sized
+    /// intermediate allocation.
+    pub fn write_bloom_cache(
+        &self,
+        segment_ids: &[String],
+        writer: &mut (impl std::io::Write + ?Sized),
+    ) -> std::io::Result<()> {
+        let state = self.state.lock();
+        write_pk_bloom(writer, segment_ids, &state.bloom)
     }
 
     /// Memory used by the bloom filter and uncommitted set.
@@ -238,9 +220,6 @@ impl PrimaryKeyIndex {
     /// caller. Existing data for segments still in `snapshot` is retained.
     /// The snapshot keeps ref counts alive so segments aren't deleted.
     pub fn refresh_incremental(&mut self, new_data: Vec<PkSegmentData>, snapshot: SegmentSnapshot) {
-        let new_seg_ids: HashSet<&str> =
-            snapshot.segment_ids().iter().map(|s| s.as_str()).collect();
-
         // Insert new segments' keys into bloom (these were uncommitted before).
         // get_mut() bypasses the mutex — safe because we have &mut self.
         let state = self.state.get_mut();
@@ -254,8 +233,22 @@ impl PrimaryKeyIndex {
             }
         }
         state.uncommitted.clear();
+        self.replace_committed_data(new_data, snapshot);
+    }
 
-        // Keep existing data for segments still in the snapshot
+    /// Refresh segment readers after a topology-only replacement.
+    ///
+    /// Merge and BP reorder outputs contain exactly the same primary keys as
+    /// their sources. Their keys are therefore already represented in the
+    /// monotonic bloom filter, and any live ingestion reservations must remain
+    /// registered while only the committed segment topology changes.
+    pub fn refresh_replacement(&mut self, new_data: Vec<PkSegmentData>, snapshot: SegmentSnapshot) {
+        self.replace_committed_data(new_data, snapshot);
+    }
+
+    fn replace_committed_data(&mut self, new_data: Vec<PkSegmentData>, snapshot: SegmentSnapshot) {
+        let new_seg_ids: HashSet<&str> =
+            snapshot.segment_ids().iter().map(|s| s.as_str()).collect();
         let mut kept: Vec<PkSegmentData> = self
             .committed_data
             .drain(..)
@@ -290,22 +283,34 @@ impl PrimaryKeyIndex {
     }
 }
 
-/// Serialize a bloom filter with the segment IDs it covers into `pk_bloom.bin` format.
+/// Write a bloom filter with the segment IDs it covers in `pk_bloom.bin` format.
 ///
 /// Layout: `[magic:u32][num_segs:u32][seg_id_hex × 32 bytes each...][bloom_bytes...]`
-pub fn serialize_pk_bloom(segment_ids: &[String], bloom_bytes: &[u8]) -> Vec<u8> {
-    let mut data = Vec::with_capacity(8 + segment_ids.len() * 32 + bloom_bytes.len());
-    data.write_u32::<LittleEndian>(PK_BLOOM_MAGIC).unwrap();
-    data.write_u32::<LittleEndian>(segment_ids.len() as u32)
-        .unwrap();
+fn write_pk_bloom(
+    writer: &mut (impl std::io::Write + ?Sized),
+    segment_ids: &[String],
+    bloom: &BloomFilter,
+) -> std::io::Result<()> {
+    writer.write_u32::<LittleEndian>(PK_BLOOM_MAGIC)?;
+    writer.write_u32::<LittleEndian>(u32::try_from(segment_ids.len()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "primary-key bloom segment count exceeds u32::MAX",
+        )
+    })?)?;
     for seg_id in segment_ids {
         let bytes = seg_id.as_bytes();
-        data.extend_from_slice(bytes);
+        if bytes.len() > 32 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "primary-key bloom segment ID exceeds 32 bytes",
+            ));
+        }
+        writer.write_all(bytes)?;
         // Pad to 32 bytes (segment IDs are 32-char hex strings)
-        data.extend(std::iter::repeat_n(0u8, 32 - bytes.len()));
+        writer.write_all(&[0u8; 32][..32 - bytes.len()])?;
     }
-    data.extend_from_slice(bloom_bytes);
-    data
+    bloom.write_to(writer)
 }
 
 /// Deserialize `pk_bloom.bin`. Returns the set of covered segment IDs and the bloom filter,
@@ -320,7 +325,7 @@ pub fn deserialize_pk_bloom(data: &[u8]) -> Option<(HashSet<String>, BloomFilter
     }
     let num_segments = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
     let header_end = 8 + num_segments * 32;
-    if data.len() < header_end + 12 {
+    if data.len() < header_end + BloomFilter::SERIALIZED_HEADER_SIZE {
         return None;
     }
     let mut segment_ids = HashSet::with_capacity(num_segments);
@@ -469,6 +474,20 @@ mod tests {
     }
 
     #[test]
+    fn replacement_refresh_preserves_uncommitted_reservations() {
+        let field = Field(0);
+        let mut pk = PrimaryKeyIndex::new(field, vec![], empty_snapshot());
+
+        assert!(pk.check_and_insert(&make_doc(field, "queued")).is_ok());
+        pk.refresh_replacement(vec![], empty_snapshot());
+
+        assert!(
+            pk.check_and_insert(&make_doc(field, "queued")).is_err(),
+            "topology-only BP refresh must not erase a queued key reservation"
+        );
+    }
+
+    #[test]
     fn test_pk_bloom_serialize_roundtrip() {
         let field = Field(0);
         let pk = PrimaryKeyIndex::new(field, vec![], empty_snapshot());
@@ -481,8 +500,8 @@ mod tests {
             "00000000000000000000000000000001".to_string(),
             "00000000000000000000000000000002".to_string(),
         ];
-        let bloom_bytes = pk.bloom_to_bytes();
-        let data = serialize_pk_bloom(&seg_ids, &bloom_bytes);
+        let mut data = Vec::new();
+        pk.write_bloom_cache(&seg_ids, &mut data).unwrap();
         let (got_ids, got_bloom) = deserialize_pk_bloom(&data).expect("deserialize failed");
 
         assert_eq!(got_ids.len(), 2);

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -633,7 +633,7 @@ impl<D: Directory + 'static> Searcher<D> {
         retrieval_depth: usize,
         parallel: bool,
     ) -> Result<Vec<Option<std::sync::Arc<crate::query::bmp::LspSegmentPlan>>>> {
-        let total_start = std::time::Instant::now();
+        let total_start = crate::observe::WallTimer::start();
         let empty = || vec![None; self.segments.len()];
         if retrieval_depth == 0 {
             return Ok(empty());
@@ -680,7 +680,7 @@ impl<D: Directory + 'static> Searcher<D> {
         if !infos.iter().any(|info| info.candidate) {
             return Ok(empty());
         }
-        let prepare_start = std::time::Instant::now();
+        let prepare_start = crate::observe::WallTimer::start();
         let Some(prepared_query) =
             crate::query::bmp::prepare_bmp_query_infos(reference_bmp.dims(), &infos)?
         else {
@@ -688,7 +688,7 @@ impl<D: Directory + 'static> Searcher<D> {
         };
         let infos: std::sync::Arc<[crate::query::SparseTermQueryInfo]> = infos.into();
         let prepared_query = std::sync::Arc::new(prepared_query);
-        let prepare_secs = prepare_start.elapsed().as_secs_f64();
+        let prepare_secs = prepare_start.secs();
 
         let local_plans = || {
             let plan = std::sync::Arc::new(crate::query::bmp::LspSegmentPlan {
@@ -715,7 +715,7 @@ impl<D: Directory + 'static> Searcher<D> {
             crate::observe::bmp_lsp(
                 self.schema.index_label(),
                 field_label,
-                total_start.elapsed().as_secs_f64(),
+                total_start.secs(),
                 prepare_secs,
                 0.0,
                 0.0,
@@ -727,7 +727,7 @@ impl<D: Directory + 'static> Searcher<D> {
             );
             return Ok(local_plans());
         }
-        let hierarchy_scan_start = std::time::Instant::now();
+        let hierarchy_scan_start = crate::observe::WallTimer::start();
         let prepare = |segment: &std::sync::Arc<crate::segment::SegmentReader>| {
             segment
                 .bmp_index(field)
@@ -758,9 +758,9 @@ impl<D: Directory + 'static> Searcher<D> {
                 .map(prepare)
                 .collect::<Result<Vec<_>>>()?
         };
-        let hierarchy_scan_secs = hierarchy_scan_start.elapsed().as_secs_f64();
+        let hierarchy_scan_secs = hierarchy_scan_start.secs();
 
-        let select_start = std::time::Instant::now();
+        let select_start = crate::observe::WallTimer::start();
         let selection =
             select_global_lsp_hierarchical(&coarse_bounds, gamma, |segment, group, out| {
                 let bmp = self.segments[segment].bmp_index(field).ok_or_else(|| {
@@ -789,11 +789,11 @@ impl<D: Directory + 'static> Searcher<D> {
                 },
             )));
         }
-        let select_secs = select_start.elapsed().as_secs_f64();
+        let select_secs = select_start.secs();
         crate::observe::bmp_lsp(
             self.schema.index_label(),
             field_label,
-            total_start.elapsed().as_secs_f64(),
+            total_start.secs(),
             prepare_secs,
             hierarchy_scan_secs,
             select_secs,

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3443,7 +3443,7 @@ async fn bench_forward_index_build() {
 
     for round in 0..3 {
         let t = std::time::Instant::now();
-        let (fwd, _) = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget).unwrap();
+        let fwd = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget).unwrap();
         println!(
             "record-level fwd build round {}: {:.1}ms ({} terms, {} postings)",
             round,
@@ -3466,7 +3466,7 @@ async fn bench_forward_index_build() {
 
     // Full-pipeline breakdown: BP itself, then the whole reorder (fwd build +
     // BP + permuted blob write + commit) — blob write ≈ total − fwd − BP.
-    let (fwd, _) = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget).unwrap();
+    let fwd = build_forward_index_from_bmps(&[&bmp], min_df, max_df, budget).unwrap();
     let t = std::time::Instant::now();
     let (_perm, converged) = graph_bisection(&fwd, 64, 20, crate::segment::BpBudget::full());
     println!(
@@ -3553,7 +3553,7 @@ async fn test_bmp_block_posting_overflow_256() {
 
     // BP forward-index build over the oversized block must not read wild
     // slices (this is the exact prod crash path).
-    let (fwd, _) =
+    let fwd =
         crate::segment::build_forward_index_from_bmps(&[bmp], 2, 1_000_000, 2 * 1024 * 1024 * 1024)
             .unwrap();
     // Needle dims have df=1 and are correctly filtered by min_doc_freq=2;

--- a/hermes-core/src/index/tests/merge.rs
+++ b/hermes-core/src/index/tests/merge.rs
@@ -706,8 +706,8 @@ async fn test_commit_with_vectors_and_background_merge() {
     assert_eq!(num_docs, 60, "Expected 60 docs, got {}", num_docs);
 }
 
-/// Stress test: force_merge with many segments (iterative batching).
-/// Verifies that merging 50 segments doesn't OOM or exhaust file descriptors.
+/// Stress test: force_merge with more segments than one merge can open.
+/// Verifies the bounded fan-in hierarchy without exhausting file descriptors.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_force_merge_many_segments() {
     use crate::directories::MmapDirectory;
@@ -720,6 +720,7 @@ async fn test_force_merge_many_segments() {
 
     let config = IndexConfig {
         max_indexing_memory_bytes: 512,
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
         ..Default::default()
     };
 
@@ -727,8 +728,8 @@ async fn test_force_merge_many_segments() {
         .await
         .unwrap();
 
-    // Create 50 tiny segments
-    for batch in 0..50 {
+    // Create 70 tiny segments, exceeding FORCE_MERGE_MAX_FAN_IN (64).
+    for batch in 0..70 {
         for i in 0..3 {
             let mut doc = Document::new();
             doc.add_text(title, format!("term_{} batch_{}", i, batch));
@@ -744,14 +745,28 @@ async fn test_force_merge_many_segments() {
     eprintln!("Segments before force_merge: {}", pre);
     assert!(pre >= 2, "Expected multiple segments, got {}", pre);
 
-    // Force merge all into one — should iterate in batches, not OOM
-    writer.force_merge().await.unwrap();
+    // Force merge all into one — one block-copy fan-in reduction followed by
+    // one final pass. Consumers must be refreshed after both replacements.
+    let refreshes = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let refresh_count = std::sync::Arc::clone(&refreshes);
+    writer
+        .force_merge_with_snapshot_refresh(move || {
+            refresh_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            std::future::ready(Ok(()))
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        refreshes.load(std::sync::atomic::Ordering::Relaxed),
+        4,
+        "initial/final refreshes plus one fan-in reduction and one final replacement"
+    );
 
     let index2 = Index::open(dir, config).await.unwrap();
     let post = index2.segment_readers().await.unwrap().len();
     eprintln!("Segments after force_merge: {}", post);
     assert_eq!(post, 1);
-    assert_eq!(index2.num_docs().await.unwrap(), 150);
+    assert_eq!(index2.num_docs().await.unwrap(), 210);
 }
 
 /// Test that background merges produce correct generation metadata.

--- a/hermes-core/src/index/tests/primary_key.rs
+++ b/hermes-core/src/index/tests/primary_key.rs
@@ -562,6 +562,65 @@ async fn test_dedup_reopen_existing_index() {
     writer2.commit().await.unwrap();
 }
 
+#[tokio::test]
+async fn test_force_merge_refreshes_primary_key_snapshot_per_batch() {
+    let (schema, pk, title) = make_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        num_indexing_threads: 1,
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
+
+    let mut writer = IndexWriter::create(dir.clone(), schema, config)
+        .await
+        .unwrap();
+    writer.init_primary_key_dedup().await.unwrap();
+
+    writer
+        .add_document(make_doc(pk, title, "first", "one"))
+        .unwrap();
+    writer.commit().await.unwrap();
+    writer
+        .add_document(make_doc(pk, title, "second", "two"))
+        .unwrap();
+    writer.commit().await.unwrap();
+
+    let old_segment_ids = writer.segment_manager().get_segment_ids().await;
+    assert_eq!(old_segment_ids.len(), 2);
+    let tracker = writer.segment_manager().tracker();
+    assert!(
+        old_segment_ids
+            .iter()
+            .all(|segment_id| tracker.ref_count(segment_id) > 0),
+        "the primary-key index must hold the pre-merge snapshot"
+    );
+
+    writer.force_merge().await.unwrap();
+    writer.segment_manager().wait_for_shutdown().await;
+
+    assert_eq!(writer.segment_manager().get_segment_ids().await.len(), 1);
+    for old_id in old_segment_ids {
+        assert_eq!(
+            tracker.ref_count(&old_id),
+            0,
+            "force merge retained an old primary-key segment snapshot"
+        );
+        let segment_id = crate::segment::SegmentId::from_hex(&old_id).unwrap();
+        let old_paths = crate::segment::SegmentFiles::new(segment_id.0).lifecycle_paths();
+        let remaining = dir.list_files_sync(std::path::Path::new("")).unwrap();
+        assert!(
+            old_paths.iter().all(|path| !remaining.contains(path)),
+            "retired source files remain after the primary-key snapshot refresh"
+        );
+    }
+
+    let error = writer
+        .add_document(make_doc(pk, title, "first", "duplicate"))
+        .unwrap_err();
+    assert!(matches!(error, Error::DuplicatePrimaryKey(_)));
+}
+
 // ---------------------------------------------------------------------------
 // Batch: some succeed, some fail — partial success
 // ---------------------------------------------------------------------------

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -152,6 +152,9 @@ pub struct IndexWriter<D: DirectoryWriter + 'static> {
     flushed_segments: Arc<parking_lot::Mutex<Vec<PreparedSegment<D>>>>,
     /// Primary key dedup index (None if schema has no primary field)
     primary_key_index: Arc<parking_lot::RwLock<Option<super::primary_key::PrimaryKeyIndex>>>,
+    /// Serializes async snapshot acquisition/loading across commits and
+    /// lifecycle-owned merge/reorder topology refreshes.
+    primary_key_refresh_lock: Arc<tokio::sync::Mutex<()>>,
     /// Tracks the owned finalizer spawned by `PreparedCommit::commit`. The
     /// requesting future may disappear, but a second commit generation must
     /// not start until this one has made publication and worker state agree.
@@ -497,6 +500,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             num_workers,
         });
         let (doc_sender, workers) = Self::spawn_workers(&worker_state, num_workers);
+        let primary_key_index = Arc::new(parking_lot::RwLock::new(None));
+        let primary_key_refresh_lock = Arc::new(tokio::sync::Mutex::new(()));
 
         Self {
             directory,
@@ -507,7 +512,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             worker_state,
             segment_manager,
             flushed_segments: Arc::new(parking_lot::Mutex::new(Vec::new())),
-            primary_key_index: Arc::new(parking_lot::RwLock::new(None)),
+            primary_key_index,
+            primary_key_refresh_lock,
             commit_finalization: Arc::new(CommitFinalizationState::default()),
             pk_reservations_retained: Arc::new(AtomicBool::new(false)),
             writer_lock: parking_lot::RwLock::new(writer_lock),
@@ -628,11 +634,50 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         use super::primary_key::{PK_BLOOM_FILE, deserialize_pk_bloom};
 
         self.commit_finalization.wait_until_idle().await;
+        self.ensure_writer_lock()?;
 
         let field = match self.schema.primary_field() {
             Some(f) => f,
             None => return Ok(()),
         };
+
+        // A merge/reorder replacement can publish while this initialization
+        // performs async segment loads. Serialize both paths so an older
+        // initialization snapshot cannot overwrite the replacement refresh
+        // and keep retired source segments pinned indefinitely.
+        let _refresh_guard = self.primary_key_refresh_lock.lock().await;
+        {
+            let callback_directory = Arc::clone(&self.directory);
+            let callback_schema = Arc::clone(&self.schema);
+            let callback_manager = Arc::downgrade(&self.segment_manager);
+            let callback_primary_key = Arc::downgrade(&self.primary_key_index);
+            let callback_refresh_lock = Arc::downgrade(&self.primary_key_refresh_lock);
+            self.segment_manager.set_replacement_refresh(move || {
+                let directory = Arc::clone(&callback_directory);
+                let schema = Arc::clone(&callback_schema);
+                let manager = callback_manager.clone();
+                let primary_key = callback_primary_key.clone();
+                let refresh_lock = callback_refresh_lock.clone();
+                async move {
+                    let (Some(manager), Some(primary_key), Some(refresh_lock)) = (
+                        manager.upgrade(),
+                        primary_key.upgrade(),
+                        refresh_lock.upgrade(),
+                    ) else {
+                        return Ok(());
+                    };
+                    refresh_primary_key_snapshot(
+                        &directory,
+                        &schema,
+                        &manager,
+                        &primary_key,
+                        &refresh_lock,
+                        PrimaryKeyRefresh::Replacement,
+                    )
+                    .await
+                }
+            });
+        }
 
         let snapshot = self.segment_manager.acquire_snapshot().await;
         let current_seg_ids: Vec<String> = snapshot.segment_ids().to_vec();
@@ -682,13 +727,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
             let pk_index = if new_start == pk_data.len() {
                 // Fast path: all segments covered by cache.
-                super::primary_key::PrimaryKeyIndex::from_persisted(
-                    field,
-                    bloom,
-                    pk_data,
-                    &[],
-                    snapshot,
-                )
+                super::primary_key::PrimaryKeyIndex::from_persisted(field, bloom, pk_data, snapshot)
             } else {
                 // Incremental: only iterate new segments' keys.
                 tokio::task::spawn_blocking(move || {
@@ -715,11 +754,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                         );
                     }
                     super::primary_key::PrimaryKeyIndex::from_persisted(
-                        field,
-                        bloom,
-                        pk_data,
-                        &[],
-                        snapshot,
+                        field, bloom, pk_data, snapshot,
                     )
                 })
                 .await
@@ -759,15 +794,23 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         pk_index: &super::primary_key::PrimaryKeyIndex,
         segment_ids: &[String],
     ) {
-        use super::primary_key::{PK_BLOOM_FILE, serialize_pk_bloom};
+        use super::primary_key::PK_BLOOM_FILE;
 
-        let bloom_bytes = pk_index.bloom_to_bytes();
-        let data = serialize_pk_bloom(segment_ids, &bloom_bytes);
-        if let Err(e) = self
+        let writer = match self
             .directory
-            .write(std::path::Path::new(PK_BLOOM_FILE), &data)
+            .streaming_writer(std::path::Path::new(PK_BLOOM_FILE))
             .await
         {
+            Ok(writer) => writer,
+            Err(error) => {
+                log::warn!("[primary_key] failed to open bloom cache: {}", error);
+                return;
+            }
+        };
+        let result = crate::segment::block_in_place_if_multithread(|| {
+            write_pk_bloom_stream(pk_index, segment_ids, writer)
+        });
+        if let Err(e) = result {
             log::warn!("[primary_key] failed to persist bloom cache: {}", e);
         }
     }
@@ -1263,8 +1306,34 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
     /// Force merge all segments into one.
     pub async fn force_merge(&mut self) -> Result<()> {
+        self.force_merge_with_snapshot_refresh(|| std::future::ready(Ok(())))
+            .await
+    }
+
+    /// Force merge while refreshing an external segment consumer after the
+    /// background-merge drain and every durable replacement.
+    ///
+    /// Segment publication refreshes the writer's primary-key topology through
+    /// the manager's lifecycle-owned hook. Servers use this callback to reload
+    /// their cached `IndexReader` as well.
+    pub async fn force_merge_with_snapshot_refresh<F, Fut>(
+        &mut self,
+        refresh_external: F,
+    ) -> Result<()>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<()>>,
+    {
         self.prepare_commit().await?.commit().await?;
-        self.segment_manager.force_merge().await
+
+        self.segment_manager
+            .force_merge_with_snapshot_refresh(refresh_external)
+            .await?;
+
+        // Segment IDs in the on-disk bloom cache need only the final
+        // generation. Persisting the unchanged bloom after every hierarchy
+        // level adds avoidable I/O on large primary-key indexes.
+        self.persist_replacement_snapshot().await
     }
 
     /// Reorder all segments via Recursive Graph Bisection (BP) for better BMP pruning.
@@ -1272,8 +1341,36 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Each segment is individually rebuilt with record-level BP reordering:
     /// ordinals are shuffled across blocks so that similar content clusters tightly.
     pub async fn reorder(&mut self) -> Result<()> {
+        self.reorder_with_snapshot_refresh(|| std::future::ready(Ok(())))
+            .await
+    }
+
+    /// Reorder while refreshing an external reader after each durable segment
+    /// replacement, so retired sources are released during a long pass.
+    pub async fn reorder_with_snapshot_refresh<F, Fut>(&mut self, refresh_external: F) -> Result<()>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<()>>,
+    {
         self.prepare_commit().await?.commit().await?;
-        self.segment_manager.reorder_segments().await
+
+        self.segment_manager
+            .reorder_segments_with_snapshot_refresh(refresh_external)
+            .await?;
+        self.persist_replacement_snapshot().await
+    }
+
+    /// Persist the final topology after a bounded series of replacements.
+    async fn persist_replacement_snapshot(&self) -> Result<()> {
+        refresh_primary_key_snapshot(
+            &self.directory,
+            &self.schema,
+            &self.segment_manager,
+            &self.primary_key_index,
+            &self.primary_key_refresh_lock,
+            PrimaryKeyRefresh::FinalReplacement,
+        )
+        .await
     }
 
     /// Get the segment manager (for background optimizer access).
@@ -1428,18 +1525,34 @@ struct OwnedCommitFinalization<D: DirectoryWriter + 'static> {
     schema: Arc<Schema>,
     segment_manager: Arc<crate::merge::SegmentManager<D>>,
     primary_key_index: Arc<parking_lot::RwLock<Option<super::primary_key::PrimaryKeyIndex>>>,
+    primary_key_refresh_lock: Arc<tokio::sync::Mutex<()>>,
     prepared: PreparedSegmentsGuard<D>,
     finalization: Option<CommitFinalizationGuard<D>>,
     publication_observed: Arc<AtomicBool>,
     pk_reservations_retained: Arc<AtomicBool>,
 }
 
-async fn refresh_primary_key_after_commit<D: DirectoryWriter + 'static>(
+#[derive(Clone, Copy)]
+enum PrimaryKeyRefresh {
+    /// A commit may introduce genuinely new keys and persists the cache.
+    Commit,
+    /// A merge/reorder only changes segment topology; keys are already in the
+    /// monotonic bloom and the intermediate segment IDs need not be persisted.
+    Replacement,
+    /// Final topology refresh: still no key hashing, but persist the new set of
+    /// segment IDs alongside the unchanged bloom.
+    FinalReplacement,
+}
+
+async fn refresh_primary_key_snapshot<D: DirectoryWriter + 'static>(
     directory: &Arc<D>,
     schema: &Arc<Schema>,
     segment_manager: &Arc<crate::merge::SegmentManager<D>>,
     primary_key_index: &Arc<parking_lot::RwLock<Option<super::primary_key::PrimaryKeyIndex>>>,
+    primary_key_refresh_lock: &Arc<tokio::sync::Mutex<()>>,
+    refresh: PrimaryKeyRefresh,
 ) -> Result<()> {
+    let _refresh_guard = primary_key_refresh_lock.lock().await;
     let existing_ids: std::collections::HashSet<String> = {
         let guard = primary_key_index.read();
         let Some(pk_index) = guard.as_ref() else {
@@ -1466,26 +1579,55 @@ async fn refresh_primary_key_after_commit<D: DirectoryWriter + 'static>(
     let new_data = futures::future::try_join_all(load_futures).await?;
     let seg_ids: Vec<String> = snapshot.segment_ids().to_vec();
 
-    let bloom_file = {
+    let persist_bloom = {
         let mut guard = primary_key_index.write();
         let Some(pk_index) = guard.as_mut() else {
             return Ok(());
         };
-        pk_index.refresh_incremental(new_data, snapshot);
-        let bloom_bytes = pk_index.bloom_to_bytes();
-        super::primary_key::serialize_pk_bloom(&seg_ids, &bloom_bytes)
+        match refresh {
+            PrimaryKeyRefresh::Commit => pk_index.refresh_incremental(new_data, snapshot),
+            PrimaryKeyRefresh::Replacement | PrimaryKeyRefresh::FinalReplacement => {
+                pk_index.refresh_replacement(new_data, snapshot);
+            }
+        }
+        matches!(
+            refresh,
+            PrimaryKeyRefresh::Commit | PrimaryKeyRefresh::FinalReplacement
+        )
     };
 
-    if let Err(error) = directory
-        .write(
-            std::path::Path::new(super::primary_key::PK_BLOOM_FILE),
-            &bloom_file,
-        )
-        .await
-    {
-        log::warn!("[primary_key] failed to persist bloom cache: {}", error);
+    if persist_bloom {
+        let writer = match directory
+            .streaming_writer(std::path::Path::new(super::primary_key::PK_BLOOM_FILE))
+            .await
+        {
+            Ok(writer) => writer,
+            Err(error) => {
+                log::warn!("[primary_key] failed to open bloom cache: {}", error);
+                return Ok(());
+            }
+        };
+        // The outer read guard prevents replacement of the PK index while the
+        // inner state lock streams its bloom. No corpus-sized Vec is created.
+        let guard = primary_key_index.read();
+        if let Some(pk_index) = guard.as_ref()
+            && let Err(error) = crate::segment::block_in_place_if_multithread(|| {
+                write_pk_bloom_stream(pk_index, &seg_ids, writer)
+            })
+        {
+            log::warn!("[primary_key] failed to persist bloom cache: {}", error);
+        }
     }
     Ok(())
+}
+
+fn write_pk_bloom_stream(
+    pk_index: &super::primary_key::PrimaryKeyIndex,
+    segment_ids: &[String],
+    mut writer: Box<dyn crate::directories::StreamingWriter>,
+) -> std::io::Result<()> {
+    pk_index.write_bloom_cache(segment_ids, writer.as_mut())?;
+    writer.finish()
 }
 
 async fn finalize_prepared_commit<D: DirectoryWriter + 'static>(
@@ -1521,11 +1663,13 @@ async fn finalize_prepared_commit<D: DirectoryWriter + 'static>(
     // retaining the generation's uncommitted keys may cause conservative
     // duplicate rejections, but can never admit a duplicate or turn a durable
     // commit into an API error.
-    match refresh_primary_key_after_commit(
+    match refresh_primary_key_snapshot(
         &commit.directory,
         &commit.schema,
         &commit.segment_manager,
         &commit.primary_key_index,
+        &commit.primary_key_refresh_lock,
+        PrimaryKeyRefresh::Commit,
     )
     .await
     {
@@ -1588,6 +1732,7 @@ impl<'a, D: DirectoryWriter + 'static> PreparedCommit<'a, D> {
             schema: Arc::clone(&self.writer.schema),
             segment_manager: Arc::clone(&self.writer.segment_manager),
             primary_key_index: Arc::clone(&self.writer.primary_key_index),
+            primary_key_refresh_lock: Arc::clone(&self.writer.primary_key_refresh_lock),
             prepared: PreparedSegmentsGuard {
                 segments: Some(segments),
                 retry_slot: Arc::clone(&self.writer.flushed_segments),

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -61,6 +61,194 @@ use crate::segment::{SegmentMerger, SegmentReader};
 
 use super::{MergePolicy, SegmentInfo};
 
+const FORCE_MERGE_MAX_FAN_IN: usize = 64;
+
+#[derive(Debug)]
+struct ForceMergeGroup {
+    segments: Vec<(String, u32)>,
+    total_docs: u64,
+}
+
+/// Deterministically pack segments into near-minimal final outputs.
+///
+/// Best-fit decreasing avoids the pathological smallest-first behavior where,
+/// for example, `4 + 4` is merged before two `6 + 4` pairs under a 10-doc
+/// limit. That old order both left excess segments and made its intermediate
+/// outputs eligible for another full BP pass. Bin packing is NP-hard; BFD is a
+/// bounded, deterministic approximation that produces maximal groups (no two
+/// output groups can still fit together).
+fn plan_force_merge_groups(
+    mut segments: Vec<(String, u32)>,
+    max_docs: u64,
+) -> Vec<ForceMergeGroup> {
+    segments.sort_unstable_by(|(left_id, left_docs), (right_id, right_docs)| {
+        right_docs
+            .cmp(left_docs)
+            .then_with(|| left_id.cmp(right_id))
+    });
+
+    let mut groups: Vec<ForceMergeGroup> = Vec::new();
+    for segment in segments {
+        let docs = u64::from(segment.1);
+        let best_group = groups
+            .iter()
+            .enumerate()
+            .filter_map(|(index, group)| {
+                group
+                    .total_docs
+                    .checked_add(docs)
+                    .filter(|&total| total <= max_docs)
+                    .map(|_| (index, group.total_docs))
+            })
+            .max_by_key(|&(index, used)| (used, std::cmp::Reverse(index)))
+            .map(|(index, _)| index);
+
+        if let Some(index) = best_group {
+            groups[index].total_docs += docs;
+            groups[index].segments.push(segment);
+        } else {
+            groups.push(ForceMergeGroup {
+                segments: vec![segment],
+                total_docs: docs,
+            });
+        }
+    }
+
+    // Preserve the old small-to-large source order inside each output. Besides
+    // stable document ordering, BMP block-copy compression depends on source
+    // alignment at group boundaries.
+    for group in &mut groups {
+        group
+            .segments
+            .sort_unstable_by(|(left_id, left_docs), (right_id, right_docs)| {
+                left_docs
+                    .cmp(right_docs)
+                    .then_with(|| left_id.cmp(right_id))
+            });
+    }
+
+    // Smallest outputs first limit transient disk headroom. Tie-break on the
+    // first (deterministically ordered) segment ID for reproducible plans.
+    groups.sort_unstable_by(|left, right| {
+        left.total_docs
+            .cmp(&right.total_docs)
+            .then_with(|| left.segments[0].0.cmp(&right.segments[0].0))
+    });
+    groups
+}
+
+fn force_merge_output_count(source_count: usize) -> usize {
+    if source_count < 2 {
+        return 0;
+    }
+    (source_count - 1).div_ceil(FORCE_MERGE_MAX_FAN_IN - 1)
+}
+
+#[derive(Debug)]
+struct ForceMergeStep {
+    /// Source or earlier-step node IDs, in final document order.
+    inputs: Vec<usize>,
+}
+
+#[derive(Debug)]
+struct ForceMergeHierarchy {
+    steps: Vec<ForceMergeStep>,
+    root: usize,
+}
+
+/// Build a shallow ordered 64-ary reduction tree with the minimum possible
+/// number of merge outputs. All internal nodes have full fan-in except one
+/// deepest partial node; distributing internal nodes evenly keeps source
+/// rewrite depth balanced without changing concatenation order.
+fn plan_force_merge_hierarchy(source_count: usize) -> ForceMergeHierarchy {
+    debug_assert!(source_count >= 2);
+    let internal_count = force_merge_output_count(source_count);
+    let max_leaves = 1usize
+        .checked_add(internal_count.saturating_mul(FORCE_MERGE_MAX_FAN_IN - 1))
+        .expect("force-merge hierarchy size exceeds usize");
+    let deficit = max_leaves - source_count;
+    debug_assert!(deficit < FORCE_MERGE_MAX_FAN_IN - 1);
+
+    fn build(
+        leaf_start: usize,
+        leaf_count: usize,
+        internal_count: usize,
+        deficit: usize,
+        source_count: usize,
+        steps: &mut Vec<ForceMergeStep>,
+    ) -> usize {
+        debug_assert!(internal_count > 0);
+        if internal_count == 1 {
+            let arity = FORCE_MERGE_MAX_FAN_IN - deficit;
+            debug_assert_eq!(leaf_count, arity);
+            debug_assert!((2..=FORCE_MERGE_MAX_FAN_IN).contains(&arity));
+            let output = source_count + steps.len();
+            steps.push(ForceMergeStep {
+                inputs: (leaf_start..leaf_start + arity).collect(),
+            });
+            return output;
+        }
+
+        // Keep this node full and place the one partial arity, if any, in the
+        // deepest/largest child. This minimizes bytes rewritten versus making
+        // the root partial (65 inputs become 2 + 63 leaves, then one final
+        // merge, rather than rewriting a 64-input prefix).
+        let child_internal_total = internal_count - 1;
+        let base = child_internal_total / FORCE_MERGE_MAX_FAN_IN;
+        let extra = child_internal_total % FORCE_MERGE_MAX_FAN_IN;
+        let mut child_internal = vec![base; FORCE_MERGE_MAX_FAN_IN];
+        for count in &mut child_internal[..extra] {
+            *count += 1;
+        }
+        let partial_child = (deficit > 0).then(|| {
+            child_internal
+                .iter()
+                .position(|&count| count > 0)
+                .expect("a non-root partial node requires an internal child")
+        });
+
+        let mut cursor = leaf_start;
+        let mut inputs = Vec::with_capacity(FORCE_MERGE_MAX_FAN_IN);
+        for (child, &child_internals) in child_internal.iter().enumerate() {
+            if child_internals == 0 {
+                inputs.push(cursor);
+                cursor += 1;
+                continue;
+            }
+            let child_deficit = usize::from(partial_child == Some(child)) * deficit;
+            let child_leaves = 1usize
+                .checked_add(child_internals.saturating_mul(FORCE_MERGE_MAX_FAN_IN - 1))
+                .and_then(|maximum| maximum.checked_sub(child_deficit))
+                .expect("force-merge child size exceeds usize");
+            inputs.push(build(
+                cursor,
+                child_leaves,
+                child_internals,
+                child_deficit,
+                source_count,
+                steps,
+            ));
+            cursor += child_leaves;
+        }
+        debug_assert_eq!(cursor, leaf_start + leaf_count);
+        let output = source_count + steps.len();
+        steps.push(ForceMergeStep { inputs });
+        output
+    }
+
+    let mut steps = Vec::with_capacity(internal_count);
+    let root = build(
+        0,
+        source_count,
+        internal_count,
+        deficit,
+        source_count,
+        &mut steps,
+    );
+    debug_assert_eq!(steps.len(), internal_count);
+    ForceMergeHierarchy { steps, root }
+}
+
 // ============================================================================
 // RAII active-operation tracking
 // ============================================================================
@@ -441,6 +629,39 @@ struct ManagerState {
     merge_policy: Box<dyn MergePolicy>,
 }
 
+type ReplacementRefresh = Arc<
+    dyn Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Reconcile a long-lived consumer after a durable segment replacement.
+/// This runs inside the same lifecycle-owned task as metadata publication, so
+/// cancelling the caller cannot leave the replacement published but unannounced.
+async fn refresh_replacement_topology(refresh: Option<ReplacementRefresh>) {
+    let Some(refresh) = refresh else {
+        return;
+    };
+    let mut last_error = None;
+    for attempt in 0..3 {
+        match refresh().await {
+            Ok(()) => return,
+            Err(error) => {
+                last_error = Some(error);
+                if attempt < 2 {
+                    tokio::time::sleep(std::time::Duration::from_secs(1 << attempt)).await;
+                }
+            }
+        }
+    }
+    if let Some(error) = last_error {
+        log::warn!(
+            "[segment_lifecycle] replacement topology refresh failed after 3 attempts: {}",
+            error,
+        );
+    }
+}
+
 #[cfg(feature = "native")]
 struct MergeTaskError {
     error: Error,
@@ -497,13 +718,45 @@ type MergeTaskResult<T> = std::result::Result<T, MergeTaskError>;
 
 #[derive(Clone, Copy)]
 enum ReplacementLayout {
-    Recomputed {
-        reordered: bool,
-        bp_converged: bool,
-    },
+    /// No BP ran while combining these sources. The combined segment is not
+    /// globally reordered, but an interrupted BP lineage remains owed its
+    /// record-level deepening pass.
+    BlockCopy,
+    /// A BP pass produced the replacement layout.
+    BpReordered { converged: bool },
     /// A vector-only rewrite leaves document order and sparse layout exactly
     /// unchanged, so its persisted BP progress must not be reset or advanced.
     PreserveSingleSource,
+}
+
+fn replacement_bp_state(
+    parent_has_debt: bool,
+    parent_unconverged_passes: u32,
+    layout: ReplacementLayout,
+) -> (bool, bool, u32) {
+    match layout {
+        ReplacementLayout::BlockCopy => (
+            false,
+            !parent_has_debt,
+            if parent_has_debt {
+                parent_unconverged_passes
+            } else {
+                0
+            },
+        ),
+        ReplacementLayout::BpReordered { converged } => (
+            true,
+            converged,
+            if converged {
+                0
+            } else {
+                parent_unconverged_passes.saturating_add(1)
+            },
+        ),
+        ReplacementLayout::PreserveSingleSource => {
+            unreachable!("preserved layouts retain the complete source metadata")
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -621,6 +874,10 @@ pub struct SegmentManager<D: DirectoryWriter + 'static> {
     /// Application-owned shared pool, when configured. This is the server
     /// path and ensures optimizer and merge-time work use the same threads.
     background_reorder_pool: Option<Arc<rayon::ThreadPool>>,
+    /// Writer-owned topology reconciler. Every durable replacement invokes
+    /// it from tracked lifecycle work so background merges cannot leave
+    /// primary-key snapshots pinning retired sources indefinitely.
+    replacement_refresh: parking_lot::RwLock<Option<ReplacementRefresh>>,
 }
 
 struct ForceMergeActivityGuard<'a>(&'a AtomicUsize);
@@ -736,7 +993,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             merge_bp_time_budget,
             bp_memory_budget_bytes,
             background_reorder_pool,
+            replacement_refresh: parking_lot::RwLock::new(None),
         }
+    }
+
+    pub(crate) fn set_replacement_refresh<F, Fut>(&self, refresh: F)
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<()>> + Send + 'static,
+    {
+        *self.replacement_refresh.write() = Some(Arc::new(move || Box::pin(refresh())));
     }
 
     /// Bounded rayon pool for background CPU (merge-time BP, manual reorder,
@@ -1232,6 +1498,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let directory = Arc::clone(&self.directory);
         let trained = Arc::clone(&self.trained);
         let tracker = Arc::clone(&self.tracker);
+        let replacement_refresh = self.replacement_refresh.read().clone();
         // Keep the producer gate raised if the requesting future is cancelled
         // after the metadata transaction has been detached. The last guard
         // clone drops only after durable metadata and ArcSwap state agree.
@@ -1269,6 +1536,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 }
             }
             tracker.complete_deletion(&ready_to_delete);
+            refresh_replacement_topology(replacement_refresh).await;
             Ok(())
         })
         .await
@@ -1516,56 +1784,22 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let ids = segment_ids_to_merge;
 
         Some(tokio::spawn(async move {
-            let mut output_cleanup = sm.output_cleanup_guard(output_id);
             let mut reevaluate = false;
             let mut retry_delay = None;
 
-            let trained_snap = sm.trained_for_segment_build();
-            let granularity = sm.merge_granularity(&ids).await;
-            let result = Self::do_merge(
-                sm.directory.as_ref(),
-                &sm.schema,
-                &ids,
-                output_id,
-                sm.term_cache_blocks,
-                trained_snap.as_deref(),
-                sm.reorder_on_merge,
-                granularity,
-                sm.merge_bp_time_budget,
-                sm.bp_memory_budget_bytes,
-                Arc::clone(&sm.reorder_permits),
-                ReorderPriority::Background,
-                Some(sm.background_cpu_pool()),
-            )
-            .await;
+            let result = sm
+                .merge_and_replace_registered(
+                    &ids,
+                    output_id,
+                    sm.reorder_on_merge,
+                    ReorderPriority::Background,
+                )
+                .await;
 
             match result {
-                Ok((new_id, doc_count, bp_converged)) => {
-                    match sm
-                        .replace_segments(
-                            &ids,
-                            new_id,
-                            doc_count,
-                            ReplacementLayout::Recomputed {
-                                reordered: sm.reorder_on_merge,
-                                bp_converged,
-                            },
-                        )
-                        .await
-                    {
-                        Ok(()) => {
-                            output_cleanup.disarm();
-                            sm.clear_merge_retry_backoff();
-                            reevaluate = true;
-                        }
-                        Err(e) => {
-                            sm.delete_output_if_unregistered(output_id, "replacement failure")
-                                .await;
-                            output_cleanup.disarm();
-                            retry_delay = Some(sm.pause_merge_retries(&e));
-                            log::error!("[merge] failed to publish merged segment: {}", e);
-                        }
-                    }
+                Ok(_) => {
+                    sm.clear_merge_retry_backoff();
+                    reevaluate = true;
                 }
                 Err(MergeTaskError {
                     error,
@@ -1577,19 +1811,13 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                         error
                     );
                     if !unavailable_segments.is_empty() {
-                        for segment_id in &unavailable_segments {
-                            sm.quarantine_segment(segment_id, &error);
-                        }
-                        // Recompute without this known-bad input. This is not a
+                        // Recompute without known-bad inputs. This is not a
                         // retry of the same candidate because policy filtering
                         // excludes every quarantined ID.
                         reevaluate = true;
                     } else {
                         retry_delay = Some(sm.pause_merge_retries(&error));
                     }
-                    sm.delete_output_if_unregistered(output_id, "merge failure")
-                        .await;
-                    output_cleanup.disarm();
                 }
             }
             // Release source/output ownership before re-evaluating policy, so
@@ -1611,6 +1839,76 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 sm.schedule_merge_retry_wakeup(retry_delay);
             }
         }))
+    }
+
+    /// Execute the common build → validate → durable replacement transaction
+    /// for a batch whose source/output IDs are already lifecycle-owned.
+    ///
+    /// Scheduling, retry policy, and post-replacement snapshot refresh remain
+    /// with the caller. Keeping the transaction here prevents background and
+    /// force-merge paths from drifting on cleanup or BP metadata semantics.
+    async fn merge_and_replace_registered(
+        self: &Arc<Self>,
+        ids: &[String],
+        output_id: SegmentId,
+        reorder_bmp: bool,
+        priority: ReorderPriority,
+    ) -> MergeTaskResult<(String, u32, bool)> {
+        let mut output_cleanup = self.output_cleanup_guard(output_id);
+        let trained = self.trained_for_segment_build();
+        let granularity = if reorder_bmp {
+            self.merge_granularity(ids).await
+        } else {
+            crate::segment::reorder::BpGranularity::Auto
+        };
+        let result = Self::do_merge(
+            self.directory.as_ref(),
+            &self.schema,
+            ids,
+            output_id,
+            self.term_cache_blocks,
+            trained.as_deref(),
+            reorder_bmp,
+            granularity,
+            self.merge_bp_time_budget,
+            self.bp_memory_budget_bytes,
+            Arc::clone(&self.reorder_permits),
+            priority,
+            Some(self.background_cpu_pool()),
+        )
+        .await;
+
+        let (new_id, doc_count, bp_converged) = match result {
+            Ok(value) => value,
+            Err(error) => {
+                for segment_id in &error.unavailable_segments {
+                    self.quarantine_segment(segment_id, &error.error);
+                }
+                self.delete_output_if_unregistered(output_id, "merge failure")
+                    .await;
+                output_cleanup.disarm();
+                return Err(error);
+            }
+        };
+
+        let layout = if reorder_bmp {
+            ReplacementLayout::BpReordered {
+                converged: bp_converged,
+            }
+        } else {
+            ReplacementLayout::BlockCopy
+        };
+        if let Err(error) = self
+            .replace_segments(ids, new_id.clone(), doc_count, layout)
+            .await
+        {
+            self.delete_output_if_unregistered(output_id, "replacement failure")
+                .await;
+            output_cleanup.disarm();
+            return Err(MergeTaskError::from(error));
+        }
+        output_cleanup.disarm();
+        Ok((new_id, doc_count, bp_converged))
     }
 
     /// Re-evaluate merge policy after a failure backoff, outside the tracked
@@ -1692,10 +1990,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         }
 
         let replacement_info = match layout {
-            ReplacementLayout::Recomputed {
-                reordered,
-                bp_converged,
-            } => {
+            ReplacementLayout::BlockCopy | ReplacementLayout::BpReordered { .. } => {
                 let generation = old_ids
                     .iter()
                     .filter_map(|id| st.metadata.segment_metas.get(id))
@@ -1710,18 +2005,19 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     .map(|info| info.bp_unconverged_passes)
                     .max()
                     .unwrap_or(0);
-                let passes = if reordered && !bp_converged {
-                    parent_unconverged_passes.saturating_add(1)
-                } else {
-                    0
-                };
+                let parent_has_debt = old_ids
+                    .iter()
+                    .filter_map(|id| st.metadata.segment_metas.get(id))
+                    .any(|info| !info.bp_converged);
+                let (reordered, bp_converged, bp_unconverged_passes) =
+                    replacement_bp_state(parent_has_debt, parent_unconverged_passes, layout);
                 SegmentMetaInfo {
                     num_docs: doc_count,
                     ancestors: old_ids.to_vec(),
                     generation,
                     reordered,
                     bp_converged,
-                    bp_unconverged_passes: passes,
+                    bp_unconverged_passes,
                 }
             }
             ReplacementLayout::PreserveSingleSource => {
@@ -1753,6 +2049,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
         let directory = Arc::clone(&self.directory);
         let tracker = Arc::clone(&self.tracker);
+        let replacement_refresh = self.replacement_refresh.read().clone();
         self.run_lifecycle_transaction(async move {
             // Durable-before-visible. If persistence fails, old metadata and
             // tracker ownership stay intact and source deletion is never armed.
@@ -1777,6 +2074,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 }
             }
             tracker.complete_deletion(&ready_to_delete);
+            refresh_replacement_topology(replacement_refresh).await;
             Ok(())
         })
         .await
@@ -1962,11 +2260,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
     /// Drain all in-flight merge tasks safely.
     ///
-    /// Tokio cannot abort a `spawn_blocking` closure once it has started. The
-    /// old implementation aborted only the async wrapper and returned while
-    /// merge-time BP still owned an `OffsetWriter`, allowing index deletion or
-    /// orphan cleanup to race a live writer. Awaiting is the only sound generic
-    /// behavior until every merge phase supports cooperative cancellation.
+    /// Merge/reorder writers use synchronous block-in-place sections, so an
+    /// abort request takes effect only after the owned writer reaches its next
+    /// await. Draining the complete task remains necessary before index
+    /// deletion or orphan cleanup can safely proceed.
     ///
     /// Cancellation-safe: dropping this future mid-drain returns un-awaited
     /// handles to `merge_handles` so later drains still see in-flight merges.
@@ -2035,7 +2332,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         }
     }
 
-    /// Force merge segments into the fewest possible segments, respecting
+    /// Force merge segments into compact, size-balanced groups, respecting
     /// `max_segment_docs` from the merge policy.
     ///
     /// If the policy defines a max segment size, segments are merged in batches
@@ -2044,7 +2341,27 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     /// Each batch is registered in `active_operations` via an RAII guard to prevent
     /// `maybe_merge` from spawning a conflicting background merge.
     pub async fn force_merge(self: &Arc<Self>) -> Result<()> {
-        const FORCE_MERGE_BATCH: usize = 64;
+        self.force_merge_with_snapshot_refresh(|| std::future::ready(Ok(())))
+            .await
+    }
+
+    /// Force merge while refreshing long-lived segment snapshots after the
+    /// initial background-merge drain and every durable replacement.
+    ///
+    /// Long-lived consumers such as the primary-key index and cached
+    /// `IndexReader` hold segment snapshots. Refreshing them only after the
+    /// complete force merge retains every retired source file for the entire
+    /// operation, which can temporarily double a large index on disk. The
+    /// hook lets the owning `IndexWriter`/server advance those snapshots after
+    /// each batch while the force merge remains otherwise memory bounded.
+    pub(crate) async fn force_merge_with_snapshot_refresh<F, Fut>(
+        self: &Arc<Self>,
+        mut refresh_snapshots: F,
+    ) -> Result<()>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<()>>,
+    {
         // Conflicting owners that never appear in `merge_handles` (background
         // reorders, a concurrent force-merge) can hold a batch segment for
         // minutes to hours; retrying without parking would busy-spin a runtime
@@ -2070,31 +2387,32 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
         // Wait for all in-flight background merges (including cascading)
         // before starting forced merges to avoid try_register conflicts.
+        let drain_start = std::time::Instant::now();
         self.wait_for_all_merges().await;
-
-        // Once pre-existing merges are drained, stop admitting new background
-        // BP passes and reserve all but one reorder slot. Existing optimizer
-        // passes finish normally; this force merge then owns the remaining
-        // capacity instead of sitting behind a continually replenished queue.
-        // Keep the guard for every force-merge batch so background work cannot
-        // interleave between batches.
-        let _foreground_reorder = if self.reorder_on_merge {
+        if drain_start.elapsed() >= std::time::Duration::from_secs(1) {
             log::info!(
-                "[force_merge] prioritizing BP capacity ({} total pass slot(s))",
-                self.reorder_permits.limit(),
+                "[force_merge] drained background merges in {:.1}s",
+                drain_start.elapsed().as_secs_f64(),
             );
-            Some(
-                Arc::clone(&self.reorder_permits)
-                    .begin_foreground()
-                    .await
-                    .map_err(|_| {
-                        Error::Internal("background reorder scheduler is closed".into())
-                    })?,
-            )
-        } else {
-            None
-        };
+        }
 
+        // A background merge may have published after the writer's preceding
+        // commit refresh but before the drain completed. Advance PK/search
+        // snapshots now so its retired sources do not survive until the first
+        // forced replacement (or forever when no batch is needed).
+        let refresh_start = std::time::Instant::now();
+        refresh_snapshots().await?;
+        if refresh_start.elapsed() >= std::time::Duration::from_secs(1) {
+            log::info!(
+                "[force_merge] initial snapshot refresh took {:.1}s",
+                refresh_start.elapsed().as_secs_f64(),
+            );
+        }
+
+        // Outputs produced by a completed bin are already maximal according
+        // to the BFD plan. Excluding them from later replanning prevents an
+        // expensive final BP output from being selected and reordered again.
+        let mut completed_outputs = HashSet::new();
         // One INFO line per wait episode, not per 1s poll; DEBUG afterwards.
         let mut logged_held_wait = false;
 
@@ -2102,68 +2420,64 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             if !self.active_operations.is_accepting() {
                 return Err(Error::IndexClosed);
             }
-            // Get segment IDs with their doc counts, sorted ascending by size
-            let mut segments: Vec<(String, u32)> = {
+
+            let segments: Vec<(String, u32)> = {
                 let st = self.state.lock().await;
                 st.metadata
                     .segment_metas
                     .iter()
+                    .filter(|(id, _)| !completed_outputs.contains(*id))
                     .map(|(id, info)| (id.clone(), info.num_docs))
                     .collect()
             };
 
-            if segments.len() < 2 {
-                return Ok(());
-            }
-
-            segments.sort_by_key(|(_, docs)| *docs);
-
-            // Route around segments owned by active operations (background
-            // reorders, concurrent force-merges) instead of insisting on the
-            // deterministic smallest-N batch: retrying a batch that contains a
-            // segment mid-BP-pass livelocked here for the whole pass (observed
-            // in prod: the optimizer holds exactly the small fresh segments
-            // force_merge wants first). Held segments are merged on a later
-            // iteration, after their owner releases them.
+            // Route around segments owned by active operations instead of
+            // retrying the same conflicting batch. Group ownership is claimed
+            // before foreground capacity, so an in-flight optimizer/retrain
+            // can finish without a capacity/ownership lock inversion.
             let active_ids = self.active_operations.snapshot();
-            let held: usize = segments
+            let held = segments
                 .iter()
                 .filter(|(id, _)| active_ids.contains(id))
                 .count();
+            let free_segments: Vec<_> = segments
+                .into_iter()
+                .filter(|(id, _)| !active_ids.contains(id))
+                .collect();
+            // Every segment format and doc map uses u32 document IDs. A policy
+            // with no explicit cap therefore means "up to the format limit",
+            // not an unrepresentable u64-sized output.
+            let max_docs = max_segment_docs
+                .map(u64::from)
+                .unwrap_or(u64::from(u32::MAX));
+            let next_group = plan_force_merge_groups(free_segments, max_docs)
+                .into_iter()
+                .find(|group| group.segments.len() >= 2);
 
-            // Build a batch of free segments respecting max_segment_docs
-            let max_docs = max_segment_docs.map(|m| m as u64).unwrap_or(u64::MAX);
-            let mut batch = Vec::new();
-            let mut batch_docs = 0u64;
-
-            for (id, docs) in &segments {
-                if active_ids.contains(id) {
-                    continue;
-                }
-                if batch.len() >= FORCE_MERGE_BATCH {
-                    break;
-                }
-                let next_total = batch_docs + *docs as u64;
-                if next_total > max_docs && !batch.is_empty() {
-                    break;
-                }
-                batch.push(id.clone());
-                batch_docs += *docs as u64;
-            }
-
-            if batch.len() < 2 {
+            let Some(group) = next_group else {
                 if held == 0 {
-                    // Nothing left that can merge and nobody will release
-                    // more candidates: force merge is complete.
+                    if !completed_outputs.is_empty() {
+                        // A segment held while earlier groups ran may now fit
+                        // with one of those outputs. Reconsider completed bins
+                        // once before declaring convergence. In the normal
+                        // no-conflict path BFD groups are pairwise maximal, so
+                        // this extra planning round performs no merge.
+                        completed_outputs.clear();
+                        continue;
+                    }
+                    // Every remaining free segment is either already at the
+                    // size cap or cannot be paired without exceeding it.
+                    // A reorder that was already running when foreground
+                    // admission began may have published after the preceding
+                    // callback. Reconcile external readers one final time so
+                    // they cannot retain its retired source indefinitely.
+                    refresh_snapshots().await?;
                     return Ok(());
                 }
-                // All remaining work is behind active owners. Their guards
-                // are RAII and their passes are time-budgeted, so this always
-                // unblocks; poll slowly rather than spinning.
                 if !logged_held_wait {
                     log::info!(
                         "[force_merge] waiting: {} segment(s) held by active \
-                         merge/reorder operations, none free to merge",
+                         merge/reorder operations, no free group can merge",
                         held
                     );
                     logged_held_wait = true;
@@ -2181,38 +2495,29 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     () = tokio::time::sleep(FORCE_MERGE_HELD_BACKOFF) => {}
                 }
                 continue;
-            }
+            };
             logged_held_wait = false;
 
-            let _global_merge_permit = tokio::select! {
-                biased;
-                () = self.active_operations.wait_for_shutdown() => {
-                    return Err(Error::IndexClosed);
-                }
-                permit = Arc::clone(&self.global_merge_permits).acquire_owned() => {
-                    permit.map_err(|_| {
-                        Error::Internal("global background merge scheduler is closed".into())
-                    })?
-                }
-            };
-
-            let output_id = SegmentId::new();
-            let output_hex = output_id.to_hex();
-
-            // Register batch + output under `state`, matching orphan cleanup's
-            // deletion barrier and preventing a stale batch from starting.
-            let mut all_ids = batch.clone();
-            all_ids.push(output_hex);
-            let guard = {
+            // Claim the complete final group and all of its future output IDs
+            // up front. This freezes the hierarchy while allowing every
+            // durable intermediate replacement to release its source files.
+            let hierarchy = plan_force_merge_hierarchy(group.segments.len());
+            let output_ids: Vec<_> = (0..hierarchy.steps.len())
+                .map(|_| SegmentId::new())
+                .collect();
+            let source_ids: Vec<_> = group.segments.iter().map(|(id, _)| id.clone()).collect();
+            let mut all_ids = source_ids.clone();
+            all_ids.extend(output_ids.iter().map(|id| id.to_hex()));
+            let group_guard = {
                 let st = self.state.lock().await;
-                batch
+                source_ids
                     .iter()
                     .all(|id| st.metadata.has_segment(id))
                     .then(|| self.active_operations.try_register(all_ids))
                     .flatten()
             };
-            let _guard = match guard {
-                Some(g) => g,
+            let _group_guard = match group_guard {
+                Some(guard) => guard,
                 None if !self.active_operations.is_accepting() => {
                     return Err(Error::IndexClosed);
                 }
@@ -2220,15 +2525,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     #[cfg(test)]
                     self.force_merge_conflict_retries
                         .fetch_add(1, Ordering::Relaxed);
-                    // Do not reserve application-wide merge capacity while
-                    // parked on a conflict.
-                    drop(_global_merge_permit);
-                    // The ownership snapshot above is advisory: an operation
-                    // can register one of our batch segments between the
-                    // snapshot and try_register. A tracked background merge
-                    // may also have slipped in — drain those first, then back
-                    // off briefly and rebuild the batch from a fresh snapshot.
-                    log::debug!("[force_merge] batch lost a registration race, rebuilding");
+                    log::debug!("[force_merge] group lost a registration race, replanning");
                     let had_tracked_merges = !self.merge_handles.lock().is_empty();
                     self.wait_for_merging_thread().await;
                     if !had_tracked_merges {
@@ -2237,70 +2534,160 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     continue;
                 }
             };
-            // Announce only after ownership is secured: this line used to
-            // print before registration, spamming once per 100ms retry while
-            // a reorder held a batch segment.
-            log::info!(
-                "[force_merge] merging batch of {} segments ({} docs)",
-                batch.len(),
-                batch_docs
-            );
-            let mut output_cleanup = self.output_cleanup_guard(output_id);
 
-            let trained_snap = self.trained_for_segment_build();
-            let granularity = self.merge_granularity(&batch).await;
-            let merge_result = Self::do_merge(
-                self.directory.as_ref(),
-                &self.schema,
-                &batch,
-                output_id,
-                self.term_cache_blocks,
-                trained_snap.as_deref(),
-                self.reorder_on_merge,
-                granularity,
-                self.merge_bp_time_budget,
-                self.bp_memory_budget_bytes,
-                Arc::clone(&self.reorder_permits),
-                ReorderPriority::Foreground,
-                Some(self.background_cpu_pool()),
-            )
-            .await;
-            let (new_segment_id, total_docs, bp_converged) = match merge_result {
-                Ok(v) => v,
-                Err(MergeTaskError {
-                    error,
-                    unavailable_segments,
-                }) => {
-                    for segment_id in &unavailable_segments {
-                        self.quarantine_segment(segment_id, &error);
+            log::info!(
+                "[force_merge] planned final group: {} segments, {} docs, {} merge pass(es)",
+                group.segments.len(),
+                group.total_docs,
+                output_ids.len(),
+            );
+
+            // Claiming the complete group before any capacity wait prevents a
+            // vector-generation pause from waiting for a global slot retained
+            // by force merge while force merge waits for that pause to end.
+            //
+            // Background merges acquire global merge capacity before the
+            // shared BP gate. Preserve that order here: wait for one group
+            // slot while background BP remains admitted, then pause new BP
+            // passes. The retained slot guarantees this hierarchy can make
+            // progress even if other indexes subsequently park at the gate.
+            let group_global_merge_permit = if self.reorder_on_merge {
+                let capacity_start = std::time::Instant::now();
+                let permit = tokio::select! {
+                    biased;
+                    () = self.active_operations.wait_for_shutdown() => {
+                        return Err(Error::IndexClosed);
                     }
-                    self.delete_output_if_unregistered(output_id, "force-merge failure")
-                        .await;
-                    output_cleanup.disarm();
-                    return Err(error);
+                    permit = Arc::clone(&self.global_merge_permits).acquire_owned() => {
+                        permit.map_err(|_| {
+                            Error::Internal(
+                                "global background merge scheduler is closed".into(),
+                            )
+                        })?
+                    }
+                };
+                if capacity_start.elapsed() >= std::time::Duration::from_secs(1) {
+                    log::info!(
+                        "[force_merge] waited {:.1}s for foreground global merge capacity",
+                        capacity_start.elapsed().as_secs_f64(),
+                    );
                 }
+                Some(permit)
+            } else {
+                None
+            };
+            let _foreground_reorder = if self.reorder_on_merge {
+                log::info!(
+                    "[force_merge] prioritizing BP capacity ({} total pass slot(s))",
+                    self.reorder_permits.limit(),
+                );
+                let admission_start = std::time::Instant::now();
+                let guard = Arc::clone(&self.reorder_permits)
+                    .begin_foreground()
+                    .await
+                    .map_err(|_| {
+                        Error::Internal("background reorder scheduler is closed".into())
+                    })?;
+                if admission_start.elapsed() >= std::time::Duration::from_secs(1) {
+                    log::info!(
+                        "[force_merge] acquired foreground BP capacity in {:.1}s",
+                        admission_start.elapsed().as_secs_f64(),
+                    );
+                }
+                Some(guard)
+            } else {
+                None
             };
 
-            if let Err(e) = self
-                .replace_segments(
-                    &batch,
-                    new_segment_id,
-                    total_docs,
-                    ReplacementLayout::Recomputed {
-                        reordered: self.reorder_on_merge,
-                        bp_converged,
-                    },
-                )
-                .await
-            {
-                self.delete_output_if_unregistered(output_id, "replacement failure")
-                    .await;
-                output_cleanup.disarm();
-                return Err(e);
-            }
-            output_cleanup.disarm();
+            let source_count = group.segments.len();
+            let mut nodes: Vec<Option<(String, u32)>> =
+                group.segments.into_iter().map(Some).collect();
+            nodes.resize_with(source_count + hierarchy.steps.len(), || None);
+            for (step_index, step) in hierarchy.steps.iter().enumerate() {
+                let final_pass = step_index + 1 == hierarchy.steps.len();
+                let mut batch_entries = Vec::with_capacity(step.inputs.len());
+                for &node in &step.inputs {
+                    let entry = nodes
+                        .get_mut(node)
+                        .and_then(Option::take)
+                        .expect("force-merge hierarchy must reference an available node");
+                    batch_entries.push(entry);
+                }
+                let batch: Vec<_> = batch_entries.iter().map(|(id, _)| id.clone()).collect();
+                let batch_docs: u64 = batch_entries.iter().map(|(_, docs)| u64::from(*docs)).sum();
+                let output_id = output_ids[step_index];
 
-            // _guard drops here, releasing operation ownership.
+                let capacity_start = std::time::Instant::now();
+                let step_global_merge_permit = if group_global_merge_permit.is_none() {
+                    Some(tokio::select! {
+                        biased;
+                        () = self.active_operations.wait_for_shutdown() => {
+                            return Err(Error::IndexClosed);
+                        }
+                        permit = Arc::clone(&self.global_merge_permits).acquire_owned() => {
+                            permit.map_err(|_| {
+                                Error::Internal(
+                                    "global background merge scheduler is closed".into(),
+                                )
+                            })?
+                        }
+                    })
+                } else {
+                    None
+                };
+                if capacity_start.elapsed() >= std::time::Duration::from_secs(1) {
+                    log::info!(
+                        "[force_merge] waited {:.1}s for global merge capacity",
+                        capacity_start.elapsed().as_secs_f64(),
+                    );
+                }
+
+                // Intermediate reductions are streaming block-copy merges.
+                // Only the final pass pays BP, so a group with hundreds of
+                // tiny sources never reorders the same documents repeatedly.
+                let reorder_bmp = final_pass && self.reorder_on_merge;
+                log::info!(
+                    "[force_merge] {} pass: {} segments ({} docs, bp={})",
+                    if final_pass {
+                        "final"
+                    } else {
+                        "fan-in reduction"
+                    },
+                    batch.len(),
+                    batch_docs,
+                    reorder_bmp,
+                );
+                let (new_segment_id, total_docs, _) = self
+                    .merge_and_replace_registered(
+                        &batch,
+                        output_id,
+                        reorder_bmp,
+                        ReorderPriority::Foreground,
+                    )
+                    .await
+                    .map_err(|error| error.error)?;
+                drop(step_global_merge_permit);
+
+                // Advance PK/read snapshots after every hierarchy level so
+                // retired sources do not accumulate until the final output.
+                let refresh_start = std::time::Instant::now();
+                refresh_snapshots().await?;
+                if refresh_start.elapsed() >= std::time::Duration::from_secs(1) {
+                    log::info!(
+                        "[force_merge] post-replacement snapshot refresh took {:.1}s",
+                        refresh_start.elapsed().as_secs_f64(),
+                    );
+                }
+
+                let output_node = source_count + step_index;
+                debug_assert!(nodes[output_node].is_none());
+                nodes[output_node] = Some((new_segment_id, total_docs));
+            }
+            let (root_id, _) = nodes[hierarchy.root]
+                .take()
+                .expect("force-merge hierarchy must produce its root");
+            debug_assert!(nodes.into_iter().all(|node| node.is_none()));
+            completed_outputs.insert(root_id);
         }
     }
 
@@ -2728,7 +3115,22 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     ///
     /// Uses active-operation ownership to prevent concurrent work on the same segment.
     pub async fn reorder_segments(self: &Arc<Self>) -> Result<()> {
+        self.reorder_segments_with_snapshot_refresh(|| std::future::ready(Ok(())))
+            .await
+    }
+
+    /// Reorder all segments while advancing long-lived snapshots after the
+    /// background-merge drain and every durable replacement.
+    pub(crate) async fn reorder_segments_with_snapshot_refresh<F, Fut>(
+        self: &Arc<Self>,
+        mut refresh_snapshots: F,
+    ) -> Result<()>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<()>>,
+    {
         self.wait_for_all_merges().await;
+        refresh_snapshots().await?;
         let segment_ids = self.get_segment_ids().await;
 
         if segment_ids.is_empty() {
@@ -2743,12 +3145,15 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 .reorder_single_segment(&seg_id, None, crate::segment::BpBudget::full())
                 .await
             {
-                Ok(true) => {}
+                Ok(true) => refresh_snapshots().await?,
                 Ok(false) => log::warn!("[reorder] segment {} skipped (in merge)", seg_id),
                 Err(e) => return Err(e),
             }
         }
 
+        // A segment skipped because another lifecycle owner held it may have
+        // been replaced after the preceding callback.
+        refresh_snapshots().await?;
         log::info!("[reorder] all segments reordered");
         Ok(())
     }
@@ -2777,6 +3182,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             .iter()
             .filter(|(id, info)| {
                 !info.reordered
+                    && info.bp_converged
                     && !active_ids.contains(*id)
                     && !quarantined.contains(*id)
                     && !paused.contains(*id)
@@ -2810,8 +3216,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             .segment_metas
             .iter()
             .filter(|(id, info)| {
-                info.reordered
-                    && !info.bp_converged
+                !info.bp_converged
                     && info.bp_unconverged_passes < max_unconverged_passes
                     && !active_ids.contains(*id)
                     && !quarantined.contains(*id)
@@ -2822,7 +3227,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     }
 
     /// Granularity for a BP pass whose sources are `ids`: `Records` when any
-    /// source is an unconverged partial reorder, `Auto` otherwise.
+    /// source carries unconverged BP debt, `Auto` otherwise.
     ///
     /// Alignment with the depth budget (docs/block-level-reorder.md): an
     /// unconverged segment is owed a deepening pass, and the output of this
@@ -2836,12 +3241,12 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             st.metadata
                 .segment_metas
                 .get(id)
-                .is_some_and(|info| info.reordered && !info.bp_converged)
+                .is_some_and(|info| !info.bp_converged)
         });
         drop(st);
         if deepening {
             log::info!(
-                "[reorder] source segment(s) unconverged — forcing record-level BP (deepening pass)",
+                "[reorder] source BP lineage unconverged — forcing record-level BP (deepening pass)",
             );
             crate::segment::reorder::BpGranularity::Records
         } else {
@@ -2866,6 +3271,13 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 "segment {} is quarantined after a deterministic source failure; repair it and restart before reordering",
                 seg_id
             )));
+        }
+        if self.force_merge_active.load(Ordering::Acquire) > 0 {
+            log::debug!(
+                "[optimizer] explicit force merge active, skipping reorder of {}",
+                seg_id,
+            );
+            return Ok(false);
         }
 
         // Whole-pass concurrency is independent from Rayon width. One pass
@@ -2898,6 +3310,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let all_ids = vec![seg_id.to_string(), output_hex];
         let (_guard, source_docs) = {
             let st = self.state.lock().await;
+            // Force merge raises this barrier under the same state lock, so
+            // this second check closes the race with the cheap early check
+            // above and prevents optimizer starvation between final groups.
+            if self.force_merge_active.load(Ordering::Acquire) > 0 {
+                log::debug!(
+                    "[optimizer] explicit force merge active, skipping reorder of {}",
+                    seg_id,
+                );
+                return Ok(false);
+            }
             let Some(source_meta) = st.metadata.segment_metas.get(seg_id) else {
                 log::info!(
                     "[optimizer] segment {} no longer in metadata (merged away), skipping reorder",
@@ -2974,9 +3396,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 &[seg_id.to_string()],
                 new_id,
                 total_docs,
-                ReplacementLayout::Recomputed {
-                    reordered: true,
-                    bp_converged: ladder_converged,
+                ReplacementLayout::BpReordered {
+                    converged: ladder_converged,
                 },
             )
             .await
@@ -3102,6 +3523,288 @@ mod tests {
             Arc::new(ReorderConcurrencyGate::new(1)),
             None,
         ))
+    }
+
+    #[test]
+    fn force_merge_planner_pairs_large_and_small_segments() {
+        let groups = plan_force_merge_groups(
+            vec![
+                ("a".into(), 6),
+                ("b".into(), 6),
+                ("c".into(), 4),
+                ("d".into(), 4),
+            ],
+            10,
+        );
+
+        assert_eq!(groups.len(), 2);
+        assert!(groups.iter().all(|group| group.total_docs == 10));
+        assert!(groups.iter().all(|group| group.segments.len() == 2));
+    }
+
+    #[test]
+    fn force_merge_planner_leaves_oversized_segments_alone() {
+        let groups = plan_force_merge_groups(
+            vec![
+                ("oversized".into(), 11),
+                ("small-a".into(), 5),
+                ("small-b".into(), 5),
+            ],
+            10,
+        );
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].total_docs, 10);
+        assert_eq!(groups[0].segments.len(), 2);
+        assert_eq!(groups[1].total_docs, 11);
+        assert_eq!(groups[1].segments.len(), 1);
+    }
+
+    #[test]
+    fn force_merge_planner_never_exceeds_segment_format_limit() {
+        let groups = plan_force_merge_groups(
+            vec![
+                ("large-a".into(), 3_000_000_000),
+                ("large-b".into(), 2_000_000_000),
+            ],
+            u64::from(u32::MAX),
+        );
+        assert_eq!(groups.len(), 2);
+        assert!(
+            groups
+                .iter()
+                .all(|group| group.total_docs <= u64::from(u32::MAX))
+        );
+    }
+
+    #[test]
+    fn force_merge_hierarchy_has_one_final_bp_pass() {
+        assert_eq!(force_merge_output_count(1), 0);
+        assert_eq!(force_merge_output_count(2), 1);
+        assert_eq!(force_merge_output_count(64), 1);
+        assert_eq!(force_merge_output_count(65), 2);
+        assert_eq!(force_merge_output_count(127), 2);
+        assert_eq!(force_merge_output_count(128), 3);
+        assert_eq!(force_merge_output_count(1_000), 16);
+    }
+
+    fn expand_force_merge_node(
+        hierarchy: &ForceMergeHierarchy,
+        source_count: usize,
+        node: usize,
+        sources: &mut Vec<usize>,
+    ) {
+        if node < source_count {
+            sources.push(node);
+            return;
+        }
+
+        let step_index = node - source_count;
+        let step = hierarchy
+            .steps
+            .get(step_index)
+            .expect("merge input must refer to an existing source or output");
+        for &input in &step.inputs {
+            assert!(
+                input < node,
+                "merge step {step_index} refers to a future output node {input}"
+            );
+            expand_force_merge_node(hierarchy, source_count, input, sources);
+        }
+    }
+
+    #[test]
+    fn force_merge_hierarchy_has_minimal_valid_arity() {
+        let source_counts = (2..=1_024).chain([4_095, 4_096, 4_097, 10_000]);
+
+        for source_count in source_counts {
+            let hierarchy = plan_force_merge_hierarchy(source_count);
+            let output_count = hierarchy.steps.len();
+
+            assert!(
+                hierarchy
+                    .steps
+                    .iter()
+                    .all(|step| (2..=FORCE_MERGE_MAX_FAN_IN).contains(&step.inputs.len())),
+                "invalid merge arity for {source_count} sources"
+            );
+            assert!(
+                source_count <= 1 + output_count * (FORCE_MERGE_MAX_FAN_IN - 1),
+                "{output_count} outputs cannot reduce {source_count} sources"
+            );
+            assert!(
+                output_count == 1
+                    || source_count > 1 + (output_count - 1) * (FORCE_MERGE_MAX_FAN_IN - 1),
+                "{output_count} outputs are not minimal for {source_count} sources"
+            );
+            assert_eq!(output_count, force_merge_output_count(source_count));
+        }
+    }
+
+    #[test]
+    fn force_merge_hierarchy_preserves_exact_source_order() {
+        for source_count in [2, 3, 63, 64, 65, 66, 126, 127, 128, 129, 1_000, 4_097] {
+            let hierarchy = plan_force_merge_hierarchy(source_count);
+            let mut sources = Vec::with_capacity(source_count);
+            expand_force_merge_node(&hierarchy, source_count, hierarchy.root, &mut sources);
+            assert_eq!(
+                sources,
+                (0..source_count).collect::<Vec<_>>(),
+                "source order changed for {source_count} sources"
+            );
+        }
+    }
+
+    fn force_merge_rewrite_cost(source_count: usize) -> usize {
+        let hierarchy = plan_force_merge_hierarchy(source_count);
+        let mut node_weights = vec![1usize; source_count];
+        let mut rewrite_cost = 0usize;
+
+        for (step_index, step) in hierarchy.steps.iter().enumerate() {
+            let output = source_count + step_index;
+            let output_weight = step
+                .inputs
+                .iter()
+                .map(|&input| {
+                    assert!(
+                        input < output,
+                        "merge step {step_index} refers to future output {input}"
+                    );
+                    node_weights[input]
+                })
+                .sum::<usize>();
+            rewrite_cost += output_weight;
+            node_weights.push(output_weight);
+        }
+
+        assert_eq!(node_weights[hierarchy.root], source_count);
+        rewrite_cost
+    }
+
+    #[test]
+    fn force_merge_hierarchy_avoids_growing_prefix_rewrites() {
+        assert_eq!(force_merge_rewrite_cost(65), 67);
+        assert_eq!(force_merge_rewrite_cost(1_000), 1_951);
+    }
+
+    #[test]
+    fn block_copy_carries_bp_debt_without_spending_an_attempt() {
+        assert_eq!(
+            replacement_bp_state(true, 3, ReplacementLayout::BlockCopy),
+            (false, false, 3),
+        );
+        assert_eq!(
+            replacement_bp_state(true, 3, ReplacementLayout::BpReordered { converged: false },),
+            (true, false, 4),
+        );
+        assert_eq!(
+            replacement_bp_state(true, 3, ReplacementLayout::BpReordered { converged: true },),
+            (true, true, 0),
+        );
+    }
+
+    #[tokio::test]
+    async fn force_merge_reconsiders_outputs_after_a_held_source_releases() {
+        let mut schema_builder = crate::dsl::SchemaBuilder::default();
+        let field = schema_builder.add_text_field("text", true, true);
+        let schema = schema_builder.build();
+        let directory = crate::directories::RamDirectory::new();
+        let config = crate::index::IndexConfig {
+            num_indexing_threads: 1,
+            merge_policy: Box::new(crate::merge::NoMergePolicy),
+            ..Default::default()
+        };
+        let mut writer = crate::index::IndexWriter::create(directory, schema, config)
+            .await
+            .unwrap();
+        for value in ["one", "two", "three"] {
+            let mut document = crate::dsl::Document::new();
+            document.add_text(field, value);
+            writer.add_document(document).unwrap();
+            writer.commit().await.unwrap();
+        }
+
+        let manager = Arc::clone(writer.segment_manager());
+        let held_id = manager.get_segment_ids().await.pop().unwrap();
+        let mut held = Some(
+            manager
+                .active_operations
+                .try_register(vec![held_id])
+                .unwrap(),
+        );
+        let batches = Arc::new(AtomicUsize::new(0));
+        let batch_count = Arc::clone(&batches);
+        writer
+            .force_merge_with_snapshot_refresh(move || {
+                let refresh = batch_count.fetch_add(1, Ordering::Relaxed) + 1;
+                // Refresh #1 follows the startup drain. Keep the source held
+                // until refresh #2, after the two free sources were replaced.
+                if refresh == 2 {
+                    drop(held.take());
+                }
+                std::future::ready(Ok(()))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(manager.get_segment_ids().await.len(), 1);
+        assert_eq!(
+            batches.load(Ordering::Relaxed),
+            4,
+            "initial/final refreshes plus two replacements are required after the held source releases"
+        );
+    }
+
+    #[tokio::test]
+    async fn force_merge_does_not_hold_global_capacity_while_vector_update_pauses_claims() {
+        let mut schema_builder = crate::dsl::SchemaBuilder::default();
+        schema_builder.set_reorder_on_merge(true);
+        let schema = schema_builder.build();
+        let mut metadata = IndexMetadata::new(schema.clone());
+        metadata.add_segment("00000000000000000000000000000001".into(), 1);
+        metadata.add_segment("00000000000000000000000000000002".into(), 1);
+
+        let global_merge_permits = Arc::new(Semaphore::new(1));
+        let manager = Arc::new(SegmentManager::new(
+            Arc::new(crate::directories::RamDirectory::new()),
+            Arc::new(schema),
+            metadata,
+            Box::new(crate::merge::NoMergePolicy),
+            0,
+            1,
+            Arc::clone(&global_merge_permits),
+            None,
+            1024,
+            Arc::new(ReorderConcurrencyGate::new(1)),
+            None,
+        ));
+
+        // Vector-generation staging rejects ordinary lifecycle claims while
+        // acquiring the shared global merge permit separately for each source.
+        // Force merge must wait before capacity admission; retaining the only
+        // global slot here would deadlock both operations between sources.
+        manager.active_operations.pause_non_indexing();
+        let force_merge = {
+            let manager = Arc::clone(&manager);
+            tokio::spawn(async move { manager.force_merge().await })
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while manager.force_merge_conflict_retries.load(Ordering::Relaxed) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("force merge never reached the paused group claim");
+
+        assert_eq!(
+            global_merge_permits.available_permits(),
+            1,
+            "force merge retained global capacity while vector staging blocked group ownership"
+        );
+
+        force_merge.abort();
+        let _ = force_merge.await;
+        manager.active_operations.resume_non_indexing();
     }
 
     #[test]
@@ -3355,6 +4058,28 @@ mod tests {
                 },
             );
             state.metadata.add_segment_meta(
+                "carried-debt".into(),
+                SegmentMetaInfo {
+                    num_docs: 15,
+                    ancestors: Vec::new(),
+                    generation: 2,
+                    reordered: false,
+                    bp_converged: false,
+                    bp_unconverged_passes: 2,
+                },
+            );
+            state.metadata.add_segment_meta(
+                "carried-debt-at-limit".into(),
+                SegmentMetaInfo {
+                    num_docs: 25,
+                    ancestors: Vec::new(),
+                    generation: 2,
+                    reordered: false,
+                    bp_converged: false,
+                    bp_unconverged_passes: 3,
+                },
+            );
+            state.metadata.add_segment_meta(
                 "converged".into(),
                 SegmentMetaInfo {
                     num_docs: 30,
@@ -3369,8 +4094,15 @@ mod tests {
         }
 
         assert_eq!(
-            manager.unconverged_segments_below(3).await,
-            vec![("eligible".into(), 10, 2)]
+            manager.unreordered_segments().await,
+            vec![("fresh".into(), 40)],
+            "a block-copy output with BP debt is not a fresh first-pass candidate",
+        );
+        let mut eligible = manager.unconverged_segments_below(3).await;
+        eligible.sort_unstable();
+        assert_eq!(
+            eligible,
+            vec![("carried-debt".into(), 15, 2), ("eligible".into(), 10, 2),],
         );
         assert!(manager.unconverged_segments_below(0).await.is_empty());
     }

--- a/hermes-core/src/observe.rs
+++ b/hermes-core/src/observe.rs
@@ -20,6 +20,39 @@ pub(crate) struct BmpQueryPhases {
     pub prefetch_ranges: usize,
 }
 
+/// Wall-clock timer for diagnostics that must also compile on platforms where
+/// `std::time::Instant` is unavailable at runtime (notably wasm32).
+///
+/// Native builds retain real timings; non-native builds fold the timer and its
+/// readings away. Metrics-only call sites should use [`Timer`] instead so they
+/// remain free when metrics are disabled.
+pub(crate) struct WallTimer {
+    #[cfg(feature = "native")]
+    start: std::time::Instant,
+}
+
+impl WallTimer {
+    #[inline]
+    pub fn start() -> Self {
+        Self {
+            #[cfg(feature = "native")]
+            start: std::time::Instant::now(),
+        }
+    }
+
+    #[inline]
+    pub fn secs(&self) -> f64 {
+        #[cfg(feature = "native")]
+        {
+            self.start.elapsed().as_secs_f64()
+        }
+        #[cfg(not(feature = "native"))]
+        {
+            0.0
+        }
+    }
+}
+
 #[cfg(all(feature = "metrics", feature = "native"))]
 mod imp {
     use super::BmpQueryPhases;

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -594,7 +594,7 @@ fn execute_bmp_inner(
     predicate: Option<&dyn Fn(crate::DocId) -> bool>,
     threshold_source: BmpThreshold<'_>,
 ) -> crate::Result<Vec<ScoredDoc>> {
-    let total_start = std::time::Instant::now();
+    let total_start = crate::observe::WallTimer::start();
     if index.num_blocks == 0
         || k == 0
         || lsp_plan.is_none() && (candidate_terms.is_empty() || scoring_terms.is_empty())
@@ -611,7 +611,7 @@ fn execute_bmp_inner(
     let num_superblocks_total = index.num_superblocks as usize;
 
     // ── Phase 1: Resolve query dimensions and quantize weights ────────
-    let prepare_start = std::time::Instant::now();
+    let prepare_start = crate::observe::WallTimer::start();
     let local_prepared;
     let prepared_query = if let Some(plan) = lsp_plan {
         plan.prepared_query.as_ref()
@@ -623,7 +623,7 @@ fn execute_bmp_inner(
         local_prepared = prepared;
         &local_prepared
     };
-    let prepare_secs = prepare_start.elapsed().as_secs_f64();
+    let prepare_secs = prepare_start.secs();
     let query_by_dim_u16 = prepared_query.query_by_dim_u16.as_slice();
     let candidate_grid_weights = prepared_query.candidate_grid_weights.as_slice();
     let candidate_mask = prepared_query.candidate_mask;
@@ -798,7 +798,7 @@ fn execute_bmp_inner(
                 phases.prefetch_ranges = phases.prefetch_ranges.saturating_add(calls);
             }
 
-            let d_grid_start = std::time::Instant::now();
+            let d_grid_start = crate::observe::WallTimer::start();
             scratch.prepared_superblocks.clear();
             let window_threshold = collector.threshold();
             let mut stop_after_window = false;
@@ -853,7 +853,7 @@ fn execute_bmp_inner(
             }
             let prepared_count = scratch.prepared_superblocks.len();
             cursor = window_start.saturating_add(prepared_count);
-            phases.d_grid_secs += d_grid_start.elapsed().as_secs_f64();
+            phases.d_grid_secs += d_grid_start.secs();
             if prepared_count == 0 {
                 break;
             }
@@ -919,7 +919,7 @@ fn execute_bmp_inner(
                     stop_after_window = true;
                     break;
                 }
-                let score_start = std::time::Instant::now();
+                let score_start = crate::observe::WallTimer::start();
                 score_superblock_blocks(
                     index,
                     prepared.block_start,
@@ -946,7 +946,7 @@ fn execute_bmp_inner(
                     },
                     &mut phases.docmap_secs,
                 );
-                phases.block_score_secs += score_start.elapsed().as_secs_f64();
+                phases.block_score_secs += score_start.secs();
                 sbs_scored += 1;
 
                 if threshold_source.publish
@@ -967,13 +967,13 @@ fn execute_bmp_inner(
             }
         }
 
-        let elapsed_ms = total_start.elapsed().as_secs_f64() * 1000.0;
+        let elapsed_ms = total_start.secs() * 1000.0;
         let threshold = collector.threshold();
         let returned = collector.real_len();
         crate::observe::bmp_query(
             index_label,
             field_label,
-            total_start.elapsed().as_secs_f64(),
+            total_start.secs(),
             phases,
             sbs_scored as usize,
             num_superblocks_total,
@@ -1278,7 +1278,7 @@ fn score_superblock_blocks(
         // doc_id. The combine_ordinal_results layer handles multi-ordinal grouping.
         let base = block_id as usize * block_size;
         let num_vdocs = index.num_virtual_docs as usize;
-        let docmap_start = std::time::Instant::now();
+        let docmap_start = crate::observe::WallTimer::start();
 
         for (word, &touched_word) in touched.iter().enumerate() {
             let mut scan = touched_word;
@@ -1323,7 +1323,7 @@ fn score_superblock_blocks(
                 }
             }
         }
-        *docmap_secs += docmap_start.elapsed().as_secs_f64();
+        *docmap_secs += docmap_start.secs();
 
         *blocks_scored += 1;
     }

--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -391,26 +391,9 @@ pub(crate) fn build_bmp_blob(
             grid_entries.push((dim_id, block_id, max_impact));
 
             // Advance cursor
+            cursors[dim_idx] = pos;
             if let Some(nb) = next_block {
-                cursors[dim_idx] = pos;
                 heap.push(Reverse((nb, dim_id, dim_idx)));
-            } else {
-                cursors[dim_idx] = pos;
-                while pos < posts.len() {
-                    let (doc_id, ordinal, weight) = posts[pos];
-                    let abs_w = weight.abs();
-                    if skip_wt || abs_w >= weight_threshold {
-                        let impact = quantize_weight(abs_w, max_weight_scale);
-                        if impact > 0 {
-                            let virtual_id = vid_lookup.get((doc_id, ordinal)) as u64;
-                            let nb = (virtual_id / bs64) as u32;
-                            cursors[dim_idx] = pos;
-                            heap.push(Reverse((nb, dim_id, dim_idx)));
-                            break;
-                        }
-                    }
-                    pos += 1;
-                }
             }
         }
 
@@ -897,32 +880,109 @@ pub(crate) fn write_grid_run(
     Ok(())
 }
 
+/// Merge sorted grid runs into one sorted run without materializing entries.
 #[cfg(feature = "native")]
-fn visit_merged_dimension(
-    run_readers: &mut [GridRunReader],
-    dimension: u32,
-    mut visitor: impl FnMut(u32, u8) -> std::io::Result<()>,
+pub(crate) fn merge_grid_runs(
+    input_paths: &[std::path::PathBuf],
+    output_path: &std::path::Path,
 ) -> std::io::Result<()> {
-    let mut heap: BinaryHeap<Reverse<(u32, u8, usize)>> =
-        BinaryHeap::with_capacity(run_readers.len());
-    for (run, reader) in run_readers.iter().enumerate() {
-        if let Some((dim, block, impact)) = reader.current
-            && dim == dimension
-        {
-            heap.push(Reverse((block, impact, run)));
+    if let [input] = input_paths {
+        let mut reader = std::io::BufReader::with_capacity(256 * 1024, std::fs::File::open(input)?);
+        let mut writer =
+            std::io::BufWriter::with_capacity(256 * 1024, std::fs::File::create(output_path)?);
+        std::io::copy(&mut reader, &mut writer)?;
+        return writer.flush();
+    }
+    let mut readers: Vec<GridRunReader> = input_paths
+        .iter()
+        .map(|path| GridRunReader::open(path))
+        .collect::<std::io::Result<_>>()?;
+    let output = std::fs::File::create(output_path)?;
+    let mut writer = std::io::BufWriter::with_capacity(256 * 1024, output);
+    let mut heap: BinaryHeap<Reverse<(u32, u32, u8, usize)>> =
+        BinaryHeap::with_capacity(readers.len());
+    for (run, reader) in readers.iter().enumerate() {
+        if let Some((dimension, block, impact)) = reader.current {
+            heap.push(Reverse((dimension, block, impact, run)));
         }
     }
-    while let Some(Reverse((block, impact, run))) = heap.pop() {
-        visitor(block, impact)?;
-        let reader = &mut run_readers[run];
+    let mut buffer = [0u8; GRID_ENTRY_DISK_SIZE];
+    while let Some(mut head) = heap.peek_mut() {
+        let Reverse((dimension, block, impact, run)) = *head;
+        buffer[0..4].copy_from_slice(&dimension.to_le_bytes());
+        buffer[4..8].copy_from_slice(&block.to_le_bytes());
+        buffer[8] = impact;
+        writer.write_all(&buffer)?;
+        let reader = &mut readers[run];
         reader.advance()?;
-        if let Some((dim, next_block, next_impact)) = reader.current
-            && dim == dimension
-        {
-            heap.push(Reverse((next_block, next_impact, run)));
+        if let Some((next_dimension, next_block, next_impact)) = reader.current {
+            *head = Reverse((next_dimension, next_block, next_impact, run));
+        } else {
+            std::collections::binary_heap::PeekMut::pop(head);
         }
     }
-    Ok(())
+    writer.flush()
+}
+
+#[cfg(feature = "native")]
+struct MergedGridCursor<'a> {
+    readers: &'a mut [GridRunReader],
+    heap: BinaryHeap<Reverse<(u32, u32, u8, usize)>>,
+}
+
+#[cfg(feature = "native")]
+impl<'a> MergedGridCursor<'a> {
+    fn new(readers: &'a mut [GridRunReader]) -> Self {
+        let mut heap = BinaryHeap::with_capacity(readers.len());
+        for (run, reader) in readers.iter().enumerate() {
+            if let Some((dimension, block, impact)) = reader.current {
+                heap.push(Reverse((dimension, block, impact, run)));
+            }
+        }
+        Self { readers, heap }
+    }
+
+    fn visit_dimension(
+        &mut self,
+        dimension: u32,
+        mut visitor: impl FnMut(u32, u8) -> std::io::Result<()>,
+    ) -> std::io::Result<()> {
+        if self
+            .heap
+            .peek()
+            .is_some_and(|Reverse((next, _, _, _))| *next < dimension)
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "BMP external grid runs are not sorted by dimension",
+            ));
+        }
+        while let Some(mut head) = self.heap.peek_mut() {
+            let Reverse((next_dimension, block, impact, run)) = *head;
+            if next_dimension != dimension {
+                break;
+            }
+            visitor(block, impact)?;
+            let reader = &mut self.readers[run];
+            reader.advance()?;
+            if let Some((next_dimension, next_block, next_impact)) = reader.current {
+                *head = Reverse((next_dimension, next_block, next_impact, run));
+            } else {
+                std::collections::binary_heap::PeekMut::pop(head);
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(self, num_dims: usize) -> std::io::Result<()> {
+        if let Some(Reverse((dimension, _, _, _))) = self.heap.peek() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("BMP grid run dimension {dimension} exceeds configured dims={num_dims}"),
+            ));
+        }
+        Ok(())
+    }
 }
 
 #[cfg(feature = "native")]
@@ -930,6 +990,7 @@ struct ProjectedRowEncoder {
     projection: GridProjection,
     cells: usize,
     widths: Vec<u8>,
+    touched_groups: Vec<usize>,
     payload: Vec<u8>,
     values: [u8; GRID_GROUP_CELLS],
     packed: [u8; GRID_GROUP_CELLS],
@@ -949,6 +1010,7 @@ impl ProjectedRowEncoder {
             projection,
             cells,
             widths: vec![0; groups],
+            touched_groups: Vec::new(),
             payload: Vec::with_capacity(payload_capacity),
             values: [0; GRID_GROUP_CELLS],
             packed: [0; GRID_GROUP_CELLS],
@@ -993,135 +1055,350 @@ impl ProjectedRowEncoder {
         let maximum = self.values.iter().copied().max().unwrap_or(0);
         let width = bit_width(maximum);
         self.widths[group] = width;
+        if width > 0 {
+            self.touched_groups.push(group);
+        }
         let payload_len = pack_group(&self.values, width, &mut self.packed)
             .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
         self.payload.extend_from_slice(&self.packed[..payload_len]);
         Ok(())
     }
 
-    fn finish(mut self) -> std::io::Result<(Vec<u8>, Vec<u8>)> {
+    fn finish_row(&mut self) -> std::io::Result<()> {
         self.finish_current_group()?;
-        Ok((self.widths, self.payload))
+        Ok(())
+    }
+
+    fn reset(&mut self) {
+        for group in self.touched_groups.drain(..) {
+            self.widths[group] = 0;
+        }
+        self.payload.clear();
+        self.current_group = None;
+        self.previous_cell = None;
     }
 }
 
 #[cfg(feature = "native")]
-fn write_compressed_grid_section_merged(
-    run_readers: &mut [GridRunReader],
-    num_dims: usize,
-    num_blocks: usize,
+struct MergedGridPlan {
     projection: GridProjection,
-    writer: &mut dyn Write,
-) -> std::io::Result<u64> {
-    let cells = projection.cells(num_blocks);
-    let layout = CompressedGridLayout::new(num_dims, cells);
-    let mut widths = vec![0u8; layout.groups()];
-    let mut row_sizes = Vec::with_capacity(num_dims);
+    cells: usize,
+    layout: CompressedGridLayout,
+    widths: Vec<u8>,
+    touched_groups: Vec<usize>,
+    payload_units: u64,
+    row_sizes: Vec<u64>,
+}
 
-    for dim in 0..num_dims as u32 {
-        widths.fill(0);
-        visit_merged_dimension(run_readers, dim, |block, impact| {
-            let (cell, value) = projection.project(block, impact);
-            if cell >= cells {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    format!("BMP grid cell {cell} exceeds configured cell count {cells}"),
-                ));
-            }
-            let group = cell / GRID_GROUP_CELLS;
-            widths[group] = widths[group].max(bit_width(value));
-            Ok(())
-        })?;
-        row_sizes.push(
-            layout
-                .row_bytes(&widths)
-                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?,
-        );
-    }
-    for reader in run_readers.iter() {
-        if let Some((dimension, _, _)) = reader.current {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("BMP grid run dimension {dimension} exceeds configured dims={num_dims}"),
-            ));
+#[cfg(feature = "native")]
+impl MergedGridPlan {
+    fn new(projection: GridProjection, num_dims: usize, num_blocks: usize) -> Self {
+        let cells = projection.cells(num_blocks);
+        let layout = CompressedGridLayout::new(num_dims, cells);
+        Self {
+            projection,
+            cells,
+            layout,
+            widths: vec![0; layout.groups()],
+            touched_groups: Vec::new(),
+            payload_units: 0,
+            row_sizes: Vec::with_capacity(num_dims),
         }
     }
 
-    for reader in run_readers.iter_mut() {
-        reader.reset()?;
+    fn observe(&mut self, block: u32, impact: u8) -> std::io::Result<()> {
+        let (cell, value) = self.projection.project(block, impact);
+        if cell >= self.cells {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "BMP grid cell {cell} exceeds configured cell count {}",
+                    self.cells
+                ),
+            ));
+        }
+        let group = cell / GRID_GROUP_CELLS;
+        let old_width = self.widths[group];
+        let new_width = old_width.max(bit_width(value));
+        if new_width != old_width {
+            if old_width == 0 {
+                self.touched_groups.push(group);
+            }
+            self.widths[group] = new_width;
+            self.payload_units = self
+                .payload_units
+                .checked_add(u64::from(new_width - old_width))
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "BMP compressed-grid row size exceeds u64",
+                    )
+                })?;
+        }
+        Ok(())
     }
-    let table_bytes = layout.write_row_offsets(&row_sizes, writer)?;
-    for (dim, &expected_row_size) in (0..num_dims as u32).zip(&row_sizes) {
-        let expected_row_size = usize::try_from(expected_row_size).map_err(|_| {
+
+    fn finish_sizing_row(&mut self) -> std::io::Result<()> {
+        let payload_bytes = self
+            .payload_units
+            .checked_mul((GRID_GROUP_CELLS / 8) as u64)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "BMP compressed-grid row size exceeds u64",
+                )
+            })?;
+        let row_size = (self.layout.row_header_bytes() as u64)
+            .checked_add(payload_bytes)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "BMP compressed-grid row size exceeds u64",
+                )
+            })?;
+        self.row_sizes.push(row_size);
+        for group in self.touched_groups.drain(..) {
+            self.widths[group] = 0;
+        }
+        self.payload_units = 0;
+        Ok(())
+    }
+
+    fn encoder(&self) -> std::io::Result<ProjectedRowEncoder> {
+        let largest_row = self.row_sizes.iter().copied().max().unwrap_or(0);
+        let largest_row = usize::try_from(largest_row).map_err(|_| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "BMP compressed-grid row exceeds addressable memory",
             )
         })?;
-        let payload_capacity = expected_row_size
-            .checked_sub(layout.row_header_bytes())
+        let payload_capacity = largest_row
+            .checked_sub(self.layout.row_header_bytes())
             .ok_or_else(|| {
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
                     "BMP compressed-grid row is shorter than its header",
                 )
             })?;
-        let mut row =
-            ProjectedRowEncoder::new(projection, cells, layout.groups(), payload_capacity);
-        visit_merged_dimension(run_readers, dim, |block, impact| row.push(block, impact))?;
-        let (widths, payload) = row.finish()?;
-        if payload.len() != payload_capacity {
+        Ok(ProjectedRowEncoder::new(
+            self.projection,
+            self.cells,
+            self.layout.groups(),
+            payload_capacity,
+        ))
+    }
+
+    fn write_row(
+        &self,
+        dimension: usize,
+        row: &mut ProjectedRowEncoder,
+        writer: &mut dyn Write,
+    ) -> std::io::Result<()> {
+        let expected_row_size = usize::try_from(self.row_sizes[dimension]).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "BMP compressed-grid row exceeds addressable memory",
+            )
+        })?;
+        let expected_payload = expected_row_size
+            .checked_sub(self.layout.row_header_bytes())
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "BMP compressed-grid row is shorter than its header",
+                )
+            })?;
+        row.finish_row()?;
+        if row.payload.len() != expected_payload {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "BMP compressed-grid row size changed between sizing and encoding",
             ));
         }
-        layout.write_row_header(&widths, projection.max_width(), writer)?;
-        writer.write_all(&payload)?;
+        self.layout
+            .write_row_header(&row.widths, self.projection.max_width(), writer)?;
+        writer.write_all(&row.payload)?;
+        row.reset();
+        Ok(())
     }
-    Ok(table_bytes + row_sizes.into_iter().sum::<u64>())
+
+    fn rows_bytes(&self) -> std::io::Result<u64> {
+        self.row_sizes.iter().try_fold(0u64, |total, &size| {
+            total.checked_add(size).ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "BMP compressed-grid section exceeds u64",
+                )
+            })
+        })
+    }
+}
+
+#[cfg(feature = "native")]
+fn copy_grid_spool(
+    path: &std::path::Path,
+    expected_bytes: u64,
+    writer: &mut dyn Write,
+) -> std::io::Result<()> {
+    use std::io::Read;
+
+    let file = std::fs::File::open(path)?;
+    let actual_bytes = file.metadata()?.len();
+    if actual_bytes != expected_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "BMP compressed-grid spool size changed: expected {expected_bytes}, got {actual_bytes}"
+            ),
+        ));
+    }
+    let mut reader = std::io::BufReader::with_capacity(1024 * 1024, file);
+    let mut buffer = vec![0u8; 1024 * 1024];
+    let mut copied = 0u64;
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        writer.write_all(&buffer[..read])?;
+        copied = copied.checked_add(read as u64).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "BMP compressed-grid spool copy exceeds u64",
+            )
+        })?;
+    }
+    if copied != expected_bytes {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::UnexpectedEof,
+            format!(
+                "short BMP compressed-grid spool copy: expected {expected_bytes}, copied {copied}"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 /// Stream-write compressed grids from multiple sorted run files.
 ///
-/// Each section uses one sizing pass and one encoding pass. Encoding buffers at
-/// most one already-compressed row, so peak memory is bounded even when a head
-/// dimension occurs in every block.
+/// The complete D/E/H hierarchy uses one sizing pass and one encoding pass
+/// over the external runs. D rows stream directly to the output; E/H rows are
+/// temporarily spooled because their offset tables follow the complete D
+/// section. Encoding buffers at most one compressed row per projection.
 #[cfg(feature = "native")]
 pub(crate) fn stream_write_grids_merged(
     run_readers: &mut [GridRunReader],
     num_dims: usize,
     num_blocks: usize,
     grid_bits: u8,
+    superblock_spool: &std::path::Path,
+    coarse_spool: &std::path::Path,
     writer: &mut dyn Write,
 ) -> std::io::Result<(u64, u64, u64)> {
-    let block_bytes = write_compressed_grid_section_merged(
-        run_readers,
-        num_dims,
-        num_blocks,
-        GridProjection::Block { bits: grid_bits },
-        writer,
-    )?;
+    let num_dims_u32 = u32::try_from(num_dims).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "BMP grid dimensions exceed u32::MAX",
+        )
+    })?;
+    let mut plans = [
+        MergedGridPlan::new(
+            GridProjection::Block { bits: grid_bits },
+            num_dims,
+            num_blocks,
+        ),
+        MergedGridPlan::new(GridProjection::Superblock, num_dims, num_blocks),
+        MergedGridPlan::new(GridProjection::CoarseSuperblock, num_dims, num_blocks),
+    ];
+
+    {
+        let mut merged = MergedGridCursor::new(run_readers);
+        for dimension in 0..num_dims_u32 {
+            merged.visit_dimension(dimension, |block, impact| {
+                for plan in &mut plans {
+                    plan.observe(block, impact)?;
+                }
+                Ok(())
+            })?;
+            for plan in &mut plans {
+                plan.finish_sizing_row()?;
+            }
+        }
+        merged.finish(num_dims)?;
+    }
     for reader in run_readers.iter_mut() {
         reader.reset()?;
     }
-    let superblock_bytes = write_compressed_grid_section_merged(
-        run_readers,
-        num_dims,
-        num_blocks,
-        GridProjection::Superblock,
-        writer,
-    )?;
-    for reader in run_readers.iter_mut() {
-        reader.reset()?;
+
+    let block_table_bytes = plans[0]
+        .layout
+        .write_row_offsets(&plans[0].row_sizes, writer)?;
+    let superblock_file = std::fs::File::create(superblock_spool)?;
+    let coarse_file = std::fs::File::create(coarse_spool)?;
+    let mut superblock_writer = std::io::BufWriter::with_capacity(1024 * 1024, superblock_file);
+    let mut coarse_writer = std::io::BufWriter::with_capacity(1024 * 1024, coarse_file);
+    let mut rows = plans
+        .iter()
+        .map(MergedGridPlan::encoder)
+        .collect::<std::io::Result<Vec<_>>>()?;
+
+    {
+        let mut merged = MergedGridCursor::new(run_readers);
+        for dimension in 0..num_dims_u32 {
+            let dimension_index = dimension as usize;
+            merged.visit_dimension(dimension, |block, impact| {
+                for row in &mut rows {
+                    row.push(block, impact)?;
+                }
+                Ok(())
+            })?;
+            plans[0].write_row(dimension_index, &mut rows[0], writer)?;
+            plans[1].write_row(dimension_index, &mut rows[1], &mut superblock_writer)?;
+            plans[2].write_row(dimension_index, &mut rows[2], &mut coarse_writer)?;
+        }
+        merged.finish(num_dims)?;
     }
-    let coarse_bytes = write_compressed_grid_section_merged(
-        run_readers,
-        num_dims,
-        num_blocks,
-        GridProjection::CoarseSuperblock,
-        writer,
-    )?;
+    superblock_writer.flush()?;
+    coarse_writer.flush()?;
+    drop(superblock_writer);
+    drop(coarse_writer);
+
+    let block_rows_bytes = plans[0].rows_bytes()?;
+    let superblock_rows_bytes = plans[1].rows_bytes()?;
+    let coarse_rows_bytes = plans[2].rows_bytes()?;
+    let superblock_table_bytes = plans[1]
+        .layout
+        .write_row_offsets(&plans[1].row_sizes, writer)?;
+    copy_grid_spool(superblock_spool, superblock_rows_bytes, writer)?;
+    let coarse_table_bytes = plans[2]
+        .layout
+        .write_row_offsets(&plans[2].row_sizes, writer)?;
+    copy_grid_spool(coarse_spool, coarse_rows_bytes, writer)?;
+
+    let block_bytes = block_table_bytes
+        .checked_add(block_rows_bytes)
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "BMP block-grid section exceeds u64",
+            )
+        })?;
+    let superblock_bytes = superblock_table_bytes
+        .checked_add(superblock_rows_bytes)
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "BMP superblock-grid section exceeds u64",
+            )
+        })?;
+    let coarse_bytes = coarse_table_bytes
+        .checked_add(coarse_rows_bytes)
+        .ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "BMP coarse-grid section exceeds u64",
+            )
+        })?;
     Ok((block_bytes, superblock_bytes, coarse_bytes))
 }
 
@@ -1350,6 +1627,65 @@ mod tests {
             .advance()
             .expect_err("a partial grid record must not be treated as clean EOF");
         assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn merged_grid_runs_are_byte_identical_to_in_memory_encoding() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut entries = vec![
+            (0, 0, 1),
+            (0, 63, 17),
+            (0, 64, 31),
+            (0, 64, 200), // duplicate cell across runs: maximum must win
+            (0, 16_383, 127),
+            (0, 16_384, 255),
+            // Dimension 1 intentionally empty.
+            (2, 1, 9),
+            (2, 64, 66),
+            (2, 16_384, 129),
+            (3, 16_383, 254),
+        ];
+        entries.sort_unstable();
+        let mut runs = [Vec::new(), Vec::new(), Vec::new()];
+        for (index, &entry) in entries.iter().enumerate() {
+            runs[index % runs.len()].push(entry);
+        }
+        let run_paths: Vec<_> = runs
+            .iter()
+            .enumerate()
+            .map(|(index, run)| {
+                let path = directory.path().join(format!("run-{index}"));
+                write_grid_run(run, &path).unwrap();
+                path
+            })
+            .collect();
+
+        for grid_bits in [2, 4] {
+            let mut expected = Vec::new();
+            let expected_sizes =
+                stream_write_grids(&entries, 4, 16_385, grid_bits, &mut expected).unwrap();
+            let mut readers: Vec<_> = run_paths
+                .iter()
+                .map(|path| GridRunReader::open(path).unwrap())
+                .collect();
+            let superblock_spool = directory.path().join(format!("sb-{grid_bits}"));
+            let coarse_spool = directory.path().join(format!("coarse-{grid_bits}"));
+            let mut actual = Vec::new();
+            let actual_sizes = stream_write_grids_merged(
+                &mut readers,
+                4,
+                16_385,
+                grid_bits,
+                &superblock_spool,
+                &coarse_spool,
+                &mut actual,
+            )
+            .unwrap();
+
+            assert_eq!(actual_sizes, expected_sizes);
+            assert_eq!(actual, expected);
+        }
     }
 
     #[test]

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -22,12 +22,169 @@ const MIN_OBJECTIVE_ITERATIONS: usize = 4;
 const OBJECTIVE_STALL_ITERATIONS: usize = 2;
 
 fn term_degree_bytes(num_terms: usize) -> usize {
+    let bitmap_words = num_terms.div_ceil(64);
     num_terms
         .saturating_mul(TERM_DEGREE_VALUE_BYTES)
-        .saturating_add(num_terms.div_ceil(64).saturating_mul(8))
+        .saturating_add(bitmap_words.saturating_mul(std::mem::size_of::<u64>()))
+        // A reusable lane remembers only bitmap words touched by its previous
+        // partition, so reset is proportional to active terms rather than the
+        // complete vocabulary.
+        .saturating_add(bitmap_words.saturating_mul(std::mem::size_of::<u32>()))
 }
 
-fn parallel_bisect_depth(
+/// Count a dense vocabulary without a cache-line-contended atomic increment
+/// for every posting. Workers own private tables, and the number of tables is
+/// capped by the caller's remaining memory budget. A single plain table is
+/// used when the budget cannot afford useful parallelism.
+fn count_frequencies_bounded<T: Sync>(
+    items: &[T],
+    num_terms: usize,
+    available_bytes: usize,
+    count_item: impl Fn(&T, &mut [u32]) + Sync,
+) -> Option<Vec<u32>> {
+    if num_terms == 0 {
+        return Some(Vec::new());
+    }
+    let table_bytes = num_terms
+        .checked_mul(std::mem::size_of::<u32>())?
+        .checked_add(std::mem::size_of::<Vec<u32>>())?;
+    let affordable_tables = available_bytes.checked_div(table_bytes)?;
+    if affordable_tables == 0 {
+        return None;
+    }
+
+    #[cfg(feature = "native")]
+    {
+        let lanes = affordable_tables
+            .min(rayon::current_num_threads().max(1))
+            .min(items.len().max(1));
+        if lanes > 1 {
+            let chunk_len = items.len().div_ceil(lanes);
+            return items
+                .par_chunks(chunk_len)
+                .map(|chunk| {
+                    let mut counts = vec![0u32; num_terms];
+                    for item in chunk {
+                        count_item(item, &mut counts);
+                    }
+                    counts
+                })
+                .reduce_with(|mut left, right| {
+                    for (total, count) in left.iter_mut().zip(right) {
+                        *total = total.saturating_add(count);
+                    }
+                    left
+                });
+        }
+    }
+
+    let mut counts = vec![0u32; num_terms];
+    for item in items {
+        count_item(item, &mut counts);
+    }
+    Some(counts)
+}
+
+/// Retain the lowest-frequency eligible dimensions while the frequency table
+/// is live. Both record- and block-level builders use the same bounded policy.
+fn select_frequency_candidates(
+    frequencies: &[u32],
+    min_frequency: usize,
+    max_frequency: usize,
+    candidate_budget_bytes: usize,
+) -> (Vec<(u32, usize)>, bool) {
+    let eligible_count = frequencies
+        .iter()
+        .filter(|&&frequency| {
+            let frequency = frequency as usize;
+            frequency >= min_frequency && frequency <= max_frequency
+        })
+        .count();
+    let capacity = candidate_budget_bytes
+        .checked_div(CANDIDATE_ENTRY_BYTES)
+        .unwrap_or(0)
+        .min(eligible_count);
+    let mut candidates = std::collections::BinaryHeap::with_capacity(capacity);
+    for (term_id, &frequency) in frequencies.iter().enumerate() {
+        let frequency = frequency as usize;
+        if frequency < min_frequency || frequency > max_frequency {
+            continue;
+        }
+        let candidate = (frequency, term_id as u32);
+        if candidates.len() < capacity {
+            candidates.push(candidate);
+        } else if capacity > 0 && candidate < *candidates.peek().unwrap() {
+            candidates.pop();
+            candidates.push(candidate);
+        }
+    }
+    let selected = candidates
+        .into_vec()
+        .into_iter()
+        .map(|(frequency, term_id)| (term_id, frequency))
+        .collect();
+    (selected, capacity < eligible_count)
+}
+
+struct CandidateFit {
+    estimated_bytes: usize,
+    retained_postings: usize,
+    dropped: usize,
+}
+
+/// Apply the shared forward-index memory model, preferring low-frequency
+/// dimensions because they add the least CSR storage and the strongest
+/// clustering signal.
+fn fit_candidates_to_budget(
+    candidates: &mut Vec<(u32, usize)>,
+    fixed_bytes: usize,
+    memory_budget_bytes: usize,
+) -> CandidateFit {
+    let total_postings = candidates.iter().fold(0usize, |total, (_, frequency)| {
+        total.saturating_add(*frequency)
+    });
+    let estimated_bytes = total_postings
+        .saturating_mul(std::mem::size_of::<u32>())
+        .saturating_add(fixed_bytes)
+        .saturating_add(candidates.len().saturating_mul(CANDIDATE_ENTRY_BYTES))
+        .saturating_add(term_degree_bytes(candidates.len()));
+    if estimated_bytes <= memory_budget_bytes || candidates.is_empty() {
+        return CandidateFit {
+            estimated_bytes,
+            retained_postings: total_postings,
+            dropped: 0,
+        };
+    }
+
+    candidates.sort_by_key(|&(_, frequency)| frequency);
+    let mut used_bytes = fixed_bytes;
+    let mut retained_postings = 0usize;
+    let mut keep = 0usize;
+    for &(_, frequency) in candidates.iter() {
+        let term_bytes = frequency
+            .saturating_mul(std::mem::size_of::<u32>())
+            .saturating_add(TERM_DEGREE_VALUE_BYTES + 1)
+            .saturating_add(CANDIDATE_ENTRY_BYTES);
+        if term_bytes > memory_budget_bytes.saturating_sub(used_bytes) {
+            break;
+        }
+        used_bytes = used_bytes.saturating_add(term_bytes);
+        retained_postings = retained_postings.saturating_add(frequency);
+        keep += 1;
+    }
+    let dropped = candidates.len() - keep;
+    candidates.truncate(keep);
+    // BinaryHeap::into_vec retains its original capacity. Release dropped
+    // candidates before allocating the remap, CSR, and graph scratch.
+    candidates.shrink_to_fit();
+    CandidateFit {
+        estimated_bytes,
+        retained_postings,
+        dropped,
+    }
+}
+
+fn parallel_bisect_lanes(
     memory_budget_bytes: usize,
     non_degree_bytes: usize,
     num_terms: usize,
@@ -42,7 +199,7 @@ fn parallel_bisect_depth(
     let worker_limit = rayon::current_num_threads().max(1);
     #[cfg(not(feature = "native"))]
     let worker_limit = 1usize;
-    affordable_nodes.min(worker_limit).ilog2() as usize
+    affordable_nodes.min(worker_limit)
 }
 
 /// Per-partition left/right term degrees with direct compact-term indexing.
@@ -55,16 +212,31 @@ fn parallel_bisect_depth(
 struct TermDegrees {
     values: Vec<std::mem::MaybeUninit<[u32; 2]>>,
     initialized: Vec<u64>,
+    touched_words: Vec<u32>,
 }
 
 impl TermDegrees {
     fn new(num_terms: usize) -> Self {
+        let bitmap_words = num_terms.div_ceil(64);
         let mut values = Vec::with_capacity(num_terms);
         values.resize_with(num_terms, std::mem::MaybeUninit::uninit);
         Self {
             values,
-            initialized: vec![0; num_terms.div_ceil(64)],
+            initialized: vec![0; bitmap_words],
+            touched_words: Vec::with_capacity(bitmap_words),
         }
+    }
+
+    /// Reuse this vocabulary-sized lane for another partition without
+    /// clearing the complete initialization bitmap.
+    fn reset(&mut self) {
+        for word in self.touched_words.drain(..) {
+            self.initialized[word as usize] = 0;
+        }
+    }
+
+    fn sort_touched_words(&mut self) {
+        self.touched_words.sort_unstable();
     }
 
     #[inline]
@@ -72,6 +244,9 @@ impl TermDegrees {
         let word = term / 64;
         let mask = 1u64 << (term % 64);
         if self.initialized[word] & mask == 0 {
+            if self.initialized[word] == 0 {
+                self.touched_words.push(word as u32);
+            }
             self.values[term].write([0, 0]);
             self.initialized[word] |= mask;
         }
@@ -92,8 +267,9 @@ impl TermDegrees {
     }
 
     fn merge_from(&mut self, other: &Self) {
-        for (word_idx, &initialized) in other.initialized.iter().enumerate() {
-            let mut pending = initialized;
+        for &word_idx in &other.touched_words {
+            let word_idx = word_idx as usize;
+            let mut pending = other.initialized[word_idx];
             while pending != 0 {
                 let bit = pending.trailing_zeros() as usize;
                 let term = word_idx * 64 + bit;
@@ -102,6 +278,40 @@ impl TermDegrees {
                 let entry = self.entry_mut(term);
                 entry[0] += left;
                 entry[1] += right;
+                pending &= pending - 1;
+            }
+        }
+    }
+
+    /// Apply directional movement counts accumulated in a reusable lane.
+    ///
+    /// Each entry is `[right_to_left, left_to_right]`. Keeping two unsigned
+    /// counters lets partition workers reuse the exact same storage as degree
+    /// construction instead of allocating a separate signed delta table.
+    fn apply_moves_to(&self, degrees: &mut Self) {
+        for &word_idx in &self.touched_words {
+            let word_idx = word_idx as usize;
+            let mut pending = self.initialized[word_idx];
+            while pending != 0 {
+                let bit = pending.trailing_zeros() as usize;
+                let term = word_idx * 64 + bit;
+                // SAFETY: `pending` is derived from the initialized bitmap.
+                let [right_to_left, left_to_right] =
+                    unsafe { *self.values[term].assume_init_ref() };
+                debug_assert!(
+                    degrees.initialized[word_idx] & (1u64 << bit) != 0,
+                    "a moved term must already exist in the partition degrees"
+                );
+                let degree = degrees.entry_mut(term);
+                let new_left =
+                    i64::from(degree[0]) + i64::from(right_to_left) - i64::from(left_to_right);
+                let new_right =
+                    i64::from(degree[1]) + i64::from(left_to_right) - i64::from(right_to_left);
+                debug_assert!(new_left >= 0 && new_right >= 0);
+                debug_assert!(new_left <= i64::from(u32::MAX));
+                debug_assert!(new_right <= i64::from(u32::MAX));
+                degree[0] = new_left as u32;
+                degree[1] = new_right as u32;
                 pending &= pending - 1;
             }
         }
@@ -119,8 +329,9 @@ impl TermDegrees {
             fast_log2_lookup(left_size, log_table) as f64,
             fast_log2_lookup(right_size, log_table) as f64,
         ];
-        for (word_idx, &initialized) in self.initialized.iter().enumerate() {
-            let mut pending = initialized;
+        for &word_idx in &self.touched_words {
+            let word_idx = word_idx as usize;
+            let mut pending = self.initialized[word_idx];
             while pending != 0 {
                 let bit = pending.trailing_zeros() as usize;
                 let term = word_idx * 64 + bit;
@@ -140,75 +351,6 @@ impl TermDegrees {
     }
 }
 
-/// Per-term change to the left degree. The right change is its negation
-/// because every moved document leaves one side and enters the other.
-///
-/// This uses the same lazy dense representation as [`TermDegrees`]. Parallel
-/// partition workers therefore pay one vocabulary-sized allocation each, but
-/// the number of workers is carved from the existing degree-array memory
-/// allowance rather than multiplying the configured BP budget.
-struct TermDeltas {
-    values: Vec<std::mem::MaybeUninit<i64>>,
-    initialized: Vec<u64>,
-}
-
-impl TermDeltas {
-    fn new(num_terms: usize) -> Self {
-        let mut values = Vec::with_capacity(num_terms);
-        values.resize_with(num_terms, std::mem::MaybeUninit::uninit);
-        Self {
-            values,
-            initialized: vec![0; num_terms.div_ceil(64)],
-        }
-    }
-
-    #[inline]
-    fn entry_mut(&mut self, term: usize) -> &mut i64 {
-        let word = term / 64;
-        let mask = 1u64 << (term % 64);
-        if self.initialized[word] & mask == 0 {
-            self.values[term].write(0);
-            self.initialized[word] |= mask;
-        }
-        // SAFETY: the bit above is set only after writing this exact slot.
-        unsafe { self.values[term].assume_init_mut() }
-    }
-
-    fn merge_from(&mut self, other: &Self) {
-        for (word_idx, &initialized) in other.initialized.iter().enumerate() {
-            let mut pending = initialized;
-            while pending != 0 {
-                let bit = pending.trailing_zeros() as usize;
-                let term = word_idx * 64 + bit;
-                // SAFETY: `pending` is derived from the initialized bitmap.
-                let delta = unsafe { *other.values[term].assume_init_ref() };
-                *self.entry_mut(term) += delta;
-                pending &= pending - 1;
-            }
-        }
-    }
-
-    fn apply_to(&self, degrees: &mut TermDegrees) {
-        for (word_idx, &initialized) in self.initialized.iter().enumerate() {
-            let mut pending = initialized;
-            while pending != 0 {
-                let bit = pending.trailing_zeros() as usize;
-                let term = word_idx * 64 + bit;
-                // SAFETY: `pending` is derived from the initialized bitmap.
-                let delta = unsafe { *self.values[term].assume_init_ref() };
-                let degree = degrees.entry_mut(term);
-                let new_left = degree[0] as i64 + delta;
-                let new_right = degree[1] as i64 - delta;
-                debug_assert!(new_left >= 0 && new_right >= 0);
-                debug_assert!(new_left <= u32::MAX as i64 && new_right <= u32::MAX as i64);
-                degree[0] = new_left as u32;
-                degree[1] = new_right as u32;
-                pending &= pending - 1;
-            }
-        }
-    }
-}
-
 // ── Forward index (CSR) ──────────────────────────────────────────────────
 
 /// Forward index in CSR format: doc `d`'s terms are `terms[offsets[d]..offsets[d+1]]`.
@@ -222,10 +364,10 @@ pub(crate) struct ForwardIndex {
     /// by dropping dims below the u32 limit.
     offsets: Vec<u64>,
     pub num_terms: usize,
-    /// Maximum recursion depth at which both children may own a vocabulary-
-    /// sized degree array concurrently. Deeper partitions still use Rayon for
-    /// gain computation, but recurse serially to honor the memory budget.
-    parallel_bisect_depth: usize,
+    /// Exact number of simultaneous vocabulary-sized degree-array lanes
+    /// allowed by the memory budget. Recursion divides this allowance between
+    /// children without rounding non-power-of-two worker pools down.
+    parallel_bisect_lanes: usize,
     /// True when the configured memory limit forced graph signal to be
     /// discarded. Callers must not report the resulting order as fully
     /// converged: a later pass with a larger budget may still improve it.
@@ -288,28 +430,11 @@ pub(crate) fn build_vid_maps(
     let expected_real = bmp.num_real_docs() as usize;
     let mut virtual_to_real = vec![u32::MAX; num_virtual];
     let mut real_to_virtual = Vec::with_capacity(expected_real);
-    for (vid, (slot, chunk)) in virtual_to_real
-        .iter_mut()
-        .zip(ids.as_chunks::<4>().0)
-        .enumerate()
-    {
-        let doc_id = u32::from_le_bytes(*chunk);
-        if doc_id != u32::MAX {
-            if real_to_virtual.len() == expected_real {
-                return Err(crate::Error::Corruption(format!(
-                    "BMP document map contains more than the footer's {expected_real} real slots"
-                )));
-            }
-            *slot = real_to_virtual.len() as u32;
-            real_to_virtual.push(vid as u32);
-        }
-    }
-    if real_to_virtual.len() != expected_real {
-        return Err(crate::Error::Corruption(format!(
-            "BMP document map has {} real slots but footer declares {expected_real}",
-            real_to_virtual.len(),
-        )));
-    }
+    debug_assert_eq!(ids.len(), virtual_to_real.len() * 4);
+    bmp.visit_real_slots_for_rewrite(|vid| {
+        virtual_to_real[vid] = real_to_virtual.len() as u32;
+        real_to_virtual.push(vid as u32);
+    })?;
     Ok((virtual_to_real, real_to_virtual))
 }
 
@@ -362,7 +487,7 @@ fn build_block_jobs(
 /// Documents are identified by dense *real* indices assigned sequentially
 /// across sources: source 0 gets 0..n0, source 1 gets n0..n0+n1, etc., where
 /// each n is the source's real (non-padding) doc count derived from its doc
-/// map via [`build_vid_maps`]. Returns `(forward_index, per_source_real_doc_counts)`.
+/// map via [`build_vid_maps`].
 ///
 /// Filters dims with doc_freq outside `[min_doc_freq, max_doc_freq]`.
 /// If the estimated forward index memory exceeds `memory_budget_bytes`, the
@@ -376,7 +501,7 @@ pub(crate) fn build_forward_index_from_bmps(
     min_doc_freq: usize,
     max_doc_freq: usize,
     memory_budget_bytes: usize,
-) -> crate::Result<(ForwardIndex, Vec<usize>)> {
+) -> crate::Result<ForwardIndex> {
     let vid_maps: Vec<(Vec<u32>, Vec<u32>)> = bmps
         .iter()
         .map(|bmp| build_vid_maps(bmp))
@@ -399,22 +524,18 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
     min_doc_freq: usize,
     max_doc_freq: usize,
     memory_budget_bytes: usize,
-) -> (ForwardIndex, Vec<usize>) {
+) -> ForwardIndex {
     debug_assert_eq!(bmps.len(), vid_maps.len());
-    let source_doc_counts: Vec<usize> = vid_maps.iter().map(|(_, r2v)| r2v.len()).collect();
-    let total_docs: usize = source_doc_counts.iter().sum();
+    let total_docs: usize = vid_maps.iter().map(|(_, r2v)| r2v.len()).sum();
 
     if total_docs == 0 {
-        return (
-            ForwardIndex {
-                terms: Vec::new(),
-                offsets: Vec::new(),
-                num_terms: 0,
-                parallel_bisect_depth: 0,
-                budget_limited: false,
-            },
-            source_doc_counts,
-        );
+        return ForwardIndex {
+            terms: Vec::new(),
+            offsets: Vec::new(),
+            num_terms: 0,
+            parallel_bisect_lanes: 1,
+            budget_limited: false,
+        };
     }
 
     // Job list: one entry per (source, block). Real ids are assigned in
@@ -423,9 +544,9 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
     // parallel, writing disjoint slices.
     let jobs = build_block_jobs(bmps, vid_maps);
 
-    // Phase 1: count doc frequency in one dense atomic table. The previous
-    // Rayon fold built a vocabulary-sized hash map per worker before the
-    // budget check, multiplying peak memory by the CPU count.
+    // Phase 1: count document frequencies in bounded worker-local tables.
+    // Shared atomics made popular dimensions a cache-coherence bottleneck;
+    // private dense tables avoid that while retaining an exact memory cap.
     let max_dims = bmps
         .iter()
         .map(|bmp| bmp.dims() as usize)
@@ -434,145 +555,89 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
     let jobs_bytes = jobs
         .len()
         .saturating_mul(std::mem::size_of::<BlockJob>().saturating_add(40));
-    let frequency_bytes =
-        max_dims.saturating_mul(std::mem::size_of::<std::sync::atomic::AtomicU32>());
+    let frequency_bytes = max_dims.saturating_mul(std::mem::size_of::<u32>());
     if frequency_bytes > memory_budget_bytes.saturating_sub(jobs_bytes) {
         log::warn!(
             "[reorder] memory budget {} cannot hold the {} dimension-frequency table; using identity order",
             crate::format_bytes(memory_budget_bytes as u64),
             crate::format_bytes(frequency_bytes as u64),
         );
-        return (
-            ForwardIndex {
-                terms: Vec::new(),
-                offsets: Vec::new(),
-                num_terms: 0,
-                parallel_bisect_depth: 0,
-                budget_limited: true,
-            },
-            source_doc_counts,
-        );
+        return ForwardIndex {
+            terms: Vec::new(),
+            offsets: Vec::new(),
+            num_terms: 0,
+            parallel_bisect_lanes: 1,
+            budget_limited: true,
+        };
     }
-    let dim_df: Vec<std::sync::atomic::AtomicU32> = (0..max_dims)
-        .map(|_| std::sync::atomic::AtomicU32::new(0))
-        .collect();
-    let count_block_df = |job: &BlockJob| {
-        let bmp = bmps[job.src as usize];
-        let (v2r, _) = &vid_maps[job.src as usize];
-        let block_size = bmp.bmp_block_size as usize;
-        for (dim_id, _, postings) in bmp.iter_block_terms(job.block_id) {
-            let mut n = 0usize;
-            for p in postings {
-                let vid = job.block_id as usize * block_size + p.local_slot as usize;
-                if v2r[vid] != u32::MAX && p.impact > 0 {
-                    n += 1;
+    let Some(dim_df) = count_frequencies_bounded(
+        &jobs,
+        max_dims,
+        memory_budget_bytes.saturating_sub(jobs_bytes),
+        |job, counts| {
+            let bmp = bmps[job.src as usize];
+            let (v2r, _) = &vid_maps[job.src as usize];
+            let block_size = bmp.bmp_block_size as usize;
+            for (dim_id, _, postings) in bmp.iter_block_terms(job.block_id) {
+                let mut frequency = 0u32;
+                for posting in postings {
+                    let vid = job.block_id as usize * block_size + posting.local_slot as usize;
+                    if v2r.get(vid).is_some_and(|&real| real != u32::MAX) && posting.impact > 0 {
+                        frequency = frequency.saturating_add(1);
+                    }
+                }
+                if frequency > 0
+                    && let Some(total) = counts.get_mut(dim_id as usize)
+                {
+                    *total = total.saturating_add(frequency);
                 }
             }
-            if n > 0
-                && let Some(count) = dim_df.get(dim_id as usize)
-            {
-                count.fetch_add(n as u32, std::sync::atomic::Ordering::Relaxed);
-            }
-        }
+        },
+    ) else {
+        log::warn!(
+            "[reorder] memory budget {} cannot hold a bounded dimension-frequency table; using identity order",
+            crate::format_bytes(memory_budget_bytes as u64),
+        );
+        return ForwardIndex {
+            terms: Vec::new(),
+            offsets: Vec::new(),
+            num_terms: 0,
+            parallel_bisect_lanes: 1,
+            budget_limited: true,
+        };
     };
-    #[cfg(feature = "native")]
-    jobs.par_iter().for_each(count_block_df);
-    #[cfg(not(feature = "native"))]
-    jobs.iter().for_each(count_block_df);
 
     // Retain the lowest-frequency candidates in a bounded heap while the
     // frequency table is live. This makes candidate discovery itself obey the
     // configured limit even for extremely large vocabularies.
-    let eligible_candidate_count = dim_df
-        .iter()
-        .filter(|df| {
-            let df = df.load(std::sync::atomic::Ordering::Relaxed) as usize;
-            df >= min_doc_freq && df <= max_doc_freq
-        })
-        .count();
-    let candidate_capacity = memory_budget_bytes
-        .saturating_sub(jobs_bytes)
-        .saturating_sub(frequency_bytes)
-        .checked_div(std::mem::size_of::<(usize, u32)>())
-        .unwrap_or(0)
-        .min(eligible_candidate_count);
-    let mut candidate_heap = std::collections::BinaryHeap::with_capacity(candidate_capacity);
-    for (dim_id, df) in dim_df.iter().enumerate() {
-        let df = df.load(std::sync::atomic::Ordering::Relaxed) as usize;
-        if df < min_doc_freq || df > max_doc_freq {
-            continue;
-        }
-        let candidate = (df, dim_id as u32);
-        if candidate_heap.len() < candidate_capacity {
-            candidate_heap.push(candidate);
-        } else if candidate_capacity > 0 && candidate < *candidate_heap.peek().unwrap() {
-            candidate_heap.pop();
-            candidate_heap.push(candidate);
-        }
-    }
+    let (mut eligible, mut budget_limited) = select_frequency_candidates(
+        &dim_df,
+        min_doc_freq,
+        max_doc_freq,
+        memory_budget_bytes
+            .saturating_sub(jobs_bytes)
+            .saturating_sub(frequency_bytes),
+    );
     drop(dim_df);
-    let mut eligible: Vec<(u32, usize)> = candidate_heap
-        .into_vec()
-        .into_iter()
-        .map(|(df, dim_id)| (dim_id, df))
-        .collect();
-    let mut budget_limited = eligible.len() < eligible_candidate_count;
 
     // Memory budget: estimate forward index + bisection scratch.
     // Includes jobs/slice descriptors, dense remap, all per-document scratch,
     // and at least one exact TermDegrees allocation.
-    let total_postings_est = eligible
-        .iter()
-        .fold(0usize, |total, (_, df)| total.saturating_add(*df));
     let entity_scratch_bytes = total_docs.saturating_mul(32);
     let remap_bytes = max_dims.saturating_mul(4);
     let fixed_bytes = entity_scratch_bytes
         .saturating_add(remap_bytes)
         .saturating_add(jobs_bytes);
-    let estimated_bytes = total_postings_est
-        .saturating_mul(4)
-        .saturating_add(fixed_bytes)
-        // Candidate metadata coexists with the dense remap until construction
-        // starts; omitting it let a huge rare-term vocabulary exceed the cap.
-        .saturating_add(eligible.len().saturating_mul(CANDIDATE_ENTRY_BYTES))
-        .saturating_add(term_degree_bytes(eligible.len()));
-
-    if estimated_bytes > memory_budget_bytes && !eligible.is_empty() {
-        // Sort by df ascending — keep discriminative low-df dims first,
-        // drop highest-df dims which contribute the most postings.
-        eligible.sort_by_key(|&(_, df)| df);
-
-        // Account for each retained term together with its postings. The old
-        // calculation charged the eight-byte degree slot for every candidate
-        // before deciding how many to retain; a large rare-term vocabulary
-        // could therefore make the target zero even when a useful subset fit.
-        let mut used_bytes = fixed_bytes;
-        let mut cum = 0usize;
-        let mut keep_count = 0;
-        for &(_, df) in &eligible {
-            let term_bytes = df
-                .saturating_mul(4)
-                .saturating_add(TERM_DEGREE_VALUE_BYTES + 1)
-                .saturating_add(CANDIDATE_ENTRY_BYTES);
-            if term_bytes > memory_budget_bytes.saturating_sub(used_bytes) {
-                break;
-            }
-            used_bytes = used_bytes.saturating_add(term_bytes);
-            cum = cum.saturating_add(df);
-            keep_count += 1;
-        }
-
-        let dropped = eligible.len() - keep_count;
-        eligible.truncate(keep_count);
-        budget_limited |= dropped > 0;
-
+    let fit = fit_candidates_to_budget(&mut eligible, fixed_bytes, memory_budget_bytes);
+    if fit.dropped > 0 {
+        budget_limited = true;
         log::warn!(
             "[reorder] memory budget {}: estimated {}, dropped {} highest-df dims, keeping {} ({} postings)",
             crate::format_bytes(memory_budget_bytes as u64),
-            crate::format_bytes(estimated_bytes as u64),
-            dropped,
-            keep_count,
-            cum,
+            crate::format_bytes(fit.estimated_bytes as u64),
+            fit.dropped,
+            eligible.len(),
+            fit.retained_postings,
         );
     }
 
@@ -581,16 +646,13 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         // signal. Avoid allocating per-document counts and u64 offsets only
         // to discover that the terms array is empty, especially when the
         // configured budget is below the fixed document scratch cost.
-        return (
-            ForwardIndex {
-                terms: Vec::new(),
-                offsets: Vec::new(),
-                num_terms: 0,
-                parallel_bisect_depth: 0,
-                budget_limited,
-            },
-            source_doc_counts,
-        );
+        return ForwardIndex {
+            terms: Vec::new(),
+            offsets: Vec::new(),
+            num_terms: 0,
+            parallel_bisect_lanes: 1,
+            budget_limited,
+        };
     }
 
     let mut term_remap = vec![u32::MAX; max_dims];
@@ -598,12 +660,16 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         term_remap[dim_id as usize] = compact_id as u32;
     }
     let num_active_terms = eligible.len();
-    let retained_postings = eligible
-        .iter()
-        .fold(0usize, |total, (_, df)| total.saturating_add(*df));
-    let non_degree_bytes = fixed_bytes.saturating_add(retained_postings.saturating_mul(4));
-    let parallel_bisect_depth =
-        parallel_bisect_depth(memory_budget_bytes, non_degree_bytes, num_active_terms);
+    // Jobs, candidate metadata, and the dense remap are construction scratch
+    // and are gone before graph recursion. Admit lanes against graph-resident
+    // CSR/entity scratch so non-power-of-two pools are not needlessly rounded
+    // down under a tight budget.
+    let non_degree_bytes = entity_scratch_bytes.saturating_add(
+        fit.retained_postings
+            .saturating_mul(std::mem::size_of::<u32>()),
+    );
+    let parallel_bisect_lanes =
+        parallel_bisect_lanes(memory_budget_bytes, non_degree_bytes, num_active_terms);
     drop(eligible);
 
     // Phase 2: count terms per doc (filtered) — per-block disjoint slices
@@ -618,7 +684,9 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
             }
             for p in postings {
                 let vid = job.block_id as usize * block_size + p.local_slot as usize;
-                let real = v2r[vid];
+                let Some(&real) = v2r.get(vid) else {
+                    continue;
+                };
                 if real != u32::MAX && p.impact > 0 {
                     out[(real - job.real_start) as usize] += 1;
                 }
@@ -666,7 +734,9 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
             }
             for p in postings {
                 let vid = job.block_id as usize * block_size + p.local_slot as usize;
-                let real = v2r[vid];
+                let Some(&real) = v2r.get(vid) else {
+                    continue;
+                };
                 if real != u32::MAX && p.impact > 0 {
                     let local = (real - job.real_start) as usize;
                     let pos =
@@ -699,16 +769,13 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         }
     }
 
-    (
-        ForwardIndex {
-            terms,
-            offsets,
-            num_terms: num_active_terms,
-            parallel_bisect_depth,
-            budget_limited,
-        },
-        source_doc_counts,
-    )
+    ForwardIndex {
+        terms,
+        offsets,
+        num_terms: num_active_terms,
+        parallel_bisect_lanes,
+        budget_limited,
+    }
 }
 
 /// Build a forward index over BLOCKS (one entity per block, its terms = the
@@ -728,7 +795,7 @@ pub(crate) fn build_forward_index_from_blocks(
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
-            parallel_bisect_depth: 0,
+            parallel_bisect_lanes: 1,
             budget_limited: false,
         };
     }
@@ -740,7 +807,8 @@ pub(crate) fn build_forward_index_from_blocks(
         .flat_map(|(src, bmp)| (0..bmp.num_blocks).map(move |b| (src as u32, b)))
         .collect();
 
-    // Phase 1: one bounded dense frequency table, shared by every worker.
+    // Phase 1: bounded worker-local frequency tables. This is the same policy
+    // as record-level BP and avoids hot atomic increments on common terms.
     let max_dims = bmps
         .iter()
         .map(|bmp| bmp.dims() as usize)
@@ -749,8 +817,7 @@ pub(crate) fn build_forward_index_from_blocks(
     let blocks_bytes = blocks
         .len()
         .saturating_mul(std::mem::size_of::<(u32, u32)>().saturating_add(32));
-    let frequency_bytes =
-        max_dims.saturating_mul(std::mem::size_of::<std::sync::atomic::AtomicU32>());
+    let frequency_bytes = max_dims.saturating_mul(std::mem::size_of::<u32>());
     if frequency_bytes > memory_budget_bytes.saturating_sub(blocks_bytes) {
         log::warn!(
             "[reorder] block-level frequency table exceeds memory budget; using identity order"
@@ -759,98 +826,57 @@ pub(crate) fn build_forward_index_from_blocks(
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
-            parallel_bisect_depth: 0,
+            parallel_bisect_lanes: 1,
             budget_limited: true,
         };
     }
-    let dim_bf: Vec<std::sync::atomic::AtomicU32> = (0..max_dims)
-        .map(|_| std::sync::atomic::AtomicU32::new(0))
-        .collect();
-    let count_block_bf = |&(src, block_id): &(u32, u32)| {
-        for (dim_id, _, _) in bmps[src as usize].iter_block_terms(block_id) {
-            if let Some(count) = dim_bf.get(dim_id as usize) {
-                count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let Some(dim_bf) = count_frequencies_bounded(
+        &blocks,
+        max_dims,
+        memory_budget_bytes.saturating_sub(blocks_bytes),
+        |&(src, block_id), counts| {
+            for (dim_id, _, _) in bmps[src as usize].iter_block_terms(block_id) {
+                if let Some(count) = counts.get_mut(dim_id as usize) {
+                    *count = count.saturating_add(1);
+                }
             }
-        }
+        },
+    ) else {
+        log::warn!(
+            "[reorder] block-level frequency table cannot fit its bounded allocation; using identity order"
+        );
+        return ForwardIndex {
+            terms: Vec::new(),
+            offsets: Vec::new(),
+            num_terms: 0,
+            parallel_bisect_lanes: 1,
+            budget_limited: true,
+        };
     };
-    #[cfg(feature = "native")]
-    blocks.par_iter().for_each(count_block_bf);
-    #[cfg(not(feature = "native"))]
-    blocks.iter().for_each(count_block_bf);
 
     let max_bf = (total_blocks as f64 * 0.9) as usize;
-    let eligible_candidate_count = dim_bf
-        .iter()
-        .filter(|bf| {
-            let bf = bf.load(std::sync::atomic::Ordering::Relaxed) as usize;
-            bf >= 2 && bf <= max_bf.max(2)
-        })
-        .count();
-    let candidate_capacity = memory_budget_bytes
-        .saturating_sub(blocks_bytes)
-        .saturating_sub(frequency_bytes)
-        .checked_div(std::mem::size_of::<(usize, u32)>())
-        .unwrap_or(0)
-        .min(eligible_candidate_count);
-    let mut candidate_heap = std::collections::BinaryHeap::with_capacity(candidate_capacity);
-    for (dim_id, bf) in dim_bf.iter().enumerate() {
-        let bf = bf.load(std::sync::atomic::Ordering::Relaxed) as usize;
-        if bf < 2 || bf > max_bf.max(2) {
-            continue;
-        }
-        let candidate = (bf, dim_id as u32);
-        if candidate_heap.len() < candidate_capacity {
-            candidate_heap.push(candidate);
-        } else if candidate_capacity > 0 && candidate < *candidate_heap.peek().unwrap() {
-            candidate_heap.pop();
-            candidate_heap.push(candidate);
-        }
-    }
+    let (mut eligible, mut budget_limited) = select_frequency_candidates(
+        &dim_bf,
+        2,
+        max_bf.max(2),
+        memory_budget_bytes
+            .saturating_sub(blocks_bytes)
+            .saturating_sub(frequency_bytes),
+    );
     drop(dim_bf);
-    let mut eligible: Vec<(u32, usize)> = candidate_heap
-        .into_vec()
-        .into_iter()
-        .map(|(bf, dim_id)| (dim_id, bf))
-        .collect();
-    let mut budget_limited = eligible.len() < eligible_candidate_count;
 
-    let total_postings_est = eligible
-        .iter()
-        .fold(0usize, |total, (_, bf)| total.saturating_add(*bf));
     let entity_scratch_bytes = total_blocks.saturating_mul(32);
     let remap_bytes = max_dims.saturating_mul(4);
     let fixed_bytes = entity_scratch_bytes
         .saturating_add(remap_bytes)
         .saturating_add(blocks_bytes);
-    let estimated_bytes = total_postings_est
-        .saturating_mul(4)
-        .saturating_add(fixed_bytes)
-        .saturating_add(eligible.len().saturating_mul(CANDIDATE_ENTRY_BYTES))
-        .saturating_add(term_degree_bytes(eligible.len()));
-    if estimated_bytes > memory_budget_bytes && !eligible.is_empty() {
-        eligible.sort_by_key(|&(_, bf)| bf);
-        let mut used_bytes = fixed_bytes;
-        let mut cum = 0usize;
-        let mut keep = 0;
-        for &(_, bf) in &eligible {
-            let term_bytes = bf
-                .saturating_mul(4)
-                .saturating_add(TERM_DEGREE_VALUE_BYTES + 1)
-                .saturating_add(CANDIDATE_ENTRY_BYTES);
-            if term_bytes > memory_budget_bytes.saturating_sub(used_bytes) {
-                break;
-            }
-            used_bytes = used_bytes.saturating_add(term_bytes);
-            cum = cum.saturating_add(bf);
-            keep += 1;
-        }
-        let dropped = eligible.len() - keep;
-        budget_limited |= dropped > 0;
+    let fit = fit_candidates_to_budget(&mut eligible, fixed_bytes, memory_budget_bytes);
+    if fit.dropped > 0 {
+        budget_limited = true;
         log::warn!(
             "[reorder] block-level fwd index over budget — dropped {} highest-bf dims",
-            dropped,
+            fit.dropped,
         );
-        eligible.truncate(keep);
     }
 
     if eligible.is_empty() {
@@ -858,7 +884,7 @@ pub(crate) fn build_forward_index_from_blocks(
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
-            parallel_bisect_depth: 0,
+            parallel_bisect_lanes: 1,
             budget_limited,
         };
     }
@@ -868,12 +894,12 @@ pub(crate) fn build_forward_index_from_blocks(
         term_remap[dim_id as usize] = compact as u32;
     }
     let num_terms = eligible.len();
-    let retained_postings = eligible
-        .iter()
-        .fold(0usize, |total, (_, bf)| total.saturating_add(*bf));
-    let non_degree_bytes = fixed_bytes.saturating_add(retained_postings.saturating_mul(4));
-    let parallel_bisect_depth =
-        parallel_bisect_depth(memory_budget_bytes, non_degree_bytes, num_terms);
+    let non_degree_bytes = entity_scratch_bytes.saturating_add(
+        fit.retained_postings
+            .saturating_mul(std::mem::size_of::<u32>()),
+    );
+    let parallel_bisect_lanes =
+        parallel_bisect_lanes(memory_budget_bytes, non_degree_bytes, num_terms);
     drop(eligible);
 
     // Phase 2+3: counts and CSR fill — one entity per block, so each block
@@ -933,7 +959,7 @@ pub(crate) fn build_forward_index_from_blocks(
         terms,
         offsets,
         num_terms,
-        parallel_bisect_depth,
+        parallel_bisect_lanes,
         budget_limited,
     }
 }
@@ -965,50 +991,57 @@ impl BpBudget {
     }
 }
 
-/// Build one partition's term degrees. At the coarse levels, each worker
-/// scans a contiguous document range into a private lazy degree table and
-/// the tables are reduced in parallel. `degree_lanes` is a power of two
-/// derived from `parallel_bisect_depth`, so all simultaneous sibling nodes
-/// together stay within the already-accounted vocabulary-array budget.
+/// Build one partition's term degrees in preallocated lanes.
+///
+/// At coarse levels each worker scans a contiguous document range into a
+/// private lane, then the lanes are reduced into `workspaces[0]`. Recursive
+/// siblings receive disjoint workspace slices, so the complete pass performs
+/// exactly the vocabulary-sized allocations admitted before BP starts.
 fn build_term_degrees(
     docs: &[u32],
     mid: usize,
     fwd: &ForwardIndex,
-    degree_lanes: usize,
-) -> TermDegrees {
-    let build_range = |start: usize, chunk: &[u32]| {
-        let mut degrees = TermDegrees::new(fwd.num_terms);
+    workspaces: &mut [TermDegrees],
+) {
+    debug_assert!(!workspaces.is_empty());
+    let build_range = |degrees: &mut TermDegrees, start: usize, chunk: &[u32]| {
+        degrees.reset();
         for (offset, &doc) in chunk.iter().enumerate() {
             let side = usize::from(start + offset >= mid);
             for &term in fwd.doc_terms(doc as usize) {
                 degrees.entry_mut(term as usize)[side] += 1;
             }
         }
-        degrees
     };
 
     #[cfg(feature = "native")]
     {
-        let workers = degree_lanes
-            .max(1)
+        let workers = workspaces
+            .len()
             .min(docs.len().div_ceil(PARALLEL_BP_MIN_ENTITIES).max(1));
         if workers > 1 {
             let chunk_len = docs.len().div_ceil(workers);
-            return docs
-                .par_chunks(chunk_len)
+            workspaces[..workers]
+                .par_iter_mut()
                 .enumerate()
-                .map(|(chunk, docs)| build_range(chunk * chunk_len, docs))
-                .reduce_with(|mut left, right| {
-                    left.merge_from(&right);
-                    left
-                })
-                .unwrap_or_else(|| TermDegrees::new(fwd.num_terms));
+                .for_each(|(worker, degrees)| {
+                    let start = worker * chunk_len;
+                    let end = (start + chunk_len).min(docs.len());
+                    build_range(degrees, start, &docs[start..end]);
+                });
+            let (degrees, partials) = workspaces[..workers]
+                .split_first_mut()
+                .expect("at least one BP degree workspace");
+            for partial in partials {
+                degrees.merge_from(partial);
+            }
+            return;
         }
+        build_range(&mut workspaces[0], 0, docs);
     }
-    #[cfg(not(feature = "native"))]
-    let _ = degree_lanes;
 
-    build_range(0, docs)
+    #[cfg(not(feature = "native"))]
+    build_range(&mut workspaces[0], 0, docs);
 }
 
 /// Convert `f32::total_cmp` ordering into an unsigned radix key.
@@ -1106,8 +1139,9 @@ fn select_gain_threshold(gains: &[f32], left_count: usize) -> (u32, usize) {
 }
 
 enum PartitionDegreeUpdate {
-    /// Parallel workers already accumulated every moved-term delta.
-    Deltas(TermDeltas),
+    /// Parallel workers accumulated directional movement counts in the first
+    /// reusable movement workspace.
+    Moves,
     /// Small partitions use the former unstable selection order. Keep its
     /// reusable rank map long enough to update only records that crossed the
     /// cut.
@@ -1152,31 +1186,30 @@ fn select_left(key: u32, threshold_key: u32, equal_seen: &mut usize, ties_left: 
 /// Output is stable within each half. Parallel workers also accumulate
 /// per-term degree deltas for moved entities, eliminating the former serial
 /// postings update without rescanning every posting after each iteration.
-/// Small partitions retain the old unstable selector: its allocation is tiny
-/// there, it is faster than four radix scans, and its within-half permutation
-/// supplies the graph algorithm's established symmetry breaking.
+/// Small partitions retain the old unstable selector in their preallocated
+/// rank slice: it is faster than four radix scans, and its within-half
+/// permutation supplies the graph algorithm's established symmetry breaking.
 fn partition_by_gain(
     docs: &[u32],
     gains: &[f32],
     mid: usize,
     fwd: &ForwardIndex,
-    degree_lanes: usize,
+    movement_workspaces: &mut [TermDegrees],
     output: &mut [u32],
-    ranked_scratch: &mut Vec<usize>,
+    ranked_scratch: &mut [usize],
 ) -> PartitionOutcome {
     #[cfg(not(feature = "native"))]
-    let _ = (fwd, degree_lanes);
+    let _ = &movement_workspaces;
 
     #[cfg(feature = "native")]
-    if degree_lanes > 1 && docs.len() >= PARALLEL_BP_MIN_ENTITIES {
+    if !movement_workspaces.is_empty() && docs.len() >= PARALLEL_BP_MIN_ENTITIES {
         let (threshold_key, strictly_lower) = select_gain_threshold(gains, mid);
         let ties_left = mid - strictly_lower;
 
         // `degrees` remains live while these deltas are built. Reserving one
-        // lane for it keeps total vocabulary arrays <= degree_lanes.
-        let chunk_count = degree_lanes
-            .saturating_sub(1)
-            .max(1)
+        // lane for it keeps total vocabulary arrays within the admitted set.
+        let chunk_count = movement_workspaces
+            .len()
             .min(docs.len().div_ceil(PARALLEL_BP_MIN_ENTITIES).max(1));
         let chunk_len = docs.len().div_ceil(chunk_count);
         let mut chunks: Vec<PartitionChunk> = gains
@@ -1230,11 +1263,12 @@ fn partition_by_gain(
         }
         debug_assert!(left_rest.is_empty() && right_rest.is_empty());
 
-        let (swap_count, deltas) = jobs
-            .into_par_iter()
+        let swap_count = movement_workspaces[..chunk_count]
+            .par_iter_mut()
+            .zip(jobs.into_par_iter())
             .map(
-                |(start, docs, gains, ties_for_chunk, left_out, right_out)| {
-                    let mut deltas = TermDeltas::new(fwd.num_terms);
+                |(moves, (start, docs, gains, ties_for_chunk, left_out, right_out))| {
+                    moves.reset();
                     let mut equal_seen = 0usize;
                     let mut left_cursor = 0usize;
                     let mut right_cursor = 0usize;
@@ -1255,32 +1289,38 @@ fn partition_by_gain(
                         let was_left = start + offset < mid;
                         if was_left != now_left {
                             swaps += 1;
-                            let left_delta = if was_left { -1 } else { 1 };
+                            // [right→left, left→right]
+                            let direction = usize::from(was_left);
                             for &term in fwd.doc_terms(doc as usize) {
-                                *deltas.entry_mut(term as usize) += left_delta;
+                                moves.entry_mut(term as usize)[direction] += 1;
                             }
                         }
                     }
                     debug_assert_eq!(left_cursor, left_out.len());
                     debug_assert_eq!(right_cursor, right_out.len());
-                    (swaps, deltas)
+                    swaps
                 },
             )
-            .reduce_with(|(left_swaps, mut left), (right_swaps, right)| {
-                left.merge_from(&right);
-                (left_swaps + right_swaps, left)
-            })
-            .unwrap_or_else(|| (0, TermDeltas::new(fwd.num_terms)));
+            .sum();
+
+        let (moves, partials) = movement_workspaces[..chunk_count]
+            .split_first_mut()
+            .expect("parallel BP partition must use at least one movement workspace");
+        for partial in partials {
+            moves.merge_from(partial);
+        }
 
         return PartitionOutcome {
             swap_count,
-            degree_update: PartitionDegreeUpdate::Deltas(deltas),
+            degree_update: PartitionDegreeUpdate::Moves,
         };
     }
 
     if docs.len() < PARALLEL_BP_MIN_ENTITIES {
-        ranked_scratch.clear();
-        ranked_scratch.extend(0..docs.len());
+        debug_assert_eq!(ranked_scratch.len(), docs.len());
+        for (index, rank) in ranked_scratch.iter_mut().enumerate() {
+            *rank = index;
+        }
         ranked_scratch.select_nth_unstable_by(mid, |&left, &right| {
             gains[left]
                 .total_cmp(&gains[right])
@@ -1663,11 +1703,11 @@ impl BpProgress<'_> {
 }
 
 /// Recursive graph bisection. Returns `(perm, converged)` where
-/// `perm[new_pos] = old_index` and `converged` is false iff the wall-clock
-/// budget ended the pass before it finished (a depth cap alone is a chosen
-/// target, not an interruption — it reports converged).
+/// `perm[new_pos] = old_index`. Convergence is false when the wall-clock or
+/// memory budget prevents the requested work from finishing; a configured
+/// depth cap is a chosen target and reports converged.
 ///
-/// `min_partition_size` should be the BMP block_size (64).
+/// `min_partition_size` should be the configured BMP block size.
 /// `max_iters` controls convergence (20 is standard).
 ///
 /// Term IDs in the forward index must be compact (0..num_terms) so we can
@@ -1746,10 +1786,42 @@ pub(crate) fn graph_bisection_with_progress(
         exhausted: &exhausted,
         progress: &progress,
     };
-    #[cfg(feature = "native")]
-    bisect(&mut docs, fwd.parallel_bisect_depth, 0, &context);
-    #[cfg(not(feature = "native"))]
-    bisect(&mut docs, 0, 0, &context);
+    let immediately_exhausted = {
+        #[cfg(feature = "native")]
+        {
+            deadline.is_some_and(|deadline| std::time::Instant::now() >= deadline)
+        }
+        #[cfg(not(feature = "native"))]
+        {
+            false
+        }
+    };
+    if immediately_exhausted {
+        exhausted.store(true, std::sync::atomic::Ordering::Relaxed);
+    } else if n > effective_min_partition {
+        // Entity scratch is allocated once for the pass and carved into
+        // disjoint slices down the recursion tree. Degree lanes are likewise
+        // allocated exactly once from the memory-budgeted lane count.
+        let mut gains = vec![0.0f32; n];
+        let mut partitioned = vec![0u32; n];
+        let mut ranked = vec![0usize; n];
+        #[cfg(feature = "native")]
+        let degree_lanes = fwd.parallel_bisect_lanes.max(1);
+        #[cfg(not(feature = "native"))]
+        let degree_lanes = 1usize;
+        let mut degree_workspaces: Vec<TermDegrees> = (0..degree_lanes)
+            .map(|_| TermDegrees::new(fwd.num_terms))
+            .collect();
+        bisect(
+            &mut docs,
+            &mut gains,
+            &mut partitioned,
+            &mut ranked,
+            &mut degree_workspaces,
+            0,
+            &context,
+        );
+    }
 
     let deadline_exhausted = exhausted.load(std::sync::atomic::Ordering::Relaxed);
     let converged = !fwd.budget_limited && !deadline_exhausted;
@@ -1786,10 +1858,21 @@ struct BisectContext<'a> {
     progress: &'a BpProgress<'a>,
 }
 
-fn bisect(docs: &mut [u32], parallel_depth: usize, level: usize, context: &BisectContext<'_>) {
-    #[cfg(not(feature = "native"))]
-    let _ = parallel_depth;
+#[allow(clippy::too_many_arguments)]
+fn bisect(
+    docs: &mut [u32],
+    gains: &mut [f32],
+    partitioned: &mut [u32],
+    ranked_scratch: &mut [usize],
+    degree_workspaces: &mut [TermDegrees],
+    level: usize,
+    context: &BisectContext<'_>,
+) {
     let n = docs.len();
+    debug_assert_eq!(gains.len(), n);
+    debug_assert_eq!(partitioned.len(), n);
+    debug_assert_eq!(ranked_scratch.len(), n);
+    debug_assert!(!degree_workspaces.is_empty());
     if n <= context.min_partition_size {
         return;
     }
@@ -1820,33 +1903,30 @@ fn bisect(docs: &mut [u32], parallel_depth: usize, level: usize, context: &Bisec
     } else {
         context.max_iters
     };
-    let degree_lanes = 1usize
-        .checked_shl(parallel_depth as u32)
-        .unwrap_or(usize::MAX)
-        .max(1);
 
     // Compact term IDs permit direct indexing. Slots are initialized lazily so
-    // deep partitions do not zero the full vocabulary on every recursive node.
-    // Coarse partitions use memory-budgeted thread-local reductions; recursion
-    // splits the same lane allowance between children.
-    let mut degrees = build_term_degrees(docs, mid, context.fwd, degree_lanes);
+    // deep partitions touch only their active terms. Coarse partitions use
+    // multiple preallocated lanes; recursion splits the exact same workspace
+    // set between children.
+    build_term_degrees(docs, mid, context.fwd, degree_workspaces);
     // A full-vocabulary objective scan pays off only on coarse partitions,
     // where one avoided refinement skips millions of postings. At fine levels
     // it cost more than the work it could save, so retain the cheap gain
     // cooling condition there.
     let track_objective = n >= PARALLEL_BP_MIN_ENTITIES;
+    if track_objective {
+        // The old bitmap scan accumulated terms in ascending order. Sorting
+        // once preserves that exact floating-point order while subsequent
+        // objective evaluations visit only words active in this partition.
+        degree_workspaces[0].sort_touched_words();
+    }
     let mut previous_objective = if track_objective {
-        degrees.bisection_objective(mid, n - mid, context.log_table)
+        degree_workspaces[0].bisection_objective(mid, n - mid, context.log_table)
     } else {
         0.0
     };
     let mut best_objective = previous_objective;
     let mut objective_stalls = 0usize;
-
-    // Scratch buffers reused across iterations
-    let mut gains: Vec<f32> = vec![0.0; n];
-    let mut partitioned: Vec<u32> = vec![0; n];
-    let mut ranked_scratch: Vec<usize> = Vec::new();
 
     for iter in 0..effective_iters {
         // Anytime cutoff between refinement passes: keep the current split.
@@ -1865,9 +1945,9 @@ fn bisect(docs: &mut [u32], parallel_depth: usize, level: usize, context: &Bisec
             docs,
             context.fwd,
             mid,
-            &degrees,
+            &degree_workspaces[0],
             context.log_table,
-            &mut gains,
+            gains,
         );
 
         // Exact median selection and stable partition. The old path allocated
@@ -1876,12 +1956,12 @@ fn bisect(docs: &mut [u32], parallel_depth: usize, level: usize, context: &Bisec
         // the same bounded worker lanes used by degree construction.
         let partition = partition_by_gain(
             docs,
-            &gains,
+            gains,
             mid,
             context.fwd,
-            degree_lanes,
-            &mut partitioned,
-            &mut ranked_scratch,
+            &mut degree_workspaces[1..],
+            partitioned,
+            ranked_scratch,
         );
 
         if partition.swap_count == 0 {
@@ -1889,35 +1969,44 @@ fn bisect(docs: &mut [u32], parallel_depth: usize, level: usize, context: &Bisec
             // Preserve the selector's within-half order before recursing.
             // Small partitions intentionally retain quickselect's established
             // symmetry-breaking permutation.
-            docs.copy_from_slice(&partitioned);
+            docs.copy_from_slice(partitioned);
             break;
         }
 
         match &partition.degree_update {
-            PartitionDegreeUpdate::Deltas(deltas) => deltas.apply_to(&mut degrees),
+            PartitionDegreeUpdate::Moves => {
+                let (degrees, movement_workspaces) = degree_workspaces
+                    .split_first_mut()
+                    .expect("BP always has one degree workspace");
+                movement_workspaces
+                    .first()
+                    .expect("parallel BP movement update requires a spare workspace")
+                    .apply_moves_to(degrees);
+            }
             PartitionDegreeUpdate::Ranked => update_degrees_for_ranked_partition(
                 docs,
-                &ranked_scratch,
+                ranked_scratch,
                 mid,
                 context.fwd,
-                &mut degrees,
+                &mut degree_workspaces[0],
             ),
             PartitionDegreeUpdate::Threshold {
                 threshold_key,
                 ties_left,
             } => update_degrees_for_threshold_partition(
                 docs,
-                &gains,
+                gains,
                 mid,
                 *threshold_key,
                 *ties_left,
                 context.fwd,
-                &mut degrees,
+                &mut degree_workspaces[0],
             ),
         }
 
         let (new_objective, objective_improvement, relative_improvement) = if track_objective {
-            let new_objective = degrees.bisection_objective(mid, n - mid, context.log_table);
+            let new_objective =
+                degree_workspaces[0].bisection_objective(mid, n - mid, context.log_table);
             let objective_improvement = new_objective - previous_objective;
             let relative_improvement = objective_improvement / previous_objective.abs().max(1.0);
             (new_objective, objective_improvement, relative_improvement)
@@ -1937,7 +2026,7 @@ fn bisect(docs: &mut [u32], parallel_depth: usize, level: usize, context: &Bisec
         // no-op. Instead, accept refinements and stop only after a warm-up plus
         // consecutive iterations that fail to improve the best exact
         // objective by a meaningful relative amount.
-        docs.copy_from_slice(&partitioned);
+        docs.copy_from_slice(partitioned);
         if track_objective {
             previous_objective = new_objective;
             let relative_best_improvement =
@@ -1973,30 +2062,83 @@ fn bisect(docs: &mut [u32], parallel_depth: usize, level: usize, context: &Bisec
         }
     }
 
-    // Drop scratch before recursion to free memory for sub-problems
-    drop(degrees);
-    drop(gains);
-    drop(partitioned);
     context.progress.partition_finished();
 
     let (left, right) = docs.split_at_mut(mid);
+    let (left_gains, right_gains) = gains.split_at_mut(mid);
+    let (left_partitioned, right_partitioned) = partitioned.split_at_mut(mid);
+    let (left_ranked, right_ranked) = ranked_scratch.split_at_mut(mid);
     #[cfg(feature = "native")]
-    if parallel_depth > 0 {
+    if degree_workspaces.len() > 1 {
+        let left_lanes = degree_workspaces.len() / 2;
+        let (left_workspaces, right_workspaces) = degree_workspaces.split_at_mut(left_lanes);
         rayon::join(
-            || bisect(left, parallel_depth - 1, level + 1, context),
-            || bisect(right, parallel_depth - 1, level + 1, context),
+            || {
+                bisect(
+                    left,
+                    left_gains,
+                    left_partitioned,
+                    left_ranked,
+                    left_workspaces,
+                    level + 1,
+                    context,
+                )
+            },
+            || {
+                bisect(
+                    right,
+                    right_gains,
+                    right_partitioned,
+                    right_ranked,
+                    right_workspaces,
+                    level + 1,
+                    context,
+                )
+            },
         );
     } else {
         // Gain computation inside each node remains parallel, so serializing
         // recursion here bounds vocabulary-sized degree arrays without leaving
         // the Rayon pool idle.
-        bisect(left, 0, level + 1, context);
-        bisect(right, 0, level + 1, context);
+        bisect(
+            left,
+            left_gains,
+            left_partitioned,
+            left_ranked,
+            degree_workspaces,
+            level + 1,
+            context,
+        );
+        bisect(
+            right,
+            right_gains,
+            right_partitioned,
+            right_ranked,
+            degree_workspaces,
+            level + 1,
+            context,
+        );
     }
     #[cfg(not(feature = "native"))]
     {
-        bisect(left, 0, level + 1, context);
-        bisect(right, 0, level + 1, context);
+        bisect(
+            left,
+            left_gains,
+            left_partitioned,
+            left_ranked,
+            degree_workspaces,
+            level + 1,
+            context,
+        );
+        bisect(
+            right,
+            right_gains,
+            right_partitioned,
+            right_ranked,
+            degree_workspaces,
+            level + 1,
+            context,
+        );
     }
 }
 
@@ -2090,8 +2232,40 @@ mod tests {
     use super::*;
 
     #[test]
+    fn bounded_frequency_count_and_candidate_selection_are_exact() {
+        let items: Vec<u32> = (0..10_000).collect();
+        let frequencies = count_frequencies_bounded(&items, 7, 16 * 1024, |item, counts| {
+            let term = *item as usize % counts.len();
+            counts[term] += 1;
+        })
+        .unwrap();
+        assert_eq!(frequencies.iter().sum::<u32>(), items.len() as u32);
+        for (term, &frequency) in frequencies.iter().enumerate() {
+            let expected = (term..items.len()).step_by(frequencies.len()).count() as u32;
+            assert_eq!(frequency, expected);
+        }
+
+        let (selected, limited) =
+            select_frequency_candidates(&[8, 3, 0, 5, 3], 1, 10, 2 * CANDIDATE_ENTRY_BYTES);
+        assert!(limited);
+        let mut selected = selected;
+        selected.sort_unstable();
+        assert_eq!(selected, vec![(1, 3), (4, 3)]);
+    }
+
+    #[test]
+    fn bounded_frequency_count_rejects_an_undersized_budget() {
+        assert!(
+            count_frequencies_bounded(&[0u32], 32, 32, |_, _| {}).is_none(),
+            "one complete dense frequency table must fit before counting"
+        );
+    }
+
+    #[test]
     fn lazy_term_degrees_initialize_only_on_first_write() {
         let mut degrees = TermDegrees::new(130);
+        let values_ptr = degrees.values.as_ptr();
+        let bitmap_ptr = degrees.initialized.as_ptr();
         assert_eq!(degrees.get(65), [0, 0]);
         degrees.entry_mut(65)[0] += 3;
         degrees.entry_mut(65)[1] += 2;
@@ -2105,6 +2279,51 @@ mod tests {
                 .sum::<u32>(),
             1
         );
+
+        degrees.reset();
+        assert_eq!(degrees.values.as_ptr(), values_ptr);
+        assert_eq!(degrees.initialized.as_ptr(), bitmap_ptr);
+        assert_eq!(degrees.get(65), [0, 0]);
+        assert!(degrees.touched_words.is_empty());
+        degrees.entry_mut(129)[1] = 7;
+        assert_eq!(degrees.get(129), [0, 7]);
+        assert_eq!(degrees.get(65), [0, 0]);
+    }
+
+    #[test]
+    fn sparse_objective_keeps_the_original_ascending_term_order() {
+        let mut degrees = TermDegrees::new(130);
+        *degrees.entry_mut(129) = [5, 2];
+        *degrees.entry_mut(1) = [3, 7];
+        *degrees.entry_mut(65) = [11, 13];
+        assert_eq!(degrees.touched_words, vec![2, 0, 1]);
+        degrees.sort_touched_words();
+        assert_eq!(degrees.touched_words, vec![0, 1, 2]);
+
+        let log_table = build_log_table(4096);
+        let actual = degrees.bisection_objective(31, 32, &log_table);
+        let side_log = [
+            fast_log2_lookup(31, &log_table) as f64,
+            fast_log2_lookup(32, &log_table) as f64,
+        ];
+        let mut original_bitmap_scan = 0.0f64;
+        for (word_idx, &initialized) in degrees.initialized.iter().enumerate() {
+            let mut pending = initialized;
+            while pending != 0 {
+                let bit = pending.trailing_zeros() as usize;
+                let term = word_idx * 64 + bit;
+                let [left, right] = degrees.get(term);
+                for (side, count) in [left, right].into_iter().enumerate() {
+                    if count > 0 {
+                        original_bitmap_scan += count as f64
+                            * (fast_log2_lookup(count as usize + 1, &log_table) as f64
+                                - side_log[side]);
+                    }
+                }
+                pending &= pending - 1;
+            }
+        }
+        assert_eq!(actual.to_bits(), original_bitmap_scan.to_bits());
     }
 
     #[test]
@@ -2167,7 +2386,7 @@ mod tests {
             terms,
             offsets,
             num_terms: TERMS,
-            parallel_bisect_depth: 2,
+            parallel_bisect_lanes: 4,
             budget_limited: false,
         };
         let docs: Vec<u32> = (0..N as u32)
@@ -2203,32 +2422,33 @@ mod tests {
 
         let mut output = vec![0; N];
         let mut ranked_scratch = Vec::new();
+        let mut movement_workspaces: Vec<_> = (0..3).map(|_| TermDegrees::new(TERMS)).collect();
         let outcome = partition_by_gain(
             &docs,
             &gains,
             mid,
             &fwd,
-            4,
+            &mut movement_workspaces,
             &mut output,
             &mut ranked_scratch,
         );
         assert_eq!(output, expected);
         assert!(
-            matches!(&outcome.degree_update, PartitionDegreeUpdate::Deltas(_)),
-            "test must exercise parallel deltas"
+            matches!(&outcome.degree_update, PartitionDegreeUpdate::Moves),
+            "test must exercise parallel movement counts"
         );
 
-        let mut updated = build_term_degrees(&docs, mid, &fwd, 4);
-        let PartitionDegreeUpdate::Deltas(deltas) = outcome.degree_update else {
-            unreachable!("assertion above verifies the parallel path")
-        };
-        deltas.apply_to(&mut updated);
-        let rebuilt = build_term_degrees(&output, mid, &fwd, 4);
+        let mut updated_workspaces: Vec<_> = (0..4).map(|_| TermDegrees::new(TERMS)).collect();
+        build_term_degrees(&docs, mid, &fwd, &mut updated_workspaces);
+        movement_workspaces[0].apply_moves_to(&mut updated_workspaces[0]);
+
+        let mut rebuilt_workspaces: Vec<_> = (0..4).map(|_| TermDegrees::new(TERMS)).collect();
+        build_term_degrees(&output, mid, &fwd, &mut rebuilt_workspaces);
         for term in 0..TERMS {
             assert_eq!(
-                updated.get(term),
-                rebuilt.get(term),
-                "parallel moved-term delta mismatch for term {term}"
+                updated_workspaces[0].get(term),
+                rebuilt_workspaces[0].get(term),
+                "parallel movement-count mismatch for term {term}"
             );
         }
     }
@@ -2261,7 +2481,7 @@ mod tests {
             terms,
             offsets,
             num_terms,
-            parallel_bisect_depth: 0,
+            parallel_bisect_lanes: 1,
             budget_limited: false,
         }
     }
@@ -2272,7 +2492,7 @@ mod tests {
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
-            parallel_bisect_depth: 0,
+            parallel_bisect_lanes: 1,
             budget_limited: false,
         };
         let (perm, _) = graph_bisection(&fwd, 4, 20, BpBudget::full());

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -36,11 +36,21 @@ fn term_degree_bytes(num_terms: usize) -> usize {
 /// for every posting. Workers own private tables, and the number of tables is
 /// capped by the caller's remaining memory budget. A single plain table is
 /// used when the budget cannot afford useful parallelism.
-fn count_frequencies_bounded<T: Sync>(
+#[cfg(feature = "native")]
+trait FrequencyParallelSafe: Sync {}
+#[cfg(feature = "native")]
+impl<T: Sync + ?Sized> FrequencyParallelSafe for T {}
+
+#[cfg(not(feature = "native"))]
+trait FrequencyParallelSafe {}
+#[cfg(not(feature = "native"))]
+impl<T: ?Sized> FrequencyParallelSafe for T {}
+
+fn count_frequencies_bounded<T: FrequencyParallelSafe>(
     items: &[T],
     num_terms: usize,
     available_bytes: usize,
-    count_item: impl Fn(&T, &mut [u32]) + Sync,
+    count_item: impl Fn(&T, &mut [u32]) + FrequencyParallelSafe,
 ) -> Option<Vec<u32>> {
     if num_terms == 0 {
         return Some(Vec::new());
@@ -1199,7 +1209,7 @@ fn partition_by_gain(
     ranked_scratch: &mut [usize],
 ) -> PartitionOutcome {
     #[cfg(not(feature = "native"))]
-    let _ = &movement_workspaces;
+    let _ = (fwd, &movement_workspaces);
 
     #[cfg(feature = "native")]
     if !movement_workspaces.is_empty() && docs.len() >= PARALLEL_BP_MIN_ENTITIES {

--- a/hermes-core/src/segment/builder/sparse.rs
+++ b/hermes-core/src/segment/builder/sparse.rs
@@ -135,27 +135,12 @@ pub(super) fn build_sparse_streaming(
                 if blob_len > 0 {
                     current_offset += blob_len;
 
-                    // For BMP, we encode the format bit in the quant byte and use
-                    // num_dims=0 with a single pseudo-dim entry containing blob location.
-                    let mut config_for_byte =
-                        crate::structures::SparseVectorConfig::from_byte(quantization as u8)
-                            .unwrap_or_default();
-                    config_for_byte.format = SparseFormat::Bmp;
-                    config_for_byte.weight_quantization = quantization;
-
-                    field_tocs.push(SparseFieldToc {
+                    field_tocs.push(SparseFieldToc::bmp(
                         field_id,
-                        quantization: config_for_byte.to_byte(),
                         total_vectors,
-                        dims: vec![SparseDimTocEntry {
-                            dim_id: 0xFFFFFFFF, // sentinel for BMP
-                            block_data_offset: blob_offset,
-                            skip_start: (blob_len & 0xFFFFFFFF) as u32,
-                            num_blocks: ((blob_len >> 32) & 0xFFFFFFFF) as u32,
-                            doc_count: 0,
-                            max_weight: 0.0,
-                        }],
-                    });
+                        blob_offset,
+                        blob_len,
+                    ));
                 }
             }
             SparseFormat::MaxScore => {

--- a/hermes-core/src/segment/format.rs
+++ b/hermes-core/src/segment/format.rs
@@ -130,10 +130,39 @@ pub struct SparseDimTocEntry {
 pub struct SparseFieldToc {
     pub field_id: u32,
     pub quantization: u8,
-    /// Total number of documents that have at least one sparse vector in this field.
-    /// Not the same as segment total_docs when some docs lack the field.
+    /// Total sparse vectors in this field. Multi-valued fields can have more
+    /// vectors than segment documents.
     pub total_vectors: u32,
     pub dims: Vec<SparseDimTocEntry>,
+}
+
+impl SparseFieldToc {
+    /// Build the sentinel TOC entry used by the self-contained BMP blob.
+    pub(crate) fn bmp(field_id: u32, total_vectors: u32, blob_offset: u64, blob_len: u64) -> Self {
+        // V18 always stores u32 dimensions and u8 impacts regardless of the
+        // generic sparse schema knobs. Persist the physical representation,
+        // not a misleading caller-supplied MaxScore descriptor.
+        let config = crate::structures::SparseVectorConfig {
+            format: crate::structures::SparseFormat::Bmp,
+            index_size: crate::structures::IndexSize::U32,
+            weight_quantization: crate::structures::WeightQuantization::UInt8,
+            ..Default::default()
+        };
+
+        Self {
+            field_id,
+            quantization: config.to_byte(),
+            total_vectors,
+            dims: vec![SparseDimTocEntry {
+                dim_id: u32::MAX,
+                block_data_offset: blob_offset,
+                skip_start: blob_len as u32,
+                num_blocks: (blob_len >> 32) as u32,
+                doc_count: 0,
+                max_weight: 0.0,
+            }],
+        }
+    }
 }
 
 /// Write V3 sparse TOC + footer.
@@ -172,4 +201,26 @@ pub fn write_sparse_toc_and_footer(
     writer.write_u32::<LittleEndian>(field_tocs.len() as u32)?;
     writer.write_u32::<LittleEndian>(SPARSE_FOOTER_MAGIC)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SparseFieldToc;
+    use crate::structures::{IndexSize, SparseFormat, SparseVectorConfig, WeightQuantization};
+
+    #[test]
+    fn bmp_toc_describes_the_physical_v18_encoding() {
+        let blob_len = u64::from(u32::MAX) + 17;
+        let toc = SparseFieldToc::bmp(7, 11, 23, blob_len);
+        let config = SparseVectorConfig::from_byte(toc.quantization).unwrap();
+
+        assert_eq!(config.format, SparseFormat::Bmp);
+        assert_eq!(config.index_size, IndexSize::U32);
+        assert_eq!(config.weight_quantization, WeightQuantization::UInt8);
+        assert_eq!(toc.total_vectors, 11);
+        assert_eq!(toc.dims[0].dim_id, u32::MAX);
+        assert_eq!(toc.dims[0].block_data_offset, 23);
+        assert_eq!(toc.dims[0].skip_start, 16);
+        assert_eq!(toc.dims[0].num_blocks, 1);
+    }
 }

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -17,8 +17,9 @@ use super::reader::SegmentReader;
 use super::types::{FieldStats, SegmentFiles, SegmentId, SegmentMeta};
 use crate::Result;
 use crate::directories::{Directory, DirectoryWriter};
-use crate::dsl::Schema;
+use crate::dsl::{FieldType, Schema};
 use crate::index::{ReorderConcurrencyGate, ReorderPriority};
+use crate::structures::SparseFormat;
 
 /// Compute per-segment doc ID offsets (each segment's docs start after the previous).
 ///
@@ -36,6 +37,35 @@ fn doc_offsets(segments: &[SegmentReader]) -> Result<Vec<u32>> {
         })?;
     }
     Ok(offsets)
+}
+
+/// Additive count stored in a `u32` field of the merged segment format.
+///
+/// Source segments are individually valid, so exceeding the limit is a
+/// property of this merge plan rather than source corruption.
+#[derive(Clone, Copy, Debug, Default)]
+struct MergeCapacity(u64);
+
+impl MergeCapacity {
+    #[inline]
+    fn add(&mut self, count: u64) -> Option<u64> {
+        self.0 = self.0.saturating_add(count);
+        (self.0 > u64::from(u32::MAX)).then_some(self.0)
+    }
+}
+
+fn field_capacity_error(
+    field_id: u32,
+    field_name: &str,
+    value_kind: &str,
+    count: u64,
+) -> crate::Error {
+    crate::Error::Schema(format!(
+        "merge would produce {count} {value_kind} for field {field_id} ('{field_name}'), \
+         exceeding the segment format limit {}; lower max_segment_docs for this \
+         multi-valued field",
+        u32::MAX,
+    ))
 }
 
 /// Statistics for merge operations
@@ -94,6 +124,47 @@ pub(crate) fn block_in_place_if_multithread<R>(f: impl FnOnce() -> R) -> R {
     } else {
         f()
     }
+}
+
+/// Append an exact-length temporary directory file to a segment output and
+/// remove it. Used by sparse skip tables so neither merge nor BP rewrite
+/// buffers a corpus-sized metadata section on heap.
+pub(crate) async fn append_and_delete_temp<D: DirectoryWriter>(
+    directory: &D,
+    path: &std::path::Path,
+    expected_bytes: u64,
+    writer: &mut OffsetWriter,
+) -> Result<()> {
+    use std::io::Write as _;
+
+    const COPY_CHUNK: u64 = 4 * 1024 * 1024;
+    let actual_bytes = directory.file_size(path).await?;
+    if actual_bytes != expected_bytes {
+        return Err(crate::Error::Corruption(format!(
+            "temporary sparse section {:?} has {} bytes, expected {}",
+            path, actual_bytes, expected_bytes,
+        )));
+    }
+    let mut offset = 0u64;
+    while offset < expected_bytes {
+        let end = (offset + COPY_CHUNK).min(expected_bytes);
+        let chunk = directory.read_range(path, offset..end).await?;
+        writer
+            .write_all(chunk.as_slice())
+            .map_err(crate::Error::Io)?;
+        offset = end;
+    }
+    if let Err(error) = directory.delete(path).await {
+        // The section is already complete in the output. This output-scoped
+        // scratch file is safe for the startup orphan sweep and must not
+        // invalidate an otherwise successful multi-hour merge.
+        log::warn!(
+            "[merge] failed to remove temporary sparse section {:?}: {}",
+            path,
+            error,
+        );
+    }
+    Ok(())
 }
 
 /// Segment merger - merges multiple segments into one
@@ -181,6 +252,137 @@ impl SegmentMerger {
         self
     }
 
+    /// Reject additive per-field counts that the on-disk formats cannot
+    /// represent. All inputs are already-open metadata views; no vector,
+    /// posting, or document payload is read here.
+    fn validate_merge_capacities(&self, segments: &[SegmentReader]) -> Result<()> {
+        // MaxScore skip entries share one u32-addressed section across fields.
+        let mut maxscore_skip_entries = MergeCapacity::default();
+
+        for (field, entry) in self.schema.fields() {
+            match entry.field_type {
+                FieldType::DenseVector | FieldType::BinaryDenseVector => {
+                    let mut vectors = MergeCapacity::default();
+                    for segment in segments {
+                        let Some(flat) = segment.flat_vectors().get(&field.0) else {
+                            continue;
+                        };
+                        if let Some(total) = vectors.add(flat.num_vectors as u64) {
+                            let value_kind = if entry.field_type == FieldType::BinaryDenseVector {
+                                "binary vectors"
+                            } else {
+                                "dense vectors"
+                            };
+                            return Err(field_capacity_error(
+                                field.0,
+                                &entry.name,
+                                value_kind,
+                                total,
+                            ));
+                        }
+                    }
+                }
+                FieldType::SparseVector => {
+                    let format = entry
+                        .sparse_vector_config
+                        .as_ref()
+                        .map(|config| config.format)
+                        .unwrap_or_default();
+                    match format {
+                        SparseFormat::Bmp => {
+                            let mut vectors = MergeCapacity::default();
+                            let mut blocks = MergeCapacity::default();
+                            let mut real_slots = MergeCapacity::default();
+                            let mut virtual_slots = MergeCapacity::default();
+
+                            for segment in segments {
+                                let Some(index) = segment.bmp_indexes().get(&field.0) else {
+                                    continue;
+                                };
+                                for (capacity, count, value_kind) in [
+                                    (&mut vectors, u64::from(index.total_vectors), "BMP vectors"),
+                                    (&mut blocks, u64::from(index.num_blocks), "BMP blocks"),
+                                    (
+                                        &mut real_slots,
+                                        u64::from(index.num_real_docs()),
+                                        "BMP real vector slots",
+                                    ),
+                                    (
+                                        &mut virtual_slots,
+                                        u64::from(index.num_virtual_docs),
+                                        "BMP padded virtual slots",
+                                    ),
+                                ] {
+                                    if let Some(total) = capacity.add(count) {
+                                        return Err(field_capacity_error(
+                                            field.0,
+                                            &entry.name,
+                                            value_kind,
+                                            total,
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                        SparseFormat::MaxScore => {
+                            let mut vectors = MergeCapacity::default();
+                            let mut dimensions: FxHashMap<u32, (MergeCapacity, MergeCapacity)> =
+                                FxHashMap::default();
+
+                            for segment in segments {
+                                let Some(index) = segment.sparse_indexes().get(&field.0) else {
+                                    continue;
+                                };
+                                if let Some(total) = vectors.add(u64::from(index.total_vectors)) {
+                                    return Err(field_capacity_error(
+                                        field.0,
+                                        &entry.name,
+                                        "MaxScore vectors",
+                                        total,
+                                    ));
+                                }
+
+                                for (dimension, doc_count, block_count) in index.dimension_counts()
+                                {
+                                    let (docs, blocks) = dimensions.entry(dimension).or_default();
+                                    if let Some(total) = docs.add(u64::from(doc_count)) {
+                                        return Err(field_capacity_error(
+                                            field.0,
+                                            &entry.name,
+                                            &format!("MaxScore postings for dimension {dimension}"),
+                                            total,
+                                        ));
+                                    }
+                                    if let Some(total) = blocks.add(u64::from(block_count)) {
+                                        return Err(field_capacity_error(
+                                            field.0,
+                                            &entry.name,
+                                            &format!("MaxScore blocks for dimension {dimension}"),
+                                            total,
+                                        ));
+                                    }
+                                    if let Some(total) =
+                                        maxscore_skip_entries.add(u64::from(block_count))
+                                    {
+                                        return Err(crate::Error::Schema(format!(
+                                            "merge would produce {total} MaxScore skip entries \
+                                             across sparse fields, exceeding the segment format \
+                                             limit {}; lower max_segment_docs for multi-valued \
+                                             sparse fields",
+                                            u32::MAX,
+                                        )));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
     /// Merge segments into one, streaming postings/positions/store directly to files.
     ///
     /// If `trained` is provided, dense vectors use O(1) cluster merge when possible
@@ -209,6 +411,8 @@ impl SegmentMerger {
                     u32::MAX
                 ))
             })?;
+
+        self.validate_merge_capacities(segments)?;
 
         let mut stats = MergeStats::default();
         let files = SegmentFiles::new(new_segment_id.0);
@@ -421,4 +625,35 @@ pub async fn delete_segment<D: Directory + DirectoryWriter>(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod capacity_tests {
+    use super::{MergeCapacity, field_capacity_error};
+
+    #[test]
+    fn merge_capacity_accepts_the_exact_u32_boundary() {
+        let mut capacity = MergeCapacity::default();
+        assert_eq!(capacity.add(u64::from(u32::MAX) - 7), None);
+        assert_eq!(capacity.add(7), None);
+    }
+
+    #[test]
+    fn merge_capacity_rejects_the_first_value_beyond_u32() {
+        let mut capacity = MergeCapacity::default();
+        assert_eq!(capacity.add(u64::from(u32::MAX)), None);
+        assert_eq!(capacity.add(1), Some(u64::from(u32::MAX) + 1));
+    }
+
+    #[test]
+    fn merge_capacity_failure_is_not_source_corruption() {
+        let error = field_capacity_error(
+            7,
+            "body_embedding",
+            "dense vectors",
+            u64::from(u32::MAX) + 1,
+        );
+        assert!(matches!(error, crate::Error::Schema(_)));
+        assert!(error.to_string().contains("lower max_segment_docs"));
+    }
 }

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -67,6 +67,14 @@ impl SegmentMerger {
         }
 
         let mut writer = OffsetWriter::new(dir.streaming_writer_cold(&files.sparse).await?);
+        let scratch_path = dir.local_path(&files.sparse).unwrap_or_else(|| {
+            std::env::temp_dir().join(
+                files
+                    .sparse
+                    .file_name()
+                    .unwrap_or_else(|| std::ffi::OsStr::new("hermes.sparse")),
+            )
+        });
 
         // Accumulated per-field data for TOC
         let mut field_tocs: Vec<SparseFieldToc> = Vec::new();
@@ -91,15 +99,6 @@ impl SegmentMerger {
                     .map(|seg| seg.bmp_indexes().get(&field.0))
                     .collect();
                 let has_bmp_data = bmp_indexes.iter().any(|bi| bi.is_some());
-                if segments
-                    .iter()
-                    .any(|segment| segment.sparse_indexes().contains_key(&field.0))
-                {
-                    return Err(crate::Error::Corruption(format!(
-                        "field {} is configured as BMP but a source segment contains MaxScore data; rebuild the index",
-                        field.0
-                    )));
-                }
                 if has_bmp_data {
                     let total_vectors_bmp: u32 = bmp_indexes
                         .iter()
@@ -155,14 +154,6 @@ impl SegmentMerger {
                             .zip(doc_offs.iter())
                             .filter_map(|(opt, &off)| opt.map(|b| (b.clone(), off)))
                             .collect();
-                        validate_bmp_sources(
-                            &sources,
-                            dims,
-                            bmp_block_size.clamp(1, 256),
-                            grid_bits,
-                            max_weight_scale,
-                        )?;
-
                         let fid = field.0;
                         let fname = field_name.clone();
                         let ilabel = self.schema.index_label().to_owned();
@@ -177,6 +168,7 @@ impl SegmentMerger {
                         let bp_budget = self.bp_budget;
                         let bp_memory_budget = self.bp_memory_budget;
                         let out_grid_bits = grid_bits;
+                        let scratch_path = scratch_path.clone();
                         let _reorder_permit = match &self.reorder_permits {
                             Some(permits) => {
                                 let gate = Arc::clone(permits);
@@ -188,13 +180,18 @@ impl SegmentMerger {
                             }
                             None => None,
                         };
-                        let (w, ft, converged) = tokio::task::spawn_blocking(move || {
+                        // `spawn_blocking` detaches its closure when the
+                        // awaiting RPC is cancelled. That used to release the
+                        // segment operation guard while this writer was still
+                        // active, allowing cleanup to race the output. A
+                        // synchronous block-in-place section cannot be
+                        // cancelled halfway through the owned writer.
+                        let (w, ft, converged) = super::block_in_place_if_multithread(move || {
                             crate::segment::reorder::reorder_bmp_field(
                                 &sources,
                                 fid,
                                 &ilabel,
                                 &fname,
-                                quantization,
                                 dims,
                                 effective_block_size,
                                 out_grid_bits,
@@ -210,15 +207,12 @@ impl SegmentMerger {
                                 // partial reorder (then Records, see
                                 // SegmentMerger::granularity).
                                 granularity,
+                                scratch_path,
                                 writer,
                                 field_tocs,
                                 pool,
                             )
-                        })
-                        .await
-                        .map_err(|e| {
-                            crate::Error::Internal(format!("merge-time reorder panicked: {}", e))
-                        })??;
+                        })?;
                         writer = w;
                         field_tocs = ft;
                         all_converged &= converged;
@@ -232,28 +226,18 @@ impl SegmentMerger {
                             &bmp_indexes,
                             &doc_offs,
                             field.0,
-                            quantization,
                             dims,
                             bmp_block_size,
                             grid_bits,
                             max_weight_scale,
                             total_vectors_bmp,
+                            &scratch_path,
                             &mut writer,
                             &mut field_tocs,
                         )
                     })?;
                 }
                 continue;
-            }
-
-            if segments
-                .iter()
-                .any(|segment| segment.bmp_indexes().contains_key(&field.0))
-            {
-                return Err(crate::Error::Corruption(format!(
-                    "field {} is configured as MaxScore but a source segment contains BMP data; rebuild the index",
-                    field.0
-                )));
             }
 
             // MaxScore format: byte-level block stacking
@@ -474,22 +458,10 @@ impl SegmentMerger {
             return Ok((0, all_converged));
         }
 
-        // Phase 2: Stream-copy skip entries from temp file to main writer (4 MB chunks)
+        // Phase 2: Stream-copy skip entries from temp file to main writer.
         let skip_offset = writer.offset();
         let skip_size = skip_count as u64 * SparseSkipEntry::SIZE as u64;
-        const SKIP_COPY_CHUNK: u64 = 4 * 1024 * 1024;
-        {
-            let mut pos = 0u64;
-            while pos < skip_size {
-                let end = (pos + SKIP_COPY_CHUNK).min(skip_size);
-                let chunk = dir.read_range(&skip_tmp, pos..end).await?;
-                writer
-                    .write_all(chunk.as_slice())
-                    .map_err(crate::Error::Io)?;
-                pos = end;
-            }
-        }
-        dir.delete(&skip_tmp).await.map_err(crate::Error::Io)?;
+        super::append_and_delete_temp(dir, &skip_tmp, skip_size, &mut writer).await?;
 
         // Phase 3 + 4: Write TOC + footer
         let toc_offset = writer.offset();
@@ -615,12 +587,12 @@ fn merge_bmp_field(
     bmp_indexes: &[Option<&BmpIndex>],
     doc_offs: &[u32],
     field_id: u32,
-    quantization: crate::structures::WeightQuantization,
     dims: u32,
     bmp_block_size: u32,
     grid_bits: u8,
     max_weight_scale: f32,
     total_vectors: u32,
+    scratch_path: &std::path::Path,
     writer: &mut OffsetWriter,
     field_tocs: &mut Vec<SparseFieldToc>,
 ) -> Result<()> {
@@ -638,38 +610,25 @@ fn merge_bmp_field(
     if sources.is_empty() {
         return Ok(());
     }
+    // Validation and every following phase are exhaustive sequential scans.
+    // Apply scan advice before touching multi-GB doc maps, not only before
+    // block-data copying.
+    let _source_pages =
+        crate::segment::reader::bmp::BmpScanPageGuard::new(sources.iter().map(|(bmp, _)| *bmp));
 
     // ── Phase 0: Validate all sources share dims, block_size, max_weight_scale ──
     let mut total_source_blocks: u32 = 0;
     let mut num_real_docs_total: u32 = 0;
 
     for &(bmp, _) in &sources {
-        if bmp.dims() != dims {
-            return Err(crate::Error::Corruption(format!(
-                "BMP merge: source dims={} != expected dims={}",
-                bmp.dims(),
-                dims
-            )));
-        }
-        if bmp.bmp_block_size != effective_block_size {
-            return Err(crate::Error::Corruption(format!(
-                "BMP merge: source block_size={} != expected {}",
-                bmp.bmp_block_size, effective_block_size
-            )));
-        }
-        if bmp.grid_bits() != grid_bits {
-            return Err(crate::Error::Corruption(format!(
-                "BMP merge: source grid_bits={} != expected {}",
-                bmp.grid_bits(),
-                grid_bits
-            )));
-        }
-        if (bmp.max_weight_scale - max_weight_scale).abs() > f32::EPSILON {
-            return Err(crate::Error::Corruption(format!(
-                "BMP merge: source max_weight_scale={:.4} != expected {:.4}",
-                bmp.max_weight_scale, max_weight_scale
-            )));
-        }
+        bmp.validate_rewrite_layout(
+            "BMP merge",
+            dims,
+            effective_block_size,
+            grid_bits,
+            max_weight_scale,
+        )?;
+        bmp.visit_real_slots_for_rewrite(|_| {})?;
         total_source_blocks = total_source_blocks
             .checked_add(bmp.num_blocks)
             .ok_or_else(|| {
@@ -716,10 +675,6 @@ fn merge_bmp_field(
         effective_block_size,
         max_weight_scale,
     );
-
-    // Restores query advice and drops scan-faulted mmap pages on every exit.
-    let _source_pages =
-        crate::segment::reader::bmp::BmpScanPageGuard::new(sources.iter().map(|(bmp, _)| *bmp));
 
     let blob_start = writer.offset();
 
@@ -779,16 +734,28 @@ fn merge_bmp_field(
     let block_grid_bytes =
         write_merged_block_grid(&sources, dims as usize, num_blocks, grid_bits, writer)?;
 
-    // ── Phase 4: Stream Section E. Source superblock coordinates restart at
-    // every segment, so this ceil-u4 section is remapped by
-    // source block offsets and repacked.
+    // ── Phase 4: Stream Sections E+H together. Source superblock coordinates
+    // restart at every segment, so E is remapped by source block offsets.
+    // H is derived from that same E row instead of decoding/filling it again.
     let sb_grid_offset = writer.offset() - blob_start;
     debug_assert_eq!(sb_grid_offset, grid_offset + block_grid_bytes);
-    let sb_grid_bytes =
-        write_merged_projected_superblock_grid(&sources, dims as usize, num_blocks, false, writer)?;
-    let coarse_grid_offset = writer.offset() - blob_start;
-    debug_assert_eq!(coarse_grid_offset, sb_grid_offset + sb_grid_bytes);
-    write_merged_projected_superblock_grid(&sources, dims as usize, num_blocks, true, writer)?;
+    let coarse_spool = scratch_path.with_file_name(format!(
+        "{}.merge_coarse_{}.tmp",
+        scratch_path
+            .file_name()
+            .map(|name| name.to_string_lossy())
+            .unwrap_or_else(|| "hermes.sparse".into()),
+        field_id,
+    ));
+    let (sb_grid_bytes, coarse_grid_bytes) =
+        write_merged_superblock_grids(&sources, dims as usize, num_blocks, &coarse_spool, writer)?;
+    let coarse_grid_offset = sb_grid_offset
+        .checked_add(sb_grid_bytes)
+        .ok_or_else(|| crate::Error::Internal("merged BMP grid offset exceeds u64".into()))?;
+    debug_assert_eq!(
+        writer.offset() - blob_start,
+        coarse_grid_offset + coarse_grid_bytes
+    );
 
     // Release grid pages
     #[cfg(feature = "native")]
@@ -865,88 +832,14 @@ fn merge_bmp_field(
     .map_err(crate::Error::Io)?;
 
     let blob_len = writer.offset() - blob_start;
-    push_bmp_field_toc(
-        field_tocs,
+    field_tocs.push(SparseFieldToc::bmp(
         field_id,
-        quantization,
         total_vectors,
         blob_start,
         blob_len,
-    );
+    ));
 
     Ok(())
-}
-
-/// Validate that all BMP merge sources share `dims`, `block_size`, and
-/// `max_weight_scale` (same invariants as the block-copy path's Phase 0).
-fn validate_bmp_sources(
-    sources: &[(BmpIndex, u32)],
-    dims: u32,
-    effective_block_size: u32,
-    expected_grid_bits: u8,
-    max_weight_scale: f32,
-) -> Result<()> {
-    for (bmp, _) in sources {
-        if bmp.dims() != dims {
-            return Err(crate::Error::Corruption(format!(
-                "BMP merge: source dims={} != expected dims={}",
-                bmp.dims(),
-                dims
-            )));
-        }
-        if bmp.bmp_block_size != effective_block_size {
-            return Err(crate::Error::Corruption(format!(
-                "BMP merge: source block_size={} != expected {}",
-                bmp.bmp_block_size, effective_block_size
-            )));
-        }
-        if bmp.grid_bits() != expected_grid_bits {
-            return Err(crate::Error::Corruption(format!(
-                "BMP merge: source grid_bits={} != expected {}",
-                bmp.grid_bits(),
-                expected_grid_bits
-            )));
-        }
-        if (bmp.max_weight_scale - max_weight_scale).abs() > f32::EPSILON {
-            return Err(crate::Error::Corruption(format!(
-                "BMP merge: source max_weight_scale={:.4} != expected {:.4}",
-                bmp.max_weight_scale, max_weight_scale
-            )));
-        }
-    }
-    Ok(())
-}
-
-/// Push a BMP sentinel field TOC entry after writing a blob.
-fn push_bmp_field_toc(
-    field_tocs: &mut Vec<SparseFieldToc>,
-    field_id: u32,
-    quantization: crate::structures::WeightQuantization,
-    total_vectors: u32,
-    blob_start: u64,
-    blob_len: u64,
-) {
-    if blob_len == 0 {
-        return;
-    }
-    let mut config_for_byte =
-        crate::structures::SparseVectorConfig::from_byte(quantization as u8).unwrap_or_default();
-    config_for_byte.format = SparseFormat::Bmp;
-    config_for_byte.weight_quantization = quantization;
-
-    field_tocs.push(SparseFieldToc {
-        field_id,
-        quantization: config_for_byte.to_byte(),
-        total_vectors,
-        dims: vec![SparseDimTocEntry {
-            dim_id: 0xFFFFFFFF, // sentinel for BMP
-            block_data_offset: blob_start,
-            skip_start: (blob_len & 0xFFFFFFFF) as u32,
-            num_blocks: ((blob_len >> 32) & 0xFFFFFFFF) as u32,
-            doc_count: 0,
-            max_weight: 0.0,
-        }],
-    });
 }
 
 enum MergedBlockGroup<'a> {
@@ -1108,7 +1001,6 @@ fn write_merged_block_grid<'a>(
                           groups: &[crate::segment::bmp_grid::PackedGridGroup<'a>],
                           values: &mut [u8; GRID_GROUP_CELLS]|
      -> Result<()> {
-        widths.fill(0);
         let mut source = 0usize;
         for (output_group, output_width) in widths.iter_mut().enumerate() {
             *output_width = match prepare_merged_block_group(
@@ -1136,16 +1028,21 @@ fn write_merged_block_grid<'a>(
         .write_row_offsets(&row_sizes, writer)
         .map_err(crate::Error::Io)?;
 
-    for dimension in 0..dims {
+    let largest_payload = row_sizes
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or(layout.row_header_bytes() as u64)
+        .saturating_sub(layout.row_header_bytes() as u64);
+    let mut row_payload = Vec::with_capacity(usize::try_from(largest_payload).map_err(|_| {
+        crate::Error::Internal("merged BMP block-grid row exceeds addressable memory".into())
+    })?);
+    let mut packed = [0u8; GRID_GROUP_CELLS];
+    for (dimension, &row_size) in row_sizes.iter().enumerate() {
         load_row(dimension, &mut row_groups)?;
-        collect_widths(&mut widths, &row_groups, &mut group_values)?;
-        layout
-            .write_row_header(&widths, grid_bits, writer)
-            .map_err(crate::Error::Io)?;
-
-        let mut packed = [0u8; GRID_GROUP_CELLS];
+        row_payload.clear();
         let mut source = 0usize;
-        for (output_group, &width) in widths.iter().enumerate() {
+        for (output_group, output_width) in widths.iter_mut().enumerate() {
             match prepare_merged_block_group(
                 output_group,
                 num_blocks,
@@ -1156,45 +1053,205 @@ fn write_merged_block_grid<'a>(
                 &mut group_values,
             )? {
                 MergedBlockGroup::Borrowed(group) => {
-                    if group.width() != width {
-                        return Err(crate::Error::Corruption(
-                            "BMP merge block-grid sizing changed during encoding".into(),
-                        ));
-                    }
-                    writer.write_all(group.bytes()).map_err(crate::Error::Io)?;
+                    *output_width = group.width();
+                    row_payload.extend_from_slice(group.bytes());
                 }
-                MergedBlockGroup::Repacked {
-                    width: actual_width,
-                } => {
-                    if actual_width != width {
-                        return Err(crate::Error::Corruption(
-                            "BMP merge block-grid sizing changed during encoding".into(),
-                        ));
-                    }
+                MergedBlockGroup::Repacked { width } => {
+                    *output_width = width;
                     let payload_len = pack_group(&group_values, width, &mut packed)?;
-                    writer
-                        .write_all(&packed[..payload_len])
-                        .map_err(crate::Error::Io)?;
+                    row_payload.extend_from_slice(&packed[..payload_len]);
                 }
             }
         }
+        let expected_payload = usize::try_from(row_size)
+            .map_err(|_| {
+                crate::Error::Internal(
+                    "merged BMP block-grid row exceeds addressable memory".into(),
+                )
+            })?
+            .checked_sub(layout.row_header_bytes())
+            .ok_or_else(|| {
+                crate::Error::Corruption(
+                    "merged BMP block-grid row is shorter than its header".into(),
+                )
+            })?;
+        if row_payload.len() != expected_payload {
+            return Err(crate::Error::Corruption(
+                "BMP merge block-grid sizing changed during encoding".into(),
+            ));
+        }
+        layout
+            .write_row_header(&widths, grid_bits, writer)
+            .map_err(crate::Error::Io)?;
+        writer.write_all(&row_payload).map_err(crate::Error::Io)?;
     }
     Ok(table_bytes + row_sizes.into_iter().sum::<u64>())
 }
 
-/// Rebuild E or H directly from source E rows.
+struct MergedSuperblockRows {
+    superblock: Vec<u8>,
+    coarse: Vec<u8>,
+    superblock_cells_touched: Vec<usize>,
+    coarse_cells_touched: Vec<usize>,
+    superblock_widths: Vec<u8>,
+    coarse_widths: Vec<u8>,
+    superblock_groups_touched: Vec<usize>,
+    coarse_groups_touched: Vec<usize>,
+    decoded: [u8; crate::segment::bmp_grid::GRID_GROUP_CELLS],
+}
+
+impl MergedSuperblockRows {
+    fn new(superblock_cells: usize, coarse_cells: usize) -> Self {
+        use crate::segment::bmp_grid::{CompressedGridLayout, GRID_GROUP_CELLS};
+
+        Self {
+            superblock: vec![0; superblock_cells],
+            coarse: vec![0; coarse_cells],
+            superblock_cells_touched: Vec::new(),
+            coarse_cells_touched: Vec::new(),
+            superblock_widths: vec![0; CompressedGridLayout::new(0, superblock_cells).groups()],
+            coarse_widths: vec![0; CompressedGridLayout::new(0, coarse_cells).groups()],
+            superblock_groups_touched: Vec::new(),
+            coarse_groups_touched: Vec::new(),
+            decoded: [0; GRID_GROUP_CELLS],
+        }
+    }
+
+    fn clear_projection(
+        row: &mut [u8],
+        cells_touched: &mut Vec<usize>,
+        widths: &mut [u8],
+        groups_touched: &mut Vec<usize>,
+    ) {
+        for cell in cells_touched.drain(..) {
+            row[cell] = 0;
+        }
+        for group in groups_touched.drain(..) {
+            widths[group] = 0;
+        }
+    }
+
+    fn prepare<'a>(
+        &mut self,
+        sources: &[(&'a BmpIndex, u32)],
+        source_block_bases: &[usize],
+        dims: usize,
+        dimension: usize,
+        source_groups: &mut Vec<crate::segment::bmp_grid::PackedGridGroup<'a>>,
+    ) -> Result<()> {
+        use crate::segment::bmp_grid::{GRID_GROUP_CELLS, bit_width};
+
+        const SB: usize = crate::segment::BMP_SUPERBLOCK_SIZE as usize;
+        Self::clear_projection(
+            &mut self.superblock,
+            &mut self.superblock_cells_touched,
+            &mut self.superblock_widths,
+            &mut self.superblock_groups_touched,
+        );
+        Self::clear_projection(
+            &mut self.coarse,
+            &mut self.coarse_cells_touched,
+            &mut self.coarse_widths,
+            &mut self.coarse_groups_touched,
+        );
+
+        for (source, &(bmp, _)) in sources.iter().enumerate() {
+            let grid = bmp.superblock_grid();
+            if grid.dims() != dims
+                || grid.max_width() != crate::segment::bmp_grid::LSP_SUPERBLOCK_GRID_BITS
+            {
+                return Err(crate::Error::Corruption(
+                    "BMP merge superblock-grid metadata disagrees with the field schema".into(),
+                ));
+            }
+            let source_blocks = bmp.num_blocks as usize;
+            source_groups.clear();
+            grid.append_row_groups(dimension, source_groups)?;
+            for (source_group, group) in source_groups.iter().copied().enumerate() {
+                let source_cell_start = source_group * GRID_GROUP_CELLS;
+                let count = GRID_GROUP_CELLS.min(grid.cells() - source_cell_start);
+                if group.width() == 0 {
+                    continue;
+                }
+                group.decode(0, count, &mut self.decoded);
+                for (within, &value) in self.decoded[..count].iter().enumerate() {
+                    if value == 0 {
+                        continue;
+                    }
+                    let source_sb = source_cell_start + within;
+                    let local_block_start = source_sb * SB;
+                    if local_block_start >= source_blocks {
+                        break;
+                    }
+                    let local_block_end = (local_block_start + SB).min(source_blocks);
+                    let global_block_start = source_block_bases[source] + local_block_start;
+                    let global_block_end = source_block_bases[source] + local_block_end;
+                    let first_output_sb = global_block_start / SB;
+                    let last_output_sb = (global_block_end - 1) / SB;
+                    for output_sb in first_output_sb..=last_output_sb {
+                        let slot = &mut self.superblock[output_sb];
+                        if *slot == 0 {
+                            self.superblock_cells_touched.push(output_sb);
+                        }
+                        *slot = (*slot).max(value);
+                    }
+                }
+            }
+        }
+
+        for &cell in &self.superblock_cells_touched {
+            let value = self.superblock[cell];
+            let group = cell / GRID_GROUP_CELLS;
+            let width = bit_width(value);
+            if self.superblock_widths[group] == 0 {
+                self.superblock_groups_touched.push(group);
+            }
+            self.superblock_widths[group] = self.superblock_widths[group].max(width);
+
+            let coarse_cell = cell / GRID_GROUP_CELLS;
+            let coarse_slot = &mut self.coarse[coarse_cell];
+            if *coarse_slot == 0 {
+                self.coarse_cells_touched.push(coarse_cell);
+            }
+            *coarse_slot = (*coarse_slot).max(value);
+        }
+        for &cell in &self.coarse_cells_touched {
+            let group = cell / GRID_GROUP_CELLS;
+            let width = bit_width(self.coarse[cell]);
+            if self.coarse_widths[group] == 0 {
+                self.coarse_groups_touched.push(group);
+            }
+            self.coarse_widths[group] = self.coarse_widths[group].max(width);
+        }
+        debug_assert!(
+            self.superblock_groups_touched
+                .windows(2)
+                .all(|pair| pair[0] < pair[1])
+        );
+        debug_assert!(
+            self.coarse_groups_touched
+                .windows(2)
+                .all(|pair| pair[0] < pair[1])
+        );
+        Ok(())
+    }
+}
+
+/// Rebuild E and H together from each source-E row.
 ///
-/// Source segment boundaries need not align to output superblocks, so E cannot
-/// always be copied byte-for-byte. This keeps one decoded output-E row in
-/// memory, then either writes it directly or reduces each 256-cell group to
-/// one H cell. It never deserializes or reserializes postings.
-fn write_merged_projected_superblock_grid<'a>(
+/// Segment boundaries need not align to output superblocks, so E cannot
+/// always be copied byte-for-byte. Both projections share two source scans:
+/// one for row sizes and one for encoding. Only touched cells/groups are
+/// cleared between dimensions; a sparse vocabulary therefore does not
+/// repeatedly zero multi-megabyte dense rows. H rows are spooled until the
+/// complete E section has been written.
+fn write_merged_superblock_grids<'a>(
     sources: &[(&'a BmpIndex, u32)],
     dims: usize,
     num_blocks: usize,
-    coarse: bool,
+    coarse_spool: &std::path::Path,
     writer: &mut dyn Write,
-) -> Result<u64> {
+) -> Result<(u64, u64)> {
     use crate::segment::bmp_grid::{CompressedGridLayout, GRID_GROUP_CELLS, pack_group};
 
     let mut source_block_bases = Vec::with_capacity(sources.len() + 1);
@@ -1216,128 +1273,169 @@ fn write_merged_projected_superblock_grid<'a>(
         ));
     }
     let superblock_cells = num_blocks.div_ceil(crate::segment::BMP_SUPERBLOCK_SIZE as usize);
-    let cells = if coarse {
-        superblock_cells.div_ceil(crate::segment::reader::bmp::BMP_COARSE_SUPERBLOCKS as usize)
-    } else {
-        superblock_cells
-    };
-    let layout = CompressedGridLayout::new(dims, cells);
-    let mut widths = vec![0u8; layout.groups()];
-    let mut row_sizes = Vec::with_capacity(dims);
-    let mut superblock_row = vec![0u8; superblock_cells];
-    let mut coarse_row = coarse.then(|| vec![0u8; cells]);
-    let mut decoded = [0u8; GRID_GROUP_CELLS];
+    let coarse_cells =
+        superblock_cells.div_ceil(crate::segment::reader::bmp::BMP_COARSE_SUPERBLOCKS as usize);
+    let superblock_layout = CompressedGridLayout::new(dims, superblock_cells);
+    let coarse_layout = CompressedGridLayout::new(dims, coarse_cells);
+
+    let mut rows = MergedSuperblockRows::new(superblock_cells, coarse_cells);
+    let mut superblock_row_sizes = Vec::with_capacity(dims);
+    let mut coarse_row_sizes = Vec::with_capacity(dims);
     let mut source_groups: Vec<crate::segment::bmp_grid::PackedGridGroup<'a>> = Vec::new();
 
-    let fill_row = |dimension: usize,
-                    row: &mut [u8],
-                    decoded: &mut [u8; GRID_GROUP_CELLS],
-                    source_groups: &mut Vec<crate::segment::bmp_grid::PackedGridGroup<'a>>|
-     -> Result<()> {
-        const SB: usize = crate::segment::BMP_SUPERBLOCK_SIZE as usize;
-        row.fill(0);
-        for (source, &(bmp, _)) in sources.iter().enumerate() {
-            let grid = bmp.superblock_grid();
-            let source_blocks = bmp.num_blocks as usize;
-            source_groups.clear();
-            grid.append_row_groups(dimension, source_groups)?;
-            for (source_group, group) in source_groups.iter().copied().enumerate() {
-                let source_cell_start = source_group * GRID_GROUP_CELLS;
-                let count = GRID_GROUP_CELLS.min(grid.cells() - source_cell_start);
-                if group.width() == 0 {
-                    continue;
-                }
-                group.decode(0, count, decoded);
-                for (within, &value) in decoded[..count].iter().enumerate() {
-                    if value == 0 {
-                        continue;
-                    }
-                    let source_sb = source_cell_start + within;
-                    let local_block_start = source_sb * SB;
-                    if local_block_start >= source_blocks {
-                        break;
-                    }
-                    let local_block_end = (local_block_start + SB).min(source_blocks);
-                    let global_block_start = source_block_bases[source] + local_block_start;
-                    let global_block_end = source_block_bases[source] + local_block_end;
-                    let first_output_sb = global_block_start / SB;
-                    let last_output_sb = (global_block_end - 1) / SB;
-                    for slot in &mut row[first_output_sb..=last_output_sb] {
-                        *slot = (*slot).max(value);
-                    }
-                }
-            }
-        }
-        Ok(())
-    };
-    let collect_widths = |row: &[u8], widths: &mut [u8]| {
-        widths.fill(0);
-        for (group, values) in row.chunks(GRID_GROUP_CELLS).enumerate() {
-            widths[group] =
-                crate::segment::bmp_grid::bit_width(values.iter().copied().max().unwrap_or(0));
-        }
-    };
-    let project_coarse = |superblocks: &[u8], coarse: &mut [u8]| {
-        for (output, values) in coarse.iter_mut().zip(superblocks.chunks(GRID_GROUP_CELLS)) {
-            *output = values.iter().copied().max().unwrap_or(0);
-        }
-    };
+    let row_size =
+        |layout: CompressedGridLayout, widths: &[u8], groups_touched: &[usize]| -> Result<u64> {
+            let payload_units = groups_touched.iter().try_fold(0u64, |total, &group| {
+                total.checked_add(u64::from(widths[group])).ok_or_else(|| {
+                    crate::Error::Internal("merged BMP projected-grid row size exceeds u64".into())
+                })
+            })?;
+            let payload_bytes = payload_units
+                .checked_mul((GRID_GROUP_CELLS / 8) as u64)
+                .ok_or_else(|| {
+                    crate::Error::Internal("merged BMP projected-grid row size exceeds u64".into())
+                })?;
+            (layout.row_header_bytes() as u64)
+                .checked_add(payload_bytes)
+                .ok_or_else(|| {
+                    crate::Error::Internal("merged BMP projected-grid row size exceeds u64".into())
+                })
+        };
 
     for dimension in 0..dims {
-        fill_row(
+        rows.prepare(
+            sources,
+            &source_block_bases,
+            dims,
             dimension,
-            &mut superblock_row,
-            &mut decoded,
             &mut source_groups,
         )?;
-        let output_row = if let Some(coarse_row) = coarse_row.as_deref_mut() {
-            project_coarse(&superblock_row, coarse_row);
-            &*coarse_row
-        } else {
-            &superblock_row
-        };
-        collect_widths(output_row, &mut widths);
-        row_sizes.push(layout.row_bytes(&widths)?);
+        superblock_row_sizes.push(row_size(
+            superblock_layout,
+            &rows.superblock_widths,
+            &rows.superblock_groups_touched,
+        )?);
+        coarse_row_sizes.push(row_size(
+            coarse_layout,
+            &rows.coarse_widths,
+            &rows.coarse_groups_touched,
+        )?);
     }
-    let table_bytes = layout
-        .write_row_offsets(&row_sizes, writer)
+
+    let superblock_table_bytes = superblock_layout
+        .write_row_offsets(&superblock_row_sizes, writer)
         .map_err(crate::Error::Io)?;
+    let coarse_file = std::fs::File::create(coarse_spool).map_err(crate::Error::Io)?;
+    struct ScratchCleanup<'a>(&'a std::path::Path);
+    impl Drop for ScratchCleanup<'_> {
+        fn drop(&mut self) {
+            if let Err(error) = std::fs::remove_file(self.0)
+                && error.kind() != std::io::ErrorKind::NotFound
+            {
+                log::warn!(
+                    "[merge_bmp] failed to remove coarse-grid spool {:?}: {}",
+                    self.0,
+                    error
+                );
+            }
+        }
+    }
+    let _coarse_cleanup = ScratchCleanup(coarse_spool);
+    let mut coarse_writer = std::io::BufWriter::with_capacity(1024 * 1024, coarse_file);
 
     let mut values = [0u8; GRID_GROUP_CELLS];
     let mut packed = [0u8; GRID_GROUP_CELLS];
-    for dimension in 0..dims {
-        fill_row(
-            dimension,
-            &mut superblock_row,
-            &mut decoded,
-            &mut source_groups,
-        )?;
-        let output_row = if let Some(coarse_row) = coarse_row.as_deref_mut() {
-            project_coarse(&superblock_row, coarse_row);
-            &*coarse_row
-        } else {
-            &superblock_row
-        };
-        collect_widths(output_row, &mut widths);
+    let mut write_row = |layout: CompressedGridLayout,
+                         row: &[u8],
+                         widths: &[u8],
+                         groups_touched: &[usize],
+                         output: &mut dyn Write|
+     -> Result<u64> {
         layout
             .write_row_header(
-                &widths,
+                widths,
                 crate::segment::bmp_grid::LSP_SUPERBLOCK_GRID_BITS,
-                writer,
+                output,
             )
             .map_err(crate::Error::Io)?;
-        for (output_group, &width) in widths.iter().enumerate() {
+        let mut bytes = layout.row_header_bytes() as u64;
+        for &output_group in groups_touched {
             values.fill(0);
             let start = output_group * GRID_GROUP_CELLS;
-            let count = GRID_GROUP_CELLS.min(cells - start);
-            values[..count].copy_from_slice(&output_row[start..start + count]);
-            let payload_len = pack_group(&values, width, &mut packed)?;
-            writer
+            let count = GRID_GROUP_CELLS.min(layout.cells() - start);
+            values[..count].copy_from_slice(&row[start..start + count]);
+            let payload_len = pack_group(&values, widths[output_group], &mut packed)?;
+            output
                 .write_all(&packed[..payload_len])
                 .map_err(crate::Error::Io)?;
+            bytes = bytes.checked_add(payload_len as u64).ok_or_else(|| {
+                crate::Error::Internal("merged BMP projected-grid row size exceeds u64".into())
+            })?;
+        }
+        Ok(bytes)
+    };
+
+    for dimension in 0..dims {
+        rows.prepare(
+            sources,
+            &source_block_bases,
+            dims,
+            dimension,
+            &mut source_groups,
+        )?;
+        let actual_superblock = write_row(
+            superblock_layout,
+            &rows.superblock,
+            &rows.superblock_widths,
+            &rows.superblock_groups_touched,
+            writer,
+        )?;
+        let actual_coarse = write_row(
+            coarse_layout,
+            &rows.coarse,
+            &rows.coarse_widths,
+            &rows.coarse_groups_touched,
+            &mut coarse_writer,
+        )?;
+        if actual_superblock != superblock_row_sizes[dimension]
+            || actual_coarse != coarse_row_sizes[dimension]
+        {
+            return Err(crate::Error::Corruption(
+                "BMP projected-grid sizing changed during encoding".into(),
+            ));
         }
     }
-    Ok(table_bytes + row_sizes.into_iter().sum::<u64>())
+    coarse_writer.flush().map_err(crate::Error::Io)?;
+    drop(coarse_writer);
+
+    let coarse_rows_bytes = coarse_row_sizes.iter().sum::<u64>();
+    let actual_coarse_bytes = std::fs::metadata(coarse_spool)
+        .map_err(crate::Error::Io)?
+        .len();
+    if actual_coarse_bytes != coarse_rows_bytes {
+        return Err(crate::Error::Corruption(format!(
+            "BMP coarse-grid spool has {actual_coarse_bytes} bytes, expected {coarse_rows_bytes}"
+        )));
+    }
+    let coarse_table_bytes = coarse_layout
+        .write_row_offsets(&coarse_row_sizes, writer)
+        .map_err(crate::Error::Io)?;
+    let coarse_file = std::fs::File::open(coarse_spool).map_err(crate::Error::Io)?;
+    let mut coarse_reader = std::io::BufReader::with_capacity(1024 * 1024, coarse_file);
+    let copied = std::io::copy(&mut coarse_reader, writer).map_err(crate::Error::Io)?;
+    if copied != coarse_rows_bytes {
+        return Err(crate::Error::Corruption(format!(
+            "short BMP coarse-grid spool copy: copied {copied}, expected {coarse_rows_bytes}"
+        )));
+    }
+
+    let superblock_bytes = superblock_table_bytes
+        .checked_add(superblock_row_sizes.into_iter().sum::<u64>())
+        .ok_or_else(|| crate::Error::Internal("merged BMP superblock grid exceeds u64".into()))?;
+    let coarse_bytes = coarse_table_bytes
+        .checked_add(coarse_rows_bytes)
+        .ok_or_else(|| crate::Error::Internal("merged BMP coarse grid exceeds u64".into()))?;
+    Ok((superblock_bytes, coarse_bytes))
 }
 
 #[cfg(test)]

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -831,6 +831,7 @@ impl BmpIndex {
     /// The footer is the source of truth for reading this blob. Rewriting with
     /// a different block width, grid width, vocabulary, or impact scale would
     /// otherwise make block slicing or copied upper bounds invalid.
+    #[cfg(any(feature = "native", test))]
     pub(crate) fn validate_rewrite_layout(
         &self,
         context: &str,
@@ -922,6 +923,7 @@ impl BmpIndex {
     /// iterators. Query parsing deliberately degrades malformed blocks to
     /// empty for availability; a rewrite must instead fail loudly so it never
     /// publishes silent data loss or indexes an invalid local slot.
+    #[cfg(any(feature = "native", test))]
     pub(crate) fn validate_block_for_rewrite(&self, block_id: u32) -> crate::Result<()> {
         if block_id >= self.num_blocks {
             return Err(crate::Error::Corruption(format!(

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -104,6 +104,9 @@ pub struct BmpIndex {
     pub max_weight_scale: f32,
     /// Total sparse vectors (from TOC entry)
     pub total_vectors: u32,
+    /// Number of documents in the containing segment. Document-map entries
+    /// must be either padding or strictly below this bound.
+    segment_num_docs: u32,
 
     // ── Section metadata ──────────────────────────────────────────────
     /// Fixed vocabulary size — grid has `dims` rows
@@ -168,7 +171,7 @@ impl BmpIndex {
         handle: FileHandle,
         blob_offset: u64,
         blob_len: u64,
-        _total_docs: u32,
+        total_docs: u32,
         total_vectors: u32,
     ) -> crate::Result<Self> {
         use crate::segment::format::{BMP_BLOB_FOOTER_SIZE, BMP_BLOB_MAGIC};
@@ -236,6 +239,7 @@ impl BmpIndex {
                 num_virtual_docs,
                 max_weight_scale,
                 total_vectors,
+                segment_num_docs: total_docs,
                 dims,
                 total_terms: 0,
                 total_postings: 0,
@@ -473,6 +477,7 @@ impl BmpIndex {
             num_virtual_docs,
             max_weight_scale,
             total_vectors,
+            segment_num_docs: total_docs,
             dims,
             total_terms,
             total_postings,
@@ -519,6 +524,9 @@ impl BmpIndex {
         debug_assert!((virtual_id as usize + 1) * 2 <= ords.len());
         unsafe {
             let doc_id = read_u32_unchecked(ids.as_ptr(), virtual_id as usize);
+            if doc_id >= self.segment_num_docs {
+                return (u32::MAX, 0);
+            }
             let p = ords.as_ptr().add(virtual_id as usize * 2);
             let ordinal = u16::from_le((p as *const u16).read_unaligned());
             (doc_id, ordinal)
@@ -534,7 +542,12 @@ impl BmpIndex {
         }
         let d = self.doc_map_ids_bytes.as_slice();
         debug_assert!((virtual_id as usize + 1) * 4 <= d.len());
-        unsafe { read_u32_unchecked(d.as_ptr(), virtual_id as usize) }
+        let doc_id = unsafe { read_u32_unchecked(d.as_ptr(), virtual_id as usize) };
+        if doc_id < self.segment_num_docs {
+            doc_id
+        } else {
+            u32::MAX
+        }
     }
 
     // ── Hot-path block-data accessors ────────────────────────────────
@@ -812,6 +825,208 @@ impl BmpIndex {
         self.dims
     }
 
+    /// Validate the persisted layout before a merge or reorder interprets it
+    /// using schema-derived output parameters.
+    ///
+    /// The footer is the source of truth for reading this blob. Rewriting with
+    /// a different block width, grid width, vocabulary, or impact scale would
+    /// otherwise make block slicing or copied upper bounds invalid.
+    pub(crate) fn validate_rewrite_layout(
+        &self,
+        context: &str,
+        expected_dims: u32,
+        expected_block_size: u32,
+        expected_grid_bits: u8,
+        expected_max_weight_scale: f32,
+    ) -> crate::Result<()> {
+        if expected_dims == 0 {
+            return Err(crate::Error::Corruption(format!(
+                "{context}: expected vocabulary is empty",
+            )));
+        }
+        if self.dims != expected_dims {
+            return Err(crate::Error::Corruption(format!(
+                "{context}: source dims={} != expected {expected_dims}",
+                self.dims,
+            )));
+        }
+        if self.bmp_block_size != expected_block_size {
+            return Err(crate::Error::Corruption(format!(
+                "{context}: source block_size={} != expected {expected_block_size}",
+                self.bmp_block_size,
+            )));
+        }
+        if self.grid_bits != expected_grid_bits {
+            return Err(crate::Error::Corruption(format!(
+                "{context}: source grid_bits={} != expected {expected_grid_bits}",
+                self.grid_bits,
+            )));
+        }
+        if !expected_max_weight_scale.is_finite() || expected_max_weight_scale <= 0.0 {
+            return Err(crate::Error::Corruption(format!(
+                "{context}: invalid expected max_weight_scale={expected_max_weight_scale}",
+            )));
+        }
+        if self.max_weight_scale.to_bits() != expected_max_weight_scale.to_bits() {
+            return Err(crate::Error::Corruption(format!(
+                "{context}: source max_weight_scale={:.4} != expected {:.4}",
+                self.max_weight_scale, expected_max_weight_scale,
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validate the document map and visit each non-padding virtual slot.
+    ///
+    /// All rewrite paths share this scan so block-copy cannot offset corrupt
+    /// source IDs into another segment while record reorder rejects them.
+    pub(crate) fn visit_real_slots_for_rewrite(
+        &self,
+        mut visitor: impl FnMut(usize),
+    ) -> crate::Result<()> {
+        let expected_real = self.num_real_docs as usize;
+        let mut real_slots = 0usize;
+        for (virtual_id, chunk) in self
+            .doc_map_ids_bytes
+            .as_slice()
+            .chunks_exact(4)
+            .enumerate()
+        {
+            let doc_id = u32::from_le_bytes(chunk.try_into().unwrap());
+            if doc_id == u32::MAX {
+                continue;
+            }
+            if doc_id >= self.segment_num_docs {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP document map contains doc id {doc_id} outside segment bound {}",
+                    self.segment_num_docs,
+                )));
+            }
+            if real_slots == expected_real {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP document map contains more than the footer's {expected_real} real slots"
+                )));
+            }
+            visitor(virtual_id);
+            real_slots += 1;
+        }
+        if real_slots != expected_real {
+            return Err(crate::Error::Corruption(format!(
+                "BMP document map has {real_slots} real slots but footer declares {expected_real}",
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validate one block before a rewrite feeds it into infallible hot-path
+    /// iterators. Query parsing deliberately degrades malformed blocks to
+    /// empty for availability; a rewrite must instead fail loudly so it never
+    /// publishes silent data loss or indexes an invalid local slot.
+    pub(crate) fn validate_block_for_rewrite(&self, block_id: u32) -> crate::Result<()> {
+        if block_id >= self.num_blocks {
+            return Err(crate::Error::Corruption(format!(
+                "BMP rewrite block {block_id} exceeds block count {}",
+                self.num_blocks,
+            )));
+        }
+        let (start, end) = self.block_data_range(block_id);
+        let start = usize::try_from(start)
+            .map_err(|_| crate::Error::Corruption("BMP block start exceeds usize".into()))?;
+        let end = usize::try_from(end)
+            .map_err(|_| crate::Error::Corruption("BMP block end exceeds usize".into()))?;
+        let block = self
+            .block_data_bytes
+            .as_slice()
+            .get(start..end)
+            .ok_or_else(|| {
+                crate::Error::Corruption(format!(
+                    "BMP block {block_id} range {start}..{end} exceeds block data",
+                ))
+            })?;
+        if block.is_empty() {
+            return Ok(());
+        }
+        if block.len() < 8 {
+            return Err(crate::Error::Corruption(format!(
+                "BMP block {block_id} is too short: {} bytes",
+                block.len(),
+            )));
+        }
+
+        let num_terms = u32::from_le_bytes(block[..4].try_into().unwrap()) as usize;
+        let header_len = num_terms
+            .checked_mul(9)
+            .and_then(|bytes| bytes.checked_add(8))
+            .ok_or_else(|| {
+                crate::Error::Corruption(format!(
+                    "BMP block {block_id} header length overflows usize",
+                ))
+            })?;
+        if header_len > block.len() || !(block.len() - header_len).is_multiple_of(2) {
+            return Err(crate::Error::Corruption(format!(
+                "BMP block {block_id} has invalid header/data lengths: header={header_len}, total={}",
+                block.len(),
+            )));
+        }
+
+        let dims_start = 4;
+        let prefixes_start = dims_start + num_terms * 4;
+        let maxima_start = prefixes_start + (num_terms + 1) * 4;
+        let postings_start = maxima_start + num_terms;
+        debug_assert_eq!(postings_start, header_len);
+        let total_postings = (block.len() - postings_start) / 2;
+        let read_prefix = |index: usize| {
+            let offset = prefixes_start + index * 4;
+            u32::from_le_bytes(block[offset..offset + 4].try_into().unwrap()) as usize
+        };
+        if read_prefix(0) != 0 || read_prefix(num_terms) != total_postings {
+            return Err(crate::Error::Corruption(format!(
+                "BMP block {block_id} posting prefixes do not span 0..{total_postings}",
+            )));
+        }
+
+        let mut previous_dim = None;
+        for term in 0..num_terms {
+            let dim_offset = dims_start + term * 4;
+            let dimension =
+                u32::from_le_bytes(block[dim_offset..dim_offset + 4].try_into().unwrap());
+            if dimension >= self.dims || previous_dim.is_some_and(|previous| dimension <= previous)
+            {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP block {block_id} has invalid/non-increasing dimension {dimension} at term {term}",
+                )));
+            }
+            previous_dim = Some(dimension);
+
+            let posting_start = read_prefix(term);
+            let posting_end = read_prefix(term + 1);
+            if posting_start >= posting_end || posting_end > total_postings {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP block {block_id} term {term} has invalid posting range {posting_start}..{posting_end}",
+                )));
+            }
+            let postings =
+                &block[postings_start + posting_start * 2..postings_start + posting_end * 2];
+            let mut observed_max = 0u8;
+            for posting in postings.chunks_exact(2) {
+                if u32::from(posting[0]) >= self.bmp_block_size {
+                    return Err(crate::Error::Corruption(format!(
+                        "BMP block {block_id} term {term} has local slot {} outside block size {}",
+                        posting[0], self.bmp_block_size,
+                    )));
+                }
+                observed_max = observed_max.max(posting[1]);
+            }
+            let stored_max = block[maxima_start + term];
+            if stored_max != observed_max {
+                return Err(crate::Error::Corruption(format!(
+                    "BMP block {block_id} term {term} maximum {stored_max} != observed {observed_max}",
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Total number of terms (unique dim×block pairs) stored in the index.
     pub fn total_terms(&self) -> u64 {
         self.total_terms
@@ -827,6 +1042,7 @@ impl BmpIndex {
         self.num_real_docs
     }
 
+    /// Number of documents in the containing segment.
     /// Whether this segment physically contains at most one vector per
     /// document. Unlike the schema's `multi` flag, this remains reliable for
     /// old or externally-created segments with inaccurate metadata.
@@ -1208,5 +1424,64 @@ mod safety_tests {
         .unwrap();
         let multi = parse(blob).unwrap();
         assert!(!multi.is_single_valued());
+    }
+
+    #[test]
+    fn rewrite_validation_rejects_out_of_range_local_slot() {
+        let mut blob = test_blob();
+        // One-term block header is 8 + 9 bytes; postings follow immediately.
+        blob[17] = 64;
+        let index = parse(blob).unwrap();
+        let error = index.validate_block_for_rewrite(0).unwrap_err();
+        assert!(matches!(error, crate::Error::Corruption(_)));
+    }
+
+    #[test]
+    fn rewrite_validation_rejects_bad_dimension_and_maximum() {
+        let mut bad_dimension = test_blob();
+        bad_dimension[4..8].copy_from_slice(&16u32.to_le_bytes());
+        let index = parse(bad_dimension).unwrap();
+        assert!(matches!(
+            index.validate_block_for_rewrite(0),
+            Err(crate::Error::Corruption(_))
+        ));
+
+        let mut bad_maximum = test_blob();
+        bad_maximum[16] = 0;
+        let index = parse(bad_maximum).unwrap();
+        assert!(matches!(
+            index.validate_block_for_rewrite(0),
+            Err(crate::Error::Corruption(_))
+        ));
+    }
+
+    #[test]
+    fn invalid_doc_map_id_is_bounded_and_rewrite_rejects_it() {
+        let mut blob = test_blob();
+        let footer = blob.len() - BMP_BLOB_FOOTER_SIZE;
+        let doc_map =
+            u64::from_le_bytes(blob[footer + 60..footer + 68].try_into().unwrap()) as usize;
+        blob[doc_map..doc_map + 4].copy_from_slice(&2u32.to_le_bytes());
+        let index = parse(blob).unwrap();
+
+        assert_eq!(index.doc_id_for_virtual(0), u32::MAX);
+        assert!(matches!(
+            crate::segment::builder::graph_bisection::build_vid_maps(&index),
+            Err(crate::Error::Corruption(_))
+        ));
+    }
+
+    #[test]
+    fn rewrite_layout_requires_exact_finite_scale() {
+        let index = parse(test_blob()).unwrap();
+        let adjacent_scale = f32::from_bits(index.max_weight_scale.to_bits() + 1);
+        assert!(matches!(
+            index.validate_rewrite_layout("test", 16, 64, 4, adjacent_scale),
+            Err(crate::Error::Corruption(_))
+        ));
+        assert!(matches!(
+            index.validate_rewrite_layout("test", 16, 64, 4, f32::NAN),
+            Err(crate::Error::Corruption(_))
+        ));
     }
 }

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -642,14 +642,6 @@ pub async fn load_sparse_file<D: Directory>(
     let mut maxscore_indexes = FxHashMap::default();
     let mut bmp_indexes = FxHashMap::default();
 
-    // Skip loading sparse file if schema has no sparse vector fields
-    let has_sparse_vectors = schema
-        .fields()
-        .any(|(_, entry)| entry.sparse_vector_config.is_some());
-    if !has_sparse_vectors {
-        return Ok(empty());
-    }
-
     // Try to open sparse file lazily (may not exist if no sparse vectors were indexed)
     let handle = match dir.open_lazy(&files.sparse).await {
         Ok(h) => h,
@@ -765,8 +757,38 @@ pub async fn load_sparse_file<D: Directory>(
                 "invalid sparse configuration byte {quantization:#04x} for field {field_id}"
             ))
         })?;
+        let schema_field = schema
+            .get_field_entry(Field(field_id))
+            .filter(|entry| entry.field_type == FieldType::SparseVector)
+            .ok_or_else(|| {
+                crate::Error::Corruption(format!(
+                    "sparse data references field {field_id}, which is absent or not sparse in the schema"
+                ))
+            })?;
+        let configured_format = schema_field
+            .sparse_vector_config
+            .as_ref()
+            .map(|config| config.format)
+            .unwrap_or_default();
+        if stored_config.format != configured_format {
+            return Err(crate::Error::Corruption(format!(
+                "sparse field {field_id} ('{}') is stored as {:?} but configured as {:?}; rebuild the index",
+                schema_field.name, stored_config.format, configured_format,
+            )));
+        }
         let is_bmp = stored_config.format == crate::structures::SparseFormat::Bmp;
 
+        if is_bmp
+            && (stored_config.index_size != crate::structures::IndexSize::U32
+                || stored_config.weight_quantization
+                    != crate::structures::WeightQuantization::UInt8)
+        {
+            return Err(crate::Error::Corruption(format!(
+                "BMP field {field_id} has non-canonical sparse descriptor \
+                 (index_size={:?}, weight_quantization={:?}); rebuild the index",
+                stored_config.index_size, stored_config.weight_quantization,
+            )));
+        }
         if is_bmp && ndims != 1 {
             return Err(crate::Error::Corruption(format!(
                 "BMP field {field_id} has {ndims} TOC entries, expected one blob marker"
@@ -1027,9 +1049,12 @@ pub async fn load_fast_fields_file<D: Directory>(
 mod tests {
     use crate::directories::{DirectoryWriter, RamDirectory};
     use crate::dsl::{DenseVectorQuantization, SchemaBuilder};
-    use crate::segment::format::{DenseVectorTocEntry, write_dense_toc_and_footer};
+    use crate::segment::format::{
+        DenseVectorTocEntry, SparseFieldToc, write_dense_toc_and_footer,
+        write_sparse_toc_and_footer,
+    };
     use crate::segment::{FlatVectorData, ann_build};
-    use crate::structures::{SparseSkipEntry, SparseVectorConfig};
+    use crate::structures::{SparseFormat, SparseSkipEntry, SparseVectorConfig};
 
     use super::{
         SegmentFiles, load_flat_vectors_file, load_sparse_file, load_vectors_file,
@@ -1071,6 +1096,12 @@ mod tests {
         vectors_file_with_payloads(vec![(0, ann_build::FLAT_TYPE, payload)])
     }
 
+    fn sparse_file_with_toc(toc: SparseFieldToc) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        write_sparse_toc_and_footer(&mut bytes, 0, 0, &[toc]).unwrap();
+        bytes
+    }
+
     fn one_dense_flat_payload() -> Vec<u8> {
         let mut payload = Vec::new();
         FlatVectorData::serialize_binary_from_flat_streaming(
@@ -1100,6 +1131,92 @@ mod tests {
 
         let result = load_sparse_file(&dir, &files, 1, &schema).await;
         assert!(matches!(result, Err(crate::Error::Corruption(_))));
+    }
+
+    #[tokio::test]
+    async fn sparse_file_format_must_match_schema() {
+        let files = SegmentFiles::new(70);
+        let dir = RamDirectory::new();
+        let maxscore = SparseVectorConfig::default();
+        dir.write(
+            &files.sparse,
+            &sparse_file_with_toc(SparseFieldToc {
+                field_id: 0,
+                quantization: maxscore.weight_quantization as u8,
+                total_vectors: 0,
+                dims: Vec::new(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let bmp = SparseVectorConfig {
+            format: SparseFormat::Bmp,
+            ..Default::default()
+        };
+        let mut schema = SchemaBuilder::default();
+        schema.add_sparse_vector_field_with_config("sparse", true, true, bmp);
+        let error = match load_sparse_file(&dir, &files, 0, &schema.build()).await {
+            Err(error) => error,
+            Ok(_) => panic!("MaxScore storage must be rejected by a BMP schema"),
+        };
+        assert!(
+            matches!(error, crate::Error::Corruption(message) if message.contains("stored as MaxScore") && message.contains("configured as Bmp"))
+        );
+    }
+
+    #[tokio::test]
+    async fn bmp_file_format_must_match_schema() {
+        let files = SegmentFiles::new(72);
+        let dir = RamDirectory::new();
+        dir.write(
+            &files.sparse,
+            &sparse_file_with_toc(SparseFieldToc::bmp(0, 0, 0, 0)),
+        )
+        .await
+        .unwrap();
+
+        let mut schema = SchemaBuilder::default();
+        schema.add_sparse_vector_field_with_config(
+            "sparse",
+            true,
+            true,
+            SparseVectorConfig::default(),
+        );
+        let error = match load_sparse_file(&dir, &files, 0, &schema.build()).await {
+            Err(error) => error,
+            Ok(_) => panic!("BMP storage must be rejected by a MaxScore schema"),
+        };
+        assert!(
+            matches!(error, crate::Error::Corruption(message) if message.contains("stored as Bmp") && message.contains("configured as MaxScore"))
+        );
+    }
+
+    #[tokio::test]
+    async fn stored_sparse_field_must_exist_in_schema() {
+        let files = SegmentFiles::new(71);
+        let dir = RamDirectory::new();
+        let maxscore = SparseVectorConfig::default();
+        dir.write(
+            &files.sparse,
+            &sparse_file_with_toc(SparseFieldToc {
+                field_id: 0,
+                quantization: maxscore.weight_quantization as u8,
+                total_vectors: 0,
+                dims: Vec::new(),
+            }),
+        )
+        .await
+        .unwrap();
+
+        let error = match load_sparse_file(&dir, &files, 0, &SchemaBuilder::default().build()).await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("stored sparse fields must exist in the schema"),
+        };
+        assert!(
+            matches!(error, crate::Error::Corruption(message) if message.contains("absent or not sparse"))
+        );
     }
 
     #[tokio::test]

--- a/hermes-core/src/segment/reader/types.rs
+++ b/hermes-core/src/segment/reader/types.rs
@@ -530,6 +530,21 @@ impl SparseIndex {
         self.dims.dim_ids.iter().copied()
     }
 
+    /// Iterate dimension counts already resident in the compact SoA table.
+    ///
+    /// Merge admission uses this to aggregate format capacities without
+    /// binary-searching the same dimension back into this table.
+    #[cfg(feature = "native")]
+    pub(crate) fn dimension_counts(&self) -> impl Iterator<Item = (u32, u32, u32)> + '_ {
+        self.dims
+            .dim_ids
+            .iter()
+            .copied()
+            .zip(self.dims.doc_counts.iter().copied())
+            .zip(self.dims.skip_counts.iter().copied())
+            .map(|((dimension, docs), blocks)| (dimension, docs, blocks))
+    }
+
     /// Get doc count for dimension (from SoA table, no I/O)
     pub fn doc_count(&self, dim_id: u32) -> u32 {
         self.dims

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -51,41 +51,99 @@ fn grid_run_prefix(field_id: u32) -> String {
 /// partially-written files on success, `?`, and panic unwind. UUID prefixes
 /// also avoid colliding with leftovers from a prior process using the same
 /// PID (common for PID 1 in containers).
-struct GridRunFiles {
+struct GridScratchFiles {
+    directory: PathBuf,
     prefix: String,
-    paths: Vec<PathBuf>,
+    run_paths: Vec<PathBuf>,
+    auxiliary_paths: Vec<PathBuf>,
+    all_paths: Vec<PathBuf>,
+    next_run_id: usize,
 }
 
-impl GridRunFiles {
-    fn new(field_id: u32) -> Self {
+impl GridScratchFiles {
+    fn new(field_id: u32, output_path: PathBuf) -> Self {
+        let directory = output_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(std::env::temp_dir);
+        let output_name = output_path
+            .file_name()
+            .map(|name| name.to_string_lossy())
+            .unwrap_or_else(|| "hermes".into());
         Self {
-            prefix: grid_run_prefix(field_id),
-            paths: Vec::new(),
+            directory,
+            prefix: format!("{output_name}.grid_run_{}", grid_run_prefix(field_id)),
+            run_paths: Vec::new(),
+            auxiliary_paths: Vec::new(),
+            all_paths: Vec::new(),
+            next_run_id: 0,
         }
     }
 
-    fn allocate(&mut self) -> PathBuf {
-        let path = std::env::temp_dir().join(format!("{}_{}.tmp", self.prefix, self.paths.len()));
-        self.paths.push(path.clone());
+    fn allocate_run(&mut self) -> PathBuf {
+        let path = self
+            .directory
+            .join(format!("{}_run_{}.tmp", self.prefix, self.next_run_id));
+        self.next_run_id += 1;
+        self.run_paths.push(path.clone());
+        self.all_paths.push(path.clone());
         path
     }
 
-    fn is_empty(&self) -> bool {
-        self.paths.is_empty()
+    fn allocate_auxiliary(&mut self, name: &str) -> PathBuf {
+        let path = self.directory.join(format!(
+            "{}_{}_{}.tmp",
+            self.prefix,
+            name,
+            self.auxiliary_paths.len()
+        ));
+        self.auxiliary_paths.push(path.clone());
+        self.all_paths.push(path.clone());
+        path
     }
 
-    fn len(&self) -> usize {
-        self.paths.len()
+    fn runs_are_empty(&self) -> bool {
+        self.run_paths.is_empty()
     }
 
-    fn iter(&self) -> impl Iterator<Item = &PathBuf> {
-        self.paths.iter()
+    fn num_runs(&self) -> usize {
+        self.run_paths.len()
+    }
+
+    fn runs(&self) -> impl Iterator<Item = &PathBuf> {
+        self.run_paths.iter()
+    }
+
+    fn consolidate_runs(&mut self, max_fan_in: usize) -> Result<()> {
+        while self.run_paths.len() > max_fan_in {
+            let inputs = std::mem::take(&mut self.run_paths);
+            for group in inputs.chunks(max_fan_in) {
+                if group.len() == 1 {
+                    self.run_paths.push(group[0].clone());
+                    continue;
+                }
+                let output = self.allocate_run();
+                crate::segment::builder::bmp::merge_grid_runs(group, &output)
+                    .map_err(crate::Error::Io)?;
+                // Retire each input group as soon as its replacement exists.
+                // Waiting for a complete new generation temporarily doubled
+                // multi-GB scratch usage.
+                for input in group {
+                    match std::fs::remove_file(input) {
+                        Ok(()) => {}
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                        Err(error) => return Err(crate::Error::Io(error)),
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 }
 
-impl Drop for GridRunFiles {
+impl Drop for GridScratchFiles {
     fn drop(&mut self) {
-        for path in &self.paths {
+        for path in &self.all_paths {
             if let Err(error) = std::fs::remove_file(path)
                 && error.kind() != std::io::ErrorKind::NotFound
             {
@@ -97,42 +155,594 @@ impl Drop for GridRunFiles {
 
 type BmpGridEntry = (u32, u32, u8);
 const MAX_GRID_RUN_ENTRIES: usize = 16 * 1024 * 1024;
+const REWRITE_IO_BUFFER_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Clone, Copy)]
+struct RecordRoute {
+    source: u32,
+    old_block: u32,
+    out_local: u32,
+    old_slot: u8,
+    new_slot: u8,
+}
+
+#[derive(Clone, Copy)]
+struct SourceBlockJob {
+    source: u32,
+    old_block: u32,
+    route_start: u32,
+    route_end: u32,
+}
+
+#[derive(Clone, Copy, Default)]
+struct RoutedPosting {
+    out_local: u32,
+    dimension: u32,
+    slot: u8,
+    impact: u8,
+}
 
 fn spill_grid_entries(
     entries: &mut Vec<BmpGridEntry>,
-    runs: &mut GridRunFiles,
+    scratch: &mut GridScratchFiles,
     field_id: u32,
+    rayon_pool: Option<&rayon::ThreadPool>,
 ) -> Result<()> {
     if entries.is_empty() {
         return Ok(());
     }
-    entries.sort_unstable();
-    let path = runs.allocate();
+    use rayon::prelude::*;
+    install_on_pool(rayon_pool, || entries.par_sort_unstable());
+    let path = scratch.allocate_run();
     crate::segment::builder::bmp::write_grid_run(entries, &path).map_err(crate::Error::Io)?;
     entries.clear();
     log::debug!(
         "[reorder_bmp] field {}: spilled grid run {} to disk",
         field_id,
-        runs.len(),
+        scratch.num_runs(),
     );
     Ok(())
 }
 
-fn extend_grid_entries_bounded(
-    entries: &mut Vec<BmpGridEntry>,
-    mut additional: &[BmpGridEntry],
-    limit: usize,
-    runs: &mut GridRunFiles,
+#[allow(clippy::too_many_arguments)]
+fn write_reorder_grids(
+    mut entries: Vec<BmpGridEntry>,
+    scratch: &mut GridScratchFiles,
     field_id: u32,
-) -> Result<()> {
-    debug_assert!(limit > 0);
-    while !additional.is_empty() {
-        if entries.len() >= limit {
-            spill_grid_entries(entries, runs, field_id)?;
+    dims: usize,
+    num_blocks: usize,
+    grid_bits: u8,
+    rayon_pool: Option<&rayon::ThreadPool>,
+    writer: &mut OffsetWriter,
+) -> Result<(u64, u64, u64)> {
+    use crate::segment::builder::bmp::{
+        GridRunReader, stream_write_grids, stream_write_grids_merged,
+    };
+
+    if scratch.runs_are_empty() {
+        use rayon::prelude::*;
+        install_on_pool(rayon_pool, || entries.par_sort_unstable());
+        return stream_write_grids(&entries, dims, num_blocks, grid_bits, writer)
+            .map_err(crate::Error::Io);
+    }
+
+    if !entries.is_empty() {
+        spill_grid_entries(&mut entries, scratch, field_id, rayon_pool)?;
+    }
+    drop(entries);
+    // Bound both file descriptors and BufReader memory. Extremely large
+    // fields can produce hundreds of sorted runs even with 16M-entry chunks.
+    scratch.consolidate_runs(64)?;
+    let mut readers: Vec<GridRunReader> = scratch
+        .runs()
+        .map(|path| GridRunReader::open(path).map_err(crate::Error::Io))
+        .collect::<Result<_>>()?;
+    // The hierarchy rows must follow the complete block-grid section in the
+    // output. Spool only the much smaller E/H rows beside the index while the
+    // second and final merged-run pass emits all three projections.
+    let superblock_spool = scratch.allocate_auxiliary("superblock");
+    let coarse_spool = scratch.allocate_auxiliary("coarse");
+    let result = stream_write_grids_merged(
+        &mut readers,
+        dims,
+        num_blocks,
+        grid_bits,
+        &superblock_spool,
+        &coarse_spool,
+        writer,
+    )
+    .map_err(crate::Error::Io);
+    // Close readers before GridScratchFiles removes the spill paths.
+    drop(readers);
+    result
+}
+
+fn install_on_pool<T: Send>(
+    pool: Option<&rayon::ThreadPool>,
+    operation: impl FnOnce() -> T + Send,
+) -> T {
+    match pool {
+        Some(pool) => pool.install(operation),
+        None => operation(),
+    }
+}
+
+#[inline]
+fn resolve_real_vid(
+    global_real: usize,
+    real_base: &[usize],
+    real_to_virtual: &[Vec<u32>],
+) -> (usize, usize) {
+    let source = if real_to_virtual.len() == 1 {
+        0
+    } else {
+        real_base.partition_point(|&base| base <= global_real) - 1
+    };
+    (
+        source,
+        real_to_virtual[source][global_real - real_base[source]] as usize,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_record_route_plan(
+    sources: &[(crate::segment::BmpIndex, u32)],
+    permutation: &[u32],
+    real_base: &[usize],
+    real_to_virtual: &[Vec<u32>],
+    block_size: usize,
+    num_real_docs: usize,
+    window_start: usize,
+    window_end: usize,
+    rayon_pool: Option<&rayon::ThreadPool>,
+) -> Result<(Vec<RecordRoute>, Vec<SourceBlockJob>)> {
+    use rayon::prelude::*;
+
+    let first_record = window_start
+        .checked_mul(block_size)
+        .ok_or_else(|| crate::Error::Internal("BMP route window start overflows usize".into()))?;
+    let last_record = window_end
+        .checked_mul(block_size)
+        .map(|end| end.min(num_real_docs))
+        .ok_or_else(|| crate::Error::Internal("BMP route window end overflows usize".into()))?;
+    let mut routes = Vec::with_capacity(last_record.saturating_sub(first_record));
+
+    for out_block in window_start..window_end {
+        let new_vid_start = out_block * block_size;
+        let new_vid_end = ((out_block + 1) * block_size).min(num_real_docs);
+        let out_local = u32::try_from(out_block - window_start).map_err(|_| {
+            crate::Error::Internal("BMP reorder window exceeds u32::MAX blocks".into())
+        })?;
+        for new_slot in 0..new_vid_end.saturating_sub(new_vid_start) {
+            let global_real = permutation[new_vid_start + new_slot] as usize;
+            let (source, old_vid) = resolve_real_vid(global_real, real_base, real_to_virtual);
+            let source_block_size = sources[source].0.bmp_block_size as usize;
+            routes.push(RecordRoute {
+                source: u32::try_from(source).map_err(|_| {
+                    crate::Error::Internal("BMP source index exceeds u32::MAX".into())
+                })?,
+                old_block: u32::try_from(old_vid / source_block_size).map_err(|_| {
+                    crate::Error::Internal("BMP source block exceeds u32::MAX".into())
+                })?,
+                out_local,
+                old_slot: (old_vid % source_block_size) as u8,
+                new_slot: new_slot as u8,
+            });
         }
-        let count = (limit - entries.len()).min(additional.len());
-        entries.extend_from_slice(&additional[..count]);
-        additional = &additional[count..];
+    }
+    install_on_pool(rayon_pool, || {
+        routes.par_sort_unstable_by_key(|route| (route.source, route.old_block, route.old_slot));
+    });
+
+    let mut jobs = Vec::new();
+    let mut start = 0usize;
+    while start < routes.len() {
+        let source = routes[start].source;
+        let old_block = routes[start].old_block;
+        let mut end = start + 1;
+        while end < routes.len()
+            && routes[end].source == source
+            && routes[end].old_block == old_block
+        {
+            end += 1;
+        }
+        jobs.push(SourceBlockJob {
+            source,
+            old_block,
+            route_start: u32::try_from(start)
+                .map_err(|_| crate::Error::Internal("BMP route count exceeds u32::MAX".into()))?,
+            route_end: u32::try_from(end)
+                .map_err(|_| crate::Error::Internal("BMP route count exceeds u32::MAX".into()))?,
+        });
+        start = end;
+    }
+    Ok((routes, jobs))
+}
+
+fn source_job_route_maps(
+    job: &SourceBlockJob,
+    routes: &[RecordRoute],
+) -> Result<([u32; 256], [u8; 256])> {
+    let mut output_blocks = [u32::MAX; 256];
+    let mut output_slots = [0u8; 256];
+    let job_routes = routes
+        .get(job.route_start as usize..job.route_end as usize)
+        .ok_or_else(|| crate::Error::Internal("BMP source-job route range is invalid".into()))?;
+    for route in job_routes {
+        if route.source != job.source || route.old_block != job.old_block {
+            return Err(crate::Error::Internal(
+                "BMP source-job routes are not grouped".into(),
+            ));
+        }
+        let slot = route.old_slot as usize;
+        if output_blocks[slot] != u32::MAX {
+            return Err(crate::Error::Internal(format!(
+                "BMP permutation maps source block {} slot {} more than once",
+                job.old_block, route.old_slot,
+            )));
+        }
+        output_blocks[slot] = route.out_local;
+        output_slots[slot] = route.new_slot;
+    }
+    Ok((output_blocks, output_slots))
+}
+
+fn count_source_job_postings(
+    sources: &[(crate::segment::BmpIndex, u32)],
+    job: &SourceBlockJob,
+    routes: &[RecordRoute],
+) -> Result<usize> {
+    let (output_blocks, _) = source_job_route_maps(job, routes)?;
+    let source = &sources[job.source as usize].0;
+    let mut count = 0usize;
+    for (_, _, postings) in source.iter_block_terms(job.old_block) {
+        for posting in postings {
+            if output_blocks[posting.local_slot as usize] != u32::MAX {
+                count = count.checked_add(1).ok_or_else(|| {
+                    crate::Error::Internal("BMP routed posting count overflows usize".into())
+                })?;
+            }
+        }
+    }
+    Ok(count)
+}
+
+fn fill_source_job_postings(
+    sources: &[(crate::segment::BmpIndex, u32)],
+    job: &SourceBlockJob,
+    routes: &[RecordRoute],
+    output: &mut [RoutedPosting],
+) -> Result<()> {
+    let (output_blocks, output_slots) = source_job_route_maps(job, routes)?;
+    let source = &sources[job.source as usize].0;
+    let mut cursor = 0usize;
+    for (dimension, _, postings) in source.iter_block_terms(job.old_block) {
+        for posting in postings {
+            let out_local = output_blocks[posting.local_slot as usize];
+            if out_local == u32::MAX {
+                continue;
+            }
+            let destination = output.get_mut(cursor).ok_or_else(|| {
+                crate::Error::Internal("BMP routed posting count changed between passes".into())
+            })?;
+            *destination = RoutedPosting {
+                out_local,
+                dimension,
+                slot: output_slots[posting.local_slot as usize],
+                impact: posting.impact,
+            };
+            cursor += 1;
+        }
+    }
+    if cursor != output.len() {
+        return Err(crate::Error::Internal(format!(
+            "BMP routed posting count changed between passes: counted {}, wrote {}",
+            output.len(),
+            cursor,
+        )));
+    }
+    Ok(())
+}
+
+fn record_window_memory_bytes(
+    routes: &Vec<RecordRoute>,
+    jobs: &Vec<SourceBlockJob>,
+    counts: &Vec<usize>,
+    posting_count: usize,
+) -> Option<usize> {
+    let routes_bytes = routes
+        .capacity()
+        .checked_mul(std::mem::size_of::<RecordRoute>())?;
+    let jobs_bytes = jobs
+        .capacity()
+        .checked_mul(std::mem::size_of::<SourceBlockJob>())?;
+    let counts_bytes = counts
+        .capacity()
+        .checked_mul(std::mem::size_of::<usize>())?;
+    let partitions_bytes = jobs
+        .capacity()
+        .checked_mul(std::mem::size_of::<(&SourceBlockJob, &mut [RoutedPosting])>())?;
+    let routed_bytes = posting_count.checked_mul(std::mem::size_of::<RoutedPosting>())?;
+    routes_bytes
+        .checked_add(jobs_bytes)?
+        .checked_add(counts_bytes)?
+        .checked_add(partitions_bytes)?
+        .checked_add(routed_bytes)
+}
+
+fn push_rewrite_bytes(buffer: &mut Vec<u8>, bytes: &[u8], writer: &mut OffsetWriter) -> Result<()> {
+    if buffer.len() + bytes.len() > buffer.capacity() {
+        writer.write_all(buffer).map_err(crate::Error::Io)?;
+        buffer.clear();
+    }
+    if bytes.len() > buffer.capacity() {
+        writer.write_all(bytes).map_err(crate::Error::Io)
+    } else {
+        buffer.extend_from_slice(bytes);
+        Ok(())
+    }
+}
+
+fn flush_rewrite_bytes(buffer: &mut Vec<u8>, writer: &mut OffsetWriter) -> Result<()> {
+    if !buffer.is_empty() {
+        writer.write_all(buffer).map_err(crate::Error::Io)?;
+        buffer.clear();
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_sorted_routed_block(
+    out_block: u32,
+    postings: &[RoutedPosting],
+    grid_entries: &mut Vec<BmpGridEntry>,
+    grid_run_entries: usize,
+    run_files: &mut GridScratchFiles,
+    field_id: u32,
+    rayon_pool: Option<&rayon::ThreadPool>,
+    posting_buffer: &mut Vec<u8>,
+    writer: &mut OffsetWriter,
+) -> Result<(u64, usize)> {
+    if postings.is_empty() {
+        return Ok((0, 0));
+    }
+    debug_assert!(
+        postings
+            .iter()
+            .all(|posting| posting.out_local == postings[0].out_local)
+    );
+
+    let num_terms = 1 + postings
+        .windows(2)
+        .filter(|pair| pair[0].dimension != pair[1].dimension)
+        .count();
+    let start_offset = writer.offset();
+    posting_buffer.clear();
+    push_rewrite_bytes(
+        posting_buffer,
+        &u32::try_from(num_terms)
+            .map_err(|_| crate::Error::Internal("BMP block term count exceeds u32::MAX".into()))?
+            .to_le_bytes(),
+        writer,
+    )?;
+
+    push_rewrite_bytes(posting_buffer, &postings[0].dimension.to_le_bytes(), writer)?;
+    for pair in postings.windows(2) {
+        if pair[0].dimension != pair[1].dimension {
+            push_rewrite_bytes(posting_buffer, &pair[1].dimension.to_le_bytes(), writer)?;
+        }
+    }
+
+    push_rewrite_bytes(posting_buffer, &0u32.to_le_bytes(), writer)?;
+    for (index, pair) in postings.windows(2).enumerate() {
+        if pair[0].dimension != pair[1].dimension {
+            push_rewrite_bytes(
+                posting_buffer,
+                &u32::try_from(index + 1)
+                    .map_err(|_| {
+                        crate::Error::Internal("BMP block posting prefix exceeds u32::MAX".into())
+                    })?
+                    .to_le_bytes(),
+                writer,
+            )?;
+        }
+    }
+    push_rewrite_bytes(
+        posting_buffer,
+        &u32::try_from(postings.len())
+            .map_err(|_| {
+                crate::Error::Internal("BMP block posting prefix exceeds u32::MAX".into())
+            })?
+            .to_le_bytes(),
+        writer,
+    )?;
+
+    let mut term_start = 0usize;
+    while term_start < postings.len() {
+        let dimension = postings[term_start].dimension;
+        let mut term_end = term_start + 1;
+        let mut max_impact = postings[term_start].impact;
+        while term_end < postings.len() && postings[term_end].dimension == dimension {
+            max_impact = max_impact.max(postings[term_end].impact);
+            term_end += 1;
+        }
+        push_rewrite_bytes(posting_buffer, &[max_impact], writer)?;
+        if grid_entries.len() == grid_run_entries {
+            spill_grid_entries(grid_entries, run_files, field_id, rayon_pool)?;
+        }
+        grid_entries.push((dimension, out_block, max_impact));
+        term_start = term_end;
+    }
+
+    for posting in postings {
+        push_rewrite_bytes(posting_buffer, &[posting.slot, posting.impact], writer)?;
+    }
+    flush_rewrite_bytes(posting_buffer, writer)?;
+    Ok((writer.offset() - start_offset, num_terms))
+}
+
+fn write_blockwise_doc_maps(
+    sources: &[(crate::segment::BmpIndex, u32)],
+    permuted_blocks: &[(u32, u32)],
+    block_size: usize,
+    writer: &mut OffsetWriter,
+    rayon_pool: Option<&rayon::ThreadPool>,
+) -> Result<()> {
+    use rayon::prelude::*;
+
+    let id_block_bytes = block_size * 4;
+    let blocks_per_chunk = (REWRITE_IO_BUFFER_BYTES / id_block_bytes).max(1);
+    let mut buffer = Vec::with_capacity(blocks_per_chunk * id_block_bytes);
+    for blocks in permuted_blocks.chunks(blocks_per_chunk) {
+        buffer.resize(blocks.len() * id_block_bytes, 0);
+        install_on_pool(rayon_pool, || {
+            buffer
+                .par_chunks_exact_mut(id_block_bytes)
+                .zip(blocks.par_iter())
+                .try_for_each(|(output, &(source, local_block))| -> Result<()> {
+                    let (bmp, doc_offset) = &sources[source as usize];
+                    let start = local_block as usize * id_block_bytes;
+                    output.copy_from_slice(&bmp.doc_map_ids_slice()[start..start + id_block_bytes]);
+                    if *doc_offset != 0 {
+                        let (ids, _) = output.as_chunks_mut::<4>();
+                        for id in ids {
+                            let source_doc_id = u32::from_le_bytes(*id);
+                            if source_doc_id != u32::MAX {
+                                *id = source_doc_id
+                                    .checked_add(*doc_offset)
+                                    .ok_or_else(|| {
+                                        crate::Error::Corruption(format!(
+                                            "BMP doc-id offset overflow: {} + {}",
+                                            source_doc_id, doc_offset,
+                                        ))
+                                    })?
+                                    .to_le_bytes();
+                            }
+                        }
+                    }
+                    Ok(())
+                })
+        })?;
+        writer.write_all(&buffer).map_err(crate::Error::Io)?;
+    }
+
+    let ordinal_block_bytes = block_size * 2;
+    let blocks_per_chunk = (REWRITE_IO_BUFFER_BYTES / ordinal_block_bytes).max(1);
+    buffer.clear();
+    buffer.reserve(
+        blocks_per_chunk
+            .saturating_mul(ordinal_block_bytes)
+            .saturating_sub(buffer.capacity()),
+    );
+    for blocks in permuted_blocks.chunks(blocks_per_chunk) {
+        buffer.resize(blocks.len() * ordinal_block_bytes, 0);
+        install_on_pool(rayon_pool, || {
+            buffer
+                .par_chunks_exact_mut(ordinal_block_bytes)
+                .zip(blocks.par_iter())
+                .for_each(|(output, &(source, local_block))| {
+                    let bmp = &sources[source as usize].0;
+                    let start = local_block as usize * ordinal_block_bytes;
+                    output.copy_from_slice(
+                        &bmp.doc_map_ordinals_slice()[start..start + ordinal_block_bytes],
+                    );
+                });
+        });
+        writer.write_all(&buffer).map_err(crate::Error::Io)?;
+    }
+    Ok(())
+}
+
+fn write_record_doc_maps(
+    sources: &[(crate::segment::BmpIndex, u32)],
+    permutation: &[u32],
+    real_base: &[usize],
+    real_to_virtual: &[Vec<u32>],
+    num_virtual_docs: usize,
+    writer: &mut OffsetWriter,
+    rayon_pool: Option<&rayon::ThreadPool>,
+) -> Result<()> {
+    use rayon::prelude::*;
+
+    let id_records_per_chunk = (REWRITE_IO_BUFFER_BYTES / 4).max(1);
+    let mut buffer = Vec::with_capacity(
+        permutation
+            .len()
+            .min(id_records_per_chunk)
+            .saturating_mul(4),
+    );
+    for records in permutation.chunks(id_records_per_chunk) {
+        buffer.resize(records.len() * 4, 0);
+        install_on_pool(rayon_pool, || {
+            buffer
+                .par_chunks_exact_mut(4)
+                .zip(records.par_iter())
+                .try_for_each(|(output, &global_real)| -> Result<()> {
+                    let (source, virtual_id) =
+                        resolve_real_vid(global_real as usize, real_base, real_to_virtual);
+                    let ids = sources[source].0.doc_map_ids_slice();
+                    let offset = virtual_id * 4;
+                    let source_doc_id =
+                        u32::from_le_bytes(ids[offset..offset + 4].try_into().unwrap());
+                    let output_doc_id =
+                        source_doc_id
+                            .checked_add(sources[source].1)
+                            .ok_or_else(|| {
+                                crate::Error::Corruption(format!(
+                                    "BMP doc-id offset overflow: {} + {}",
+                                    source_doc_id, sources[source].1,
+                                ))
+                            })?;
+                    output.copy_from_slice(&output_doc_id.to_le_bytes());
+                    Ok(())
+                })
+        })?;
+        writer.write_all(&buffer).map_err(crate::Error::Io)?;
+    }
+    let padding = num_virtual_docs
+        .checked_sub(permutation.len())
+        .ok_or_else(|| {
+            crate::Error::Internal(format!(
+                "BMP document-map permutation has {} records for {} virtual slots",
+                permutation.len(),
+                num_virtual_docs,
+            ))
+        })?;
+    if padding > 0 {
+        buffer.clear();
+        buffer.resize(padding * 4, u8::MAX);
+        writer.write_all(&buffer).map_err(crate::Error::Io)?;
+    }
+
+    let ordinal_records_per_chunk = (REWRITE_IO_BUFFER_BYTES / 2).max(1);
+    buffer.clear();
+    buffer.reserve(
+        permutation
+            .len()
+            .min(ordinal_records_per_chunk)
+            .saturating_mul(2)
+            .saturating_sub(buffer.capacity()),
+    );
+    for records in permutation.chunks(ordinal_records_per_chunk) {
+        buffer.resize(records.len() * 2, 0);
+        install_on_pool(rayon_pool, || {
+            buffer
+                .par_chunks_exact_mut(2)
+                .zip(records.par_iter())
+                .for_each(|(output, &global_real)| {
+                    let (source, virtual_id) =
+                        resolve_real_vid(global_real as usize, real_base, real_to_virtual);
+                    let ordinals = sources[source].0.doc_map_ordinals_slice();
+                    let offset = virtual_id * 2;
+                    output.copy_from_slice(&ordinals[offset..offset + 2]);
+                });
+        });
+        writer.write_all(&buffer).map_err(crate::Error::Io)?;
+    }
+    if padding > 0 {
+        buffer.clear();
+        buffer.resize(padding * 2, 0);
+        writer.write_all(&buffer).map_err(crate::Error::Io)?;
     }
     Ok(())
 }
@@ -194,8 +804,9 @@ struct CoherenceStats {
 
 /// Compute [`CoherenceStats`] from a streaming pass over block headers:
 /// per-dim record frequencies come from posting-slice lengths, no weight
-/// decode. Dim ids in block headers are raw (not bounded by the configured
-/// grid dims), so counts live in a hash map; segments above
+/// decode. Rewrite validation has already proved every dim is below the
+/// configured vocabulary size, so a compact direct-addressed table avoids
+/// hashing up to a million sampled headers. Segments above
 /// [`MAX_COHERENCE_SCAN_BLOCKS`] are stride-sampled and all aggregates
 /// come from the sampled sub-population, which keeps the estimator
 /// consistent at both the clustered and scrambled extremes.
@@ -209,6 +820,7 @@ struct CoherenceStats {
 fn block_coherence(
     sources: &[(crate::segment::BmpIndex, u32)],
     block_size: usize,
+    dims: usize,
 ) -> CoherenceStats {
     let total_blocks: usize = sources.iter().map(|(b, _)| b.num_blocks as usize).sum();
     if total_blocks == 0 {
@@ -216,7 +828,7 @@ fn block_coherence(
             d: 0.0,
             d_rand: 0.0,
             d_max: 0.0,
-            norm: 0.0,
+            norm: 1.0,
             scanned_blocks: 0,
             total_blocks,
         };
@@ -224,7 +836,7 @@ fn block_coherence(
 
     let stride = total_blocks.div_ceil(MAX_COHERENCE_SCAN_BLOCKS).max(1);
     // dim → (record count, block count) within the sampled blocks
-    let mut df: rustc_hash::FxHashMap<u32, (u64, u64)> = rustc_hash::FxHashMap::default();
+    let mut df = vec![(0u64, 0u64); dims];
     let mut scanned_blocks = 0usize;
     let mut global_block = 0usize;
     for (bmp, _) in sources {
@@ -232,7 +844,7 @@ fn block_coherence(
             if global_block.is_multiple_of(stride) {
                 scanned_blocks += 1;
                 for (dim_id, _, posts) in bmp.iter_block_terms(block_id) {
-                    let e = df.entry(dim_id).or_insert((0, 0));
+                    let e = &mut df[dim_id as usize];
                     e.0 += posts.len() as u64;
                     e.1 += 1;
                 }
@@ -247,7 +859,7 @@ fn block_coherence(
     let mut terms: u64 = 0;
     let mut expected_rand_pairs = 0.0f64;
     let mut min_pairs = 0u64;
-    for &(records, blocks) in df.values() {
+    for &(records, blocks) in &df {
         if records < 2 {
             continue; // singleton: inert for clustering, see above
         }
@@ -262,7 +874,7 @@ fn block_coherence(
             d: 0.0,
             d_rand: 0.0,
             d_max: 0.0,
-            norm: 0.0,
+            norm: 1.0,
             scanned_blocks,
             total_blocks,
         };
@@ -525,7 +1137,7 @@ async fn clone_segment_file<D: Directory + DirectoryWriter>(
             .read_bytes_range(offset..end)
             .await
             .map_err(crate::Error::Io)?;
-        writer = tokio::task::spawn_blocking(move || {
+        writer = super::merger::block_in_place_if_multithread(move || {
             writer.write_all(data.as_slice())?;
             // Drop source pages behind the copy cursor — a whole-file copy
             // must not leave the complete source resident in page cache.
@@ -533,10 +1145,6 @@ async fn clone_segment_file<D: Directory + DirectoryWriter>(
             data.madvise_range(0..data.len(), libc::MADV_DONTNEED);
             Ok::<_, std::io::Error>(writer)
         })
-        .await
-        .map_err(|error| {
-            crate::Error::Internal(format!("segment clone worker failed for {src:?}: {error}"))
-        })?
         .map_err(crate::Error::Io)?;
         offset = end;
     }
@@ -549,13 +1157,7 @@ async fn clone_segment_file<D: Directory + DirectoryWriter>(
             source_len,
         )));
     }
-    tokio::task::spawn_blocking(move || writer.finish())
-        .await
-        .map_err(|error| {
-            crate::Error::Internal(format!(
-                "segment clone finalizer failed for {dst:?}: {error}"
-            ))
-        })?
+    super::merger::block_in_place_if_multithread(move || writer.finish())
         .map_err(crate::Error::Io)?;
 
     Ok(())
@@ -621,13 +1223,26 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
     }
 
     let mut all_converged = true;
+    let scratch_path = dir.local_path(&dst_files.sparse).unwrap_or_else(|| {
+        std::env::temp_dir().join(
+            dst_files
+                .sparse
+                .file_name()
+                .unwrap_or_else(|| std::ffi::OsStr::new("hermes.sparse")),
+        )
+    });
     let mut writer = OffsetWriter::new(
         dir.streaming_writer_cold(&dst_files.sparse)
             .await
             .map_err(crate::Error::Io)?,
     );
+    let skip_tmp = dst_files.sparse_skip_temp();
+    let mut skip_writer = dir
+        .streaming_writer_cold(&skip_tmp)
+        .await
+        .map_err(crate::Error::Io)?;
     let mut field_tocs: Vec<SparseFieldToc> = Vec::new();
-    let mut all_skip_bytes: Vec<u8> = Vec::new();
+    let mut skip_entry_buffer = Vec::with_capacity(crate::structures::SparseSkipEntry::SIZE);
     let mut skip_count: u32 = 0;
 
     for (field, sparse_config, reorder, field_name) in &sparse_fields {
@@ -648,7 +1263,6 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                     copy_bmp_blob(
                         bmp_idx,
                         field.0,
-                        quantization,
                         bmp_idx.total_vectors,
                         &mut writer,
                         &mut field_tocs,
@@ -681,13 +1295,13 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                 let fname = field_name.clone();
                 let ilabel = schema.index_label().to_owned();
                 let pool = rayon_pool.clone();
-                let (w, ft, converged) = tokio::task::spawn_blocking(move || {
+                let scratch_path = scratch_path.clone();
+                let (w, ft, converged) = super::merger::block_in_place_if_multithread(move || {
                     reorder_bmp_field(
                         &bmp_sources,
                         fid,
                         &ilabel,
                         &fname,
-                        quantization,
                         dims,
                         effective_block_size,
                         grid_bits,
@@ -696,15 +1310,12 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                         memory_budget,
                         bp_budget,
                         granularity,
+                        scratch_path,
                         writer,
                         field_tocs,
                         pool,
                     )
-                })
-                .await
-                .map_err(|e| {
-                    crate::Error::Internal(format!("reorder_bmp_field panicked: {}", e))
-                })??;
+                })?;
                 writer = w;
                 field_tocs = ft;
                 all_converged &= converged;
@@ -718,28 +1329,29 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                     quantization,
                     &mut writer,
                     &mut field_tocs,
-                    &mut all_skip_bytes,
+                    skip_writer.as_mut(),
+                    &mut skip_entry_buffer,
                     &mut skip_count,
                 )
                 .await?;
             }
         }
     }
+    skip_writer.finish().map_err(crate::Error::Io)?;
 
     if field_tocs.is_empty() {
         drop(writer);
         let _ = dir.delete(&dst_files.sparse).await;
+        let _ = dir.delete(&skip_tmp).await;
         return Ok(all_converged);
     }
 
     // Write skip section (MaxScore fields only)
     let skip_offset = writer.offset();
-    if !all_skip_bytes.is_empty() {
-        writer
-            .write_all(&all_skip_bytes)
-            .map_err(crate::Error::Io)?;
-    }
-    drop(all_skip_bytes);
+    let skip_bytes = u64::from(skip_count)
+        .checked_mul(crate::structures::SparseSkipEntry::SIZE as u64)
+        .ok_or_else(|| crate::Error::Internal("sparse skip section exceeds u64::MAX".into()))?;
+    super::merger::append_and_delete_temp(dir, &skip_tmp, skip_bytes, &mut writer).await?;
 
     // Write TOC + footer
     let toc_offset = writer.offset();
@@ -770,7 +1382,6 @@ fn reorder_bmp_field_blockwise(
     field_id: u32,
     index_label: &str,
     field_name: &str,
-    quantization: crate::structures::WeightQuantization,
     dims: u32,
     effective_block_size: usize,
     grid_bits: u8,
@@ -778,21 +1389,27 @@ fn reorder_bmp_field_blockwise(
     total_vectors: u32,
     memory_budget: usize,
     bp_budget: crate::segment::BpBudget,
+    scratch_path: PathBuf,
+    source_pages: &crate::segment::reader::bmp::BmpScanPageGuard<'_>,
     mut writer: OffsetWriter,
     mut field_tocs: Vec<SparseFieldToc>,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
 ) -> Result<(OffsetWriter, Vec<SparseFieldToc>, bool)> {
-    use crate::segment::builder::bmp::{
-        GridRunReader, stream_write_grids, stream_write_grids_merged, write_bmp_footer,
-    };
+    use crate::segment::builder::bmp::write_bmp_footer;
     use crate::segment::builder::graph_bisection::{
         BpProgressLabel, build_forward_index_from_blocks, graph_bisection_with_progress,
     };
     use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
 
     let bmp_refs: Vec<&crate::segment::BmpIndex> = sources.iter().map(|(b, _)| b).collect();
-    let source_pages =
-        crate::segment::reader::bmp::BmpScanPageGuard::new(sources.iter().map(|(bmp, _)| bmp));
+    {
+        use rayon::prelude::*;
+        install_on_pool(rayon_pool.as_deref(), || {
+            bmp_refs
+                .par_iter()
+                .try_for_each(|bmp| bmp.visit_real_slots_for_rewrite(|_| {}))
+        })?;
+    }
     let num_blocks_total = bmp_refs
         .iter()
         .try_fold(0usize, |total, bmp| {
@@ -889,6 +1506,7 @@ fn reorder_bmp_field_blockwise(
             (source as u32, local_block as u32)
         })
         .collect();
+    drop(perm);
     log::info!(
         "[reorder_bmp] field {}: blockwise BP over {} blocks in {:.1}ms (converged={})",
         field_id,
@@ -899,6 +1517,7 @@ fn reorder_bmp_field_blockwise(
     source_pages.switch_to_random();
 
     // ── Write blob: permuted block copy ─────────────────────────────────
+    let rewrite_start = std::time::Instant::now();
     let blob_start = writer.offset();
 
     // Section B: block data verbatim, in permuted order
@@ -925,7 +1544,7 @@ fn reorder_bmp_field_blockwise(
     let grid_run_entries =
         (grid_budget / std::mem::size_of::<BmpGridEntry>()).clamp(1, MAX_GRID_RUN_ENTRIES);
     let mut grid_entries = Vec::with_capacity(grid_run_entries);
-    let mut run_files = GridRunFiles::new(field_id);
+    let mut run_files = GridScratchFiles::new(field_id, scratch_path);
 
     for (new_block, &(src, lb)) in permuted_blocks.iter().enumerate() {
         let bmp = bmp_refs[src as usize];
@@ -941,7 +1560,12 @@ fn reorder_bmp_field_blockwise(
         cumulative += bytes.len() as u64;
         for (dimension, max_impact, _) in bmp.iter_block_terms(lb) {
             if grid_entries.len() == grid_run_entries {
-                spill_grid_entries(&mut grid_entries, &mut run_files, field_id)?;
+                spill_grid_entries(
+                    &mut grid_entries,
+                    &mut run_files,
+                    field_id,
+                    rayon_pool.as_deref(),
+                )?;
             }
             grid_entries.push((dimension, new_block as u32, max_impact));
         }
@@ -956,52 +1580,34 @@ fn reorder_bmp_field_blockwise(
             .write_all(&[0u8; 8][..padding])
             .map_err(crate::Error::Io)?;
     }
-    for &v in &block_data_starts {
-        writer
-            .write_all(&v.to_le_bytes())
-            .map_err(crate::Error::Io)?;
-    }
+    crate::segment::builder::bmp::write_u64_slice_le(&mut writer, &block_data_starts)
+        .map_err(crate::Error::Io)?;
     drop(block_data_starts);
+    let block_data_elapsed = rewrite_start.elapsed();
 
     // Sections D + E + H: exact maxima from the copied blocks, compressed in one
     // bounded external-sort pass. Block payloads above remained byte-identical.
+    let grids_start = std::time::Instant::now();
     let grid_offset = writer.offset() - blob_start;
-    let (block_grid_bytes, superblock_grid_bytes, _) = if run_files.is_empty() {
-        grid_entries.sort_unstable();
-        let result = stream_write_grids(
-            &grid_entries,
-            dims as usize,
-            num_blocks_total,
-            grid_bits,
-            &mut writer,
-        )
-        .map_err(crate::Error::Io)?;
-        drop(grid_entries);
-        result
-    } else {
-        if !grid_entries.is_empty() {
-            spill_grid_entries(&mut grid_entries, &mut run_files, field_id)?;
-        }
-        drop(grid_entries);
-        let mut readers: Vec<GridRunReader> = run_files
-            .iter()
-            .map(|path| GridRunReader::open(path).map_err(crate::Error::Io))
-            .collect::<Result<_>>()?;
-        let result = stream_write_grids_merged(
-            &mut readers,
-            dims as usize,
-            num_blocks_total,
-            grid_bits,
-            &mut writer,
-        )
-        .map_err(crate::Error::Io)?;
-        drop(readers);
-        result
-    };
+    let (block_grid_bytes, superblock_grid_bytes, _) = write_reorder_grids(
+        grid_entries,
+        &mut run_files,
+        field_id,
+        dims as usize,
+        num_blocks_total,
+        grid_bits,
+        rayon_pool.as_deref(),
+        &mut writer,
+    )?;
     let sb_grid_offset = grid_offset + block_grid_bytes;
     let coarse_grid_offset = sb_grid_offset + superblock_grid_bytes;
+    // Release potentially multi-GB sorted runs and hierarchy spools before
+    // the doc-map phase starts consuming more output space.
+    drop(run_files);
+    let grids_elapsed = grids_start.elapsed();
 
     // Sections F + G: doc maps copied per block chunk, ids offset-patched
+    let doc_maps_start = std::time::Instant::now();
     let doc_map_offset = writer.offset() - blob_start;
     let bs = effective_block_size;
     let mut num_real_docs: u32 = 0;
@@ -1014,40 +1620,14 @@ fn reorder_bmp_field_blockwise(
                 )
             })?;
     }
-    let mut id_chunk = vec![0u8; bs * 4];
-    for &(src, lb) in &permuted_blocks {
-        let src = src as usize;
-        let lb = lb as usize;
-        let (bmp, doc_offset) = (&sources[src].0, sources[src].1);
-        let ids = bmp.doc_map_ids_slice();
-        id_chunk.copy_from_slice(&ids[lb * bs * 4..(lb + 1) * bs * 4]);
-        if doc_offset != 0 {
-            let (chunks, _) = id_chunk.as_chunks_mut::<4>();
-            for e in chunks {
-                let doc_id = u32::from_le_bytes(*e);
-                if doc_id != u32::MAX {
-                    *e = doc_id
-                        .checked_add(doc_offset)
-                        .ok_or_else(|| {
-                            crate::Error::Corruption(format!(
-                                "BMP doc-id offset overflow: {} + {}",
-                                doc_id, doc_offset
-                            ))
-                        })?
-                        .to_le_bytes();
-                }
-            }
-        }
-        writer.write_all(&id_chunk).map_err(crate::Error::Io)?;
-    }
-    for &(src, lb) in &permuted_blocks {
-        let src = src as usize;
-        let lb = lb as usize;
-        let ords = bmp_refs[src].doc_map_ordinals_slice();
-        writer
-            .write_all(&ords[lb * bs * 2..(lb + 1) * bs * 2])
-            .map_err(crate::Error::Io)?;
-    }
+    write_blockwise_doc_maps(
+        sources,
+        &permuted_blocks,
+        bs,
+        &mut writer,
+        rayon_pool.as_deref(),
+    )?;
+    let doc_maps_elapsed = doc_maps_start.elapsed();
 
     // Footer
     write_bmp_footer(
@@ -1069,29 +1649,22 @@ fn reorder_bmp_field_blockwise(
     .map_err(crate::Error::Io)?;
 
     let blob_len = writer.offset() - blob_start;
-    let mut config_for_byte =
-        crate::structures::SparseVectorConfig::from_byte(quantization as u8).unwrap_or_default();
-    config_for_byte.format = SparseFormat::Bmp;
-    config_for_byte.weight_quantization = quantization;
-    field_tocs.push(SparseFieldToc {
+    field_tocs.push(SparseFieldToc::bmp(
         field_id,
-        quantization: config_for_byte.to_byte(),
         total_vectors,
-        dims: vec![crate::segment::format::SparseDimTocEntry {
-            dim_id: 0xFFFFFFFF,
-            block_data_offset: blob_start,
-            skip_start: (blob_len & 0xFFFFFFFF) as u32,
-            num_blocks: ((blob_len >> 32) & 0xFFFFFFFF) as u32,
-            doc_count: 0,
-            max_weight: 0.0,
-        }],
-    });
+        blob_start,
+        blob_len,
+    ));
 
     log::info!(
-        "[reorder_bmp] field {}: blockwise reorder done — {} blocks, {}",
+        "[reorder_bmp] field {}: blockwise reorder done — {} blocks, {}, phases: data+offsets={:.1}s grids={:.1}s doc_maps={:.1}s total={:.1}s",
         field_id,
         num_blocks_total,
         crate::format_bytes(blob_len),
+        block_data_elapsed.as_secs_f64(),
+        grids_elapsed.as_secs_f64(),
+        doc_maps_elapsed.as_secs_f64(),
+        rewrite_start.elapsed().as_secs_f64(),
     );
 
     Ok((writer, field_tocs, converged))
@@ -1103,7 +1676,6 @@ fn reorder_bmp_field_blockwise(
 fn copy_bmp_blob(
     bmp: &crate::segment::BmpIndex,
     field_id: u32,
-    quantization: crate::structures::WeightQuantization,
     total_vectors: u32,
     writer: &mut OffsetWriter,
     field_tocs: &mut Vec<SparseFieldToc>,
@@ -1116,24 +1688,12 @@ fn copy_bmp_blob(
     }
     let blob_len = writer.offset() - blob_start;
 
-    let mut config_for_byte =
-        crate::structures::SparseVectorConfig::from_byte(quantization as u8).unwrap_or_default();
-    config_for_byte.format = SparseFormat::Bmp;
-    config_for_byte.weight_quantization = quantization;
-
-    field_tocs.push(SparseFieldToc {
+    field_tocs.push(SparseFieldToc::bmp(
         field_id,
-        quantization: config_for_byte.to_byte(),
         total_vectors,
-        dims: vec![crate::segment::format::SparseDimTocEntry {
-            dim_id: 0xFFFFFFFF, // sentinel for BMP
-            block_data_offset: blob_start,
-            skip_start: (blob_len & 0xFFFFFFFF) as u32,
-            num_blocks: ((blob_len >> 32) & 0xFFFFFFFF) as u32,
-            doc_count: 0,
-            max_weight: 0.0,
-        }],
-    });
+        blob_start,
+        blob_len,
+    ));
     Ok(())
 }
 
@@ -1145,7 +1705,8 @@ async fn copy_maxscore_field(
     quantization: crate::structures::WeightQuantization,
     writer: &mut OffsetWriter,
     field_tocs: &mut Vec<SparseFieldToc>,
-    all_skip_bytes: &mut Vec<u8>,
+    skip_writer: &mut (dyn Write + Send),
+    skip_entry_buffer: &mut Vec<u8>,
     skip_count: &mut u32,
 ) -> Result<()> {
     let all_dims: Vec<u32> = sparse_idx.active_dimensions().collect();
@@ -1168,17 +1729,26 @@ async fn copy_maxscore_field(
 
         let block_data_offset = writer.offset();
         let skip_start = *skip_count;
-        let num_blocks = raw.skip_entries.len() as u32;
+        let num_blocks = u32::try_from(raw.skip_entries.len()).map_err(|_| {
+            crate::Error::Internal("sparse dimension skip-entry count exceeds u32::MAX".into())
+        })?;
 
         // Write raw block data (identity copy)
         writer
             .write_all(raw.raw_block_data.as_slice())
             .map_err(crate::Error::Io)?;
 
-        // Accumulate skip entries (offsets are already correct for single source)
+        // Stream skip entries to the segment-scoped temp file. Offsets are
+        // already correct for a single source.
         for entry in &raw.skip_entries {
-            entry.write_to_vec(all_skip_bytes);
-            *skip_count += 1;
+            skip_entry_buffer.clear();
+            entry.write_to_vec(skip_entry_buffer);
+            skip_writer
+                .write_all(skip_entry_buffer)
+                .map_err(crate::Error::Io)?;
+            *skip_count = skip_count.checked_add(1).ok_or_else(|| {
+                crate::Error::Internal("sparse skip-entry count exceeds u32::MAX".into())
+            })?;
         }
 
         dim_toc_entries.push(crate::segment::format::SparseDimTocEntry {
@@ -1218,10 +1788,10 @@ async fn copy_maxscore_field(
 /// padding. Interior padding is compacted away in the output: the written
 /// blob always has tail-only padding.
 ///
-/// This is a synchronous function called from `spawn_blocking` so the
-/// entire CPU-heavy reorder (forward index build, BP, blob write) runs
-/// off tokio worker threads. The `OffsetWriter` streams directly to disk
-/// — no in-memory buffering of the output blob.
+/// This is a synchronous function called from a Tokio block-in-place section,
+/// so cancellation cannot detach its owned output writer. The
+/// `OffsetWriter` streams directly to disk — no in-memory buffering of the
+/// output blob.
 ///
 /// When `rayon_pool` is `Some`, all rayon parallel work runs on that pool
 /// instead of the global pool, bounding optimizer CPU usage.
@@ -1231,7 +1801,6 @@ pub(crate) fn reorder_bmp_field(
     field_id: u32,
     index_label: &str,
     field_name: &str,
-    quantization: crate::structures::WeightQuantization,
     dims: u32,
     effective_block_size: usize,
     grid_bits: u8,
@@ -1240,6 +1809,7 @@ pub(crate) fn reorder_bmp_field(
     memory_budget: usize,
     bp_budget: crate::segment::BpBudget,
     granularity: BpGranularity,
+    scratch_path: PathBuf,
     mut writer: OffsetWriter,
     mut field_tocs: Vec<SparseFieldToc>,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
@@ -1250,9 +1820,7 @@ pub(crate) fn reorder_bmp_field(
             effective_block_size
         )));
     }
-    use crate::segment::builder::bmp::{
-        GridRunReader, stream_write_grids, stream_write_grids_merged, write_bmp_footer,
-    };
+    use crate::segment::builder::bmp::write_bmp_footer;
     use crate::segment::builder::graph_bisection::{
         BpProgressLabel, build_forward_index_from_bmps_with_maps, build_vid_maps,
         graph_bisection_with_progress,
@@ -1261,6 +1829,40 @@ pub(crate) fn reorder_bmp_field(
     if sources.is_empty() {
         return Ok((writer, field_tocs, true));
     }
+    // Validation, coherence, forward construction, and rewrite are exhaustive
+    // scans. Apply sequential page advice before the first one, not only after
+    // two cold passes have already completed.
+    let source_pages =
+        crate::segment::reader::bmp::BmpScanPageGuard::new(sources.iter().map(|(bmp, _)| bmp));
+    for (source, _) in sources {
+        source.validate_rewrite_layout(
+            "BMP reorder",
+            dims,
+            effective_block_size as u32,
+            grid_bits,
+            max_weight_scale,
+        )?;
+    }
+    let validation_start = std::time::Instant::now();
+    {
+        use rayon::prelude::*;
+        install_on_pool(rayon_pool.as_deref(), || {
+            sources.par_iter().try_for_each(|(source, _)| {
+                (0..source.num_blocks)
+                    .into_par_iter()
+                    .try_for_each(|block| source.validate_block_for_rewrite(block))
+            })
+        })?;
+    }
+    log::info!(
+        "[reorder_bmp] field {}: validated {} source block(s) in {:.1}ms",
+        field_id,
+        sources
+            .iter()
+            .map(|(source, _)| u64::from(source.num_blocks))
+            .sum::<u64>(),
+        validation_start.elapsed().as_secs_f64() * 1000.0,
+    );
 
     // ── Granularity decision (docs/block-level-reorder.md) ──────────────
     // The coherence scan runs only for `Auto`: explicit granularity (manual
@@ -1269,7 +1871,7 @@ pub(crate) fn reorder_bmp_field(
     let effective_granularity = match granularity {
         BpGranularity::Auto => {
             let stats_start = std::time::Instant::now();
-            let coherence = block_coherence(sources, effective_block_size);
+            let coherence = block_coherence(sources, effective_block_size, dims as usize);
             let chosen = if coherence.norm >= BLOCKWISE_NORM_COHERENCE_THRESHOLD {
                 BpGranularity::Blocks
             } else {
@@ -1315,7 +1917,6 @@ pub(crate) fn reorder_bmp_field(
             field_id,
             index_label,
             field_name,
-            quantization,
             dims,
             effective_block_size,
             grid_bits,
@@ -1323,6 +1924,8 @@ pub(crate) fn reorder_bmp_field(
             total_vectors,
             memory_budget,
             bp_budget,
+            scratch_path,
+            &source_pages,
             writer,
             field_tocs,
             rayon_pool,
@@ -1361,7 +1964,6 @@ pub(crate) fn reorder_bmp_field(
             field_id,
             index_label,
             field_name,
-            quantization,
             dims,
             effective_block_size,
             grid_bits,
@@ -1369,15 +1971,14 @@ pub(crate) fn reorder_bmp_field(
             total_vectors,
             memory_budget,
             bp_budget,
+            scratch_path,
+            &source_pages,
             writer,
             field_tocs,
             rayon_pool,
         )?;
         return Ok((writer, field_tocs, false));
     }
-
-    let source_pages =
-        crate::segment::reader::bmp::BmpScanPageGuard::new(sources.iter().map(|(bmp, _)| bmp));
 
     // ── Phase 1: Build forward index and run BP ─────────────────────────
     let bp_start = std::time::Instant::now();
@@ -1386,10 +1987,15 @@ pub(crate) fn reorder_bmp_field(
     // Build padding-aware maps once. Forward-index construction needs both
     // directions; output encoding reuses real→virtual instead of rescanning
     // every source document map.
-    let mut vid_maps: Vec<(Vec<u32>, Vec<u32>)> = bmp_refs
-        .iter()
-        .map(|bmp| build_vid_maps(bmp))
-        .collect::<Result<_>>()?;
+    let mut vid_maps: Vec<(Vec<u32>, Vec<u32>)> = {
+        use rayon::prelude::*;
+        install_on_pool(rayon_pool.as_deref(), || {
+            bmp_refs
+                .par_iter()
+                .map(|bmp| build_vid_maps(bmp))
+                .collect::<Result<_>>()
+        })?
+    };
     // Prefix sums of real doc counts: source s owns global real ids
     // real_base[s]..real_base[s+1].
     let mut real_base = Vec::with_capacity(vid_maps.len() + 1);
@@ -1461,7 +2067,7 @@ pub(crate) fn reorder_bmp_field(
                 forward_budget,
             )
         };
-        let (fwd, _source_doc_counts) = if let Some(ref pool) = rayon_pool {
+        let fwd = if let Some(ref pool) = rayon_pool {
             pool.install(build_forward)
         } else {
             build_forward()
@@ -1548,6 +2154,7 @@ pub(crate) fn reorder_bmp_field(
             )
         })?;
 
+    let rewrite_start = std::time::Instant::now();
     let blob_start = writer.offset();
     let mut block_data_starts: Vec<u64> = Vec::with_capacity(new_num_blocks + 1);
     let mut total_terms: u64 = 0;
@@ -1582,195 +2189,161 @@ pub(crate) fn reorder_bmp_field(
     let grid_run_entries =
         (grid_entries_budget / std::mem::size_of::<BmpGridEntry>()).clamp(1, MAX_GRID_RUN_ENTRIES);
     let mut grid_entries: Vec<BmpGridEntry> = Vec::with_capacity(grid_run_entries);
-    let mut run_files = GridRunFiles::new(field_id);
+    let mut run_files = GridScratchFiles::new(field_id, scratch_path);
 
-    // Encode one output block: gather its records from source blocks and
-    // serialize the current block layout. Pure function of `perm` + read-only
-    // sources — output blocks encode independently.
-    //
-    // Global real ids resolve to a source via `real_base`, then to a
-    // virtual vid (block/slot position) via that source's real→virtual map.
-    // Old block/slot arithmetic uses each source's own stored block size
-    // (uniform with the output in practice — merge validates it — but the
-    // source footer is the ground truth for parsing source blocks).
-    // (serialized block bytes, its (dim, out_block, max_impact) grid entries)
-    type EncodedBlock = (Vec<u8>, Vec<BmpGridEntry>);
-    let encode_block = |out_block: usize| -> Result<EncodedBlock> {
-        let new_vid_start = out_block * effective_block_size;
-        if new_vid_start >= num_real_docs {
-            return Ok((Vec::new(), Vec::new()));
-        }
-        let new_vid_end = ((out_block + 1) * effective_block_size).min(num_real_docs);
-        let slots_count = new_vid_end - new_vid_start;
-
-        // Group records by (source, source block), scatter matching slots
-        // All 256 u8 values are valid slots when bmp_block_size=256. The old
-        // u8::MAX "unmapped" sentinel therefore dropped a posting whenever
-        // source slot 255 mapped to output slot 255.
-        let mut slot_map = [u16::MAX; 256];
-        let mut block_mappings: rustc_hash::FxHashMap<(usize, usize), Vec<(u8, u8)>> =
-            rustc_hash::FxHashMap::default();
-        for new_local_slot in 0..slots_count {
-            let global_real = perm[new_vid_start + new_local_slot] as usize;
-            let src = real_base.partition_point(|&b| b <= global_real) - 1;
-            let old_vid = real_to_virtual[src][global_real - real_base[src]] as usize;
-            let src_block_size = sources[src].0.bmp_block_size.max(1) as usize;
-            let old_block = old_vid / src_block_size;
-            let old_slot = (old_vid % src_block_size) as u8;
-            block_mappings
-                .entry((src, old_block))
-                .or_default()
-                .push((old_slot, new_local_slot as u8));
-        }
-
-        let mut dim_postings: rustc_hash::FxHashMap<u32, Vec<(u8, u8)>> =
-            rustc_hash::FxHashMap::default();
-        for (&(src, old_block), mappings) in &block_mappings {
-            for &(old_s, new_s) in mappings {
-                slot_map[old_s as usize] = u16::from(new_s);
-            }
-
-            for (dim_id, _, postings) in sources[src].0.iter_block_terms(old_block as u32) {
-                for p in postings {
-                    let new_slot = slot_map[p.local_slot as usize];
-                    if new_slot != u16::MAX {
-                        dim_postings
-                            .entry(dim_id)
-                            .or_default()
-                            .push((new_slot as u8, p.impact));
-                    }
-                }
-            }
-
-            for &(old_s, _) in mappings {
-                slot_map[old_s as usize] = u16::MAX;
-            }
-        }
-
-        if dim_postings.is_empty() {
-            return Ok((Vec::new(), Vec::new()));
-        }
-
-        let mut sorted_dims: Vec<u32> = dim_postings.keys().copied().collect();
-        sorted_dims.sort_unstable();
-        let nt = sorted_dims.len();
-
-        let mut blk_buf: Vec<u8> = Vec::with_capacity(4 + nt * 8 + 4);
-        let nt_u32 = u32::try_from(nt)
-            .map_err(|_| crate::Error::Internal("BMP block term count exceeds u32::MAX".into()))?;
-        blk_buf.extend_from_slice(&nt_u32.to_le_bytes());
-
-        for &dim_id in &sorted_dims {
-            blk_buf.extend_from_slice(&dim_id.to_le_bytes());
-        }
-
-        // u32 prefix sums: a block/dimension can exceed 65,535 postings.
-        let mut cum: u32 = 0;
-        for &dim_id in &sorted_dims {
-            blk_buf.extend_from_slice(&cum.to_le_bytes());
-            let posting_count = u32::try_from(dim_postings[&dim_id].len()).map_err(|_| {
-                crate::Error::Internal("BMP block/dimension posting count exceeds u32::MAX".into())
-            })?;
-            cum = cum.checked_add(posting_count).ok_or_else(|| {
-                crate::Error::Internal("BMP block posting prefix exceeds u32::MAX".into())
-            })?;
-        }
-        blk_buf.extend_from_slice(&cum.to_le_bytes());
-
-        let max_impacts: Vec<u8> = sorted_dims
-            .iter()
-            .map(|dim_id| {
-                dim_postings[dim_id]
-                    .iter()
-                    .map(|&(_, impact)| impact)
-                    .max()
-                    .unwrap_or(0)
-            })
-            .collect();
-        blk_buf.extend_from_slice(&max_impacts);
-
-        let mut grid: Vec<(u32, u32, u8)> = Vec::with_capacity(nt);
-        for (&dim_id, &max_impact) in sorted_dims.iter().zip(&max_impacts) {
-            for &(slot, impact) in &dim_postings[&dim_id] {
-                blk_buf.push(slot);
-                blk_buf.push(impact);
-            }
-            grid.push((dim_id, out_block as u32, max_impact));
-        }
-        Ok((blk_buf, grid))
-    };
-
-    // Encode blocks in parallel per bounded window (blob order is fixed, so
-    // the write itself stays serial; the window caps buffered bytes).
-    let source_block_bytes = bmp_refs
-        .iter()
-        .map(|bmp| bmp.block_data_slice().len())
-        .fold(0usize, usize::saturating_add);
-    let source_blocks = bmp_refs
-        .iter()
-        .map(|bmp| bmp.num_blocks as usize)
-        .fold(0usize, usize::saturating_add);
-    // Encoded bytes and grid tuples coexist. Twice the average source block
-    // size is a conservative estimate; the byte budget prevents a pathological
-    // high-dimensional corpus from buffering several GB merely because the
-    // old fixed window admitted 4096 blocks.
-    let estimated_bytes_per_block = source_block_bytes
-        .checked_div(source_blocks.max(1))
+    // Transpose records through exact-counted flat tuples. Block encoding
+    // streams directly to the buffered output, so admission covers only the
+    // live routes/jobs/counts/partitions/tuples plus one reusable write buffer.
+    let posting_buffer_bytes = (encode_window_budget / 16)
+        .clamp(64 * 1024, REWRITE_IO_BUFFER_BYTES)
+        .min(encode_window_budget.saturating_div(2))
+        .max(2);
+    let transpose_budget = encode_window_budget.saturating_sub(posting_buffer_bytes);
+    let mut posting_buffer = Vec::with_capacity(posting_buffer_bytes);
+    let total_source_postings = sources.iter().fold(0u64, |total, (source, _)| {
+        total.saturating_add(source.total_postings())
+    });
+    let average_postings = usize::try_from(
+        total_source_postings.div_ceil(u64::try_from(num_real_docs).unwrap_or(u64::MAX)),
+    )
+    .unwrap_or(usize::MAX);
+    let estimated_record_bytes = std::mem::size_of::<RecordRoute>()
+        .saturating_add(average_postings.saturating_mul(std::mem::size_of::<RoutedPosting>()))
+        // A fully scattered output window can touch one distinct source block
+        // per routed record, so speculative route planning must charge job,
+        // count, and partition metadata per record too.
+        .saturating_add(std::mem::size_of::<SourceBlockJob>())
+        .saturating_add(std::mem::size_of::<usize>())
+        .saturating_add(std::mem::size_of::<(&SourceBlockJob, &mut [RoutedPosting])>());
+    let estimated_block_bytes = effective_block_size
+        .saturating_mul(estimated_record_bytes)
+        .max(1);
+    let max_parallel_window = transpose_budget
+        .checked_div(estimated_block_bytes)
         .unwrap_or(0)
-        .saturating_mul(2)
         .max(1);
-    // More queued blocks than workers cannot improve parallelism, but their
-    // variable-size buffers all remain live until the serial write phase.
-    // Two waves keep workers fed while imposing a hard small-count ceiling on
-    // estimation error from heavily skewed blocks.
-    let parallel_width = rayon_pool
-        .as_ref()
-        .map(|pool| pool.current_num_threads())
-        .unwrap_or_else(rayon::current_num_threads)
-        .max(1);
-    let max_parallel_window = parallel_width.saturating_mul(2);
-    let encode_window =
-        (encode_window_budget / estimated_bytes_per_block).clamp(1, max_parallel_window);
-    let mut encoded: Vec<Result<EncodedBlock>> = Vec::new();
-    for window_start in (0..new_num_blocks).step_by(encode_window) {
-        let window_end = (window_start + encode_window).min(new_num_blocks);
-        encoded.clear();
+    let mut source_block_scans = 0u64;
+    let mut window_start = 0usize;
+    while window_start < new_num_blocks {
+        let initial_end = window_start
+            .saturating_add(max_parallel_window)
+            .min(new_num_blocks);
+        let mut window_end = initial_end;
+        let (routes, jobs, counts, posting_count, admitted_bytes) = loop {
+            let (routes, jobs) = build_record_route_plan(
+                sources,
+                &perm,
+                &real_base,
+                &real_to_virtual,
+                effective_block_size,
+                num_real_docs,
+                window_start,
+                window_end,
+                rayon_pool.as_deref(),
+            )?;
+            let counts = {
+                use rayon::prelude::*;
+                install_on_pool(rayon_pool.as_deref(), || {
+                    jobs.par_iter()
+                        .map(|job| count_source_job_postings(sources, job, &routes))
+                        .collect::<Result<Vec<_>>>()
+                })?
+            };
+            let posting_count = counts.iter().try_fold(0usize, |total, &count| {
+                total.checked_add(count).ok_or_else(|| {
+                    crate::Error::Internal("BMP routed posting count overflows usize".into())
+                })
+            })?;
+            let required = record_window_memory_bytes(&routes, &jobs, &counts, posting_count)
+                .ok_or_else(|| {
+                    crate::Error::Internal("BMP route-window memory size overflows usize".into())
+                })?;
+            if required <= transpose_budget {
+                break (routes, jobs, counts, posting_count, required);
+            }
+            let window_blocks = window_end - window_start;
+            if window_blocks == 1 {
+                return Err(crate::Error::Internal(format!(
+                    "one BMP output block needs {} of the {} record-transpose budget",
+                    crate::format_bytes(required as u64),
+                    crate::format_bytes(transpose_budget as u64),
+                )));
+            }
+            window_end = window_start + (window_blocks / 2).max(1);
+        };
+        if window_end < initial_end {
+            log::debug!(
+                "[reorder_bmp] field {}: record window reduced from {} to {} blocks ({} admitted of {} budget)",
+                field_id,
+                initial_end - window_start,
+                window_end - window_start,
+                crate::format_bytes(admitted_bytes as u64),
+                crate::format_bytes(transpose_budget as u64),
+            );
+        }
+        source_block_scans = source_block_scans.saturating_add(jobs.len() as u64);
+
+        let mut routed = vec![RoutedPosting::default(); posting_count];
+        let mut partitions = Vec::with_capacity(jobs.len());
+        let mut remaining = routed.as_mut_slice();
+        for (job, &count) in jobs.iter().zip(&counts) {
+            let (output, tail) = remaining.split_at_mut(count);
+            partitions.push((job, output));
+            remaining = tail;
+        }
+        debug_assert!(remaining.is_empty());
         {
             use rayon::prelude::*;
-            let run = |out: &mut Vec<Result<EncodedBlock>>| {
-                (window_start..window_end)
-                    .into_par_iter()
-                    .map(encode_block)
-                    .collect_into_vec(out);
-            };
-            if let Some(ref pool) = rayon_pool {
-                pool.install(|| run(&mut encoded));
-            } else {
-                run(&mut encoded);
-            }
+            install_on_pool(rayon_pool.as_deref(), || {
+                partitions.into_par_iter().try_for_each(|(job, output)| {
+                    fill_source_job_postings(sources, job, &routes, output)
+                })
+            })?;
+            install_on_pool(rayon_pool.as_deref(), || {
+                routed.par_sort_unstable_by_key(|posting| {
+                    (
+                        posting.out_local,
+                        posting.dimension,
+                        posting.slot,
+                        posting.impact,
+                    )
+                });
+            });
         }
 
-        for encoded_block in encoded.drain(..) {
-            let (blk_buf, grid) = encoded_block?;
+        let mut posting_cursor = 0usize;
+        for out_local in 0..window_end - window_start {
+            let block_posting_start = posting_cursor;
+            while posting_cursor < routed.len()
+                && routed[posting_cursor].out_local == out_local as u32
+            {
+                posting_cursor += 1;
+            }
+            let block_postings = &routed[block_posting_start..posting_cursor];
             block_data_starts.push(cumulative_bytes);
-            if blk_buf.is_empty() {
+            if block_postings.is_empty() {
                 continue;
             }
-            total_terms += grid.len() as u64;
-            // layout: 4 + nt*4 dims + (nt+1)*4 prefixes + nt maxima + postings*2
-            total_postings += ((blk_buf.len() - 8 - grid.len() * 9) / 2) as u64;
-            extend_grid_entries_bounded(
+            let global_block = u32::try_from(window_start + out_local)
+                .map_err(|_| crate::Error::Internal("BMP output block exceeds u32::MAX".into()))?;
+            let (block_bytes, block_terms) = write_sorted_routed_block(
+                global_block,
+                block_postings,
                 &mut grid_entries,
-                &grid,
                 grid_run_entries,
                 &mut run_files,
                 field_id,
+                rayon_pool.as_deref(),
+                &mut posting_buffer,
+                &mut writer,
             )?;
-            writer.write_all(&blk_buf).map_err(crate::Error::Io)?;
-            cumulative_bytes += blk_buf.len() as u64;
+            total_terms = total_terms.saturating_add(block_terms as u64);
+            total_postings = total_postings.saturating_add(block_postings.len() as u64);
+            cumulative_bytes = cumulative_bytes.saturating_add(block_bytes);
         }
+        debug_assert_eq!(posting_cursor, routed.len());
+        window_start = window_end;
     }
-    drop(encoded);
 
     // Sentinel
     block_data_starts.push(cumulative_bytes);
@@ -1790,109 +2363,45 @@ pub(crate) fn reorder_bmp_field(
     }
 
     // Section A: block_data_starts
-    for &val in &block_data_starts {
-        writer
-            .write_all(&val.to_le_bytes())
-            .map_err(crate::Error::Io)?;
-    }
+    crate::segment::builder::bmp::write_u64_slice_le(&mut writer, &block_data_starts)
+        .map_err(crate::Error::Io)?;
     drop(block_data_starts);
+    let block_data_elapsed = rewrite_start.elapsed();
 
     // Sections D+E+H: block, superblock, and coarse-superblock grids.
+    let grids_start = std::time::Instant::now();
     let grid_offset = writer.offset() - blob_start;
-    let (packed_bytes, sb_bytes, _coarse_bytes) = if run_files.is_empty() {
-        // Fast path: all entries fit in memory, use existing function
-        grid_entries.sort_unstable();
-        let result = stream_write_grids(
-            &grid_entries,
-            dims as usize,
-            new_num_blocks,
-            grid_bits,
-            &mut writer,
-        )
-        .map_err(crate::Error::Io)?;
-        drop(grid_entries);
-        result
-    } else {
-        // Flush remaining in-memory entries as the final run if non-empty
-        if !grid_entries.is_empty() {
-            spill_grid_entries(&mut grid_entries, &mut run_files, field_id)?;
-        }
-        drop(grid_entries);
-
-        // Open run readers for K-way merge
-        let mut run_readers: Vec<GridRunReader> = Vec::with_capacity(run_files.len());
-        for path in run_files.iter() {
-            run_readers.push(GridRunReader::open(path).map_err(crate::Error::Io)?);
-        }
-
-        let result = stream_write_grids_merged(
-            &mut run_readers,
-            dims as usize,
-            new_num_blocks,
-            grid_bits,
-            &mut writer,
-        )
-        .map_err(crate::Error::Io)?;
-
-        // Readers must close before the RAII owner removes the run files.
-        drop(run_readers);
-
-        result
-    };
+    let (packed_bytes, sb_bytes, _coarse_bytes) = write_reorder_grids(
+        grid_entries,
+        &mut run_files,
+        field_id,
+        dims as usize,
+        new_num_blocks,
+        grid_bits,
+        rayon_pool.as_deref(),
+        &mut writer,
+    )?;
     let sb_grid_offset = grid_offset + packed_bytes;
     let coarse_grid_offset = sb_grid_offset + sb_bytes;
+    // The grids are durable in the output stream now; keep no external-sort
+    // scratch alive during the doc-map/footer phases.
+    drop(run_files);
+    let grids_elapsed = grids_start.elapsed();
 
     // Sections F+G: doc_map [new_num_virtual_docs each]
+    let doc_maps_start = std::time::Instant::now();
     let doc_map_offset = writer.offset() - blob_start;
 
-    // Resolve a global real id to (source, virtual vid within source).
-    let resolve = |global_real: usize| -> (usize, usize) {
-        let src = real_base.partition_point(|&b| b <= global_real) - 1;
-        (
-            src,
-            real_to_virtual[src][global_real - real_base[src]] as usize,
-        )
-    };
-
-    // Section F: doc_map_ids [u32-LE × new_num_virtual_docs], doc ids patched
-    // with each source's offset in the output segment. Real slots are never
-    // the u32::MAX sentinel (realness came from the doc map itself).
-    for &global_real in perm.iter().take(num_real_docs) {
-        let (src, vid) = resolve(global_real as usize);
-        let ids = sources[src].0.doc_map_ids_slice();
-        let off = vid * 4;
-        let source_doc_id = u32::from_le_bytes(ids[off..off + 4].try_into().unwrap());
-        let doc_id = source_doc_id.checked_add(sources[src].1).ok_or_else(|| {
-            crate::Error::Corruption(format!(
-                "BMP doc-id offset overflow: {} + {}",
-                source_doc_id, sources[src].1
-            ))
-        })?;
-        writer
-            .write_all(&doc_id.to_le_bytes())
-            .map_err(crate::Error::Io)?;
-    }
-    for _ in num_real_docs..new_num_virtual_docs {
-        writer
-            .write_all(&u32::MAX.to_le_bytes())
-            .map_err(crate::Error::Io)?;
-    }
-
-    // Section G: doc_map_ordinals [u16-LE × new_num_virtual_docs]
-    for &global_real in perm.iter().take(num_real_docs) {
-        let (src, vid) = resolve(global_real as usize);
-        let ords = sources[src].0.doc_map_ordinals_slice();
-        let off = vid * 2;
-        let ordinal = u16::from_le_bytes(ords[off..off + 2].try_into().unwrap());
-        writer
-            .write_all(&ordinal.to_le_bytes())
-            .map_err(crate::Error::Io)?;
-    }
-    for _ in num_real_docs..new_num_virtual_docs {
-        writer
-            .write_all(&0u16.to_le_bytes())
-            .map_err(crate::Error::Io)?;
-    }
+    write_record_doc_maps(
+        sources,
+        &perm[..num_real_docs],
+        &real_base,
+        &real_to_virtual,
+        new_num_virtual_docs,
+        &mut writer,
+        rayon_pool.as_deref(),
+    )?;
+    let doc_maps_elapsed = doc_maps_start.elapsed();
 
     // V18 footer.
     write_bmp_footer(
@@ -1915,33 +2424,25 @@ pub(crate) fn reorder_bmp_field(
 
     let blob_len = writer.offset() - blob_start;
 
-    // Push BMP sentinel TOC entry
-    let mut config_for_byte =
-        crate::structures::SparseVectorConfig::from_byte(quantization as u8).unwrap_or_default();
-    config_for_byte.format = SparseFormat::Bmp;
-    config_for_byte.weight_quantization = quantization;
-
-    field_tocs.push(SparseFieldToc {
+    field_tocs.push(SparseFieldToc::bmp(
         field_id,
-        quantization: config_for_byte.to_byte(),
         total_vectors,
-        dims: vec![crate::segment::format::SparseDimTocEntry {
-            dim_id: 0xFFFFFFFF, // sentinel for BMP
-            block_data_offset: blob_start,
-            skip_start: (blob_len & 0xFFFFFFFF) as u32,
-            num_blocks: ((blob_len >> 32) & 0xFFFFFFFF) as u32,
-            doc_count: 0,
-            max_weight: 0.0,
-        }],
-    });
+        blob_start,
+        blob_len,
+    ));
 
     log::info!(
-        "[reorder_bmp] field {}: done — {} blocks, {} terms, {} postings, {}",
+        "[reorder_bmp] field {}: done — {} blocks, {} terms, {} postings, {}, source-block scans={}, phases: transpose+data+offsets={:.1}s grids={:.1}s doc_maps={:.1}s total={:.1}s",
         field_id,
         new_num_blocks,
         total_terms,
         total_postings,
         crate::format_bytes(blob_len),
+        source_block_scans,
+        block_data_elapsed.as_secs_f64(),
+        grids_elapsed.as_secs_f64(),
+        doc_maps_elapsed.as_secs_f64(),
+        rewrite_start.elapsed().as_secs_f64(),
     );
 
     Ok((writer, field_tocs, converged))
@@ -2005,9 +2506,11 @@ mod grid_run_prefix_tests {
 
     #[test]
     fn grid_run_files_remove_partial_spills_on_drop() {
+        let directory = tempfile::tempdir().unwrap();
         let path = {
-            let mut runs = super::GridRunFiles::new(7);
-            let path = runs.allocate();
+            let mut runs =
+                super::GridScratchFiles::new(7, directory.path().join("seg_test.sparse"));
+            let path = runs.allocate_run();
             std::fs::write(&path, b"partial run").unwrap();
             assert!(path.exists());
             path
@@ -2016,23 +2519,5 @@ mod grid_run_prefix_tests {
             !path.exists(),
             "spill owner must remove files on unwind/drop"
         );
-    }
-
-    #[test]
-    fn grid_entry_spills_never_exceed_the_run_limit() {
-        let mut entries = Vec::with_capacity(3);
-        let mut runs = super::GridRunFiles::new(9);
-        let additional: Vec<super::BmpGridEntry> =
-            (0..8).rev().map(|block| (1, block, 1)).collect();
-
-        super::extend_grid_entries_bounded(&mut entries, &additional, 3, &mut runs, 9).unwrap();
-
-        assert_eq!(runs.len(), 2);
-        assert_eq!(entries.len(), 2);
-        assert_eq!(entries.capacity(), 3);
-        for path in runs.iter() {
-            // Three 9-byte serialized entries per complete run.
-            assert_eq!(std::fs::metadata(path).unwrap().len(), 27);
-        }
     }
 }

--- a/hermes-core/src/structures/sstable.rs
+++ b/hermes-core/src/structures/sstable.rs
@@ -45,6 +45,7 @@ pub const BLOOM_BITS_PER_KEY: usize = 10;
 
 /// Bloom filter hash count (optimal for 10 bits/key)
 pub const BLOOM_HASH_COUNT: usize = 7;
+const BLOOM_FILTER_HEADER_SIZE: usize = 16;
 
 const MAX_SSTABLE_BLOCK_BYTES: usize = 64 * 1024 * 1024;
 const MAX_SSTABLE_DICTIONARY_BYTES: u64 = 16 * 1024 * 1024;
@@ -116,9 +117,38 @@ impl BloomBits {
             BloomBits::Bytes(b) => b.len(),
         }
     }
+
+    fn write_to(&self, writer: &mut (impl Write + ?Sized)) -> io::Result<()> {
+        match self {
+            BloomBits::Vec(words) => {
+                #[cfg(target_endian = "little")]
+                {
+                    // SAFETY: u64 has no padding and the native byte order is
+                    // the on-disk little-endian order.
+                    let bytes = unsafe {
+                        std::slice::from_raw_parts(
+                            words.as_ptr().cast::<u8>(),
+                            words.len().saturating_mul(8),
+                        )
+                    };
+                    writer.write_all(bytes)
+                }
+                #[cfg(target_endian = "big")]
+                {
+                    for &word in words {
+                        writer.write_u64::<LittleEndian>(word)?;
+                    }
+                    Ok(())
+                }
+            }
+            BloomBits::Bytes(bytes) => writer.write_all(bytes.as_slice()),
+        }
+    }
 }
 
 impl BloomFilter {
+    pub(crate) const SERIALIZED_HEADER_SIZE: usize = BLOOM_FILTER_HEADER_SIZE;
+
     /// Create a new bloom filter sized for expected number of keys
     pub fn new(expected_keys: usize, bits_per_key: usize) -> Self {
         let num_bits = expected_keys.saturating_mul(bits_per_key).max(64);
@@ -134,18 +164,24 @@ impl BloomFilter {
     /// Unlike `from_owned_bytes`, this copies data into a `Vec<u64>` so that
     /// `insert()` works. Used by the primary-key bloom cache.
     pub fn from_bytes_mutable(data: &[u8]) -> io::Result<Self> {
-        if data.len() < 12 {
+        if data.len() < BLOOM_FILTER_HEADER_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Bloom filter data too short",
             ));
         }
-        let num_bits = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
-        let num_hashes = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
-        let num_words = u32::from_le_bytes([data[8], data[9], data[10], data[11]]) as usize;
+        let num_bits = usize::try_from(u64::from_le_bytes(data[0..8].try_into().unwrap()))
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Bloom filter bit count exceeds addressable memory",
+                )
+            })?;
+        let num_hashes = u32::from_le_bytes(data[8..12].try_into().unwrap()) as usize;
+        let num_words = u32::from_le_bytes(data[12..16].try_into().unwrap()) as usize;
 
         validate_bloom_header(data.len(), num_bits, num_hashes, num_words)?;
-        let expected_len = 12 + num_words * 8;
+        let expected_len = BLOOM_FILTER_HEADER_SIZE + num_words * 8;
         if data.len() != expected_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -155,7 +191,7 @@ impl BloomFilter {
 
         let mut vec = vec![0u64; num_words];
         for (i, v) in vec.iter_mut().enumerate() {
-            let off = 12 + i * 8;
+            let off = BLOOM_FILTER_HEADER_SIZE + i * 8;
             *v = u64::from_le_bytes(data[off..off + 8].try_into().unwrap());
         }
 
@@ -168,19 +204,25 @@ impl BloomFilter {
 
     /// Create from serialized OwnedBytes (zero-copy for mmap)
     pub fn from_owned_bytes(data: OwnedBytes) -> io::Result<Self> {
-        if data.len() < 12 {
+        if data.len() < BLOOM_FILTER_HEADER_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Bloom filter data too short",
             ));
         }
         let d = data.as_slice();
-        let num_bits = u32::from_le_bytes([d[0], d[1], d[2], d[3]]) as usize;
-        let num_hashes = u32::from_le_bytes([d[4], d[5], d[6], d[7]]) as usize;
-        let num_words = u32::from_le_bytes([d[8], d[9], d[10], d[11]]) as usize;
+        let num_bits =
+            usize::try_from(u64::from_le_bytes(d[0..8].try_into().unwrap())).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Bloom filter bit count exceeds addressable memory",
+                )
+            })?;
+        let num_hashes = u32::from_le_bytes(d[8..12].try_into().unwrap()) as usize;
+        let num_words = u32::from_le_bytes(d[12..16].try_into().unwrap()) as usize;
 
         validate_bloom_header(d.len(), num_bits, num_hashes, num_words)?;
-        let expected_len = 12 + num_words * 8;
+        let expected_len = BLOOM_FILTER_HEADER_SIZE + num_words * 8;
         if d.len() != expected_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -188,8 +230,9 @@ impl BloomFilter {
             ));
         }
 
-        // Slice past the 12-byte header to get raw u64 LE words (zero-copy)
-        let bits_bytes = data.slice(12..12 + num_words * 8);
+        // Slice past the header to get raw u64 LE words (zero-copy).
+        let bits_bytes =
+            data.slice(BLOOM_FILTER_HEADER_SIZE..BLOOM_FILTER_HEADER_SIZE + num_words * 8);
 
         Ok(Self {
             bits: BloomBits::Bytes(bits_bytes),
@@ -198,18 +241,23 @@ impl BloomFilter {
         })
     }
 
-    /// Serialize to bytes
-    pub fn to_bytes(&self) -> Vec<u8> {
+    /// Serialized header + word bytes.
+    pub fn serialized_len(&self) -> usize {
+        BLOOM_FILTER_HEADER_SIZE + self.bits.len() * 8
+    }
+
+    /// Stream the serialized representation without an intermediate buffer.
+    pub fn write_to(&self, writer: &mut (impl Write + ?Sized)) -> io::Result<()> {
         let num_words = self.bits.len();
-        let mut data = Vec::with_capacity(12 + num_words * 8);
-        data.write_u32::<LittleEndian>(self.num_bits as u32)
-            .unwrap();
-        data.write_u32::<LittleEndian>(self.num_hashes as u32)
-            .unwrap();
-        data.write_u32::<LittleEndian>(num_words as u32).unwrap();
-        for i in 0..num_words {
-            data.write_u64::<LittleEndian>(self.bits.get(i)).unwrap();
-        }
+        write_bloom_header(writer, self.num_bits, self.num_hashes, num_words)?;
+        self.bits.write_to(writer)
+    }
+
+    /// Serialize to bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(self.serialized_len());
+        self.write_to(&mut data)
+            .expect("writing a bloom filter to Vec cannot fail");
         data
     }
 
@@ -243,7 +291,7 @@ impl BloomFilter {
 
     /// Size in bytes
     pub fn size_bytes(&self) -> usize {
-        12 + self.bits.size_bytes()
+        BLOOM_FILTER_HEADER_SIZE + self.bits.size_bytes()
     }
 
     /// Insert a pre-computed hash pair into the filter
@@ -279,6 +327,33 @@ impl BloomFilter {
     }
 }
 
+fn write_bloom_header(
+    writer: &mut (impl Write + ?Sized),
+    num_bits: usize,
+    num_hashes: usize,
+    num_words: usize,
+) -> io::Result<()> {
+    writer.write_u64::<LittleEndian>(u64::try_from(num_bits).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Bloom filter bit count exceeds u64",
+        )
+    })?)?;
+    writer.write_u32::<LittleEndian>(u32::try_from(num_hashes).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Bloom filter hash count exceeds u32",
+        )
+    })?)?;
+    writer.write_u32::<LittleEndian>(u32::try_from(num_words).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "Bloom filter word count exceeds u32",
+        )
+    })?)?;
+    Ok(())
+}
+
 fn validate_bloom_header(
     data_len: usize,
     num_bits: usize,
@@ -294,7 +369,7 @@ fn validate_bloom_header(
     let word_bytes = num_words
         .checked_mul(8)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "bloom filter size overflow"))?;
-    let expected_len = 12usize
+    let expected_len = BLOOM_FILTER_HEADER_SIZE
         .checked_add(word_bytes)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "bloom filter size overflow"))?;
     let capacity_bits = num_words
@@ -1010,10 +1085,9 @@ impl<W: Write, V: SSTableValue> SSTableWriter<W, V> {
 
         // Write bloom filter if present
         let bloom_offset = if let Some(ref bloom) = bloom_filter {
-            let bloom_data = bloom.to_bytes();
             let offset = self.current_offset;
-            self.writer.write_all(&bloom_data)?;
-            self.current_offset += bloom_data.len() as u64;
+            bloom.write_to(&mut self.writer)?;
+            self.current_offset += bloom.serialized_len() as u64;
             offset
         } else {
             0
@@ -1259,8 +1333,9 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
             } else {
                 footer_start
             };
-            // Read bloom filter size first (12 bytes header)
-            let bloom_header_end = bloom_start.checked_add(12).ok_or_else(|| {
+            // Read the canonical header first to determine the payload size.
+            let header_size = BloomFilter::SERIALIZED_HEADER_SIZE as u64;
+            let bloom_header_end = bloom_start.checked_add(header_size).ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "bloom filter range overflow")
             })?;
             if bloom_header_end > bloom_end {
@@ -1273,14 +1348,14 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
                 .read_bytes_range(bloom_start..bloom_header_end)
                 .await?;
             let num_words = u32::from_le_bytes([
-                bloom_header[8],
-                bloom_header[9],
-                bloom_header[10],
-                bloom_header[11],
+                bloom_header[12],
+                bloom_header[13],
+                bloom_header[14],
+                bloom_header[15],
             ]) as u64;
             let bloom_size = num_words
                 .checked_mul(8)
-                .and_then(|bytes| bytes.checked_add(12))
+                .and_then(|bytes| bytes.checked_add(header_size))
                 .ok_or_else(|| {
                     io::Error::new(io::ErrorKind::InvalidData, "bloom filter size overflow")
                 })?;
@@ -1987,6 +2062,18 @@ mod tests {
         assert!(restored.may_contain(b"key1"));
         assert!(restored.may_contain(b"key2"));
         assert!(!restored.may_contain(b"key3"));
+    }
+
+    #[test]
+    fn bloom_header_preserves_bit_counts_above_u32() {
+        let num_bits = u32::MAX as usize + 1;
+        let mut header = Vec::new();
+        write_bloom_header(&mut header, num_bits, BLOOM_HASH_COUNT, 1).unwrap();
+        assert_eq!(header.len(), BLOOM_FILTER_HEADER_SIZE);
+        assert_eq!(
+            u64::from_le_bytes(header[0..8].try_into().unwrap()),
+            num_bits as u64
+        );
     }
 
     #[test]

--- a/hermes-server/README.md
+++ b/hermes-server/README.md
@@ -313,48 +313,50 @@ import grpc
 from hermes_pb2 import *
 from hermes_pb2_grpc import IndexServiceStub, SearchServiceStub
 
-channel = grpc.insecure_channel('localhost:50051')
+channel = grpc.insecure_channel("localhost:50051")
 index_service = IndexServiceStub(channel)
 search_service = SearchServiceStub(channel)
 
 # Create index
-schema = '''
+schema = """
 index articles {
     title: text indexed stored
     body: text indexed stored
 }
-'''
-index_service.CreateIndex(CreateIndexRequest(
-    index_name="articles",
-    schema=schema
-))
+"""
+index_service.CreateIndex(CreateIndexRequest(index_name="articles", schema=schema))
 
 # Index documents
 docs = [
-    NamedDocument(fields={
-        "title": FieldValue(text="Hello World"),
-        "body": FieldValue(text="This is my first article")
-    }),
-    NamedDocument(fields={
-        "title": FieldValue(text="Goodbye World"),
-        "body": FieldValue(text="This is my last article")
-    })
+    NamedDocument(
+        fields={
+            "title": FieldValue(text="Hello World"),
+            "body": FieldValue(text="This is my first article"),
+        }
+    ),
+    NamedDocument(
+        fields={
+            "title": FieldValue(text="Goodbye World"),
+            "body": FieldValue(text="This is my last article"),
+        }
+    ),
 ]
-index_service.BatchIndexDocuments(BatchIndexDocumentsRequest(
-    index_name="articles",
-    documents=docs
-))
+index_service.BatchIndexDocuments(
+    BatchIndexDocumentsRequest(index_name="articles", documents=docs)
+)
 
 # Commit
 index_service.Commit(CommitRequest(index_name="articles"))
 
 # Search
-response = search_service.Search(SearchRequest(
-    index_name="articles",
-    query=Query(term=TermQuery(field="title", term="hello")),
-    limit=10,
-    fields_to_load=["title", "body"]
-))
+response = search_service.Search(
+    SearchRequest(
+        index_name="articles",
+        query=Query(term=TermQuery(field="title", term="hello")),
+        limit=10,
+        fields_to_load=["title", "body"],
+    )
+)
 
 for hit in response.hits:
     print(f"Doc {hit.doc_id}: {hit.score} - {hit.fields}")

--- a/hermes-server/src/index_service.rs
+++ b/hermes-server/src/index_service.rs
@@ -350,20 +350,22 @@ impl IndexService for IndexServiceImpl {
         let index = self.registry.get_or_open_index(&req.index_name).await?;
         let writer = self.registry.get_writer(&req.index_name).await?;
 
+        let reload_index = Arc::clone(&index);
         writer
             .write()
             .await
-            .force_merge()
+            .force_merge_with_snapshot_refresh(move || {
+                let index = Arc::clone(&reload_index);
+                async move {
+                    index.reader().await?.reload().await?;
+                    Ok(())
+                }
+            })
             .await
             .map_err(crate::error::hermes_error_to_status)?;
 
-        // Force reader reload to pick up merged segments
         let reader = index
             .reader()
-            .await
-            .map_err(crate::error::hermes_error_to_status)?;
-        reader
-            .reload()
             .await
             .map_err(crate::error::hermes_error_to_status)?;
         let searcher = reader
@@ -420,20 +422,22 @@ impl IndexService for IndexServiceImpl {
         let index = self.registry.get_or_open_index(&req.index_name).await?;
         let writer = self.registry.get_writer(&req.index_name).await?;
 
+        let reload_index = Arc::clone(&index);
         writer
             .write()
             .await
-            .reorder()
+            .reorder_with_snapshot_refresh(move || {
+                let index = Arc::clone(&reload_index);
+                async move {
+                    index.reader().await?.reload().await?;
+                    Ok(())
+                }
+            })
             .await
             .map_err(crate::error::hermes_error_to_status)?;
 
-        // Force reader reload to pick up reordered segments
         let reader = index
             .reader()
-            .await
-            .map_err(crate::error::hermes_error_to_status)?;
-        reader
-            .reload()
             .await
             .map_err(crate::error::hermes_error_to_status)?;
         let searcher = reader

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -135,10 +135,9 @@ struct Args {
     #[arg(long, default_value = "3")]
     optimizer_max_unconverged_passes: u32,
 
-    /// Wall-clock budget in seconds for merge-time BP reorder. Must be finite;
-    /// 0 is invalid and falls back to 600 seconds. A truncated pass still
-    /// produces a valid, better-ordered segment; it is marked unconverged and
-    /// the background optimizer deepens it later.
+    /// Wall-clock budget in seconds for merge-time BP reorder (0 = unbudgeted).
+    /// A truncated pass still produces a valid, better-ordered segment; it is
+    /// marked unconverged and the background optimizer deepens it later.
     #[arg(long, default_value = "600")]
     merge_bp_budget_secs: u64,
 
@@ -351,12 +350,7 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
         .bp_memory_budget_mb
         .checked_mul(1024 * 1024)
         .ok_or_else(|| anyhow::anyhow!("--bp-memory-budget-mb is too large"))?;
-    let merge_bp_budget_secs = if args.merge_bp_budget_secs == 0 {
-        warn!("--merge-bp-budget-secs=0 would leave giant merges unbounded; using 600 seconds");
-        600
-    } else {
-        args.merge_bp_budget_secs
-    };
+    let merge_bp_time_budget = merge_bp_time_budget(args.merge_bp_budget_secs);
     let concurrent_reorder_passes = args
         .optimizer_concurrent_passes
         .clamp(1, hermes_core::index::MAX_CONCURRENT_REORDER_PASSES);
@@ -427,7 +421,7 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
         merge_policy: Box::new(merge_policy),
         max_concurrent_merges: args.max_concurrent_merges,
         background_merge_permits: Arc::new(tokio::sync::Semaphore::new(args.max_concurrent_merges)),
-        merge_bp_time_budget: Some(Duration::from_secs(merge_bp_budget_secs)),
+        merge_bp_time_budget,
         bp_memory_budget_bytes,
         background_reorder_permits: Arc::new(hermes_core::index::ReorderConcurrencyGate::new(
             concurrent_reorder_passes,
@@ -493,6 +487,13 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
         args.max_merged_docs,
         args.max_segment_docs,
     );
+    match merge_bp_time_budget {
+        Some(budget) => info!(
+            "Merge BP time budget: {:.0}s per field",
+            budget.as_secs_f64()
+        ),
+        None => info!("Merge BP time budget: unbudgeted"),
+    }
     if args.optimizer_threads > 0 {
         info!(
             "Optimizer: {} shared BP threads, {} concurrent pass(es), {}s scan interval, {}-pass unconverged follow-up threshold",
@@ -572,6 +573,10 @@ async fn shutdown_signal() {
     }
 }
 
+fn merge_bp_time_budget(seconds: u64) -> Option<Duration> {
+    (seconds != 0).then(|| Duration::from_secs(seconds))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -592,5 +597,11 @@ mod tests {
         .unwrap();
         assert_eq!(configured.vector_training_max_samples, 20_000_000);
         assert_eq!(configured.vector_training_memory_mb, 3_072);
+    }
+
+    #[test]
+    fn zero_merge_bp_budget_is_unbudgeted() {
+        assert_eq!(merge_bp_time_budget(0), None);
+        assert_eq!(merge_bp_time_budget(600), Some(Duration::from_secs(600)));
     }
 }

--- a/hermes-server/src/optimizer.rs
+++ b/hermes-server/src/optimizer.rs
@@ -290,6 +290,7 @@ async fn scan_and_optimize(
             let idx_name = name.clone();
             let sid = seg_id.clone();
             let pool = segment_manager.background_cpu_pool();
+            let refresh_index = Arc::clone(&index);
 
             // Size-tiered budget: small segments get full-depth BP (seconds of
             // work); large ones get a depth- and wall-clock-budgeted FIRST
@@ -333,6 +334,20 @@ async fn scan_and_optimize(
 
                 match sm.reorder_single_segment(&sid, Some(pool), budget).await {
                     Ok(true) => {
+                        match refresh_index.reader().await {
+                            Ok(reader) => {
+                                if let Err(error) = reader.reload().await {
+                                    warn!(
+                                        "[optimizer] reordered segment {} in index '{}' but failed to reload reader: {}",
+                                        sid, idx_name, error,
+                                    );
+                                }
+                            }
+                            Err(error) => warn!(
+                                "[optimizer] reordered segment {} in index '{}' but failed to open reader: {}",
+                                sid, idx_name, error,
+                            ),
+                        }
                         info!(
                             "[optimizer] reordered segment {} in index '{}' ({:.1}s)",
                             sid,


### PR DESCRIPTION
## Summary
- replace growing-prefix force merges with a bounded balanced 64-way hierarchy and fix merge/BP admission deadlocks
- bound and deduplicate BP working memory, parallel frequency counting, sparse grid generation, and lifecycle cleanup
- add early per-field merge capacity validation for multi-valued dense, binary, BMP, and MaxScore data
- make primary-key/Bloom refresh and persistence streaming and topology-safe

## Validation
- cargo test -p hermes-core --features native (923 passed, 0 failed)
- cargo test -p hermes-server (33 passed, 0 failed)
- cargo clippy -p hermes-core --features native --all-targets -- -D warnings
- cargo clippy -p hermes-server --all-targets -- -D warnings
- cargo check -p hermes-core --no-default-features
- cargo fmt --all -- --check
- git diff --check