### PR TITLE
fix(core): prevent merge BP from starving optimizer

### DIFF
--- a/docs/budgeted-reorder.md
+++ b/docs/budgeted-reorder.md
@@ -56,9 +56,9 @@ cold-IO writer, so at least they no longer evict the cache.
   merge-time BP pass, and resets after convergence or a non-reordered merge.
   `0` disables optimizer follow-up deepening; it does not disable explicitly
   configured merge-time reorder.
-- Merge-time reorder uses its own finite `--merge-bp-budget-secs` deadline. A
-  server value of `0` falls back to 600 seconds instead of making a giant
-  merge unbounded. A truncated output joins the same paced deepening ladder.
+- Merge-time reorder uses its own `--merge-bp-budget-secs` deadline. A server
+  value of `0` explicitly selects an unbudgeted pass. A truncated output joins
+  the same paced deepening ladder.
 
 Observability: `converged` in reorder logs, `bp_converged` in metadata, and
 the Grafana superblock/block skip-ratio panels are the quality metric — a

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -65,7 +65,13 @@ pub const MAX_CONCURRENT_REORDER_PASSES: usize = 2;
 #[cfg(feature = "native")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ReorderPriority {
-    Background,
+    /// Periodic optimizer and explicit standalone reorder work. This class
+    /// must retain capacity while automatic merges continuously arrive,
+    /// otherwise fresh segments stay unordered for minutes behind giant BP
+    /// passes and query pruning recovers slowly after ingestion.
+    Optimizer,
+    /// BP performed while producing an automatic merge output.
+    AutomaticMerge,
     Foreground,
 }
 
@@ -78,6 +84,10 @@ pub(crate) enum ReorderPriority {
 #[derive(Debug)]
 pub struct ReorderConcurrencyGate {
     permits: Arc<tokio::sync::Semaphore>,
+    /// Automatic merges may consume all but one whole-pass slot. The reserved
+    /// slot lets short optimizer passes continuously retire fresh segments.
+    /// With a one-pass configuration both classes share the only slot.
+    automatic_merge_permits: Arc<tokio::sync::Semaphore>,
     limit: usize,
     foreground_lock: Arc<tokio::sync::Mutex<()>>,
     foreground_active: std::sync::atomic::AtomicBool,
@@ -154,8 +164,10 @@ impl Drop for BmpIoPermit<'_> {
 impl ReorderConcurrencyGate {
     pub fn new(requested_limit: usize) -> Self {
         let limit = requested_limit.clamp(1, MAX_CONCURRENT_REORDER_PASSES);
+        let automatic_merge_limit = limit.saturating_sub(1).max(1);
         Self {
             permits: Arc::new(tokio::sync::Semaphore::new(limit)),
+            automatic_merge_permits: Arc::new(tokio::sync::Semaphore::new(automatic_merge_limit)),
             limit,
             foreground_lock: Arc::new(tokio::sync::Mutex::new(())),
             foreground_active: std::sync::atomic::AtomicBool::new(false),
@@ -170,9 +182,15 @@ impl ReorderConcurrencyGate {
     pub(crate) async fn acquire(
         self: &Arc<Self>,
         priority: ReorderPriority,
-    ) -> std::result::Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError> {
+    ) -> std::result::Result<ReorderPermit, tokio::sync::AcquireError> {
         match priority {
-            ReorderPriority::Background => self.acquire_background().await,
+            ReorderPriority::Optimizer => self.acquire_background(None).await,
+            ReorderPriority::AutomaticMerge => {
+                let merge_permit = Arc::clone(&self.automatic_merge_permits)
+                    .acquire_owned()
+                    .await?;
+                self.acquire_background(Some(merge_permit)).await
+            }
             ReorderPriority::Foreground => self.acquire_foreground().await,
         }
     }
@@ -180,7 +198,8 @@ impl ReorderConcurrencyGate {
     /// Acquire capacity for periodic optimizer or automatic merge work.
     async fn acquire_background(
         self: &Arc<Self>,
-    ) -> std::result::Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError> {
+        automatic_merge: Option<tokio::sync::OwnedSemaphorePermit>,
+    ) -> std::result::Result<ReorderPermit, tokio::sync::AcquireError> {
         loop {
             if self
                 .foreground_active
@@ -201,7 +220,10 @@ impl ReorderConcurrencyGate {
                 .foreground_active
                 .load(std::sync::atomic::Ordering::Acquire)
             {
-                return Ok(permit);
+                return Ok(ReorderPermit {
+                    _permit: permit,
+                    _automatic_merge: automatic_merge,
+                });
             }
             // A foreground operation started between the check and permit
             // acquisition. Yield the slot instead of extending its queue.
@@ -212,8 +234,12 @@ impl ReorderConcurrencyGate {
     /// Acquire the one BP slot left available to a foreground force merge.
     async fn acquire_foreground(
         self: &Arc<Self>,
-    ) -> std::result::Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError> {
-        Arc::clone(&self.permits).acquire_owned().await
+    ) -> std::result::Result<ReorderPermit, tokio::sync::AcquireError> {
+        let permit = Arc::clone(&self.permits).acquire_owned().await?;
+        Ok(ReorderPermit {
+            _permit: permit,
+            _automatic_merge: None,
+        })
     }
 
     /// Prioritize one explicit force merge across all indexes using this gate.
@@ -245,6 +271,12 @@ impl ReorderConcurrencyGate {
         }
         Ok(guard)
     }
+}
+
+#[cfg(feature = "native")]
+pub(crate) struct ReorderPermit {
+    _permit: tokio::sync::OwnedSemaphorePermit,
+    _automatic_merge: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
 #[cfg(feature = "native")]

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -63,22 +63,62 @@ fn reorder_gate_clamps_oversubscription() {
 
 #[cfg(feature = "native")]
 #[tokio::test]
-async fn foreground_reorder_pauses_new_background_passes() {
+async fn automatic_merge_reorder_leaves_capacity_for_optimizer() {
     use super::ReorderPriority;
     use std::sync::Arc;
     use std::time::Duration;
 
     let gate = Arc::new(super::ReorderConcurrencyGate::new(2));
-    let existing = gate.acquire(ReorderPriority::Background).await.unwrap();
+    let first_merge = gate.acquire(ReorderPriority::AutomaticMerge).await.unwrap();
+
+    // A second automatic merge must wait even though one total slot remains.
+    let second_merge = tokio::time::timeout(
+        Duration::from_millis(25),
+        gate.acquire(ReorderPriority::AutomaticMerge),
+    )
+    .await;
+    assert!(second_merge.is_err());
+
+    // The remaining slot is deliberately available to the optimizer so short
+    // fresh-segment passes cannot queue behind minutes-long merge BP work.
+    let optimizer = tokio::time::timeout(
+        Duration::from_millis(100),
+        gate.acquire(ReorderPriority::Optimizer),
+    )
+    .await
+    .expect("optimizer should retain one whole-pass slot")
+    .unwrap();
+
+    drop(optimizer);
+    drop(first_merge);
+
+    tokio::time::timeout(
+        Duration::from_millis(100),
+        gate.acquire(ReorderPriority::AutomaticMerge),
+    )
+    .await
+    .expect("automatic merges should resume when their slot is released")
+    .unwrap();
+}
+
+#[cfg(feature = "native")]
+#[tokio::test]
+async fn foreground_reorder_pauses_new_optimizer_passes() {
+    use super::ReorderPriority;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    let gate = Arc::new(super::ReorderConcurrencyGate::new(2));
+    let existing = gate.acquire(ReorderPriority::Optimizer).await.unwrap();
     let foreground = gate.begin_foreground().await.unwrap();
 
-    // Free the one non-reserved slot. A background waiter must still remain
+    // Free the one non-reserved slot. An optimizer waiter must still remain
     // paused while a force merge is active, whereas foreground BP can use it.
     drop(existing);
     assert!(
         tokio::time::timeout(
             Duration::from_millis(25),
-            gate.acquire(ReorderPriority::Background),
+            gate.acquire(ReorderPriority::Optimizer),
         )
         .await
         .is_err()
@@ -95,23 +135,23 @@ async fn foreground_reorder_pauses_new_background_passes() {
 
     let _resumed = tokio::time::timeout(
         Duration::from_millis(100),
-        gate.acquire(ReorderPriority::Background),
+        gate.acquire(ReorderPriority::Optimizer),
     )
     .await
-    .expect("background BP should resume when force merge finishes")
+    .expect("optimizer BP should resume when force merge finishes")
     .unwrap();
 }
 
 #[cfg(feature = "native")]
 #[tokio::test]
-async fn cancelled_foreground_wait_resumes_background_passes() {
+async fn cancelled_foreground_wait_resumes_optimizer_passes() {
     use super::ReorderPriority;
     use std::sync::Arc;
     use std::time::Duration;
 
     let gate = Arc::new(super::ReorderConcurrencyGate::new(2));
-    let first = gate.acquire(ReorderPriority::Background).await.unwrap();
-    let second = gate.acquire(ReorderPriority::Background).await.unwrap();
+    let first = gate.acquire(ReorderPriority::Optimizer).await.unwrap();
+    let second = gate.acquire(ReorderPriority::Optimizer).await.unwrap();
 
     // begin_foreground marks the gate active before waiting for its reserved
     // permit. Cancelling that wait must not leave background admission paused.
@@ -123,10 +163,10 @@ async fn cancelled_foreground_wait_resumes_background_passes() {
     drop(first);
     let resumed = tokio::time::timeout(
         Duration::from_millis(100),
-        gate.acquire(ReorderPriority::Background),
+        gate.acquire(ReorderPriority::Optimizer),
     )
     .await
-    .expect("cancelled foreground reservation must release background waiters")
+    .expect("cancelled foreground reservation must release optimizer waiters")
     .unwrap();
     drop(resumed);
     drop(second);

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -1792,7 +1792,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     &ids,
                     output_id,
                     sm.reorder_on_merge,
-                    ReorderPriority::Background,
+                    ReorderPriority::AutomaticMerge,
                 )
                 .await;
 
@@ -3290,7 +3290,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             () = self.active_operations.wait_for_shutdown() => {
                 return Err(Error::IndexClosed);
             }
-            permit = reorder_gate.acquire(ReorderPriority::Background) => {
+            permit = reorder_gate.acquire(ReorderPriority::Optimizer) => {
                 permit.map_err(|_| {
                     Error::Internal("background reorder scheduler is closed".into())
                 })?

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -207,7 +207,7 @@ impl SegmentMerger {
             bp_budget: crate::segment::BpBudget::full(),
             bp_memory_budget: crate::segment::reorder::DEFAULT_MEMORY_BUDGET,
             reorder_permits: None,
-            reorder_priority: ReorderPriority::Background,
+            reorder_priority: ReorderPriority::AutomaticMerge,
         }
     }
 

--- a/hermes-server/README.md
+++ b/hermes-server/README.md
@@ -92,14 +92,14 @@ These are deliberately separate controls:
 | Option                                   |   Default | Meaning                                                                                                                                  |
 | ---------------------------------------- | --------: | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `--optimizer-threads`                    |       `0` | Threads in the shared BP pool. `0` disables periodic optimizer scans; merge-time and manual BP still use the process-wide fallback pool. |
-| `--optimizer-concurrent-passes`          |       `2` | Maximum simultaneous whole-segment BP passes across background, merge-time, and manual reorder. Values are clamped to `1..=2`.          |
+| `--optimizer-concurrent-passes`          |       `2` | Maximum simultaneous whole-segment BP passes across optimizer, merge-time, and manual reorder. Values are clamped to `1..=2`; automatic merges use at most one slot so fresh-segment optimization retains capacity. |
 | `--optimizer-scan-interval-secs`         |      `60` | Interval between background scans.                                                                                                       |
 | `--optimizer-large-segment-docs`         | `5000000` | Document threshold for partial/budgeted first passes.                                                                                    |
 | `--optimizer-time-budget-secs`           |     `600` | Wall-clock budget for an optimizer pass on a large segment.                                                                              |
 | `--optimizer-partial-min-partition-docs` |     `256` | Initial depth floor for large segments (one default LSP superblock).                                                                     |
 | `--optimizer-unconverged-cooldown-secs`  |     `600` | Delay after a rewrite finishes before another deepening pass.                                                                            |
 | `--optimizer-max-unconverged-passes`     |       `3` | Optimizer follow-up eligibility limit per truncated lineage, including the initial partial pass. `0` disables follow-up deepening.       |
-| `--merge-bp-budget-secs`                 |     `600` | Finite wall-clock budget for BP performed inside a merge; `0` falls back to `600` rather than making giant merges unbounded.             |
+| `--merge-bp-budget-secs`                 |     `600` | Wall-clock budget for BP performed inside a merge; `0` explicitly selects an unbudgeted pass.                                           |
 | `--bp-memory-budget-mb`                  |   `24576` | Per-pass algorithmic working-set bound; not a reservation or a total-process RSS limit.                                                  |
 
 An active BP pass is CPU-bound and is expected to occupy up to
@@ -107,9 +107,11 @@ An active BP pass is CPU-bound and is expected to occupy up to
 second pass primarily raises simultaneous working sets and outstanding IO; it
 does not create another pool per pass or per index. Explicit force merges pause
 new background BP admission and reserve foreground capacity after existing
-merges drain. For predictable service
-latency, start with one pass and a CPU width that leaves capacity for query and
-indexing work.
+merges drain. With two-pass admission, automatic merge BP uses at most one
+slot; the other remains available to retire short fresh-segment optimizer
+passes instead of queueing them behind multi-minute merges. For predictable
+service latency, start with one pass and a CPU width that leaves capacity for
+query and indexing work.
 
 The dominant graph representation is roughly `4 bytes/posting + 32
 bytes/document`. The limit also accounts for record maps, vocabulary-sized

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -104,7 +104,8 @@ struct Args {
 
     /// Maximum simultaneous whole-segment BP passes across optimizer,
     /// merge-time, and manual reorders. Clamped to 1..=2 because each pass can
-    /// use all optimizer threads and up to the full BP memory budget.
+    /// use all optimizer threads and up to the full BP memory budget. With two
+    /// slots, automatic merges use at most one so optimizer work cannot starve.
     #[arg(long, default_value = "2")]
     optimizer_concurrent_passes: usize,
 


### PR DESCRIPTION
## Summary
- reserve one of the two whole-pass BP slots for optimizer/standalone reorder work
- cap automatic merge-time BP at one concurrent pass without restoring unsafe global oversubscription
- preserve force-merge admission and cancellation behavior
- document the scheduling and current zero-budget semantics

## Validation
- `cargo test -p hermes-core "index::tests::" --features native` (165 passed)
- `cargo check --workspace --all-targets`
- `cargo clippy -p hermes-core -p hermes-server --all-targets -- -D warnings`