### PR TITLE
fix(server): drain background work on shutdown

### DIFF
--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -279,6 +279,7 @@ struct ActiveSegmentOperations {
     inner: parking_lot::Mutex<ActiveOperationState>,
     idle: Notify,
     shutdown: Notify,
+    shutdown_requested: Arc<AtomicBool>,
 }
 
 impl ActiveSegmentOperations {
@@ -294,6 +295,7 @@ impl ActiveSegmentOperations {
             }),
             idle: Notify::new(),
             shutdown: Notify::new(),
+            shutdown_requested: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -398,6 +400,7 @@ impl ActiveSegmentOperations {
     /// Atomically prevent new lifecycle work from starting. Existing guards
     /// remain valid and can be drained with [`Self::wait_until_idle`].
     fn stop_accepting(&self) {
+        self.shutdown_requested.store(true, Ordering::Release);
         let mut inner = self.inner.lock();
         inner.accepting = false;
         self.shutdown.notify_waiters();
@@ -417,6 +420,10 @@ impl ActiveSegmentOperations {
 
     fn is_accepting(&self) -> bool {
         self.inner.lock().accepting
+    }
+
+    fn cancellation_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.shutdown_requested)
     }
 
     /// Wait until every operation that started before shutdown has released
@@ -1802,6 +1809,15 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     reevaluate = true;
                 }
                 Err(MergeTaskError {
+                    error: Error::IndexClosed,
+                    ..
+                }) => {
+                    log::debug!(
+                        "[merge] background merge for segments {:?} cancelled during shutdown",
+                        ids,
+                    );
+                }
+                Err(MergeTaskError {
                     error,
                     unavailable_segments,
                 }) => {
@@ -1874,6 +1890,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             self.bp_memory_budget_bytes,
             Arc::clone(&self.reorder_permits),
             priority,
+            self.active_operations.cancellation_flag(),
             Some(self.background_cpu_pool()),
         )
         .await;
@@ -2098,6 +2115,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         bp_memory_budget_bytes: usize,
         reorder_permits: Arc<ReorderConcurrencyGate>,
         reorder_priority: ReorderPriority,
+        cancellation: Arc<AtomicBool>,
         bg_cpu_pool: Option<Arc<rayon::ThreadPool>>,
     ) -> MergeTaskResult<(String, u32, bool)> {
         let output_hex = output_segment_id.to_hex();
@@ -2213,6 +2231,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 min_partition_docs: None,
                 time_budget: merge_bp_time_budget,
             })
+            .with_cancellation(cancellation)
             .with_bp_memory_budget(bp_memory_budget_bytes)
             .with_reorder_permits(reorder_permits)
             .with_reorder_priority(reorder_priority)
@@ -3366,6 +3385,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             bp_budget,
             granularity,
             rayon_pool,
+            Some(self.active_operations.cancellation_flag()),
         )
         .await;
         let (new_id, total_docs, bp_converged) = match reorder_result {
@@ -3975,7 +3995,9 @@ mod tests {
     async fn shutdown_rejects_new_work_and_waits_for_existing_guard() {
         let active = Arc::new(ActiveSegmentOperations::new());
         let guard = active.try_register(vec!["live".into()]).unwrap();
+        let cancellation = active.cancellation_flag();
         active.stop_accepting();
+        assert!(cancellation.load(Ordering::Acquire));
         assert!(active.try_register(vec!["new".into()]).is_none());
 
         let waiter = {

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -879,12 +879,21 @@ fn write_built_runs(
 
 /// Pure-copy normal merge. Corpus-sized source columns are never decoded or
 /// rewritten; only this compact directory is regenerated with adjusted bases.
-#[cfg(feature = "native")]
+#[cfg(all(feature = "native", test))]
 pub(crate) fn write_merged_ann(
     sources: &[(&AnnDiskIndex, u32)],
     writer: &mut (impl Write + ?Sized),
 ) -> io::Result<u64> {
-    write_merged_ann_with_extra(sources, &[], writer)
+    write_merged_ann_impl(sources, &[], writer, None)
+}
+
+#[cfg(feature = "native")]
+pub(crate) fn write_merged_ann_cancellable(
+    sources: &[(&AnnDiskIndex, u32)],
+    writer: &mut (impl Write + ?Sized),
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
+) -> io::Result<u64> {
+    write_merged_ann_impl(sources, &[], writer, cancellation)
 }
 
 /// [`write_merged_ann`] plus freshly built runs appended to the payload —
@@ -895,6 +904,17 @@ pub(crate) fn write_merged_ann_with_extra(
     sources: &[(&AnnDiskIndex, u32)],
     extra: &[BuildRun<'_>],
     writer: &mut (impl Write + ?Sized),
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
+) -> io::Result<u64> {
+    write_merged_ann_impl(sources, extra, writer, cancellation)
+}
+
+#[cfg(feature = "native")]
+fn write_merged_ann_impl(
+    sources: &[(&AnnDiskIndex, u32)],
+    extra: &[BuildRun<'_>],
+    writer: &mut (impl Write + ?Sized),
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> io::Result<u64> {
     let Some((first, _)) = sources.first() else {
         return Err(invalid_data("cannot merge an empty ANN source list"));
@@ -944,7 +964,12 @@ pub(crate) fn write_merged_ann_with_extra(
             .ok_or_else(|| invalid_data("ANN source has no payload runs"))?;
         let output_payload_start = offset;
         output_payload_starts.push(output_payload_start);
-        copy_range(writer, &source.raw, ANN_HEADER_SIZE..payload_end)?;
+        copy_range(
+            writer,
+            &source.raw,
+            ANN_HEADER_SIZE..payload_end,
+            cancellation,
+        )?;
         offset = checked_advance(offset, payload_end - ANN_HEADER_SIZE)?;
     }
 
@@ -1177,6 +1202,7 @@ fn copy_range(
     writer: &mut (impl Write + ?Sized),
     bytes: &OwnedBytes,
     range: Range<usize>,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> io::Result<()> {
     if range.is_empty() {
         return Ok(());
@@ -1186,6 +1212,14 @@ fn copy_range(
     let first_end = chunk_start.saturating_add(COPY_CHUNK).min(range_end);
     bytes.madvise_range(chunk_start..first_end, libc::MADV_WILLNEED);
     while chunk_start < range_end {
+        if cancellation
+            .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "ANN merge copy cancelled",
+            ));
+        }
         let chunk_end = chunk_start.saturating_add(COPY_CHUNK).min(range_end);
         let next_end = chunk_end.saturating_add(COPY_CHUNK).min(range_end);
         if chunk_end < next_end {

--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -488,8 +488,14 @@ pub(crate) fn build_bmp_blob(
     // Sections D+E+H: block, superblock, and coarse-superblock grids.
     // `dims` rows (not num_dims)
     let grid_offset = bytes_written;
-    let (packed_bytes, sb_bytes, coarse_bytes) =
-        stream_write_grids(&grid_entries, dims as usize, num_blocks, grid_bits, writer)?;
+    let (packed_bytes, sb_bytes, coarse_bytes) = stream_write_grids(
+        &grid_entries,
+        dims as usize,
+        num_blocks,
+        grid_bits,
+        writer,
+        None,
+    )?;
     let sb_grid_offset = bytes_written + packed_bytes;
     let coarse_grid_offset = sb_grid_offset + sb_bytes;
     bytes_written += packed_bytes + sb_bytes + coarse_bytes;
@@ -715,6 +721,7 @@ fn write_compressed_grid_section(
     num_blocks: usize,
     projection: GridProjection,
     writer: &mut dyn Write,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> std::io::Result<u64> {
     let cells = projection.cells(num_blocks);
     let layout = CompressedGridLayout::new(num_dims, cells);
@@ -723,6 +730,14 @@ fn write_compressed_grid_section(
 
     let mut entry = 0usize;
     for dim in 0..num_dims as u32 {
+        if cancellation
+            .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "BMP grid write cancelled",
+            ));
+        }
         let start = entry;
         while entry < grid_entries.len() && grid_entries[entry].0 == dim {
             entry += 1;
@@ -747,6 +762,14 @@ fn write_compressed_grid_section(
     let table_bytes = layout.write_row_offsets(&row_sizes, writer)?;
     entry = 0;
     for dim in 0..num_dims as u32 {
+        if cancellation
+            .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "BMP grid write cancelled",
+            ));
+        }
         let start = entry;
         while entry < grid_entries.len() && grid_entries[entry].0 == dim {
             entry += 1;
@@ -776,6 +799,7 @@ pub(crate) fn stream_write_grids(
     num_blocks: usize,
     grid_bits: u8,
     writer: &mut dyn Write,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> std::io::Result<(u64, u64, u64)> {
     let block_bytes = write_compressed_grid_section(
         grid_entries,
@@ -783,6 +807,7 @@ pub(crate) fn stream_write_grids(
         num_blocks,
         GridProjection::Block { bits: grid_bits },
         writer,
+        cancellation,
     )?;
     let superblock_bytes = write_compressed_grid_section(
         grid_entries,
@@ -790,6 +815,7 @@ pub(crate) fn stream_write_grids(
         num_blocks,
         GridProjection::Superblock,
         writer,
+        cancellation,
     )?;
     let coarse_bytes = write_compressed_grid_section(
         grid_entries,
@@ -797,6 +823,7 @@ pub(crate) fn stream_write_grids(
         num_blocks,
         GridProjection::CoarseSuperblock,
         writer,
+        cancellation,
     )?;
     Ok((block_bytes, superblock_bytes, coarse_bytes))
 }
@@ -1239,6 +1266,7 @@ fn copy_grid_spool(
     path: &std::path::Path,
     expected_bytes: u64,
     writer: &mut dyn Write,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> std::io::Result<()> {
     use std::io::Read;
 
@@ -1256,6 +1284,14 @@ fn copy_grid_spool(
     let mut buffer = vec![0u8; 1024 * 1024];
     let mut copied = 0u64;
     loop {
+        if cancellation
+            .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "BMP grid spool copy cancelled",
+            ));
+        }
         let read = reader.read(&mut buffer)?;
         if read == 0 {
             break;
@@ -1286,6 +1322,7 @@ fn copy_grid_spool(
 /// temporarily spooled because their offset tables follow the complete D
 /// section. Encoding buffers at most one compressed row per projection.
 #[cfg(feature = "native")]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn stream_write_grids_merged(
     run_readers: &mut [GridRunReader],
     num_dims: usize,
@@ -1294,6 +1331,7 @@ pub(crate) fn stream_write_grids_merged(
     superblock_spool: &std::path::Path,
     coarse_spool: &std::path::Path,
     writer: &mut dyn Write,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> std::io::Result<(u64, u64, u64)> {
     let num_dims_u32 = u32::try_from(num_dims).map_err(|_| {
         std::io::Error::new(
@@ -1314,6 +1352,14 @@ pub(crate) fn stream_write_grids_merged(
     {
         let mut merged = MergedGridCursor::new(run_readers);
         for dimension in 0..num_dims_u32 {
+            if cancellation
+                .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "BMP grid sizing cancelled",
+                ));
+            }
             merged.visit_dimension(dimension, |block, impact| {
                 for plan in &mut plans {
                     plan.observe(block, impact)?;
@@ -1345,6 +1391,14 @@ pub(crate) fn stream_write_grids_merged(
     {
         let mut merged = MergedGridCursor::new(run_readers);
         for dimension in 0..num_dims_u32 {
+            if cancellation
+                .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Interrupted,
+                    "BMP grid encoding cancelled",
+                ));
+            }
             let dimension_index = dimension as usize;
             merged.visit_dimension(dimension, |block, impact| {
                 for row in &mut rows {
@@ -1369,11 +1423,16 @@ pub(crate) fn stream_write_grids_merged(
     let superblock_table_bytes = plans[1]
         .layout
         .write_row_offsets(&plans[1].row_sizes, writer)?;
-    copy_grid_spool(superblock_spool, superblock_rows_bytes, writer)?;
+    copy_grid_spool(
+        superblock_spool,
+        superblock_rows_bytes,
+        writer,
+        cancellation,
+    )?;
     let coarse_table_bytes = plans[2]
         .layout
         .write_row_offsets(&plans[2].row_sizes, writer)?;
-    copy_grid_spool(coarse_spool, coarse_rows_bytes, writer)?;
+    copy_grid_spool(coarse_spool, coarse_rows_bytes, writer, cancellation)?;
 
     let block_bytes = block_table_bytes
         .checked_add(block_rows_bytes)
@@ -1425,6 +1484,16 @@ mod tests {
     }
 
     #[test]
+    fn compressed_grid_write_honors_shutdown_cancellation() {
+        let cancellation = std::sync::atomic::AtomicBool::new(true);
+        let mut encoded = Vec::new();
+        let error = stream_write_grids(&[(0, 0, 1)], 1, 1, 4, &mut encoded, Some(&cancellation))
+            .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Interrupted);
+    }
+
+    #[test]
     fn coarse_grid_is_exact_max_projection_of_superblock_grid() {
         use crate::directories::OwnedBytes;
         use crate::segment::bmp_grid::{CompressedGrid, GRID_GROUP_CELLS};
@@ -1437,7 +1506,7 @@ mod tests {
         ];
         let mut encoded = Vec::new();
         let (block_bytes, superblock_bytes, coarse_bytes) =
-            stream_write_grids(&entries, 2, num_blocks, 4, &mut encoded).unwrap();
+            stream_write_grids(&entries, 2, num_blocks, 4, &mut encoded, None).unwrap();
         assert_eq!(
             encoded.len() as u64,
             block_bytes + superblock_bytes + coarse_bytes
@@ -1664,7 +1733,7 @@ mod tests {
         for grid_bits in [2, 4] {
             let mut expected = Vec::new();
             let expected_sizes =
-                stream_write_grids(&entries, 4, 16_385, grid_bits, &mut expected).unwrap();
+                stream_write_grids(&entries, 4, 16_385, grid_bits, &mut expected, None).unwrap();
             let mut readers: Vec<_> = run_paths
                 .iter()
                 .map(|path| GridRunReader::open(path).unwrap())
@@ -1680,6 +1749,7 @@ mod tests {
                 &superblock_spool,
                 &coarse_spool,
                 &mut actual,
+                None,
             )
             .unwrap();
 

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -1012,11 +1012,18 @@ fn build_term_degrees(
     mid: usize,
     fwd: &ForwardIndex,
     workspaces: &mut [TermDegrees],
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) {
     debug_assert!(!workspaces.is_empty());
     let build_range = |degrees: &mut TermDegrees, start: usize, chunk: &[u32]| {
         degrees.reset();
         for (offset, &doc) in chunk.iter().enumerate() {
+            if offset.is_multiple_of(1024)
+                && cancellation
+                    .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+            {
+                break;
+            }
             let side = usize::from(start + offset >= mid);
             for &term in fwd.doc_terms(doc as usize) {
                 degrees.entry_mut(term as usize)[side] += 1;
@@ -1616,7 +1623,13 @@ impl<'a> BpProgress<'a> {
         );
     }
 
-    fn finish(&self, converged: bool, memory_limited: bool, deadline_exhausted: bool) {
+    fn finish(
+        &self,
+        converged: bool,
+        memory_limited: bool,
+        deadline_exhausted: bool,
+        cancelled: bool,
+    ) {
         let elapsed = self.start.elapsed().as_secs_f64();
         let partitions = self
             .partitions_completed
@@ -1632,7 +1645,9 @@ impl<'a> BpProgress<'a> {
         let objective_stops = self
             .objective_stops
             .load(std::sync::atomic::Ordering::Relaxed);
-        let stop_reason = if memory_limited {
+        let stop_reason = if cancelled {
+            "shutdown"
+        } else if memory_limited {
             "memory_budget"
         } else if deadline_exhausted {
             "time_budget"
@@ -1709,7 +1724,7 @@ impl BpProgress<'_> {
     fn partition_finished(&self) {}
     fn iteration(&self, _: usize, _: usize, _: f64, _: f64) {}
     fn objective_stop(&self) {}
-    fn finish(&self, _: bool, _: bool, _: bool) {}
+    fn finish(&self, _: bool, _: bool, _: bool, _: bool) {}
 }
 
 /// Recursive graph bisection. Returns `(perm, converged)` where
@@ -1734,6 +1749,7 @@ pub(crate) fn graph_bisection(
         min_partition_size,
         max_iters,
         budget,
+        None,
         BpProgressLabel::anonymous(),
     )
 }
@@ -1743,6 +1759,7 @@ pub(crate) fn graph_bisection_with_progress(
     min_partition_size: usize,
     max_iters: usize,
     budget: BpBudget,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
     progress_label: BpProgressLabel<'_>,
 ) -> (Vec<u32>, bool) {
     let n = fwd.num_docs();
@@ -1794,6 +1811,7 @@ pub(crate) fn graph_bisection_with_progress(
         #[cfg(not(feature = "native"))]
         deadline,
         exhausted: &exhausted,
+        cancellation,
         progress: &progress,
     };
     let immediately_exhausted = {
@@ -1806,7 +1824,9 @@ pub(crate) fn graph_bisection_with_progress(
             false
         }
     };
-    if immediately_exhausted {
+    let initially_cancelled =
+        cancellation.is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Acquire));
+    if immediately_exhausted || initially_cancelled {
         exhausted.store(true, std::sync::atomic::Ordering::Relaxed);
     } else if n > effective_min_partition {
         // Entity scratch is allocated once for the pass and carved into
@@ -1833,15 +1853,19 @@ pub(crate) fn graph_bisection_with_progress(
         );
     }
 
-    let deadline_exhausted = exhausted.load(std::sync::atomic::Ordering::Relaxed);
-    let converged = !fwd.budget_limited && !deadline_exhausted;
-    progress.finish(converged, fwd.budget_limited, deadline_exhausted);
+    let stopped_early = exhausted.load(std::sync::atomic::Ordering::Relaxed);
+    let cancelled =
+        cancellation.is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Acquire));
+    let deadline_exhausted = stopped_early && !cancelled;
+    let converged = !fwd.budget_limited && !stopped_early && !cancelled;
+    progress.finish(converged, fwd.budget_limited, deadline_exhausted, cancelled);
     if !converged {
         log::info!(
-            "BP graph_bisection: budget incomplete at n={} (time={:?}, memory_limited={}) — emitting partial (still valid) permutation",
+            "BP graph_bisection: pass incomplete at n={} (time={:?}, memory_limited={}, cancelled={}) — emitting partial (still valid) permutation",
             n,
             budget.time_budget,
             fwd.budget_limited,
+            cancelled,
         );
     }
     (docs, converged)
@@ -1865,6 +1889,7 @@ struct BisectContext<'a> {
     #[cfg(not(feature = "native"))]
     deadline: Option<()>,
     exhausted: &'a std::sync::atomic::AtomicBool,
+    cancellation: Option<&'a std::sync::atomic::AtomicBool>,
     progress: &'a BpProgress<'a>,
 }
 
@@ -1887,7 +1912,14 @@ fn bisect(
         return;
     }
     // Anytime cutoff: leave this subtree in its current (valid) order.
-    if context.exhausted.load(std::sync::atomic::Ordering::Relaxed) {
+    if context.exhausted.load(std::sync::atomic::Ordering::Relaxed)
+        || context
+            .cancellation
+            .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Acquire))
+    {
+        context
+            .exhausted
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         return;
     }
     #[cfg(feature = "native")]
@@ -1918,7 +1950,22 @@ fn bisect(
     // deep partitions touch only their active terms. Coarse partitions use
     // multiple preallocated lanes; recursion splits the exact same workspace
     // set between children.
-    build_term_degrees(docs, mid, context.fwd, degree_workspaces);
+    build_term_degrees(
+        docs,
+        mid,
+        context.fwd,
+        degree_workspaces,
+        context.cancellation,
+    );
+    if context
+        .cancellation
+        .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Acquire))
+    {
+        context
+            .exhausted
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        return;
+    }
     // A full-vocabulary objective scan pays off only on coarse partitions,
     // where one avoided refinement skips millions of postings. At fine levels
     // it cost more than the work it could save, so retain the cheap gain
@@ -1940,6 +1987,15 @@ fn bisect(
 
     for iter in 0..effective_iters {
         // Anytime cutoff between refinement passes: keep the current split.
+        if context
+            .cancellation
+            .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Acquire))
+        {
+            context
+                .exhausted
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            break;
+        }
         #[cfg(feature = "native")]
         if let Some(dl) = context.deadline
             && std::time::Instant::now() >= dl
@@ -1959,6 +2015,15 @@ fn bisect(
             context.log_table,
             gains,
         );
+        if context
+            .cancellation
+            .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Acquire))
+        {
+            context
+                .exhausted
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            break;
+        }
 
         // Exact median selection and stable partition. The old path allocated
         // `Vec<usize>` (8 bytes/entity) and selected/applied it serially; the
@@ -2449,11 +2514,11 @@ mod tests {
         );
 
         let mut updated_workspaces: Vec<_> = (0..4).map(|_| TermDegrees::new(TERMS)).collect();
-        build_term_degrees(&docs, mid, &fwd, &mut updated_workspaces);
+        build_term_degrees(&docs, mid, &fwd, &mut updated_workspaces, None);
         movement_workspaces[0].apply_moves_to(&mut updated_workspaces[0]);
 
         let mut rebuilt_workspaces: Vec<_> = (0..4).map(|_| TermDegrees::new(TERMS)).collect();
-        build_term_degrees(&output, mid, &fwd, &mut rebuilt_workspaces);
+        build_term_degrees(&output, mid, &fwd, &mut rebuilt_workspaces, None);
         for term in 0..TERMS {
             assert_eq!(
                 updated_workspaces[0].get(term),
@@ -2635,6 +2700,30 @@ mod tests {
         let mut sorted = perm.clone();
         sorted.sort();
         assert_eq!(sorted, (0..64).collect::<Vec<u32>>());
+    }
+
+    #[test]
+    fn test_bp_shutdown_cancellation_emits_valid_partial_permutation() {
+        let docs: Vec<Vec<u32>> = (0..64).map(|i| vec![i % 4]).collect();
+        let doc_refs: Vec<&[u32]> = docs.iter().map(Vec::as_slice).collect();
+        let fwd = make_fwd(&doc_refs, 4);
+        let cancellation = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let budget = BpBudget {
+            min_partition_docs: None,
+            time_budget: None,
+        };
+
+        let (perm, converged) = graph_bisection_with_progress(
+            &fwd,
+            4,
+            20,
+            budget,
+            Some(cancellation.as_ref()),
+            BpProgressLabel::anonymous(),
+        );
+
+        assert!(!converged, "cancelled BP must report unconverged");
+        assert_eq!(perm, (0..64).collect::<Vec<u32>>());
     }
 
     #[test]

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -58,6 +58,7 @@ async fn feed_segment(
     field: crate::dsl::Field,
     doc_id_offset: u32,
     mut add_batch: impl FnMut(&[(u32, u16)], &[f32]) -> Result<()>,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> crate::Result<usize> {
     let lazy_flat = match segment.flat_vectors().get(&field.0) {
         Some(f) => f,
@@ -76,6 +77,11 @@ async fn feed_segment(
     let mut labels = Vec::with_capacity(VECTOR_BATCH_SIZE);
 
     for batch_start in (0..n).step_by(VECTOR_BATCH_SIZE) {
+        if cancellation
+            .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+        {
+            return Err(crate::Error::IndexClosed);
+        }
         let batch_count = VECTOR_BATCH_SIZE.min(n - batch_start);
         let batch_bytes = lazy_flat
             .read_vectors_batch(batch_start, batch_count)
@@ -118,6 +124,7 @@ async fn feed_segment(
 ///
 /// Doc_id map is streamed in DOC_ID_CHUNK entries (384 KB) instead of
 /// buffering all at once (was 60 MB for 10M vectors).
+#[allow(clippy::too_many_arguments)]
 async fn write_flat_entry(
     field_id: u32,
     dim: usize,
@@ -126,6 +133,7 @@ async fn write_flat_entry(
     segments: &[SegmentReader],
     doc_offs: &[u32],
     writer: &mut OffsetWriter,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<()> {
     FlatVectorData::write_binary_header(dim, total_vectors, quantization, writer)?;
 
@@ -136,6 +144,11 @@ async fn write_flat_entry(
             let base_offset = lazy_flat.vectors_byte_offset();
             let handle = lazy_flat.handle();
             for chunk_start in (0..total_bytes).step_by(FLAT_VECTOR_CHUNK as usize) {
+                if cancellation
+                    .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+                {
+                    return Err(crate::Error::IndexClosed);
+                }
                 let chunk_end = chunk_start
                     .saturating_add(FLAT_VECTOR_CHUNK)
                     .min(total_bytes);
@@ -170,6 +183,11 @@ async fn write_flat_entry(
             let offset = doc_offs[seg_idx];
             let count = lazy_flat.num_vectors;
             for chunk_start in (0..count).step_by(DOC_ID_CHUNK) {
+                if cancellation
+                    .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+                {
+                    return Err(crate::Error::IndexClosed);
+                }
                 buf.clear();
                 let chunk_end = (chunk_start + DOC_ID_CHUNK).min(count);
                 for i in chunk_start..chunk_end {
@@ -213,6 +231,7 @@ impl SegmentMerger {
         let mut fields_to_write: Vec<FieldInfo> = Vec::new();
 
         for (field, entry) in self.schema.fields() {
+            self.ensure_not_cancelled()?;
             if !matches!(
                 entry.field_type,
                 FieldType::DenseVector | FieldType::BinaryDenseVector
@@ -276,6 +295,7 @@ impl SegmentMerger {
         let mut toc: Vec<DenseVectorTocEntry> = Vec::new();
 
         for fi in &fields_to_write {
+            self.ensure_not_cancelled()?;
             let field = fi.field;
             let entry = self.schema.get_field_entry(field).unwrap();
             let config = entry.dense_vector_config.as_ref();
@@ -375,6 +395,7 @@ impl SegmentMerger {
                 segments,
                 &doc_offs,
                 &mut writer,
+                self.cancellation.as_deref(),
             )
             .await?;
             let data_size = writer.offset() - data_offset;
@@ -520,10 +541,15 @@ impl SegmentMerger {
             return Ok(None);
         }
         let data_offset = writer.offset();
-        super::block_in_place_if_multithread(|| {
-            crate::segment::ann_disk::write_merged_ann(&sources, writer)
-        })
-        .map_err(crate::Error::Io)?;
+        let result = super::block_in_place_if_multithread(|| {
+            crate::segment::ann_disk::write_merged_ann_cancellable(
+                &sources,
+                writer,
+                self.cancellation.as_deref(),
+            )
+        });
+        self.ensure_not_cancelled()?;
+        result.map_err(crate::Error::Io)?;
         let data_size = writer.offset() - data_offset;
         log::debug!(
             "[dense_vector_merge] field {}: copied {} compatible ANN run source(s), {}",
@@ -598,10 +624,15 @@ impl SegmentMerger {
 
         if missing_segments.is_empty() {
             let data_offset = writer.offset();
-            super::block_in_place_if_multithread(|| {
-                crate::segment::ann_disk::write_merged_ann(&sources, writer)
-            })
-            .map_err(crate::Error::Io)?;
+            let result = super::block_in_place_if_multithread(|| {
+                crate::segment::ann_disk::write_merged_ann_cancellable(
+                    &sources,
+                    writer,
+                    self.cancellation.as_deref(),
+                )
+            });
+            self.ensure_not_cancelled()?;
+            result.map_err(crate::Error::Io)?;
             let data_size = writer.offset() - data_offset;
             log::debug!(
                 "[merge_vectors] field {}: copied {} compatible TQ run source(s), {} bytes",
@@ -649,6 +680,7 @@ impl SegmentMerger {
                         ))
                     })
                 },
+                self.cancellation.as_deref(),
             )
             .await?;
         }
@@ -675,10 +707,16 @@ impl SegmentMerger {
             } else {
                 std::slice::from_ref(&extra)
             };
-            super::block_in_place_if_multithread(|| {
-                crate::segment::ann_disk::write_merged_ann_with_extra(&sources, extra_runs, writer)
-            })
-            .map_err(crate::Error::Io)?;
+            let result = super::block_in_place_if_multithread(|| {
+                crate::segment::ann_disk::write_merged_ann_with_extra(
+                    &sources,
+                    extra_runs,
+                    writer,
+                    self.cancellation.as_deref(),
+                )
+            });
+            self.ensure_not_cancelled()?;
+            result.map_err(crate::Error::Io)?;
         }
         log::info!(
             "[merge_vectors] field {}: TQ re-encoded {} vectors in {:.1}s ({} sources copied)",
@@ -768,10 +806,15 @@ impl SegmentMerger {
             return Ok(None);
         }
         let data_offset = writer.offset();
-        super::block_in_place_if_multithread(|| {
-            crate::segment::ann_disk::write_merged_ann(&sources, writer)
-        })
-        .map_err(crate::Error::Io)?;
+        let result = super::block_in_place_if_multithread(|| {
+            crate::segment::ann_disk::write_merged_ann_cancellable(
+                &sources,
+                writer,
+                self.cancellation.as_deref(),
+            )
+        });
+        self.ensure_not_cancelled()?;
+        result.map_err(crate::Error::Io)?;
         let data_size = writer.offset() - data_offset;
         log::debug!(
             "[merge_vectors] field {}: copied {} compatible IVF-TQ run source(s), {} bytes",
@@ -835,6 +878,7 @@ impl SegmentMerger {
                         ))
                     })
                 },
+                self.cancellation.as_deref(),
             )
             .await?;
             total_fed = total_fed.checked_add(fed).ok_or_else(|| {

--- a/hermes-core/src/segment/merger/fast_fields.rs
+++ b/hermes-core/src/segment/merger/fast_fields.rs
@@ -68,6 +68,7 @@ impl SegmentMerger {
         let mut current_offset = 0u64;
 
         for &(field_id, ref field_type) in &sorted_fields {
+            self.ensure_not_cancelled()?;
             let is_multi = self
                 .schema
                 .get_field_entry(crate::dsl::Field(field_id))

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -9,6 +9,7 @@ mod store;
 pub(crate) use dense::AnnWriteMode;
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use rustc_hash::FxHashMap;
 
@@ -187,6 +188,9 @@ pub struct SegmentMerger {
     /// a merge slot for the full BP depth — a truncated pass is marked
     /// `bp_converged = false` and the background optimizer deepens it.
     bp_budget: crate::segment::BpBudget,
+    /// Process-shutdown cancellation, kept separate from the public BP budget
+    /// so low-level callers retain the existing budget API.
+    cancellation: Option<Arc<AtomicBool>>,
     /// Memory budget for the BP forward index during merge-time reorder.
     bp_memory_budget: usize,
     /// Shared whole-pass concurrency limit. Tests and low-level callers may
@@ -205,6 +209,7 @@ impl SegmentMerger {
             background_pool: None,
             granularity: crate::segment::reorder::BpGranularity::Auto,
             bp_budget: crate::segment::BpBudget::full(),
+            cancellation: None,
             bp_memory_budget: crate::segment::reorder::DEFAULT_MEMORY_BUDGET,
             reorder_permits: None,
             reorder_priority: ReorderPriority::AutomaticMerge,
@@ -235,6 +240,11 @@ impl SegmentMerger {
         self
     }
 
+    pub(crate) fn with_cancellation(mut self, cancellation: Arc<AtomicBool>) -> Self {
+        self.cancellation = Some(cancellation);
+        self
+    }
+
     /// Memory budget for the BP forward index (see `bp_memory_budget`).
     pub fn with_bp_memory_budget(mut self, bytes: usize) -> Self {
         self.bp_memory_budget = bytes;
@@ -250,6 +260,18 @@ impl SegmentMerger {
     pub(crate) fn with_reorder_priority(mut self, priority: ReorderPriority) -> Self {
         self.reorder_priority = priority;
         self
+    }
+
+    pub(super) fn ensure_not_cancelled(&self) -> Result<()> {
+        if self
+            .cancellation
+            .as_ref()
+            .is_some_and(|cancelled| cancelled.load(Ordering::Acquire))
+        {
+            Err(crate::Error::IndexClosed)
+        } else {
+            Ok(())
+        }
     }
 
     /// Reject additive per-field counts that the on-disk formats cannot
@@ -399,6 +421,7 @@ impl SegmentMerger {
         new_segment_id: SegmentId,
         trained: Option<&TrainedVectorStructures>,
     ) -> Result<(SegmentMeta, MergeStats)> {
+        self.ensure_not_cancelled()?;
         // Reject an unrepresentable merge before creating any output files.
         // The previous late check left a complete orphan output behind after
         // doing all expensive phases.
@@ -489,6 +512,7 @@ impl SegmentMerger {
 
         let (postings_result, store_result, fast_bytes) =
             tokio::try_join!(postings_fut, store_fut, fast_fut)?;
+        self.ensure_not_cancelled()?;
 
         log::info!(
             "[merge] stage 1 done in {:.1}s (postings + store + fast)",
@@ -515,6 +539,7 @@ impl SegmentMerger {
         } else {
             tokio::try_join!(sparse_fut, dense_fut)?
         };
+        self.ensure_not_cancelled()?;
         let (store_bytes, store_num_docs) = store_result;
         stats.terms_processed = postings_result.0;
         stats.term_dict_bytes = postings_result.1;
@@ -531,6 +556,7 @@ impl SegmentMerger {
         );
 
         // === Mandatory: merge field stats + write meta ===
+        self.ensure_not_cancelled()?;
         let mut merged_field_stats: FxHashMap<u32, FieldStats> = FxHashMap::default();
         for segment in segments {
             for (&field_id, field_stats) in &segment.meta().field_stats {

--- a/hermes-core/src/segment/merger/postings.rs
+++ b/hermes-core/src/segment/merger/postings.rs
@@ -109,6 +109,7 @@ impl SegmentMerger {
         let mut sources: Vec<(usize, TermInfo, u32)> = Vec::with_capacity(segments.len());
 
         while !heap.is_empty() {
+            self.ensure_not_cancelled()?;
             // Get the smallest key (move, not clone)
             let first = heap.pop().unwrap();
             let current_key = first.key;

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -13,7 +13,7 @@
 //! skip entries (24 bytes per block) are written fresh in a separate section.
 //! The raw block bytes are copied directly from mmap.
 
-use std::io::Write;
+use std::io::{Read, Write};
 use std::sync::Arc;
 
 use super::OffsetWriter;
@@ -28,6 +28,10 @@ use crate::segment::format::{SparseDimTocEntry, SparseFieldToc, write_sparse_toc
 use crate::segment::reader::{DimRawData, SegmentReader};
 use crate::segment::types::SegmentFiles;
 use crate::structures::{SparseFormat, SparseSkipEntry};
+
+fn cancellation_requested(cancellation: Option<&std::sync::atomic::AtomicBool>) -> bool {
+    cancellation.is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Acquire))
+}
 
 impl SegmentMerger {
     /// Merge sparse vector indexes via byte-level block stacking (V3 format).
@@ -86,6 +90,7 @@ impl SegmentMerger {
         let mut skip_entry_buf = Vec::with_capacity(SparseSkipEntry::SIZE);
 
         for (field, sparse_config, field_reorder, field_name) in &sparse_fields {
+            self.ensure_not_cancelled()?;
             let format = sparse_config.as_ref().map(|c| c.format).unwrap_or_default();
             let quantization = sparse_config
                 .as_ref()
@@ -166,6 +171,7 @@ impl SegmentMerger {
                             sources.len(),
                         );
                         let bp_budget = self.bp_budget;
+                        let cancellation = self.cancellation.clone();
                         let bp_memory_budget = self.bp_memory_budget;
                         let out_grid_bits = grid_bits;
                         let scratch_path = scratch_path.clone();
@@ -203,6 +209,7 @@ impl SegmentMerger {
                                 // pass is marked unconverged and the background
                                 // optimizer deepens it (warm-started).
                                 bp_budget,
+                                cancellation,
                                 // Auto unless a source is an unconverged
                                 // partial reorder (then Records, see
                                 // SegmentMerger::granularity).
@@ -234,6 +241,7 @@ impl SegmentMerger {
                             &scratch_path,
                             &mut writer,
                             &mut field_tocs,
+                            self.cancellation.as_deref(),
                         )
                     })?;
                 }
@@ -287,6 +295,7 @@ impl SegmentMerger {
             let mut dim_toc_entries: Vec<SparseDimTocEntry> = Vec::with_capacity(all_dims.len());
 
             for &dim_id in &all_dims {
+                self.ensure_not_cancelled()?;
                 // Collect raw data from each segment (skip entries + raw block bytes)
                 let mut sources = Vec::with_capacity(segments.len());
                 for (seg_idx, sparse_idx) in sparse_indexes.iter().enumerate() {
@@ -595,6 +604,7 @@ fn merge_bmp_field(
     scratch_path: &std::path::Path,
     writer: &mut OffsetWriter,
     field_tocs: &mut Vec<SparseFieldToc>,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<()> {
     use crate::segment::builder::bmp::write_bmp_footer;
     let effective_block_size = bmp_block_size.clamp(1, 256);
@@ -621,6 +631,9 @@ fn merge_bmp_field(
     let mut num_real_docs_total: u32 = 0;
 
     for &(bmp, _) in &sources {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         bmp.validate_rewrite_layout(
             "BMP merge",
             dims,
@@ -693,6 +706,9 @@ fn merge_bmp_field(
         let sentinel = bmp.block_data_sentinel() as usize;
         let src_data = &bmp.block_data_slice()[..sentinel];
         for chunk in src_data.chunks(CHUNK_SIZE) {
+            if cancellation_requested(cancellation) {
+                return Err(crate::Error::IndexClosed);
+            }
             writer.write_all(chunk).map_err(crate::Error::Io)?;
         }
         cumulative_bytes += sentinel as u64;
@@ -731,8 +747,14 @@ fn merge_bmp_field(
     // coordinates are copied byte-for-byte; shifted output groups use a
     // bounded 256-cell decode/repack.
     let grid_offset = writer.offset() - blob_start;
-    let block_grid_bytes =
-        write_merged_block_grid(&sources, dims as usize, num_blocks, grid_bits, writer)?;
+    let block_grid_bytes = write_merged_block_grid(
+        &sources,
+        dims as usize,
+        num_blocks,
+        grid_bits,
+        writer,
+        cancellation,
+    )?;
 
     // ── Phase 4: Stream Sections E+H together. Source superblock coordinates
     // restart at every segment, so E is remapped by source block offsets.
@@ -747,8 +769,14 @@ fn merge_bmp_field(
             .unwrap_or_else(|| "hermes.sparse".into()),
         field_id,
     ));
-    let (sb_grid_bytes, coarse_grid_bytes) =
-        write_merged_superblock_grids(&sources, dims as usize, num_blocks, &coarse_spool, writer)?;
+    let (sb_grid_bytes, coarse_grid_bytes) = write_merged_superblock_grids(
+        &sources,
+        dims as usize,
+        num_blocks,
+        &coarse_spool,
+        writer,
+        cancellation,
+    )?;
     let coarse_grid_offset = sb_grid_offset
         .checked_add(sb_grid_bytes)
         .ok_or_else(|| crate::Error::Internal("merged BMP grid offset exceeds u64".into()))?;
@@ -775,10 +803,16 @@ fn merge_bmp_field(
 
         if doc_offset == 0 {
             for chunk in src_ids[..n * 4].chunks(CHUNK_SIZE) {
+                if cancellation_requested(cancellation) {
+                    return Err(crate::Error::IndexClosed);
+                }
                 writer.write_all(chunk).map_err(crate::Error::Io)?;
             }
         } else {
             for chunk_start in (0..n).step_by(DOC_MAP_CHUNK) {
+                if cancellation_requested(cancellation) {
+                    return Err(crate::Error::IndexClosed);
+                }
                 let chunk_end = (chunk_start + DOC_MAP_CHUNK).min(n);
                 let chunk_len = chunk_end - chunk_start;
                 let src = &src_ids[chunk_start * 4..chunk_end * 4];
@@ -808,6 +842,9 @@ fn merge_bmp_field(
         let src_ords = bmp.doc_map_ordinals_slice();
         let n = bmp.num_virtual_docs as usize;
         for chunk in src_ords[..n * 2].chunks(CHUNK_SIZE) {
+            if cancellation_requested(cancellation) {
+                return Err(crate::Error::IndexClosed);
+            }
             writer.write_all(chunk).map_err(crate::Error::Io)?;
         }
     }
@@ -934,6 +971,7 @@ fn write_merged_block_grid<'a>(
     num_blocks: usize,
     grid_bits: u8,
     writer: &mut dyn Write,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<u64> {
     use crate::segment::bmp_grid::{CompressedGridLayout, GRID_GROUP_CELLS, pack_group};
 
@@ -1020,6 +1058,9 @@ fn write_merged_block_grid<'a>(
     };
 
     for dimension in 0..dims {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         load_row(dimension, &mut row_groups)?;
         collect_widths(&mut widths, &row_groups, &mut group_values)?;
         row_sizes.push(layout.row_bytes(&widths)?);
@@ -1039,6 +1080,9 @@ fn write_merged_block_grid<'a>(
     })?);
     let mut packed = [0u8; GRID_GROUP_CELLS];
     for (dimension, &row_size) in row_sizes.iter().enumerate() {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         load_row(dimension, &mut row_groups)?;
         row_payload.clear();
         let mut source = 0usize;
@@ -1251,6 +1295,7 @@ fn write_merged_superblock_grids<'a>(
     num_blocks: usize,
     coarse_spool: &std::path::Path,
     writer: &mut dyn Write,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<(u64, u64)> {
     use crate::segment::bmp_grid::{CompressedGridLayout, GRID_GROUP_CELLS, pack_group};
 
@@ -1303,6 +1348,9 @@ fn write_merged_superblock_grids<'a>(
         };
 
     for dimension in 0..dims {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         rows.prepare(
             sources,
             &source_block_bases,
@@ -1376,6 +1424,9 @@ fn write_merged_superblock_grids<'a>(
     };
 
     for dimension in 0..dims {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         rows.prepare(
             sources,
             &source_block_bases,
@@ -1422,7 +1473,25 @@ fn write_merged_superblock_grids<'a>(
         .map_err(crate::Error::Io)?;
     let coarse_file = std::fs::File::open(coarse_spool).map_err(crate::Error::Io)?;
     let mut coarse_reader = std::io::BufReader::with_capacity(1024 * 1024, coarse_file);
-    let copied = std::io::copy(&mut coarse_reader, writer).map_err(crate::Error::Io)?;
+    let mut copy_buffer = vec![0u8; 1024 * 1024];
+    let mut copied = 0u64;
+    loop {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
+        let read = coarse_reader
+            .read(&mut copy_buffer)
+            .map_err(crate::Error::Io)?;
+        if read == 0 {
+            break;
+        }
+        writer
+            .write_all(&copy_buffer[..read])
+            .map_err(crate::Error::Io)?;
+        copied = copied
+            .checked_add(read as u64)
+            .ok_or_else(|| crate::Error::Internal("merged BMP coarse grid exceeds u64".into()))?;
+    }
     if copied != coarse_rows_bytes {
         return Err(crate::Error::Corruption(format!(
             "short BMP coarse-grid spool copy: copied {copied}, expected {coarse_rows_bytes}"

--- a/hermes-core/src/segment/merger/store.rs
+++ b/hermes-core/src/segment/merger/store.rs
@@ -48,15 +48,21 @@ impl SegmentMerger {
 
         let mut store_merger = StoreMerger::new(store_writer);
         for segment in segments {
+            self.ensure_not_cancelled()?;
             if segment.store_has_dict() {
-                store_merger
-                    .append_store_recompressing(segment.store())
-                    .await
-                    .map_err(crate::Error::Io)?;
+                let result = store_merger
+                    .append_store_recompressing(segment.store(), self.cancellation.as_deref())
+                    .await;
+                self.ensure_not_cancelled()?;
+                result.map_err(crate::Error::Io)?;
             } else {
                 let raw_blocks = segment.store_raw_blocks();
                 let data_slice = segment.store_data_slice();
-                store_merger.append_store(data_slice, &raw_blocks).await?;
+                let result = store_merger
+                    .append_store(data_slice, &raw_blocks, self.cancellation.as_deref())
+                    .await;
+                self.ensure_not_cancelled()?;
+                result.map_err(crate::Error::Io)?;
             }
         }
         let store_num_docs = store_merger.finish()?;

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -29,6 +29,10 @@ use crate::structures::SparseFormat;
 /// `IndexConfig::default().bp_memory_budget_bytes`.
 pub const DEFAULT_MEMORY_BUDGET: usize = 24 * 1024 * 1024 * 1024;
 
+fn cancellation_requested(cancellation: Option<&std::sync::atomic::AtomicBool>) -> bool {
+    cancellation.is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Acquire))
+}
+
 /// Unique prefix for a pass's spilled grid-run temp files.
 ///
 /// MUST be unique per pass, not per (process, field): in a container the
@@ -214,6 +218,7 @@ fn write_reorder_grids(
     grid_bits: u8,
     rayon_pool: Option<&rayon::ThreadPool>,
     writer: &mut OffsetWriter,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<(u64, u64, u64)> {
     use crate::segment::builder::bmp::{
         GridRunReader, stream_write_grids, stream_write_grids_merged,
@@ -221,18 +226,32 @@ fn write_reorder_grids(
 
     if scratch.runs_are_empty() {
         use rayon::prelude::*;
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         install_on_pool(rayon_pool, || entries.par_sort_unstable());
-        return stream_write_grids(&entries, dims, num_blocks, grid_bits, writer)
-            .map_err(crate::Error::Io);
+        let result =
+            stream_write_grids(&entries, dims, num_blocks, grid_bits, writer, cancellation);
+        return if cancellation_requested(cancellation) {
+            Err(crate::Error::IndexClosed)
+        } else {
+            result.map_err(crate::Error::Io)
+        };
     }
 
     if !entries.is_empty() {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         spill_grid_entries(&mut entries, scratch, field_id, rayon_pool)?;
     }
     drop(entries);
     // Bound both file descriptors and BufReader memory. Extremely large
     // fields can produce hundreds of sorted runs even with 16M-entry chunks.
     scratch.consolidate_runs(64)?;
+    if cancellation_requested(cancellation) {
+        return Err(crate::Error::IndexClosed);
+    }
     let mut readers: Vec<GridRunReader> = scratch
         .runs()
         .map(|path| GridRunReader::open(path).map_err(crate::Error::Io))
@@ -250,11 +269,15 @@ fn write_reorder_grids(
         &superblock_spool,
         &coarse_spool,
         writer,
-    )
-    .map_err(crate::Error::Io);
+        cancellation,
+    );
     // Close readers before GridScratchFiles removes the spill paths.
     drop(readers);
-    result
+    if cancellation_requested(cancellation) {
+        Err(crate::Error::IndexClosed)
+    } else {
+        result.map_err(crate::Error::Io)
+    }
 }
 
 fn install_on_pool<T: Send>(
@@ -587,6 +610,7 @@ fn write_blockwise_doc_maps(
     block_size: usize,
     writer: &mut OffsetWriter,
     rayon_pool: Option<&rayon::ThreadPool>,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<()> {
     use rayon::prelude::*;
 
@@ -594,6 +618,9 @@ fn write_blockwise_doc_maps(
     let blocks_per_chunk = (REWRITE_IO_BUFFER_BYTES / id_block_bytes).max(1);
     let mut buffer = Vec::with_capacity(blocks_per_chunk * id_block_bytes);
     for blocks in permuted_blocks.chunks(blocks_per_chunk) {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         buffer.resize(blocks.len() * id_block_bytes, 0);
         install_on_pool(rayon_pool, || {
             buffer
@@ -635,6 +662,9 @@ fn write_blockwise_doc_maps(
             .saturating_sub(buffer.capacity()),
     );
     for blocks in permuted_blocks.chunks(blocks_per_chunk) {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         buffer.resize(blocks.len() * ordinal_block_bytes, 0);
         install_on_pool(rayon_pool, || {
             buffer
@@ -653,6 +683,7 @@ fn write_blockwise_doc_maps(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_record_doc_maps(
     sources: &[(crate::segment::BmpIndex, u32)],
     permutation: &[u32],
@@ -661,6 +692,7 @@ fn write_record_doc_maps(
     num_virtual_docs: usize,
     writer: &mut OffsetWriter,
     rayon_pool: Option<&rayon::ThreadPool>,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<()> {
     use rayon::prelude::*;
 
@@ -672,6 +704,9 @@ fn write_record_doc_maps(
             .saturating_mul(4),
     );
     for records in permutation.chunks(id_records_per_chunk) {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         buffer.resize(records.len() * 4, 0);
         install_on_pool(rayon_pool, || {
             buffer
@@ -724,6 +759,9 @@ fn write_record_doc_maps(
             .saturating_sub(buffer.capacity()),
     );
     for records in permutation.chunks(ordinal_records_per_chunk) {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         buffer.resize(records.len() * 2, 0);
         install_on_pool(rayon_pool, || {
             buffer
@@ -925,7 +963,7 @@ fn block_coherence(
 /// residual coherence, potentially take the blockwise path, report converged,
 /// and end the deepening cascade at partial quality.
 #[allow(clippy::too_many_arguments)]
-pub async fn reorder_segment<D: Directory + DirectoryWriter>(
+pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
     dir: &D,
     schema: &Arc<Schema>,
     source_id: SegmentId,
@@ -935,6 +973,7 @@ pub async fn reorder_segment<D: Directory + DirectoryWriter>(
     bp_budget: crate::segment::BpBudget,
     granularity: BpGranularity,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
+    cancellation: Option<Arc<std::sync::atomic::AtomicBool>>,
 ) -> Result<(String, u32, bool)> {
     let reader = SegmentReader::open(dir, source_id, Arc::clone(schema), term_cache_blocks).await?;
     let num_docs = reader.num_docs();
@@ -971,7 +1010,10 @@ pub async fn reorder_segment<D: Directory + DirectoryWriter>(
             !reader.vector_indexes().is_empty() || !reader.flat_vectors().is_empty(),
         ),
     ] {
-        clone_segment_file(dir, src, dst, required).await?;
+        if cancellation_requested(cancellation.as_deref()) {
+            return Err(crate::Error::IndexClosed);
+        }
+        clone_segment_file(dir, src, dst, required, cancellation.as_deref()).await?;
     }
     log::info!(
         "[reorder] copied files in {:.1}s",
@@ -986,6 +1028,7 @@ pub async fn reorder_segment<D: Directory + DirectoryWriter>(
         schema,
         memory_budget,
         bp_budget,
+        cancellation,
         granularity,
         rayon_pool,
     )
@@ -1051,7 +1094,7 @@ pub async fn rewrite_vector_segment<D: Directory + DirectoryWriter>(
             !reader.sparse_indexes().is_empty() || !reader.bmp_indexes().is_empty(),
         ),
     ] {
-        clone_segment_file(dir, src, dst, required).await?;
+        clone_segment_file(dir, src, dst, required, None).await?;
     }
 
     let merger = SegmentMerger::new(Arc::clone(schema)).with_background_pool(rayon_pool);
@@ -1095,7 +1138,11 @@ async fn clone_segment_file<D: Directory + DirectoryWriter>(
     src: &Path,
     dst: &Path,
     required: bool,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<()> {
+    if cancellation_requested(cancellation) {
+        return Err(crate::Error::IndexClosed);
+    }
     match dir.link(src, dst).await {
         Ok(()) => return Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound && !required => return Ok(()),
@@ -1132,6 +1179,9 @@ async fn clone_segment_file<D: Directory + DirectoryWriter>(
     let source_len = handle.len();
     let mut offset = 0u64;
     while offset < source_len {
+        if cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         let end = (offset + CHUNK as u64).min(source_len);
         let data = handle
             .read_bytes_range(offset..end)
@@ -1176,6 +1226,7 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
     schema: &Schema,
     memory_budget: usize,
     bp_budget: crate::segment::BpBudget,
+    cancellation: Option<Arc<std::sync::atomic::AtomicBool>>,
     granularity: BpGranularity,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
 ) -> Result<bool> {
@@ -1218,7 +1269,14 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
             reader.meta().id,
         );
         let src_files = SegmentFiles::new(reader.meta().id);
-        clone_segment_file(dir, &src_files.sparse, &dst_files.sparse, true).await?;
+        clone_segment_file(
+            dir,
+            &src_files.sparse,
+            &dst_files.sparse,
+            true,
+            cancellation.as_deref(),
+        )
+        .await?;
         return Ok(true);
     }
 
@@ -1246,6 +1304,9 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
     let mut skip_count: u32 = 0;
 
     for (field, sparse_config, reorder, field_name) in &sparse_fields {
+        if cancellation_requested(cancellation.as_deref()) {
+            return Err(crate::Error::IndexClosed);
+        }
         let format = sparse_config.as_ref().map(|c| c.format).unwrap_or_default();
         let quantization = sparse_config
             .as_ref()
@@ -1296,6 +1357,8 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                 let ilabel = schema.index_label().to_owned();
                 let pool = rayon_pool.clone();
                 let scratch_path = scratch_path.clone();
+                let field_bp_budget = bp_budget;
+                let field_cancellation = cancellation.clone();
                 let (w, ft, converged) = super::merger::block_in_place_if_multithread(move || {
                     reorder_bmp_field(
                         &bmp_sources,
@@ -1308,7 +1371,8 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                         max_weight_scale,
                         total_vectors,
                         memory_budget,
-                        bp_budget,
+                        field_bp_budget,
+                        field_cancellation,
                         granularity,
                         scratch_path,
                         writer,
@@ -1389,6 +1453,7 @@ fn reorder_bmp_field_blockwise(
     total_vectors: u32,
     memory_budget: usize,
     bp_budget: crate::segment::BpBudget,
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
     scratch_path: PathBuf,
     source_pages: &crate::segment::reader::bmp::BmpScanPageGuard<'_>,
     mut writer: OffsetWriter,
@@ -1402,6 +1467,9 @@ fn reorder_bmp_field_blockwise(
     use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
 
     let bmp_refs: Vec<&crate::segment::BmpIndex> = sources.iter().map(|(b, _)| b).collect();
+    if cancellation_requested(cancellation) {
+        return Err(crate::Error::IndexClosed);
+    }
     {
         use rayon::prelude::*;
         install_on_pool(rayon_pool.as_deref(), || {
@@ -1477,6 +1545,7 @@ fn reorder_bmp_field_blockwise(
                 sb,
                 20,
                 block_budget,
+                cancellation,
                 BpProgressLabel {
                     index: index_label,
                     field: field_name,
@@ -1495,6 +1564,9 @@ fn reorder_bmp_field_blockwise(
     } else {
         run_bp()
     };
+    if cancellation_requested(cancellation) {
+        return Err(crate::Error::IndexClosed);
+    }
     // Resolving a global block through source prefix sums is cheap once, but
     // catastrophic inside the `dims × blocks` grid rewrite below (billions
     // of calls on production-sized fields). Cache the compact source/local
@@ -1547,6 +1619,9 @@ fn reorder_bmp_field_blockwise(
     let mut run_files = GridScratchFiles::new(field_id, scratch_path);
 
     for (new_block, &(src, lb)) in permuted_blocks.iter().enumerate() {
+        if new_block.is_multiple_of(1024) && cancellation_requested(cancellation) {
+            return Err(crate::Error::IndexClosed);
+        }
         let bmp = bmp_refs[src as usize];
         let start = bmp.block_data_start(lb) as usize;
         let end = if lb + 1 < bmp.num_blocks {
@@ -1598,6 +1673,7 @@ fn reorder_bmp_field_blockwise(
         grid_bits,
         rayon_pool.as_deref(),
         &mut writer,
+        cancellation,
     )?;
     let sb_grid_offset = grid_offset + block_grid_bytes;
     let coarse_grid_offset = sb_grid_offset + superblock_grid_bytes;
@@ -1626,6 +1702,7 @@ fn reorder_bmp_field_blockwise(
         bs,
         &mut writer,
         rayon_pool.as_deref(),
+        cancellation,
     )?;
     let doc_maps_elapsed = doc_maps_start.elapsed();
 
@@ -1808,12 +1885,16 @@ pub(crate) fn reorder_bmp_field(
     total_vectors: u32,
     memory_budget: usize,
     bp_budget: crate::segment::BpBudget,
+    cancellation: Option<Arc<std::sync::atomic::AtomicBool>>,
     granularity: BpGranularity,
     scratch_path: PathBuf,
     mut writer: OffsetWriter,
     mut field_tocs: Vec<SparseFieldToc>,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
 ) -> Result<(OffsetWriter, Vec<SparseFieldToc>, bool)> {
+    if cancellation_requested(cancellation.as_deref()) {
+        return Err(crate::Error::IndexClosed);
+    }
     if !(1..=256).contains(&effective_block_size) {
         return Err(crate::Error::Internal(format!(
             "invalid BMP reorder block size {} (expected 1..=256)",
@@ -1924,6 +2005,7 @@ pub(crate) fn reorder_bmp_field(
             total_vectors,
             memory_budget,
             bp_budget,
+            cancellation.as_deref(),
             scratch_path,
             &source_pages,
             writer,
@@ -1971,6 +2053,7 @@ pub(crate) fn reorder_bmp_field(
             total_vectors,
             memory_budget,
             bp_budget,
+            cancellation.as_deref(),
             scratch_path,
             &source_pages,
             writer,
@@ -2102,6 +2185,7 @@ pub(crate) fn reorder_bmp_field(
                     effective_block_size,
                     20,
                     graph_budget,
+                    cancellation.as_deref(),
                     BpProgressLabel {
                         index: index_label,
                         field: field_name,
@@ -2128,6 +2212,10 @@ pub(crate) fn reorder_bmp_field(
             )
         }
     };
+
+    if cancellation_requested(cancellation.as_deref()) {
+        return Err(crate::Error::IndexClosed);
+    }
 
     let real_to_virtual: Vec<Vec<u32>> = vid_maps.into_iter().map(|(_, real)| real).collect();
 
@@ -2225,6 +2313,9 @@ pub(crate) fn reorder_bmp_field(
     let mut source_block_scans = 0u64;
     let mut window_start = 0usize;
     while window_start < new_num_blocks {
+        if cancellation_requested(cancellation.as_deref()) {
+            return Err(crate::Error::IndexClosed);
+        }
         let initial_end = window_start
             .saturating_add(max_parallel_window)
             .min(new_num_blocks);
@@ -2369,6 +2460,9 @@ pub(crate) fn reorder_bmp_field(
     let block_data_elapsed = rewrite_start.elapsed();
 
     // Sections D+E+H: block, superblock, and coarse-superblock grids.
+    if cancellation_requested(cancellation.as_deref()) {
+        return Err(crate::Error::IndexClosed);
+    }
     let grids_start = std::time::Instant::now();
     let grid_offset = writer.offset() - blob_start;
     let (packed_bytes, sb_bytes, _coarse_bytes) = write_reorder_grids(
@@ -2380,6 +2474,7 @@ pub(crate) fn reorder_bmp_field(
         grid_bits,
         rayon_pool.as_deref(),
         &mut writer,
+        cancellation.as_deref(),
     )?;
     let sb_grid_offset = grid_offset + packed_bytes;
     let coarse_grid_offset = sb_grid_offset + sb_bytes;
@@ -2389,6 +2484,9 @@ pub(crate) fn reorder_bmp_field(
     let grids_elapsed = grids_start.elapsed();
 
     // Sections F+G: doc_map [new_num_virtual_docs each]
+    if cancellation_requested(cancellation.as_deref()) {
+        return Err(crate::Error::IndexClosed);
+    }
     let doc_maps_start = std::time::Instant::now();
     let doc_map_offset = writer.offset() - blob_start;
 
@@ -2400,6 +2498,7 @@ pub(crate) fn reorder_bmp_field(
         new_num_virtual_docs,
         &mut writer,
         rayon_pool.as_deref(),
+        cancellation.as_deref(),
     )?;
     let doc_maps_elapsed = doc_maps_start.elapsed();
 
@@ -2458,12 +2557,12 @@ mod grid_run_prefix_tests {
         let missing = std::path::Path::new("missing");
         let output = std::path::Path::new("output");
 
-        super::clone_segment_file(&dir, missing, output, false)
+        super::clone_segment_file(&dir, missing, output, false, None)
             .await
             .unwrap();
         assert!(!dir.exists(output).await.unwrap());
 
-        let error = super::clone_segment_file(&dir, missing, output, true)
+        let error = super::clone_segment_file(&dir, missing, output, true, None)
             .await
             .unwrap_err();
         assert!(matches!(error, crate::Error::Corruption(_)));
@@ -2477,7 +2576,7 @@ mod grid_run_prefix_tests {
         let data = vec![0x5a; 4 * 1024 * 1024 + 17];
         dir.write(source, &data).await.unwrap();
 
-        super::clone_segment_file(&dir, source, output, true)
+        super::clone_segment_file(&dir, source, output, true, None)
             .await
             .unwrap();
 

--- a/hermes-core/src/segment/store.rs
+++ b/hermes-core/src/segment/store.rs
@@ -1301,8 +1301,17 @@ impl<'a, W: Write> StoreMerger<'a, W> {
         &mut self,
         data_slice: &FileHandle,
         blocks: &[RawStoreBlock],
+        cancellation: Option<&std::sync::atomic::AtomicBool>,
     ) -> io::Result<()> {
         for block in blocks {
+            if cancellation
+                .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "store merge cancelled",
+                ));
+            }
             // Read raw compressed block data
             let start = block.offset;
             let end = start.checked_add(block.length as u64).ok_or_else(|| {
@@ -1348,12 +1357,24 @@ impl<'a, W: Write> StoreMerger<'a, W> {
     /// directly because the decompressor needs the original dictionary.
     /// This method decompresses each block with the source dict, then
     /// recompresses without a dictionary so the merged output is self-contained.
-    pub async fn append_store_recompressing(&mut self, store: &AsyncStoreReader) -> io::Result<()> {
+    pub async fn append_store_recompressing(
+        &mut self,
+        store: &AsyncStoreReader,
+        cancellation: Option<&std::sync::atomic::AtomicBool>,
+    ) -> io::Result<()> {
         let dict = store.dict();
         let data_slice = store.data_slice();
         let blocks = store.block_index();
 
         for block in blocks {
+            if cancellation
+                .is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Relaxed))
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "store merge cancelled",
+                ));
+            }
             let start = block.offset;
             let end = start.checked_add(block.length as u64).ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "store block range overflow")

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -447,8 +447,12 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
         registry: Arc::clone(&registry),
     };
 
+    // One application-level signal coordinates tonic admission, optimizer
+    // admission, and index lifecycle cancellation.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
     // Spawn background optimizer
-    let _optimizer_handle = optimizer::spawn_optimizer(
+    let optimizer_handle = optimizer::spawn_optimizer(
         Arc::clone(&registry),
         optimizer::OptimizerConfig {
             threads: args.optimizer_threads,
@@ -460,6 +464,7 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
             unconverged_cooldown: Duration::from_secs(args.optimizer_unconverged_cooldown_secs),
             max_unconverged_passes: args.optimizer_max_unconverged_passes,
         },
+        shutdown_rx,
     );
 
     info!("Hermes server v{}", env!("CARGO_PKG_VERSION"));
@@ -511,7 +516,9 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
     const INDEX_MAX_DECODE: usize = 256 * 1024 * 1024; // 256 MB (batch indexing)
     const INDEX_MAX_ENCODE: usize = 64 * 1024 * 1024; // 64 MB (responses are medium)
 
-    Server::builder()
+    let signal_registry = Arc::clone(&registry);
+    let signal_shutdown = shutdown_tx.clone();
+    let serve_result = Server::builder()
         // Connection management
         .tcp_keepalive(Some(Duration::from_secs(60)))
         .http2_keepalive_interval(Some(Duration::from_secs(30)))
@@ -539,9 +546,30 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
                 .accept_compressed(CompressionEncoding::Zstd)
                 .send_compressed(CompressionEncoding::Zstd),
         )
-        .serve_with_shutdown(addr, shutdown_signal())
-        .await?;
+        .serve_with_shutdown(addr, async move {
+            shutdown_signal().await;
+            // Stop core lifecycle admission immediately; BP observes this
+            // cancellation while tonic drains requests.
+            signal_registry.begin_shutdown();
+            let _ = signal_shutdown.send(true);
+        })
+        .await;
 
+    // A transport failure also takes the complete application through the
+    // same ordered shutdown path.
+    registry.begin_shutdown();
+    let _ = shutdown_tx.send(true);
+
+    info!("[shutdown] gRPC server drained; waiting for background work");
+    let optimizer_result = match optimizer_handle {
+        Some(handle) => handle.await,
+        None => Ok(()),
+    };
+    let registry_result = registry.shutdown().await;
+
+    serve_result?;
+    optimizer_result?;
+    registry_result?;
     info!("Hermes server shut down gracefully");
     Ok(())
 }

--- a/hermes-server/src/optimizer.rs
+++ b/hermes-server/src/optimizer.rs
@@ -11,7 +11,8 @@ use std::time::{Duration, Instant};
 
 use hermes_core::segment::BpBudget;
 use log::{debug, info, warn};
-use tokio::sync::{Semaphore, TryAcquireError};
+use tokio::sync::{Semaphore, TryAcquireError, watch};
+use tokio::task::JoinSet;
 
 use crate::registry::IndexRegistry;
 
@@ -104,6 +105,7 @@ impl Drop for DeepeningPermit {
 pub fn spawn_optimizer(
     registry: Arc<IndexRegistry>,
     config: OptimizerConfig,
+    shutdown: watch::Receiver<bool>,
 ) -> Option<tokio::task::JoinHandle<()>> {
     if config.threads == 0 {
         return None;
@@ -120,7 +122,7 @@ pub fn spawn_optimizer(
     let semaphore = Arc::new(Semaphore::new(config.concurrent_passes.max(1)));
 
     Some(tokio::spawn(async move {
-        optimizer_loop(registry, semaphore, config).await;
+        optimizer_loop(registry, semaphore, config, shutdown).await;
     }))
 }
 
@@ -129,30 +131,68 @@ async fn optimizer_loop(
     registry: Arc<IndexRegistry>,
     semaphore: Arc<Semaphore>,
     config: OptimizerConfig,
+    mut shutdown: watch::Receiver<bool>,
 ) {
     // Initial delay: let the server finish startup before scanning.
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    tokio::select! {
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+        _ = shutdown.changed() => return,
+    }
 
     // A timed-out pass replaces its source with a new unconverged segment ID.
     // Gate that lineage globally and start its cooldown only when work ends.
     let deepening_gate = Arc::new(DeepeningGate::default());
     let mut next_index = 0usize;
+    let mut tasks = JoinSet::new();
 
-    loop {
-        if let Err(e) = scan_and_optimize(
+    'optimizer: loop {
+        let scan = scan_and_optimize(
             &registry,
             &semaphore,
             &config,
             &deepening_gate,
             &mut next_index,
-        )
-        .await
-        {
+            &mut tasks,
+        );
+        let scan_result = tokio::select! {
+            result = scan => result,
+            _ = shutdown.changed() => break 'optimizer,
+        };
+        if *shutdown.borrow() {
+            break;
+        }
+        if let Err(e) = scan_result {
             warn!("[optimizer] scan failed: {}", e);
         }
 
-        tokio::time::sleep(config.scan_interval).await;
+        while let Some(result) = tasks.try_join_next() {
+            if let Err(error) = result {
+                warn!("[optimizer] reorder task failed: {}", error);
+            }
+        }
+
+        let sleep = tokio::time::sleep(config.scan_interval);
+        tokio::pin!(sleep);
+        loop {
+            tokio::select! {
+                _ = &mut sleep => break,
+                _ = shutdown.changed() => break 'optimizer,
+                result = tasks.join_next(), if !tasks.is_empty() => {
+                    if let Some(Err(error)) = result {
+                        warn!("[optimizer] reorder task failed: {}", error);
+                    }
+                }
+            }
+        }
     }
+
+    semaphore.close();
+    while let Some(result) = tasks.join_next().await {
+        if let Err(error) = result {
+            warn!("[optimizer] reorder task failed during shutdown: {}", error);
+        }
+    }
+    info!("[optimizer] shut down");
 }
 
 /// One scan cycle: list indexes, find candidates, spawn reorder tasks.
@@ -166,6 +206,7 @@ async fn scan_and_optimize(
     config: &OptimizerConfig,
     deepening_gate: &Arc<DeepeningGate>,
     next_index: &mut usize,
+    tasks: &mut JoinSet<()>,
 ) -> Result<(), tonic::Status> {
     let mut index_names = registry.list_indexes().await?;
     // A busy first index used to consume every slot on every scan. Rotate the
@@ -325,7 +366,7 @@ async fn scan_and_optimize(
                 BpBudget::full()
             };
 
-            tokio::spawn(async move {
+            tasks.spawn(async move {
                 let _permit = permit;
                 // Starts cooldown when the task finishes, not when it was
                 // queued. Also releases the in-flight gate on panic unwind.
@@ -359,6 +400,12 @@ async fn scan_and_optimize(
                         debug!(
                             "[optimizer] segment {} in index '{}' skipped (in merge)",
                             sid, idx_name
+                        );
+                    }
+                    Err(hermes_core::Error::IndexClosed) => {
+                        debug!(
+                            "[optimizer] segment {} in index '{}' cancelled during shutdown",
+                            sid, idx_name,
                         );
                     }
                     Err(e) => {
@@ -400,5 +447,35 @@ mod tests {
             gate.try_acquire(Duration::ZERO).is_some(),
             "the gate should reopen after its cooldown"
         );
+    }
+
+    #[tokio::test]
+    async fn optimizer_supervisor_stops_on_application_shutdown() {
+        let registry = Arc::new(IndexRegistry::new(
+            std::env::temp_dir().join("hermes_optimizer_shutdown_test"),
+            hermes_core::IndexConfig::default(),
+        ));
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let handle = spawn_optimizer(
+            registry,
+            OptimizerConfig {
+                threads: 1,
+                concurrent_passes: 1,
+                scan_interval: Duration::from_secs(60),
+                large_segment_docs: 1_000_000,
+                time_budget: Duration::from_secs(60),
+                partial_min_partition_docs: 256,
+                unconverged_cooldown: Duration::from_secs(60),
+                max_unconverged_passes: 1,
+            },
+            shutdown_rx,
+        )
+        .expect("optimizer must be enabled");
+
+        shutdown_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("optimizer ignored shutdown")
+            .unwrap();
     }
 }

--- a/hermes-server/src/registry.rs
+++ b/hermes-server/src/registry.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 
 use parking_lot::RwLock;
@@ -90,6 +91,7 @@ pub struct IndexRegistry {
     open_locks: RwLock<HashMap<String, Weak<tokio::sync::Mutex<()>>>>,
     pub(crate) data_dir: PathBuf,
     config: IndexConfig,
+    shutting_down: AtomicBool,
 }
 
 impl IndexRegistry {
@@ -99,6 +101,62 @@ impl IndexRegistry {
             open_locks: RwLock::new(HashMap::new()),
             data_dir,
             config,
+            shutting_down: AtomicBool::new(false),
+        }
+    }
+
+    fn ensure_running(&self) -> Result<(), Status> {
+        if self.shutting_down.load(Ordering::Acquire) {
+            Err(Status::unavailable("Hermes server is shutting down"))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Close lifecycle admission immediately when process shutdown starts.
+    ///
+    /// This method is synchronous so the signal future can stop new work
+    /// before tonic finishes draining in-flight RPCs.
+    pub fn begin_shutdown(&self) {
+        if self.shutting_down.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        for handle in self.handles.read().values() {
+            handle.index.segment_manager().begin_shutdown();
+        }
+    }
+
+    /// Stop all index writers while Tokio is still alive, then drain every
+    /// merge, reorder, metadata transaction, and deferred cleanup.
+    pub async fn shutdown(&self) -> Result<(), Status> {
+        self.begin_shutdown();
+        let handles = std::mem::take(&mut *self.handles.write());
+        info!(
+            "[shutdown] stopping writers for {} open index(es)",
+            handles.len()
+        );
+        let mut managers = Vec::with_capacity(handles.len());
+        let mut first_error = None;
+
+        for (name, handle) in handles {
+            let manager = Arc::clone(handle.index.segment_manager());
+            if let Err(error) = handle.writer.write().await.shutdown().await
+                && first_error.is_none()
+            {
+                first_error = Some(crate::error::hermes_error_to_status(error));
+            }
+            drop(handle);
+            managers.push((name, manager));
+        }
+
+        for (name, manager) in managers {
+            manager.wait_for_shutdown().await;
+            info!("[shutdown] index '{}' drained", name);
+        }
+
+        match first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
         }
     }
 
@@ -154,6 +212,7 @@ impl IndexRegistry {
     /// Without this, two concurrent requests can both miss the cache and open the
     /// index twice (wasting ~30s loading segments redundantly).
     pub async fn get_or_open_index(&self, name: &str) -> Result<Arc<Index<MmapDirectory>>, Status> {
+        self.ensure_running()?;
         Self::validate_index_name(name)?;
 
         // Fast path: already cached
@@ -166,6 +225,7 @@ impl IndexRegistry {
 
         // Serialize open attempts for the same index name
         let _guard = lock.lock().await;
+        self.ensure_running()?;
 
         // Re-check cache after acquiring lock (another task may have opened it)
         if let Some(h) = self.handles.read().get(name) {
@@ -208,20 +268,40 @@ impl IndexRegistry {
 
         Self::precache_idf_files(&index);
 
-        self.handles.write().insert(
-            name.to_string(),
-            IndexHandle {
-                index: Arc::clone(&index),
-                writer,
-            },
-        );
-        Ok(index)
+        {
+            let mut handles = self.handles.write();
+            if !self.shutting_down.load(Ordering::Acquire) {
+                handles.insert(
+                    name.to_string(),
+                    IndexHandle {
+                        index: Arc::clone(&index),
+                        writer,
+                    },
+                );
+                return Ok(index);
+            }
+        }
+
+        let manager = Arc::clone(index.segment_manager());
+        manager.begin_shutdown();
+        writer
+            .write()
+            .await
+            .shutdown()
+            .await
+            .map_err(crate::error::hermes_error_to_status)?;
+        drop(writer);
+        drop(index);
+        manager.wait_for_shutdown().await;
+        Err(Status::unavailable("Hermes server is shutting down"))
     }
 
     /// Create a new index
     pub async fn create_index(&self, name: &str, schema: Schema) -> Result<(), Status> {
+        self.ensure_running()?;
         Self::validate_index_name(name)?;
         let _open_guard = self.open_lock(name).lock_owned().await;
+        self.ensure_running()?;
         let index_path = self.data_dir.join(name);
 
         if index_path.exists() {
@@ -248,14 +328,32 @@ impl IndexRegistry {
 
         Self::precache_idf_files(&index);
 
-        self.handles.write().insert(
-            name.to_string(),
-            IndexHandle {
-                index: Arc::clone(&index),
-                writer,
-            },
-        );
-        Ok(())
+        {
+            let mut handles = self.handles.write();
+            if !self.shutting_down.load(Ordering::Acquire) {
+                handles.insert(
+                    name.to_string(),
+                    IndexHandle {
+                        index: Arc::clone(&index),
+                        writer,
+                    },
+                );
+                return Ok(());
+            }
+        }
+
+        let manager = Arc::clone(index.segment_manager());
+        manager.begin_shutdown();
+        writer
+            .write()
+            .await
+            .shutdown()
+            .await
+            .map_err(crate::error::hermes_error_to_status)?;
+        drop(writer);
+        drop(index);
+        manager.wait_for_shutdown().await;
+        Err(Status::unavailable("Hermes server is shutting down"))
     }
 
     /// Get writer for an index (opens index if needed)
@@ -263,6 +361,7 @@ impl IndexRegistry {
         &self,
         name: &str,
     ) -> Result<Arc<tokio::sync::RwLock<IndexWriter<MmapDirectory>>>, Status> {
+        self.ensure_running()?;
         if let Some(h) = self.handles.read().get(name) {
             return Ok(Arc::clone(&h.writer));
         }
@@ -316,6 +415,7 @@ impl IndexRegistry {
     /// open/create. The marker is installed before eviction and the returned
     /// lease keeps the lock until filesystem removal completes.
     pub async fn begin_delete(&self, name: &str) -> Result<IndexDeleteLease, Status> {
+        self.ensure_running()?;
         Self::validate_index_name(name)?;
         let open_guard = self.open_lock(name).lock_owned().await;
         let index_path = self.data_dir.join(name);
@@ -485,6 +585,7 @@ impl IndexRegistry {
     /// Filesystem I/O is done inside `spawn_blocking` to avoid stalling
     /// the tokio worker threads under heavy load.
     pub async fn list_indexes(&self) -> Result<Vec<String>, Status> {
+        self.ensure_running()?;
         let data_dir = self.data_dir.clone();
         tokio::task::spawn_blocking(move || {
             let mut names: Vec<String> = std::fs::read_dir(&data_dir)
@@ -553,6 +654,56 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(!root.join("held").exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn process_shutdown_drains_indexes_and_rejects_new_work() {
+        let root = std::env::temp_dir().join(format!(
+            "hermes_registry_shutdown_{}",
+            SegmentId::new().to_hex()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let registry = IndexRegistry::new(
+            root.clone(),
+            IndexConfig {
+                num_indexing_threads: 1,
+                ..Default::default()
+            },
+        );
+        registry
+            .create_index("open", hermes_core::SchemaBuilder::default().build())
+            .await
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), registry.shutdown())
+            .await
+            .expect("registry shutdown timed out")
+            .unwrap();
+
+        assert_eq!(
+            registry
+                .get_or_open_index("open")
+                .await
+                .err()
+                .expect("open must be rejected")
+                .code(),
+            tonic::Code::Unavailable,
+        );
+        assert_eq!(
+            registry
+                .create_index("new", hermes_core::SchemaBuilder::default().build())
+                .await
+                .unwrap_err()
+                .code(),
+            tonic::Code::Unavailable,
+        );
+        assert_eq!(
+            registry.list_indexes().await.unwrap_err().code(),
+            tonic::Code::Unavailable,
+        );
+
+        drop(registry);
         std::fs::remove_dir_all(root).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- coordinate SIGTERM across gRPC, optimizer, registry, and index writers
- cooperatively cancel long-running merge, reorder, ANN, BMP, and graph-bisection work
- wait for every background worker before reporting graceful shutdown
- add regression coverage for shutdown ordering and cancellation

## Validation

- cargo test -p hermes-core
- cargo test -p hermes-server
- cargo clippy -p hermes-core -p hermes-server --all-targets -- -D warnings
- cargo check -p hermes-core --no-default-features
- real SIGTERM smoke test