### PR TITLE
perf(core): level-synchronize BP and accelerate compaction

### DIFF
--- a/docs/cold-io.md
+++ b/docs/cold-io.md
@@ -23,10 +23,14 @@ special handling for the final unaligned tail, and silently degrades to
 buffered IO on some filesystems. The same eviction guarantee is achieved
 with the write-behind discipline used by rsync/borg/RocksDB:
 
-- **Linux**: every 64 MB window, `sync_file_range(WAIT_BEFORE|WRITE|WAIT_AFTER)`
-  forces the window to storage, then `posix_fadvise(POSIX_FADV_DONTNEED)`
-  drops its (now clean) pages. Steady-state page-cache footprint of a merge
-  write is one window instead of the whole segment.
+- **Linux**: each completed 64 MB window starts asynchronous writeback with
+  `sync_file_range(WRITE)`. One window later, `posix_fadvise(DONTNEED)` drops
+  the preceding clean pages; `finish()` fsyncs and drops the tail. Steady-state
+  page-cache footprint is bounded instead of growing with the segment.
+- **Linux byte-identical ranges**: BMP block payloads and ordinal maps use
+  `copy_file_range`, so they do not cross a userspace buffer or fault the
+  source mmap merely to copy it. Filesystems that do not support the syscall
+  fall back to the portable mmap + streaming-write path before emitting bytes.
 - **macOS**: `fcntl(fd, F_NOCACHE, 1)` at creation — the kernel bypasses the
   buffer cache for this file descriptor.
 - Other platforms / non-fs directories: plain buffered writer (loudly

--- a/hermes-core/src/directories/cold_io.rs
+++ b/hermes-core/src/directories/cold_io.rs
@@ -193,6 +193,23 @@ impl StreamingWriter for ColdStreamingWriter {
     fn bytes_written(&self) -> u64 {
         self.written + self.buf.len() as u64
     }
+
+    fn copy_from_file_range(
+        &mut self,
+        source: &std::fs::File,
+        source_offset: &mut u64,
+        len: usize,
+    ) -> io::Result<usize> {
+        self.flush_buf()?;
+        let copied =
+            super::directory::copy_file_range_once(source, source_offset, &self.file, len)?;
+        self.written = self
+            .written
+            .checked_add(copied as u64)
+            .ok_or_else(|| io::Error::other("cold-writer byte count overflow"))?;
+        self.maybe_drop(false);
+        Ok(copied)
+    }
 }
 
 #[cfg(test)]
@@ -234,5 +251,41 @@ mod tests {
         let got = std::fs::read(&path).unwrap();
         assert_eq!(got.len(), expected.len());
         assert_eq!(got, expected, "cold writer corrupted the byte stream");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_cold_streaming_writer_kernel_range_copy_is_exact() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source_path = tmp.path().join("source.bin");
+        let output_path = tmp.path().join("output.bin");
+        let source_bytes: Vec<u8> = (0..256u16)
+            .cycle()
+            .take(2 * 1024 * 1024 + 37)
+            .map(|value| value as u8)
+            .collect();
+        std::fs::write(&source_path, &source_bytes).unwrap();
+
+        let source = std::fs::File::open(&source_path).unwrap();
+        let output = std::fs::File::create(&output_path).unwrap();
+        let mut writer: Box<dyn StreamingWriter> = Box::new(ColdStreamingWriter::new(
+            output,
+            std::sync::Arc::from("test"),
+        ));
+        writer.write_all(b"prefix").unwrap();
+        let mut source_offset = 13u64;
+        let length = source_bytes.len() - 31;
+        let copied = writer
+            .copy_from_file_range(&source, &mut source_offset, length)
+            .unwrap();
+        assert_eq!(copied, length);
+        assert_eq!(source_offset, 13 + length as u64);
+        writer.write_all(b"suffix").unwrap();
+        writer.finish().unwrap();
+
+        let mut expected = b"prefix".to_vec();
+        expected.extend_from_slice(&source_bytes[13..13 + length]);
+        expected.extend_from_slice(b"suffix");
+        assert_eq!(std::fs::read(output_path).unwrap(), expected);
     }
 }

--- a/hermes-core/src/directories/directory.rs
+++ b/hermes-core/src/directories/directory.rs
@@ -580,6 +580,25 @@ pub trait StreamingWriter: io::Write + Send {
 
     /// Bytes written so far.
     fn bytes_written(&self) -> u64;
+
+    /// Copy one local-file range at the current output position without
+    /// routing bytes through a userspace buffer.
+    ///
+    /// Filesystem writers implement this with Linux `copy_file_range`.
+    /// Other backends return `Unsupported`, allowing merge code to fall back
+    /// to its portable mmap/read + write path before any bytes are copied.
+    #[cfg(feature = "native")]
+    fn copy_from_file_range(
+        &mut self,
+        _source: &std::fs::File,
+        _source_offset: &mut u64,
+        _len: usize,
+    ) -> io::Result<usize> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "streaming writer does not support kernel-assisted range copies",
+        ))
+    }
 }
 
 /// StreamingWriter backed by Vec<u8>, finalized via DirectoryWriter::write.
@@ -660,6 +679,73 @@ impl StreamingWriter for FileStreamingWriter {
 
     fn bytes_written(&self) -> u64 {
         self.written
+    }
+
+    fn copy_from_file_range(
+        &mut self,
+        source: &std::fs::File,
+        source_offset: &mut u64,
+        len: usize,
+    ) -> io::Result<usize> {
+        io::Write::flush(&mut self.file)?;
+        let copied = copy_file_range_once(source, source_offset, self.file.get_ref(), len)?;
+        self.written = self
+            .written
+            .checked_add(copied as u64)
+            .ok_or_else(|| io::Error::other("streaming-writer byte count overflow"))?;
+        Ok(copied)
+    }
+}
+
+#[cfg(feature = "native")]
+pub(crate) fn copy_file_range_once(
+    source: &std::fs::File,
+    source_offset: &mut u64,
+    destination: &std::fs::File,
+    len: usize,
+) -> io::Result<usize> {
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::fd::AsRawFd;
+
+        let mut offset = libc::loff_t::try_from(*source_offset).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "source offset exceeds i64")
+        })?;
+        let copied = unsafe {
+            libc::copy_file_range(
+                source.as_raw_fd(),
+                &mut offset,
+                destination.as_raw_fd(),
+                std::ptr::null_mut(),
+                len,
+                0,
+            )
+        };
+        if copied < 0 {
+            let error = io::Error::last_os_error();
+            let unsupported = error.raw_os_error().is_some_and(|code| {
+                code == libc::ENOSYS
+                    || code == libc::EXDEV
+                    || code == libc::EOPNOTSUPP
+                    || code == libc::EINVAL
+            });
+            return if unsupported {
+                Err(io::Error::new(io::ErrorKind::Unsupported, error))
+            } else {
+                Err(error)
+            };
+        }
+        *source_offset = u64::try_from(offset)
+            .map_err(|_| io::Error::other("copy_file_range returned a negative source offset"))?;
+        Ok(copied as usize)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (source, source_offset, destination, len);
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "kernel-assisted range copies are only available on Linux",
+        ))
     }
 }
 

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -1583,6 +1583,90 @@ async fn test_bmp_merge_with_reorder_on_merge() {
     );
 }
 
+/// A severe segment backlog must compact before running merge-time BP.
+/// Otherwise every merge slot can hold dozens of source segments for the
+/// duration of a serialized BP pass, allowing instant indexing to grow the
+/// searchable topology without bound.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_bmp_severe_backlog_defers_reorder_until_after_compaction() {
+    use crate::directories::MmapDirectory;
+
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    let sparse = sb.add_sparse_vector_field_with_config("sparse", true, true, bmp_config());
+    sb.set_reorder(sparse, true);
+    sb.set_reorder_on_merge(true);
+    let schema = sb.build();
+    let temp = tempfile::tempdir().unwrap();
+    let dir = MmapDirectory::new(temp.path());
+
+    // Hold the process-wide merge slot while publishing the burst so the
+    // scheduler observes the complete six-segment topology at once.
+    let global_merge_permits = std::sync::Arc::new(tokio::sync::Semaphore::new(1));
+    let merge_blocker = std::sync::Arc::clone(&global_merge_permits)
+        .acquire_owned()
+        .await
+        .unwrap();
+    let policy = crate::merge::TieredMergePolicy {
+        segments_per_tier: 2,
+        max_merge_at_once: 6,
+        tier_floor: 1000,
+        floor_segment_docs: 1000,
+        budget_trigger: true,
+        scored_selection: true,
+        ..Default::default()
+    };
+    let config = IndexConfig {
+        num_indexing_threads: 1,
+        max_concurrent_merges: 1,
+        background_merge_permits: global_merge_permits,
+        merge_policy: Box::new(policy),
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config)
+        .await
+        .unwrap();
+
+    for segment in 0..6 {
+        for doc_id in 0..4 {
+            let mut doc = Document::new();
+            doc.add_text(title, format!("segment-{segment}-doc-{doc_id}"));
+            doc.add_sparse_vector(
+                sparse,
+                vec![((segment * 10 + doc_id) as u32, 1.0), (9999, 0.1)],
+            );
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+    assert_eq!(writer.segment_manager.get_segment_ids().await.len(), 6);
+
+    drop(merge_blocker);
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            // A capacity wakeup may race this explicit trigger. Repeating is
+            // harmless and avoids making the test depend on task scheduling.
+            writer.maybe_merge().await;
+            writer.wait_for_all_merges().await;
+            if writer.segment_manager.get_segment_ids().await.len() == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("severe-backlog compaction did not finish");
+
+    let metadata = crate::index::IndexMetadata::load(&dir).await.unwrap();
+    assert_eq!(metadata.segment_metas.len(), 1);
+    let output = metadata.segment_metas.values().next().unwrap();
+    assert!(
+        !output.reordered,
+        "severe backlog should block-copy first and leave one final optimizer pass"
+    );
+    assert_eq!(output.num_docs, 24);
+}
+
 /// Per-field reorder gate: a BMP field WITHOUT the `reorder` schema attribute
 /// must come out of writer.reorder() byte-identical (insertion order
 /// preserved), while a field WITH the attribute gets BP-reordered. Both must

--- a/hermes-core/src/merge/mod.rs
+++ b/hermes-core/src/merge/mod.rs
@@ -36,6 +36,17 @@ pub trait MergePolicy: Send + Sync + Debug {
     /// Multiple candidates can run concurrently as long as they don't share segments.
     fn find_merges(&self, segments: &[SegmentInfo]) -> Vec<MergeCandidate>;
 
+    /// Whether segment topology is far enough over its target that compaction
+    /// latency should take precedence over optional merge-time optimization.
+    ///
+    /// The segment manager uses this signal only when `reorder_on_merge` is
+    /// enabled: urgent merges block-copy BMP data and leave the merged output
+    /// for the standalone optimizer. This avoids many long BP passes holding
+    /// every merge slot while an ingestion burst keeps publishing segments.
+    fn has_severe_backlog(&self, _segments: &[SegmentInfo]) -> bool {
+        false
+    }
+
     /// Clone the policy into a boxed trait object
     fn clone_box(&self) -> Box<dyn MergePolicy>;
 
@@ -238,6 +249,15 @@ impl TieredMergePolicy {
         num_tiers * self.segments_per_tier
     }
 
+    fn eligible_segments<'a>(&self, segments: &'a [SegmentInfo]) -> Vec<&'a SegmentInfo> {
+        let effective_max = self.effective_max_docs();
+        let oversized_limit = (effective_max as f64 * self.oversized_threshold) as u64;
+        segments
+            .iter()
+            .filter(|segment| (segment.num_docs as u64) <= oversized_limit || oversized_limit == 0)
+            .collect()
+    }
+
     /// Score a merge group. Lower score = better (more balanced) merge.
     /// Uses Lucene-style skew scoring: `skew * size_factor`.
     /// - skew = largest_floored / total_floored (1/N for perfectly balanced, 1.0 for singleton)
@@ -398,12 +418,7 @@ impl MergePolicy for TieredMergePolicy {
         }
 
         // Phase 1: Filter oversized segments
-        let effective_max = self.effective_max_docs();
-        let oversized_limit = (effective_max as f64 * self.oversized_threshold) as u64;
-        let eligible: Vec<&SegmentInfo> = segments
-            .iter()
-            .filter(|s| (s.num_docs as u64) <= oversized_limit || oversized_limit == 0)
-            .collect();
+        let eligible = self.eligible_segments(segments);
 
         if eligible.len() < 2 {
             return Vec::new();
@@ -428,6 +443,22 @@ impl MergePolicy for TieredMergePolicy {
         } else {
             self.find_merges_greedy(&sorted)
         }
+    }
+
+    fn has_severe_backlog(&self, segments: &[SegmentInfo]) -> bool {
+        if !self.budget_trigger {
+            return false;
+        }
+        let eligible = self.eligible_segments(segments);
+        if eligible.len() < 2 {
+            return false;
+        }
+        let total_docs: u64 = segments
+            .iter()
+            .map(|segment| u64::from(segment.num_docs))
+            .sum();
+        let ideal = self.compute_ideal_segment_count(total_docs);
+        eligible.len() > ideal.saturating_mul(2)
     }
 
     fn clone_box(&self) -> Box<dyn MergePolicy> {
@@ -829,6 +860,37 @@ mod tests {
 
         let candidates = policy.find_merges(&segments);
         assert!(!candidates.is_empty(), "should merge when over budget");
+    }
+
+    #[test]
+    fn test_severe_backlog_requires_more_than_twice_the_budget() {
+        let policy = TieredMergePolicy {
+            segments_per_tier: 3,
+            tier_factor: 10.0,
+            tier_floor: 1000,
+            floor_segment_docs: 1000,
+            budget_trigger: true,
+            ..Default::default()
+        };
+
+        // Every segment is at the floor, so 3 segments is the ideal budget.
+        // Ordinary pressure still uses reorder-on-merge.
+        let six: Vec<_> = (0..6)
+            .map(|i| SegmentInfo {
+                id: format!("seg_{i}"),
+                num_docs: 1000,
+            })
+            .collect();
+        assert!(!policy.has_severe_backlog(&six));
+
+        // Once the eligible population exceeds 2x budget, topology reduction
+        // becomes urgent and merge-time BP should be deferred.
+        let mut seven = six;
+        seven.push(SegmentInfo {
+            id: "seg_6".into(),
+            num_docs: 1000,
+        });
+        assert!(policy.has_severe_backlog(&seven));
     }
 
     #[test]

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -1684,21 +1684,30 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             let quarantined = self.quarantined_segments.lock().clone();
             let active_ids = self.active_operations.snapshot();
 
-            // Exclude segments owned by another operation, pending retirement,
-            // or quarantined after a persistent open/validation failure.
-            let segments: Vec<SegmentInfo> = st
+            // Backlog pressure is based on every metadata-live segment, not
+            // only currently available inputs. Otherwise a wave of in-flight
+            // merges hides most of the topology and makes later candidates
+            // look healthy while the original backlog still exists.
+            let live_segments: Vec<SegmentInfo> = st
                 .metadata
                 .segment_metas
                 .iter()
                 .filter(|(id, _)| {
-                    !self.tracker.is_pending_deletion(id)
-                        && !active_ids.contains(*id)
-                        && !quarantined.contains(*id)
+                    !self.tracker.is_pending_deletion(id) && !quarantined.contains(*id)
                 })
                 .map(|(id, info)| SegmentInfo {
                     id: id.clone(),
                     num_docs: info.num_docs,
                 })
+                .collect();
+            let severe_backlog = st.merge_policy.has_severe_backlog(&live_segments);
+
+            // Exclude segments owned by another operation. Pending retirement
+            // and quarantined segments were already removed above.
+            let segments: Vec<SegmentInfo> = live_segments
+                .iter()
+                .filter(|segment| !active_ids.contains(&segment.id))
+                .cloned()
                 .collect();
 
             log::debug!("[maybe_merge] {} eligible segments", segments.len());
@@ -1731,11 +1740,25 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 if handles.len() >= slots_available {
                     break;
                 }
-                if let Some(h) = self.spawn_merge(c.segment_ids) {
+                // Under severe topology pressure, retire segments first. BP
+                // remains optional for correctness and the block-copy output
+                // is explicitly marked unreordered, so the optimizer performs
+                // one pass after the compaction wave instead of every merge
+                // task serializing behind the whole-pass gate.
+                let reorder_bmp = self.reorder_on_merge && !severe_backlog;
+                if let Some(h) = self.spawn_merge(c.segment_ids, reorder_bmp) {
                     handles.push(h);
                 }
             }
             if !handles.is_empty() {
+                if severe_backlog && self.reorder_on_merge {
+                    log::info!(
+                        "[maybe_merge] severe backlog: {} live segments; started {} fast \
+                         block-copy merge(s), deferring BP to the optimizer",
+                        live_segments.len(),
+                        handles.len(),
+                    );
+                }
                 // Publish handles before releasing `state`. A force merge
                 // raises its admission barrier under the same lock, then
                 // drains this list, so no spawned merge can fall into the
@@ -1753,7 +1776,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     ///
     /// On completion, the task auto-triggers `maybe_merge` to evaluate cascading merges.
     /// Returns the JoinHandle if the merge was spawned, None if it was skipped.
-    fn spawn_merge(self: &Arc<Self>, segment_ids_to_merge: Vec<String>) -> Option<JoinHandle<()>> {
+    fn spawn_merge(
+        self: &Arc<Self>,
+        segment_ids_to_merge: Vec<String>,
+        reorder_bmp: bool,
+    ) -> Option<JoinHandle<()>> {
         if self.force_merge_active.load(Ordering::Acquire) > 0 {
             log::debug!("[spawn_merge] skipped: explicit force merge has priority");
             return None;
@@ -1798,7 +1825,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 .merge_and_replace_registered(
                     &ids,
                     output_id,
-                    sm.reorder_on_merge,
+                    reorder_bmp,
                     ReorderPriority::AutomaticMerge,
                 )
                 .await;
@@ -2406,6 +2433,18 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
         // Wait for all in-flight background merges (including cascading)
         // before starting forced merges to avoid try_register conflicts.
+        let background_merges = self
+            .merge_handles
+            .lock()
+            .iter()
+            .filter(|handle| !handle.is_finished())
+            .count();
+        if background_merges > 0 {
+            log::info!(
+                "[force_merge] waiting for {} in-flight background merge(s) before planning",
+                background_merges,
+            );
+        }
         let drain_start = std::time::Instant::now();
         self.wait_for_all_merges().await;
         if drain_start.elapsed() >= std::time::Duration::from_secs(1) {

--- a/hermes-core/src/segment/bmp_grid.rs
+++ b/hermes-core/src/segment/bmp_grid.rs
@@ -13,6 +13,7 @@
 //! without walking earlier payload. All-zero groups have width zero and no
 //! payload. Row offsets are a small, separately pinnable `u64` table.
 
+#[cfg(any(feature = "native", feature = "wasm", test))]
 use std::io::Write;
 #[cfg(feature = "native")]
 use std::ops::Range;
@@ -52,6 +53,7 @@ pub(crate) fn block_grid_scale(grid_bits: u8) -> u32 {
 }
 
 /// Ceiling-quantize an exact u8 maximum without underestimating it.
+#[cfg(any(feature = "native", feature = "wasm", test))]
 #[inline]
 pub(crate) fn quantize_block_maximum(value: u8, grid_bits: u8) -> u8 {
     if value == 0 {
@@ -103,6 +105,7 @@ impl CompressedGridLayout {
             + usize::from(remainder != 0) * (std::mem::size_of::<u32>() + selector_bytes(remainder))
     }
 
+    #[cfg(any(feature = "native", feature = "wasm", test))]
     pub(crate) fn row_bytes(self, widths: &[u8]) -> crate::Result<u64> {
         if widths.len() != self.groups {
             return Err(crate::Error::Internal(format!(
@@ -129,6 +132,7 @@ impl CompressedGridLayout {
     }
 
     /// Write the row-offset table. Offsets are relative to the first row byte.
+    #[cfg(any(feature = "native", feature = "wasm", test))]
     pub(crate) fn write_row_offsets(
         self,
         row_sizes: &[u64],
@@ -150,6 +154,7 @@ impl CompressedGridLayout {
     }
 
     /// Write the fixed-size metadata header for one row.
+    #[cfg(any(feature = "native", feature = "wasm", test))]
     pub(crate) fn write_row_header(
         self,
         widths: &[u8],
@@ -1313,6 +1318,7 @@ impl CompressedGrid {
 }
 
 #[inline]
+#[cfg(any(feature = "native", feature = "wasm", test))]
 pub(crate) fn bit_width(value: u8) -> u8 {
     (u8::BITS - value.leading_zeros()) as u8
 }
@@ -1321,6 +1327,7 @@ pub(crate) fn bit_width(value: u8) -> u8 {
 ///
 /// Callers zero-pad the unused tail of the last logical group. The returned
 /// payload always occupies `width * 32` bytes.
+#[cfg(any(feature = "native", feature = "wasm", test))]
 pub(crate) fn pack_group(
     values: &[u8; GRID_GROUP_CELLS],
     width: u8,

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -1,10 +1,13 @@
-//! Recursive Graph Bisection (BP) for BMP document ordering.
+//! Level-synchronized Graph Bisection (BP) for BMP document ordering.
 //!
 //! Based on Dhulipala et al. (KDD 2016) and Mackenzie et al. — the same
 //! algorithm used in Lucene and PISA for document reordering.
 //!
 //! Directly optimizes log-gap cost: docs sharing dimensions end up in the
 //! same BMP blocks, producing tight upper bounds and effective pruning.
+//!
+//! Scheduling follows Mackenzie et al.'s level-synchronized iterative variant:
+//! all partitions at one depth finish before the next depth begins.
 //!
 //! Memory is budgeted: CSR terms plus roughly 32 bytes/document of graph
 //! scratch, with lazily initialized direct-index term-degree arrays.
@@ -1079,7 +1082,11 @@ fn gain_order_key(gain: f32) -> u32 {
 /// Find the gain key of the last entity admitted to the left half and the
 /// number of strictly lower keys. Four byte-histogram passes replace the old
 /// serial `select_nth_unstable_by` over an 8-byte index per entity.
-fn select_gain_threshold(gains: &[f32], left_count: usize) -> (u32, usize) {
+fn select_gain_threshold(
+    gains: &[f32],
+    left_count: usize,
+    allow_inner_parallelism: bool,
+) -> (u32, usize) {
     debug_assert!(left_count > 0 && left_count <= gains.len());
     let mut rank_within_prefix = left_count - 1;
     let mut strictly_lower = 0usize;
@@ -1090,7 +1097,7 @@ fn select_gain_threshold(gains: &[f32], left_count: usize) -> (u32, usize) {
         let histogram = {
             #[cfg(feature = "native")]
             {
-                if gains.len() >= PARALLEL_BP_MIN_ENTITIES {
+                if allow_inner_parallelism && gains.len() >= PARALLEL_BP_MIN_ENTITIES {
                     gains
                         .par_iter()
                         .fold(
@@ -1206,6 +1213,7 @@ fn select_left(key: u32, threshold_key: u32, equal_seen: &mut usize, ties_left: 
 /// Small partitions retain the old unstable selector in their preallocated
 /// rank slice: it is faster than four radix scans, and its within-half
 /// permutation supplies the graph algorithm's established symmetry breaking.
+#[allow(clippy::too_many_arguments)]
 fn partition_by_gain(
     docs: &[u32],
     gains: &[f32],
@@ -1214,13 +1222,18 @@ fn partition_by_gain(
     movement_workspaces: &mut [TermDegrees],
     output: &mut [u32],
     ranked_scratch: &mut [usize],
+    allow_inner_parallelism: bool,
 ) -> PartitionOutcome {
     #[cfg(not(feature = "native"))]
     let _ = (fwd, &movement_workspaces);
 
     #[cfg(feature = "native")]
-    if !movement_workspaces.is_empty() && docs.len() >= PARALLEL_BP_MIN_ENTITIES {
-        let (threshold_key, strictly_lower) = select_gain_threshold(gains, mid);
+    if allow_inner_parallelism
+        && !movement_workspaces.is_empty()
+        && docs.len() >= PARALLEL_BP_MIN_ENTITIES
+    {
+        let (threshold_key, strictly_lower) =
+            select_gain_threshold(gains, mid, allow_inner_parallelism);
         let ties_left = mid - strictly_lower;
 
         // `degrees` remains live while these deltas are built. Reserving one
@@ -1355,7 +1368,8 @@ fn partition_by_gain(
         };
     }
 
-    let (threshold_key, strictly_lower) = select_gain_threshold(gains, mid);
+    let (threshold_key, strictly_lower) =
+        select_gain_threshold(gains, mid, allow_inner_parallelism);
     let ties_left = mid - strictly_lower;
     let mut equal_seen = 0usize;
     let mut left_cursor = 0usize;
@@ -1488,12 +1502,14 @@ impl<'a> BpProgress<'a> {
         total_entities: usize,
         total_postings: u64,
         expected_depth: usize,
+        degree_lanes: usize,
     ) -> Self {
         log::info!(
-            "[reorder][bp] started: index={} field={} entity_kind={} entities={} postings={} expected_depth={} objective_stall_threshold={:.1e}x{} min_objective_iterations={}",
+            "[reorder][bp] started: index={} field={} entity_kind={} scheduler=level_synchronized degree_lanes={} entities={} postings={} expected_depth={} objective_stall_threshold={:.1e}x{} min_objective_iterations={}",
             label.index,
             label.field,
             label.entity_kind,
+            degree_lanes,
             total_entities,
             total_postings,
             expected_depth,
@@ -1717,7 +1733,7 @@ struct BpProgress<'a>(std::marker::PhantomData<&'a ()>);
 
 #[cfg(not(feature = "native"))]
 impl BpProgress<'_> {
-    fn new(_: BpProgressLabel<'_>, _: usize, _: u64, _: usize) -> Self {
+    fn new(_: BpProgressLabel<'_>, _: usize, _: u64, _: usize, _: usize) -> Self {
         Self(std::marker::PhantomData)
     }
     fn partition_started(&self, _: usize) {}
@@ -1727,7 +1743,7 @@ impl BpProgress<'_> {
     fn finish(&self, _: bool, _: bool, _: bool, _: bool) {}
 }
 
-/// Recursive graph bisection. Returns `(perm, converged)` where
+/// Level-synchronized graph bisection. Returns `(perm, converged)` where
 /// `perm[new_pos] = old_index`. Convergence is false when the wall-clock or
 /// memory budget prevents the requested work from finishing; a configured
 /// depth cap is a chosen target and reports converged.
@@ -1770,7 +1786,12 @@ pub(crate) fn graph_bisection_with_progress(
     let effective_min_partition = budget
         .min_partition_docs
         .unwrap_or(0)
-        .max(min_partition_size);
+        .max(min_partition_size)
+        // A singleton cannot be bisected. The public callers use a positive
+        // BMP block size, but enforcing the structural minimum here also
+        // prevents an accidental zero configuration from walking empty tree
+        // levels until the partition counter overflows.
+        .max(1);
 
     let mut docs: Vec<u32> = (0..n as u32).collect();
     let depth = if effective_min_partition > 0 {
@@ -1780,8 +1801,12 @@ pub(crate) fn graph_bisection_with_progress(
     } else {
         0
     };
+    #[cfg(feature = "native")]
+    let degree_lanes = fwd.parallel_bisect_lanes.max(1);
+    #[cfg(not(feature = "native"))]
+    let degree_lanes = 1usize;
     let log_table = build_log_table(4096);
-    let progress = BpProgress::new(progress_label, n, fwd.total_postings(), depth);
+    let progress = BpProgress::new(progress_label, n, fwd.total_postings(), depth, degree_lanes);
 
     log::debug!(
         "BP graph_bisection: n={}, min_partition={}, max_iters={}, depth=~{}, time_budget={:?}",
@@ -1829,26 +1854,21 @@ pub(crate) fn graph_bisection_with_progress(
     if immediately_exhausted || initially_cancelled {
         exhausted.store(true, std::sync::atomic::Ordering::Relaxed);
     } else if n > effective_min_partition {
-        // Entity scratch is allocated once for the pass and carved into
-        // disjoint slices down the recursion tree. Degree lanes are likewise
-        // allocated exactly once from the memory-budgeted lane count.
+        // Entity scratch and vocabulary-sized degree lanes are allocated
+        // exactly once. At each depth, workers dynamically claim disjoint
+        // partitions and reuse their lane for the whole level.
         let mut gains = vec![0.0f32; n];
         let mut partitioned = vec![0u32; n];
         let mut ranked = vec![0usize; n];
-        #[cfg(feature = "native")]
-        let degree_lanes = fwd.parallel_bisect_lanes.max(1);
-        #[cfg(not(feature = "native"))]
-        let degree_lanes = 1usize;
         let mut degree_workspaces: Vec<TermDegrees> = (0..degree_lanes)
             .map(|_| TermDegrees::new(fwd.num_terms))
             .collect();
-        bisect(
+        bisect_level_synchronized(
             &mut docs,
             &mut gains,
             &mut partitioned,
             &mut ranked,
             &mut degree_workspaces,
-            0,
             &context,
         );
     }
@@ -1871,14 +1891,11 @@ pub(crate) fn graph_bisection_with_progress(
     (docs, converged)
 }
 
-/// Recursive bisection of a document slice.
+/// Context shared by all partitions in a level-synchronized BP pass.
 ///
 /// Uses flat `Vec<u32>` degree arrays indexed by compact term_id for cache-friendly
 /// O(1) lookups (vs FxHashMap which has poor cache locality at scale).
 ///
-/// Gain computation is parallelized via rayon for large partitions (n > 4096).
-/// Adaptive iteration count reduces work at top levels where coarse splits
-/// converge faster and dominate total runtime.
 struct BisectContext<'a> {
     fwd: &'a ForwardIndex,
     min_partition_size: usize,
@@ -1893,14 +1910,290 @@ struct BisectContext<'a> {
     progress: &'a BpProgress<'a>,
 }
 
+/// Return the range of partition `partition_id` at a fixed recursion `level`.
+///
+/// Replaying the path bits produces exactly the same floor-left/ceil-right
+/// boundaries as recursive `split_at_mut(len / 2)`, including for non-power
+/// of-two collection sizes.
+fn partition_range(total: usize, level: usize, partition_id: usize) -> std::ops::Range<usize> {
+    debug_assert!(level < usize::BITS as usize);
+    debug_assert!(partition_id < (1usize << level));
+    let mut start = 0usize;
+    let mut len = total;
+    for bit in (0..level).rev() {
+        let left_len = len / 2;
+        if partition_id & (1usize << bit) == 0 {
+            len = left_len;
+        } else {
+            start += left_len;
+            len -= left_len;
+        }
+    }
+    start..start + len
+}
+
+/// Collect all active partitions when they fit in `limit` lanes. Returning
+/// `None` means there are more active partitions than lanes, so the caller
+/// should use dynamic claiming instead of assigning multiple lanes per node.
+fn small_active_partition_set(
+    total: usize,
+    level: usize,
+    min_partition_size: usize,
+    limit: usize,
+) -> Option<Vec<usize>> {
+    let partition_count = 1usize.checked_shl(level as u32)?;
+    let mut active = Vec::with_capacity(partition_count.min(limit));
+    for partition_id in 0..partition_count {
+        if partition_range(total, level, partition_id).len() <= min_partition_size {
+            continue;
+        }
+        active.push(partition_id);
+        if active.len() > limit {
+            return None;
+        }
+    }
+    Some(active)
+}
+
+/// Mutable pass buffers shared by native level workers.
+///
+/// The scheduler hands each claimed partition ID to exactly one worker, and
+/// `partition_range` yields non-overlapping ranges at a fixed level. The level
+/// barrier completes before any buffer is accessed again or the next level is
+/// started. Those invariants make concurrent slice construction sound.
+#[cfg(feature = "native")]
+#[derive(Clone, Copy)]
+struct LevelBuffers {
+    docs: *mut u32,
+    gains: *mut f32,
+    partitioned: *mut u32,
+    ranked: *mut usize,
+    len: usize,
+}
+
+#[cfg(feature = "native")]
+unsafe impl Send for LevelBuffers {}
+#[cfg(feature = "native")]
+unsafe impl Sync for LevelBuffers {}
+
+#[cfg(feature = "native")]
+impl LevelBuffers {
+    fn new(
+        docs: &mut [u32],
+        gains: &mut [f32],
+        partitioned: &mut [u32],
+        ranked: &mut [usize],
+    ) -> Self {
+        debug_assert_eq!(docs.len(), gains.len());
+        debug_assert_eq!(docs.len(), partitioned.len());
+        debug_assert_eq!(docs.len(), ranked.len());
+        Self {
+            docs: docs.as_mut_ptr(),
+            gains: gains.as_mut_ptr(),
+            partitioned: partitioned.as_mut_ptr(),
+            ranked: ranked.as_mut_ptr(),
+            len: docs.len(),
+        }
+    }
+
+    /// # Safety
+    ///
+    /// During one level, every requested range must be in bounds and disjoint
+    /// from every range concurrently handed out from this `LevelBuffers`.
+    unsafe fn with_slices<R>(
+        &self,
+        range: std::ops::Range<usize>,
+        use_slices: impl for<'a> FnOnce(
+            &'a mut [u32],
+            &'a mut [f32],
+            &'a mut [u32],
+            &'a mut [usize],
+        ) -> R,
+    ) -> R {
+        debug_assert!(range.start <= range.end && range.end <= self.len);
+        let len = range.len();
+        // SAFETY: upheld by the caller as documented above. All four backing
+        // allocations remain live and immovable until the level barrier.
+        unsafe {
+            use_slices(
+                std::slice::from_raw_parts_mut(self.docs.add(range.start), len),
+                std::slice::from_raw_parts_mut(self.gains.add(range.start), len),
+                std::slice::from_raw_parts_mut(self.partitioned.add(range.start), len),
+                std::slice::from_raw_parts_mut(self.ranked.add(range.start), len),
+            )
+        }
+    }
+}
+
+/// Process the recursion tree breadth-first. Same-depth partitions have
+/// similar sizes and dynamically claim bounded degree lanes, avoiding the
+/// inter-level contention and permanently imbalanced descendant ownership of
+/// recursive fork-join BP.
+fn bisect_level_synchronized(
+    docs: &mut [u32],
+    gains: &mut [f32],
+    partitioned: &mut [u32],
+    ranked_scratch: &mut [usize],
+    degree_workspaces: &mut [TermDegrees],
+    context: &BisectContext<'_>,
+) {
+    debug_assert_eq!(docs.len(), gains.len());
+    debug_assert_eq!(docs.len(), partitioned.len());
+    debug_assert_eq!(docs.len(), ranked_scratch.len());
+    debug_assert!(!degree_workspaces.is_empty());
+
+    #[cfg(feature = "native")]
+    {
+        let buffers = LevelBuffers::new(docs, gains, partitioned, ranked_scratch);
+        let mut level = 0usize;
+        while let Some(partition_count) = 1usize.checked_shl(level as u32) {
+            let small_set = small_active_partition_set(
+                docs.len(),
+                level,
+                context.min_partition_size,
+                degree_workspaces.len(),
+            );
+
+            match small_set {
+                Some(active) if active.is_empty() => break,
+                Some(active) => {
+                    // With fewer partitions than degree lanes, give each node
+                    // a lane group so its frequency/gain work can still use
+                    // the whole pool during BP's startup levels.
+                    let active_count = active.len();
+                    let allow_inner_parallelism =
+                        active_count < rayon::current_num_threads().max(1);
+                    let mut rest: &mut [TermDegrees] = &mut *degree_workspaces;
+                    let mut groups = Vec::with_capacity(active_count);
+                    for remaining_groups in (1..=active_count).rev() {
+                        let group_len = rest.len().div_ceil(remaining_groups);
+                        let (group, tail) = rest.split_at_mut(group_len);
+                        groups.push(group);
+                        rest = tail;
+                    }
+                    debug_assert!(rest.is_empty());
+                    groups.into_par_iter().zip(active.into_par_iter()).for_each(
+                        |(workspaces, partition_id)| {
+                            let range = partition_range(docs.len(), level, partition_id);
+                            // SAFETY: active IDs are unique at one fixed level,
+                            // hence their ranges are disjoint. `for_each` is
+                            // the barrier before buffers are reused.
+                            unsafe {
+                                buffers.with_slices(
+                                    range,
+                                    |part_docs, part_gains, part_output, part_ranked| {
+                                        bisect_partition(
+                                            part_docs,
+                                            part_gains,
+                                            part_output,
+                                            part_ranked,
+                                            workspaces,
+                                            level,
+                                            allow_inner_parallelism,
+                                            context,
+                                        );
+                                    },
+                                );
+                            }
+                        },
+                    );
+                }
+                None => {
+                    // More partitions than degree lanes: one long-lived worker
+                    // per admitted lane repeatedly claims the next partition.
+                    // This preserves the memory bound and lets short/deep work
+                    // steal naturally instead of pinning a whole subtree to a
+                    // lane for the remainder of the pass.
+                    let next = std::sync::atomic::AtomicUsize::new(0);
+                    let allow_inner_parallelism =
+                        degree_workspaces.len() < rayon::current_num_threads().max(1);
+                    degree_workspaces.par_iter_mut().for_each(|workspace| {
+                        loop {
+                            let partition_id =
+                                next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            if partition_id >= partition_count {
+                                break;
+                            }
+                            let range = partition_range(docs.len(), level, partition_id);
+                            if range.len() <= context.min_partition_size {
+                                continue;
+                            }
+                            // SAFETY: `fetch_add` assigns every partition ID
+                            // once, and fixed-level partition ranges are
+                            // pairwise disjoint.
+                            unsafe {
+                                buffers.with_slices(
+                                    range,
+                                    |part_docs, part_gains, part_output, part_ranked| {
+                                        bisect_partition(
+                                            part_docs,
+                                            part_gains,
+                                            part_output,
+                                            part_ranked,
+                                            std::slice::from_mut(workspace),
+                                            level,
+                                            allow_inner_parallelism,
+                                            context,
+                                        );
+                                    },
+                                );
+                            }
+                        }
+                    });
+                }
+            }
+
+            if context.exhausted.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            level += 1;
+        }
+    }
+
+    #[cfg(not(feature = "native"))]
+    {
+        let mut level = 0usize;
+        while let Some(partition_count) = 1usize.checked_shl(level as u32) {
+            let mut active = false;
+            for partition_id in 0..partition_count {
+                let range = partition_range(docs.len(), level, partition_id);
+                if range.len() <= context.min_partition_size {
+                    continue;
+                }
+                active = true;
+                bisect_partition(
+                    &mut docs[range.clone()],
+                    &mut gains[range.clone()],
+                    &mut partitioned[range.clone()],
+                    &mut ranked_scratch[range],
+                    degree_workspaces,
+                    level,
+                    false,
+                    context,
+                );
+            }
+            if !active || context.exhausted.load(std::sync::atomic::Ordering::Relaxed) {
+                break;
+            }
+            level += 1;
+        }
+    }
+}
+
+/// Bisection of one document slice, without scheduling its children.
+///
+/// Uses flat `Vec<u32>` degree arrays indexed by compact term_id for
+/// cache-friendly O(1) lookups. Adaptive iteration count reduces work at top
+/// levels where coarse splits converge faster and dominate total runtime.
 #[allow(clippy::too_many_arguments)]
-fn bisect(
+fn bisect_partition(
     docs: &mut [u32],
     gains: &mut [f32],
     partitioned: &mut [u32],
     ranked_scratch: &mut [usize],
     degree_workspaces: &mut [TermDegrees],
     level: usize,
+    allow_inner_parallelism: bool,
     context: &BisectContext<'_>,
 ) {
     let n = docs.len();
@@ -1948,8 +2241,8 @@ fn bisect(
 
     // Compact term IDs permit direct indexing. Slots are initialized lazily so
     // deep partitions touch only their active terms. Coarse partitions use
-    // multiple preallocated lanes; recursion splits the exact same workspace
-    // set between children.
+    // multiple preallocated lanes; fine levels dynamically reuse one lane per
+    // active partition.
     build_term_degrees(
         docs,
         mid,
@@ -1964,6 +2257,7 @@ fn bisect(
         context
             .exhausted
             .store(true, std::sync::atomic::Ordering::Relaxed);
+        context.progress.partition_finished();
         return;
     }
     // A full-vocabulary objective scan pays off only on coarse partitions,
@@ -2014,6 +2308,7 @@ fn bisect(
             &degree_workspaces[0],
             context.log_table,
             gains,
+            allow_inner_parallelism,
         );
         if context
             .cancellation
@@ -2037,11 +2332,12 @@ fn bisect(
             &mut degree_workspaces[1..],
             partitioned,
             ranked_scratch,
+            allow_inner_parallelism,
         );
 
         if partition.swap_count == 0 {
             context.progress.iteration(n, 0, 0.0, 0.0);
-            // Preserve the selector's within-half order before recursing.
+            // Preserve the selector's within-half order for the next level.
             // Small partitions intentionally retain quickselect's established
             // symmetry-breaking permutation.
             docs.copy_from_slice(partitioned);
@@ -2138,83 +2434,6 @@ fn bisect(
     }
 
     context.progress.partition_finished();
-
-    let (left, right) = docs.split_at_mut(mid);
-    let (left_gains, right_gains) = gains.split_at_mut(mid);
-    let (left_partitioned, right_partitioned) = partitioned.split_at_mut(mid);
-    let (left_ranked, right_ranked) = ranked_scratch.split_at_mut(mid);
-    #[cfg(feature = "native")]
-    if degree_workspaces.len() > 1 {
-        let left_lanes = degree_workspaces.len() / 2;
-        let (left_workspaces, right_workspaces) = degree_workspaces.split_at_mut(left_lanes);
-        rayon::join(
-            || {
-                bisect(
-                    left,
-                    left_gains,
-                    left_partitioned,
-                    left_ranked,
-                    left_workspaces,
-                    level + 1,
-                    context,
-                )
-            },
-            || {
-                bisect(
-                    right,
-                    right_gains,
-                    right_partitioned,
-                    right_ranked,
-                    right_workspaces,
-                    level + 1,
-                    context,
-                )
-            },
-        );
-    } else {
-        // Gain computation inside each node remains parallel, so serializing
-        // recursion here bounds vocabulary-sized degree arrays without leaving
-        // the Rayon pool idle.
-        bisect(
-            left,
-            left_gains,
-            left_partitioned,
-            left_ranked,
-            degree_workspaces,
-            level + 1,
-            context,
-        );
-        bisect(
-            right,
-            right_gains,
-            right_partitioned,
-            right_ranked,
-            degree_workspaces,
-            level + 1,
-            context,
-        );
-    }
-    #[cfg(not(feature = "native"))]
-    {
-        bisect(
-            left,
-            left_gains,
-            left_partitioned,
-            left_ranked,
-            degree_workspaces,
-            level + 1,
-            context,
-        );
-        bisect(
-            right,
-            right_gains,
-            right_partitioned,
-            right_ranked,
-            degree_workspaces,
-            level + 1,
-            context,
-        );
-    }
 }
 
 /// Compute gains for all documents, parallelized via rayon for large partitions.
@@ -2230,6 +2449,7 @@ fn compute_gains(
     degrees: &TermDegrees,
     log_table: &[f32],
     gains: &mut [f32],
+    allow_inner_parallelism: bool,
 ) {
     // Single coherent key: HIGH = belongs in the RIGHT half.
     // Left docs get +approx_one(from=left, to=right) — a misplaced left doc
@@ -2260,7 +2480,7 @@ fn compute_gains(
 
     #[cfg(feature = "native")]
     {
-        if docs.len() > 4096 {
+        if allow_inner_parallelism && docs.len() > 4096 {
             gains
                 .par_iter_mut()
                 .enumerate()
@@ -2435,7 +2655,7 @@ mod tests {
         sorted.sort_unstable();
 
         for left_count in 1..=gains.len() {
-            let (threshold, lower) = select_gain_threshold(&gains, left_count);
+            let (threshold, lower) = select_gain_threshold(&gains, left_count, true);
             assert_eq!(threshold, sorted[left_count - 1].0);
             assert_eq!(lower, sorted.partition_point(|&(key, _)| key < threshold),);
         }
@@ -2506,6 +2726,7 @@ mod tests {
             &mut movement_workspaces,
             &mut output,
             &mut ranked_scratch,
+            true,
         );
         assert_eq!(output, expected);
         assert!(
@@ -2559,6 +2780,121 @@ mod tests {
             parallel_bisect_lanes: 1,
             budget_limited: false,
         }
+    }
+
+    #[test]
+    fn level_partition_ranges_match_recursive_halving() {
+        for total in 1..=129 {
+            let mut expected: Vec<std::ops::Range<usize>> = std::iter::once(0..total).collect();
+            for level in 0..8 {
+                let actual: Vec<_> = (0..(1usize << level))
+                    .map(|partition_id| partition_range(total, level, partition_id))
+                    .collect();
+                assert_eq!(actual, expected, "total={total}, level={level}");
+
+                expected = expected
+                    .into_iter()
+                    .flat_map(|range| {
+                        let mid = range.start + range.len() / 2;
+                        [range.start..mid, mid..range.end]
+                    })
+                    .collect();
+            }
+        }
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn level_synchronized_scheduler_is_thread_count_deterministic() {
+        let docs: Vec<Vec<u32>> = (0..1_027)
+            .map(|doc| {
+                vec![
+                    (doc % 31) as u32,
+                    ((doc / 5) % 53) as u32,
+                    ((doc * 29 + 3) % 97) as u32,
+                ]
+            })
+            .collect();
+        let doc_refs: Vec<_> = docs.iter().map(Vec::as_slice).collect();
+        let mut fwd = make_fwd(&doc_refs, 97);
+        fwd.parallel_bisect_lanes = 8;
+        let one_thread = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap();
+        let eight_threads = rayon::ThreadPoolBuilder::new()
+            .num_threads(8)
+            .build()
+            .unwrap();
+
+        let one = one_thread.install(|| graph_bisection(&fwd, 8, 12, BpBudget::full()).0);
+        let eight = eight_threads.install(|| graph_bisection(&fwd, 8, 12, BpBudget::full()).0);
+
+        assert_eq!(eight, one);
+    }
+
+    /// Scheduler benchmark on a posting-skewed graph. Run manually:
+    /// `cargo test -p hermes-core --release --features native \
+    ///    bench_level_synchronized_scheduler -- --ignored --nocapture`
+    #[cfg(feature = "native")]
+    #[test]
+    #[ignore]
+    fn bench_level_synchronized_scheduler() {
+        const DOCS: usize = 500_000;
+        const TERMS: usize = 32_768;
+        const ROUNDS: usize = 3;
+
+        let mut terms = Vec::with_capacity(DOCS * 12);
+        let mut offsets = Vec::with_capacity(DOCS + 1);
+        offsets.push(0);
+        for doc in 0..DOCS {
+            // Make posting work deliberately uneven between neighboring
+            // neighboring tree regions. Dynamic same-level claiming should
+            // absorb this skew instead of pinning it to one lane.
+            let term_count = 4 + ((doc.wrapping_mul(2_654_435_761) >> 12) % 17);
+            for term in 0..term_count {
+                terms.push(
+                    ((doc / 64)
+                        .wrapping_mul(131)
+                        .wrapping_add(term.wrapping_mul(7_919))
+                        % TERMS) as u32,
+                );
+            }
+            offsets.push(terms.len() as u64);
+        }
+        let fwd = ForwardIndex {
+            terms,
+            offsets,
+            num_terms: TERMS,
+            parallel_bisect_lanes: 8,
+            budget_limited: false,
+        };
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(8)
+            .build()
+            .unwrap();
+        let mut level_times = Vec::with_capacity(ROUNDS);
+        let mut expected_output = None;
+
+        pool.install(|| {
+            for _ in 0..ROUNDS {
+                let started = std::time::Instant::now();
+                let output = graph_bisection(&fwd, 32, 12, BpBudget::full()).0;
+                level_times.push(started.elapsed());
+                if let Some(expected) = &expected_output {
+                    assert_eq!(&output, expected);
+                } else {
+                    expected_output = Some(output);
+                }
+            }
+        });
+
+        level_times.sort_unstable();
+        let level = level_times[ROUNDS / 2];
+        println!(
+            "BP level-synchronized scheduler median: {:.3}s",
+            level.as_secs_f64(),
+        );
     }
 
     #[test]

--- a/hermes-core/src/segment/format.rs
+++ b/hermes-core/src/segment/format.rs
@@ -43,6 +43,7 @@ pub const DENSE_TOC_ENTRY_SIZE: u64 = 4 + 1 + 8 + 8; // 21
 ///
 /// Called after all field data has been written. `toc_offset` is the
 /// current file position (byte offset where the TOC starts).
+#[cfg(any(feature = "native", feature = "wasm", test))]
 pub fn write_dense_toc_and_footer(
     writer: &mut (impl std::io::Write + ?Sized),
     toc_offset: u64,
@@ -112,6 +113,7 @@ pub const BMP_BLOB_FOOTER_SIZE: usize = 80;
 pub const SPARSE_FOOTER_SIZE: u64 = 24;
 
 /// Per-dim TOC entry accumulated during V3 sparse build/merge.
+#[cfg(any(feature = "native", feature = "wasm", test))]
 pub struct SparseDimTocEntry {
     pub dim_id: u32,
     /// Absolute byte offset in file where block data starts for this dim
@@ -127,6 +129,7 @@ pub struct SparseDimTocEntry {
 }
 
 /// Per-field TOC entry accumulated during V3 sparse build/merge.
+#[cfg(any(feature = "native", feature = "wasm", test))]
 pub struct SparseFieldToc {
     pub field_id: u32,
     pub quantization: u8,
@@ -136,6 +139,7 @@ pub struct SparseFieldToc {
     pub dims: Vec<SparseDimTocEntry>,
 }
 
+#[cfg(any(feature = "native", feature = "wasm", test))]
 impl SparseFieldToc {
     /// Build the sentinel TOC entry used by the self-contained BMP blob.
     pub(crate) fn bmp(field_id: u32, total_vectors: u32, blob_offset: u64, blob_len: u64) -> Self {
@@ -174,6 +178,7 @@ impl SparseFieldToc {
 /// [TOC: per-field header(13B) + per-dim entries(28B each)]
 /// [footer: skip_offset(8) + toc_offset(8) + num_fields(4) + magic(4)]
 /// ```
+#[cfg(any(feature = "native", feature = "wasm", test))]
 pub fn write_sparse_toc_and_footer(
     writer: &mut (impl std::io::Write + ?Sized),
     skip_offset: u64,

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -8,6 +8,7 @@ mod store;
 
 pub(crate) use dense::AnnWriteMode;
 
+use std::io::Write as _;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -127,6 +128,100 @@ pub(crate) fn block_in_place_if_multithread<R>(f: impl FnOnce() -> R) -> R {
     }
 }
 
+/// Attempt a byte-identical local range copy through the streaming writer's
+/// kernel-assisted path. Returns `Ok(false)` without emitting bytes when the
+/// backend/filesystem does not support it.
+fn try_copy_local_file_range(
+    writer: &mut OffsetWriter,
+    source_path: &std::path::Path,
+    source_range: std::ops::Range<u64>,
+    cancellation: Option<&AtomicBool>,
+    context: &str,
+) -> Result<bool> {
+    const COPY_CHUNK: usize = 16 * 1024 * 1024;
+
+    let source = std::fs::File::open(source_path).map_err(crate::Error::Io)?;
+    let expected = source_range
+        .end
+        .checked_sub(source_range.start)
+        .ok_or_else(|| crate::Error::Corruption(format!("{context} source range is inverted")))?;
+    let mut source_offset = source_range.start;
+    let mut copied = 0u64;
+    while copied < expected {
+        if cancellation.is_some_and(|flag| flag.load(Ordering::Acquire)) {
+            return Err(crate::Error::IndexClosed);
+        }
+        let requested = usize::try_from((expected - copied).min(COPY_CHUNK as u64))
+            .expect("bounded copy chunk fits usize");
+        match writer.copy_from_file_range(&source, &mut source_offset, requested) {
+            Ok(0) => {
+                return Err(crate::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "kernel {context} copy stopped after {copied} of {expected} bytes from \
+                         {source_path:?}",
+                    ),
+                )));
+            }
+            Ok(count) => {
+                copied = copied.checked_add(count as u64).ok_or_else(|| {
+                    crate::Error::Internal(format!("{context} copied-byte count exceeds u64"))
+                })?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(error) if error.kind() == std::io::ErrorKind::Unsupported && copied == 0 => {
+                return Ok(false);
+            }
+            Err(error) => return Err(crate::Error::Io(error)),
+        }
+    }
+
+    static LOGGED: AtomicBool = AtomicBool::new(false);
+    if !LOGGED.swap(true, Ordering::Relaxed) {
+        log::info!("[merge] byte-identical local ranges use kernel-assisted file copies");
+    }
+    Ok(true)
+}
+
+/// Copy a byte-identical range, falling back to already-mapped bytes for
+/// abstract directories and filesystems without range-copy support.
+pub(super) fn copy_local_range_or_bytes(
+    writer: &mut OffsetWriter,
+    source_path: Option<&std::path::Path>,
+    source_range: std::ops::Range<u64>,
+    bytes: &[u8],
+    cancellation: Option<&AtomicBool>,
+    context: &str,
+) -> Result<()> {
+    let range_len = source_range
+        .end
+        .checked_sub(source_range.start)
+        .ok_or_else(|| crate::Error::Corruption(format!("{context} source range is inverted")))?;
+    if range_len != bytes.len() as u64 {
+        return Err(crate::Error::Corruption(format!(
+            "{context} source range is {range_len} bytes but mapped section is {} bytes",
+            bytes.len(),
+        )));
+    }
+    if bytes.is_empty() {
+        return Ok(());
+    }
+
+    if let Some(path) = source_path
+        && try_copy_local_file_range(writer, path, source_range, cancellation, context)?
+    {
+        return Ok(());
+    }
+
+    for chunk in bytes.chunks(4 * 1024 * 1024) {
+        if cancellation.is_some_and(|flag| flag.load(Ordering::Acquire)) {
+            return Err(crate::Error::IndexClosed);
+        }
+        writer.write_all(chunk).map_err(crate::Error::Io)?;
+    }
+    Ok(())
+}
+
 /// Append an exact-length temporary directory file to a segment output and
 /// remove it. Used by sparse skip tables so neither merge nor BP rewrite
 /// buffers a corpus-sized metadata section on heap.
@@ -146,14 +241,29 @@ pub(crate) async fn append_and_delete_temp<D: DirectoryWriter>(
             path, actual_bytes, expected_bytes,
         )));
     }
-    let mut offset = 0u64;
-    while offset < expected_bytes {
-        let end = (offset + COPY_CHUNK).min(expected_bytes);
-        let chunk = directory.read_range(path, offset..end).await?;
-        writer
-            .write_all(chunk.as_slice())
-            .map_err(crate::Error::Io)?;
-        offset = end;
+    let copied_in_kernel = if let Some(local_path) = directory.local_path(path) {
+        block_in_place_if_multithread(|| {
+            try_copy_local_file_range(
+                writer,
+                &local_path,
+                0..expected_bytes,
+                None,
+                "sparse scratch",
+            )
+        })?
+    } else {
+        false
+    };
+    if !copied_in_kernel {
+        let mut offset = 0u64;
+        while offset < expected_bytes {
+            let end = (offset + COPY_CHUNK).min(expected_bytes);
+            let chunk = directory.read_range(path, offset..end).await?;
+            writer
+                .write_all(chunk.as_slice())
+                .map_err(crate::Error::Io)?;
+            offset = end;
+        }
     }
     if let Err(error) = directory.delete(path).await {
         // The section is already complete in the output. This output-scoped
@@ -620,12 +730,11 @@ impl SegmentMerger {
         // only copy of the merged documents across a power failure.
         dir.write_durable(&files.meta, &meta.serialize()?).await?;
 
-        let label = if trained.is_some() {
-            "ANN merge"
-        } else {
-            "Merge"
-        };
-        log::info!("{} complete: {} docs, {}", label, total_docs, stats);
+        // Dense ANN payloads are byte-copied during an ordinary merge; the
+        // wall-clock timer also includes postings, store, sparse BP and any BP
+        // scheduler wait. Calling this an "ANN merge" made long sparse waits
+        // look like ANN construction in production logs.
+        log::info!("[merge] complete: {} docs, {}", total_docs, stats);
 
         Ok((meta, stats))
     }

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -48,6 +48,14 @@ impl SegmentMerger {
         files: &SegmentFiles,
     ) -> Result<(usize, bool)> {
         let doc_offs = doc_offsets(segments)?;
+        // Local backends expose source paths so the byte-identical portions
+        // of BMP block-copy merges can stay inside the kernel. Remote and
+        // in-memory directories leave these as `None` and use mmap/read +
+        // streaming-write fallback.
+        let source_sparse_paths: Vec<Option<std::path::PathBuf>> = segments
+            .iter()
+            .map(|segment| dir.local_path(&SegmentFiles::new(segment.meta().id).sparse))
+            .collect();
         // False iff any merge-time BP pass hit its wall-clock budget.
         let mut all_converged = true;
 
@@ -175,6 +183,7 @@ impl SegmentMerger {
                         let bp_memory_budget = self.bp_memory_budget;
                         let out_grid_bits = grid_bits;
                         let scratch_path = scratch_path.clone();
+                        let permit_wait_start = std::time::Instant::now();
                         let _reorder_permit = match &self.reorder_permits {
                             Some(permits) => {
                                 let gate = Arc::clone(permits);
@@ -186,6 +195,14 @@ impl SegmentMerger {
                             }
                             None => None,
                         };
+                        let permit_wait = permit_wait_start.elapsed();
+                        if permit_wait >= std::time::Duration::from_secs(1) {
+                            log::info!(
+                                "[merge_bmp] field {}: waited {:.1}s for the BP scheduler",
+                                fid,
+                                permit_wait.as_secs_f64(),
+                            );
+                        }
                         // `spawn_blocking` detaches its closure when the
                         // awaiting RPC is cancelled. That used to release the
                         // segment operation guard while this writer was still
@@ -232,6 +249,7 @@ impl SegmentMerger {
                         merge_bmp_field(
                             &bmp_indexes,
                             &doc_offs,
+                            &source_sparse_paths,
                             field.0,
                             dims,
                             bmp_block_size,
@@ -595,6 +613,7 @@ fn validate_sparse_merge_source(dim_id: u32, source_index: usize, raw: &DimRawDa
 fn merge_bmp_field(
     bmp_indexes: &[Option<&BmpIndex>],
     doc_offs: &[u32],
+    source_sparse_paths: &[Option<std::path::PathBuf>],
     field_id: u32,
     dims: u32,
     bmp_block_size: u32,
@@ -616,10 +635,16 @@ fn merge_bmp_field(
         .zip(doc_offs.iter().copied())
         .filter_map(|(opt, doc_off)| opt.map(|bmp| (bmp, doc_off)))
         .collect();
+    let source_paths: Vec<Option<&std::path::Path>> = bmp_indexes
+        .iter()
+        .zip(source_sparse_paths)
+        .filter_map(|(bmp, path)| bmp.as_ref().map(|_| path.as_deref()))
+        .collect();
 
     if sources.is_empty() {
         return Ok(());
     }
+    debug_assert_eq!(sources.len(), source_paths.len());
     // Validation and every following phase are exhaustive sequential scans.
     // Apply scan advice before touching multi-GB doc maps, not only before
     // block-data copying.
@@ -691,8 +716,6 @@ fn merge_bmp_field(
 
     let blob_start = writer.offset();
 
-    const CHUNK_SIZE: usize = 4 * 1024 * 1024; // 4 MB
-
     // ═══ Sequential block-copy merge ════════════════════════════════════
     // Blocks are self-contained — copy directly from sources in order.
     // BP reorder is a separate post-merge step (see segment::reorder).
@@ -701,16 +724,18 @@ fn merge_bmp_field(
     let mut source_byte_offsets: Vec<u64> = Vec::with_capacity(sources.len());
     let mut cumulative_bytes: u64 = 0;
 
-    for &(bmp, _) in &sources {
+    for (source_index, &(bmp, _)) in sources.iter().enumerate() {
         source_byte_offsets.push(cumulative_bytes);
         let sentinel = bmp.block_data_sentinel() as usize;
         let src_data = &bmp.block_data_slice()[..sentinel];
-        for chunk in src_data.chunks(CHUNK_SIZE) {
-            if cancellation_requested(cancellation) {
-                return Err(crate::Error::IndexClosed);
-            }
-            writer.write_all(chunk).map_err(crate::Error::Io)?;
-        }
+        super::copy_local_range_or_bytes(
+            writer,
+            source_paths[source_index],
+            bmp.block_data_file_range(),
+            src_data,
+            cancellation,
+            "BMP block data",
+        )?;
         cumulative_bytes += sentinel as u64;
     }
 
@@ -797,17 +822,19 @@ fn merge_bmp_field(
     const DOC_MAP_CHUNK: usize = 64 * 1024;
     let mut id_buf = vec![0u8; DOC_MAP_CHUNK * 4];
 
-    for &(bmp, doc_offset) in &sources {
+    for (source_index, &(bmp, doc_offset)) in sources.iter().enumerate() {
         let src_ids = bmp.doc_map_ids_slice();
         let n = bmp.num_virtual_docs as usize;
 
         if doc_offset == 0 {
-            for chunk in src_ids[..n * 4].chunks(CHUNK_SIZE) {
-                if cancellation_requested(cancellation) {
-                    return Err(crate::Error::IndexClosed);
-                }
-                writer.write_all(chunk).map_err(crate::Error::Io)?;
-            }
+            super::copy_local_range_or_bytes(
+                writer,
+                source_paths[source_index],
+                bmp.doc_map_ids_file_range(),
+                &src_ids[..n * 4],
+                cancellation,
+                "BMP document IDs",
+            )?;
         } else {
             for chunk_start in (0..n).step_by(DOC_MAP_CHUNK) {
                 if cancellation_requested(cancellation) {
@@ -838,15 +865,17 @@ fn merge_bmp_field(
     }
     drop(id_buf);
 
-    for &(bmp, _) in &sources {
+    for (source_index, &(bmp, _)) in sources.iter().enumerate() {
         let src_ords = bmp.doc_map_ordinals_slice();
         let n = bmp.num_virtual_docs as usize;
-        for chunk in src_ords[..n * 2].chunks(CHUNK_SIZE) {
-            if cancellation_requested(cancellation) {
-                return Err(crate::Error::IndexClosed);
-            }
-            writer.write_all(chunk).map_err(crate::Error::Io)?;
-        }
+        super::copy_local_range_or_bytes(
+            writer,
+            source_paths[source_index],
+            bmp.doc_map_ordinals_file_range(),
+            &src_ords[..n * 2],
+            cancellation,
+            "BMP ordinals",
+        )?;
     }
 
     // ── Phase 6: Write V18 footer ───────────────────────────────────────

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -65,6 +65,25 @@ impl OffsetWriter {
     pub(crate) fn finish(self) -> std::io::Result<()> {
         self.inner.finish()
     }
+
+    /// Copy a local source range at the current output position using the
+    /// writer backend's kernel-assisted path when available.
+    #[cfg(feature = "native")]
+    pub(crate) fn copy_from_file_range(
+        &mut self,
+        source: &std::fs::File,
+        source_offset: &mut u64,
+        len: usize,
+    ) -> std::io::Result<usize> {
+        let copied = self
+            .inner
+            .copy_from_file_range(source, source_offset, len)?;
+        self.offset = self
+            .offset
+            .checked_add(copied as u64)
+            .ok_or_else(|| std::io::Error::other("offset-writer byte count overflow"))?;
+        Ok(copied)
+    }
 }
 
 #[cfg(any(feature = "native", feature = "wasm"))]

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -152,6 +152,11 @@ pub struct BmpIndex {
     blob_offset: u64,
     #[cfg_attr(not(feature = "native"), allow(dead_code))]
     blob_len: u64,
+    /// Offset of Section F within the blob. Retained so local block-copy
+    /// merges can pass byte-identical document-map ranges directly to
+    /// `copy_file_range` without faulting their mmap pages into userspace.
+    #[cfg_attr(not(feature = "native"), allow(dead_code))]
+    doc_map_offset: u64,
 }
 
 // SAFETY: All raw pointer access is derived from OwnedBytes which are Send+Sync
@@ -258,6 +263,7 @@ impl BmpIndex {
                 source: handle,
                 blob_offset,
                 blob_len,
+                doc_map_offset,
             });
         }
 
@@ -496,6 +502,7 @@ impl BmpIndex {
             source: handle,
             blob_offset,
             blob_len,
+            doc_map_offset,
         })
     }
 
@@ -881,6 +888,7 @@ impl BmpIndex {
     ///
     /// All rewrite paths share this scan so block-copy cannot offset corrupt
     /// source IDs into another segment while record reorder rejects them.
+    #[cfg(any(feature = "native", feature = "wasm", test))]
     pub(crate) fn visit_real_slots_for_rewrite(
         &self,
         mut visitor: impl FnMut(usize),
@@ -1148,6 +1156,26 @@ impl BmpIndex {
     #[inline]
     pub fn doc_map_ordinals_slice(&self) -> &[u8] {
         self.doc_map_ordinals_bytes.as_slice()
+    }
+
+    /// Native source-file range containing Section B (block payload).
+    #[cfg(feature = "native")]
+    pub(crate) fn block_data_file_range(&self) -> std::ops::Range<u64> {
+        self.blob_offset..self.blob_offset + self.block_data_sentinel()
+    }
+
+    /// Native source-file range containing Section F (document IDs).
+    #[cfg(feature = "native")]
+    pub(crate) fn doc_map_ids_file_range(&self) -> std::ops::Range<u64> {
+        let start = self.blob_offset + self.doc_map_offset;
+        start..start + u64::from(self.num_virtual_docs) * 4
+    }
+
+    /// Native source-file range containing Section G (ordinals).
+    #[cfg(feature = "native")]
+    pub(crate) fn doc_map_ordinals_file_range(&self) -> std::ops::Range<u64> {
+        let start = self.blob_offset + self.doc_map_offset + u64::from(self.num_virtual_docs) * 4;
+        start..start + u64::from(self.num_virtual_docs) * 2
     }
 
     /// Advise the kernel about sequential access patterns for merge.


### PR DESCRIPTION
## Summary
- replace recursive fork-join BP with level-synchronized breadth-first scheduling and dynamic reuse of bounded degree workspaces
- defer merge-time BP during severe segment backlogs so instant indexing compacts topology first
- use Linux copy_file_range for byte-identical BMP and sparse scratch ranges with safe portable fallback
- clarify merge/BP scheduler timing in production logs and eliminate feature-build warnings

## Measured result
- posting-skewed 500k-entity, 8-thread scheduler benchmark: 1.131s recursive vs 0.880s level-synchronized median (1.28x), with identical permutations

## Validation
- cargo test -p hermes-core --features native: 931 passed
- cargo test -p hermes-server: 35 passed
- core and server Clippy with warnings denied
- cargo check -p hermes-core --no-default-features
- formatting and git diff checks
- BP thread-count determinism and recursive-boundary equivalence coverage