### PR TITLE
fix(core): silence non-native BP scheduler flags

### DIFF
--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -1087,6 +1087,9 @@ fn select_gain_threshold(
     left_count: usize,
     allow_inner_parallelism: bool,
 ) -> (u32, usize) {
+    #[cfg(not(feature = "native"))]
+    let _ = allow_inner_parallelism;
+
     debug_assert!(left_count > 0 && left_count <= gains.len());
     let mut rank_within_prefix = left_count - 1;
     let mut strictly_lower = 0usize;
@@ -2451,6 +2454,9 @@ fn compute_gains(
     gains: &mut [f32],
     allow_inner_parallelism: bool,
 ) {
+    #[cfg(not(feature = "native"))]
+    let _ = allow_inner_parallelism;
+
     // Single coherent key: HIGH = belongs in the RIGHT half.
     // Left docs get +approx_one(from=left, to=right) — a misplaced left doc
     // (terms concentrated right) scores high. Right docs get


### PR DESCRIPTION
## Summary
- mark BP inner-parallelism controls as intentionally unused in non-native builds
- restore the WASM build under warnings-as-errors

## Validation
- `RUSTFLAGS="-D warnings" cargo check -p hermes-core --no-default-features`
- `cargo test -p hermes-core --features native segment::builder::graph_bisection --lib` (19 passed, 1 ignored)
- `cargo clippy -p hermes-core --features native --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Follow-up to #111.