### PR TITLE
perf(core): reduce allocation and memory overhead

### DIFF
--- a/hermes-core/Cargo.toml
+++ b/hermes-core/Cargo.toml
@@ -110,6 +110,10 @@ name = "bmp_payload_layout"
 harness = false
 
 [[bench]]
+name = "core_structures"
+harness = false
+
+[[bench]]
 name = "hermes_benchmark"
 path = "benches/hermes_benchmark/main.rs"
 harness = false

--- a/hermes-core/benches/core_structures.rs
+++ b/hermes-core/benches/core_structures.rs
@@ -1,0 +1,175 @@
+//! Focused benchmarks for allocation-sensitive core structures.
+
+use std::hint::black_box;
+use std::path::Path;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use hermes_core::directories::{Directory, DirectoryWriter, RamDirectory, SliceCachingDirectory};
+use hermes_core::query::{Collector, ScoredPosition, SearchResult, TopKCollector};
+use hermes_core::structures::fast_field::codec::{auto_read_batch, serialize_auto};
+use hermes_core::structures::{BlockSparsePostingList, SparseBlock, WeightQuantization};
+
+fn sparse_postings(count: usize) -> Vec<(u32, u16, f32)> {
+    (0..count)
+        .map(|index| {
+            (
+                index as u32 * 3,
+                (index % 7) as u16,
+                ((index * 17 % 101) as f32 + 1.0) / 101.0,
+            )
+        })
+        .collect()
+}
+
+fn bench_top_k(c: &mut Criterion) {
+    const CANDIDATES: usize = 100_000;
+    const K: usize = 1_000;
+
+    let mut group = c.benchmark_group("core_structures/top_k");
+    group.throughput(Throughput::Elements(CANDIDATES as u64));
+    group.bench_function("scores_only", |bencher| {
+        bencher.iter(|| {
+            let mut collector = TopKCollector::new(K);
+            for index in 0..CANDIDATES {
+                let score = ((index * 2_654_435_761usize) as u32) as f32;
+                collector.collect(index as u32, black_box(score), &[]);
+            }
+            black_box(collector.into_results_with_count())
+        });
+    });
+    group.finish();
+}
+
+fn bench_extract_ordinals(c: &mut Criterion) {
+    let positions = (0..8)
+        .map(|field| {
+            let values = (0..128)
+                .map(|index| {
+                    let ordinal = (index % 16) as u32;
+                    ScoredPosition::new((ordinal << 20) | index as u32, index as f32)
+                })
+                .collect();
+            (field, values)
+        })
+        .collect();
+    let result = SearchResult {
+        doc_id: 7,
+        score: 1.0,
+        segment_id: 11,
+        positions,
+    };
+
+    c.bench_function("core_structures/extract_ordinals", |bencher| {
+        bencher.iter(|| black_box(black_box(&result).extract_ordinals()));
+    });
+}
+
+fn bench_sparse_blocks(c: &mut Criterion) {
+    let one_block = sparse_postings(128);
+    let many_blocks = sparse_postings(128 * 64);
+    let list =
+        BlockSparsePostingList::from_postings(&many_blocks, WeightQuantization::Float16).unwrap();
+    let decode_block = SparseBlock::from_postings(&one_block, WeightQuantization::Float16).unwrap();
+
+    let mut group = c.benchmark_group("core_structures/sparse_block");
+    for quantization in [
+        WeightQuantization::Float32,
+        WeightQuantization::Float16,
+        WeightQuantization::UInt8,
+        WeightQuantization::UInt4,
+    ] {
+        group.bench_with_input(
+            BenchmarkId::new("build_128", format!("{quantization:?}")),
+            &quantization,
+            |bencher, &quantization| {
+                bencher.iter(|| {
+                    black_box(
+                        SparseBlock::from_postings(black_box(&one_block), quantization).unwrap(),
+                    )
+                });
+            },
+        );
+    }
+    group.throughput(Throughput::Elements(many_blocks.len() as u64));
+    group.bench_function("serialize_64_blocks", |bencher| {
+        bencher.iter(|| black_box(black_box(&list).serialize().unwrap()));
+    });
+    group.bench_function("decode_f16_128", |bencher| {
+        let mut output = Vec::with_capacity(128);
+        bencher.iter(|| {
+            decode_block.decode_weights_into(&mut output);
+            black_box(&output);
+        });
+    });
+    group.finish();
+}
+
+fn bench_slice_cache_hit(c: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let ram = RamDirectory::new();
+    let path = Path::new("cached.bin");
+    let bytes = vec![0x5au8; 1024 * 1024];
+    runtime.block_on(ram.write(path, &bytes)).unwrap();
+    let cached = SliceCachingDirectory::new(ram, bytes.len());
+    runtime
+        .block_on(cached.read_range(path, 0..bytes.len() as u64))
+        .unwrap();
+
+    let mut group = c.benchmark_group("core_structures/slice_cache");
+    group.throughput(Throughput::Bytes(bytes.len() as u64));
+    group.bench_function("one_mib_hit", |bencher| {
+        bencher.iter(|| {
+            black_box(
+                runtime
+                    .block_on(cached.read_range(path, 0..bytes.len() as u64))
+                    .unwrap(),
+            )
+        });
+    });
+    group.finish();
+}
+
+fn bench_fast_field_blockwise(c: &mut Criterion) {
+    const VALUES: usize = 64 * 1024;
+    const BLOCK: usize = 512;
+
+    let values: Vec<u64> = (0..VALUES)
+        .map(|index| {
+            let block = index / BLOCK;
+            let offset = index % BLOCK;
+            block as u64 * 1_000_000 + offset as u64 * (block as u64 % 7 + 1)
+        })
+        .collect();
+    let mut encoded = Vec::new();
+    serialize_auto(&values, &mut encoded).unwrap();
+    assert_eq!(encoded[0], 3, "benchmark data must select blockwise codec");
+
+    let mut group = c.benchmark_group("core_structures/fast_field_blockwise");
+    group.throughput(Throughput::Elements(VALUES as u64));
+    group.bench_function("serialize", |bencher| {
+        let mut output = Vec::new();
+        bencher.iter(|| {
+            output.clear();
+            serialize_auto(black_box(&values), &mut output).unwrap();
+            black_box(&output);
+        });
+    });
+    group.bench_function("read_batch", |bencher| {
+        let mut output = vec![0u64; VALUES];
+        bencher.iter(|| {
+            auto_read_batch(black_box(&encoded), 0, &mut output);
+            black_box(&output);
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_top_k,
+    bench_extract_ordinals,
+    bench_sparse_blocks,
+    bench_slice_cache_hit,
+    bench_fast_field_blockwise,
+);
+criterion_main!(benches);

--- a/hermes-core/src/directories/slice_cache.rs
+++ b/hermes-core/src/directories/slice_cache.rs
@@ -28,8 +28,9 @@ const SLICE_CACHE_VERSION: u32 = 2;
 struct CachedSlice {
     /// Byte range in the file
     range: Range<u64>,
-    /// The cached data
-    data: Arc<Vec<u8>>,
+    /// Arc-backed cached data. Cache hits return cheap sub-slices instead of
+    /// allocating and copying the requested range.
+    data: OwnedBytes,
     /// Access counter for LRU eviction
     access_count: u64,
 }
@@ -61,13 +62,17 @@ impl FileSliceCache {
             buf.extend_from_slice(&slice.range.end.to_le_bytes());
             // Data length and data
             buf.extend_from_slice(&(slice.data.len() as u32).to_le_bytes());
-            buf.extend_from_slice(&slice.data);
+            buf.extend_from_slice(slice.data.as_slice());
         }
         buf
     }
 
     /// Deserialize from bytes, returns (cache, bytes_consumed)
-    fn deserialize(data: &[u8], access_counter: u64) -> io::Result<(Self, usize)> {
+    fn deserialize(
+        data: &[u8],
+        access_counter: u64,
+        max_bytes: usize,
+    ) -> io::Result<(Self, usize)> {
         let mut pos = 0;
         if data.len() < 4 {
             return Err(io::Error::new(
@@ -93,24 +98,40 @@ impl FileSliceCache {
             let data_len = u32::from_le_bytes(data[pos..pos + 4].try_into().unwrap()) as usize;
             pos += 4;
 
-            if pos + data_len > data.len() {
+            let data_end = pos.checked_add(data_len).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "slice data length overflow")
+            })?;
+            if data_end > data.len() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "truncated slice data",
                 ));
             }
-            let slice_data = data[pos..pos + data_len].to_vec();
-            pos += data_len;
+            if range_end < range_start || range_end - range_start != data_len as u64 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "slice range and data length are inconsistent",
+                ));
+            }
+            let slice_range = range_start..range_end;
+            pos = data_end;
 
-            cache.total_bytes += slice_data.len();
-            cache.slices.insert(
-                range_start,
-                CachedSlice {
-                    range: range_start..range_end,
-                    data: Arc::new(slice_data),
-                    access_count: access_counter,
-                },
-            );
+            // Do not duplicate an oversized serialized entry just to evict it
+            // after the complete cache has been reconstructed. Retain at most
+            // one cache budget while parsing each file.
+            if data_len <= max_bytes {
+                let bytes_to_free = cache
+                    .total_bytes
+                    .saturating_add(data_len)
+                    .saturating_sub(max_bytes);
+                cache.evict_lru(bytes_to_free);
+                cache.insert(
+                    slice_range,
+                    OwnedBytes::new(data[data_end - data_len..data_end].to_vec()),
+                    access_counter,
+                );
+                debug_assert!(cache.total_bytes <= max_bytes);
+            }
         }
         Ok((cache, pos))
     }
@@ -122,7 +143,7 @@ impl FileSliceCache {
     }
 
     /// Try to read from cache, returns None if not fully cached
-    fn try_read(&mut self, range: Range<u64>, access_counter: &mut u64) -> Option<Vec<u8>> {
+    fn try_read(&mut self, range: Range<u64>, access_counter: &mut u64) -> Option<OwnedBytes> {
         // Find slices that might contain our range
         let start = range.start;
         let end = range.end;
@@ -145,7 +166,7 @@ impl FileSliceCache {
             *access_counter += 1;
             if let Some(s) = self.slices.get_mut(&key) {
                 s.access_count = *access_counter;
-                return Some(s.data[offset..offset + len].to_vec());
+                return Some(s.data.slice(offset..offset + len));
             }
         }
 
@@ -154,7 +175,7 @@ impl FileSliceCache {
 
     /// Insert a slice, merging with overlapping slices
     /// Returns the net change in bytes (can be negative if merge reduces size, but typically positive)
-    fn insert(&mut self, range: Range<u64>, data: Vec<u8>, access_counter: u64) -> isize {
+    fn insert(&mut self, range: Range<u64>, data: OwnedBytes, access_counter: u64) -> isize {
         let start = range.start;
         let end = range.end;
         let data_len = data.len();
@@ -163,7 +184,7 @@ impl FileSliceCache {
         let mut to_remove = Vec::new();
         let mut merged_start = start;
         let mut merged_end = end;
-        let mut merged_data: Option<Vec<u8>> = None;
+        let mut merged_data: Option<OwnedBytes> = None;
         let mut bytes_removed: usize = 0;
 
         for (&slice_start, slice) in &self.slices {
@@ -186,7 +207,8 @@ impl FileSliceCache {
             for &slice_start in &to_remove {
                 if let Some(slice) = self.slices.get(&slice_start) {
                     let offset = (slice_start - merged_start) as usize;
-                    new_data[offset..offset + slice.data.len()].copy_from_slice(&slice.data);
+                    new_data[offset..offset + slice.data.len()]
+                        .copy_from_slice(slice.data.as_slice());
                     bytes_removed += slice.data.len();
                     self.total_bytes -= slice.data.len();
                 }
@@ -194,14 +216,14 @@ impl FileSliceCache {
 
             // Copy new data (overwrites any overlapping parts)
             let offset = (start - merged_start) as usize;
-            new_data[offset..offset + data_len].copy_from_slice(&data);
+            new_data[offset..offset + data_len].copy_from_slice(data.as_slice());
 
             // Remove old slices
             for slice_start in to_remove {
                 self.slices.remove(&slice_start);
             }
 
-            merged_data = Some(new_data);
+            merged_data = Some(OwnedBytes::new(new_data));
         }
 
         // Insert the (possibly merged) slice
@@ -218,7 +240,7 @@ impl FileSliceCache {
             final_start,
             CachedSlice {
                 range: final_start..final_start + bytes_added as u64,
-                data: Arc::new(final_data),
+                data: final_data,
                 access_count: access_counter,
             },
         );
@@ -251,6 +273,43 @@ impl FileSliceCache {
 
         freed
     }
+}
+
+fn evict_cached_slices(
+    caches: &mut std::collections::HashMap<PathBuf, FileSliceCache>,
+    current_bytes: &mut usize,
+    max_bytes: usize,
+    needed: usize,
+) {
+    let target = current_bytes
+        .saturating_add(needed)
+        .saturating_sub(max_bytes);
+    let mut freed = 0;
+
+    while freed < target {
+        let oldest_file = caches
+            .iter()
+            .filter(|(_, cache)| !cache.slices.is_empty())
+            .min_by_key(|(_, cache)| {
+                cache
+                    .slices
+                    .values()
+                    .map(|slice| slice.access_count)
+                    .min()
+                    .unwrap_or(u64::MAX)
+            })
+            .map(|(path, _)| path.clone());
+
+        let Some(path) = oldest_file else {
+            break;
+        };
+        let Some(file_cache) = caches.get_mut(&path) else {
+            break;
+        };
+        freed += file_cache.evict_lru(target - freed);
+    }
+
+    *current_bytes = current_bytes.saturating_sub(freed);
 }
 
 /// Slice-caching directory wrapper
@@ -296,7 +355,7 @@ impl<D: Directory> SliceCachingDirectory<D> {
     }
 
     /// Try to read from cache
-    fn try_cache_read(&self, path: &Path, range: Range<u64>) -> Option<Vec<u8>> {
+    fn try_cache_read(&self, path: &Path, range: Range<u64>) -> Option<OwnedBytes> {
         let mut caches = self.caches.write();
         let mut counter = self.access_counter.write();
 
@@ -308,71 +367,34 @@ impl<D: Directory> SliceCachingDirectory<D> {
     }
 
     /// Insert into cache, evicting if necessary
-    fn cache_insert(&self, path: &Path, range: Range<u64>, data: Vec<u8>) {
+    fn cache_insert(&self, path: &Path, range: Range<u64>, data: OwnedBytes) {
         let data_len = data.len();
-
-        // Check if we need to evict
-        {
-            let current = *self.current_bytes.read();
-            if current + data_len > self.max_bytes {
-                self.evict_to_fit(data_len);
-            }
+        // An individual entry larger than the entire cache can never fit.
+        // Bypass it instead of evicting useful data and exceeding the cap.
+        if data_len > self.max_bytes {
+            return;
         }
 
         let mut caches = self.caches.write();
+        let mut current = self.current_bytes.write();
         let counter = *self.access_counter.read();
 
+        // Free enough space before merging. Besides keeping the retained size
+        // bounded, this avoids constructing a large merged allocation only to
+        // evict it immediately afterward.
+        evict_cached_slices(&mut caches, &mut current, self.max_bytes, data_len);
         let file_cache = caches
             .entry(path.to_path_buf())
             .or_insert_with(FileSliceCache::new);
 
         let net_change = file_cache.insert(range, data, counter);
-        let mut current = self.current_bytes.write();
         if net_change >= 0 {
             *current += net_change as usize;
         } else {
             *current = current.saturating_sub((-net_change) as usize);
         }
-    }
-
-    /// Evict slices to make room for new data
-    fn evict_to_fit(&self, needed: usize) {
-        let mut caches = self.caches.write();
-        let mut current = self.current_bytes.write();
-
-        let target = if *current + needed > self.max_bytes {
-            (*current + needed) - self.max_bytes
-        } else {
-            return;
-        };
-
-        let mut freed = 0;
-
-        // Evict from all file caches until we have enough space
-        while freed < target {
-            // Find the file cache with the oldest access
-            let oldest_file = caches
-                .iter()
-                .filter(|(_, fc)| !fc.slices.is_empty())
-                .min_by_key(|(_, fc)| {
-                    fc.slices
-                        .values()
-                        .map(|s| s.access_count)
-                        .min()
-                        .unwrap_or(u64::MAX)
-                })
-                .map(|(p, _)| p.clone());
-
-            if let Some(path) = oldest_file {
-                if let Some(file_cache) = caches.get_mut(&path) {
-                    freed += file_cache.evict_lru(target - freed);
-                }
-            } else {
-                break;
-            }
-        }
-
-        *current = current.saturating_sub(freed);
+        evict_cached_slices(&mut caches, &mut current, self.max_bytes, 0);
+        debug_assert!(*current <= self.max_bytes);
     }
 
     /// Get cache statistics
@@ -513,13 +535,22 @@ impl<D: Directory> SliceCachingDirectory<D> {
             pos += path_len;
 
             // File cache
-            let (file_cache, consumed) = FileSliceCache::deserialize(&data[pos..], counter)?;
+            let (file_cache, consumed) =
+                FileSliceCache::deserialize(&data[pos..], counter, self.max_bytes)?;
             pos += consumed;
 
-            // Merge into existing cache
-            *current_bytes += file_cache.total_bytes;
-            caches.insert(path, file_cache);
+            let new_bytes = file_cache.total_bytes;
+            if let Some(previous) = caches.insert(path, file_cache) {
+                *current_bytes = current_bytes.saturating_sub(previous.total_bytes);
+            }
+            *current_bytes = current_bytes.saturating_add(new_bytes);
+            evict_cached_slices(&mut caches, &mut current_bytes, self.max_bytes, 0);
         }
+
+        // Recompute once after loading as a consistency check for serialized
+        // caches containing duplicate paths or overlapping ranges.
+        *current_bytes = caches.values().map(|cache| cache.total_bytes).sum();
+        evict_cached_slices(&mut caches, &mut current_bytes, self.max_bytes, 0);
 
         // Load file sizes
         if pos + 4 <= data.len() {
@@ -625,7 +656,7 @@ impl<D: Directory> Directory for SliceCachingDirectory<D> {
 
         // Try cache first for full file
         if let Some(data) = self.try_cache_read(path, full_range.clone()) {
-            return Ok(FileHandle::from_bytes(OwnedBytes::new(data)));
+            return Ok(FileHandle::from_bytes(data));
         }
 
         // Read from inner
@@ -633,7 +664,7 @@ impl<D: Directory> Directory for SliceCachingDirectory<D> {
         let bytes = handle.read_bytes().await?;
 
         // Cache the full file
-        self.cache_insert(path, full_range, bytes.as_slice().to_vec());
+        self.cache_insert(path, full_range, bytes.clone());
 
         Ok(FileHandle::from_bytes(bytes))
     }
@@ -641,14 +672,14 @@ impl<D: Directory> Directory for SliceCachingDirectory<D> {
     async fn read_range(&self, path: &Path, range: Range<u64>) -> io::Result<OwnedBytes> {
         // Try cache first
         if let Some(data) = self.try_cache_read(path, range.clone()) {
-            return Ok(OwnedBytes::new(data));
+            return Ok(data);
         }
 
         // Read from inner
         let data = self.inner.read_range(path, range.clone()).await?;
 
         // Cache the result
-        self.cache_insert(path, range, data.as_slice().to_vec());
+        self.cache_insert(path, range, data.clone());
 
         Ok(data)
     }
@@ -684,7 +715,7 @@ impl<D: Directory> Directory for SliceCachingDirectory<D> {
                     if let Some(file_cache) = caches_guard.get_mut(&path)
                         && let Some(data) = file_cache.try_read(range.clone(), &mut counter)
                     {
-                        return Ok(OwnedBytes::new(data));
+                        return Ok(data);
                     }
                 }
 
@@ -694,30 +725,23 @@ impl<D: Directory> Directory for SliceCachingDirectory<D> {
                 let data = inner.read_range(&path, range.clone()).await?;
 
                 // Cache the result
-                let data_len = data.as_slice().len();
-                {
-                    // Check if we need to evict
-                    let current = *current_bytes.read();
-                    if current + data_len > max_bytes {
-                        // Simple eviction: just skip caching if over limit
-                        // Full eviction would require more complex logic here
+                let data_len = data.len();
+                if data_len <= max_bytes {
+                    let mut caches_guard = caches.write();
+                    let mut current = current_bytes.write();
+                    let counter = *access_counter.read();
+                    evict_cached_slices(&mut caches_guard, &mut current, max_bytes, data_len);
+                    let file_cache = caches_guard
+                        .entry(path.clone())
+                        .or_insert_with(FileSliceCache::new);
+                    let net_change = file_cache.insert(range, data.clone(), counter);
+                    if net_change >= 0 {
+                        *current += net_change as usize;
                     } else {
-                        let mut caches_guard = caches.write();
-                        let counter = *access_counter.read();
-
-                        let file_cache = caches_guard
-                            .entry(path.clone())
-                            .or_insert_with(FileSliceCache::new);
-
-                        let net_change =
-                            file_cache.insert(range, data.as_slice().to_vec(), counter);
-                        let mut current = current_bytes.write();
-                        if net_change >= 0 {
-                            *current += net_change as usize;
-                        } else {
-                            *current = current.saturating_sub((-net_change) as usize);
-                        }
+                        *current = current.saturating_sub((-net_change) as usize);
                     }
+                    evict_cached_slices(&mut caches_guard, &mut current, max_bytes, 0);
+                    debug_assert!(*current <= max_bytes);
                 }
 
                 Ok(data)
@@ -862,6 +886,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn slice_cache_hits_reuse_the_cached_backing_allocation() {
+        let ram = RamDirectory::new();
+        ram.write(Path::new("test.bin"), &[7; 64]).await.unwrap();
+        let cached = SliceCachingDirectory::new(ram, 64);
+
+        let miss = cached
+            .read_range(Path::new("test.bin"), 8..56)
+            .await
+            .unwrap();
+        let hit = cached
+            .read_range(Path::new("test.bin"), 8..56)
+            .await
+            .unwrap();
+
+        assert_eq!(miss.as_slice(), hit.as_slice());
+        assert_eq!(miss.as_slice().as_ptr(), hit.as_slice().as_ptr());
+    }
+
+    #[tokio::test]
+    async fn oversized_slice_bypasses_cache_instead_of_exceeding_limit() {
+        let ram = RamDirectory::new();
+        ram.write(Path::new("test.bin"), &[3; 32]).await.unwrap();
+        let cached = SliceCachingDirectory::new(ram, 8);
+
+        let data = cached
+            .read_range(Path::new("test.bin"), 0..32)
+            .await
+            .unwrap();
+        assert_eq!(data.len(), 32);
+        assert_eq!(cached.stats().total_bytes, 0);
+    }
+
+    #[tokio::test]
     async fn test_slice_cache_overlap_merge() {
         let ram = RamDirectory::new();
         ram.write(Path::new("test.bin"), &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
@@ -986,5 +1043,20 @@ mod tests {
         let cached2 = SliceCachingDirectory::new(RamDirectory::new(), 1024);
         cached2.deserialize(&serialized).unwrap();
         assert!(cached2.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deserialization_enforces_the_destination_cache_limit() {
+        let ram = RamDirectory::new();
+        ram.write(Path::new("test.bin"), &[1; 64]).await.unwrap();
+        let source = SliceCachingDirectory::new(ram.clone(), 64);
+        source
+            .read_range(Path::new("test.bin"), 0..64)
+            .await
+            .unwrap();
+
+        let destination = SliceCachingDirectory::new(ram, 8);
+        destination.deserialize(&source.serialize()).unwrap();
+        assert!(destination.stats().total_bytes <= 8);
     }
 }

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -1318,9 +1318,7 @@ fn score_superblock_blocks(
                     continue;
                 }
 
-                if collector.would_enter_candidate(doc_id, score, ordinal) {
-                    collector.insert_with_ordinal(doc_id, score, ordinal);
-                }
+                collector.insert_with_ordinal(doc_id, score, ordinal);
             }
         }
         *docmap_secs += docmap_start.secs();

--- a/hermes-core/src/query/collector.rs
+++ b/hermes-core/src/query/collector.rs
@@ -128,25 +128,25 @@ impl SearchResult {
     /// For text fields: ordinal = position >> 20 (from encoded position)
     /// For vector fields: position IS the ordinal directly
     pub fn extract_ordinals(&self) -> Vec<MatchedField> {
-        use rustc_hash::FxHashSet;
-
         self.positions
             .iter()
             .map(|(field_id, scored_positions)| {
-                let mut ordinals: FxHashSet<u32> = FxHashSet::default();
-                for sp in scored_positions {
-                    // For text fields with encoded positions, extract ordinal
-                    // For vector fields, position IS the ordinal
-                    // We use a heuristic: if position > 0xFFFFF (20 bits), it's encoded
-                    let ordinal = if sp.position > 0xFFFFF {
+                // Position lists are typically short. Collecting into one
+                // compact buffer and deduplicating in place avoids both the
+                // hash-table allocation and the second allocation needed to
+                // turn that table back into a sorted response vector.
+                let mut ordinals = Vec::with_capacity(scored_positions.len());
+                ordinals.extend(scored_positions.iter().map(|sp| {
+                    // For text fields with encoded positions, extract ordinal.
+                    // For vector fields, position IS the ordinal.
+                    if sp.position > 0xFFFFF {
                         sp.position >> 20
                     } else {
                         sp.position
-                    };
-                    ordinals.insert(ordinal);
-                }
-                let mut ordinals: Vec<u32> = ordinals.into_iter().collect();
+                    }
+                }));
                 ordinals.sort_unstable();
+                ordinals.dedup();
                 MatchedField {
                     field_id: *field_id,
                     ordinals,
@@ -237,11 +237,88 @@ pub trait Collector {
     }
 }
 
+/// Compact score-only heap entry.
+///
+/// A segment-local collector does not know its segment ID yet and ordinary
+/// searches do not retain positions. Keeping only these two words while the
+/// scorer runs makes the common heap 8 bytes per hit instead of storing a
+/// full `SearchResult` (including an empty `Vec` and a zero `u128`).
+#[derive(Debug, Clone, Copy)]
+struct ScoreOnlyResult {
+    doc_id: DocId,
+    score: Score,
+}
+
+impl PartialEq for ScoreOnlyResult {
+    fn eq(&self, other: &Self) -> bool {
+        self.score.to_bits() == other.score.to_bits() && self.doc_id == other.doc_id
+    }
+}
+
+impl Eq for ScoreOnlyResult {}
+
+impl PartialOrd for ScoreOnlyResult {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ScoreOnlyResult {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .score
+            .total_cmp(&self.score)
+            .then_with(|| self.doc_id.cmp(&other.doc_id))
+    }
+}
+
+/// Position-aware heap entry. The segment ID is stamped after collection, so
+/// omitting it here also keeps this variant smaller than `SearchResult`.
+#[derive(Debug, Clone)]
+struct PositionedResult {
+    doc_id: DocId,
+    score: Score,
+    positions: super::MatchedPositions,
+}
+
+impl PartialEq for PositionedResult {
+    fn eq(&self, other: &Self) -> bool {
+        self.score.to_bits() == other.score.to_bits() && self.doc_id == other.doc_id
+    }
+}
+
+impl Eq for PositionedResult {}
+
+impl PartialOrd for PositionedResult {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PositionedResult {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .score
+            .total_cmp(&self.score)
+            .then_with(|| self.doc_id.cmp(&other.doc_id))
+    }
+}
+
+enum TopKHeap {
+    Scores(BinaryHeap<ScoreOnlyResult>),
+    Positions(BinaryHeap<PositionedResult>),
+}
+
+#[inline(always)]
+fn ranks_ahead(doc_id: DocId, score: Score, worst_doc_id: DocId, worst_score: Score) -> bool {
+    let order = score.total_cmp(&worst_score);
+    order.is_gt() || (order.is_eq() && doc_id < worst_doc_id)
+}
+
 /// Collector for top-k results
 pub struct TopKCollector {
-    heap: BinaryHeap<SearchResult>,
+    heap: TopKHeap,
     k: usize,
-    collect_positions: bool,
     /// Total documents seen by this collector
     total_seen: u32,
 }
@@ -255,9 +332,8 @@ const MAX_INITIAL_TOP_K_CAPACITY: usize = 8 * 1024;
 impl TopKCollector {
     pub fn new(k: usize) -> Self {
         Self {
-            heap: BinaryHeap::with_capacity(k.min(MAX_INITIAL_TOP_K_CAPACITY)),
+            heap: TopKHeap::Scores(BinaryHeap::with_capacity(k.min(MAX_INITIAL_TOP_K_CAPACITY))),
             k,
-            collect_positions: false,
             total_seen: 0,
         }
     }
@@ -265,9 +341,8 @@ impl TopKCollector {
     /// Create a collector that also collects positions
     pub fn with_positions(k: usize) -> Self {
         Self {
-            heap: BinaryHeap::with_capacity(k.min(MAX_INITIAL_TOP_K_CAPACITY)),
+            heap: TopKHeap::Positions(BinaryHeap::with_capacity(k.min(MAX_INITIAL_TOP_K_CAPACITY))),
             k,
-            collect_positions: true,
             total_seen: 0,
         }
     }
@@ -278,9 +353,42 @@ impl TopKCollector {
     }
 
     pub fn into_sorted_results(self) -> Vec<SearchResult> {
-        let mut results: Vec<_> = self.heap.into_vec();
-        results.sort_unstable_by(compare_search_results_desc);
-        results
+        match self.heap {
+            TopKHeap::Scores(heap) => {
+                let mut compact = heap.into_vec();
+                compact.sort_unstable_by(|a, b| {
+                    b.score
+                        .total_cmp(&a.score)
+                        .then_with(|| a.doc_id.cmp(&b.doc_id))
+                });
+                compact
+                    .into_iter()
+                    .map(|result| SearchResult {
+                        doc_id: result.doc_id,
+                        score: result.score,
+                        segment_id: 0,
+                        positions: Vec::new(),
+                    })
+                    .collect()
+            }
+            TopKHeap::Positions(heap) => {
+                let mut positioned = heap.into_vec();
+                positioned.sort_unstable_by(|a, b| {
+                    b.score
+                        .total_cmp(&a.score)
+                        .then_with(|| a.doc_id.cmp(&b.doc_id))
+                });
+                positioned
+                    .into_iter()
+                    .map(|result| SearchResult {
+                        doc_id: result.doc_id,
+                        score: result.score,
+                        segment_id: 0,
+                        positions: result.positions,
+                    })
+                    .collect()
+            }
+        }
     }
 
     /// Consume collector and return (sorted_results, total_seen)
@@ -291,66 +399,114 @@ impl TopKCollector {
 }
 
 impl Collector for TopKCollector {
+    #[inline]
     fn collect(&mut self, doc_id: DocId, score: Score, positions: &[(u32, Vec<ScoredPosition>)]) {
         self.total_seen = self.total_seen.saturating_add(1);
-
-        // Only clone positions when the document will actually be kept in the heap.
-        // This avoids deep-cloning Vec<ScoredPosition> for documents that are
-        // immediately discarded (the common case for large result sets).
-        if !self.would_collect(doc_id, score) {
+        if self.k == 0 {
             return;
         }
 
-        let positions = if self.collect_positions {
-            positions.to_vec()
-        } else {
-            Vec::new()
-        };
-
-        if self.heap.len() >= self.k {
-            self.heap.pop();
+        match &mut self.heap {
+            TopKHeap::Scores(heap) => {
+                let result = ScoreOnlyResult { doc_id, score };
+                if heap.len() < self.k {
+                    heap.push(result);
+                } else if heap
+                    .peek()
+                    .is_some_and(|worst| ranks_ahead(doc_id, score, worst.doc_id, worst.score))
+                {
+                    *heap.peek_mut().expect("full top-k heap") = result;
+                }
+            }
+            TopKHeap::Positions(heap) => {
+                if heap.len() >= self.k
+                    && !heap
+                        .peek()
+                        .is_some_and(|worst| ranks_ahead(doc_id, score, worst.doc_id, worst.score))
+                {
+                    return;
+                }
+                let result = PositionedResult {
+                    doc_id,
+                    score,
+                    // Only clone positions after the hit is known to be
+                    // competitive. Replacing the root drops its old positions.
+                    positions: positions.to_vec(),
+                };
+                if heap.len() < self.k {
+                    heap.push(result);
+                } else {
+                    *heap.peek_mut().expect("full top-k heap") = result;
+                }
+            }
         }
-        self.heap.push(SearchResult {
-            doc_id,
-            score,
-            segment_id: 0,
-            positions,
-        });
     }
 
+    #[inline]
     fn would_collect(&self, doc_id: DocId, score: Score) -> bool {
-        self.k > 0
-            && (self.heap.len() < self.k
-                || self.heap.peek().is_some_and(|min| {
-                    score.total_cmp(&min.score).is_gt()
-                        || (score.total_cmp(&min.score).is_eq() && doc_id < min.doc_id)
-                }))
+        if self.k == 0 {
+            return false;
+        }
+        match &self.heap {
+            TopKHeap::Scores(heap) => {
+                heap.len() < self.k
+                    || heap
+                        .peek()
+                        .is_some_and(|min| ranks_ahead(doc_id, score, min.doc_id, min.score))
+            }
+            TopKHeap::Positions(heap) => {
+                heap.len() < self.k
+                    || heap
+                        .peek()
+                        .is_some_and(|min| ranks_ahead(doc_id, score, min.doc_id, min.score))
+            }
+        }
     }
 
+    #[inline]
     fn collect_owned(&mut self, doc_id: DocId, score: Score, positions: super::MatchedPositions) {
         self.total_seen = self.total_seen.saturating_add(1);
-
-        if !self.would_collect(doc_id, score) {
+        if self.k == 0 {
             return;
         }
 
-        if self.heap.len() >= self.k {
-            self.heap.pop();
+        match &mut self.heap {
+            TopKHeap::Scores(heap) => {
+                let result = ScoreOnlyResult { doc_id, score };
+                if heap.len() < self.k {
+                    heap.push(result);
+                } else if heap
+                    .peek()
+                    .is_some_and(|worst| ranks_ahead(doc_id, score, worst.doc_id, worst.score))
+                {
+                    *heap.peek_mut().expect("full top-k heap") = result;
+                }
+            }
+            TopKHeap::Positions(heap) => {
+                if heap.len() >= self.k
+                    && !heap
+                        .peek()
+                        .is_some_and(|worst| ranks_ahead(doc_id, score, worst.doc_id, worst.score))
+                {
+                    return;
+                }
+                let result = PositionedResult {
+                    doc_id,
+                    score,
+                    positions,
+                };
+                if heap.len() < self.k {
+                    heap.push(result);
+                } else {
+                    *heap.peek_mut().expect("full top-k heap") = result;
+                }
+            }
         }
-        self.heap.push(SearchResult {
-            doc_id,
-            score,
-            segment_id: 0,
-            positions: if self.collect_positions {
-                positions
-            } else {
-                Vec::new()
-            },
-        });
     }
 
+    #[inline]
     fn needs_positions(&self) -> bool {
-        self.collect_positions
+        matches!(&self.heap, TopKHeap::Positions(_))
     }
 }
 
@@ -926,7 +1082,64 @@ mod tests {
     fn huge_top_k_does_not_trigger_a_huge_initial_allocation() {
         let collector = TopKCollector::new(usize::MAX);
 
-        assert!(collector.heap.capacity() <= MAX_INITIAL_TOP_K_CAPACITY);
+        let TopKHeap::Scores(heap) = collector.heap else {
+            panic!("score-only constructor selected the position heap");
+        };
+        assert!(heap.capacity() <= MAX_INITIAL_TOP_K_CAPACITY);
+    }
+
+    #[test]
+    fn score_only_heap_entry_stays_compact() {
+        assert_eq!(std::mem::size_of::<ScoreOnlyResult>(), 8);
+        assert!(std::mem::size_of::<SearchResult>() >= 4 * std::mem::size_of::<ScoreOnlyResult>());
+    }
+
+    #[test]
+    fn top_k_replacement_preserves_score_and_doc_ties() {
+        let mut collector = TopKCollector::new(3);
+        for (doc_id, score) in [(9, 2.0), (8, 2.0), (7, 2.0), (6, 2.0), (1, 1.0)] {
+            collector.collect(doc_id, score, &[]);
+        }
+
+        let results = collector.into_sorted_results();
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| (result.doc_id, result.score))
+                .collect::<Vec<_>>(),
+            vec![(6, 2.0), (7, 2.0), (8, 2.0)]
+        );
+    }
+
+    #[test]
+    fn extract_ordinals_sorts_and_deduplicates_without_hashing() {
+        let result = SearchResult {
+            doc_id: 1,
+            score: 1.0,
+            segment_id: 0,
+            positions: vec![
+                (
+                    3,
+                    vec![
+                        ScoredPosition::new(5 << 20, 1.0),
+                        ScoredPosition::new(2 << 20, 1.0),
+                        ScoredPosition::new(5 << 20, 2.0),
+                    ],
+                ),
+                (
+                    7,
+                    vec![
+                        ScoredPosition::new(4, 1.0),
+                        ScoredPosition::new(1, 1.0),
+                        ScoredPosition::new(4, 2.0),
+                    ],
+                ),
+            ],
+        };
+
+        let fields = result.extract_ordinals();
+        assert_eq!(fields[0].ordinals, vec![2, 5]);
+        assert_eq!(fields[1].ordinals, vec![1, 4]);
     }
 
     #[test]

--- a/hermes-core/src/query/scoring.rs
+++ b/hermes-core/src/query/scoring.rs
@@ -13,6 +13,11 @@ use log::{debug, warn};
 
 use crate::DocId;
 
+/// Avoid eagerly reserving an arbitrarily large top-k heap. Most searches
+/// return far fewer hits than a very large requested limit, so let the heap
+/// grow on demand beyond this point.
+const MAX_INITIAL_SCORE_COLLECTOR_CAPACITY: usize = 8 * 1024;
+
 /// Entry for top-k min-heap
 #[derive(Clone, Copy)]
 pub struct HeapEntry {
@@ -68,21 +73,20 @@ pub struct ScoreCollector {
     /// Cached threshold: avoids repeated heap.peek() in hot loops.
     /// Updated only when the heap changes (insert/pop).
     cached_threshold: f32,
-    /// Number of real entries in the heap. Threshold seeding fills unused
-    /// slots with sentinels, so `heap.len()` alone cannot answer this.
-    real_len: usize,
+    /// Score of the logical sentinel filling every unused top-k slot after
+    /// threshold seeding. Keeping one score here instead of `k - heap.len()`
+    /// entries makes filling those unused slots O(1) time and memory.
+    virtual_threshold: Option<f32>,
 }
 
 impl ScoreCollector {
     /// Create a new collector for top-k results
     pub fn new(k: usize) -> Self {
-        // Cap capacity to avoid allocation overflow for very large k
-        let capacity = k.saturating_add(1).min(1_000_000);
         Self {
-            heap: BinaryHeap::with_capacity(capacity),
+            heap: BinaryHeap::with_capacity(k.min(MAX_INITIAL_SCORE_COLLECTOR_CAPACITY)),
             k,
             cached_threshold: 0.0,
-            real_len: 0,
+            virtual_threshold: None,
         }
     }
 
@@ -95,7 +99,9 @@ impl ScoreCollector {
     /// Recompute cached threshold from heap state
     #[inline]
     fn update_threshold(&mut self) {
-        self.cached_threshold = if self.heap.len() >= self.k {
+        self.cached_threshold = if let Some(threshold) = self.virtual_threshold {
+            threshold
+        } else if self.heap.len() >= self.k {
             self.heap.peek().map(|e| e.score).unwrap_or(0.0)
         } else {
             0.0
@@ -122,21 +128,28 @@ impl ScoreCollector {
             ordinal,
         };
         if self.heap.len() < self.k {
+            if let Some(threshold) = self.virtual_threshold {
+                let sentinel = HeapEntry {
+                    doc_id: u32::MAX,
+                    score: threshold,
+                    ordinal: 0,
+                };
+                if entry >= sentinel {
+                    return false;
+                }
+            }
+
             self.heap.push(entry);
-            self.real_len += 1;
-            // Only recompute threshold when heap just became full
+            // The final real entry displaces the last virtual sentinel.
             if self.heap.len() == self.k {
+                self.virtual_threshold = None;
                 self.update_threshold();
             }
             true
         } else if self.heap.peek().is_some_and(|worst| entry < *worst) {
-            self.heap.push(entry);
-            if self
-                .heap
-                .pop()
-                .is_some_and(|evicted| evicted.doc_id == u32::MAX)
             {
-                self.real_len += 1;
+                let mut worst = self.heap.peek_mut().expect("full heap has a root");
+                *worst = entry;
             }
             self.update_threshold();
             true
@@ -148,7 +161,7 @@ impl ScoreCollector {
     /// Check if a score could potentially enter top-k
     #[inline]
     pub fn would_enter(&self, score: f32) -> bool {
-        self.heap.len() < self.k || score > self.cached_threshold
+        self.len() < self.k || score > self.cached_threshold
     }
 
     /// Check whether this fully identified candidate ranks ahead of the current
@@ -163,37 +176,50 @@ impl ScoreCollector {
             score,
             ordinal,
         };
-        self.heap.len() < self.k || self.heap.peek().is_some_and(|worst| entry < *worst)
+        if let Some(threshold) = self.virtual_threshold {
+            let sentinel = HeapEntry {
+                doc_id: u32::MAX,
+                score: threshold,
+                ordinal: 0,
+            };
+            entry < sentinel
+        } else {
+            self.heap.len() < self.k || self.heap.peek().is_some_and(|worst| entry < *worst)
+        }
     }
 
-    /// Get number of documents collected so far
+    /// Get the conceptual heap length, including virtual threshold sentinels.
     #[inline]
     pub fn len(&self) -> usize {
-        self.heap.len()
+        if self.virtual_threshold.is_some() {
+            self.k
+        } else {
+            self.heap.len()
+        }
     }
 
     /// Number of real results retained, excluding threshold sentinels.
     #[inline]
     pub fn real_len(&self) -> usize {
-        self.real_len
+        self.heap.len()
     }
 
     /// Check if collector is empty
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.heap.is_empty()
+        self.len() == 0
     }
 
     /// Seed the threshold from a cross-segment shared value.
     ///
-    /// Fills unused slots and replaces retained entries below the new floor
-    /// with dummy entries. This can be called repeatedly while another
-    /// segment raises the shared threshold; equal-scoring real candidates win
-    /// the deterministic doc-id tie break over sentinels.
+    /// Logically fills unused slots and replaces retained entries below the new
+    /// floor with virtual dummy entries. This can be called repeatedly while
+    /// another segment raises the shared threshold; equal-scoring real
+    /// candidates win the deterministic doc-id tie break over sentinels.
     pub fn seed_threshold(&mut self, initial_threshold: f32) {
         if initial_threshold <= 0.0
             || self.k == 0
-            || (self.heap.len() >= self.k && initial_threshold <= self.cached_threshold)
+            || (self.len() >= self.k && initial_threshold <= self.cached_threshold)
         {
             return;
         }
@@ -203,18 +229,28 @@ impl ScoreCollector {
             score: initial_threshold,
             ordinal: 0,
         };
-        while self.heap.len() < self.k {
-            self.heap.push(sentinel);
-        }
-        while self.heap.peek().is_some_and(|worst| sentinel < *worst) {
-            self.heap.push(sentinel);
-            if self
-                .heap
-                .pop()
-                .is_some_and(|evicted| evicted.doc_id != u32::MAX)
-            {
-                self.real_len -= 1;
+
+        // When unused slots are already represented by a virtual sentinel, a
+        // new seed only changes the heap if it outranks the old floor. With an
+        // all-real full heap, it must similarly outrank the current root.
+        if let Some(current_threshold) = self.virtual_threshold {
+            let current = HeapEntry {
+                doc_id: u32::MAX,
+                score: current_threshold,
+                ordinal: 0,
+            };
+            if sentinel >= current {
+                return;
             }
+        } else if self.heap.len() >= self.k
+            && !self.heap.peek().is_some_and(|worst| sentinel < *worst)
+        {
+            return;
+        }
+
+        self.virtual_threshold = Some(initial_threshold);
+        while self.heap.peek().is_some_and(|worst| sentinel < *worst) {
+            self.heap.pop();
         }
         self.update_threshold();
     }
@@ -1301,6 +1337,57 @@ mod tests {
         assert_eq!(collector.real_len(), 2);
         let results = collector.into_sorted_results();
         assert_eq!(results, vec![(1, 10.0, 0), (3, 6.0, 0)]);
+    }
+
+    #[test]
+    fn test_large_seed_uses_virtual_sentinels() {
+        let k = 1_000_000_000;
+        let mut collector = ScoreCollector::new(k);
+        assert!(collector.heap.capacity() <= MAX_INITIAL_SCORE_COLLECTOR_CAPACITY);
+
+        collector.seed_threshold(42.0);
+
+        // Seeding a huge top-k is constant-time and does not materialize any
+        // of its conceptual sentinel entries.
+        assert_eq!(collector.heap.len(), 0);
+        assert!(collector.heap.capacity() <= MAX_INITIAL_SCORE_COLLECTOR_CAPACITY);
+        assert_eq!(collector.len(), k);
+        assert_eq!(collector.real_len(), 0);
+        assert_eq!(collector.threshold(), 42.0);
+        assert!(!collector.is_empty());
+
+        // A real result tied with the floor beats the sentinel by doc-id, while
+        // a lower score remains below the conceptual threshold.
+        assert!(collector.insert_with_ordinal(9, 42.0, 7));
+        assert!(!collector.insert(10, 41.0));
+        assert!(collector.insert(11, 43.0));
+        assert_eq!(collector.len(), k);
+        assert_eq!(collector.real_len(), 2);
+        assert_eq!(
+            collector.into_sorted_results(),
+            vec![(11, 43.0, 0), (9, 42.0, 7)]
+        );
+    }
+
+    #[test]
+    fn test_virtual_sentinels_preserve_tie_order_when_filled() {
+        let mut collector = ScoreCollector::new(3);
+        collector.seed_threshold(5.0);
+
+        assert!(collector.insert_with_ordinal(3, 5.0, 2));
+        assert!(collector.insert_with_ordinal(2, 5.0, 8));
+        assert!(collector.insert_with_ordinal(1, 5.0, 4));
+        assert_eq!(collector.real_len(), 3);
+        assert!(collector.virtual_threshold.is_none());
+
+        // Once all virtual slots have been displaced, canonical doc/ordinal
+        // ordering still controls root replacement at an equal score.
+        assert!(collector.insert_with_ordinal(2, 5.0, 1));
+        assert!(!collector.insert_with_ordinal(4, 5.0, 0));
+        assert_eq!(
+            collector.into_sorted_results(),
+            vec![(1, 5.0, 4), (2, 5.0, 1), (2, 5.0, 8)]
+        );
     }
 
     #[test]

--- a/hermes-core/src/segment/store.rs
+++ b/hermes-core/src/segment/store.rs
@@ -13,8 +13,14 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use lru::LruCache;
 use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
+#[cfg(feature = "native")]
+use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::sync::Arc;
+#[cfg(feature = "native")]
+use std::sync::mpsc::{Receiver, SyncSender};
+#[cfg(feature = "native")]
+use std::thread::JoinHandle;
 
 use crate::DocId;
 use crate::compression::CompressionDict;
@@ -224,84 +230,253 @@ struct CompressedBlock {
     compressed: Vec<u8>,
 }
 
+#[cfg(feature = "native")]
+struct CompressionJob {
+    seq: usize,
+    first_doc_id: DocId,
+    num_docs: u32,
+    data: Vec<u8>,
+}
+
+/// Fixed-width compression pool used by [`EagerParallelStoreWriter`].
+///
+/// The producer separately limits the number of submitted-but-not-written
+/// blocks. The bounded job channel provides backpressure as a second line of
+/// defence and prevents a fast store-file scan from creating an unbounded task
+/// queue.
+#[cfg(feature = "native")]
+struct StoreCompressionPool {
+    jobs: Option<SyncSender<CompressionJob>>,
+    results: Receiver<io::Result<CompressedBlock>>,
+    workers: Vec<JoinHandle<()>>,
+    num_threads: usize,
+}
+
+#[cfg(feature = "native")]
+impl StoreCompressionPool {
+    fn new(
+        num_threads: usize,
+        dict: Option<Arc<CompressionDict>>,
+        compression_level: CompressionLevel,
+    ) -> Self {
+        // A zero-width pool can never make progress. Treat zero as the
+        // conservative single-worker setting; the public configuration did
+        // not historically reject zero.
+        let num_threads = num_threads.max(1);
+        let (job_sender, job_receiver) =
+            std::sync::mpsc::sync_channel::<CompressionJob>(num_threads);
+        let job_receiver = Arc::new(std::sync::Mutex::new(job_receiver));
+        let (result_sender, result_receiver) = std::sync::mpsc::channel();
+        let mut workers = Vec::with_capacity(num_threads);
+
+        for worker_id in 0..num_threads {
+            let jobs = Arc::clone(&job_receiver);
+            let results = result_sender.clone();
+            let dict = dict.clone();
+            let worker = std::thread::Builder::new()
+                .name(format!("hermes-store-compress-{worker_id}"))
+                .spawn(move || {
+                    loop {
+                        // std::sync::mpsc::Receiver is single-consumer, so the
+                        // short receive operation is mutex-protected. The lock
+                        // is released before compression and all workers can
+                        // then run concurrently.
+                        let job = {
+                            let receiver = jobs
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            receiver.recv()
+                        };
+                        let Ok(job) = job else {
+                            break;
+                        };
+
+                        // Always produce exactly one result for every accepted
+                        // job. Without catch_unwind, one unexpected codec panic
+                        // would leave the ordered producer waiting forever for
+                        // the missing sequence number.
+                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                            let compressed = if let Some(ref dict) = dict {
+                                crate::compression::compress_with_dict(
+                                    &job.data,
+                                    compression_level,
+                                    dict,
+                                )
+                            } else {
+                                crate::compression::compress(&job.data, compression_level)
+                            }?;
+                            Ok(CompressedBlock {
+                                seq: job.seq,
+                                first_doc_id: job.first_doc_id,
+                                num_docs: job.num_docs,
+                                compressed,
+                            })
+                        }))
+                        .unwrap_or_else(|_| {
+                            Err(io::Error::other(
+                                "document-store compression worker panicked",
+                            ))
+                        });
+
+                        if results.send(result).is_err() {
+                            break;
+                        }
+                    }
+                })
+                .expect("failed to spawn document-store compression worker");
+            workers.push(worker);
+        }
+        drop(result_sender);
+
+        Self {
+            jobs: Some(job_sender),
+            results: result_receiver,
+            workers,
+            num_threads,
+        }
+    }
+
+    #[inline]
+    fn num_threads(&self) -> usize {
+        self.num_threads
+    }
+
+    fn submit(&self, job: CompressionJob) -> io::Result<()> {
+        self.jobs
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "compression pool is closed"))?
+            .send(job)
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "document-store compression workers stopped",
+                )
+            })
+    }
+
+    fn receive(&self) -> io::Result<CompressedBlock> {
+        self.results.recv().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "document-store compression result channel closed",
+            )
+        })?
+    }
+
+    fn shutdown(&mut self) -> io::Result<()> {
+        // Closing the only producer wakes idle workers. All submitted jobs have
+        // already yielded results before the normal finish path reaches here.
+        self.jobs.take();
+        let mut panicked = false;
+        for worker in self.workers.drain(..) {
+            panicked |= worker.join().is_err();
+        }
+        if panicked {
+            Err(io::Error::other(
+                "document-store compression worker panicked",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+impl Drop for StoreCompressionPool {
+    fn drop(&mut self) {
+        // Also clean up on an early write/compression error. The result channel
+        // is unbounded, so workers can finish the small bounded tail without
+        // deadlocking while this thread joins them.
+        self.jobs.take();
+        for worker in self.workers.drain(..) {
+            let _ = worker.join();
+        }
+    }
+}
+
 /// Parallel document store writer - compresses blocks immediately when queued
 ///
-/// Spawns compression tasks as soon as blocks are ready, overlapping document
-/// ingestion with compression to reduce total indexing time.
-///
-/// Uses background threads to compress blocks while the main thread continues
-/// accepting documents.
+/// A fixed number of workers compress blocks while the caller continues
+/// accepting documents. Submitted blocks and out-of-order results are bounded,
+/// and completed blocks are written continuously in sequence order.
 #[cfg(feature = "native")]
 pub struct EagerParallelStoreWriter<'a> {
     writer: &'a mut dyn Write,
     block_buffer: Vec<u8>,
     /// Reusable buffer for document serialization (avoids per-doc allocation)
     serialize_buf: Vec<u8>,
-    /// Compressed blocks ready to be written (may arrive out of order)
-    compressed_blocks: Vec<CompressedBlock>,
-    /// Handles for in-flight compression tasks
-    pending_handles: Vec<std::thread::JoinHandle<CompressedBlock>>,
+    workers: StoreCompressionPool,
+    /// Completed blocks waiting for an earlier sequence number.
+    ready_blocks: BTreeMap<usize, CompressedBlock>,
+    /// Number of submitted jobs whose result has not yet been received.
+    pending_results: usize,
+    /// Maximum submitted-but-not-written blocks.
+    max_in_flight: usize,
     next_seq: usize,
+    next_write_seq: usize,
     next_doc_id: DocId,
     block_first_doc: DocId,
+    index: Vec<StoreBlockIndex>,
+    current_offset: u64,
     dict: Option<Arc<CompressionDict>>,
-    compression_level: CompressionLevel,
 }
 
 #[cfg(feature = "native")]
 impl<'a> EagerParallelStoreWriter<'a> {
     /// Create a new eager parallel store writer
-    pub fn new(writer: &'a mut dyn Write, _num_threads: usize) -> Self {
-        Self::with_compression_level(writer, _num_threads, DEFAULT_COMPRESSION_LEVEL)
+    pub fn new(writer: &'a mut dyn Write, num_threads: usize) -> Self {
+        Self::with_compression_level(writer, num_threads, DEFAULT_COMPRESSION_LEVEL)
     }
 
     /// Create with specific compression level
     pub fn with_compression_level(
         writer: &'a mut dyn Write,
-        _num_threads: usize,
+        num_threads: usize,
         compression_level: CompressionLevel,
     ) -> Self {
-        Self {
-            writer,
-            block_buffer: Vec::with_capacity(STORE_BLOCK_SIZE),
-            serialize_buf: Vec::with_capacity(512),
-            compressed_blocks: Vec::new(),
-            pending_handles: Vec::new(),
-            next_seq: 0,
-            next_doc_id: 0,
-            block_first_doc: 0,
-            dict: None,
-            compression_level,
-        }
+        Self::with_optional_dict(writer, None, num_threads, compression_level)
     }
 
     /// Create with dictionary
-    pub fn with_dict(
-        writer: &'a mut dyn Write,
-        dict: CompressionDict,
-        _num_threads: usize,
-    ) -> Self {
-        Self::with_dict_and_level(writer, dict, _num_threads, DEFAULT_COMPRESSION_LEVEL)
+    pub fn with_dict(writer: &'a mut dyn Write, dict: CompressionDict, num_threads: usize) -> Self {
+        Self::with_dict_and_level(writer, dict, num_threads, DEFAULT_COMPRESSION_LEVEL)
     }
 
     /// Create with dictionary and specific compression level
     pub fn with_dict_and_level(
         writer: &'a mut dyn Write,
         dict: CompressionDict,
-        _num_threads: usize,
+        num_threads: usize,
         compression_level: CompressionLevel,
     ) -> Self {
+        Self::with_optional_dict(writer, Some(Arc::new(dict)), num_threads, compression_level)
+    }
+
+    fn with_optional_dict(
+        writer: &'a mut dyn Write,
+        dict: Option<Arc<CompressionDict>>,
+        num_threads: usize,
+        compression_level: CompressionLevel,
+    ) -> Self {
+        let workers = StoreCompressionPool::new(num_threads, dict.clone(), compression_level);
+        // One active block plus one queued block per worker keeps the pool
+        // saturated without retaining the complete compressed store.
+        let max_in_flight = workers.num_threads().saturating_mul(2).max(1);
         Self {
             writer,
             block_buffer: Vec::with_capacity(STORE_BLOCK_SIZE),
             serialize_buf: Vec::with_capacity(512),
-            compressed_blocks: Vec::new(),
-            pending_handles: Vec::new(),
+            workers,
+            ready_blocks: BTreeMap::new(),
+            pending_results: 0,
+            max_in_flight,
             next_seq: 0,
+            next_write_seq: 0,
             next_doc_id: 0,
             block_first_doc: 0,
-            dict: Some(Arc::new(dict)),
-            compression_level,
+            index: Vec::new(),
+            current_offset: 0,
+            dict,
         }
     }
 
@@ -322,7 +497,7 @@ impl<'a> EagerParallelStoreWriter<'a> {
             .write_u32::<LittleEndian>(self.serialize_buf.len() as u32)?;
         self.block_buffer.extend_from_slice(&self.serialize_buf);
         if self.block_buffer.len() >= STORE_BLOCK_SIZE {
-            self.spawn_compression();
+            self.queue_compression()?;
         }
         Ok(doc_id)
     }
@@ -346,114 +521,110 @@ impl<'a> EagerParallelStoreWriter<'a> {
         self.block_buffer.extend_from_slice(doc_bytes);
 
         if self.block_buffer.len() >= STORE_BLOCK_SIZE {
-            self.spawn_compression();
+            self.queue_compression()?;
         }
 
         Ok(doc_id)
     }
 
-    /// Spawn compression for the current block immediately
-    fn spawn_compression(&mut self) {
+    /// Queue the current block and apply ordered backpressure when the bounded
+    /// in-flight window is full.
+    fn queue_compression(&mut self) -> io::Result<()> {
         if self.block_buffer.is_empty() {
-            return;
+            return Ok(());
         }
 
         let num_docs = self.next_doc_id - self.block_first_doc;
         let data = std::mem::replace(&mut self.block_buffer, Vec::with_capacity(STORE_BLOCK_SIZE));
         let seq = self.next_seq;
         let first_doc_id = self.block_first_doc;
-        let dict = self.dict.clone();
 
-        self.next_seq += 1;
+        self.workers.submit(CompressionJob {
+            seq,
+            first_doc_id,
+            num_docs,
+            data,
+        })?;
+        self.next_seq = self
+            .next_seq
+            .checked_add(1)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "store block overflow"))?;
+        self.pending_results += 1;
         self.block_first_doc = self.next_doc_id;
 
-        // Spawn compression task using thread
-        let level = self.compression_level;
-        let handle = std::thread::spawn(move || {
-            let compressed = if let Some(ref d) = dict {
-                crate::compression::compress_with_dict(&data, level, d).expect("compression failed")
-            } else {
-                crate::compression::compress(&data, level).expect("compression failed")
-            };
+        while self.outstanding_blocks() >= self.max_in_flight {
+            self.receive_and_write_ready()?;
+        }
 
-            CompressedBlock {
-                seq,
-                first_doc_id,
-                num_docs,
-                compressed,
-            }
-        });
-
-        self.pending_handles.push(handle);
+        Ok(())
     }
 
-    /// Collect any completed compression tasks
-    fn collect_completed(&mut self) {
-        let mut remaining = Vec::new();
-        for handle in self.pending_handles.drain(..) {
-            if handle.is_finished() {
-                match handle.join() {
-                    Ok(block) => self.compressed_blocks.push(block),
-                    Err(payload) => std::panic::resume_unwind(payload),
-                }
-            } else {
-                remaining.push(handle);
-            }
+    #[inline]
+    fn outstanding_blocks(&self) -> usize {
+        self.next_seq - self.next_write_seq
+    }
+
+    fn receive_and_write_ready(&mut self) -> io::Result<()> {
+        if self.pending_results == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "missing document-store compression result",
+            ));
         }
-        self.pending_handles = remaining;
+        let block = self.workers.receive()?;
+        self.pending_results -= 1;
+        if block.seq < self.next_write_seq || self.ready_blocks.insert(block.seq, block).is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "duplicate document-store compression result",
+            ));
+        }
+        self.write_ready_blocks()
+    }
+
+    fn write_ready_blocks(&mut self) -> io::Result<()> {
+        while let Some(block) = self.ready_blocks.remove(&self.next_write_seq) {
+            let length = u32::try_from(block.compressed.len()).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "compressed store block too large",
+                )
+            })?;
+            self.writer.write_all(&block.compressed)?;
+            self.index.push(StoreBlockIndex {
+                first_doc_id: block.first_doc_id,
+                offset: self.current_offset,
+                length,
+                num_docs: block.num_docs,
+            });
+            self.current_offset = self
+                .current_offset
+                .checked_add(u64::from(length))
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "store size overflow"))?;
+            self.next_write_seq += 1;
+        }
+        Ok(())
     }
 
     pub fn finish(mut self) -> io::Result<u32> {
-        // Spawn compression for any remaining data
-        self.spawn_compression();
-
-        // Collect any already-completed tasks
-        self.collect_completed();
-
-        // Wait for all remaining compression tasks
-        for handle in self.pending_handles.drain(..) {
-            match handle.join() {
-                Ok(block) => self.compressed_blocks.push(block),
-                Err(payload) => std::panic::resume_unwind(payload),
-            }
+        // Queue any remaining data, then receive and stream every bounded
+        // out-of-order result before writing the footer.
+        self.queue_compression()?;
+        while self.next_write_seq < self.next_seq {
+            self.receive_and_write_ready()?;
         }
+        debug_assert_eq!(self.pending_results, 0);
+        debug_assert!(self.ready_blocks.is_empty());
+        self.workers.shutdown()?;
 
-        if self.compressed_blocks.is_empty() {
+        if self.index.is_empty() {
             write_store_index_and_footer(&mut self.writer, &[], 0, 0, 0, false)?;
             return Ok(0);
         }
 
-        // Sort by sequence to maintain order
-        self.compressed_blocks.sort_by_key(|b| b.seq);
-
-        // Write blocks in order and build index
-        let mut index = Vec::with_capacity(self.compressed_blocks.len());
-        let mut current_offset = 0u64;
-
-        for block in &self.compressed_blocks {
-            index.push(StoreBlockIndex {
-                first_doc_id: block.first_doc_id,
-                offset: current_offset,
-                length: u32::try_from(block.compressed.len()).map_err(|_| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        "compressed store block too large",
-                    )
-                })?,
-                num_docs: block.num_docs,
-            });
-
-            self.writer.write_all(&block.compressed)?;
-            current_offset = current_offset
-                .checked_add(block.compressed.len() as u64)
-                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "store size overflow"))?;
-        }
-
-        let data_end_offset = current_offset;
-
         // Write dictionary if present
         let dict_offset = if let Some(ref dict) = self.dict {
-            let offset = current_offset;
+            let offset = self.current_offset;
             let dict_bytes = dict.as_bytes();
             self.writer
                 .write_u32::<LittleEndian>(dict_bytes.len() as u32)?;
@@ -466,8 +637,8 @@ impl<'a> EagerParallelStoreWriter<'a> {
         // Write index + footer
         write_store_index_and_footer(
             &mut self.writer,
-            &index,
-            data_end_offset,
+            &self.index,
+            self.current_offset,
             dict_offset.unwrap_or(0),
             self.next_doc_id,
             self.dict.is_some(),
@@ -1496,8 +1667,93 @@ impl AsyncStoreReader {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "native")]
+    fn raw_store_bytes(num_threads: usize, documents: &[Vec<u8>]) -> Vec<u8> {
+        let mut output = Vec::new();
+        let mut store = EagerParallelStoreWriter::with_compression_level(
+            &mut output,
+            num_threads,
+            CompressionLevel::FAST,
+        );
+        for document in documents {
+            store.store_raw(document).unwrap();
+        }
+        assert_eq!(store.finish().unwrap() as usize, documents.len());
+        output
+    }
+
     fn cached_test_block(byte: u8) -> Arc<CachedBlock> {
         Arc::new(CachedBlock::build(vec![4, 0, 0, 0, byte, byte, byte, byte], 1).unwrap())
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn parallel_store_is_byte_identical_across_worker_counts() {
+        // Variable-sized, non-uniform blocks make completion order differ
+        // readily without changing block boundaries or encoded bytes.
+        let documents: Vec<Vec<u8>> = (0..64usize)
+            .map(|doc| {
+                let len = 1_000 + (doc * 7_919 % 40_000);
+                (0..len)
+                    .map(|offset| ((doc * 17 + offset * 31 + offset / 7) % 251) as u8)
+                    .collect()
+            })
+            .collect();
+
+        let single_worker = raw_store_bytes(1, &documents);
+        let four_workers = raw_store_bytes(4, &documents);
+        assert_eq!(four_workers, single_worker);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn parallel_store_bounds_in_flight_blocks_and_streams_before_finish() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingWriter(Arc<AtomicUsize>);
+        impl Write for CountingWriter {
+            fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+                self.0.fetch_add(bytes.len(), Ordering::Relaxed);
+                Ok(bytes.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let bytes_written = Arc::new(AtomicUsize::new(0));
+        let mut output = CountingWriter(Arc::clone(&bytes_written));
+        let mut store = EagerParallelStoreWriter::new(&mut output, 3);
+        assert_eq!(store.workers.num_threads(), 3);
+        assert_eq!(store.max_in_flight, 6);
+
+        let document = vec![7u8; STORE_BLOCK_SIZE];
+        for _ in 0..24 {
+            store.store_raw(&document).unwrap();
+            assert!(store.outstanding_blocks() < store.max_in_flight);
+            assert_eq!(
+                store.outstanding_blocks(),
+                store.pending_results + store.ready_blocks.len()
+            );
+        }
+
+        // Hitting the in-flight bound drains sequence-ready results directly
+        // to the destination instead of retaining the complete store.
+        assert!(bytes_written.load(Ordering::Relaxed) > 0);
+        assert_eq!(store.finish().unwrap(), 24);
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn parallel_store_zero_threads_falls_back_to_one_worker() {
+        let mut output = Vec::new();
+        let store = EagerParallelStoreWriter::new(&mut output, 0);
+        assert_eq!(store.workers.num_threads(), 1);
+        assert_eq!(store.max_in_flight, 2);
+        assert_eq!(store.finish().unwrap(), 0);
+        // Empty block index (u32 count) plus the 32-byte footer.
+        assert_eq!(output.len(), 36);
     }
 
     #[test]

--- a/hermes-core/src/structures/fast_field/codec.rs
+++ b/hermes-core/src/structures/fast_field/codec.rs
@@ -494,61 +494,139 @@ pub fn linear_read(data: &[u8], index: usize) -> u64 {
 ///
 /// Header: codec_id(1) + num_values(4) + num_blocks(4)
 /// Per block: first(8) + last(8) + offset(8) + bpv(1) + packed_len(4) + packed_data
+#[derive(Clone, Copy)]
+struct BlockwiseLinearBlockEstimate {
+    min_residual: i64,
+    bits_per_value: u8,
+    serialized_size: u64,
+}
+
 #[derive(Default)]
 pub struct BlockwiseLinearEstimator {
-    values: Vec<u64>,
+    count: usize,
+    completed_size: u64,
+    current_block: Vec<u64>,
+    completed_blocks: Vec<BlockwiseLinearBlockEstimate>,
+    tail_estimate: Option<BlockwiseLinearBlockEstimate>,
+    overflow: bool,
+}
+
+impl BlockwiseLinearEstimator {
+    /// Collect a complete column without retaining it.
+    ///
+    /// `serialize_auto` already owns the input slice, so full blocks can be
+    /// estimated in place. Keeping this pass separate from the other
+    /// per-value estimators also leaves their hot loop branch-free.
+    fn collect_values(&mut self, values: &[u64]) {
+        debug_assert_eq!(self.count, 0);
+        debug_assert!(self.current_block.is_empty());
+
+        self.count = values.len();
+        let mut blocks = values.chunks_exact(BLOCKWISE_LINEAR_BLOCK_SIZE);
+        for block in &mut blocks {
+            match estimate_blockwise_linear_block(block) {
+                Some(estimate) => {
+                    self.completed_size += estimate.serialized_size;
+                    self.completed_blocks.push(estimate);
+                }
+                None => {
+                    self.overflow = true;
+                    return;
+                }
+            }
+        }
+        self.current_block.extend_from_slice(blocks.remainder());
+    }
+}
+
+/// Return the serialized size of one block, excluding the global header.
+///
+/// A block is buffered until its final value is known because that value is
+/// part of the interpolation line. Keeping only this bounded scratch block
+/// avoids retaining a second copy of the entire column during auto-selection.
+fn estimate_blockwise_linear_block(block: &[u64]) -> Option<BlockwiseLinearBlockEstimate> {
+    debug_assert!(!block.is_empty());
+    let block_len = block.len();
+    if block_len < 2 {
+        return Some(BlockwiseLinearBlockEstimate {
+            min_residual: 0,
+            bits_per_value: 0,
+            serialized_size: 29,
+        });
+    }
+
+    let first = block[0];
+    let last = block[block_len - 1];
+    let mut min_res = i128::MAX;
+    let mut max_res = i128::MIN;
+    for (i, &val) in block.iter().enumerate() {
+        let pred = interpolate(first, last, block_len, i);
+        let res = val as i128 - pred as i128;
+        min_res = min_res.min(res);
+        max_res = max_res.max(res);
+    }
+
+    // Per-block offset is stored as i64. If either residual bound cannot be
+    // represented, the codec cannot encode this column.
+    if min_res < i64::MIN as i128 || max_res > i64::MAX as i128 {
+        return None;
+    }
+
+    let bits_per_value = bits_needed_u64((max_res - min_res) as u64);
+    let data_bytes = (block_len as u64 * u64::from(bits_per_value)).div_ceil(8);
+    Some(BlockwiseLinearBlockEstimate {
+        min_residual: min_res as i64,
+        bits_per_value,
+        serialized_size: 29 + data_bytes,
+    })
 }
 
 impl CodecEstimator for BlockwiseLinearEstimator {
     fn collect(&mut self, value: u64) {
-        self.values.push(value);
+        self.count += 1;
+        self.tail_estimate = None;
+        if self.overflow {
+            return;
+        }
+
+        self.current_block.push(value);
+        if self.current_block.len() == BLOCKWISE_LINEAR_BLOCK_SIZE {
+            match estimate_blockwise_linear_block(&self.current_block) {
+                Some(estimate) => {
+                    self.completed_size += estimate.serialized_size;
+                    self.completed_blocks.push(estimate);
+                }
+                None => self.overflow = true,
+            }
+            self.current_block.clear();
+        }
+    }
+
+    fn finalize(&mut self) {
+        self.tail_estimate = if self.current_block.is_empty() || self.overflow {
+            None
+        } else {
+            estimate_blockwise_linear_block(&self.current_block)
+        };
+        if !self.current_block.is_empty() && self.tail_estimate.is_none() {
+            self.overflow = true;
+        }
     }
 
     fn estimate(&self) -> Option<u64> {
-        let n = self.values.len();
-        if n < 2 * BLOCKWISE_LINEAR_BLOCK_SIZE {
+        if self.count < 2 * BLOCKWISE_LINEAR_BLOCK_SIZE || self.overflow {
             // Only useful when there are enough values to amortize the per-block headers
             return None;
         }
 
-        let num_blocks = n.div_ceil(BLOCKWISE_LINEAR_BLOCK_SIZE);
-        // Global header
-        let mut total = 9u64; // codec_id(1) + num_values(4) + num_blocks(4)
-
-        for b in 0..num_blocks {
-            let start = b * BLOCKWISE_LINEAR_BLOCK_SIZE;
-            let end = (start + BLOCKWISE_LINEAR_BLOCK_SIZE).min(n);
-            let block = &self.values[start..end];
-            let block_len = block.len();
-
-            if block_len < 2 {
-                // Block header + 0 data
-                total += 29; // first(8)+last(8)+offset(8)+bpv(1)+packed_len(4)
-                continue;
-            }
-
-            let first = block[0];
-            let last = block[block_len - 1];
-            let mut min_res = i128::MAX;
-            let mut max_res = i128::MIN;
-            for (i, &val) in block.iter().enumerate() {
-                let pred = interpolate(first, last, block_len, i);
-                let res = val as i128 - pred as i128;
-                min_res = min_res.min(res);
-                max_res = max_res.max(res);
-            }
-            // Per-block offset is stored as i64 — if any block's residuals
-            // exceed i64 range, this codec cannot represent the data.
-            if min_res < i64::MIN as i128 || max_res > i64::MAX as i128 {
-                return None;
-            }
-            let range = (max_res - min_res) as u64;
-            let bpv = bits_needed_u64(range) as u64;
-            let data_bits = block_len as u64 * bpv;
-            let data_bytes = data_bits.div_ceil(8);
-            total += 29 + data_bytes;
+        // codec_id(1) + num_values(4) + num_blocks(4)
+        let mut total = 9 + self.completed_size;
+        if !self.current_block.is_empty() {
+            total += self
+                .tail_estimate
+                .or_else(|| estimate_blockwise_linear_block(&self.current_block))?
+                .serialized_size;
         }
-
         Some(total)
     }
 
@@ -560,6 +638,14 @@ impl CodecEstimator for BlockwiseLinearEstimator {
         writer.write_u32::<LittleEndian>(n as u32)?;
         writer.write_u32::<LittleEndian>(num_blocks as u32)?;
         let mut bytes_written = 9u64;
+
+        // Both scratch buffers are bounded by one block and reused across all
+        // blocks, avoiding one allocation pair per block.
+        let mut shifted = Vec::new();
+        let mut packed = Vec::new();
+        let estimates_match = self.count == n
+            && self.completed_blocks.len() == n / BLOCKWISE_LINEAR_BLOCK_SIZE
+            && (n.is_multiple_of(BLOCKWISE_LINEAR_BLOCK_SIZE) || self.tail_estimate.is_some());
 
         for b in 0..num_blocks {
             let start = b * BLOCKWISE_LINEAR_BLOCK_SIZE;
@@ -574,49 +660,40 @@ impl CodecEstimator for BlockwiseLinearEstimator {
                 first
             };
 
-            // Compute residuals using i128 to avoid overflow
-            let mut min_residual = i128::MAX;
-            if block_len >= 2 {
-                for (i, &val) in block.iter().enumerate() {
-                    let pred = interpolate(first, last, block_len, i);
-                    let res = val as i128 - pred as i128;
-                    min_residual = min_residual.min(res);
-                }
+            let estimate = if estimates_match {
+                self.completed_blocks.get(b).copied().or(self.tail_estimate)
             } else {
-                min_residual = 0;
-            }
+                None
+            };
+            let estimate = match estimate {
+                Some(estimate) => estimate,
+                None => estimate_blockwise_linear_block(block).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "blockwise linear codec: per-block residual offset exceeds i64 range",
+                    )
+                })?,
+            };
+            let min_residual = i128::from(estimate.min_residual);
 
-            let shifted: Vec<u64> = block
-                .iter()
-                .enumerate()
-                .map(|(i, &val)| {
-                    if block_len < 2 {
-                        return 0;
-                    }
+            shifted.clear();
+            shifted.extend(block.iter().enumerate().map(|(i, &val)| {
+                if block_len < 2 {
+                    0
+                } else {
                     let pred = interpolate(first, last, block_len, i);
                     let res = val as i128 - pred as i128;
                     (res - min_residual) as u64
-                })
-                .collect();
-            let max_shifted = shifted.iter().copied().max().unwrap_or(0);
-            let bpv = bits_needed_u64(max_shifted);
-
-            // Per-block offset is stored as i64 — reject data that doesn't fit.
-            if min_residual < i64::MIN as i128 || min_residual > i64::MAX as i128 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "blockwise linear codec: per-block residual offset exceeds i64 range",
-                ));
-            }
-            let min_res_i64 = min_residual as i64;
+                }
+            }));
             writer.write_u64::<LittleEndian>(first)?;
             writer.write_u64::<LittleEndian>(last)?;
-            writer.write_i64::<LittleEndian>(min_res_i64)?;
-            writer.write_u8(bpv)?;
+            writer.write_i64::<LittleEndian>(estimate.min_residual)?;
+            writer.write_u8(estimate.bits_per_value)?;
 
-            let mut packed = Vec::new();
-            if bpv > 0 {
-                bitpack_write(&shifted, bpv, &mut packed);
+            packed.clear();
+            if estimate.bits_per_value > 0 {
+                bitpack_write(&shifted, estimate.bits_per_value, &mut packed);
             }
             writer.write_u32::<LittleEndian>(packed.len() as u32)?;
             writer.write_all(&packed)?;
@@ -666,6 +743,69 @@ pub fn blockwise_linear_read(data: &[u8], index: usize) -> u64 {
     0 // Should not reach here
 }
 
+/// Batch-read consecutive values from a blockwise-linear column.
+///
+/// Variable-length block records are scanned once to reach `start_index`, then
+/// consumed in order. This avoids re-scanning every preceding block header for
+/// each value in the batch.
+pub fn blockwise_linear_read_batch(data: &[u8], start_index: usize, out: &mut [u64]) {
+    if out.is_empty() {
+        return;
+    }
+
+    let num_values = u32::from_le_bytes(data[0..4].try_into().unwrap()) as usize;
+    let num_blocks = u32::from_le_bytes(data[4..8].try_into().unwrap()) as usize;
+    let valid_len = out.len().min(num_values.saturating_sub(start_index));
+    out[valid_len..].fill(0);
+    if valid_len == 0 {
+        return;
+    }
+
+    let target_block = start_index / BLOCKWISE_LINEAR_BLOCK_SIZE;
+    let mut pos = 8usize;
+    let mut written = 0usize;
+
+    for block_idx in 0..num_blocks {
+        let packed_len = u32::from_le_bytes(data[pos + 25..pos + 29].try_into().unwrap()) as usize;
+        if block_idx < target_block {
+            pos += 29 + packed_len;
+            continue;
+        }
+
+        let first = u64::from_le_bytes(data[pos..pos + 8].try_into().unwrap());
+        let last = u64::from_le_bytes(data[pos + 8..pos + 16].try_into().unwrap());
+        let offset = i64::from_le_bytes(data[pos + 16..pos + 24].try_into().unwrap());
+        let bpv = data[pos + 24];
+        let packed = &data[pos + 29..pos + 29 + packed_len];
+
+        let block_start = block_idx * BLOCKWISE_LINEAR_BLOCK_SIZE;
+        let block_len = (num_values - block_start).min(BLOCKWISE_LINEAR_BLOCK_SIZE);
+        let index_in_block = if block_idx == target_block {
+            start_index - block_start
+        } else {
+            0
+        };
+        let take = (block_len - index_in_block).min(valid_len - written);
+
+        for (i, value) in out[written..written + take].iter_mut().enumerate() {
+            let block_index = index_in_block + i;
+            let predicted = interpolate(first, last, block_len, block_index);
+            let residual = if bpv == 0 {
+                0
+            } else {
+                bitpack_read(packed, bpv, block_index)
+            };
+            *value = (predicted as i128 + offset as i128 + residual as i128) as u64;
+        }
+
+        written += take;
+        if written == valid_len {
+            break;
+        }
+        pos += 29 + packed_len;
+    }
+}
+
 // ── Auto-selection ───────────────────────────────────────────────────────
 
 /// Serialize values using the codec that produces the smallest output.
@@ -682,8 +822,8 @@ pub fn serialize_auto(values: &[u64], writer: &mut dyn Write) -> io::Result<u64>
         constant.collect(v);
         bitpacked.collect(v);
         linear.collect(v);
-        blockwise.collect(v);
     }
+    blockwise.collect_values(values);
 
     // Finalize
     constant.finalize();
@@ -789,11 +929,7 @@ pub fn auto_read_batch(data: &[u8], start_index: usize, out: &mut [u64]) {
                 *v = linear_read(rest, start_index + i);
             }
         }
-        Some(CodecType::BlockwiseLinear) => {
-            for (i, v) in out.iter_mut().enumerate() {
-                *v = blockwise_linear_read(rest, start_index + i);
-            }
-        }
+        Some(CodecType::BlockwiseLinear) => blockwise_linear_read_batch(rest, start_index, out),
         None => out.iter_mut().for_each(|v| *v = 0),
     }
 }
@@ -830,6 +966,76 @@ mod tests {
         let mut buf = Vec::new();
         serialize_auto(values, &mut buf).unwrap();
         (0..values.len()).map(|i| auto_read(&buf, i)).collect()
+    }
+
+    fn blockwise_values(len: usize) -> Vec<u64> {
+        (0..len)
+            .map(|i| {
+                let block = i / BLOCKWISE_LINEAR_BLOCK_SIZE;
+                let index = i % BLOCKWISE_LINEAR_BLOCK_SIZE;
+                block as u64 * 1_000_000
+                    + index as u64 * (block as u64 + 3)
+                    + ((i * 17 + block * 11) % 23) as u64
+            })
+            .collect()
+    }
+
+    /// Reference implementation matching the original allocation-per-block
+    /// serializer. This guards the on-disk representation while the production
+    /// implementation reuses bounded scratch buffers.
+    fn serialize_blockwise_reference(values: &[u64]) -> Vec<u8> {
+        let n = values.len();
+        let num_blocks = n.div_ceil(BLOCKWISE_LINEAR_BLOCK_SIZE);
+        let mut encoded = Vec::new();
+        encoded.push(CodecType::BlockwiseLinear as u8);
+        encoded.extend_from_slice(&(n as u32).to_le_bytes());
+        encoded.extend_from_slice(&(num_blocks as u32).to_le_bytes());
+
+        for block in values.chunks(BLOCKWISE_LINEAR_BLOCK_SIZE) {
+            let block_len = block.len();
+            let first = block[0];
+            let last = if block_len > 1 {
+                block[block_len - 1]
+            } else {
+                first
+            };
+            let min_residual = if block_len < 2 {
+                0
+            } else {
+                block
+                    .iter()
+                    .enumerate()
+                    .map(|(i, &value)| {
+                        value as i128 - interpolate(first, last, block_len, i) as i128
+                    })
+                    .min()
+                    .unwrap()
+            };
+            let shifted: Vec<u64> = block
+                .iter()
+                .enumerate()
+                .map(|(i, &value)| {
+                    if block_len < 2 {
+                        0
+                    } else {
+                        let predicted = interpolate(first, last, block_len, i);
+                        (value as i128 - predicted as i128 - min_residual) as u64
+                    }
+                })
+                .collect();
+            let bpv = bits_needed_u64(shifted.iter().copied().max().unwrap_or(0));
+            let mut packed = Vec::new();
+            bitpack_write(&shifted, bpv, &mut packed);
+
+            encoded.extend_from_slice(&first.to_le_bytes());
+            encoded.extend_from_slice(&last.to_le_bytes());
+            encoded.extend_from_slice(&(min_residual as i64).to_le_bytes());
+            encoded.push(bpv);
+            encoded.extend_from_slice(&(packed.len() as u32).to_le_bytes());
+            encoded.extend_from_slice(&packed);
+        }
+
+        encoded
     }
 
     #[test]
@@ -872,6 +1078,36 @@ mod tests {
         }
         let result = roundtrip(&values);
         assert_eq!(result, values);
+    }
+
+    #[test]
+    fn test_blockwise_estimate_is_bounded_and_serialization_is_byte_compatible() {
+        for len in [1024, 1025, 1536, 1537, 4097] {
+            let values = blockwise_values(len);
+            let reference = serialize_blockwise_reference(&values);
+            let mut estimator = BlockwiseLinearEstimator::default();
+            for &value in &values {
+                estimator.collect(value);
+            }
+            estimator.finalize();
+
+            assert_eq!(estimator.estimate(), Some(reference.len() as u64));
+            assert!(
+                estimator.current_block.len() < BLOCKWISE_LINEAR_BLOCK_SIZE,
+                "estimator retained more than one partial block"
+            );
+            assert!(
+                estimator.current_block.capacity() <= BLOCKWISE_LINEAR_BLOCK_SIZE,
+                "estimator scratch grew beyond one block"
+            );
+
+            let mut encoded = Vec::new();
+            estimator.serialize(&values, &mut encoded).unwrap();
+            assert_eq!(
+                encoded, reference,
+                "serialized bytes changed for {len} values"
+            );
+        }
     }
 
     #[test]
@@ -997,6 +1233,36 @@ mod tests {
             });
         }
         roundtrip_batch(&values);
+    }
+
+    #[test]
+    fn test_blockwise_batch_read_across_block_boundaries() {
+        let values = blockwise_values(2053);
+        let estimator = BlockwiseLinearEstimator::default();
+        let mut encoded = Vec::new();
+        estimator.serialize(&values, &mut encoded).unwrap();
+        assert_eq!(encoded[0], CodecType::BlockwiseLinear as u8);
+
+        for (start, len) in [
+            (0, values.len()),
+            (510, 5),
+            (511, 3),
+            (512, 513),
+            (777, 900),
+            (1023, 514),
+            (1535, 518),
+            (2048, 5),
+        ] {
+            let expected = &values[start..start + len];
+
+            let mut direct = vec![u64::MAX; len];
+            blockwise_linear_read_batch(&encoded[1..], start, &mut direct);
+            assert_eq!(direct, expected, "direct batch mismatch at {start}");
+
+            let mut auto = vec![u64::MAX; len];
+            auto_read_batch(&encoded, start, &mut auto);
+            assert_eq!(auto, expected, "auto batch mismatch at {start}");
+        }
     }
 
     /// Regression: zigzag-encoded i64 timestamps mixed with FAST_FIELD_MISSING (u64::MAX).

--- a/hermes-core/src/structures/postings/sparse/block.rs
+++ b/hermes-core/src/structures/postings/sparse/block.rs
@@ -89,49 +89,50 @@ impl SparseBlock {
         let count = postings.len();
         let first_doc_id = postings[0].0;
 
-        // Delta encode doc IDs
-        let mut deltas = Vec::with_capacity(count);
+        // Blocks are hard-bounded at 256 entries. Keep the transient columns
+        // on the stack so building each block allocates only its three encoded
+        // output buffers.
+        let mut deltas = [0u32; MAX_BLOCK_SIZE];
+        let mut ordinals = [0u32; MAX_BLOCK_SIZE];
+        let mut weights = [0.0f32; MAX_BLOCK_SIZE];
         let mut prev = first_doc_id;
-        for &(doc_id, _, _) in postings {
-            deltas.push(doc_id.saturating_sub(prev));
+        let mut max_ordinal = 0u16;
+        let mut max_weight = 0.0f32;
+        for (index, &(doc_id, ordinal, weight)) in postings.iter().enumerate() {
+            deltas[index] = doc_id.saturating_sub(prev);
+            ordinals[index] = u32::from(ordinal);
+            weights[index] = weight;
+            max_ordinal = max_ordinal.max(ordinal);
+            max_weight = max_weight.max(weight.abs());
             prev = doc_id;
         }
         deltas[0] = 0;
 
-        let doc_id_bits = simd::round_bit_width(find_optimal_bit_width(&deltas[1..]));
-        let ordinals: Vec<u16> = postings.iter().map(|(_, o, _)| *o).collect();
-        let max_ordinal = ordinals.iter().copied().max().unwrap_or(0);
+        let doc_id_bits = simd::round_bit_width(find_optimal_bit_width(&deltas[1..count]));
         let ordinal_bits = if max_ordinal == 0 {
             0
         } else {
             simd::round_bit_width(bits_needed_u16(max_ordinal))
         };
 
-        let weights: Vec<f32> = postings.iter().map(|(_, _, w)| *w).collect();
-        let max_weight = weights
-            .iter()
-            .copied()
-            .fold(0.0f32, |acc, w| acc.max(w.abs()));
-
         let doc_ids_data = OwnedBytes::new({
             let rounded = simd::RoundedBitWidth::from_u8(doc_id_bits);
             let num_deltas = count - 1;
             let byte_count = num_deltas * rounded.bytes_per_value();
             let mut data = vec![0u8; byte_count];
-            simd::pack_rounded(&deltas[1..], rounded, &mut data);
+            simd::pack_rounded(&deltas[1..count], rounded, &mut data);
             data
         });
         let ordinals_data = OwnedBytes::new(if ordinal_bits > 0 {
             let rounded = simd::RoundedBitWidth::from_u8(ordinal_bits);
             let byte_count = count * rounded.bytes_per_value();
             let mut data = vec![0u8; byte_count];
-            let ord_u32: Vec<u32> = ordinals.iter().map(|&o| o as u32).collect();
-            simd::pack_rounded(&ord_u32, rounded, &mut data);
+            simd::pack_rounded(&ordinals[..count], rounded, &mut data);
             data
         } else {
             Vec::new()
         });
-        let weights_data = OwnedBytes::new(encode_weights(&weights, weight_quant)?);
+        let weights_data = OwnedBytes::new(encode_weights(&weights[..count], weight_quant)?);
 
         let last_doc_id = postings.last().unwrap().0;
 
@@ -646,15 +647,31 @@ impl BlockSparsePostingList {
     /// The caller writes block data first, accumulates skip entries, then
     /// writes all skip entries in a contiguous section at the file tail.
     pub fn serialize(&self) -> io::Result<(Vec<u8>, Vec<super::SparseSkipEntry>)> {
-        // Serialize all blocks to get their sizes
-        let mut block_data = Vec::new();
+        let serialized_bytes = self.blocks.iter().try_fold(0usize, |total, block| {
+            total
+                .checked_add(
+                    BlockHeader::SIZE
+                        + 8
+                        + block.doc_ids_data.len()
+                        + block.ordinals_data.len()
+                        + block.weights_data.len(),
+                )
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "sparse posting size overflow")
+                })
+        })?;
+        let mut block_data = Vec::with_capacity(serialized_bytes);
         let mut skip_entries = Vec::with_capacity(self.blocks.len());
-        let mut offset = 0u64;
 
         for block in &self.blocks {
-            let mut buf = Vec::new();
-            block.write(&mut buf)?;
-            let length = buf.len() as u32;
+            let offset = block_data.len();
+            block.write(&mut block_data)?;
+            let length = u32::try_from(block_data.len() - offset).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "serialized sparse block is too large",
+                )
+            })?;
 
             let first_doc = block.header.first_doc_id;
             let last_doc = block.last_doc_id;
@@ -662,13 +679,10 @@ impl BlockSparsePostingList {
             skip_entries.push(super::SparseSkipEntry::new(
                 first_doc,
                 last_doc,
-                offset,
+                offset as u64,
                 length,
                 block.header.max_weight,
             ));
-
-            block_data.extend_from_slice(&buf);
-            offset += length as u64;
         }
 
         Ok((block_data, skip_entries))
@@ -985,7 +999,13 @@ fn bits_needed_u16(val: u16) -> u8 {
 // ============================================================================
 
 fn encode_weights(weights: &[f32], quant: WeightQuantization) -> io::Result<Vec<u8>> {
-    let mut data = Vec::new();
+    let encoded_len = match quant {
+        WeightQuantization::Float32 => weights.len().saturating_mul(4),
+        WeightQuantization::Float16 => weights.len().saturating_mul(2),
+        WeightQuantization::UInt8 => 8usize.saturating_add(weights.len()),
+        WeightQuantization::UInt4 => 8usize.saturating_add(weights.len().div_ceil(2)),
+    };
+    let mut data = Vec::with_capacity(encoded_len);
     match quant {
         WeightQuantization::Float32 => {
             for &w in weights {
@@ -1055,13 +1075,13 @@ fn decode_weights_into(data: &[u8], quant: WeightQuantization, count: usize, out
             use half::slice::HalfFloatSliceExt;
             let byte_count = count * 2;
             let src = &data[..byte_count];
-            let mut f16_buf: Vec<f16> = Vec::with_capacity(count);
-            for chunk in src.as_chunks::<2>().0 {
-                f16_buf.push(f16::from_bits(u16::from_le_bytes([chunk[0], chunk[1]])));
+            let mut f16_buf = [f16::ZERO; MAX_BLOCK_SIZE];
+            for (value, chunk) in f16_buf[..count].iter_mut().zip(src.as_chunks::<2>().0) {
+                *value = f16::from_bits(u16::from_le_bytes([chunk[0], chunk[1]]));
             }
             let start = out.len();
             out.resize(start + count, 0.0);
-            f16_buf.convert_to_f32_slice(&mut out[start..start + count]);
+            f16_buf[..count].convert_to_f32_slice(&mut out[start..start + count]);
         }
         WeightQuantization::UInt8 => {
             let mut cursor = Cursor::new(data);
@@ -1177,6 +1197,51 @@ mod tests {
                 .unwrap();
 
         assert_eq!(list.doc_count(), list2.doc_count());
+    }
+
+    #[test]
+    fn streaming_serialization_is_byte_identical_to_per_block_buffers() {
+        let postings: Vec<(DocId, u16, f32)> = (0..1_000)
+            .map(|index| {
+                (
+                    index / 2,
+                    (index % 2) as u16,
+                    (index * 17 % 101) as f32 / 101.0,
+                )
+            })
+            .collect();
+        let list = BlockSparsePostingList::from_postings_with_block_size(
+            &postings,
+            WeightQuantization::Float16,
+            64,
+        )
+        .unwrap();
+
+        let mut reference_data = Vec::new();
+        let mut reference_skip = Vec::new();
+        for block in &list.blocks {
+            let mut buffered = Vec::new();
+            block.write(&mut buffered).unwrap();
+            reference_skip.push(super::super::SparseSkipEntry::new(
+                block.header.first_doc_id,
+                block.last_doc_id,
+                reference_data.len() as u64,
+                buffered.len() as u32,
+                block.header.max_weight,
+            ));
+            reference_data.extend_from_slice(&buffered);
+        }
+
+        let (data, skip) = list.serialize().unwrap();
+        assert_eq!(data, reference_data);
+        assert_eq!(skip.len(), reference_skip.len());
+        for (actual, expected) in skip.iter().zip(&reference_skip) {
+            assert_eq!(actual.first_doc, expected.first_doc);
+            assert_eq!(actual.last_doc, expected.last_doc);
+            assert_eq!(actual.offset, expected.offset);
+            assert_eq!(actual.length, expected.length);
+            assert_eq!(actual.max_weight.to_bits(), expected.max_weight.to_bits());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- make slice-cache hits zero-copy and enforce strict cache budgets
- compact top-k/scoring heaps and virtualize threshold sentinels
- bound document-store compression workers and stream ordered output
- remove whole-column/block scratch allocations from fast fields and sparse postings
- add focused Criterion coverage for allocation-sensitive core structures

## Benchmark highlights

- 1 MiB slice-cache hit: 18.65 us -> 83.99 ns
- blockwise batch read: 10.26 ms -> 170.20 us
- sparse serialization: 12.81 us -> 1.27 us
- score-only top-k: 477.19 us -> 355.80 us

## Validation

- cargo test -p hermes-core --lib --no-fail-fast (944 passed, 5 ignored)
- all hermes-core integration targets passed
- no-default and wasm-feature library checks passed
- cargo clippy -p hermes-core --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check