### PR TITLE
perf(core): adapt BMP flat-inverted blocks

### DIFF
--- a/docs/bmp-grid-compression.md
+++ b/docs/bmp-grid-compression.md
@@ -1,6 +1,6 @@
 # BMP LSP/0 and Maximum-Grid Compression
 
-Status: implemented in the BMP V18 format (2026-07-23).
+Status: implemented in the BMP V19 format (2026-07-24).
 
 The production field shape is:
 
@@ -14,7 +14,7 @@ field embedding: sparse_vector<u32> [indexed<
 >]
 ```
 
-V18 is the only supported BMP representation. There is no compatibility
+V19 is the only supported BMP representation. There is no compatibility
 reader or migration path; rebuild the index after upgrading.
 
 ## Space anatomy
@@ -36,17 +36,32 @@ H bytes     = d × ceil(coarse / 2)       # ceil-u4 256-superblock maxima
 
 For `d = 105,879`:
 
-| vectors | blocks | superblocks | coarse | dense D | dense E | dense H | dense total |
-| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 18M | 562,500 | 70,313 | 275 | 29.78 GB | 3.72 GB | 14.61 MB | **33.52 GB** |
-| 100M | 3,125,000 | 390,625 | 1,526 | 165.44 GB | 20.68 GB | 80.79 MB | **186.20 GB** |
-| 1B | 31,250,000 | 3,906,250 | 15,259 | 1.654 TB | 206.79 GB | 807.86 MB | **1.862 TB** |
+| vectors |     blocks | superblocks | coarse |   dense D |   dense E |   dense H |   dense total |
+| ------: | ---------: | ----------: | -----: | --------: | --------: | --------: | ------------: |
+|     18M |    562,500 |      70,313 |    275 |  29.78 GB |   3.72 GB |  14.61 MB |  **33.52 GB** |
+|    100M |  3,125,000 |     390,625 |  1,526 | 165.44 GB |  20.68 GB |  80.79 MB | **186.20 GB** |
+|      1B | 31,250,000 |   3,906,250 | 15,259 |  1.654 TB | 206.79 GB | 807.86 MB |  **1.862 TB** |
 
-Those are dense-reference sizes, not the V18 on-disk sizes. V18 omits
+Those are dense-reference sizes, not the V19 on-disk sizes. V19 omits
 all-zero payload groups and uses each group’s actual local width. The encoded
 size depends on term density and BP ordering, so projections captured for the
-old 64-block/exact-u8 hierarchy are not valid for V18. The segment load log’s
+old 64-block/exact-u8 hierarchy are not valid for V19. The segment load log’s
 separate D/E/H byte counts are authoritative after a rebuild.
+
+At fixed vocabulary and similar sparsity/locality, encoded grid bytes scale
+approximately linearly with vector count:
+
+```text
+projected_1B_grid_bytes =
+    observed_encoded_D_E_H_bytes × 1,000,000,000 / observed_vectors
+```
+
+For block 32, the 1B dense reference is 1.693 TiB. A 10%, 20%, 25%, 33%, or
+50% observed encoded/dense ratio projects to approximately 173, 347, 433,
+572, or 867 GiB resident respectively. A machine intended to keep the whole
+grid resident should leave another 15–25% for the process, payload working
+set, document map, and OS. Hermes normally pins H and row-offset tables only;
+D and E remain pageable.
 
 The other persistent sections are:
 
@@ -54,21 +69,52 @@ The other persistent sections are:
 T = total non-empty (block, dimension) pairs
 P = total document-term postings
 B = total blocks
+K = total non-empty blocks
 N = padded vector/ordinal count
+A_i = adaptive payload bytes in non-empty block i
+t_i = terms in non-empty block i
+w_i = 2 when A_i <= 32,767, otherwise 4
 
-Section B, Flat-Inv payload = 8 × non-empty_blocks + 9T + 2P
+Section B, adaptive Flat-Inv
+  = Σ_i [4 + 4t_i + w_i(t_i + 1) + ceil(t_i / 2) + A_i]
 Section A, block offsets    = 8 × (B + 1)
 Sections F+G, document map  = 6N
 ```
 
-The `9T` term-header component is four bytes for the dimension, four bytes for
-its posting start, and one byte for its exact block maximum. The final posting
-start contributes the other four bytes per non-empty block. Retaining the
-exact maximum costs `T` bytes, but lets a D2 BP/reorder regenerate a tight
-ceil-u4 E grid without rereading `2P` posting bytes. Empty blocks have no
-Section B payload.
+Each term chooses the smaller of sparse `(slot, impact)` pairs and one
+`b`-byte dense impact row, so `A_i <= 2P_i`. Dense encoding is used only when
+slots are unique; duplicate slots remain sparse to preserve additive scoring.
+The high bit of a term’s start offset records that choice. The high bit of
+`num_terms` selects 32-bit offsets for unusually large payloads; ordinary
+blocks use 16-bit offsets.
 
-## V18 grid representation
+In the narrow case the formula reduces to
+`6K + 6T + Σ ceil(t_i / 2) + Σ A_i`. Maxima are packed u4 rather than exact
+u8. The reconstructed `17 × ceil(exact / 17)` representative regenerates
+exactly the same u4 and u2 pruning cells, so BP/reorder does not need to scan
+payloads. Even a wide-offset block is never larger than V18’s
+`8K + 9T + 2P` Flat-Inv representation.
+
+### Block size 16 versus 32
+
+On the production-shaped fixture used by `bmp_payload_layout`—65,536 vectors,
+approximately 96 terms/vector, and the same vectors at both widths—V19
+Section B measured:
+
+| locality            |     block 32 |     block 16 | block-16 increase |
+| ------------------- | -----------: | -----------: | ----------------: |
+| diffuse topics      | 40,907,020 B | 46,030,796 B |         **12.5%** |
+| BP-clustered topics | 22,092,013 B | 23,636,520 B |          **7.0%** |
+
+The document map is unchanged. Section A doubles but grows by only `N/4`
+bytes relative to block 32. D has twice as many logical cells. With the
+current fixed eight blocks/superblock, E, H, and per-thread superblock scratch
+also double. A future block-16 experiment should first use 16
+blocks/superblock to preserve LSP’s 256-vector footprint; then E/H and query
+scratch stay unchanged, although dense-reference D still doubles. This is why
+V19 keeps block size 32 for production.
+
+## V19 grid representation
 
 D, E, and H are independent dimension-major grids partitioned into 256-cell
 codec groups. H has one logical cell per 256 E superblocks. Each exact
@@ -117,7 +163,7 @@ Codec groups do not pad the logical BMP block or superblock counts.
 
 ## LSP/0 execution
 
-V18 implements LSP/0 as a query-level operation:
+V19 implements LSP/0 as a query-level operation:
 
 1. Use all bounded query dimensions for candidate generation by default.
    An explicit `query<pruning: beta>` can retain only the strongest fraction,
@@ -141,12 +187,12 @@ The global selection is important: 50 immutable segments still visit at most
 
 Automatic gamma follows the paper’s zero-shot depths:
 
-| requested candidate depth | gamma |
-| ---: | ---: |
-| `1..=10` | 250 |
-| `11..=100` | 500 |
-| `101..=1000` | 1,000 |
-| `> 1000` | `max(2000, depth)` |
+| requested candidate depth |              gamma |
+| ------------------------: | -----------------: |
+|                  `1..=10` |                250 |
+|                `11..=100` |                500 |
+|              `101..=1000` |              1,000 |
+|                  `> 1000` | `max(2000, depth)` |
 
 Set query `lsp_gamma: 0` for exhaustive traversal, or a positive value for an
 explicit cap. `heap_factor: 1.0` and ceiling bounds are rank-safe when query
@@ -161,10 +207,11 @@ floating-point rounding difference from lowering an unpruned bound.
 
 ## Build, merge, and BP reorder
 
-Initial build and BP/reorder write grids from sorted
-`(dimension, block, exact_u8_maximum)` entries. Exact maxima are retained in
-each block header, so D, E, and H can be regenerated without scanning or
-reserializing postings.
+Initial build writes grids from sorted
+`(dimension, block, exact_u8_maximum)` entries. Each block header retains the
+ceil-u4 maximum. BP/reorder reconstructs its conservative u8 representative,
+which regenerates identical D, E, and H cells without scanning or
+reserializing payloads.
 
 Ordinary merge remains a streaming block-copy operation:
 
@@ -178,8 +225,8 @@ Ordinary merge remains a streaming block-copy operation:
   postings are never decoded or reserialized.
 - Document maps are chunked copies with document-ID offset patching.
 
-A later BP pass rebuilds tight E/H values from exact block headers. Reordering
-changes block coordinates first and then projects exact maxima into
+A later BP pass rebuilds tight E/H values from packed block headers. Reordering
+changes block coordinates first and then projects their representatives into
 `floor(new_block / 8)`, so ceil quantization composes correctly with any
 permutation.
 
@@ -199,7 +246,7 @@ and block payload remain pageable with random-access advice.
 
 ## Match to the LSP paper
 
-V18 follows the core design in
+V19 follows the core design in
 [Carlson et al., “Efficiency Optimizations for Superblock-based Sparse Retrieval”](https://arxiv.org/html/2602.02883v1):
 
 - 256 independently decodable maximum cells per compressed group;
@@ -227,34 +274,34 @@ space/build-time tradeoff rather than a claim that 32 is the paper optimum.
 ## Flat-Inv versus the paper’s Fwd layout
 
 Hermes does **not** use the paper’s document-major Fwd payload for persistent
-BMP scoring. Section B is a block-local Flat-Inv layout:
+BMP scoring. Section B is an adaptive block-local Flat-Inv layout:
 
 ```text
 sorted term IDs
-term offsets
-(local_slot: u8, impact: u8) postings
+u16/u32 byte offsets + packed-u4 maxima
+per-term sparse (local_slot, impact) pairs or dense impact rows
 ```
 
 The paper finds Fwd faster for small blocks, including `b = 32`, but its
 Compact-Inv format explicitly assumes a vocabulary that fits two-byte term
 IDs. Hermes production fields use roughly 105,879 dimensions, so a direct
 Hermes Fwd layout requires four-byte IDs. At minimum, separate u32 term IDs
-and u8 weights cost `5P` bytes plus document offsets, while current Section B
-costs `2P + 9T + block headers`. Which representation is smaller therefore
-depends on the measured `T/P` ratio; vocabulary size alone does not settle it.
-Ignoring the small offset/header terms, Fwd becomes smaller only when
-`T/P > 1/3`; repeated dimensions within a 32-vector block push that ratio
-down and favor Flat-Inv.
+and u8 weights cost `5P` bytes plus document offsets. V19 adaptive Flat-Inv
+usually uses approximately `2P + 6.5T + block headers`, and dense terms lower
+the `2P` component. Which representation is smaller therefore depends on the
+measured `T/P` ratio and density; vocabulary size alone does not settle it.
+Repeated dimensions within a 32-vector block lower `T/P` and favor Flat-Inv.
 Flat-Inv also lets the scorer fetch only postings for query-present terms,
 whereas Fwd streams every term in every candidate document.
 
 At `b = 32` the paper reports a material Fwd latency advantage on its SPLADE
-workload, so this remains a legitimate optimization candidate. Hermes now has
-the production-shaped `bmp_payload_layout` benchmark using block size 32,
-u32 vocabulary IDs, D-selected SPLADE-like topical blocks, query widths
-8/32/64, and both sorted-merge and dense-query-lookup Fwd scorers. A persistent
-format replacement is justified only if the best Fwd scorer wins both hot/cold
-latency and total Section B bytes there.
+workload. Hermes’s production-shaped `bmp_payload_layout` benchmark uses u32
+vocabulary IDs, D-selected SPLADE-like topical blocks, and query widths
+8/32/64. In that benchmark V19 adaptive Flat-Inv reduced Section B by
+17.7–21.1% versus V18. The production decoder was at parity for the
+diffuse eight-term case and 8–45% faster in the other measured
+locality/query-width combinations. Its Fwd variants did not beat that
+combination of size and latency, so V19 keeps Flat-Inv.
 
 “Forward indexes” elsewhere in Hermes are temporary BP/reorder structures
 used to compute a document or block permutation. They are memory-budgeted,
@@ -268,16 +315,20 @@ The test suite pins:
 - every local width round trip and malformed metadata rejection;
 - SSE4.1/NEON/scalar-equivalent u4 and u8 accumulation tails;
 - exact BMP-versus-MaxScore top-k parity in exhaustive mode;
+- narrow sparse, dense-row, duplicate-slot, and wide-offset round trips;
+- score parity through dense rows and blocks above the 15-bit payload range;
 - u2-versus-u4 rank-safe parity;
 - a single global gamma across multiple segments;
 - non-aligned D merge and overlapping E/H-bound propagation;
 - record and blockwise BP reorder;
-- E regeneration from exact block-header maxima;
+- E regeneration from packed block-header maxima;
 - bounded external-run construction.
 
 After a production rebuild, record D/E/H encoded bytes, hot and cold
 p50/p95/p99, page faults, global selected/visited superblocks, blocks visited,
 and recall against the original floating-point sparse dot-product ground truth.
+The build log reports V19 and legacy-V18 Section B bytes, their ratio, dense
+term percentage, and number of wide-offset blocks.
 `cargo bench --bench bmp_vs_maxscore` reports Recall@10/100 and p50/p95 for
 exhaustive and several gamma/alpha settings. Its `f32` columns measure
 end-to-end loss against the original unquantized corpus; its `idx` columns

--- a/docs/seismic-research.md
+++ b/docs/seismic-research.md
@@ -38,14 +38,14 @@ An _approximate_ sparse index that abandons the document-space grid entirely:
 
 ## Why this matters for Hermes at 1B scale
 
-BMP's maximum grids are O(dims × vectors / block_size) before V18's local
+BMP's maximum grids are O(dims × vectors / `block_size`) before V19's local
 bit packing. At 1B vectors, `dims=105879`, `b=32`, and eight blocks per
-superblock, the dense D+E+H reference is 1.862 TB; actual V18 size is
+superblock, the dense D+E+H reference is 1.862 TB; actual V19 size is
 data-dependent because zero groups disappear and every 256-cell group uses
 its local width. H adds only 807.86 MB in that dense reference and avoids
 sweeping the 206.79 GB dense E reference at query time. Seismic's memory is
 O(kept postings): λ caps every list, so
-the index grows with _vocabulary_, not corpus × dims. That is a structurally
+the index grows with vocabulary, not corpus × dims. That is a structurally
 attractive shape for 1B vectors. The trade: approximate-only (no rank-safe
 mode), parameter-sensitive, and per-list clustering makes incremental
 merging awkward (blocks must be re-clustered per list — a rebuild-style
@@ -55,15 +55,15 @@ operation like our reorder, not a byte-stack merge).
 
 Most building blocks already exist:
 
-| Seismic component               | Hermes equivalent                                         |
-| ------------------------------- | --------------------------------------------------------- |
-| top-λ list pruning              | `pruning` (per-list fraction) — needs absolute-λ variant  |
-| α-mass summaries                | `doc_mass` logic (same cropping, applied to a max-vector) |
-| u8 quantization                 | `WeightQuantization::UInt8` + max_weight scale            |
-| shallow k-means                 | shared deterministic k-means++/Lloyd trainer             |
+| Seismic component               | Hermes equivalent                                                                                                                                            |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| top-λ list pruning              | `pruning` (per-list fraction) — needs absolute-λ variant                                                                                                     |
+| α-mass summaries                | `doc_mass` logic (same cropping, applied to a max-vector)                                                                                                    |
+| u8 quantization                 | `WeightQuantization::UInt8` + max_weight scale                                                                                                               |
+| shallow k-means                 | shared deterministic k-means++/Lloyd trainer                                                                                                                 |
 | forward index for exact scoring | BMP has the same values in block-local Flat-Inv form; a Seismic scorer would need a persistent document-major Fwd layout or an equivalent exact-vector store |
-| heap_factor pruning             | same knob/semantics as BMP/MaxScore                       |
-| kNN graph (Wave)                | could reuse the global dense IVF HNSW topology            |
+| heap_factor pruning             | same knob/semantics as BMP/MaxScore                                                                                                                          |
+| kNN graph (Wave)                | could reuse the global dense IVF HNSW topology                                                                                                               |
 
 Sketch: a third `SparseFormat::Seismic` with per-list blocked-cluster layout
 

--- a/hermes-core/benches/bmp_payload_layout.rs
+++ b/hermes-core/benches/bmp_payload_layout.rs
@@ -1,14 +1,27 @@
-//! Production-shaped comparison of BMP's block-local flat inverted payload
-//! against a document-major forward payload.
+//! Production-shaped comparison of BMP document payloads:
+//!
+//! - current Flat-Inv (`u32` posting starts, sparse `(slot, impact)` pairs);
+//! - compact sparse Flat-Inv (adaptive `u16`/`u32` byte offsets and u4 maxima);
+//! - adaptive Flat-Inv (compact directory plus dense 32-impact rows whenever
+//!   they are no larger than sparse pairs);
+//! - document-major forward payloads retained as a historical comparison.
 //!
 //! Run:
 //! `cargo bench -p hermes-core --bench bmp_payload_layout`
 //!
 //! Scale the corpus with `BMP_LAYOUT_BLOCKS` and `BMP_LAYOUT_TERMS_PER_DOC`.
+//! By default both diffuse (2,048 topic dimensions) and BP-clustered (128)
+//! workloads run. Set `BMP_LAYOUT_TOPIC_VOCAB` to benchmark one custom
+//! locality level.
 
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+#[allow(dead_code)]
+#[path = "../src/segment/bmp_adaptive.rs"]
+mod bmp_adaptive;
+use bmp_adaptive::{AdaptiveBlock, AdaptiveEncodeScratch, AdaptivePostings};
 
 const BLOCK_SIZE: usize = 32;
 const VOCABULARY: u32 = 105_879;
@@ -38,6 +51,52 @@ struct FlatBlock {
     postings: Vec<Posting>,
 }
 
+struct AdaptiveFlatBlock {
+    bytes: Vec<u8>,
+    dense_terms: usize,
+}
+
+impl AdaptiveFlatBlock {
+    fn from_flat(block: &FlatBlock, enable_dense_rows: bool) -> Self {
+        let posting_counts: Vec<u32> = block
+            .posting_starts
+            .windows(2)
+            .map(|range| range[1] - range[0])
+            .collect();
+        let mut sparse_postings = Vec::with_capacity(block.postings.len() * 2);
+        for posting in &block.postings {
+            sparse_postings.extend_from_slice(&[posting.slot, posting.impact]);
+        }
+        let mut bytes = Vec::new();
+        let mut scratch = AdaptiveEncodeScratch::default();
+        scratch
+            .encode(
+                BLOCK_SIZE,
+                enable_dense_rows,
+                &block.dimensions,
+                &posting_counts,
+                &block.maxima,
+                &sparse_postings,
+                &mut bytes,
+            )
+            .unwrap();
+        let parsed = AdaptiveBlock::parse(&bytes, BLOCK_SIZE).unwrap();
+        let dense_terms = parsed
+            .terms()
+            .filter(|&(_, _, postings)| matches!(postings, AdaptivePostings::Dense(_)))
+            .count();
+        Self { bytes, dense_terms }
+    }
+
+    fn wire_bytes(&self) -> usize {
+        self.bytes.len()
+    }
+
+    fn uses_narrow_offsets(&self) -> bool {
+        u32::from_le_bytes(self.bytes[..4].try_into().unwrap()) & (1 << 31) == 0
+    }
+}
+
 struct ForwardBlock {
     document_starts: Vec<u32>,
     dimensions: Vec<u32>,
@@ -51,7 +110,11 @@ fn env_usize(name: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
-fn generate_blocks(count: usize, terms_per_document: usize) -> (Vec<FlatBlock>, Vec<ForwardBlock>) {
+fn generate_blocks(
+    count: usize,
+    terms_per_document: usize,
+    topic_vocabulary: u32,
+) -> (Vec<FlatBlock>, Vec<ForwardBlock>) {
     let mut rng = Rng(0x9e37_79b9_7f4a_7c15);
     let mut flat = Vec::with_capacity(count);
     let mut forward = Vec::with_capacity(count);
@@ -66,7 +129,7 @@ fn generate_blocks(count: usize, terms_per_document: usize) -> (Vec<FlatBlock>, 
             let mut document = Vec::with_capacity(terms_per_document);
             for term in 0..terms_per_document {
                 let dimension = if term * 4 < terms_per_document * 3 {
-                    (topic_base + rng.next() % 2_048) % VOCABULARY
+                    (topic_base + rng.next() % topic_vocabulary) % VOCABULARY
                 } else {
                     rng.next() % VOCABULARY
                 };
@@ -142,12 +205,12 @@ fn generate_blocks(count: usize, terms_per_document: usize) -> (Vec<FlatBlock>, 
     (flat, forward)
 }
 
-fn query(dimensions: usize) -> Vec<(u32, u16)> {
+fn query(dimensions: usize, topic_vocabulary: u32) -> Vec<(u32, u16)> {
     let mut rng = Rng(0xd1b5_4a32_d192_ed03 ^ dimensions as u64);
     let mut query = Vec::with_capacity(dimensions);
     for index in 0..dimensions {
         let dimension = if index * 4 < dimensions * 3 {
-            rng.next() % 2_048
+            rng.next() % topic_vocabulary
         } else {
             rng.next() % VOCABULARY
         };
@@ -169,6 +232,39 @@ fn score_flat(block: &FlatBlock, query: &[(u32, u16)], scores: &mut [u32; BLOCK_
         let end = block.posting_starts[term + 1] as usize;
         for posting in &block.postings[start..end] {
             scores[posting.slot as usize] += u32::from(posting.impact) * u32::from(weight);
+        }
+    }
+}
+
+#[inline]
+fn score_adaptive_flat(
+    block: &AdaptiveFlatBlock,
+    query: &[(u32, u16)],
+    scores: &mut [u32; BLOCK_SIZE],
+) {
+    scores.fill(0);
+    let decoded = AdaptiveBlock::parse(&block.bytes, BLOCK_SIZE).unwrap();
+    for &(dimension, weight) in query {
+        let term = if query.len() <= 8 {
+            decoded.find_dimension_branching(dimension)
+        } else {
+            decoded.find_dimension(dimension)
+        };
+        let Some(term) = term else {
+            continue;
+        };
+        match decoded.postings(term).unwrap() {
+            AdaptivePostings::Dense(impacts) => {
+                for (score, &impact) in scores.iter_mut().zip(impacts) {
+                    *score += u32::from(impact) * u32::from(weight);
+                }
+            }
+            AdaptivePostings::Sparse(postings) => {
+                for posting in postings {
+                    scores[posting.local_slot as usize] +=
+                        u32::from(posting.impact) * u32::from(weight);
+                }
+            }
         }
     }
 }
@@ -238,74 +334,159 @@ fn forward_wire_bytes(blocks: &[ForwardBlock]) -> usize {
         .sum()
 }
 
+fn adaptive_wire_bytes(blocks: &[AdaptiveFlatBlock]) -> usize {
+    blocks.iter().map(AdaptiveFlatBlock::wire_bytes).sum()
+}
+
 fn benchmark(c: &mut Criterion) {
     let block_count = env_usize("BMP_LAYOUT_BLOCKS", 2_048);
     let terms_per_document = env_usize("BMP_LAYOUT_TERMS_PER_DOC", 96);
-    let (flat, forward) = generate_blocks(block_count, terms_per_document);
-    let flat_bytes = flat_wire_bytes(&flat);
-    let forward_bytes = forward_wire_bytes(&forward);
-    eprintln!(
-        "BMP payload layout: blocks={block_count}, block_size={BLOCK_SIZE}, \
-         terms/doc≈{terms_per_document}, Flat-Inv={flat_bytes} B, \
-         Fwd={forward_bytes} B, Fwd/Flat={:.3}",
-        forward_bytes as f64 / flat_bytes as f64,
+    let requested_topic_vocabulary = std::env::var("BMP_LAYOUT_TOPIC_VOCAB")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok());
+    let scenarios: Vec<(&str, u32)> = requested_topic_vocabulary.map_or_else(
+        || vec![("diffuse", 2_048), ("clustered", 128)],
+        |vocabulary| vec![("custom", vocabulary.clamp(1, VOCABULARY))],
     );
 
-    let mut group = c.benchmark_group("bmp_payload_layout");
-    group.throughput(Throughput::Elements(block_count as u64));
-    for query_dimensions in [8, 32, 64] {
-        let query = query(query_dimensions);
-        let mut query_lookup = vec![0u16; VOCABULARY as usize];
-        for &(dimension, weight) in &query {
-            query_lookup[dimension as usize] = weight;
+    for (scenario, topic_vocabulary) in scenarios {
+        let (flat, forward) = generate_blocks(block_count, terms_per_document, topic_vocabulary);
+        let compact: Vec<_> = flat
+            .iter()
+            .map(|block| AdaptiveFlatBlock::from_flat(block, false))
+            .collect();
+        let adaptive: Vec<_> = flat
+            .iter()
+            .map(|block| AdaptiveFlatBlock::from_flat(block, true))
+            .collect();
+        let flat_bytes = flat_wire_bytes(&flat);
+        let compact_bytes = adaptive_wire_bytes(&compact);
+        let adaptive_bytes = adaptive_wire_bytes(&adaptive);
+        let forward_bytes = forward_wire_bytes(&forward);
+        let total_terms: usize = flat.iter().map(|block| block.dimensions.len()).sum();
+        let dense_terms: usize = adaptive.iter().map(|block| block.dense_terms).sum();
+        let narrow_blocks = adaptive
+            .iter()
+            .filter(|block| block.uses_narrow_offsets())
+            .count();
+        eprintln!(
+            "BMP payload layout [{scenario}]: blocks={block_count}, block_size={BLOCK_SIZE}, \
+             topic_vocab={topic_vocabulary}, terms/doc≈{terms_per_document}, \
+             Flat-Inv={flat_bytes} B, Compact-Sparse={compact_bytes} B ({:.3}x), \
+             Adaptive-Flat={adaptive_bytes} B ({:.3}x), \
+             Fwd={forward_bytes} B ({:.3}x), dense_terms={dense_terms}/{total_terms} ({:.2}%), \
+             narrow_blocks={narrow_blocks}/{block_count}",
+            compact_bytes as f64 / flat_bytes as f64,
+            adaptive_bytes as f64 / flat_bytes as f64,
+            forward_bytes as f64 / flat_bytes as f64,
+            dense_terms as f64 * 100.0 / total_terms as f64,
+        );
+
+        let mut group = c.benchmark_group(format!("bmp_payload_layout/{scenario}"));
+        group.throughput(Throughput::Elements(block_count as u64));
+        for query_dimensions in [8, 32, 64] {
+            let query = query(query_dimensions, topic_vocabulary);
+            let mut query_lookup = vec![0u16; VOCABULARY as usize];
+            for &(dimension, weight) in &query {
+                query_lookup[dimension as usize] = weight;
+            }
+
+            let mut expected = [0u32; BLOCK_SIZE];
+            let mut actual = [0u32; BLOCK_SIZE];
+            for ((flat_block, compact_block), adaptive_block) in
+                flat.iter().zip(&compact).zip(&adaptive)
+            {
+                score_flat(flat_block, &query, &mut expected);
+                score_adaptive_flat(compact_block, &query, &mut actual);
+                assert_eq!(
+                    actual, expected,
+                    "Compact sparse Flat-Inv changed scores in {scenario}/{query_dimensions}",
+                );
+                score_adaptive_flat(adaptive_block, &query, &mut actual);
+                assert_eq!(
+                    actual, expected,
+                    "Adaptive Flat-Inv changed scores in {scenario}/{query_dimensions}",
+                );
+            }
+
+            group.bench_with_input(
+                BenchmarkId::new("flat_inv", query_dimensions),
+                &query,
+                |bencher, query| {
+                    let mut scores = [0u32; BLOCK_SIZE];
+                    bencher.iter(|| {
+                        let mut checksum = 0u32;
+                        for block in &flat {
+                            score_flat(block, black_box(query), &mut scores);
+                            checksum ^= scores.iter().copied().max().unwrap_or(0);
+                        }
+                        black_box(checksum)
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("compact_sparse", query_dimensions),
+                &query,
+                |bencher, query| {
+                    let mut scores = [0u32; BLOCK_SIZE];
+                    bencher.iter(|| {
+                        let mut checksum = 0u32;
+                        for block in &compact {
+                            score_adaptive_flat(block, black_box(query), &mut scores);
+                            checksum ^= scores.iter().copied().max().unwrap_or(0);
+                        }
+                        black_box(checksum)
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("adaptive_flat", query_dimensions),
+                &query,
+                |bencher, query| {
+                    let mut scores = [0u32; BLOCK_SIZE];
+                    bencher.iter(|| {
+                        let mut checksum = 0u32;
+                        for block in &adaptive {
+                            score_adaptive_flat(block, black_box(query), &mut scores);
+                            checksum ^= scores.iter().copied().max().unwrap_or(0);
+                        }
+                        black_box(checksum)
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("forward_merge", query_dimensions),
+                &query,
+                |bencher, query| {
+                    let mut scores = [0u32; BLOCK_SIZE];
+                    bencher.iter(|| {
+                        let mut checksum = 0u32;
+                        for block in &forward {
+                            score_forward(block, black_box(query), &mut scores);
+                            checksum ^= scores.iter().copied().max().unwrap_or(0);
+                        }
+                        black_box(checksum)
+                    });
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new("forward_lookup", query_dimensions),
+                &query_lookup,
+                |bencher, query_lookup| {
+                    let mut scores = [0u32; BLOCK_SIZE];
+                    bencher.iter(|| {
+                        let mut checksum = 0u32;
+                        for block in &forward {
+                            score_forward_lookup(block, black_box(query_lookup), &mut scores);
+                            checksum ^= scores.iter().copied().max().unwrap_or(0);
+                        }
+                        black_box(checksum)
+                    });
+                },
+            );
         }
-        group.bench_with_input(
-            BenchmarkId::new("flat_inv", query_dimensions),
-            &query,
-            |bencher, query| {
-                let mut scores = [0u32; BLOCK_SIZE];
-                bencher.iter(|| {
-                    let mut checksum = 0u32;
-                    for block in &flat {
-                        score_flat(block, black_box(query), &mut scores);
-                        checksum ^= scores.iter().copied().max().unwrap_or(0);
-                    }
-                    black_box(checksum)
-                });
-            },
-        );
-        group.bench_with_input(
-            BenchmarkId::new("forward_merge", query_dimensions),
-            &query,
-            |bencher, query| {
-                let mut scores = [0u32; BLOCK_SIZE];
-                bencher.iter(|| {
-                    let mut checksum = 0u32;
-                    for block in &forward {
-                        score_forward(block, black_box(query), &mut scores);
-                        checksum ^= scores.iter().copied().max().unwrap_or(0);
-                    }
-                    black_box(checksum)
-                });
-            },
-        );
-        group.bench_with_input(
-            BenchmarkId::new("forward_lookup", query_dimensions),
-            &query_lookup,
-            |bencher, query_lookup| {
-                let mut scores = [0u32; BLOCK_SIZE];
-                bencher.iter(|| {
-                    let mut checksum = 0u32;
-                    for block in &forward {
-                        score_forward_lookup(block, black_box(query_lookup), &mut scores);
-                        checksum ^= scores.iter().copied().max().unwrap_or(0);
-                    }
-                    black_box(checksum)
-                });
-            },
-        );
+        group.finish();
     }
-    group.finish();
 }
 
 criterion_group!(benches, benchmark);

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3583,8 +3583,9 @@ async fn bench_forward_index_build() {
 #[tokio::test]
 async fn test_bmp_block_posting_overflow_256() {
     // 256 docs × 301 dims each → 77,056 postings in block 0 (> u16::MAX).
-    // Needle dims (50_000 + d) sort after the shared mass, so their prefix
-    // offsets exceed 65,535 — exactly where the u16 wrap corrupted reads.
+    // The V19 adaptive payload exceeds its 15-bit narrow-offset range, forcing
+    // the u32-wide fallback. Needle dims sort after the shared dense mass and
+    // exercise terms near the end of that wide payload.
     let config = SparseVectorConfig {
         format: SparseFormat::Bmp,
         weight_quantization: WeightQuantization::UInt8,
@@ -3627,7 +3628,7 @@ async fn test_bmp_block_posting_overflow_256() {
     for d in [0u32, 100, 255] {
         let query = SparseVectorQuery::new(sparse, vec![(50_000 + d, 1.0)]);
         let r = searcher.search(&query, 5).await.unwrap();
-        assert_eq!(r.len(), 1, "needle {d} lost past the 65,535th posting");
+        assert_eq!(r.len(), 1, "needle {d} lost in a wide-offset block");
         assert_eq!(r[0].doc_id, d);
     }
     // Shared dims still score correctly across the whole block.
@@ -3636,13 +3637,13 @@ async fn test_bmp_block_posting_overflow_256() {
     assert_eq!(r.len(), 10);
 
     // BP forward-index build over the oversized block must not read wild
-    // slices (this is the exact prod crash path).
+    // slices while decoding dense and sparse terms from a wide-offset block.
     let fwd =
         crate::segment::build_forward_index_from_bmps(&[bmp], 2, 1_000_000, 2 * 1024 * 1024 * 1024)
             .unwrap();
     // Needle dims have df=1 and are correctly filtered by min_doc_freq=2;
     // the 300 shared dims × 256 docs must all survive — reading them walks
-    // every posting slice past the old u16 wrap point.
+    // every shared dense row in the block.
     assert_eq!(fwd.total_postings(), 300 * 256);
 }
 

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -38,11 +38,12 @@
 //! - **Early termination**: stop when superblock/block UB < top-k threshold
 
 use super::scoring::{ScoreCollector, ScoredDoc, SharedThreshold};
+use crate::segment::bmp_adaptive::{AdaptiveBlock, AdaptivePostings};
 use crate::segment::bmp_grid::{
     CompressedGrid, GRID_GROUP_CELLS, LSP_SUPERBLOCK_GRID_BITS, accumulate_packed_u4,
     accumulate_u8, block_grid_scale,
 };
-use crate::segment::{BMP_SUPERBLOCK_SIZE, BmpIndex, block_term_postings, find_dim_in_block_data};
+use crate::segment::{BMP_SUPERBLOCK_SIZE, BmpIndex};
 
 // dim_id is used directly as grid row index. No dim_idx indirection.
 
@@ -1057,6 +1058,19 @@ fn zero_touched_acc(acc: &mut [u32], touched: &[u64; 4]) {
     }
 }
 
+/// Dense rows deliberately mark their whole block. At the density crossover
+/// at least half of those slots already contain postings, and a full-word mask
+/// lets the accumulation loop remain branch-free and vectorizable.
+#[inline(always)]
+fn touch_dense_block(touched: &mut [u64; 4], block_size: usize) {
+    let full_words = block_size / 64;
+    touched[..full_words].fill(u64::MAX);
+    let remainder = block_size % 64;
+    if remainder != 0 {
+        touched[full_words] |= (1u64 << remainder) - 1;
+    }
+}
+
 /// Score a block using integer arithmetic (u32 accumulators, u16 weights).
 ///
 /// Uses one per-query-dimension block-presence bitset before binary search.
@@ -1075,10 +1089,7 @@ fn zero_touched_acc(acc: &mut [u32], touched: &[u64; 4]) {
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
 fn score_block_bsearch_int(
-    num_terms: u32,
-    dim_ptr: *const u8,
-    ps_ptr: *const u8,
-    post_ptr: *const u8,
+    block: AdaptiveBlock<'_>,
     query_by_dim_u16: &[(u32, u16)],
     query_mask: u64,
     candidate_mask: u64,
@@ -1087,8 +1098,13 @@ fn score_block_bsearch_int(
     acc: &mut [u32],
     touched: &mut [u64; 4],
     block_size: usize,
-    total_block_postings: u32,
 ) {
+    let valid_query_bits = if query_by_dim_u16.len() == u64::BITS as usize {
+        u64::MAX
+    } else {
+        (1u64 << query_by_dim_u16.len()) - 1
+    };
+    let narrow_query = (query_mask & valid_query_bits).count_ones() <= 8;
     for (q, &(dim_id, w)) in query_by_dim_u16.iter().enumerate() {
         // The fused grid decoder produces one block-presence bitset per query
         // dimension. Avoid transposing those bits into 64 per-block masks.
@@ -1098,17 +1114,38 @@ fn score_block_bsearch_int(
         {
             continue;
         }
-        // find_dim_in_block_data always uses u32 dim_ids
-        if let Some(local_term) = find_dim_in_block_data(dim_ptr, num_terms, dim_id) {
-            let postings =
-                unsafe { block_term_postings(ps_ptr, post_ptr, local_term, total_block_postings) };
-            for p in postings {
-                let slot = p.local_slot as usize;
-                if slot >= block_size {
-                    continue;
+        let local_term = if narrow_query {
+            block.find_dimension_branching(dim_id)
+        } else {
+            block.find_dimension(dim_id)
+        };
+        if let Some(local_term) = local_term
+            && let Some(postings) = block.postings(local_term)
+        {
+            match postings {
+                AdaptivePostings::Sparse(postings) => {
+                    for p in postings {
+                        let slot = p.local_slot as usize;
+                        if slot >= block_size {
+                            continue;
+                        }
+                        // At most MAX_QUERY_TERMS=64 distinct u16×u8
+                        // contributions reach one slot, whose worst-case sum
+                        // is below u32::MAX. Plain addition keeps this loop
+                        // vector/scalar friendly without changing overflow
+                        // semantics for any valid query.
+                        acc[slot] += w as u32 * p.impact as u32;
+                        touched[slot / 64] |= 1u64 << (slot % 64);
+                    }
                 }
-                acc[slot] = acc[slot].saturating_add(w as u32 * p.impact as u32);
-                touched[slot / 64] |= 1u64 << (slot % 64);
+                AdaptivePostings::Dense(impacts) => {
+                    let weight = w as u32;
+                    for (score, &impact) in acc[..block_size].iter_mut().zip(impacts) {
+                        // Same bounded-sum invariant as the sparse loop.
+                        *score += weight * impact as u32;
+                    }
+                    touch_dense_block(touched, block_size);
+                }
             }
         }
     }
@@ -1195,17 +1232,12 @@ fn score_superblock_blocks(
             }
         }
 
-        let (num_terms, dim_ptr, ps_ptr, _, post_ptr, total_block_postings) =
-            index.parse_block(block_id);
         let mut touched = [0u64; 4];
-        if num_terms > 0 {
+        if let Some(block) = index.parse_block(block_id) {
             if two_phase && collector.len() >= k {
                 // Phase 1: Score only the heaviest dims
                 score_block_bsearch_int(
-                    num_terms,
-                    dim_ptr,
-                    ps_ptr,
-                    post_ptr,
+                    block,
                     query_by_dim_u16,
                     phase1_mask,
                     candidate_mask,
@@ -1214,7 +1246,6 @@ fn score_superblock_blocks(
                     acc,
                     &mut touched,
                     block_size,
-                    total_block_postings,
                 );
 
                 // Keep the subtraction and addition in integer accumulator
@@ -1235,10 +1266,7 @@ fn score_superblock_blocks(
 
                 // Phase 2: Score remaining dims
                 score_block_bsearch_int(
-                    num_terms,
-                    dim_ptr,
-                    ps_ptr,
-                    post_ptr,
+                    block,
                     query_by_dim_u16,
                     !phase1_mask,
                     candidate_mask,
@@ -1247,15 +1275,11 @@ fn score_superblock_blocks(
                     acc,
                     &mut touched,
                     block_size,
-                    total_block_postings,
                 );
             } else {
                 // Single-phase: score all dims at once
                 score_block_bsearch_int(
-                    num_terms,
-                    dim_ptr,
-                    ps_ptr,
-                    post_ptr,
+                    block,
                     query_by_dim_u16,
                     u64::MAX,
                     candidate_mask,
@@ -1264,7 +1288,6 @@ fn score_superblock_blocks(
                     acc,
                     &mut touched,
                     block_size,
-                    total_block_postings,
                 );
             }
         }

--- a/hermes-core/src/segment/bmp_adaptive.rs
+++ b/hermes-core/src/segment/bmp_adaptive.rs
@@ -1,0 +1,851 @@
+//! Adaptive per-block payload codec for BMP V19.
+//!
+//! A block keeps sorted `u32` dimensions, but adapts the rest of its header
+//! and payload to the data:
+//!
+//! ```text
+//! raw_num_terms: u32
+//! dimensions:    [u32; num_terms]
+//! byte_offsets:  [u16 | u32; num_terms + 1]
+//! maxima_u4:     [u8; ceil(num_terms / 2)]
+//! payload:       sparse `(slot, impact)` pairs or dense impact rows
+//! ```
+//!
+//! `raw_num_terms`' high bit selects 32-bit offsets; otherwise offsets are
+//! 16-bit. The high bit of each term's start offset selects a dense impact
+//! row. The remaining bits are byte offsets into `payload`. A dense row is
+//! chosen exactly when it is no larger than the sparse pairs and slots are
+//! unique, so the representation never grows because of adaptation.
+
+const WIDE_BLOCK_FLAG: u32 = 1 << 31;
+const NARROW_DENSE_FLAG: u16 = 1 << 15;
+const WIDE_DENSE_FLAG: u32 = 1 << 31;
+const NARROW_OFFSET_MASK: u16 = !NARROW_DENSE_FLAG;
+const WIDE_OFFSET_MASK: u32 = !WIDE_DENSE_FLAG;
+const MAXIMUM_QUANTUM: u8 = 17;
+
+/// A single posting in BMP's block-local inverted index.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(C)]
+pub(crate) struct BmpPosting {
+    pub(crate) local_slot: u8,
+    pub(crate) impact: u8,
+}
+
+const _: [(); 2] = [(); std::mem::size_of::<BmpPosting>()];
+const _: [(); 1] = [(); std::mem::align_of::<BmpPosting>()];
+
+/// Reusable bounded scratch for encoding one adaptive block.
+#[derive(Default)]
+pub(crate) struct AdaptiveEncodeScratch {
+    offsets: Vec<u32>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct AdaptiveEncodeStats {
+    pub(crate) dense_terms: usize,
+    pub(crate) wide_offsets: bool,
+}
+
+impl AdaptiveEncodeScratch {
+    /// Encode one non-empty block.
+    ///
+    /// `sparse_postings` contains two bytes per logical posting in the same
+    /// term-major order described by `posting_counts`.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn encode(
+        &mut self,
+        block_size: usize,
+        enable_dense_rows: bool,
+        dimensions: &[u32],
+        posting_counts: &[u32],
+        exact_maxima: &[u8],
+        sparse_postings: &[u8],
+        output: &mut Vec<u8>,
+    ) -> std::io::Result<AdaptiveEncodeStats> {
+        if !sparse_postings.len().is_multiple_of(2) {
+            return Err(invalid_data(
+                "BMP adaptive sparse posting payload has an odd byte count",
+            ));
+        }
+        self.encode_postings(
+            block_size,
+            enable_dense_rows,
+            dimensions,
+            posting_counts,
+            exact_maxima,
+            sparse_postings.len() / 2,
+            |index| BmpPosting {
+                local_slot: sparse_postings[index * 2],
+                impact: sparse_postings[index * 2 + 1],
+            },
+            output,
+        )
+    }
+
+    /// Encode from an indexable logical-posting source. Reorder uses this to
+    /// read routed tuples in place instead of materializing a second pair
+    /// buffer for every output block.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn encode_postings(
+        &mut self,
+        block_size: usize,
+        enable_dense_rows: bool,
+        dimensions: &[u32],
+        posting_counts: &[u32],
+        exact_maxima: &[u8],
+        total_postings: usize,
+        mut posting_at: impl FnMut(usize) -> BmpPosting,
+        output: &mut Vec<u8>,
+    ) -> std::io::Result<AdaptiveEncodeStats> {
+        if !(1..=256).contains(&block_size) {
+            return Err(invalid_data("BMP adaptive block size must be in 1..=256"));
+        }
+        let num_terms = dimensions.len();
+        if num_terms == 0 || posting_counts.len() != num_terms || exact_maxima.len() != num_terms {
+            return Err(invalid_data(
+                "BMP adaptive block arrays have inconsistent lengths",
+            ));
+        }
+        if num_terms > WIDE_OFFSET_MASK as usize {
+            return Err(invalid_data(
+                "BMP adaptive block term count exceeds the u31 format limit",
+            ));
+        }
+
+        self.offsets.clear();
+        self.offsets.reserve_exact(num_terms);
+        let mut posting_start = 0usize;
+        let mut payload_len = 0usize;
+        let mut dense_terms = 0usize;
+        let mut previous_dimension = None;
+
+        for term in 0..num_terms {
+            let dimension = dimensions[term];
+            if previous_dimension.is_some_and(|previous| dimension <= previous) {
+                return Err(invalid_data(
+                    "BMP adaptive block dimensions are not strictly increasing",
+                ));
+            }
+            previous_dimension = Some(dimension);
+
+            let count = posting_counts[term] as usize;
+            if count == 0 {
+                return Err(invalid_data("BMP adaptive term has no postings"));
+            }
+            let posting_end = posting_start.checked_add(count).ok_or_else(|| {
+                invalid_data("BMP adaptive logical posting range overflows usize")
+            })?;
+            if posting_end > total_postings {
+                return Err(invalid_data(
+                    "BMP adaptive posting counts exceed the logical payload",
+                ));
+            }
+            let source_bytes = count.checked_mul(2).ok_or_else(|| {
+                invalid_data("BMP adaptive sparse posting byte count overflows usize")
+            })?;
+
+            let mut observed_max = 0u8;
+            let mut occupied = [0u64; 4];
+            let mut unique_slots = true;
+            for index in posting_start..posting_end {
+                let posting = posting_at(index);
+                let slot = posting.local_slot as usize;
+                let impact = posting.impact;
+                if slot >= block_size {
+                    return Err(invalid_data(
+                        "BMP adaptive posting slot exceeds the block size",
+                    ));
+                }
+                if impact == 0 {
+                    return Err(invalid_data("BMP adaptive posting has zero impact"));
+                }
+                let bit = 1u64 << (slot % 64);
+                let word = &mut occupied[slot / 64];
+                unique_slots &= *word & bit == 0;
+                *word |= bit;
+                observed_max = observed_max.max(impact);
+            }
+            if exact_maxima[term] != observed_max {
+                return Err(invalid_data(
+                    "BMP adaptive term maximum does not match its postings",
+                ));
+            }
+
+            let dense = enable_dense_rows && count >= block_size.div_ceil(2) && unique_slots;
+            dense_terms += usize::from(dense);
+            let term_bytes = if dense { block_size } else { source_bytes };
+            let raw_offset = u32::try_from(payload_len)
+                .map_err(|_| invalid_data("BMP adaptive payload exceeds the u32 format limit"))?;
+            if raw_offset > WIDE_OFFSET_MASK {
+                return Err(invalid_data(
+                    "BMP adaptive payload exceeds the u31 format limit",
+                ));
+            }
+            self.offsets
+                .push(raw_offset | if dense { WIDE_DENSE_FLAG } else { 0 });
+            payload_len = payload_len
+                .checked_add(term_bytes)
+                .ok_or_else(|| invalid_data("BMP adaptive payload byte count overflows usize"))?;
+            posting_start = posting_end;
+        }
+        if posting_start != total_postings {
+            return Err(invalid_data(
+                "BMP adaptive logical payload has trailing postings",
+            ));
+        }
+        if payload_len > WIDE_OFFSET_MASK as usize {
+            return Err(invalid_data(
+                "BMP adaptive payload exceeds the u31 format limit",
+            ));
+        }
+
+        let wide = payload_len > NARROW_OFFSET_MASK as usize;
+        let offset_width = if wide { 4usize } else { 2usize };
+        let offsets_bytes = num_terms
+            .checked_add(1)
+            .and_then(|count| count.checked_mul(offset_width))
+            .ok_or_else(|| invalid_data("BMP adaptive offset header overflows usize"))?;
+        let header_len = 4usize
+            .checked_add(
+                num_terms
+                    .checked_mul(4)
+                    .ok_or_else(|| invalid_data("BMP adaptive dimension header overflows usize"))?,
+            )
+            .and_then(|len| len.checked_add(offsets_bytes))
+            .and_then(|len| len.checked_add(num_terms.div_ceil(2)))
+            .ok_or_else(|| invalid_data("BMP adaptive header overflows usize"))?;
+        let encoded_len = header_len
+            .checked_add(payload_len)
+            .ok_or_else(|| invalid_data("BMP adaptive block size overflows usize"))?;
+
+        output.clear();
+        output.reserve_exact(encoded_len);
+        let raw_num_terms = num_terms as u32 | if wide { WIDE_BLOCK_FLAG } else { 0 };
+        output.extend_from_slice(&raw_num_terms.to_le_bytes());
+        for &dimension in dimensions {
+            output.extend_from_slice(&dimension.to_le_bytes());
+        }
+        if wide {
+            for &encoded in &self.offsets {
+                output.extend_from_slice(&encoded.to_le_bytes());
+            }
+            output.extend_from_slice(&(payload_len as u32).to_le_bytes());
+        } else {
+            for &wide_encoded in &self.offsets {
+                let offset = wide_encoded & WIDE_OFFSET_MASK;
+                let dense = wide_encoded & WIDE_DENSE_FLAG != 0;
+                let encoded = offset as u16 | if dense { NARROW_DENSE_FLAG } else { 0 };
+                output.extend_from_slice(&encoded.to_le_bytes());
+            }
+            output.extend_from_slice(&(payload_len as u16).to_le_bytes());
+        }
+        for maxima in exact_maxima.chunks(2) {
+            let low = quantize_maximum(maxima[0]);
+            let high = maxima.get(1).copied().map_or(0, quantize_maximum);
+            output.push(low | high << 4);
+        }
+
+        posting_start = 0;
+        for (term, &count) in posting_counts.iter().enumerate() {
+            let posting_end = posting_start + count as usize;
+            if self.offsets[term] & WIDE_DENSE_FLAG != 0 {
+                let row_start = output.len();
+                output.resize(row_start + block_size, 0);
+                let row = &mut output[row_start..];
+                for index in posting_start..posting_end {
+                    let posting = posting_at(index);
+                    row[posting.local_slot as usize] = posting.impact;
+                }
+            } else {
+                for index in posting_start..posting_end {
+                    let posting = posting_at(index);
+                    output.extend_from_slice(&[posting.local_slot, posting.impact]);
+                }
+            }
+            posting_start = posting_end;
+        }
+        debug_assert_eq!(output.len(), encoded_len);
+        Ok(AdaptiveEncodeStats {
+            dense_terms,
+            wide_offsets: wide,
+        })
+    }
+}
+
+/// A parsed zero-copy adaptive block.
+#[derive(Clone, Copy)]
+pub(crate) struct AdaptiveBlock<'a> {
+    bytes: &'a [u8],
+    block_size: usize,
+    num_terms: usize,
+    dimensions_start: usize,
+    offsets_start: usize,
+    maxima_start: usize,
+    payload_start: usize,
+    offset_width: usize,
+}
+
+impl<'a> AdaptiveBlock<'a> {
+    /// Parse the constant-time structural envelope needed by the query path.
+    ///
+    /// Per-term ranges and postings are checked lazily by `postings`; exhaustive
+    /// rewrite validation uses `validate`.
+    #[inline(always)]
+    pub(crate) fn parse(bytes: &'a [u8], block_size: usize) -> Option<Self> {
+        if bytes.len() < 4 || !(1..=256).contains(&block_size) {
+            return None;
+        }
+        let raw_num_terms = read_u32(bytes, 0)?;
+        let wide = raw_num_terms & WIDE_BLOCK_FLAG != 0;
+        let num_terms = (raw_num_terms & WIDE_OFFSET_MASK) as usize;
+        if num_terms == 0 {
+            return None;
+        }
+        let offset_width = if wide { 4usize } else { 2usize };
+        let dimensions_start = 4usize;
+        let offsets_start = dimensions_start.checked_add(num_terms.checked_mul(4)?)?;
+        let maxima_start =
+            offsets_start.checked_add(num_terms.checked_add(1)?.checked_mul(offset_width)?)?;
+        let payload_start = maxima_start.checked_add(num_terms.div_ceil(2))?;
+        if payload_start > bytes.len() {
+            return None;
+        }
+        let block = Self {
+            bytes,
+            block_size,
+            num_terms,
+            dimensions_start,
+            offsets_start,
+            maxima_start,
+            payload_start,
+            offset_width,
+        };
+        let (first, _) = block.offset(0)?;
+        let (sentinel, sentinel_dense) = block.offset(num_terms)?;
+        if first != 0 || sentinel_dense || sentinel != bytes.len() - payload_start {
+            return None;
+        }
+        Some(block)
+    }
+
+    #[inline(always)]
+    pub(crate) fn find_dimension(&self, dimension: u32) -> Option<usize> {
+        // Match the standard library's branch-minimized binary search. Term
+        // lookups dominate wide sparse queries, and a three-way branch at
+        // every level is measurably slower on mmap-backed headers.
+        let mut size = self.num_terms;
+        let mut base = 0usize;
+        while size > 1 {
+            let half = size / 2;
+            let middle = base + half;
+            // SAFETY: `middle < num_terms`; parse validated the complete
+            // dimension array once when constructing this block view.
+            let value = unsafe { self.dimension_unchecked(middle) };
+            base = std::hint::select_unpredictable(value > dimension, base, middle);
+            size -= half;
+        }
+        // SAFETY: AdaptiveBlock::parse rejects zero-term blocks, and the loop
+        // maintains `base < num_terms`.
+        if unsafe { self.dimension_unchecked(base) } == dimension {
+            Some(base)
+        } else {
+            None
+        }
+    }
+
+    /// Early-exit binary search for narrow queries. When most looked-up terms
+    /// are present, returning at the matching level avoids enough header loads
+    /// to beat the fixed-depth branch-minimized search.
+    #[inline(always)]
+    pub(crate) fn find_dimension_branching(&self, dimension: u32) -> Option<usize> {
+        let mut low = 0usize;
+        let mut high = self.num_terms;
+        while low < high {
+            let middle = low + (high - low) / 2;
+            // SAFETY: `middle < num_terms`; parse validated the dimension
+            // array once when constructing this view.
+            let value = unsafe { self.dimension_unchecked(middle) };
+            match value.cmp(&dimension) {
+                std::cmp::Ordering::Less => low = middle + 1,
+                std::cmp::Ordering::Equal => return Some(middle),
+                std::cmp::Ordering::Greater => high = middle,
+            }
+        }
+        None
+    }
+
+    #[inline(always)]
+    pub(crate) fn dimension(&self, term: usize) -> Option<u32> {
+        if term >= self.num_terms {
+            return None;
+        }
+        // SAFETY: The term bound and parsed header envelope cover this read.
+        Some(unsafe { self.dimension_unchecked(term) })
+    }
+
+    /// Reconstruct the conservative u8 representative of the packed u4 max.
+    ///
+    /// Re-quantizing this value to either a u4 or u2 pruning grid gives the
+    /// same cell as quantizing the original exact maximum.
+    #[inline(always)]
+    pub(crate) fn max_impact(&self, term: usize) -> Option<u8> {
+        if term >= self.num_terms {
+            return None;
+        }
+        // SAFETY: The term bound and parsed header envelope cover this byte.
+        let packed = unsafe { *self.bytes.get_unchecked(self.maxima_start + term / 2) };
+        let quantized = if term.is_multiple_of(2) {
+            packed & 0x0f
+        } else {
+            packed >> 4
+        };
+        Some(quantized * MAXIMUM_QUANTUM)
+    }
+
+    #[inline(always)]
+    pub(crate) fn postings(&self, term: usize) -> Option<AdaptivePostings<'a>> {
+        if term >= self.num_terms {
+            return None;
+        }
+        // SAFETY: Both entries belong to the parsed offset table.
+        let (start, dense) = unsafe { self.offset_unchecked(term) };
+        let (end, _) = unsafe { self.offset_unchecked(term + 1) };
+        let payload_len = self.bytes.len() - self.payload_start;
+        if end <= start || end > payload_len {
+            return None;
+        }
+        // SAFETY: `end <= payload_len` proves the complete range is inside
+        // the block. `start < end` proves its start is inside as well.
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                self.bytes.as_ptr().add(self.payload_start + start),
+                end - start,
+            )
+        };
+        if dense {
+            if bytes.len() != self.block_size {
+                return None;
+            }
+            Some(AdaptivePostings::Dense(bytes))
+        } else {
+            if !bytes.len().is_multiple_of(2) {
+                return None;
+            }
+            // SAFETY: BmpPosting contains two u8 fields and therefore has
+            // alignment one. The byte count was checked to be even.
+            let postings = unsafe {
+                std::slice::from_raw_parts(bytes.as_ptr().cast::<BmpPosting>(), bytes.len() / 2)
+            };
+            Some(AdaptivePostings::Sparse(postings))
+        }
+    }
+
+    #[inline]
+    pub(crate) fn terms(self) -> AdaptiveTermIter<'a> {
+        AdaptiveTermIter {
+            block: self,
+            current: 0,
+        }
+    }
+
+    /// Exhaustively validate a block before background rewrite or graph work.
+    #[cfg(any(feature = "native", test))]
+    pub(crate) fn validate(self, dimensions: u32) -> Result<(), String> {
+        if self.num_terms == 0 {
+            return Err("block contains no terms".into());
+        }
+        if self.num_terms % 2 == 1 && self.bytes[self.maxima_start + self.num_terms / 2] & 0xf0 != 0
+        {
+            return Err("unused packed-maximum nibble is non-zero".into());
+        }
+
+        let mut previous_dimension = None;
+        for term in 0..self.num_terms {
+            let dimension = self
+                .dimension(term)
+                .ok_or_else(|| format!("term {term} has no dimension"))?;
+            if dimension >= dimensions
+                || previous_dimension.is_some_and(|previous| dimension <= previous)
+            {
+                return Err(format!(
+                    "term {term} has invalid/non-increasing dimension {dimension}"
+                ));
+            }
+            previous_dimension = Some(dimension);
+
+            let postings = self
+                .postings(term)
+                .ok_or_else(|| format!("term {term} has an invalid payload range"))?;
+            let mut observed_max = 0u8;
+            let mut count = 0usize;
+            match postings {
+                AdaptivePostings::Sparse(values) => {
+                    for posting in values {
+                        if posting.local_slot as usize >= self.block_size {
+                            return Err(format!(
+                                "term {term} has local slot {} outside block size {}",
+                                posting.local_slot, self.block_size
+                            ));
+                        }
+                        if posting.impact == 0 {
+                            return Err(format!("term {term} has a zero sparse impact"));
+                        }
+                        observed_max = observed_max.max(posting.impact);
+                        count += 1;
+                    }
+                }
+                AdaptivePostings::Dense(values) => {
+                    for &impact in values {
+                        if impact != 0 {
+                            observed_max = observed_max.max(impact);
+                            count += 1;
+                        }
+                    }
+                }
+            }
+            if count == 0 {
+                return Err(format!("term {term} has no postings"));
+            }
+            let stored = self
+                .max_impact(term)
+                .ok_or_else(|| format!("term {term} has no maximum"))?;
+            if stored != u4_representative(observed_max) {
+                return Err(format!(
+                    "term {term} packed maximum {stored} does not cover observed {observed_max}"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn offset(&self, term: usize) -> Option<(usize, bool)> {
+        if term > self.num_terms {
+            return None;
+        }
+        // SAFETY: The term bound and parsed header envelope cover this entry.
+        Some(unsafe { self.offset_unchecked(term) })
+    }
+
+    #[inline(always)]
+    unsafe fn dimension_unchecked(&self, term: usize) -> u32 {
+        unsafe { read_u32_unchecked(self.bytes, self.dimensions_start + term * 4) }
+    }
+
+    #[inline(always)]
+    unsafe fn offset_unchecked(&self, term: usize) -> (usize, bool) {
+        let byte = self.offsets_start + term * self.offset_width;
+        if self.offset_width == 2 {
+            let raw = unsafe { read_u16_unchecked(self.bytes, byte) };
+            (
+                (raw & NARROW_OFFSET_MASK) as usize,
+                raw & NARROW_DENSE_FLAG != 0,
+            )
+        } else {
+            let raw = unsafe { read_u32_unchecked(self.bytes, byte) };
+            (
+                (raw & WIDE_OFFSET_MASK) as usize,
+                raw & WIDE_DENSE_FLAG != 0,
+            )
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum AdaptivePostings<'a> {
+    Sparse(&'a [BmpPosting]),
+    Dense(&'a [u8]),
+}
+
+impl AdaptivePostings<'_> {
+    #[cfg(any(feature = "native", test))]
+    #[inline]
+    pub(crate) fn len(self) -> usize {
+        match self {
+            Self::Sparse(postings) => postings.len(),
+            Self::Dense(impacts) => impacts.iter().filter(|&&impact| impact != 0).count(),
+        }
+    }
+}
+
+pub(crate) enum AdaptivePostingIter<'a> {
+    Sparse(std::iter::Copied<std::slice::Iter<'a, BmpPosting>>),
+    Dense(std::iter::Enumerate<std::slice::Iter<'a, u8>>),
+}
+
+impl Iterator for AdaptivePostingIter<'_> {
+    type Item = BmpPosting;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Sparse(postings) => postings.next(),
+            Self::Dense(impacts) => {
+                for (slot, &impact) in impacts.by_ref() {
+                    if impact != 0 {
+                        return Some(BmpPosting {
+                            local_slot: slot as u8,
+                            impact,
+                        });
+                    }
+                }
+                None
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Sparse(postings) => postings.size_hint(),
+            Self::Dense(impacts) => (0, Some(impacts.len())),
+        }
+    }
+}
+
+impl<'a> IntoIterator for AdaptivePostings<'a> {
+    type Item = BmpPosting;
+    type IntoIter = AdaptivePostingIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::Sparse(postings) => AdaptivePostingIter::Sparse(postings.iter().copied()),
+            Self::Dense(impacts) => AdaptivePostingIter::Dense(impacts.iter().enumerate()),
+        }
+    }
+}
+
+pub(crate) struct AdaptiveTermIter<'a> {
+    block: AdaptiveBlock<'a>,
+    current: usize,
+}
+
+impl<'a> Iterator for AdaptiveTermIter<'a> {
+    type Item = (u32, u8, AdaptivePostings<'a>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current == self.block.num_terms {
+            return None;
+        }
+        let term = self.current;
+        self.current += 1;
+        Some((
+            self.block.dimension(term)?,
+            self.block.max_impact(term)?,
+            self.block.postings(term)?,
+        ))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.block.num_terms - self.current;
+        (remaining, Some(remaining))
+    }
+}
+
+#[inline]
+fn quantize_maximum(maximum: u8) -> u8 {
+    u4_representative(maximum) / MAXIMUM_QUANTUM
+}
+
+#[inline]
+fn u4_representative(maximum: u8) -> u8 {
+    if maximum == 0 {
+        0
+    } else {
+        u16::from(maximum).div_ceil(u16::from(MAXIMUM_QUANTUM)) as u8 * MAXIMUM_QUANTUM
+    }
+}
+
+#[inline]
+fn read_u32(bytes: &[u8], start: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(
+        bytes.get(start..start.checked_add(4)?)?.try_into().ok()?,
+    ))
+}
+
+#[inline(always)]
+unsafe fn read_u16_unchecked(bytes: &[u8], start: usize) -> u16 {
+    unsafe { u16::from_le((bytes.as_ptr().add(start) as *const u16).read_unaligned()) }
+}
+
+#[inline(always)]
+unsafe fn read_u32_unchecked(bytes: &[u8], start: usize) -> u32 {
+    unsafe { u32::from_le((bytes.as_ptr().add(start) as *const u32).read_unaligned()) }
+}
+
+fn invalid_data(message: &'static str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode(
+        block_size: usize,
+        dimensions: &[u32],
+        counts: &[u32],
+        maxima: &[u8],
+        postings: &[u8],
+    ) -> Vec<u8> {
+        let mut scratch = AdaptiveEncodeScratch::default();
+        let mut bytes = Vec::new();
+        scratch
+            .encode(
+                block_size, true, dimensions, counts, maxima, postings, &mut bytes,
+            )
+            .unwrap();
+        bytes
+    }
+
+    #[test]
+    fn narrow_sparse_and_dense_terms_round_trip() {
+        let mut postings = vec![1, 19, 7, 255];
+        for slot in 0..16u8 {
+            postings.extend_from_slice(&[slot, slot.saturating_add(1)]);
+        }
+        let bytes = encode(32, &[3, 9], &[2, 16], &[255, 16], &postings);
+        let block = AdaptiveBlock::parse(&bytes, 32).unwrap();
+        assert_eq!(block.num_terms, 2);
+        assert_eq!(block.find_dimension(3), Some(0));
+        assert_eq!(block.find_dimension(9), Some(1));
+        assert_eq!(block.find_dimension(8), None);
+        assert_eq!(block.max_impact(0), Some(255));
+        assert_eq!(block.max_impact(1), Some(17));
+        assert!(matches!(
+            block.postings(0),
+            Some(AdaptivePostings::Sparse(_))
+        ));
+        assert!(matches!(
+            block.postings(1),
+            Some(AdaptivePostings::Dense(_))
+        ));
+        assert_eq!(
+            block.postings(0).unwrap().into_iter().collect::<Vec<_>>(),
+            vec![
+                BmpPosting {
+                    local_slot: 1,
+                    impact: 19
+                },
+                BmpPosting {
+                    local_slot: 7,
+                    impact: 255
+                }
+            ]
+        );
+        assert_eq!(block.postings(1).unwrap().len(), 16);
+        block.validate(10).unwrap();
+    }
+
+    #[test]
+    fn duplicate_slots_stay_sparse() {
+        let postings = [1, 10, 1, 20, 2, 30, 2, 40];
+        let bytes = encode(4, &[7], &[4], &[40], &postings);
+        let block = AdaptiveBlock::parse(&bytes, 4).unwrap();
+        assert!(matches!(
+            block.postings(0),
+            Some(AdaptivePostings::Sparse(_))
+        ));
+        assert_eq!(block.postings(0).unwrap().len(), 4);
+    }
+
+    #[test]
+    fn adaptive_encoding_never_exceeds_v18_flat_blocks() {
+        for num_terms in 1..=128usize {
+            let dimensions: Vec<u32> = (0..num_terms as u32).collect();
+            let counts: Vec<u32> = (0..num_terms)
+                .map(|term| (term * 7 % 32 + 1) as u32)
+                .collect();
+            let maxima = vec![255; num_terms];
+            let mut postings = Vec::new();
+            for &count in &counts {
+                for slot in 0..count as u8 {
+                    postings.extend_from_slice(&[slot, 255]);
+                }
+            }
+            let bytes = encode(32, &dimensions, &counts, &maxima, &postings);
+            let v18_bytes = 8 + 9 * num_terms + postings.len();
+            assert!(
+                bytes.len() <= v18_bytes,
+                "terms={num_terms}: V19={} > V18={v18_bytes}",
+                bytes.len(),
+            );
+        }
+    }
+
+    #[test]
+    fn wide_offsets_round_trip() {
+        let dimensions: Vec<u32> = (0..130).collect();
+        let counts = vec![128; dimensions.len()];
+        let maxima = vec![255; dimensions.len()];
+        let mut postings = Vec::with_capacity(dimensions.len() * 256);
+        for _ in &dimensions {
+            for slot in 0..128u8 {
+                postings.extend_from_slice(&[slot, 255]);
+            }
+        }
+        let bytes = encode(256, &dimensions, &counts, &maxima, &postings);
+        assert_ne!(
+            u32::from_le_bytes(bytes[..4].try_into().unwrap()) & WIDE_BLOCK_FLAG,
+            0
+        );
+        let block = AdaptiveBlock::parse(&bytes, 256).unwrap();
+        assert_eq!(block.find_dimension(129), Some(129));
+        assert_eq!(block.postings(129).unwrap().len(), 128);
+        block.validate(130).unwrap();
+    }
+
+    #[test]
+    fn packed_u4_requantizes_identically_for_u4_and_u2_grids() {
+        for exact in 0..=u8::MAX {
+            let representative = u4_representative(exact);
+            assert_eq!(quantize_maximum(exact), quantize_maximum(representative));
+            let exact_u2 = if exact == 0 {
+                0
+            } else {
+                (u16::from(exact) * 3).div_ceil(255) as u8
+            };
+            let representative_u2 = if representative == 0 {
+                0
+            } else {
+                (u16::from(representative) * 3).div_ceil(255) as u8
+            };
+            assert_eq!(exact_u2, representative_u2);
+        }
+    }
+
+    #[test]
+    fn malformed_offset_is_rejected_without_panicking() {
+        let mut bytes = encode(32, &[1], &[1], &[7], &[3, 7]);
+        // Narrow sentinel follows raw count, one dimension, and one start.
+        bytes[10..12].copy_from_slice(&u16::MAX.to_le_bytes());
+        assert!(AdaptiveBlock::parse(&bytes, 32).is_none());
+    }
+
+    #[test]
+    fn branch_minimized_dimension_search_matches_slice_binary_search() {
+        for len in 1..=300usize {
+            let dimensions: Vec<u32> = (0..len as u32).map(|value| value * 3 + 1).collect();
+            let counts = vec![1; len];
+            let maxima = vec![1; len];
+            let postings = [0, 1].repeat(len);
+            let bytes = encode(32, &dimensions, &counts, &maxima, &postings);
+            let block = AdaptiveBlock::parse(&bytes, 32).unwrap();
+            for target in 0..=(len as u32 * 3 + 2) {
+                let expected = dimensions.binary_search(&target).ok();
+                assert_eq!(
+                    block.find_dimension(target),
+                    expected,
+                    "length={len}, target={target}",
+                );
+                assert_eq!(
+                    block.find_dimension_branching(target),
+                    expected,
+                    "branching length={len}, target={target}",
+                );
+            }
+        }
+    }
+}

--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -1,10 +1,12 @@
-//! BMP (Block-Max Pruning) index builder for sparse vectors — **V18 format**.
+//! BMP (Block-Max Pruning) index builder for sparse vectors — **V19 format**.
 //!
 //! Builds a block-at-a-time (BAAT) index using **compact virtual coordinates**:
 //! sequential IDs are assigned to unique `(doc_id, ordinal)` pairs. A lookup
 //! table enables query-time recovery of the original coordinates.
 //!
-//! Postings are 2 bytes each: `(local_slot: u8, impact: u8)`.
+//! Per-term payloads adapt between 2-byte `(local_slot, impact)` postings and
+//! dense impact rows. Byte offsets use u16 unless a block payload exceeds the
+//! 15-bit inline range, and block maxima are packed u4.
 //!
 //! Based on Mallia, Suel & Tonellotto (SIGIR 2024).
 //!
@@ -18,7 +20,7 @@
 //!
 //! Peak memory: `input + grid_entries + O(num_blocks) block_data_starts`.
 //!
-//! ## BMP V18 Blob Layout (data-first, block-interleaved)
+//! ## BMP V19 Blob Layout (data-first, block-interleaved)
 //!
 //! ```text
 //! Section B:  block_data         [per-block interleaved data]   variable-length
@@ -31,13 +33,13 @@
 //! Section G:  doc_map_ordinals   [u16-LE × num_virtual_docs]
 //!
 //! Per-block data layout (for non-empty blocks):
-//!   num_terms: u32                                    offset 0
+//!   raw_num_terms: u32                                high bit = u32 offsets
 //!   term_dim_ids: [u32-LE × num_terms]                offset 4
-//!   posting_starts: [u32-LE × (num_terms + 1)]        relative cumulative counts
-//!   term_max_impacts: [u8 × num_terms]                exact per-block maxima
-//!   postings: [(u8, u8) × total_block_postings]       BmpPosting pairs
+//!   payload_offsets: [u16/u32 × (num_terms + 1)]       byte offsets; high bit = dense
+//!   term_max_impacts: [packed-u4 × num_terms]          conservative maxima
+//!   payload: sparse [(u8, u8)] or dense [u8; block_size] per term
 //!
-//! BMP V18 Footer (80 bytes):
+//! BMP V19 Footer (80 bytes):
 //!   total_terms: u64              //  0- 7  (stats only)
 //!   total_postings: u64           //  8-15  (stats only)
 //!   grid_offset: u64              // 16-23  (byte offset of Section D)
@@ -51,7 +53,7 @@
 //!   doc_map_offset: u64           // 60-67  (byte offset of Section F)
 //!   num_real_docs: u32            // 68-71  (actual vector count before padding)
 //!   grid_bits: u32                // 72-75  (2 or 4)
-//!   magic: u32                    // 76-79  (BMP8 = 0x38504D42)
+//!   magic: u32                    // 76-79  (BMP9 = 0x39504D42)
 //! ```
 
 use std::cmp::Reverse;
@@ -89,6 +91,7 @@ impl VidLookup {
 }
 
 use crate::DocId;
+use crate::segment::bmp_adaptive::AdaptiveEncodeScratch;
 use crate::segment::bmp_grid::{
     CompressedGridLayout, GRID_GROUP_CELLS, LSP_SUPERBLOCK_GRID_BITS, bit_width, pack_group,
     quantize_block_maximum,
@@ -96,7 +99,7 @@ use crate::segment::bmp_grid::{
 use crate::segment::format::{BMP_BLOB_FOOTER_SIZE, BMP_BLOB_MAGIC};
 use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
 
-/// Build a BMP V18 blob from per-dimension postings.
+/// Build a BMP V19 blob from per-dimension postings.
 ///
 /// **Takes ownership** of the postings HashMap. All per-dim Vecs are moved
 /// out of the HashMap into `dim_vecs` before the K-way merge starts, and
@@ -196,7 +199,7 @@ pub(crate) fn build_bmp_blob(
     if num_real_docs > u32::MAX as usize {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            "BMP real document count exceeds the V18 u32 format limit",
+            "BMP real document count exceeds the V19 u32 format limit",
         ));
     }
 
@@ -221,7 +224,7 @@ pub(crate) fn build_bmp_blob(
     if num_virtual_docs > u32::MAX as usize {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            "BMP padded document count exceeds the V18 u32 format limit",
+            "BMP padded document count exceeds the V19 u32 format limit",
         ));
     }
 
@@ -308,6 +311,9 @@ pub(crate) fn build_bmp_blob(
     let mut total_terms: u64 = 0;
     let mut total_postings: u64 = 0;
     let mut cumulative_bytes: u64 = 0;
+    let mut legacy_block_bytes: u64 = 0;
+    let mut dense_terms: u64 = 0;
+    let mut wide_blocks: u64 = 0;
     let mut last_block_filled: i64 = -1;
 
     // Per-block scratch (reused per block, bounded by one block's data ~4 KB)
@@ -316,6 +322,7 @@ pub(crate) fn build_bmp_blob(
     let mut blk_posting_counts: Vec<u32> = Vec::new();
     let mut blk_max_impacts: Vec<u8> = Vec::new();
     let mut blk_postings: Vec<u8> = Vec::new();
+    let mut adaptive_scratch = AdaptiveEncodeScratch::default();
 
     while let Some(&Reverse((block_id, _, _))) = heap.peek() {
         // Fill block_data_starts for empty blocks before this one
@@ -399,45 +406,21 @@ pub(crate) fn build_bmp_blob(
 
         // Serialize and write this block's data directly to writer
         if !blk_dim_ids.is_empty() {
-            blk_buf.clear();
-            let nt = blk_dim_ids.len();
-
-            // num_terms (u32)
-            let nt_u32 = u32::try_from(nt).map_err(|_| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "BMP block term count exceeds the V18 u32 format limit",
-                )
-            })?;
-            blk_buf.extend_from_slice(&nt_u32.to_le_bytes());
-
-            // term_dim_ids [u32 × nt]
-            for &did in &blk_dim_ids {
-                blk_buf.extend_from_slice(&did.to_le_bytes());
-            }
-
-            // posting_starts [u32 × (nt + 1)] — relative cumulative.
-            // A 256-vector block with hundreds of dimensions can exceed
-            // 65,535 postings, so both counts and prefixes are u32.
-            let mut cum: u32 = 0;
-            for &count in &blk_posting_counts {
-                blk_buf.extend_from_slice(&cum.to_le_bytes());
-                cum = cum.checked_add(count).ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "BMP block posting prefix exceeds u32::MAX",
-                    )
-                })?;
-            }
-            blk_buf.extend_from_slice(&cum.to_le_bytes());
-
-            // Exact per-term block maxima. The compressed D grid keeps its
-            // existing ceil-u4 semantics; these exact values let reorder
-            // rebuild tight ceil-u4 superblock maxima without rescanning postings.
-            blk_buf.extend_from_slice(&blk_max_impacts);
-
-            // postings [(u8, u8) × total_block_postings]
-            blk_buf.extend_from_slice(&blk_postings);
+            let encoding = adaptive_scratch.encode(
+                effective_block_size as usize,
+                true,
+                &blk_dim_ids,
+                &blk_posting_counts,
+                &blk_max_impacts,
+                &blk_postings,
+                &mut blk_buf,
+            )?;
+            dense_terms = dense_terms.saturating_add(encoding.dense_terms as u64);
+            wide_blocks += u64::from(encoding.wide_offsets);
+            legacy_block_bytes = legacy_block_bytes.saturating_add(
+                8u64.saturating_add((blk_dim_ids.len() as u64).saturating_mul(9))
+                    .saturating_add(blk_postings.len() as u64),
+            );
 
             writer.write_all(&blk_buf)?;
             cumulative_bytes += blk_buf.len() as u64;
@@ -455,8 +438,9 @@ pub(crate) fn build_bmp_blob(
     grid_entries.sort_unstable();
 
     log::info!(
-        "[bmp_build] V18 vectors={} padded={} blocks={} dims={} \
-         terms={} postings={} grid_entries={}",
+        "[bmp_build] V19 vectors={} padded={} blocks={} dims={} \
+         terms={} postings={} grid_entries={} section_b={} legacy_v18_section_b={} \
+         adaptive_ratio={:.3} dense_terms={} ({:.2}%) wide_blocks={}",
         num_real_docs,
         num_virtual_docs,
         num_blocks,
@@ -464,6 +448,12 @@ pub(crate) fn build_bmp_blob(
         total_terms,
         total_postings,
         grid_entries.len(),
+        crate::format_bytes(cumulative_bytes),
+        crate::format_bytes(legacy_block_bytes),
+        cumulative_bytes as f64 / legacy_block_bytes.max(1) as f64,
+        dense_terms,
+        dense_terms as f64 * 100.0 / total_terms.max(1) as f64,
+        wide_blocks,
     );
 
     // Free K-way merge inputs — reclaims per-dim posting Vecs and vid lookup.
@@ -525,7 +515,7 @@ pub(crate) fn build_bmp_blob(
 
     drop(vid_pairs); // Free after last use (~6 bytes × num_real_docs)
 
-    // BMP V18 footer.
+    // BMP V19 footer.
     write_bmp_footer(
         writer,
         total_terms,
@@ -547,7 +537,7 @@ pub(crate) fn build_bmp_blob(
     Ok(bytes_written)
 }
 
-/// Write the BMP V18 footer.
+/// Write the BMP V19 footer.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn write_bmp_footer(
     writer: &mut dyn Write,

--- a/hermes-core/src/segment/format.rs
+++ b/hermes-core/src/segment/format.rs
@@ -92,21 +92,20 @@ pub fn read_dense_toc(
 /// Field header: field_id(4) + quant(1) + num_dims(4) + total_vectors(4) = 13B
 pub const SPARSE_FOOTER_MAGIC: u32 = 0x34525053;
 
-/// Magic number for the current BMP V18 blob footer ("BMP8" in LE).
+/// Magic number for the current BMP V19 blob footer ("BMP9" in LE).
 ///
-/// V18 uses LSP/0's 256-vector superblocks and ceil-u4 maximum weights at all
-/// pruning levels. In addition to the block and superblock grids, it persists
-/// an exact coarse grid over groups of 256 superblocks. The coarse grid lets
-/// query planning find the global top-gamma superblocks without sweeping the
-/// data-sized superblock grid.
+/// V19 keeps V18's LSP/0 pruning hierarchy and replaces each block's flat
+/// header/payload with adaptive u16/u32 byte offsets, packed-u4 term maxima,
+/// and per-term sparse-pair or dense-impact encoding.
 ///
 /// Every grid retains independently addressable, locally bit-packed 256-cell
-/// groups and exact per-term block-header maxima.
+/// groups. Packed block-header maxima reconstruct conservative u8
+/// representatives that re-quantize to exactly the persisted u4/u2 cells.
 /// This is the only accepted BMP representation; indexes are rebuilt on format
 /// changes rather than carrying compatibility parsers.
-pub const BMP_BLOB_MAGIC: u32 = 0x38504D42;
+pub const BMP_BLOB_MAGIC: u32 = 0x39504D42;
 
-/// Current BMP V18 blob footer size.
+/// Current BMP V19 blob footer size.
 pub const BMP_BLOB_FOOTER_SIZE: usize = 80;
 
 /// V3 footer size: skip_offset(8) + toc_offset(8) + num_fields(4) + magic(4) = 24
@@ -143,7 +142,7 @@ pub struct SparseFieldToc {
 impl SparseFieldToc {
     /// Build the sentinel TOC entry used by the self-contained BMP blob.
     pub(crate) fn bmp(field_id: u32, total_vectors: u32, blob_offset: u64, blob_len: u64) -> Self {
-        // V18 always stores u32 dimensions and u8 impacts regardless of the
+        // V19 always stores u32 dimensions and u8 impacts regardless of the
         // generic sparse schema knobs. Persist the physical representation,
         // not a misleading caller-supplied MaxScore descriptor.
         let config = crate::structures::SparseVectorConfig {

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -119,7 +119,7 @@ impl SegmentMerger {
                         .try_fold(0u32, |total, vectors| total.checked_add(vectors))
                         .ok_or_else(|| {
                             crate::Error::Internal(
-                                "merged BMP vector count exceeds the V18 u32 format limit".into(),
+                                "merged BMP vector count exceeds the V19 u32 format limit".into(),
                             )
                         })?;
                     let bmp_block_size = sparse_config
@@ -592,7 +592,7 @@ fn validate_sparse_merge_source(dim_id: u32, source_index: usize, raw: &DimRawDa
     Ok(())
 }
 
-/// Merge BMP fields with the **streaming block-copy V18 format**.
+/// Merge BMP fields with the **streaming block-copy V19 format**.
 ///
 /// Block-copy merge: all segments share the same `dims`, `bmp_block_size`,
 /// and `max_weight_scale`, so blocks are self-contained and can be copied directly.
@@ -605,7 +605,7 @@ fn validate_sparse_merge_source(dim_id: u32, source_index: usize, raw: &DimRawDa
 /// 4. Stream Sections E+H — ceil-u4 values decoded/repacked into the output
 ///    superblock and coarse-superblock coordinate systems
 /// 5. Stream Section F+G (doc_map) — bulk copy with offset patching
-/// 6. Write the V18 footer
+/// 6. Write the V19 footer
 ///
 /// Peak memory is one row's group descriptors/selectors, one superblock row,
 /// and fixed-size copy/decode buffers; it does not scale with postings.
@@ -671,14 +671,14 @@ fn merge_bmp_field(
             .checked_add(bmp.num_blocks)
             .ok_or_else(|| {
                 crate::Error::Internal(
-                    "merged BMP block count exceeds the V18 u32 format limit".into(),
+                    "merged BMP block count exceeds the V19 u32 format limit".into(),
                 )
             })?;
         num_real_docs_total = num_real_docs_total
             .checked_add(bmp.num_real_docs())
             .ok_or_else(|| {
                 crate::Error::Internal(
-                    "merged BMP real-document count exceeds the V18 u32 format limit".into(),
+                    "merged BMP real-document count exceeds the V19 u32 format limit".into(),
                 )
             })?;
     }
@@ -693,7 +693,7 @@ fn merge_bmp_field(
         .filter(|&count| count <= u32::MAX as usize)
         .ok_or_else(|| {
             crate::Error::Internal(
-                "merged BMP virtual-document count exceeds the V18 u32 format limit".into(),
+                "merged BMP virtual-document count exceeds the V19 u32 format limit".into(),
             )
         })?;
     // Pre-compute aggregate stats (needed for footer, independent of block order)
@@ -878,7 +878,7 @@ fn merge_bmp_field(
         )?;
     }
 
-    // ── Phase 6: Write V18 footer ───────────────────────────────────────
+    // ── Phase 6: Write V19 footer ───────────────────────────────────────
     write_bmp_footer(
         writer,
         total_terms,

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod ann_build;
 mod ann_disk;
+pub(crate) mod bmp_adaptive;
 pub(crate) mod bmp_grid;
 #[cfg(any(feature = "native", feature = "wasm"))]
 mod builder;
@@ -29,7 +30,6 @@ pub(crate) use merger::block_in_place_if_multithread;
 pub use merger::{MergeStats, SegmentMerger, delete_segment};
 pub(crate) use reader::BmpIndex;
 pub(crate) use reader::bmp::BMP_SUPERBLOCK_SIZE;
-pub(crate) use reader::bmp::{block_term_postings, find_dim_in_block_data};
 pub(crate) use reader::combine_ordinal_results;
 #[cfg(feature = "native")]
 pub mod pin;

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -1,6 +1,6 @@
-//! BMP (Block-Max Pruning) index reader for sparse vectors — **V18 zero-copy**.
+//! BMP (Block-Max Pruning) index reader for sparse vectors — **V19 zero-copy**.
 //!
-//! V18 uses fixed `dims` (vocabulary size) and dim_id directly in per-block data.
+//! V19 uses fixed `dims` (vocabulary size) and dim_id directly in per-block data.
 //! Grid is indexed by dim_id as row index (no Section C dim_ids array).
 //! Data-first layout: block data (Section B) appears before block_data_starts
 //! (Section A). The reader derives the Section A offset from
@@ -20,6 +20,7 @@
 //! Based on Mallia, Suel & Tonellotto (SIGIR 2024).
 
 use crate::directories::{FileHandle, OwnedBytes};
+use crate::segment::bmp_adaptive::{AdaptiveBlock, AdaptivePostings};
 use crate::segment::bmp_grid::CompressedGrid;
 
 /// Number of BMP blocks grouped into one LSP/0 superblock.
@@ -36,16 +37,6 @@ pub const BMP_SUPERBLOCK_SIZE: u32 = 8;
 /// one promising coarse cell therefore reads one independently addressable
 /// 256-superblock group from E for each query dimension.
 pub const BMP_COARSE_SUPERBLOCKS: u32 = 256;
-
-/// A single posting in BMP's block-local flat inverted index.
-///
-/// Exactly 2 bytes: `[local_slot: u8, impact: u8]`.
-#[derive(Clone, Copy)]
-#[repr(C)]
-pub struct BmpPosting {
-    pub local_slot: u8,
-    pub impact: u8,
-}
 
 // ── u32 read helpers ─────────────────────────────────────────────────────────
 
@@ -79,9 +70,9 @@ unsafe fn read_u64_unchecked(base: *const u8, idx: usize) -> u64 {
     }
 }
 
-/// BMP V18 index for a single sparse field — fully zero-copy mmap-backed.
+/// BMP V19 index for a single sparse field — fully zero-copy mmap-backed.
 ///
-/// V18 format with Recursive Graph Bisection (BP) document ordering.
+/// V19 format with Recursive Graph Bisection (BP) document ordering.
 ///
 /// All data sections are `OwnedBytes` slices into the same underlying mmap Arc.
 /// No heap allocation — the superblock grid is persisted on disk and loaded as
@@ -165,12 +156,12 @@ pub struct BmpIndex {
 // inherits Send+Sync automatically through its fields.
 
 impl BmpIndex {
-    /// Parse a BMP V18 blob from the given file handle.
+    /// Parse a BMP V19 blob from the given file handle.
     ///
     /// Reads the footer, then acquires the entire blob as a single
     /// `OwnedBytes` and slices it into zero-copy sections.
     ///
-    /// V18 data-first layout: Section B (per-block interleaved data) first,
+    /// V19 data-first layout: Section B (per-block interleaved data) first,
     /// then Section A (block_data_starts with u64 entries), grids, doc_map.
     pub fn parse(
         handle: FileHandle,
@@ -183,7 +174,7 @@ impl BmpIndex {
 
         if blob_len < BMP_BLOB_FOOTER_SIZE as u64 {
             return Err(crate::Error::Corruption(
-                "BMP blob too small for V18 footer".into(),
+                "BMP blob too small for V19 footer".into(),
             ));
         }
 
@@ -214,7 +205,7 @@ impl BmpIndex {
 
         if magic != BMP_BLOB_MAGIC {
             return Err(crate::Error::Corruption(format!(
-                "Invalid BMP blob magic: {:#x} (expected BMP8 {:#x}); rebuild \
+                "Invalid BMP blob magic: {:#x} (expected BMP9 {:#x}); rebuild \
                  the index with this version.",
                 magic, BMP_BLOB_MAGIC
             )));
@@ -457,7 +448,7 @@ impl BmpIndex {
         }
 
         log::debug!(
-            "BMP V18 index loaded: num_blocks={}, num_superblocks={}, coarse_groups={}, dims={}, bmp_block_size={}, \
+            "BMP V19 index loaded: num_blocks={}, num_superblocks={}, coarse_groups={}, dims={}, bmp_block_size={}, \
              num_virtual_docs={}, num_real_docs={}, max_weight_scale={:.4}, postings={}, \
              block_grid={}, superblock_grid={}, coarse_grid={}, single_valued={}, block_data={}, doc_map={}",
             num_blocks,
@@ -506,7 +497,7 @@ impl BmpIndex {
         })
     }
 
-    /// Read the entire raw V18 blob (including footer) from the source file.
+    /// Read the entire raw V19 blob (including footer) from the source file.
     ///
     /// Used by reorder paths (native-only) to copy a field byte-identically
     /// when its `reorder` schema attribute is unset.
@@ -703,95 +694,21 @@ impl BmpIndex {
         }
     }
 
-    /// Parse a block header: returns
-    /// (num_terms, dim_ptr, ps_ptr, max_ptr, post_ptr, total_block_postings).
-    /// All pointers are within block_data_bytes — guaranteed contiguous.
-    ///
-    /// Always 4-byte (u32) dim IDs.
-    ///
-    /// Returns zero terms and null section pointers for empty blocks.
+    /// Parse one adaptive block. Malformed and empty blocks degrade to `None`
+    /// in the availability-oriented query path.
     #[inline(always)]
-    pub(crate) fn parse_block(
-        &self,
-        block_id: u32,
-    ) -> (u32, *const u8, *const u8, *const u8, *const u8, u32) {
+    pub(crate) fn parse_block(&self, block_id: u32) -> Option<AdaptiveBlock<'_>> {
         if block_id >= self.num_blocks {
-            return (
-                0,
-                std::ptr::null(),
-                std::ptr::null(),
-                std::ptr::null(),
-                std::ptr::null(),
-                0,
-            );
+            return None;
         }
         let (start, end) = self.block_data_range(block_id);
         if start == end {
-            return (
-                0,
-                std::ptr::null(),
-                std::ptr::null(),
-                std::ptr::null(),
-                std::ptr::null(),
-                0,
-            );
+            return None;
         }
-        let invalid = || {
-            (
-                0,
-                std::ptr::null(),
-                std::ptr::null(),
-                std::ptr::null(),
-                std::ptr::null(),
-                0,
-            )
-        };
-        let Ok(block_len) = usize::try_from(end - start) else {
-            return invalid();
-        };
-        if block_len < 8 {
-            return invalid();
-        }
-        let base = unsafe {
-            self.block_data_bytes
-                .as_slice()
-                .as_ptr()
-                .add(start as usize)
-        };
-        let num_terms = unsafe { u32::from_le((base as *const u32).read_unaligned()) };
-        let Some(header_len) = (num_terms as usize)
-            .checked_mul(9)
-            .and_then(|bytes| bytes.checked_add(8))
-        else {
-            return invalid();
-        };
-        if header_len > block_len || !(block_len - header_len).is_multiple_of(2) {
-            return invalid();
-        }
-        let total_block_postings = (block_len - header_len) / 2;
-        let Ok(total_block_postings_u32) = u32::try_from(total_block_postings) else {
-            return invalid();
-        };
-        let dim_ptr = unsafe { base.add(4) };
-        // Always u32 dim IDs (4 bytes each)
-        let ps_ptr = unsafe { dim_ptr.add(num_terms as usize * 4) };
-        let max_ptr = unsafe { ps_ptr.add((num_terms as usize + 1) * 4) };
-        let post_ptr = unsafe { max_ptr.add(num_terms as usize) };
-        let first = unsafe { u32::from_le((ps_ptr as *const u32).read_unaligned()) };
-        let last = unsafe {
-            u32::from_le((ps_ptr.add(num_terms as usize * 4) as *const u32).read_unaligned())
-        };
-        if first != 0 || last != total_block_postings_u32 {
-            return invalid();
-        }
-        (
-            num_terms,
-            dim_ptr,
-            ps_ptr,
-            max_ptr,
-            post_ptr,
-            total_block_postings_u32,
-        )
+        let start = usize::try_from(start).ok()?;
+        let end = usize::try_from(end).ok()?;
+        let bytes = self.block_data_bytes.as_slice().get(start..end)?;
+        AdaptiveBlock::parse(bytes, self.bmp_block_size as usize)
     }
 
     /// Get a raw pointer to block_data_starts at the given block.
@@ -807,22 +724,14 @@ impl BmpIndex {
         }
     }
 
-    /// Iterate terms in a block (for merger). Returns (dim_id, &[BmpPosting]) per term.
-    ///
-    /// Reads u32 dim_id directly from block data (no dim_idx→dim_id lookup).
-    pub fn iter_block_terms(&self, block_id: u32) -> BlockTermIter<'_> {
-        let (num_terms, dim_ptr, ps_ptr, max_ptr, post_ptr, total_postings) =
-            self.parse_block(block_id);
-        BlockTermIter {
-            dim_ptr,
-            ps_ptr,
-            max_ptr,
-            post_ptr,
-            num_terms,
-            total_postings,
-            current: 0,
-            _marker: std::marker::PhantomData,
-        }
+    /// Iterate `(dimension, conservative maximum, postings)` for one block.
+    pub(crate) fn iter_block_terms(
+        &self,
+        block_id: u32,
+    ) -> impl Iterator<Item = (u32, u8, AdaptivePostings<'_>)> + '_ {
+        self.parse_block(block_id)
+            .into_iter()
+            .flat_map(AdaptiveBlock::terms)
     }
 
     // ── Non-hot-path accessors ───────────────────────────────────────
@@ -956,85 +865,15 @@ impl BmpIndex {
         if block.is_empty() {
             return Ok(());
         }
-        if block.len() < 8 {
-            return Err(crate::Error::Corruption(format!(
-                "BMP block {block_id} is too short: {} bytes",
-                block.len(),
-            )));
-        }
-
-        let num_terms = u32::from_le_bytes(block[..4].try_into().unwrap()) as usize;
-        let header_len = num_terms
-            .checked_mul(9)
-            .and_then(|bytes| bytes.checked_add(8))
-            .ok_or_else(|| {
+        let parsed =
+            AdaptiveBlock::parse(block, self.bmp_block_size as usize).ok_or_else(|| {
                 crate::Error::Corruption(format!(
-                    "BMP block {block_id} header length overflows usize",
+                    "BMP block {block_id} has an invalid adaptive envelope"
                 ))
             })?;
-        if header_len > block.len() || !(block.len() - header_len).is_multiple_of(2) {
-            return Err(crate::Error::Corruption(format!(
-                "BMP block {block_id} has invalid header/data lengths: header={header_len}, total={}",
-                block.len(),
-            )));
-        }
-
-        let dims_start = 4;
-        let prefixes_start = dims_start + num_terms * 4;
-        let maxima_start = prefixes_start + (num_terms + 1) * 4;
-        let postings_start = maxima_start + num_terms;
-        debug_assert_eq!(postings_start, header_len);
-        let total_postings = (block.len() - postings_start) / 2;
-        let read_prefix = |index: usize| {
-            let offset = prefixes_start + index * 4;
-            u32::from_le_bytes(block[offset..offset + 4].try_into().unwrap()) as usize
-        };
-        if read_prefix(0) != 0 || read_prefix(num_terms) != total_postings {
-            return Err(crate::Error::Corruption(format!(
-                "BMP block {block_id} posting prefixes do not span 0..{total_postings}",
-            )));
-        }
-
-        let mut previous_dim = None;
-        for term in 0..num_terms {
-            let dim_offset = dims_start + term * 4;
-            let dimension =
-                u32::from_le_bytes(block[dim_offset..dim_offset + 4].try_into().unwrap());
-            if dimension >= self.dims || previous_dim.is_some_and(|previous| dimension <= previous)
-            {
-                return Err(crate::Error::Corruption(format!(
-                    "BMP block {block_id} has invalid/non-increasing dimension {dimension} at term {term}",
-                )));
-            }
-            previous_dim = Some(dimension);
-
-            let posting_start = read_prefix(term);
-            let posting_end = read_prefix(term + 1);
-            if posting_start >= posting_end || posting_end > total_postings {
-                return Err(crate::Error::Corruption(format!(
-                    "BMP block {block_id} term {term} has invalid posting range {posting_start}..{posting_end}",
-                )));
-            }
-            let postings =
-                &block[postings_start + posting_start * 2..postings_start + posting_end * 2];
-            let mut observed_max = 0u8;
-            for posting in postings.chunks_exact(2) {
-                if u32::from(posting[0]) >= self.bmp_block_size {
-                    return Err(crate::Error::Corruption(format!(
-                        "BMP block {block_id} term {term} has local slot {} outside block size {}",
-                        posting[0], self.bmp_block_size,
-                    )));
-                }
-                observed_max = observed_max.max(posting[1]);
-            }
-            let stored_max = block[maxima_start + term];
-            if stored_max != observed_max {
-                return Err(crate::Error::Corruption(format!(
-                    "BMP block {block_id} term {term} maximum {stored_max} != observed {observed_max}",
-                )));
-            }
-        }
-        Ok(())
+        parsed.validate(self.dims).map_err(|reason| {
+            crate::Error::Corruption(format!("BMP block {block_id} is invalid: {reason}"))
+        })
     }
 
     /// Total number of terms (unique dim×block pairs) stored in the index.
@@ -1281,121 +1120,6 @@ impl Drop for BmpScanPageGuard<'_> {
     }
 }
 
-/// Iterator over terms in a block. Returns `(dim_id, &[BmpPosting])` per term.
-///
-/// Reads u32 dim_id directly from block data (no dim_idx→dim_id lookup).
-pub struct BlockTermIter<'a> {
-    dim_ptr: *const u8,
-    ps_ptr: *const u8,
-    max_ptr: *const u8,
-    post_ptr: *const u8,
-    num_terms: u32,
-    total_postings: u32,
-    current: u32,
-    // lifetime marker for the underlying BmpIndex data
-    _marker: std::marker::PhantomData<&'a ()>,
-}
-
-// Manually implement Send+Sync. The raw pointers are derived from OwnedBytes
-// (which is Send+Sync) and are never mutated. The iterator borrows &BmpIndex.
-unsafe impl<'a> Send for BlockTermIter<'a> {}
-unsafe impl<'a> Sync for BlockTermIter<'a> {}
-
-impl<'a> Iterator for BlockTermIter<'a> {
-    type Item = (u32, u8, &'a [BmpPosting]);
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.current >= self.num_terms {
-            return None;
-        }
-        let i = self.current;
-        self.current += 1;
-
-        // Read u32 dim_id directly from block data
-        let dim_id = unsafe { read_u32_unchecked(self.dim_ptr, i as usize) };
-        let max_impact = unsafe { *self.max_ptr.add(i as usize) };
-
-        // Get postings from block-local ps_ptr/post_ptr
-        let postings =
-            unsafe { block_term_postings(self.ps_ptr, self.post_ptr, i, self.total_postings) };
-        Some((dim_id, max_impact, postings))
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let rem = (self.num_terms - self.current) as usize;
-        (rem, Some(rem))
-    }
-}
-
-impl<'a> ExactSizeIterator for BlockTermIter<'a> {}
-
-// ============================================================================
-// Block-data free functions (used by query and merger)
-// ============================================================================
-
-/// Binary search for a dimension ID in a block's term_dim_ids.
-///
-/// Always u32 dim_ids. `dim_ptr` points to the block's term_dim_ids array.
-/// Returns the local term index (0..num_terms) if found.
-///
-/// # Safety
-/// `dim_ptr` must be valid for `num_terms * 4` bytes.
-#[inline(always)]
-pub(crate) fn find_dim_in_block_data(
-    dim_ptr: *const u8,
-    num_terms: u32,
-    dim_id: u32,
-) -> Option<u32> {
-    let count = num_terms as usize;
-    if count == 0 {
-        return None;
-    }
-
-    let mut lo = 0usize;
-    let mut hi = count;
-    while lo < hi {
-        let mid = lo + (hi - lo) / 2;
-        let val = unsafe { read_u32_unchecked(dim_ptr, mid) };
-        match val.cmp(&dim_id) {
-            std::cmp::Ordering::Less => lo = mid + 1,
-            std::cmp::Ordering::Equal => return Some(mid as u32),
-            std::cmp::Ordering::Greater => hi = mid,
-        }
-    }
-    None
-}
-
-/// Get postings for a local term index within a parsed block.
-///
-/// `ps_ptr` points to the block's posting_starts array [u32 × (num_terms + 1)].
-/// `post_ptr` points to the block's postings array [(u8, u8) × total].
-///
-/// # Safety
-/// Pointers must be valid and derived from a BmpIndex's block_data_bytes.
-#[inline(always)]
-#[allow(unsafe_op_in_unsafe_fn)]
-pub(crate) unsafe fn block_term_postings<'a>(
-    ps_ptr: *const u8,
-    post_ptr: *const u8,
-    local_term: u32,
-    total_block_postings: u32,
-) -> &'a [BmpPosting] {
-    let start_p = ps_ptr.add(local_term as usize * 4);
-    let end_p = ps_ptr.add((local_term as usize + 1) * 4);
-    let start = u32::from_le((start_p as *const u32).read_unaligned()) as usize;
-    let end = u32::from_le((end_p as *const u32).read_unaligned()) as usize;
-    // Prefix sums are cumulative — a non-monotonic pair means the block is
-    // corrupt. Never build a wild slice from it (`end - start` can underflow).
-    if end <= start || end > total_block_postings as usize {
-        return &[];
-    }
-    let count = end - start;
-    // SAFETY: BmpPosting is #[repr(C)] with align=1 (two u8 fields).
-    let ptr = post_ptr.add(start * 2) as *const BmpPosting;
-    std::slice::from_raw_parts(ptr, count)
-}
-
 #[cfg(test)]
 mod safety_tests {
     use super::BmpIndex;
@@ -1459,8 +1183,8 @@ mod safety_tests {
     #[test]
     fn rewrite_validation_rejects_out_of_range_local_slot() {
         let mut blob = test_blob();
-        // One-term block header is 8 + 9 bytes; postings follow immediately.
-        blob[17] = 64;
+        // One-term narrow V19 header: count(4) + dim(4) + offsets(4) + max(1).
+        blob[13] = 64;
         let index = parse(blob).unwrap();
         let error = index.validate_block_for_rewrite(0).unwrap_err();
         assert!(matches!(error, crate::Error::Corruption(_)));
@@ -1477,7 +1201,7 @@ mod safety_tests {
         ));
 
         let mut bad_maximum = test_blob();
-        bad_maximum[16] = 0;
+        bad_maximum[12] = 0;
         let index = parse(bad_maximum).unwrap();
         assert!(matches!(
             index.validate_block_for_rewrite(0),

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use crate::Result;
 use crate::directories::{Directory, DirectoryWriter};
 use crate::dsl::{FieldType, Schema};
+use crate::segment::bmp_adaptive::{AdaptiveEncodeScratch, BmpPosting};
 use crate::segment::format::{SparseFieldToc, write_sparse_toc_and_footer};
 use crate::segment::reader::SegmentReader;
 use crate::segment::types::{SegmentFiles, SegmentId, SegmentMeta};
@@ -493,37 +494,26 @@ fn record_window_memory_bytes(
         .checked_add(routed_bytes)
 }
 
-fn push_rewrite_bytes(buffer: &mut Vec<u8>, bytes: &[u8], writer: &mut OffsetWriter) -> Result<()> {
-    if buffer.len() + bytes.len() > buffer.capacity() {
-        writer.write_all(buffer).map_err(crate::Error::Io)?;
-        buffer.clear();
-    }
-    if bytes.len() > buffer.capacity() {
-        writer.write_all(bytes).map_err(crate::Error::Io)
-    } else {
-        buffer.extend_from_slice(bytes);
-        Ok(())
-    }
-}
-
-fn flush_rewrite_bytes(buffer: &mut Vec<u8>, writer: &mut OffsetWriter) -> Result<()> {
-    if !buffer.is_empty() {
-        writer.write_all(buffer).map_err(crate::Error::Io)?;
-        buffer.clear();
-    }
-    Ok(())
+#[derive(Default)]
+struct RoutedBlockEncodeScratch {
+    dimensions: Vec<u32>,
+    posting_counts: Vec<u32>,
+    maxima: Vec<u8>,
+    codec: AdaptiveEncodeScratch,
 }
 
 #[allow(clippy::too_many_arguments)]
 fn write_sorted_routed_block(
     out_block: u32,
     postings: &[RoutedPosting],
+    block_size: usize,
     grid_entries: &mut Vec<BmpGridEntry>,
     grid_run_entries: usize,
     run_files: &mut GridScratchFiles,
     field_id: u32,
     rayon_pool: Option<&rayon::ThreadPool>,
-    posting_buffer: &mut Vec<u8>,
+    scratch: &mut RoutedBlockEncodeScratch,
+    encoded_block: &mut Vec<u8>,
     writer: &mut OffsetWriter,
 ) -> Result<(u64, usize)> {
     if postings.is_empty() {
@@ -535,50 +525,16 @@ fn write_sorted_routed_block(
             .all(|posting| posting.out_local == postings[0].out_local)
     );
 
+    scratch.dimensions.clear();
+    scratch.posting_counts.clear();
+    scratch.maxima.clear();
     let num_terms = 1 + postings
         .windows(2)
         .filter(|pair| pair[0].dimension != pair[1].dimension)
         .count();
-    let start_offset = writer.offset();
-    posting_buffer.clear();
-    push_rewrite_bytes(
-        posting_buffer,
-        &u32::try_from(num_terms)
-            .map_err(|_| crate::Error::Internal("BMP block term count exceeds u32::MAX".into()))?
-            .to_le_bytes(),
-        writer,
-    )?;
-
-    push_rewrite_bytes(posting_buffer, &postings[0].dimension.to_le_bytes(), writer)?;
-    for pair in postings.windows(2) {
-        if pair[0].dimension != pair[1].dimension {
-            push_rewrite_bytes(posting_buffer, &pair[1].dimension.to_le_bytes(), writer)?;
-        }
-    }
-
-    push_rewrite_bytes(posting_buffer, &0u32.to_le_bytes(), writer)?;
-    for (index, pair) in postings.windows(2).enumerate() {
-        if pair[0].dimension != pair[1].dimension {
-            push_rewrite_bytes(
-                posting_buffer,
-                &u32::try_from(index + 1)
-                    .map_err(|_| {
-                        crate::Error::Internal("BMP block posting prefix exceeds u32::MAX".into())
-                    })?
-                    .to_le_bytes(),
-                writer,
-            )?;
-        }
-    }
-    push_rewrite_bytes(
-        posting_buffer,
-        &u32::try_from(postings.len())
-            .map_err(|_| {
-                crate::Error::Internal("BMP block posting prefix exceeds u32::MAX".into())
-            })?
-            .to_le_bytes(),
-        writer,
-    )?;
+    scratch.dimensions.reserve_exact(num_terms);
+    scratch.posting_counts.reserve_exact(num_terms);
+    scratch.maxima.reserve_exact(num_terms);
 
     let mut term_start = 0usize;
     while term_start < postings.len() {
@@ -589,7 +545,13 @@ fn write_sorted_routed_block(
             max_impact = max_impact.max(postings[term_end].impact);
             term_end += 1;
         }
-        push_rewrite_bytes(posting_buffer, &[max_impact], writer)?;
+        scratch.dimensions.push(dimension);
+        scratch
+            .posting_counts
+            .push(u32::try_from(term_end - term_start).map_err(|_| {
+                crate::Error::Internal("BMP block posting count exceeds u32::MAX".into())
+            })?);
+        scratch.maxima.push(max_impact);
         if grid_entries.len() == grid_run_entries {
             spill_grid_entries(grid_entries, run_files, field_id, rayon_pool)?;
         }
@@ -597,10 +559,25 @@ fn write_sorted_routed_block(
         term_start = term_end;
     }
 
-    for posting in postings {
-        push_rewrite_bytes(posting_buffer, &[posting.slot, posting.impact], writer)?;
-    }
-    flush_rewrite_bytes(posting_buffer, writer)?;
+    debug_assert_eq!(scratch.dimensions.len(), num_terms);
+    scratch
+        .codec
+        .encode_postings(
+            block_size,
+            true,
+            &scratch.dimensions,
+            &scratch.posting_counts,
+            &scratch.maxima,
+            postings.len(),
+            |index| BmpPosting {
+                local_slot: postings[index].slot,
+                impact: postings[index].impact,
+            },
+            encoded_block,
+        )
+        .map_err(crate::Error::Io)?;
+    let start_offset = writer.offset();
+    writer.write_all(encoded_block).map_err(crate::Error::Io)?;
     Ok((writer.offset() - start_offset, num_terms))
 }
 
@@ -1491,7 +1468,7 @@ fn reorder_bmp_field_blockwise(
     }
     if num_blocks_total > u32::MAX as usize {
         return Err(crate::Error::Internal(
-            "reordered BMP block count exceeds the V18 u32 format limit".into(),
+            "reordered BMP block count exceeds the V19 u32 format limit".into(),
         ));
     }
     let num_virtual_docs = num_blocks_total
@@ -1499,7 +1476,7 @@ fn reorder_bmp_field_blockwise(
         .filter(|&count| count <= u32::MAX as usize)
         .ok_or_else(|| {
             crate::Error::Internal(
-                "reordered BMP virtual-document count exceeds the V18 u32 format limit".into(),
+                "reordered BMP virtual-document count exceeds the V19 u32 format limit".into(),
             )
         })?;
 
@@ -1692,7 +1669,7 @@ fn reorder_bmp_field_blockwise(
             .checked_add(b.num_real_docs())
             .ok_or_else(|| {
                 crate::Error::Internal(
-                    "reordered BMP real-document count exceeds the V18 u32 format limit".into(),
+                    "reordered BMP real-document count exceeds the V19 u32 format limit".into(),
                 )
             })?;
     }
@@ -2100,7 +2077,7 @@ pub(crate) fn reorder_bmp_field(
     }
     if num_real_docs > u32::MAX as usize {
         return Err(crate::Error::Internal(
-            "reordered BMP real-document count exceeds the V18 u32 format limit".into(),
+            "reordered BMP real-document count exceeds the V19 u32 format limit".into(),
         ));
     }
 
@@ -2230,7 +2207,7 @@ pub(crate) fn reorder_bmp_field(
     let new_num_blocks = num_real_docs.div_ceil(effective_block_size);
     if new_num_blocks > u32::MAX as usize {
         return Err(crate::Error::Internal(
-            "reordered BMP block count exceeds the V18 u32 format limit".into(),
+            "reordered BMP block count exceeds the V19 u32 format limit".into(),
         ));
     }
     let new_num_virtual_docs = new_num_blocks
@@ -2238,7 +2215,7 @@ pub(crate) fn reorder_bmp_field(
         .filter(|&count| count <= u32::MAX as usize)
         .ok_or_else(|| {
             crate::Error::Internal(
-                "reordered BMP virtual-document count exceeds the V18 u32 format limit".into(),
+                "reordered BMP virtual-document count exceeds the V19 u32 format limit".into(),
             )
         })?;
 
@@ -2279,15 +2256,15 @@ pub(crate) fn reorder_bmp_field(
     let mut grid_entries: Vec<BmpGridEntry> = Vec::with_capacity(grid_run_entries);
     let mut run_files = GridScratchFiles::new(field_id, scratch_path);
 
-    // Transpose records through exact-counted flat tuples. Block encoding
-    // streams directly to the buffered output, so admission covers only the
-    // live routes/jobs/counts/partitions/tuples plus one reusable write buffer.
+    // Transpose records through exact-counted flat tuples. One block's
+    // adaptive header/payload and term metadata are reused across the window.
     let posting_buffer_bytes = (encode_window_budget / 16)
         .clamp(64 * 1024, REWRITE_IO_BUFFER_BYTES)
         .min(encode_window_budget.saturating_div(2))
         .max(2);
     let transpose_budget = encode_window_budget.saturating_sub(posting_buffer_bytes);
-    let mut posting_buffer = Vec::with_capacity(posting_buffer_bytes);
+    let mut encoded_block = Vec::with_capacity(posting_buffer_bytes);
+    let mut block_encode_scratch = RoutedBlockEncodeScratch::default();
     let total_source_postings = sources.iter().fold(0u64, |total, (source, _)| {
         total.saturating_add(source.total_postings())
     });
@@ -2420,12 +2397,14 @@ pub(crate) fn reorder_bmp_field(
             let (block_bytes, block_terms) = write_sorted_routed_block(
                 global_block,
                 block_postings,
+                effective_block_size,
                 &mut grid_entries,
                 grid_run_entries,
                 &mut run_files,
                 field_id,
                 rayon_pool.as_deref(),
-                &mut posting_buffer,
+                &mut block_encode_scratch,
+                &mut encoded_block,
                 &mut writer,
             )?;
             total_terms = total_terms.saturating_add(block_terms as u64);
@@ -2502,7 +2481,7 @@ pub(crate) fn reorder_bmp_field(
     )?;
     let doc_maps_elapsed = doc_maps_start.elapsed();
 
-    // V18 footer.
+    // V19 footer.
     write_bmp_footer(
         &mut writer,
         total_terms,


### PR DESCRIPTION
## Summary

- introduce BMP V19 adaptive Flat-Inv blocks with narrow/wide byte offsets
- pack block maxima as u4 and select sparse pairs or dense impact rows per term
- integrate the zero-copy decoder through build, query, merge, reorder, and validation paths
- retain the production block size of 32 and document the 1B-vector memory model
- extend the production-shaped payload benchmark

## Results

- Section B is 21.1% smaller on the diffuse fixture and 17.7% smaller after BP-style clustering
- query scoring is at parity in the diffuse 8-term case and 8–45% faster in the other measured cases
- every adaptive block is guaranteed to be no larger than the prior V18 Flat-Inv representation

## Compatibility

The format magic changes from BMP8 to BMP9. Existing BMP indexes must be rebuilt.

## Validation

- cargo test -p hermes-core --features native --lib (951 passed, 5 ignored)
- cargo clippy -p hermes-core --features native --all-targets -- -D warnings
- cargo check -p hermes-core --no-default-features --features wasm
- cargo fmt --all --check
- git diff --check
