### PR TITLE
perf(core): improve IVF training and retrieval quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Hermes
 
-A hybrid search engine combining BM25 text search, sparse vectors (SPLADE), and dense vectors (global IVF-PQ with HNSW coarse routing) in a single embeddable Rust library. Runs natively, over gRPC, in browsers via WASM, and over IPFS.
+A hybrid search engine combining BM25 text search, sparse vectors (SPLADE), and dense vectors (global IVF-TQ with HNSW coarse routing) in a single embeddable Rust library. Runs natively, over gRPC, in browsers via WASM, and over IPFS.
 
 ## Why Hermes?
 
-| Feature                 | Hermes                 | Tantivy | Qdrant  | Elasticsearch |
-| ----------------------- | ---------------------- | ------- | ------- | ------------- |
-| BM25 Full-text search   | Yes                    | Yes     | No      | Yes           |
-| Dense vectors (ANN)     | Yes (IVF-PQ + HNSW)    | No      | Yes     | Plugin        |
-| Sparse vectors (SPLADE) | Yes (native)           | No      | Partial | No            |
-| WASM / Browser          | Yes                    | No      | No      | No            |
-| IPFS storage            | Yes                    | No      | No      | No            |
-| Embeddable library      | Yes                    | Yes     | No      | No            |
+| Feature                 | Hermes              | Tantivy | Qdrant  | Elasticsearch |
+| ----------------------- | ------------------- | ------- | ------- | ------------- |
+| BM25 Full-text search   | Yes                 | Yes     | No      | Yes           |
+| Dense vectors (ANN)     | Yes (IVF-TQ + HNSW) | No      | Yes     | Plugin        |
+| Sparse vectors (SPLADE) | Yes (native)        | No      | Partial | No            |
+| WASM / Browser          | Yes                 | No      | No      | No            |
+| IPFS storage            | Yes                 | No      | No      | No            |
+| Embeddable library      | Yes                 | Yes     | No      | No            |
 
 ## Packages
 
@@ -210,7 +210,7 @@ await index.save_cache_to_idb();
 
 ## Key Features
 
-**Unified hybrid search** -- BM25 text ranking, SPLADE sparse vectors, and global IVF-PQ dense vectors share the same index, segments, and query pipeline. No sidecar services required.
+**Unified hybrid search** -- BM25 text ranking, SPLADE sparse vectors, and global IVF-TQ dense vectors share the same index, segments, and query pipeline. No sidecar services required.
 
 **6 posting list formats** -- Adaptive format selection per list: HorizontalBP128, VerticalBP128, Elias-Fano, Partitioned Elias-Fano, Roaring bitmaps, and OptP4D. The engine picks the best format based on list density and length.
 
@@ -220,7 +220,7 @@ await index.save_cache_to_idb();
 
 **Matryoshka reranking** -- L2 reranker supports Matryoshka dimensionality reduction: scores candidates on leading dimensions first, then full-dimension exact scoring on survivors only. Skips 50-70% of cosine computations.
 
-**SOAR multi-probe** -- IVF indexes use Google's SOAR (Spilling with Orthogonality-Amplified Residuals) for 5-15% recall improvement by assigning vectors to multiple clusters with orthogonal residuals.
+**SOAR multi-probe** -- IVF-TQ indexes default to Google's SOAR (Spilling with Orthogonality-Amplified Residuals) in selective mode, calibrating one secondary assignment for at most 30% of vectors; `soar: off` disables it explicitly.
 
 **SimHash dedup pipeline** -- Stream-oriented CLI tools for near-duplicate detection: pipe through `simhash`, `sort`, then `index` to deduplicate million-document corpora before indexing.
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -271,14 +271,20 @@ field embedding: dense_vector<DIM, uint8> [indexed]       # scalar quantized, 4�
 Float fields have two ANN formats, both built on the TurboQuant codec
 (`docs/turboquant-quantization.md`). `ivf_tq` (the default) combines the
 corpus-trained coarse centroid router with training-free TQ leaf codes of
-each vector's centroid residual — only centroids are trained, never a
-codebook. `tq` is fully training-free: each segment carries a 4-bit
+each normalized vector's centroid residual — only centroids are trained,
+never a codebook. Training samples, ANN copies, and queries are normalized
+for cosine routing while original stored values remain available for exact
+reranking. `tq` is fully training-free: each segment carries a 4-bit
 compressed payload built at commit with no global artifacts, scanned
 exhaustively with SIMD lookup tables and exact-reranked. Ordinary segment
 merges copy both formats' immutable run columns byte-for-byte and rewrite
 only their compact document-base directory. `flat` remains available for
 exact brute-force search and as the accumulation format before an `ivf_tq`
 build.
+
+Only the cosine-normalized IVF-TQ generation is supported. Older unmarked
+trained generations and ANN payloads are rejected while opening the index;
+rebuild the index with a current Hermes version.
 
 `ivf_pq` (residual product quantization) was removed after IVF-TQ superseded
 it on recall, latency, and training cost; indexes created with it must be
@@ -310,13 +316,17 @@ documents through fixed-size buffers.
 IVF-TQ supports SOAR — spilling each vector
 into a secondary cluster with an orthogonality-amplified residual. This
 improves recall at the same `nprobe` in exchange for larger cluster storage
-(~1.2-2x assignments):
+(~1.3× assignments for the build-calibrated selective preset, 2× for full).
+Omitting `soar` enables the selective preset by default: training calibrates
+one secondary assignment for at most 30% of the calibration sample. Use
+`soar: off` to disable secondary assignments explicitly:
 
 ```
-field e: dense_vector<768, f16> [indexed<ivf_tq, soar: selective>]  # spill boundary vectors
+field e: dense_vector<768, f16> [indexed<ivf_tq>]                   # default: selective, at most 30% spill
+field e: dense_vector<768, f16> [indexed<ivf_tq, soar: selective>]  # calibrate to at most a 30% spill budget
 field e: dense_vector<768, f16> [indexed<ivf_tq, soar: full>]       # spill every vector once
-field e: dense_vector<768, f16> [indexed<ivf_tq, soar: aggressive>] # spill every vector twice
-field e: dense_vector<768, f16> [indexed<ivf_tq, soar: off>]        # no spilling (default)
+field e: dense_vector<768, f16> [indexed<ivf_tq, soar: aggressive>] # full one-secondary spill
+field e: dense_vector<768, f16> [indexed<ivf_tq, soar: off>]        # explicitly disable spilling
 ```
 
 ### Example
@@ -407,10 +417,10 @@ merge/reorder invariants, and the Flat-Inv versus Fwd design choice.
 
 Sparse posting lists support configurable weight quantization and pruning via `SparseVectorConfig`:
 
-| Preset         | Quantization | Destructive pruning |
-| -------------- | ------------ | ------------------- |
-| `conservative` | Float16      | disabled            |
-| `splade`       | UInt8        | disabled            |
+| Preset         | Quantization | Destructive pruning                   |
+| -------------- | ------------ | ------------------------------------- |
+| `conservative` | Float16      | disabled                              |
+| `splade`       | UInt8        | disabled                              |
 | `compact`      | UInt4        | enabled; benchmark quality before use |
 
 These are configured programmatically, not in SDL.

--- a/docs/turboquant-quantization.md
+++ b/docs/turboquant-quantization.md
@@ -213,9 +213,11 @@ the recall evidence.
 
 Sub-linear probing with the training-free leaf codec: the trained global
 coarse router (same `build_vector_index()` machinery, HNSW/SOAR supported)
-plus TQ codes of the centroid residual `r = x − c` per leaf. Residual norms
-carry ranking information, so each vector stores `scale = ‖r‖` next to
-`gamma`, and the leaf estimate is
+plus TQ codes of the centroid residual `r = x̂ − c` per leaf. Training
+samples, indexed ANN copies, and queries are always normalized before
+routing and residual encoding; original stored vectors remain unchanged for
+exact reranking. Residual norms carry ranking information, so each vector
+stores `scale = ‖r‖` next to `gamma`, and the leaf estimate is
 
 ```
 ⟨q̂, x⟩ = ⟨q̂, c⟩ + scale · est⟨q̂, r̂⟩
@@ -227,8 +229,31 @@ probed cluster — plan build is `O(P·16 + nprobe·dim)` instead of IVF-PQ's
 `nprobe` ADC tables (which dominated its measured per-query cost). Blocks are
 `[16 scales][16 gammas][nibbles]`; runs are per-leaf, merges byte-copy.
 On disk `quantizer_version` is the trained centroid generation and
-`codebook_version` carries the codec fingerprint; only centroids are stored
-as trained artifacts (`codebook_file` must be absent).
+also carries the cosine-format marker; `codebook_version` carries the codec
+fingerprint. Only centroids are stored as trained artifacts
+(`codebook_file` must be absent).
+
+Unmarked, pre-cosine IVF-TQ artifacts are unsupported and rejected while the
+trained generation or ANN payload is opened. Rebuild the index with a current
+Hermes version; the current reader and writer do not load or migrate the legacy
+format.
+
+Coarse training draws a deterministic uniform point sample directly at the
+256-points-per-centroid ceiling and keeps it as one contiguous matrix. Small
+codebooks use k-means++ initialization; large codebooks use bounded k-means||
+rounds with at most `2K` candidates total. When a second seed is affordable, an
+in-buffer held-out suffix selects by exact distortion, routed distortion, and
+posting-list balance. Hierarchical child counts are proportional to parent
+population.
+
+Construction routing is intentionally wider than query routing: HNSW uses a
+larger build search budget and two-level routing inspects at least four
+populated parents when available. This improves permanent posting assignment
+without changing the bounded production query path. Selective SOAR calibrates
+to at most its target spill fraction on the calibration sample; a tied quantile
+underfills rather than exceeding the posting-storage budget. IVF-TQ enables
+this one-secondary, at-most-30% selective preset when `soar` is omitted;
+`soar: off` explicitly disables secondary assignments.
 
 ```sdl
 field e: dense_vector<768, f16> [indexed<ivf_tq, num_clusters: 1024, nprobe: 64>]

--- a/hermes-core/benches/hermes_benchmark/main.rs
+++ b/hermes-core/benches/hermes_benchmark/main.rs
@@ -225,6 +225,10 @@ async fn run_benchmarks() {
         }
     }
     writer.commit().await.expect("Failed to commit");
+    writer
+        .build_vector_index()
+        .await
+        .expect("Failed to train and build IVF-TQ index");
     writer.wait_for_merging_thread().await;
     println!("\r    Indexed {} docs", num_docs);
 

--- a/hermes-core/benches/vector_indexing.rs
+++ b/hermes-core/benches/vector_indexing.rs
@@ -1,4 +1,5 @@
-//! Dense ANN microbenchmarks: TQ LUT16 block scoring and IVF-TQ plan build.
+//! Dense ANN microbenchmarks: coarse training, TQ LUT16 block scoring, and
+//! IVF-TQ plan build.
 //!
 //! The end-to-end method comparison (flat vs tq vs ivf_tq, with recall)
 //! lives in the ignored `tq_dense_ann_benchmark` integration test; this file
@@ -82,10 +83,11 @@ fn bench_lut16_scan(c: &mut Criterion) {
 
 fn bench_ivf_tq_plan(c: &mut Criterion) {
     let vectors = random_unit_vectors(10_000, DIM, 42);
-    let coarse = CoarseCentroids::train(
+    let mut coarse = CoarseCentroids::train(
         &CoarseConfig::new(DIM, 256).with_routing(IvfRoutingMode::Flat),
         &vectors,
     );
+    coarse.version = hermes_core::structures::mark_ivf_tq_cosine_generation(coarse.version);
     let codec = tq_shared_codec(DIM);
     let query = random_unit_vectors(1, DIM, 9).pop().unwrap();
 
@@ -106,5 +108,38 @@ fn bench_ivf_tq_plan(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_lut16_scan, bench_ivf_tq_plan);
+fn bench_ivf_coarse_training(c: &mut Criterion) {
+    const TRAIN_DIM: usize = 16;
+    const POINTS_PER_CENTROID: usize = 39;
+
+    let mut group = c.benchmark_group("ivf_coarse_training");
+    group.sample_size(10);
+    // Exercise both sides of the adaptive initialization boundary. The larger
+    // case guards the bounded-total-candidate k-means|| path without making
+    // routine benchmark runs prohibitively long.
+    for clusters in [64usize, 257] {
+        let points = clusters * POINTS_PER_CENTROID;
+        let vectors = random_unit_vectors(points, TRAIN_DIM, clusters as u64);
+        let config = CoarseConfig::new(TRAIN_DIM, clusters)
+            .with_routing(IvfRoutingMode::Flat)
+            .with_max_iters(5);
+        group.throughput(criterion::Throughput::Elements(points as u64));
+        group.bench_with_input(BenchmarkId::new("clusters", clusters), &clusters, |b, _| {
+            b.iter(|| {
+                black_box(CoarseCentroids::train(
+                    black_box(&config),
+                    black_box(&vectors),
+                ))
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_lut16_scan,
+    bench_ivf_tq_plan,
+    bench_ivf_coarse_training
+);
 criterion_main!(benches);

--- a/hermes-core/src/dsl/schema.rs
+++ b/hermes-core/src/dsl/schema.rs
@@ -254,14 +254,23 @@ pub struct DenseVectorConfig {
     /// Whether stored vectors are pre-normalized to unit L2 norm.
     /// When true, scoring skips per-vector norm computation (cosine = dot / ||q||),
     /// reducing compute by ~40%. Common for embedding models (e.g. OpenAI, Cohere).
+    /// New IVF-TQ generations index a normalized ANN-only copy while retaining
+    /// the original values for exact reranking. Legacy unnormalized IVF-TQ
+    /// generations must be rebuilt before they can be searched.
     /// Default: true (most embedding models produce L2-normalized vectors).
     #[serde(default = "default_unit_norm")]
     pub unit_norm: bool,
-    /// SOAR spilled cluster assignments for IVF-PQ.
+    /// SOAR spilled cluster assignments for IVF-TQ.
     /// Assigns vectors to a secondary cluster with an orthogonality-amplified
     /// residual, improving recall at the same nprobe for ~1.2-2x assignment storage.
-    /// Default: None (disabled). Ignored while a field remains flat.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Default: selective spilling calibrated to at most 30% of vectors for
+    /// IVF-TQ. Set this to `None` to disable SOAR. Ignored by non-IVF formats.
+    ///
+    /// Unlike optional fields whose `None` value is omitted on serialization,
+    /// this field serializes `None` as `null`: omission means "use the new
+    /// selective default", while an explicit `null` must continue to mean off
+    /// across a schema round trip.
+    #[serde(default = "default_soar")]
     pub soar: Option<crate::structures::SoarConfig>,
 }
 
@@ -271,6 +280,10 @@ fn default_nprobe() -> usize {
 
 fn default_unit_norm() -> bool {
     true
+}
+
+fn default_soar() -> Option<crate::structures::SoarConfig> {
+    Some(crate::structures::SoarConfig::default())
 }
 
 impl DenseVectorConfig {
@@ -283,7 +296,7 @@ impl DenseVectorConfig {
             ivf_routing: IvfRoutingMode::Auto,
             nprobe: 64,
             unit_norm: true,
-            soar: None,
+            soar: Some(crate::structures::SoarConfig::default()),
         }
     }
 
@@ -325,7 +338,7 @@ impl DenseVectorConfig {
             ivf_routing: IvfRoutingMode::Auto,
             nprobe,
             unit_norm: true,
-            soar: None,
+            soar: Some(crate::structures::SoarConfig::default()),
         }
     }
 
@@ -355,6 +368,12 @@ impl DenseVectorConfig {
     /// Enable SOAR spilled secondary cluster assignments (IVF-based indexes only)
     pub fn with_soar(mut self, soar: crate::structures::SoarConfig) -> Self {
         self.soar = Some(soar);
+        self
+    }
+
+    /// Explicitly disable SOAR secondary assignments.
+    pub fn without_soar(mut self) -> Self {
+        self.soar = None;
         self
     }
 
@@ -1272,6 +1291,54 @@ mod tests {
         assert_eq!(schema.get_field("body"), Some(body));
         assert_eq!(schema.get_field("count"), Some(count));
         assert_eq!(schema.get_field("nonexistent"), None);
+    }
+
+    #[test]
+    fn ivf_tq_defaults_to_selective_soar() {
+        for config in [
+            DenseVectorConfig::new(8),
+            DenseVectorConfig::ivf_tq(8, Some(4), 2),
+        ] {
+            let soar = config.soar.expect("IVF-TQ should enable SOAR by default");
+            assert_eq!(soar.num_secondary, 1);
+            assert!(soar.selective);
+            assert_eq!(soar.calibration_target(), Some(0.30));
+        }
+
+        assert!(DenseVectorConfig::flat(8).soar.is_none());
+        assert!(DenseVectorConfig::tq(8).soar.is_none());
+    }
+
+    #[test]
+    fn omitted_and_explicitly_disabled_soar_are_distinct_in_serde() {
+        let omitted: DenseVectorConfig = serde_json::from_value(serde_json::json!({
+            "dim": 8,
+            "index_type": "ivf_tq"
+        }))
+        .unwrap();
+        let default_soar = omitted
+            .soar
+            .as_ref()
+            .expect("an omitted SOAR setting should enable the selective default");
+        assert_eq!(default_soar.num_secondary, 1);
+        assert!(default_soar.selective);
+        assert_eq!(default_soar.calibration_target(), Some(0.30));
+
+        let disabled: DenseVectorConfig = serde_json::from_value(serde_json::json!({
+            "dim": 8,
+            "index_type": "ivf_tq",
+            "soar": null
+        }))
+        .unwrap();
+        assert!(disabled.soar.is_none());
+
+        let encoded = serde_json::to_value(&disabled).unwrap();
+        assert_eq!(encoded.get("soar"), Some(&serde_json::Value::Null));
+        let round_trip: DenseVectorConfig = serde_json::from_value(encoded).unwrap();
+        assert!(
+            round_trip.soar.is_none(),
+            "explicit off must survive a schema round trip"
+        );
     }
 
     #[test]

--- a/hermes-core/src/dsl/sdl/mod.rs
+++ b/hermes-core/src/dsl/sdl/mod.rs
@@ -253,12 +253,24 @@ fn parse_field_type(type_str: &str) -> Result<FieldType> {
 
 /// Index configuration parsed from indexed<...> attribute
 #[derive(Debug, Clone, Default)]
+enum SoarDirective {
+    /// No `soar:` keyword was present. IVF-TQ resolves this to its selective
+    /// default after the final index type is known.
+    #[default]
+    Unspecified,
+    /// `soar: off` was explicitly requested.
+    Disabled,
+    /// An explicit selective/full/aggressive preset.
+    Enabled(crate::structures::SoarConfig),
+}
+
+#[derive(Debug, Clone, Default)]
 struct IndexConfig {
     index_type: Option<super::schema::VectorIndexType>,
     num_clusters: Option<usize>,
     nprobe: Option<usize>,
     ivf_routing: Option<super::schema::IvfRoutingMode>,
-    soar: Option<crate::structures::SoarConfig>,
+    soar: SoarDirective,
     binary_index_type: Option<super::schema::BinaryIndexType>,
     // Sparse vector index params
     sparse_format: Option<SparseFormat>,
@@ -435,10 +447,10 @@ fn parse_single_index_config_param(config: &mut IndexConfig, p: pest::iterators:
             if let Some(s) = p.into_inner().next() {
                 use crate::structures::SoarConfig;
                 config.soar = match s.as_str() {
-                    "selective" => Some(SoarConfig::new()),
-                    "full" => Some(SoarConfig::full()),
-                    "aggressive" => Some(SoarConfig::aggressive()),
-                    _ => None, // "off"
+                    "selective" => SoarDirective::Enabled(SoarConfig::new()),
+                    "full" => SoarDirective::Enabled(SoarConfig::full()),
+                    "aggressive" => SoarDirective::Enabled(SoarConfig::aggressive()),
+                    _ => SoarDirective::Disabled, // "off"
                 };
             }
         }
@@ -868,15 +880,26 @@ fn apply_index_config_to_dense_vector(config: &mut DenseVectorConfig, idx_cfg: I
 
 /// Apply SOAR spilling if specified (IVF-based indexes only)
 fn apply_soar_to_dense_vector(config: &mut DenseVectorConfig, idx_cfg: IndexConfig) {
-    if idx_cfg.soar.is_some() {
-        if config.uses_ivf() {
-            config.soar = idx_cfg.soar;
-        } else {
-            log::warn!(
-                "'soar' requires the IVF-PQ index; \
-                 ignoring for index type {:?}",
-                config.index_type
-            );
+    match idx_cfg.soar {
+        SoarDirective::Unspecified => {
+            config.soar = config
+                .uses_ivf()
+                .then(crate::structures::SoarConfig::default);
+        }
+        SoarDirective::Disabled => {
+            config.soar = None;
+        }
+        SoarDirective::Enabled(soar) => {
+            if config.uses_ivf() {
+                config.soar = Some(soar);
+            } else {
+                config.soar = None;
+                log::warn!(
+                    "'soar' requires the IVF-TQ index; \
+                     ignoring for index type {:?}",
+                    config.index_type
+                );
+            }
         }
     }
 }
@@ -1824,6 +1847,23 @@ mod tests {
 
     #[test]
     fn test_dense_vector_with_soar() {
+        // Omission resolves to the selective one-secondary default.
+        let sdl = r#"
+            index documents {
+                field embedding: dense_vector<768> [indexed<ivf_tq>]
+            }
+        "#;
+        let indexes = parse_sdl(sdl).unwrap();
+        let config = indexes[0].fields[0].dense_vector_config.as_ref().unwrap();
+        let soar = config
+            .soar
+            .as_ref()
+            .expect("omitted SOAR should enable selective spilling");
+        assert_eq!(soar.num_secondary, 1);
+        assert!(soar.selective);
+        assert_eq!(soar.calibration_target(), Some(0.30));
+
+        // The explicit selective preset resolves to the same policy.
         let sdl = r#"
             index documents {
                 field embedding: dense_vector<768> [indexed<ivf_tq, num_clusters: 256, soar: selective>, stored]
@@ -1837,7 +1877,7 @@ mod tests {
         assert_eq!(soar.num_secondary, 1);
         assert!(soar.selective);
 
-        // aggressive preset: 2 secondary clusters, no selectivity
+        // aggressive is a compatibility alias for full one-secondary spilling
         let sdl = r#"
             index documents {
                 field embedding: dense_vector<768> [indexed<ivf_tq, soar: aggressive>]
@@ -1846,7 +1886,7 @@ mod tests {
         let indexes = parse_sdl(sdl).unwrap();
         let config = indexes[0].fields[0].dense_vector_config.as_ref().unwrap();
         let soar = config.soar.as_ref().expect("soar should be enabled");
-        assert_eq!(soar.num_secondary, 2);
+        assert_eq!(soar.num_secondary, 1);
         assert!(!soar.selective);
 
         // off keeps soar disabled
@@ -1858,6 +1898,29 @@ mod tests {
         let indexes = parse_sdl(sdl).unwrap();
         let config = indexes[0].fields[0].dense_vector_config.as_ref().unwrap();
         assert!(config.soar.is_none());
+    }
+
+    #[test]
+    fn omitted_soar_is_canonicalized_off_for_non_ivf_formats() {
+        let sdl = r#"
+            index documents {
+                field tq: dense_vector<768> [indexed<tq>]
+                field flat: dense_vector<768> [indexed<flat>]
+            }
+        "#;
+        let indexes = parse_sdl(sdl).unwrap();
+        for field in &indexes[0].fields {
+            assert!(
+                field
+                    .dense_vector_config
+                    .as_ref()
+                    .expect("dense config")
+                    .soar
+                    .is_none(),
+                "{} should not retain an ignored SOAR default",
+                field.name,
+            );
+        }
     }
 
     #[test]

--- a/hermes-core/src/dsl/sdl/sdl.pest
+++ b/hermes-core/src/dsl/sdl/sdl.pest
@@ -182,8 +182,8 @@ doc_mass_kwarg = { "doc_mass" ~ ":" ~ pruning_spec }
 // SOAR spilled secondary cluster assignments for IVF-based dense indexes:
 //   soar: selective  # spill only vectors near cluster boundaries (recommended)
 //   soar: full       # spill every vector to 1 secondary cluster
-//   soar: aggressive # spill every vector to 2 secondary clusters
-//   soar: off        # no spilling (default)
+//   soar: aggressive # compatibility alias for full one-secondary spilling
+//   soar: off        # explicitly disable default selective spilling
 soar_kwarg = { "soar" ~ ":" ~ soar_spec }
 soar_spec = { "selective" | "full" | "aggressive" | "off" }
 nprobe_spec = @{ ASCII_DIGIT+ }

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -511,6 +511,12 @@ impl IndexMetadata {
                             "trained centroids for field {field_id} do not match metadata/schema"
                         )));
                     }
+                    if !crate::structures::is_ivf_tq_cosine_generation(c.version) {
+                        return Err(Error::Corruption(format!(
+                            "trained IVF-TQ centroids for field {field_id} use an \
+                             unsupported legacy generation; rebuild the index"
+                        )));
+                    }
                     c.validate_routing(schema_config.ivf_routing)
                         .map_err(|error| {
                             Error::Corruption(format!(
@@ -766,7 +772,7 @@ mod tests {
             num_clusters: 1,
             dim: 2,
             centroids: vec![0.25, 0.75],
-            version: 7,
+            version: crate::structures::mark_ivf_tq_cosine_generation(7),
             soar_config: None,
             routing_index: None,
         }
@@ -916,6 +922,30 @@ mod tests {
         .expect("IVF-TQ Built state with a codebook file must fail")
         .to_string();
         assert!(error.contains("codebook"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn legacy_ivf_tq_centroid_generation_is_rejected_while_loading() {
+        let (schema, field) = dense_schema(VectorIndexType::IvfTq);
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(schema.clone());
+        metadata.init_field(field.0, VectorIndexType::IvfTq);
+        metadata.mark_field_built(field.0, 10, 1, "field_0_centroids.bin".into(), None);
+        let mut legacy = test_centroids();
+        legacy.version = 7;
+        write_bincode(&directory, "field_0_centroids.bin", &legacy).await;
+
+        let error = IndexMetadata::try_load_trained_from_fields(
+            &metadata.vector_fields,
+            &schema,
+            &directory,
+        )
+        .await
+        .err()
+        .expect("legacy IVF-TQ centroid state must fail while loading")
+        .to_string();
+        assert!(error.contains("unsupported legacy generation"), "{error}");
+        assert!(error.contains("rebuild the index"), "{error}");
     }
 
     #[tokio::test]

--- a/hermes-core/src/index/tests/tq_bench.rs
+++ b/hermes-core/src/index/tests/tq_bench.rs
@@ -6,10 +6,22 @@
 //!     tq_dense_ann_benchmark -- --ignored --nocapture
 //! ```
 //!
+//! Compare the previous IVF-TQ default (SOAR disabled) with the selective
+//! SOAR default:
+//! ```bash
+//! cargo test --release -p hermes-core --features native \
+//!     ivf_tq_selective_soar_benchmark -- --ignored --nocapture
+//! ```
+//! The SOAR comparison defaults to a quicker 6k × 96-dimensional corpus.
+//! Override it with `SOAR_BENCH_DOCS`, `SOAR_BENCH_CLUSTERS`,
+//! `SOAR_BENCH_QUERIES`, `SOAR_BENCH_IVF_CLUSTERS`, and
+//! `SOAR_BENCH_NPROBE`.
+//!
 //! Clustered unit-norm corpus, queries perturbed from corpus points. Ground
 //! truth is the flat index's own exact cosine top-k. Reports recall@k after
-//! re-rank, p50/p95 end-to-end query latency, .vectors bytes, and build/train
-//! wall time per method.
+//! re-rank, p50/p95 end-to-end query latency, sequential query throughput,
+//! ANN postings per source vector, .vectors bytes, and build/train wall time
+//! per method.
 
 use crate::directories::MmapDirectory;
 use crate::dsl::{DenseVectorConfig, Document, SchemaBuilder};
@@ -23,6 +35,14 @@ const QUERIES: usize = 100;
 const K: usize = 10;
 const IVF_NUM_CLUSTERS: usize = 1_024;
 const NPROBE: usize = 64;
+
+const SOAR_DIM: usize = 96;
+const SOAR_DOCS: usize = 6_000;
+const SOAR_CLUSTERS: usize = 32;
+const SOAR_QUERIES: usize = 100;
+const SOAR_IVF_NUM_CLUSTERS: usize = 64;
+const SOAR_NPROBE: usize = 4;
+const SELECTIVE_SOAR_TARGET: f64 = 0.30;
 
 /// Scale overrides so the same harness runs 100k smoke and 1M validation:
 /// TQ_BENCH_DOCS, TQ_BENCH_CLUSTERS, TQ_BENCH_QUERIES, TQ_BENCH_IVF_CLUSTERS,
@@ -60,6 +80,20 @@ impl BenchScale {
                 .unwrap_or(2.0),
         }
     }
+
+    fn soar_from_env() -> Self {
+        Self {
+            docs: env_usize("SOAR_BENCH_DOCS", SOAR_DOCS),
+            clusters: env_usize("SOAR_BENCH_CLUSTERS", SOAR_CLUSTERS),
+            queries: env_usize("SOAR_BENCH_QUERIES", SOAR_QUERIES),
+            ivf_clusters: env_usize("SOAR_BENCH_IVF_CLUSTERS", SOAR_IVF_NUM_CLUSTERS),
+            nprobe: env_usize("SOAR_BENCH_NPROBE", SOAR_NPROBE),
+            rerank_factor: std::env::var("SOAR_BENCH_RERANK")
+                .ok()
+                .map(|value| value.parse().expect("SOAR_BENCH_RERANK must be a float"))
+                .unwrap_or(2.0),
+        }
+    }
 }
 
 fn splitmix(state: &mut u64) -> u64 {
@@ -91,16 +125,16 @@ fn normalize(mut values: Vec<f32>) -> Vec<f32> {
     values
 }
 
-fn build_corpus(scale: BenchScale) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) {
+fn build_corpus(dim: usize, scale: BenchScale) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) {
     use rayon::prelude::*;
     let centers: Vec<Vec<f32>> = (0..scale.clusters)
-        .map(|c| gaussian_unit(DIM, 1_000 + c as u64))
+        .map(|c| gaussian_unit(dim, 1_000 + c as u64))
         .collect();
     let corpus: Vec<Vec<f32>> = (0..scale.docs)
         .into_par_iter()
         .map(|i| {
             let center = &centers[i % scale.clusters];
-            let noise = gaussian_unit(DIM, 50_000 + i as u64);
+            let noise = gaussian_unit(dim, 50_000 + i as u64);
             normalize(
                 center
                     .iter()
@@ -113,7 +147,7 @@ fn build_corpus(scale: BenchScale) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) {
     let queries: Vec<Vec<f32>> = (0..scale.queries)
         .map(|q| {
             let base = &corpus[(q * 977) % scale.docs];
-            let noise = gaussian_unit(DIM, 900_000 + q as u64);
+            let noise = gaussian_unit(dim, 900_000 + q as u64);
             normalize(base.iter().zip(&noise).map(|(v, n)| v + 0.3 * n).collect())
         })
         .collect();
@@ -128,6 +162,8 @@ struct MethodReport {
     ann_kind: String,
     p50_ms: f64,
     p95_ms: f64,
+    query_qps: f64,
+    ann_postings: usize,
     results: Vec<Vec<u64>>,
 }
 
@@ -139,6 +175,7 @@ async fn run_method(
     nprobe: usize,
     rerank_factor: f32,
 ) -> MethodReport {
+    let should_train = config.uses_ivf();
     let temp = tempfile::tempdir().expect("bench tempdir");
     let dir = MmapDirectory::new(temp.path());
     let mut sb = SchemaBuilder::default();
@@ -177,7 +214,7 @@ async fn run_method(
     let build_secs = build_start.elapsed().as_secs_f64();
 
     let train_start = std::time::Instant::now();
-    let train_secs = if label == "ivf_tq" {
+    let train_secs = if should_train {
         let writer = IndexWriter::open(dir.clone(), index_config.clone())
             .await
             .expect("reopen writer for training");
@@ -205,6 +242,15 @@ async fn run_method(
         .next()
         .unwrap_or("none")
         .to_string();
+    let ann_postings = segments
+        .iter()
+        .filter_map(|segment| segment.vector_indexes().get(&embedding.0))
+        .map(|ann| match ann {
+            crate::segment::VectorIndex::BinaryIvf(index) => index.get().header().vector_count,
+            crate::segment::VectorIndex::Tq { index, .. }
+            | crate::segment::VectorIndex::IvfTq { index, .. } => index.get().header().vector_count,
+        })
+        .sum();
     let vectors_bytes: u64 = {
         let mut total = 0u64;
         for entry in std::fs::read_dir(temp.path()).expect("read bench dir") {
@@ -251,6 +297,8 @@ async fn run_method(
         }
         results.push(originals);
     }
+    let measured_secs = latencies.iter().sum::<f64>() / 1_000.0;
+    let query_qps = queries.len() as f64 / measured_secs;
     latencies.sort_by(|a, b| a.total_cmp(b));
     let p50_ms = latencies[latencies.len() / 2];
     let p95_ms = latencies[(latencies.len() * 95) / 100];
@@ -263,6 +311,8 @@ async fn run_method(
         ann_kind,
         p50_ms,
         p95_ms,
+        query_qps,
+        ann_postings,
         results,
     }
 }
@@ -290,7 +340,7 @@ async fn tq_dense_ann_benchmark() {
         scale.docs, scale.clusters, scale.queries, scale.nprobe, scale.ivf_clusters,
     );
     let corpus_start = std::time::Instant::now();
-    let (corpus, queries) = build_corpus(scale);
+    let (corpus, queries) = build_corpus(DIM, scale);
     println!(
         "corpus generated in {:.1}s",
         corpus_start.elapsed().as_secs_f64()
@@ -335,18 +385,26 @@ async fn tq_dense_ann_benchmark() {
     );
 
     println!(
-        "\n{:<8} {:>10} {:>10} {:>12} {:>9} {:>9} {:>9}",
-        "method", "build(s)", "train(s)", "vectors(MB)", "p50(ms)", "p95(ms)", "recall@10"
+        "\n{:<8} {:>10} {:>10} {:>12} {:>9} {:>9} {:>10} {:>9}",
+        "method",
+        "build(s)",
+        "train(s)",
+        "vectors(MB)",
+        "p50(ms)",
+        "p95(ms)",
+        "query/s",
+        "recall@10"
     );
     for report in [&flat, &tq, &ivf_tq] {
         println!(
-            "{:<8} {:>10.1} {:>10.1} {:>12.1} {:>9.2} {:>9.2} {:>9.3}",
+            "{:<8} {:>10.1} {:>10.1} {:>12.1} {:>9.2} {:>9.2} {:>10.1} {:>9.3}",
             report.label,
             report.build_secs,
             report.train_secs,
             report.vectors_bytes as f64 / (1024.0 * 1024.0),
             report.p50_ms,
             report.p95_ms,
+            report.query_qps,
             recall(&flat.results, &report.results),
         );
     }
@@ -355,5 +413,125 @@ async fn tq_dense_ann_benchmark() {
         "\nANN payload overhead vs flat storage: tq +{:.1} MB, ivf_tq +{:.1} MB",
         (tq.vectors_bytes as f64 - flat_bytes) / (1024.0 * 1024.0),
         (ivf_tq.vectors_bytes as f64 - flat_bytes) / (1024.0 * 1024.0),
+    );
+}
+
+/// Deterministic quality/storage comparison for the selective SOAR default.
+///
+/// This is deliberately a reporting benchmark rather than a recall gate:
+/// selective spilling may trade a different amount of latency for recall as
+/// the corpus, nprobe, and rerank settings change. Assertions cover format and
+/// metric invariants so experiments with the environment overrides remain
+/// useful instead of becoming flaky pass/fail tests.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
+async fn ivf_tq_selective_soar_benchmark() {
+    let arch = std::env::consts::ARCH;
+    let scale = BenchScale::soar_from_env();
+    println!(
+        "\n=== Selective SOAR benchmark: {} docs, dim {SOAR_DIM}, {} source clusters, \
+         {} queries, k={K}, nprobe={}/{}, arch={arch} ===",
+        scale.docs, scale.clusters, scale.queries, scale.nprobe, scale.ivf_clusters,
+    );
+
+    let corpus_start = std::time::Instant::now();
+    let (corpus, queries) = build_corpus(SOAR_DIM, scale);
+    println!(
+        "corpus generated in {:.1}s",
+        corpus_start.elapsed().as_secs_f64()
+    );
+
+    let flat = run_method(
+        "flat",
+        DenseVectorConfig::flat(SOAR_DIM),
+        &corpus,
+        &queries,
+        scale.nprobe,
+        scale.rerank_factor,
+    )
+    .await;
+    let off = run_method(
+        "ivf_tq_off",
+        DenseVectorConfig::ivf_tq(SOAR_DIM, Some(scale.ivf_clusters), scale.nprobe).without_soar(),
+        &corpus,
+        &queries,
+        scale.nprobe,
+        scale.rerank_factor,
+    )
+    .await;
+    let selective = run_method(
+        "ivf_tq_default",
+        DenseVectorConfig::ivf_tq(SOAR_DIM, Some(scale.ivf_clusters), scale.nprobe),
+        &corpus,
+        &queries,
+        scale.nprobe,
+        scale.rerank_factor,
+    )
+    .await;
+
+    assert_eq!(flat.ann_kind, "none", "flat truth must remain exact");
+    assert_eq!(off.ann_kind, "ivf_tq");
+    assert_eq!(selective.ann_kind, "ivf_tq");
+    assert_eq!(
+        off.ann_postings,
+        corpus.len(),
+        "SOAR-off must write exactly one posting per source vector"
+    );
+    assert!(
+        (corpus.len()..=corpus.len().saturating_mul(2)).contains(&selective.ann_postings),
+        "one-secondary SOAR must write between one and two postings per source vector"
+    );
+
+    let off_recall = recall(&flat.results, &off.results);
+    let selective_recall = recall(&flat.results, &selective.results);
+    assert!((0.0..=1.0).contains(&off_recall));
+    assert!((0.0..=1.0).contains(&selective_recall));
+    assert!(off.p50_ms.is_finite() && off.p95_ms.is_finite() && off.query_qps.is_finite());
+    assert!(
+        selective.p50_ms.is_finite()
+            && selective.p95_ms.is_finite()
+            && selective.query_qps.is_finite()
+    );
+
+    let off_amplification = off.ann_postings as f64 / corpus.len() as f64;
+    let selective_amplification = selective.ann_postings as f64 / corpus.len() as f64;
+    println!(
+        "\n{:<15} {:>10} {:>12} {:>12} {:>9} {:>9} {:>10} {:>10} {:>10}",
+        "method",
+        "recall@10",
+        "postings",
+        "postings/x",
+        "p50(ms)",
+        "p95(ms)",
+        "query/s",
+        "build(s)",
+        "train(s)"
+    );
+    for (report, method_recall, amplification) in [
+        (&off, off_recall, off_amplification),
+        (&selective, selective_recall, selective_amplification),
+    ] {
+        println!(
+            "{:<15} {:>10.4} {:>12} {:>12.3} {:>9.2} {:>9.2} {:>10.1} {:>10.1} {:>10.1}",
+            report.label,
+            method_recall,
+            report.ann_postings,
+            amplification,
+            report.p50_ms,
+            report.p95_ms,
+            report.query_qps,
+            report.build_secs,
+            report.train_secs,
+        );
+    }
+    println!(
+        "\nselective - off: recall@10 {:+.4}, postings {:+.3}x \
+         (training target +{SELECTIVE_SOAR_TARGET:.2}x), p95 {:+.2} ms, query/s {:+.1}, \
+         .vectors {:+.2} MiB",
+        selective_recall - off_recall,
+        selective_amplification - off_amplification,
+        selective.p95_ms - off.p95_ms,
+        selective.query_qps - off.query_qps,
+        (selective.vectors_bytes as f64 - off.vectors_bytes as f64) / (1024.0 * 1024.0),
     );
 }

--- a/hermes-core/src/index/tests/vector.rs
+++ b/hermes-core/src/index/tests/vector.rs
@@ -1326,6 +1326,15 @@ async fn binary_ivf_multi_value_exact_scores() {
     near.add_binary_dense_vector(bvec, near_vec);
     writer.add_document(near).unwrap();
 
+    // Aggregate doc: neither ordinal is individually competitive with the
+    // exact match, but their Sum must win at document level.
+    let aggregate_vec = vec![0xFE_u8; byte_len];
+    let mut aggregate = Document::new();
+    aggregate.add_text(title, "aggregate");
+    aggregate.add_binary_dense_vector(bvec, aggregate_vec.clone());
+    aggregate.add_binary_dense_vector(bvec, aggregate_vec);
+    writer.add_document(aggregate).unwrap();
+
     // Hay: two vectors per doc, at most half the bits set (score <= ~0.75).
     for i in 0u32..30 {
         let mut doc = Document::new();
@@ -1354,7 +1363,7 @@ async fn binary_ivf_multi_value_exact_scores() {
             segments[0].get_vector_index(bvec),
             Some(crate::segment::VectorIndex::BinaryIvf(_))
         ),
-        "binary IVF index should be built at commit (63 vectors >= threshold 50)"
+        "binary IVF index should be built at commit (65 vectors >= threshold 50)"
     );
 
     let reader = index.reader().await.unwrap();
@@ -1388,6 +1397,31 @@ async fn binary_ivf_multi_value_exact_scores() {
         (results[1].score - expected_near).abs() < 1e-6,
         "near doc must keep its exact Hamming score {expected_near}, got {}",
         results[1].score
+    );
+
+    let summed = searcher
+        .search(
+            &BinaryDenseVectorQuery::new(bvec, vec![0xFF_u8; byte_len])
+                .with_combiner(crate::query::MultiValueCombiner::Sum),
+            1,
+        )
+        .await
+        .unwrap();
+    let summed_top = searcher
+        .doc(summed[0].segment_id, summed[0].doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        summed_top.get_first(title).unwrap().as_text().unwrap(),
+        "aggregate",
+        "non-Max combiners must rank documents after aggregating all ordinals"
+    );
+    let expected_sum = 2.0 * (1.0 - byte_len as f32 / dim_bits as f32);
+    assert!(
+        (summed[0].score - expected_sum).abs() < 1e-6,
+        "aggregate document must retain its exact Sum score {expected_sum}, got {}",
+        summed[0].score
     );
 }
 
@@ -1909,4 +1943,138 @@ async fn test_ivf_tq_end_to_end_with_merge() {
         target_title.as_str(),
         "doc bases must survive the merge"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ivf_tq_non_unit_vectors_preserve_cosine_ranking() {
+    use crate::dsl::DenseVectorConfig;
+    use crate::query::DenseVectorQuery;
+
+    let dim = 8;
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    let mut dense_config = DenseVectorConfig::ivf_tq(dim, Some(2), 2);
+    dense_config.unit_norm = false;
+    let embedding = sb.add_dense_vector_field_with_config("embedding", true, true, dense_config);
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    let mut exact = Document::new();
+    exact.add_text(title, "exact angle");
+    exact.add_dense_vector(embedding, vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
+    writer.add_document(exact).unwrap();
+
+    // These vectors dominate an inner-product candidate stage by magnitude,
+    // while all have a worse cosine angle than the unit vector above.
+    for i in 0..12 {
+        let mut large = Document::new();
+        large.add_text(title, format!("large magnitude {i}"));
+        large.add_dense_vector(
+            embedding,
+            vec![100.0 + i as f32, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        );
+        writer.add_document(large).unwrap();
+    }
+    for i in 0..52 {
+        let mut hay = Document::new();
+        hay.add_text(title, format!("orthogonal {i}"));
+        hay.add_dense_vector(
+            embedding,
+            vec![0.0, 1.0 + i as f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        );
+        writer.add_document(hay).unwrap();
+    }
+    writer.commit().await.unwrap();
+    writer.build_vector_index().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert!(matches!(
+        index.segment_readers().await.unwrap()[0].get_vector_index(embedding),
+        Some(crate::segment::VectorIndex::IvfTq { .. })
+    ));
+    let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+    let query = DenseVectorQuery::new(embedding, vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        .with_nprobe(2);
+    let results = searcher.search(&query, 1).await.unwrap();
+    let top = searcher
+        .doc(results[0].segment_id, results[0].doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        top.get_first(title).unwrap().as_text().unwrap(),
+        "exact angle"
+    );
+    assert!(
+        (results[0].score - 1.0).abs() < 1e-4,
+        "exact cosine score should remain approximately one, got {}",
+        results[0].score
+    );
+}
+
+#[tokio::test]
+async fn test_tq_multi_value_sum_aggregates_before_candidate_cut() {
+    use crate::dsl::DenseVectorConfig;
+    use crate::query::{DenseVectorQuery, MultiValueCombiner};
+
+    let dim = 8;
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    let embedding =
+        sb.add_dense_vector_field_with_config("embedding", true, true, DenseVectorConfig::tq(dim));
+    sb.set_multi(embedding, true);
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    let mut exact = Document::new();
+    exact.add_text(title, "best ordinal");
+    exact.add_dense_vector(embedding, vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
+    writer.add_document(exact).unwrap();
+
+    let mut aggregate = Document::new();
+    aggregate.add_text(title, "best document sum");
+    for second in [0.6, -0.6] {
+        aggregate.add_dense_vector(embedding, vec![0.8, second, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
+    }
+    writer.add_document(aggregate).unwrap();
+
+    for i in 0..60 {
+        let mut hay = Document::new();
+        hay.add_text(title, format!("hay {i}"));
+        hay.add_dense_vector(embedding, vec![0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
+        writer.add_document(hay).unwrap();
+    }
+    writer.commit().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert!(matches!(
+        index.segment_readers().await.unwrap()[0].get_vector_index(embedding),
+        Some(crate::segment::VectorIndex::Tq { .. })
+    ));
+    let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+    let query = DenseVectorQuery::new(embedding, vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        .with_combiner(MultiValueCombiner::Sum);
+    let results = searcher.search(&query, 1).await.unwrap();
+    let top = searcher
+        .doc(results[0].segment_id, results[0].doc_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        top.get_first(title).unwrap().as_text().unwrap(),
+        "best document sum"
+    );
+    assert!((results[0].score - 1.6).abs() < 1e-5);
 }

--- a/hermes-core/src/index/vector_builder.rs
+++ b/hermes-core/src/index/vector_builder.rs
@@ -31,7 +31,22 @@ const COARSE_TRAINING_POINTS_PER_CENTROID: usize = 256;
 /// Bound transient I/O/dequantization buffers independently of the configured
 /// total training sample budget.
 const MAX_SAMPLE_READ_BYTES: usize = 64 * 1024 * 1024;
-const SAMPLE_BLOCK: usize = 256;
+/// Coalesce nearby point-sample reads only while the extra I/O remains bounded.
+/// This keeps point-level sampling statistically useful without turning a dense
+/// sample into one range read per vector.
+const MAX_SAMPLE_READ_AMPLIFICATION: usize = 4;
+/// A held-out sample is large enough to expose routing/occupancy tails but stays
+/// bounded when codebooks are trained from millions of points.
+const VALIDATION_SAMPLE_DENOMINATOR: usize = 10;
+const MAX_VALIDATION_SAMPLES: usize = 65_536;
+/// Bound the exact centroid scan used to measure router recall. Even for very
+/// large codebooks, retain at least one held-out row when the sample permits.
+const MAX_VALIDATION_COORDINATE_WORK: usize = 512_000_000;
+/// A second deterministic initialization is useful on modest training jobs.
+/// Large jobs retain the same quality-report scaffold without silently doubling
+/// their already substantial Lloyd cost.
+const MODEL_SELECTION_SEEDS: [u64; 2] = [42, 0x9e37_79b9_7f4a_7c15];
+const MAX_MULTI_SEED_COORDINATE_WORK: usize = 4_000_000_000;
 /// Generation-qualified filenames make retraining crash-safe: the currently
 /// published metadata never points at a file being overwritten in place.
 const VECTOR_ARTIFACT_PREFIX: &str = "vector_artifact_";
@@ -94,8 +109,31 @@ impl IvfFieldConfig {
 }
 
 enum TrainingSample {
-    Float(Vec<Vec<f32>>),
+    /// Contiguous row-major matrix, retained in this form through training.
+    Float(Vec<f32>),
     Binary(Vec<u8>),
+}
+
+#[derive(Clone, Copy, Debug)]
+struct OccupancyQuality {
+    p95: usize,
+    p99: usize,
+    max: usize,
+    empty: usize,
+    penalty: f64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FloatBuildQuality {
+    objective: f64,
+    mean_exact_distortion: f64,
+    mean_routed_distortion: f64,
+    router_recall_at_1: f64,
+    mean_construction_assignments: f64,
+    residual_p50: f32,
+    residual_p95: f32,
+    residual_p99: f32,
+    occupancy: OccupancyQuality,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -107,7 +145,7 @@ enum VectorGenerationMode {
 impl TrainingSample {
     fn len(&self, dim: usize) -> usize {
         match self {
-            Self::Float(vectors) => vectors.len(),
+            Self::Float(values) => values.len() / dim,
             Self::Binary(codes) => codes.len() / dim.div_ceil(8),
         }
     }
@@ -227,6 +265,283 @@ fn training_sample_limit(
         )));
     }
     Ok(max_samples.min(memory_limited))
+}
+
+/// Resolve the codebook size against the complete configured sample budget,
+/// then select that final training sample directly. In particular, callers no
+/// longer collect a larger block-correlated sample and stride-thin it later.
+fn final_training_sample_count(
+    config: &IvfFieldConfig,
+    corpus_count: usize,
+    sample_limit: usize,
+) -> Result<usize> {
+    let available = corpus_count.min(sample_limit);
+    if available == 0 {
+        return Ok(0);
+    }
+    let clusters = effective_field_num_clusters(config, corpus_count, available)?;
+    Ok(available.min(clusters.saturating_mul(COARSE_TRAINING_POINTS_PER_CENTROID)))
+}
+
+/// Uniform point sample without replacement, sorted only after selection so
+/// storage reads remain monotonic. `rand::seq::index::sample` uses bounded
+/// memory proportional to the selected set rather than materializing a corpus
+/// permutation.
+fn deterministic_sample_ordinals(total: usize, take: usize, seed: u64) -> Vec<usize> {
+    debug_assert!(take <= total);
+    if take == 0 {
+        return Vec::new();
+    }
+    if take == total {
+        return (0..total).collect();
+    }
+    let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(seed);
+    let mut ordinals = rand::seq::index::sample(&mut rng, total, take).into_vec();
+    ordinals.sort_unstable();
+    ordinals
+}
+
+fn validation_sample_count(
+    sample_count: usize,
+    num_clusters: usize,
+    values_per_vector: usize,
+) -> usize {
+    if sample_count <= num_clusters {
+        return 0;
+    }
+    let quality_floor = num_clusters.saturating_mul(MIN_TRAINING_POINTS_PER_CENTROID);
+    let minimum_training = if sample_count >= quality_floor {
+        quality_floor
+    } else {
+        num_clusters
+    };
+    let exact_scan_limit = MAX_VALIDATION_COORDINATE_WORK
+        .checked_div(num_clusters.saturating_mul(values_per_vector).max(1))
+        .unwrap_or(0)
+        .max(1);
+    sample_count
+        .div_ceil(VALIDATION_SAMPLE_DENOMINATOR)
+        .clamp(1, MAX_VALIDATION_SAMPLES)
+        .min(exact_scan_limit)
+        .min(sample_count - minimum_training)
+}
+
+fn model_selection_seeds(
+    training_count: usize,
+    num_clusters: usize,
+    dim: usize,
+    has_validation: bool,
+) -> &'static [u64] {
+    if !has_validation {
+        return &MODEL_SELECTION_SEEDS[..1];
+    }
+    let distance_passes = crate::structures::vector::estimated_euclidean_kmeans_distance_multiplier(
+        training_count,
+        num_clusters,
+        25,
+    );
+    let work = training_count
+        .saturating_mul(num_clusters)
+        .saturating_mul(dim)
+        .saturating_mul(distance_passes)
+        .saturating_mul(MODEL_SELECTION_SEEDS.len());
+    if work <= MAX_MULTI_SEED_COORDINATE_WORK {
+        &MODEL_SELECTION_SEEDS
+    } else {
+        &MODEL_SELECTION_SEEDS[..1]
+    }
+}
+
+fn percentile_index(len: usize, percentile: usize) -> usize {
+    debug_assert!(len > 0 && percentile <= 100);
+    (len - 1).saturating_mul(percentile).div_ceil(100)
+}
+
+fn occupancy_quality(mut counts: Vec<usize>, observations: usize) -> OccupancyQuality {
+    if counts.is_empty() {
+        return OccupancyQuality {
+            p95: 0,
+            p99: 0,
+            max: 0,
+            empty: 0,
+            penalty: 0.0,
+        };
+    }
+    counts.sort_unstable();
+    let p95 = counts[percentile_index(counts.len(), 95)];
+    let p99 = counts[percentile_index(counts.len(), 99)];
+    let max = counts.last().copied().unwrap_or(0);
+    let empty = counts.partition_point(|&count| count == 0);
+    let expected = observations as f64 / counts.len() as f64;
+    let denominator = expected.max(1.0);
+    let p99_excess = (p99 as f64 / denominator - 1.0).max(0.0);
+    let max_excess = (max as f64 / denominator - 1.0).max(0.0);
+    let empty_fraction = empty as f64 / counts.len() as f64;
+    // Distortion remains the dominant selection signal. These terms only
+    // reject seeds with materially worse posting-list tails at similar error.
+    let penalty = 0.02 * p99_excess + 0.005 * max_excess + 0.05 * empty_fraction;
+    OccupancyQuality {
+        p95,
+        p99,
+        max,
+        empty,
+        penalty,
+    }
+}
+
+fn float_model_selection_objective(
+    mean_exact_distortion: f64,
+    mean_routed_distortion: f64,
+    occupancy_penalty: f64,
+) -> f64 {
+    let scale = mean_exact_distortion.max(f64::from(f32::EPSILON));
+    let routed_distortion_excess = (mean_routed_distortion - mean_exact_distortion).max(0.0);
+    mean_exact_distortion + scale * occupancy_penalty + routed_distortion_excess
+}
+
+/// Move a deterministic uniform holdout into the matrix suffix and return the
+/// element offset separating training and validation rows. Row swaps avoid a
+/// second vector allocation and keep the original sample capacity available to
+/// the trainer.
+fn partition_contiguous_holdout_suffix<T>(
+    values: &mut [T],
+    values_per_vector: usize,
+    validation_count: usize,
+    seed: u64,
+) -> usize {
+    assert!(values_per_vector > 0);
+    assert_eq!(values.len() % values_per_vector, 0);
+    let sample_count = values.len() / values_per_vector;
+    assert!(validation_count <= sample_count);
+    if validation_count == 0 {
+        return values.len();
+    }
+    let validation_indices =
+        deterministic_sample_ordinals(sample_count, validation_count, seed ^ 0x5641_4c49_4441_5445);
+    let split_row = sample_count - validation_count;
+    let prefix_validation_count = validation_indices.partition_point(|&index| index < split_row);
+    let mut right = sample_count;
+    for &left in &validation_indices[..prefix_validation_count] {
+        loop {
+            right -= 1;
+            if validation_indices.binary_search(&right).is_err() {
+                break;
+            }
+        }
+        debug_assert!(right >= split_row);
+        for component in 0..values_per_vector {
+            values.swap(
+                left * values_per_vector + component,
+                right * values_per_vector + component,
+            );
+        }
+    }
+    split_row * values_per_vector
+}
+
+fn evaluate_float_build_quality(
+    centroids: &crate::structures::CoarseCentroids,
+    validation: &[f32],
+    routing: crate::dsl::IvfRoutingMode,
+) -> Option<FloatBuildQuality> {
+    let dim = centroids.dim;
+    let validation_count = validation.len() / dim;
+    if validation_count == 0 {
+        return None;
+    }
+    let mut occupancy = vec![0usize; centroids.num_clusters as usize];
+    let mut residual_scales = Vec::with_capacity(validation_count);
+    let mut exact_distortion_sum = 0.0f64;
+    let mut routed_distortion_sum = 0.0f64;
+    let mut router_hits = 0usize;
+    let mut construction_assignments = 0usize;
+    let effective_routing = crate::structures::vector::ivf::routing::effective_routing_mode(
+        routing,
+        centroids.num_clusters as usize,
+    );
+    let exact_routing = effective_routing == crate::dsl::IvfRoutingMode::Flat;
+    for vector in validation.chunks_exact(dim) {
+        let (exact_cluster_id, routed_cluster_id) = if exact_routing {
+            if centroids.soar_config.is_some() {
+                // Flat SOAR already performs the exact all-centroid pass needed
+                // for its primary and secondary assignments. Its primary is
+                // therefore both the exact and query-routed nearest centroid.
+                let construction_assignment = centroids.assign_with_routing(vector, routing);
+                let exact_cluster_id = construction_assignment.primary_cluster;
+                for cluster_id in construction_assignment.all_clusters() {
+                    occupancy[cluster_id as usize] += 1;
+                    construction_assignments += 1;
+                }
+                (exact_cluster_id, exact_cluster_id)
+            } else {
+                // With neither an approximate router nor SOAR, one exact pass
+                // supplies exact quality, query routing, and construction
+                // occupancy.
+                let exact_cluster_id = centroids.find_nearest(vector);
+                occupancy[exact_cluster_id as usize] += 1;
+                construction_assignments += 1;
+                (exact_cluster_id, exact_cluster_id)
+            }
+        } else {
+            let exact_cluster_id = centroids.find_nearest(vector);
+            let routed_cluster_id = centroids.probe(vector, 1, routing).cluster_ids[0];
+            let construction_assignment = centroids.assign_with_routing(vector, routing);
+            for cluster_id in construction_assignment.all_clusters() {
+                occupancy[cluster_id as usize] += 1;
+                construction_assignments += 1;
+            }
+            (exact_cluster_id, routed_cluster_id)
+        };
+        router_hits += usize::from(routed_cluster_id == exact_cluster_id);
+        let exact_distance = vector
+            .iter()
+            .zip(centroids.get_centroid(exact_cluster_id))
+            .map(|(&value, &center)| {
+                let delta = value - center;
+                delta * delta
+            })
+            .sum::<f32>();
+        let routed_distance = if routed_cluster_id == exact_cluster_id {
+            exact_distance
+        } else {
+            vector
+                .iter()
+                .zip(centroids.get_centroid(routed_cluster_id))
+                .map(|(&value, &center)| {
+                    let delta = value - center;
+                    delta * delta
+                })
+                .sum::<f32>()
+        };
+        exact_distortion_sum += f64::from(exact_distance);
+        routed_distortion_sum += f64::from(routed_distance);
+        residual_scales.push(exact_distance.max(0.0).sqrt());
+    }
+    residual_scales.sort_unstable_by(f32::total_cmp);
+    let occupancy = occupancy_quality(occupancy, construction_assignments);
+    let mean_exact_distortion = exact_distortion_sum / validation_count as f64;
+    let mean_routed_distortion = routed_distortion_sum / validation_count as f64;
+    let router_recall_at_1 = router_hits as f64 / validation_count as f64;
+    let mean_construction_assignments = construction_assignments as f64 / validation_count as f64;
+    // Keep exact codebook distortion as the primary signal. Price approximate
+    // routing by its measured excess distortion rather than treating all
+    // misses equally; retain recall@1 as a separately reported diagnostic.
+    let objective = float_model_selection_objective(
+        mean_exact_distortion,
+        mean_routed_distortion,
+        occupancy.penalty,
+    );
+    Some(FloatBuildQuality {
+        objective,
+        mean_exact_distortion,
+        mean_routed_distortion,
+        router_recall_at_1,
+        mean_construction_assignments,
+        residual_p50: residual_scales[percentile_index(validation_count, 50)],
+        residual_p95: residual_scales[percentile_index(validation_count, 95)],
+        residual_p99: residual_scales[percentile_index(validation_count, 99)],
+        occupancy,
+    })
 }
 
 /// Validate the configured centroid count and cap it to the training sample.
@@ -409,7 +724,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             // one bounded sample, one field's clustering scratch, and one
             // generated artifact set can coexist.
             let corpus_count = total_vectors.get(&field.0).copied().unwrap_or(0);
-            let Some(sample) = self
+            let Some(mut sample) = self
                 .collect_training_sample(segment_ids, *field, config, corpus_count)
                 .await?
             else {
@@ -421,7 +736,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     Self::train_field_model(
                         *field,
                         config,
-                        &sample,
+                        &mut sample,
                         corpus_count,
                         artifact_generation,
                     )
@@ -651,31 +966,15 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             self.config.vector_training_memory_bytes,
             bytes_per_sample,
         )?;
-        let take = total.min(limit);
-        let mut rng = <rand::rngs::StdRng as rand::SeedableRng>::seed_from_u64(
-            0x4845_524d_4553_4956 ^ field.0 as u64 ^ total as u64,
-        );
-        let mut ordinals = Vec::with_capacity(take);
-        if take == total {
-            ordinals.extend(0..total);
-        } else {
-            let blocks = take.div_ceil(SAMPLE_BLOCK);
-            for block in 0..blocks {
-                let block_len = SAMPLE_BLOCK.min(take - ordinals.len());
-                let stratum_start = block.saturating_mul(total) / blocks;
-                let stratum_end = (block + 1).saturating_mul(total) / blocks;
-                let latest_start = stratum_end.saturating_sub(block_len);
-                let start = if latest_start > stratum_start {
-                    rand::Rng::random_range(&mut rng, stratum_start..=latest_start)
-                } else {
-                    stratum_start
-                };
-                ordinals.extend(start..start + block_len);
-            }
-        }
+        let take = final_training_sample_count(config, total, limit)?;
+        let sample_seed = 0x4845_524d_4553_4956 ^ field.0 as u64 ^ total as u64;
+        let ordinals = deterministic_sample_ordinals(total, take, sample_seed);
 
         let mut sample = match config {
-            IvfFieldConfig::Float(_) => TrainingSample::Float(Vec::with_capacity(take)),
+            IvfFieldConfig::Float(config) => TrainingSample::Float(Vec::with_capacity(
+                take.checked_mul(config.dim)
+                    .ok_or_else(|| Error::Schema("float training sample size overflows".into()))?,
+            )),
             IvfFieldConfig::Binary(_) => TrainingSample::Binary(Vec::with_capacity(
                 take.checked_mul(bytes_per_sample)
                     .ok_or_else(|| Error::Schema("binary training sample size overflows".into()))?,
@@ -707,21 +1006,25 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             let mut run_start = 0;
             while run_start < selected.len() {
                 let mut run_end = run_start + 1;
-                while run_end < selected.len()
-                    && run_end - run_start < max_read_vectors
-                    && selected[run_end] == selected[run_end - 1] + 1
-                {
+                while run_end < selected.len() {
+                    let selected_count = run_end - run_start + 1;
+                    let span = selected[run_end] - selected[run_start] + 1;
+                    if span > max_read_vectors
+                        || span > selected_count.saturating_mul(MAX_SAMPLE_READ_AMPLIFICATION)
+                    {
+                        break;
+                    }
                     run_end += 1;
                 }
                 let local_start = selected[run_start] - base;
-                let run_len = run_end - run_start;
+                let read_len = selected[run_end - 1] - selected[run_start] + 1;
                 let bytes = lazy_flat
-                    .read_vectors_batch(local_start, run_len)
+                    .read_vectors_batch(local_start, read_len)
                     .await
                     .map_err(crate::Error::Io)?;
                 match &mut sample {
                     TrainingSample::Binary(codes) => {
-                        let expected = run_len.checked_mul(bytes_per_sample).ok_or_else(|| {
+                        let expected = read_len.checked_mul(bytes_per_sample).ok_or_else(|| {
                             Error::Corruption("binary sample read size overflows".into())
                         })?;
                         if bytes.len() != expected {
@@ -730,11 +1033,17 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                                 bytes.len(),
                             )));
                         }
-                        codes.extend_from_slice(bytes.as_slice());
+                        for &ordinal in &selected[run_start..run_end] {
+                            let relative = ordinal - selected[run_start];
+                            let offset = relative * bytes_per_sample;
+                            codes.extend_from_slice(
+                                &bytes.as_slice()[offset..offset + bytes_per_sample],
+                            );
+                        }
                     }
-                    TrainingSample::Float(vectors) => {
+                    TrainingSample::Float(values) => {
                         let dim = lazy_flat.dim;
-                        let float_count = run_len.checked_mul(dim).ok_or_else(|| {
+                        let float_count = read_len.checked_mul(dim).ok_or_else(|| {
                             Error::Corruption("float sample read size overflows".into())
                         })?;
                         let mut decoded = vec![0.0; float_count];
@@ -745,7 +1054,11 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                             &mut decoded,
                         )
                         .map_err(crate::Error::Io)?;
-                        vectors.extend(decoded.chunks_exact(dim).map(<[f32]>::to_vec));
+                        for &ordinal in &selected[run_start..run_end] {
+                            let relative = ordinal - selected[run_start];
+                            let offset = relative * dim;
+                            values.extend_from_slice(&decoded[offset..offset + dim]);
+                        }
                     }
                 }
                 run_start = run_end;
@@ -777,7 +1090,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     fn train_field_model(
         field: Field,
         config: &IvfFieldConfig,
-        sample: &TrainingSample,
+        sample: &mut TrainingSample,
         corpus_count: usize,
         artifact_generation: &str,
     ) -> Result<TrainedFieldModel> {
@@ -804,53 +1117,138 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             format!("{VECTOR_ARTIFACT_PREFIX}{artifact_generation}_field_{field_id}_centroids.bin");
 
         let artifacts = match (config, sample) {
-            (IvfFieldConfig::Float(config), TrainingSample::Float(vectors))
+            (IvfFieldConfig::Float(config), TrainingSample::Float(values))
                 if config.index_type == VectorIndexType::IvfTq =>
             {
-                let mut coarse_config = crate::structures::CoarseConfig::new(dim, num_clusters)
+                values
+                    .chunks_exact_mut(dim)
+                    .for_each(crate::structures::vector::ivf::routing::normalize_cosine_in_place);
+                let candidate_validation_count =
+                    validation_sample_count(sample_count, num_clusters, dim);
+                let candidate_training_count = sample_count - candidate_validation_count;
+                let seeds = model_selection_seeds(
+                    candidate_training_count,
+                    num_clusters,
+                    dim,
+                    candidate_validation_count > 0,
+                );
+                let split_seed =
+                    MODEL_SELECTION_SEEDS[0] ^ u64::from(field_id) ^ corpus_count as u64;
+                let split = if seeds.len() > 1 {
+                    partition_contiguous_holdout_suffix(
+                        values.as_mut_slice(),
+                        dim,
+                        candidate_validation_count,
+                        split_seed,
+                    )
+                } else {
+                    values.len()
+                };
+                let (training_values, validation) = values.as_slice().split_at(split);
+                let training_count = training_values.len() / dim;
+                let validation_count = validation.len() / dim;
+                if seeds.len() > 1 {
+                    log::info!(
+                        "Field {field_id}: {} training + {} held-out vectors; evaluating {} deterministic centroid seed(s)",
+                        training_count,
+                        validation_count,
+                        seeds.len(),
+                    );
+                } else {
+                    log::info!(
+                        "Field {field_id}: training all {} sampled vectors with one deterministic \
+                         centroid seed; model-selection holdout disabled",
+                        training_count,
+                    );
+                }
+
+                let mut base_config = crate::structures::CoarseConfig::new(dim, num_clusters)
                     .with_routing(config.ivf_routing);
                 if let Some(soar) = config.soar.clone() {
-                    coarse_config = coarse_config.with_soar(soar);
+                    base_config = base_config.with_soar(soar);
                 }
-                // Faiss-style clustering ceiling: past ~256 points per
-                // centroid, extra samples multiply every Lloyd iteration
-                // without materially moving the centroids. Stride-subsample
-                // the (already stratified) training set past that.
-                let ceiling = num_clusters.saturating_mul(COARSE_TRAINING_POINTS_PER_CENTROID);
-                let training_set: Vec<Vec<f32>> = if vectors.len() > ceiling && ceiling > 0 {
-                    log::info!(
-                        "Field {field_id}: capping coarse training at {ceiling} of {} samples \
-                         ({COARSE_TRAINING_POINTS_PER_CENTROID}/centroid)",
-                        vectors.len(),
+
+                let mut selected: Option<(
+                    crate::structures::CoarseCentroids,
+                    Option<FloatBuildQuality>,
+                    u64,
+                )> = None;
+                for &seed in seeds {
+                    let candidate = crate::structures::CoarseCentroids::train_contiguous(
+                        &base_config.clone().with_seed(seed),
+                        training_values,
+                        training_count,
                     );
-                    (0..ceiling)
-                        .map(|index| vectors[index.saturating_mul(vectors.len()) / ceiling].clone())
-                        .collect()
+                    let quality =
+                        evaluate_float_build_quality(&candidate, validation, config.ivf_routing);
+                    if let Some(quality) = quality {
+                        log::info!(
+                            "Field {field_id} IVF candidate seed={seed}: objective={:.6}, \
+                             exact/routed_mean_distortion={:.6}/{:.6}, router_recall@1={:.4}, \
+                             construction_postings/vector={:.3}, \
+                             residual_scale[p50/p95/p99]={:.4}/{:.4}/{:.4}, \
+                             construction_occupancy[p95/p99/max/empty]={}/{}/{}/{}",
+                            quality.objective,
+                            quality.mean_exact_distortion,
+                            quality.mean_routed_distortion,
+                            quality.router_recall_at_1,
+                            quality.mean_construction_assignments,
+                            quality.residual_p50,
+                            quality.residual_p95,
+                            quality.residual_p99,
+                            quality.occupancy.p95,
+                            quality.occupancy.p99,
+                            quality.occupancy.max,
+                            quality.occupancy.empty,
+                        );
+                    }
+                    let replace = selected.as_ref().is_none_or(|(_, best, _)| {
+                        quality
+                            .map(|quality| quality.objective)
+                            .unwrap_or(f64::INFINITY)
+                            .total_cmp(
+                                &best
+                                    .map(|quality| quality.objective)
+                                    .unwrap_or(f64::INFINITY),
+                            )
+                            .is_lt()
+                    });
+                    if replace {
+                        selected = Some((candidate, quality, seed));
+                    }
+                }
+                let (mut centroids, quality, seed) =
+                    selected.expect("the fixed centroid seed bank is non-empty");
+                if let Some(quality) = quality {
+                    log::info!(
+                        "Field {field_id}: selected IVF seed {seed} with held-out objective {:.6} \
+                         (occupancy penalty {:.4})",
+                        quality.objective,
+                        quality.occupancy.penalty,
+                    );
                 } else {
-                    Vec::new()
-                };
-                let training_ref: &[Vec<f32>] = if training_set.is_empty() {
-                    vectors
-                } else {
-                    &training_set
-                };
-                TrainedFieldArtifacts::FloatCentroids(crate::structures::CoarseCentroids::train(
-                    &coarse_config,
-                    training_ref,
-                ))
+                    log::info!(
+                        "Field {field_id}: selected IVF seed {seed} without a model-selection \
+                         holdout",
+                    );
+                }
+                centroids.version =
+                    crate::structures::mark_ivf_tq_cosine_generation(centroids.version);
+                TrainedFieldArtifacts::FloatCentroids(centroids)
             }
             (IvfFieldConfig::Binary(config), TrainingSample::Binary(codes)) => {
+                let byte_len = dim.div_ceil(8);
+                let training_count = codes.len() / byte_len;
                 let mut binary_config = crate::structures::BinaryIvfConfig::new(dim, num_clusters);
-                binary_config.max_train_samples = sample_count;
+                binary_config.max_train_samples = training_count;
                 binary_config.routing = config.ivf_routing;
-                TrainedFieldArtifacts::Binary(
-                    crate::structures::BinaryCoarseQuantizer::train(
-                        binary_config,
-                        codes,
-                        sample_count,
-                    )
-                    .map_err(Error::Io)?,
+                let quantizer = crate::structures::BinaryCoarseQuantizer::train(
+                    binary_config,
+                    codes,
+                    training_count,
                 )
+                .map_err(Error::Io)?;
+                TrainedFieldArtifacts::Binary(quantizer)
             }
             _ => {
                 return Err(Error::Internal(format!(
@@ -1004,6 +1402,139 @@ mod tests {
     }
 
     #[test]
+    fn final_sample_is_selected_at_the_points_per_centroid_ceiling() {
+        let config = IvfFieldConfig::Float(DenseVectorConfig::ivf_tq(8, Some(4), 1));
+        assert_eq!(
+            final_training_sample_count(&config, 10_000, 10_000).unwrap(),
+            4 * COARSE_TRAINING_POINTS_PER_CENTROID,
+        );
+        assert_eq!(
+            final_training_sample_count(&config, 10_000, 512).unwrap(),
+            512,
+        );
+    }
+
+    #[test]
+    fn holdout_preserves_the_training_points_per_centroid_floor() {
+        assert_eq!(validation_sample_count(390, 10, 8), 0);
+        assert_eq!(validation_sample_count(391, 10, 8), 1);
+
+        let config = IvfFieldConfig::Float(ivf_config(None));
+        let sample_count = 1_000;
+        let clusters = effective_field_num_clusters(&config, 10_000, sample_count).unwrap();
+        let held_out = validation_sample_count(sample_count, clusters, config.dim());
+        assert!(
+            sample_count - held_out >= clusters.saturating_mul(MIN_TRAINING_POINTS_PER_CENTROID)
+        );
+    }
+
+    #[test]
+    fn deterministic_point_sample_is_sorted_unique_and_repeatable() {
+        let first = deterministic_sample_ordinals(10_000, 1_000, 7);
+        let repeated = deterministic_sample_ordinals(10_000, 1_000, 7);
+        let other_seed = deterministic_sample_ordinals(10_000, 1_000, 8);
+        assert_eq!(first, repeated);
+        assert_ne!(first, other_seed);
+        assert_eq!(first.len(), 1_000);
+        assert!(first.windows(2).all(|pair| pair[0] < pair[1]));
+        assert!(first.iter().all(|&ordinal| ordinal < 10_000));
+    }
+
+    #[test]
+    fn model_selection_accounts_for_initialization_and_all_lloyd_passes() {
+        assert_eq!(model_selection_seeds(1_000, 16, 8, true).len(), 2);
+        assert_eq!(model_selection_seeds(1_000, 16, 8, false).len(), 1);
+        // A single assignment pass is only 180M coordinate comparisons, but
+        // two complete initialization/refinement candidates exceed the budget.
+        assert_eq!(model_selection_seeds(1_800, 1_000, 100, true).len(), 1);
+        assert_eq!(
+            model_selection_seeds(MAX_MULTI_SEED_COORDINATE_WORK, 2, 1, true).len(),
+            1,
+        );
+    }
+
+    #[test]
+    fn flat_float_sample_partitions_a_deterministic_holdout_suffix() {
+        let original: Vec<f32> = (0..20).map(|value| value as f32).collect();
+        let mut first = original.clone();
+        let mut repeated = original.clone();
+        let validation_count = validation_sample_count(10, 2, 2);
+        let first_split = partition_contiguous_holdout_suffix(&mut first, 2, validation_count, 11);
+        let repeated_split =
+            partition_contiguous_holdout_suffix(&mut repeated, 2, validation_count, 11);
+
+        assert_eq!(first, repeated);
+        assert_eq!(first_split, repeated_split);
+        assert_eq!(first_split, 18);
+        assert_eq!(first.len(), original.len());
+        assert_eq!(first[first_split..].len(), 2);
+
+        let mut first_components: Vec<u32> =
+            first.chunks_exact(2).map(|row| row[0] as u32).collect();
+        first_components.sort_unstable();
+        assert_eq!(first_components, vec![0, 2, 4, 6, 8, 10, 12, 14, 16, 18]);
+        assert!(first.chunks_exact(2).all(|row| row[1] == row[0] + 1.0));
+    }
+
+    #[test]
+    fn occupancy_report_exposes_tail_and_empty_cells() {
+        let report = occupancy_quality(vec![0, 1, 2, 7], 10);
+        assert_eq!(report.p95, 7);
+        assert_eq!(report.p99, 7);
+        assert_eq!(report.max, 7);
+        assert_eq!(report.empty, 1);
+        assert!(report.penalty > 0.0);
+    }
+
+    #[test]
+    fn model_selection_objective_prices_routed_distortion_excess() {
+        let objective = float_model_selection_objective(2.0, 3.0, 0.1);
+        assert!((objective - 3.2).abs() < f64::EPSILON);
+        assert_eq!(float_model_selection_objective(2.0, 1.5, 0.0), 2.0);
+    }
+
+    #[test]
+    fn float_quality_reports_exact_query_router_recall() {
+        let training = [0.0, 0.0, 0.1, 0.0, 10.0, 10.0, 10.1, 10.0];
+        let config = crate::structures::CoarseConfig::new(2, 2);
+        let centroids = crate::structures::CoarseCentroids::train_contiguous(&config, &training, 4);
+        for routing in [
+            crate::dsl::IvfRoutingMode::Flat,
+            crate::dsl::IvfRoutingMode::Auto,
+        ] {
+            let quality =
+                evaluate_float_build_quality(&centroids, &[0.05, 0.0, 10.05, 10.0], routing)
+                    .unwrap();
+
+            assert_eq!(quality.router_recall_at_1, 1.0);
+            assert!(
+                (quality.mean_exact_distortion - quality.mean_routed_distortion).abs()
+                    < f64::EPSILON
+            );
+            assert_eq!(quality.mean_construction_assignments, 1.0);
+            assert_eq!(quality.occupancy.empty, 0);
+        }
+    }
+
+    #[test]
+    fn float_quality_counts_soar_secondary_postings_in_occupancy() {
+        let training = [0.0, 0.0, 0.1, 0.0, 10.0, 10.0, 10.1, 10.0];
+        let config = crate::structures::CoarseConfig::new(2, 2)
+            .with_routing(crate::dsl::IvfRoutingMode::Flat)
+            .with_soar(crate::structures::SoarConfig::full());
+        let centroids = crate::structures::CoarseCentroids::train_contiguous(&config, &training, 4);
+        let quality = evaluate_float_build_quality(
+            &centroids,
+            &[0.05, 0.0, 10.05, 10.0],
+            crate::dsl::IvfRoutingMode::Flat,
+        )
+        .unwrap();
+
+        assert_eq!(quality.mean_construction_assignments, 2.0);
+        assert_eq!(quality.occupancy.empty, 0);
+    }
+
+    #[test]
     fn artifact_writer_enforces_limit_without_writing_past_it() {
         let mut output = Vec::new();
         let mut writer = SizeLimitedWriter::new(&mut output, 3);
@@ -1011,6 +1542,59 @@ mod tests {
         let error = writer.write_all(&[3, 4]).unwrap_err().to_string();
         assert!(error.contains("3-byte safety limit"), "{error}");
         assert_eq!(output, vec![1, 2]);
+    }
+
+    #[test]
+    fn ivf_tq_training_marks_generation_normalizes_and_calibrates_default_soar() {
+        let config = IvfFieldConfig::Float(DenseVectorConfig::ivf_tq(2, Some(1), 1));
+        let mut sample = TrainingSample::Float(vec![3.0, 4.0, 30.0, 40.0, 300.0, 400.0]);
+        let model = IndexWriter::<crate::directories::RamDirectory>::train_field_model(
+            Field(3),
+            &config,
+            &mut sample,
+            3,
+            "test",
+        )
+        .unwrap();
+        let TrainedFieldArtifacts::FloatCentroids(centroids) = model.artifacts else {
+            panic!("expected float IVF-TQ centroids");
+        };
+
+        assert!(crate::structures::is_ivf_tq_cosine_generation(
+            centroids.version
+        ));
+        assert!((centroids.centroids[0] - 0.6).abs() < 1e-6);
+        assert!((centroids.centroids[1] - 0.8).abs() < 1e-6);
+        let soar = centroids
+            .soar_config
+            .as_ref()
+            .expect("default SOAR should propagate into the trained router");
+        assert_eq!(soar.num_secondary, 1);
+        assert!(soar.selective);
+        assert!(
+            soar.spill_threshold > 0.0,
+            "the negative 30% target tag should be replaced by a calibrated threshold"
+        );
+        assert_eq!(soar.calibration_target(), None);
+    }
+
+    #[test]
+    fn explicitly_disabled_soar_stays_off_during_ivf_tq_training() {
+        let config = IvfFieldConfig::Float(DenseVectorConfig::ivf_tq(2, Some(1), 1).without_soar());
+        let mut sample = TrainingSample::Float(vec![3.0, 4.0, 30.0, 40.0, 300.0, 400.0]);
+        let model = IndexWriter::<crate::directories::RamDirectory>::train_field_model(
+            Field(3),
+            &config,
+            &mut sample,
+            3,
+            "test-no-soar",
+        )
+        .unwrap();
+        let TrainedFieldArtifacts::FloatCentroids(centroids) = model.artifacts else {
+            panic!("expected float IVF-TQ centroids");
+        };
+
+        assert!(centroids.soar_config.is_none());
     }
 
     // ===== rebuild destructive-downgrade regression tests =====

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -2753,6 +2753,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         &self,
         reader: &SegmentReader,
         field_ids: &[u32],
+        trained: &TrainedVectorStructures,
         rewrite_existing: bool,
     ) -> Result<bool> {
         for &field_id in field_ids {
@@ -2797,7 +2798,31 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                         config.index_type == crate::dsl::VectorIndexType::IvfTq
                     }) =>
                 {
-                    matches!(ann, Some(crate::segment::VectorIndex::IvfTq { .. }))
+                    let config = entry
+                        .dense_vector_config
+                        .as_ref()
+                        .expect("matched IVF-TQ configuration");
+                    match (ann, trained.centroids.get(&field_id)) {
+                        (
+                            Some(crate::segment::VectorIndex::IvfTq { index, .. }),
+                            Some(centroids),
+                        ) => {
+                            let header = index.get().header();
+                            crate::structures::is_ivf_tq_cosine_generation(centroids.version)
+                                && crate::structures::is_ivf_tq_cosine_generation(
+                                    header.quantizer_version,
+                                )
+                                && header.dim == config.dim
+                                && header.num_clusters == centroids.num_clusters
+                                && header.quantizer_version == centroids.version
+                                && header.codebook_version
+                                    == crate::structures::vector::quantization::tq_expected_fingerprint(
+                                        config.dim,
+                                    )
+                                && header.routing == config.ivf_routing
+                        }
+                        _ => false,
+                    }
                 }
                 // Only ivf_tq dense fields are trainable; other dense
                 // index types never reach a vector-generation rewrite.
@@ -2939,7 +2964,12 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 self.term_cache_blocks,
             )
             .await?;
-            if !self.segment_needs_vector_rewrite(&reader, field_ids, rewrite_existing)? {
+            if !self.segment_needs_vector_rewrite(
+                &reader,
+                field_ids,
+                trained.as_ref(),
+                rewrite_existing,
+            )? {
                 continue;
             }
             drop(reader);
@@ -2961,7 +2991,12 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 self.term_cache_blocks,
             )
             .await?;
-            if self.segment_needs_vector_rewrite(&output_reader, field_ids, false)? {
+            if self.segment_needs_vector_rewrite(
+                &output_reader,
+                field_ids,
+                trained.as_ref(),
+                false,
+            )? {
                 return Err(Error::Corruption(format!(
                     "staged vector segment {new_id} does not match its candidate codebook generation"
                 )));
@@ -3025,7 +3060,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             self.term_cache_blocks,
         )
         .await?;
-        if !self.segment_needs_vector_rewrite(&reader, field_ids, false)? {
+        if !self.segment_needs_vector_rewrite(&reader, field_ids, trained.as_ref(), false)? {
             return Ok(VectorSegmentRewriteOutcome::AlreadyCurrent);
         }
         drop(reader);

--- a/hermes-core/src/segment/ann_build.rs
+++ b/hermes-core/src/segment/ann_build.rs
@@ -20,8 +20,8 @@ pub const IVF_TQ_TYPE: u8 = 8;
 #[cfg(feature = "native")]
 use crate::structures::CoarseCentroids;
 
-/// Encode one segment's vectors into IVF-TQ leaves against the trained
-/// global coarse centroids.
+/// Encode one segment's vectors into IVF-TQ leaves against the trained global
+/// cosine-space centroids.
 #[cfg(feature = "native")]
 pub fn build_ivf_tq(
     dim: usize,
@@ -30,6 +30,13 @@ pub fn build_ivf_tq(
     doc_id_ordinals: &[(u32, u16)],
     vectors: &[f32],
 ) -> crate::Result<Vec<u8>> {
+    if !crate::structures::is_ivf_tq_cosine_generation(centroids.version) {
+        return Err(crate::Error::Corruption(
+            "legacy raw IVF-TQ centroids cannot encode a correct cosine index; \
+             rebuild the index with a current Hermes version"
+                .into(),
+        ));
+    }
     let codec = crate::structures::vector::quantization::tq_shared_codec(dim);
     let mut index = crate::structures::IvfTqIndex::new(dim, routing, centroids.version, codec);
     index
@@ -58,4 +65,56 @@ pub fn build_tq_flat(
     crate::segment::ann_disk::write_built_tq_flat(&builder, &mut bytes)
         .map_err(crate::Error::Io)?;
     Ok(bytes)
+}
+
+#[cfg(all(test, feature = "native"))]
+mod tests {
+    use super::*;
+    use crate::directories::OwnedBytes;
+    use crate::dsl::IvfRoutingMode;
+    use crate::segment::ann_disk::{AnnDiskIndex, AnnKind};
+
+    #[test]
+    fn ivf_tq_header_preserves_cosine_generation_marker() {
+        let marked = crate::structures::mark_ivf_tq_cosine_generation(7);
+        let centroids = CoarseCentroids {
+            num_clusters: 1,
+            dim: 2,
+            centroids: vec![1.0, 0.0],
+            version: marked,
+            soar_config: None,
+            routing_index: None,
+        };
+        let bytes = build_ivf_tq(
+            2,
+            IvfRoutingMode::Flat,
+            &centroids,
+            &[(0, 0)],
+            &[100.0, 0.0],
+        )
+        .unwrap();
+        let disk = AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::IvfTq, 1).unwrap();
+
+        assert_eq!(disk.header().quantizer_version, marked);
+        assert!(crate::structures::is_ivf_tq_cosine_generation(
+            disk.header().quantizer_version
+        ));
+    }
+
+    #[test]
+    fn ivf_tq_build_rejects_legacy_raw_generation() {
+        let centroids = CoarseCentroids {
+            num_clusters: 1,
+            dim: 2,
+            centroids: vec![1.0, 0.0],
+            version: 7,
+            soar_config: None,
+            routing_index: None,
+        };
+        let error = build_ivf_tq(2, IvfRoutingMode::Flat, &centroids, &[(0, 0)], &[1.0, 0.0])
+            .expect_err("legacy IVF-TQ generation must not encode new segments")
+            .to_string();
+        assert!(error.contains("legacy raw IVF-TQ"), "{error}");
+        assert!(error.contains("rebuild the index"), "{error}");
+    }
 }

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -24,7 +24,7 @@ use crate::dsl::IvfRoutingMode;
 
 #[cfg(feature = "native")]
 use crate::structures::BinaryIvfIndex;
-use crate::structures::vector::index::BoundedAnnCollector;
+use crate::structures::vector::index::{BoundedAnnCollector, BoundedUniqueAnnCollector};
 
 const ANN_HEADER_MAGIC: u32 = 0x3152_4e41; // "ANR1"
 const ANN_FOOTER_MAGIC: u32 = 0x3146_4e41; // "ANF1"
@@ -42,8 +42,11 @@ const BINARY_SCORE_BATCH: usize = 8_192;
 /// with `γ < 1`, kept with slack so pruning can never drop a candidate the
 /// unpruned scan would have kept (pinned by a test).
 const TQ_PRUNE_ESTIMATE_BOUND: f32 = 1.3;
-/// Flat TQ scans fan out across Rayon above this vector count; the merge of
-/// per-task collectors costs ~k per task, so small segments stay sequential.
+/// Flat TQ scans fan out across Rayon above this vector count. Rayon folds
+/// chunks into one collector per worker before reducing those collectors, so
+/// temporary top-k memory is bounded by the active worker count rather than
+/// the number of chunks. Small segments stay sequential because fan-out
+/// overhead would dominate.
 #[cfg(feature = "native")]
 const TQ_PARALLEL_SCAN_MIN_VECTORS: usize = 65_536;
 #[cfg(feature = "native")]
@@ -127,6 +130,17 @@ pub(crate) struct AnnDiskIndex {
     raw: OwnedBytes,
     header: AnnDiskHeader,
     runs: Vec<AnnRun>,
+}
+
+/// A document selected by a combiner-aware compressed scan.
+///
+/// This intentionally has no ordinal: `score` combines every value belonging
+/// to the document and must never be reused as an individual vector score by
+/// an exact reranker.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct AnnDocumentCandidate {
+    pub(crate) doc_id: u32,
+    pub(crate) score: f32,
 }
 
 impl AnnDiskIndex {
@@ -364,6 +378,179 @@ impl AnnDiskIndex {
             self.raw.madvise_range(range, libc::MADV_WILLNEED);
         }
     }
+
+    /// Score a flat TQ payload while every value of a document is still in
+    /// hand, combine those approximate scores, and retain document-level
+    /// top-k. TQ build runs preserve `(doc_id, ordinal)` input order, so the
+    /// scratch space is bounded by one document plus the retained heap.
+    pub(crate) fn search_tq_combined_documents(
+        &self,
+        k: usize,
+        plan: &crate::structures::TqQueryPlan,
+        combiner: crate::query::MultiValueCombiner,
+    ) -> io::Result<Vec<AnnDocumentCandidate>> {
+        use crate::structures::vector::quantization::{TQ_BLOCK_LANES, tq_block_bytes};
+
+        combiner
+            .validate()
+            .map_err(|message| io::Error::new(io::ErrorKind::InvalidInput, message))?;
+        if plan.padded_dim() != self.header.code_size * 2 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TQ query plan does not match the payload dimension",
+            ));
+        }
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+
+        let block_bytes = tq_block_bytes(self.header.code_size);
+        let bytes = self.raw.as_slice();
+        let mut top_documents = BoundedAnnCollector::<true, true>::new(k);
+        let mut ordinal_scores = Vec::new();
+        let mut scores = [0.0f32; TQ_BLOCK_LANES];
+
+        for run in &self.runs {
+            let mut current_doc = None;
+            let codes = &bytes[run.codes.clone()];
+            for (block_index, block) in codes.chunks_exact(block_bytes).enumerate() {
+                crate::structures::vector::quantization::tq_score_block(plan, block, &mut scores);
+                let lane_base = block_index * TQ_BLOCK_LANES;
+                let lanes = TQ_BLOCK_LANES.min(run.count.saturating_sub(lane_base));
+                for (lane, &score) in scores.iter().enumerate().take(lanes) {
+                    let index = lane_base + lane;
+                    let doc_id = run_doc_id(bytes, run, index)?;
+                    if current_doc.is_some_and(|previous| doc_id < previous) {
+                        return Err(invalid_data("flat TQ run is not grouped by document ID"));
+                    }
+                    if current_doc.is_some_and(|previous| doc_id != previous) {
+                        retain_combined_document(
+                            &mut top_documents,
+                            current_doc.expect("current document is present"),
+                            &ordinal_scores,
+                            combiner,
+                        );
+                        ordinal_scores.clear();
+                    }
+                    current_doc = Some(doc_id);
+                    if score.is_finite() {
+                        ordinal_scores.push((
+                            u32::from(read_u16(bytes, run.ordinals.start + index * 2)),
+                            score,
+                        ));
+                    }
+                }
+            }
+            if let Some(doc_id) = current_doc {
+                retain_combined_document(&mut top_documents, doc_id, &ordinal_scores, combiner);
+                ordinal_scores.clear();
+            }
+        }
+
+        Ok(top_documents
+            .into_sorted_results()
+            .into_iter()
+            .map(|(doc_id, _, score)| AnnDocumentCandidate { doc_id, score })
+            .collect())
+    }
+
+    /// Score every posting in the probed IVF-TQ leaves, deduplicate SOAR
+    /// assignments by `(doc_id, ordinal)`, combine every approximate ordinal
+    /// present in the probed leaves, and retain at most `k` documents.
+    ///
+    /// Unlike the Max path, this deliberately performs no individual-score
+    /// pruning: an ordinal that cannot enter vector top-k may still change a
+    /// Sum, Avg, LogSumExp, or WeightedTopK document score.
+    pub(crate) fn search_ivf_tq_combined_documents(
+        &self,
+        k: usize,
+        plan: &crate::structures::TqIvfQueryPlan,
+        combiner: crate::query::MultiValueCombiner,
+    ) -> io::Result<Vec<AnnDocumentCandidate>> {
+        use crate::structures::vector::quantization::{
+            TQ_BLOCK_LANES, tq_ivf_block_bytes, tq_score_ivf_block,
+        };
+
+        validate_combined_search(combiner)?;
+        let tq_plan = plan.tq_plan();
+        self.validate_ivf_tq_query_plan(plan)?;
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        #[cfg(feature = "native")]
+        self.prefetch_cluster_runs(&plan.cluster_ids);
+
+        let block_bytes = tq_ivf_block_bytes(self.header.code_size);
+        let bytes = self.raw.as_slice();
+        let mut ordinal_scores = Vec::new();
+        ordinal_scores
+            .try_reserve_exact(probed_posting_count(self, &plan.cluster_ids)?)
+            .map_err(|_| invalid_data("IVF-TQ combined score buffer allocation failed"))?;
+        let mut scores = [0.0f32; TQ_BLOCK_LANES];
+        for (cluster_id, cluster_dot) in plan.cluster_dots() {
+            for run in self.cluster_runs(cluster_id) {
+                let codes = &bytes[run.codes.clone()];
+                for (block_index, block) in codes.chunks_exact(block_bytes).enumerate() {
+                    tq_score_ivf_block(tq_plan, block, cluster_dot, &mut scores);
+                    let lane_base = block_index * TQ_BLOCK_LANES;
+                    let lanes = TQ_BLOCK_LANES.min(run.count.saturating_sub(lane_base));
+                    for (lane, &score) in scores.iter().enumerate().take(lanes) {
+                        if !score.is_finite() {
+                            continue;
+                        }
+                        let index = lane_base + lane;
+                        ordinal_scores.push((
+                            run_doc_id(bytes, run, index)?,
+                            read_u16(bytes, run.ordinals.start + index * 2),
+                            score,
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(combine_scored_ordinals(ordinal_scores, k, combiner))
+    }
+
+    /// Score packed codes in the selected binary-IVF leaves, deduplicate
+    /// repeated `(doc_id, ordinal)` assignments, combine per document, and
+    /// retain at most `k` approximate document candidates.
+    pub(crate) fn search_binary_combined_documents(
+        &self,
+        k: usize,
+        query: &[u8],
+        cluster_ids: &[u32],
+        combiner: crate::query::MultiValueCombiner,
+    ) -> io::Result<Vec<AnnDocumentCandidate>> {
+        validate_combined_search(combiner)?;
+        if query.len() != self.header.code_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "binary ANN query has the wrong byte length",
+            ));
+        }
+        if k == 0 {
+            return Ok(Vec::new());
+        }
+        #[cfg(feature = "native")]
+        self.prefetch_cluster_runs(cluster_ids);
+
+        let bytes = self.raw.as_slice();
+        let mut score_batch = vec![0.0f32; BINARY_SCORE_BATCH.min(self.header.vector_count)];
+        let mut ordinal_scores = Vec::new();
+        ordinal_scores
+            .try_reserve_exact(probed_posting_count(self, cluster_ids)?)
+            .map_err(|_| invalid_data("binary combined score buffer allocation failed"))?;
+        score_binary_cluster_runs(
+            self,
+            bytes,
+            query,
+            cluster_ids,
+            &mut score_batch,
+            &mut ordinal_scores,
+        )?;
+        Ok(combine_scored_ordinals(ordinal_scores, k, combiner))
+    }
+
     /// Score every TQ block against the query plan and keep the top `k`
     /// distinct documents by estimated similarity.
     pub(crate) fn search_tq_distinct(
@@ -382,54 +569,58 @@ impl AnnDiskIndex {
         let block_bytes = tq_block_bytes(self.header.code_size);
         let bytes = self.raw.as_slice();
 
-        // Large flat scans are CPU-bound on the LUT16 kernel; fan blocks out
-        // across the Rayon pool with per-task collectors and merge. Small
-        // segments stay sequential — the fan-out overhead would dominate.
+        // Large flat scans are CPU-bound on the LUT16 kernel. Fold chunks into
+        // worker-local collectors and reduce them directly: materializing one
+        // top-k Vec per chunk would make temporary memory O(chunks * k) on
+        // large segments instead of O(workers * k).
         #[cfg(feature = "native")]
         if self.header.vector_count >= TQ_PARALLEL_SCAN_MIN_VECTORS {
             use rayon::prelude::*;
-            let partials: Vec<io::Result<Vec<(u32, u16, f32)>>> = self
+            let collector = self
                 .runs
                 .par_iter()
-                .flat_map_iter(|run| {
+                .flat_map(|run| {
                     let codes = &bytes[run.codes.clone()];
                     let blocks = codes.len() / block_bytes;
                     (0..blocks.div_ceil(TQ_PARALLEL_SCAN_CHUNK_BLOCKS))
+                        .into_par_iter()
                         .map(move |chunk| (run, chunk * TQ_PARALLEL_SCAN_CHUNK_BLOCKS, blocks))
                 })
-                .map(|(run, first_block, total_blocks)| {
-                    let codes = &bytes[run.codes.clone()];
-                    let last_block =
-                        (first_block + TQ_PARALLEL_SCAN_CHUNK_BLOCKS).min(total_blocks);
-                    let mut collector = BoundedAnnCollector::<true, true>::new(k);
-                    let mut scores = [0.0f32; TQ_BLOCK_LANES];
-                    for block_index in first_block..last_block {
-                        let block = &codes[block_index * block_bytes..][..block_bytes];
-                        crate::structures::vector::quantization::tq_score_block(
-                            plan,
-                            block,
-                            &mut scores,
-                        );
-                        let lane_base = block_index * TQ_BLOCK_LANES;
-                        let lanes = TQ_BLOCK_LANES.min(run.count.saturating_sub(lane_base));
-                        for (lane, &score) in scores.iter().enumerate().take(lanes) {
-                            let index = lane_base + lane;
-                            collector.insert(
-                                run_doc_id(bytes, run, index)?,
-                                read_u16(bytes, run.ordinals.start + index * 2),
-                                score,
+                .try_fold(
+                    || BoundedAnnCollector::<true, true>::new(k),
+                    |mut collector, (run, first_block, total_blocks)| {
+                        let codes = &bytes[run.codes.clone()];
+                        let last_block =
+                            (first_block + TQ_PARALLEL_SCAN_CHUNK_BLOCKS).min(total_blocks);
+                        let mut scores = [0.0f32; TQ_BLOCK_LANES];
+                        for block_index in first_block..last_block {
+                            let block = &codes[block_index * block_bytes..][..block_bytes];
+                            crate::structures::vector::quantization::tq_score_block(
+                                plan,
+                                block,
+                                &mut scores,
                             );
+                            let lane_base = block_index * TQ_BLOCK_LANES;
+                            let lanes = TQ_BLOCK_LANES.min(run.count.saturating_sub(lane_base));
+                            for (lane, &score) in scores.iter().enumerate().take(lanes) {
+                                let index = lane_base + lane;
+                                collector.insert(
+                                    run_doc_id(bytes, run, index)?,
+                                    read_u16(bytes, run.ordinals.start + index * 2),
+                                    score,
+                                );
+                            }
                         }
-                    }
-                    Ok(collector.into_sorted_results())
-                })
-                .collect();
-            let mut collector = BoundedAnnCollector::<true, true>::new(k);
-            for partial in partials {
-                for (doc_id, ordinal, score) in partial? {
-                    collector.insert(doc_id, ordinal, score);
-                }
-            }
+                        Ok::<_, io::Error>(collector)
+                    },
+                )
+                .try_reduce(
+                    || BoundedAnnCollector::<true, true>::new(k),
+                    |mut collector, partial| {
+                        collector.merge_from(partial);
+                        Ok(collector)
+                    },
+                )?;
             return Ok(collector.into_sorted_results());
         }
 
@@ -455,11 +646,12 @@ impl AnnDiskIndex {
     }
 
     /// Score the probed IVF-TQ leaves and keep the top `k` distinct
-    /// documents by estimated similarity (`⟨q̂,c⟩ + scale·⟨q̂,r̂⟩`).
+    /// documents by estimated cosine similarity
+    /// (`⟨q̂,c⟩ + scale·⟨q̂,r̂⟩`).
     ///
-    /// Blocks whose best possible estimate cannot beat the running k-th
-    /// score are skipped; clusters are serialized in descending residual
-    /// scale, so the first losing block ends its run.
+    /// Blocks whose best possible estimate cannot beat the running k-th score
+    /// terminate their run. The supported cosine generation guarantees that
+    /// residual scales are stored in descending order.
     pub(crate) fn search_ivf_tq_distinct(
         &self,
         k: usize,
@@ -470,12 +662,7 @@ impl AnnDiskIndex {
         };
 
         let tq_plan = plan.tq_plan();
-        if tq_plan.padded_dim() != self.header.code_size * 2 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "IVF-TQ query plan does not match the payload dimension",
-            ));
-        }
+        self.validate_ivf_tq_query_plan(plan)?;
         #[cfg(feature = "native")]
         self.prefetch_cluster_runs(&plan.cluster_ids);
         let block_bytes = tq_ivf_block_bytes(self.header.code_size);
@@ -487,20 +674,12 @@ impl AnnDiskIndex {
         for (cluster_id, cluster_dot) in plan.cluster_dots() {
             for run in self.cluster_runs(cluster_id) {
                 let codes = &bytes[run.codes.clone()];
-                let total_blocks = codes.len() / block_bytes;
+                let block_count = codes.len() / block_bytes;
                 for (block_index, block) in codes.chunks_exact(block_bytes).enumerate() {
-                    // Clusters are written in descending residual-scale
-                    // order, so once this block's best possible score cannot
-                    // beat the running k-th, no later block in the run can.
                     if let Some(threshold) = collector.pruning_threshold() {
-                        let max_scale = block[..TQ_BLOCK_LANES * size_of::<f32>()]
-                            .chunks_exact(4)
-                            .map(|lane| {
-                                f32::from_le_bytes(lane.try_into().expect("scale is 4 bytes"))
-                            })
-                            .fold(0.0f32, f32::max);
+                        let max_scale = tq_ivf_block_max_scale(block);
                         if cluster_dot + max_scale * TQ_PRUNE_ESTIMATE_BOUND <= threshold {
-                            pruned_blocks += total_blocks - block_index;
+                            pruned_blocks += block_count - block_index;
                             break;
                         }
                     }
@@ -528,13 +707,35 @@ impl AnnDiskIndex {
         Ok(collector.into_sorted_results())
     }
 
+    fn validate_ivf_tq_query_plan(
+        &self,
+        plan: &crate::structures::TqIvfQueryPlan,
+    ) -> io::Result<()> {
+        if self.header.kind != AnnKind::IvfTq
+            || !crate::structures::is_ivf_tq_cosine_generation(self.header.quantizer_version)
+        {
+            return Err(invalid_data(
+                "legacy raw IVF-TQ payloads cannot be searched; rebuild the index",
+            ));
+        }
+        if plan.tq_plan().padded_dim() != self.header.code_size * 2
+            || plan.quantizer_version != self.header.quantizer_version
+            || plan.fingerprint != self.header.codebook_version
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "IVF-TQ query plan does not match the payload generation",
+            ));
+        }
+        Ok(())
+    }
+
     pub(crate) fn search_binary_clusters<const BY_DOCUMENT: bool>(
         &self,
         query: &[u8],
         k: usize,
         cluster_ids: &[u32],
     ) -> io::Result<Vec<(u32, u16, f32)>> {
-        let mut collector = BoundedAnnCollector::<BY_DOCUMENT, true>::new(k);
         if query.len() != self.header.code_size {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -545,19 +746,33 @@ impl AnnDiskIndex {
         self.prefetch_cluster_runs(cluster_ids);
         let bytes = self.raw.as_slice();
         let mut scores = vec![0.0f32; BINARY_SCORE_BATCH.min(self.header.vector_count)];
-        for &cluster_id in cluster_ids {
-            for run in self.cluster_runs(cluster_id) {
-                score_binary_run(
-                    bytes,
-                    run,
-                    query,
-                    self.header.dim,
-                    self.header.code_size,
-                    &mut scores,
-                    &mut collector,
-                )?;
-            }
+        if BY_DOCUMENT {
+            let mut collector = BoundedAnnCollector::<true, true>::new(k);
+            score_binary_cluster_runs(
+                self,
+                bytes,
+                query,
+                cluster_ids,
+                &mut scores,
+                &mut collector,
+            )?;
+            return Ok(collector.into_sorted_results());
         }
+
+        // A probe plan returns each leaf once and every indexed vector belongs
+        // to exactly one leaf, so `(doc_id, ordinal)` keys are unique here.
+        // Avoid the deduplication hash map in the common single-value path.
+        debug_assert!(
+            {
+                let mut seen = rustc_hash::FxHashSet::default();
+                cluster_ids
+                    .iter()
+                    .all(|cluster_id| seen.insert(*cluster_id))
+            },
+            "an IVF probe plan must not repeat a cluster",
+        );
+        let mut collector = BoundedUniqueAnnCollector::<true>::new(k);
+        score_binary_cluster_runs(self, bytes, query, cluster_ids, &mut scores, &mut collector)?;
         Ok(collector.into_sorted_results())
     }
 }
@@ -583,14 +798,78 @@ fn coalesce_prefetch_ranges(ranges: &mut Vec<Range<usize>>) {
     ranges.truncate(output_len);
 }
 
-fn score_binary_run<const BY_DOCUMENT: bool>(
+trait AnnScoreSink {
+    fn insert_score(&mut self, doc_id: u32, ordinal: u16, score: f32);
+}
+
+impl<const BY_DOCUMENT: bool> AnnScoreSink for BoundedAnnCollector<BY_DOCUMENT, true> {
+    #[inline]
+    fn insert_score(&mut self, doc_id: u32, ordinal: u16, score: f32) {
+        self.insert(doc_id, ordinal, score);
+    }
+}
+
+impl AnnScoreSink for BoundedUniqueAnnCollector<true> {
+    #[inline]
+    fn insert_score(&mut self, doc_id: u32, ordinal: u16, score: f32) {
+        self.insert(doc_id, ordinal, score);
+    }
+}
+
+impl AnnScoreSink for Vec<(u32, u16, f32)> {
+    #[inline]
+    fn insert_score(&mut self, doc_id: u32, ordinal: u16, score: f32) {
+        if score.is_finite() {
+            self.push((doc_id, ordinal, score));
+        }
+    }
+}
+
+fn probed_posting_count(index: &AnnDiskIndex, cluster_ids: &[u32]) -> io::Result<usize> {
+    cluster_ids.iter().try_fold(0usize, |count, &cluster_id| {
+        index
+            .cluster_runs(cluster_id)
+            .iter()
+            .try_fold(count, |count, run| {
+                count
+                    .checked_add(run.count)
+                    .ok_or_else(|| invalid_data("ANN probed posting count overflows usize"))
+            })
+    })
+}
+
+fn score_binary_cluster_runs(
+    index: &AnnDiskIndex,
+    bytes: &[u8],
+    query: &[u8],
+    cluster_ids: &[u32],
+    scores: &mut [f32],
+    collector: &mut impl AnnScoreSink,
+) -> io::Result<()> {
+    for &cluster_id in cluster_ids {
+        for run in index.cluster_runs(cluster_id) {
+            score_binary_run(
+                bytes,
+                run,
+                query,
+                index.header.dim,
+                index.header.code_size,
+                scores,
+                collector,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn score_binary_run(
     bytes: &[u8],
     run: &AnnRun,
     query: &[u8],
     dim_bits: usize,
     code_size: usize,
     scores: &mut [f32],
-    collector: &mut BoundedAnnCollector<BY_DOCUMENT, true>,
+    collector: &mut impl AnnScoreSink,
 ) -> io::Result<()> {
     for batch_start in (0..run.count).step_by(BINARY_SCORE_BATCH) {
         let batch_count = BINARY_SCORE_BATCH.min(run.count - batch_start);
@@ -605,7 +884,7 @@ fn score_binary_run<const BY_DOCUMENT: bool>(
         );
         for (batch_index, &score) in scores.iter().enumerate().take(batch_count) {
             let index = batch_start + batch_index;
-            collector.insert(
+            collector.insert_score(
                 run_doc_id(bytes, run, index)?,
                 read_u16(bytes, run.ordinals.start + index * 2),
                 score,
@@ -613,6 +892,88 @@ fn score_binary_run<const BY_DOCUMENT: bool>(
         }
     }
     Ok(())
+}
+
+#[inline]
+fn retain_combined_document(
+    collector: &mut BoundedAnnCollector<true, true>,
+    doc_id: u32,
+    ordinal_scores: &[(u32, f32)],
+    combiner: crate::query::MultiValueCombiner,
+) {
+    if !ordinal_scores.is_empty() {
+        collector.insert(doc_id, 0, combiner.combine(ordinal_scores));
+    }
+}
+
+fn validate_combined_search(combiner: crate::query::MultiValueCombiner) -> io::Result<()> {
+    combiner
+        .validate()
+        .map_err(|message| io::Error::new(io::ErrorKind::InvalidInput, message))
+}
+
+/// Sort arbitrary probed-run output into complete documents, retain the best
+/// estimate for every duplicated `(doc_id, ordinal)` SOAR assignment, then
+/// apply the requested combiner. The corpus-dependent scratch is one compact
+/// tuple per probed posting and never expands to unprobed leaves or raw
+/// vectors; final retained state is O(k).
+fn combine_scored_ordinals(
+    mut scores: Vec<(u32, u16, f32)>,
+    k: usize,
+    combiner: crate::query::MultiValueCombiner,
+) -> Vec<AnnDocumentCandidate> {
+    if k == 0 || scores.is_empty() {
+        return Vec::new();
+    }
+    scores.retain(|entry| entry.2.is_finite());
+    scores.sort_unstable_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+
+    // Compact duplicates in place. IVF-TQ SOAR copies can have slightly
+    // different residual estimates; preserving the highest one matches the
+    // legacy Max collector's duplicate semantics without double-counting it
+    // for additive combiners.
+    let mut unique_len = 0usize;
+    for read_index in 0..scores.len() {
+        let candidate = scores[read_index];
+        if unique_len > 0
+            && scores[unique_len - 1].0 == candidate.0
+            && scores[unique_len - 1].1 == candidate.1
+        {
+            if candidate.2.total_cmp(&scores[unique_len - 1].2).is_gt() {
+                scores[unique_len - 1].2 = candidate.2;
+            }
+        } else {
+            scores[unique_len] = candidate;
+            unique_len += 1;
+        }
+    }
+    scores.truncate(unique_len);
+
+    let mut top_documents = BoundedAnnCollector::<true, true>::new(k);
+    let mut current_doc = None;
+    let mut ordinal_scores = Vec::new();
+    for (doc_id, ordinal, score) in scores {
+        if current_doc.is_some_and(|current| current != doc_id) {
+            retain_combined_document(
+                &mut top_documents,
+                current_doc.expect("current document is present"),
+                &ordinal_scores,
+                combiner,
+            );
+            ordinal_scores.clear();
+        }
+        current_doc = Some(doc_id);
+        ordinal_scores.push((u32::from(ordinal), score));
+    }
+    if let Some(doc_id) = current_doc {
+        retain_combined_document(&mut top_documents, doc_id, &ordinal_scores, combiner);
+    }
+
+    top_documents
+        .into_sorted_results()
+        .into_iter()
+        .map(|(doc_id, _, score)| AnnDocumentCandidate { doc_id, score })
+        .collect()
 }
 
 #[cfg(feature = "native")]
@@ -657,6 +1018,11 @@ pub(crate) fn write_built_ivf_tq(
 ) -> io::Result<u64> {
     use crate::structures::vector::quantization::{TQ_BLOCK_LANES, tq_pack_ivf_block};
 
+    if !crate::structures::is_ivf_tq_cosine_generation(index.centroids_version) {
+        return Err(invalid_data(
+            "legacy raw IVF-TQ generations cannot be serialized; rebuild the index",
+        ));
+    }
     let codec = index.codec();
     let padded_dim = codec.padded_dim();
     let mut clusters: Vec<_> = index.clusters.iter().collect();
@@ -919,6 +1285,13 @@ fn write_merged_ann_impl(
     let Some((first, _)) = sources.first() else {
         return Err(invalid_data("cannot merge an empty ANN source list"));
     };
+    if first.header.kind == AnnKind::IvfTq
+        && !crate::structures::is_ivf_tq_cosine_generation(first.header.quantizer_version)
+    {
+        return Err(invalid_data(
+            "legacy raw IVF-TQ generations cannot be merged; rebuild the index",
+        ));
+    }
     let mut header = first.header.clone();
     header.vector_count = 0;
     for &(source, _) in sources {
@@ -1243,6 +1616,13 @@ fn checked_advance(offset: u64, length: usize) -> io::Result<u64> {
 }
 
 fn validate_header(header: &AnnDiskHeader) -> io::Result<()> {
+    if header.kind == AnnKind::IvfTq
+        && !crate::structures::is_ivf_tq_cosine_generation(header.quantizer_version)
+    {
+        return Err(invalid_data(
+            "IVF-TQ payload uses an unsupported legacy generation; rebuild the index",
+        ));
+    }
     if header.dim == 0
         || header.code_size == 0
         || header.num_clusters == 0
@@ -1276,6 +1656,18 @@ fn read_u32(bytes: &[u8], offset: usize) -> u32 {
 
 fn read_u16(bytes: &[u8], offset: usize) -> u16 {
     u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap())
+}
+
+#[inline]
+fn tq_ivf_block_max_scale(block: &[u8]) -> f32 {
+    // Supported cosine-generation writers sort the complete run by descending
+    // residual scale, so lane zero is both this block's maximum and an upper
+    // bound for every following block.
+    f32::from_le_bytes(
+        block[..size_of::<f32>()]
+            .try_into()
+            .expect("scale is one f32"),
+    )
 }
 
 fn run_doc_id(bytes: &[u8], run: &AnnRun, index: usize) -> io::Result<u32> {
@@ -1442,6 +1834,134 @@ mod tests {
         assert_eq!(docs, [0, 1, 2, 3, 4, 5]);
     }
 
+    #[test]
+    fn legacy_ivf_tq_payload_is_rejected_while_opening() {
+        let dim = 8;
+        let marked_version = crate::structures::mark_ivf_tq_cosine_generation(7);
+        let centroids = crate::structures::CoarseCentroids {
+            num_clusters: 1,
+            dim,
+            centroids: vec![0.0; dim],
+            version: marked_version,
+            soar_config: None,
+            routing_index: None,
+        };
+        let mut bytes = crate::segment::ann_build::build_ivf_tq(
+            dim,
+            IvfRoutingMode::Flat,
+            &centroids,
+            &[(0, 0)],
+            &[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        )
+        .unwrap();
+
+        // The fixed header stores quantizer_version at bytes 24..32.
+        bytes[24..32].copy_from_slice(&7u64.to_le_bytes());
+        let error = AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::IvfTq, 1)
+            .err()
+            .expect("legacy IVF-TQ payload must fail while opening")
+            .to_string();
+        assert!(error.contains("unsupported legacy generation"), "{error}");
+    }
+
+    #[test]
+    fn binary_combined_search_deduplicates_soar_and_bounds_document_results() {
+        // doc 0 / ordinal 0 occurs in both leaves, as it can under SOAR.
+        // Without `(doc, ordinal)` dedup it would beat doc 1 for both Sum and
+        // default LogSumExp; with correct dedup doc 1's two distinct values win.
+        let cluster_0_docs = [0u32, 0, 1];
+        let cluster_0_ordinals = [0u16, 1, 0];
+        let cluster_0_codes = [0x00u8, 0xff, 0x03];
+        let cluster_1_docs = [0u32, 1, 2];
+        let cluster_1_ordinals = [0u16, 1, 0];
+        let cluster_1_codes = [0x00u8, 0x0c, 0xf0];
+        let runs = [
+            BuildRun {
+                cluster_id: 0,
+                doc_ids: &cluster_0_docs,
+                ordinals: &cluster_0_ordinals,
+                codes: &cluster_0_codes,
+            },
+            BuildRun {
+                cluster_id: 1,
+                doc_ids: &cluster_1_docs,
+                ordinals: &cluster_1_ordinals,
+                codes: &cluster_1_codes,
+            },
+        ];
+        let mut bytes = Vec::new();
+        write_built_runs(binary_header(6), &runs, &mut bytes).unwrap();
+        let disk = AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::BinaryIvf, 3).unwrap();
+
+        for combiner in [
+            crate::query::MultiValueCombiner::Sum,
+            crate::query::MultiValueCombiner::default(),
+        ] {
+            let result = disk
+                .search_binary_combined_documents(1, &[0], &[0, 1], combiner)
+                .unwrap();
+            assert_eq!(result.len(), 1, "combined search must honor k");
+            assert_eq!(
+                result[0].doc_id, 1,
+                "SOAR duplicate changed {combiner:?} ranking: {result:?}",
+            );
+        }
+
+        let top_two = disk
+            .search_binary_combined_documents(
+                2,
+                &[0],
+                &[0, 1],
+                crate::query::MultiValueCombiner::Sum,
+            )
+            .unwrap();
+        assert_eq!(
+            top_two
+                .iter()
+                .map(|candidate| candidate.doc_id)
+                .collect::<Vec<_>>(),
+            vec![1, 0],
+        );
+        assert_eq!(top_two.len(), 2, "full probing must still return at most k");
+    }
+
+    #[test]
+    fn combined_ordinal_reduction_handles_out_of_order_runs_for_every_combiner() {
+        let out_of_order_with_duplicate = vec![
+            (7, 1, 0.4),
+            (3, 0, 0.8),
+            (7, 0, 0.6),
+            (3, 1, 0.2),
+            (7, 1, 0.5), // higher SOAR estimate replaces 0.4, never adds to it
+        ];
+        for combiner in [
+            crate::query::MultiValueCombiner::Max,
+            crate::query::MultiValueCombiner::Sum,
+            crate::query::MultiValueCombiner::Avg,
+            crate::query::MultiValueCombiner::default(),
+            crate::query::MultiValueCombiner::WeightedTopK { k: 2, decay: 0.7 },
+        ] {
+            let actual = combine_scored_ordinals(out_of_order_with_duplicate.clone(), 2, combiner);
+            let mut expected = vec![
+                AnnDocumentCandidate {
+                    doc_id: 3,
+                    score: combiner.combine(&[(0, 0.8), (1, 0.2)]),
+                },
+                AnnDocumentCandidate {
+                    doc_id: 7,
+                    score: combiner.combine(&[(0, 0.6), (1, 0.5)]),
+                },
+            ];
+            expected.sort_unstable_by(|left, right| {
+                right
+                    .score
+                    .total_cmp(&left.score)
+                    .then_with(|| left.doc_id.cmp(&right.doc_id))
+            });
+            assert_eq!(actual, expected, "combiner {combiner:?}");
+        }
+    }
+
     fn build_tq_payload(dim: usize, count: usize, seed: u64) -> (Vec<u8>, Vec<Vec<f32>>) {
         let codec = std::sync::Arc::new(crate::structures::TqCodec::new(dim));
         let mut builder = crate::structures::TqFlatBuilder::new(std::sync::Arc::clone(&codec));
@@ -1466,6 +1986,57 @@ mod tests {
         let mut bytes = Vec::new();
         write_built_tq_flat(&builder, &mut bytes).unwrap();
         (bytes, vectors)
+    }
+
+    #[test]
+    fn tq_combined_scan_ranks_complete_documents_instead_of_individual_values() {
+        let dim = 8;
+        let codec = std::sync::Arc::new(crate::structures::TqCodec::new(dim));
+        let mut builder = crate::structures::TqFlatBuilder::new(std::sync::Arc::clone(&codec));
+        let labels = [(0u32, 0u16), (1, 0), (1, 1)];
+        let vectors = [
+            1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, // doc 0: best single value
+            0.8, 0.6, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, // doc 1: two good values
+            0.8, -0.6, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        ];
+        builder.add_batch(&labels, &vectors).unwrap();
+        builder.finish();
+        let mut bytes = Vec::new();
+        write_built_tq_flat(&builder, &mut bytes).unwrap();
+        let disk = AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::TqFlat, 2).unwrap();
+        let query = [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
+        let plan = crate::structures::TqQueryPlan::build(&codec, &query);
+
+        let max = disk.search_tq_distinct(1, &plan).unwrap();
+        let sum = disk
+            .search_tq_combined_documents(1, &plan, crate::query::MultiValueCombiner::Sum)
+            .unwrap();
+        let default_combiner = disk
+            .search_tq_combined_documents(1, &plan, crate::query::MultiValueCombiner::default())
+            .unwrap();
+        assert_eq!(max[0].0, 0, "fixture must favor doc 0 by Max: {max:?}");
+        assert_eq!(
+            sum[0].doc_id, 1,
+            "two complete values must make doc 1 win by Sum: {sum:?}"
+        );
+        assert_eq!(
+            default_combiner[0].doc_id, 1,
+            "default LogSumExp must aggregate complete documents: {default_combiner:?}"
+        );
+        assert!(sum[0].score > max[0].2);
+
+        // Pure-copy upgrade merges may append a re-encoded older segment
+        // after copied runs, so global run order need not follow doc IDs.
+        // Documents remain complete within each run and must still combine.
+        let (single_bytes, _) = build_tq_payload(dim, 1, 91);
+        let single = AnnDiskIndex::open(OwnedBytes::new(single_bytes), AnnKind::TqFlat, 1).unwrap();
+        let mut merged_bytes = Vec::new();
+        write_merged_ann(&[(&disk, 1), (&single, 0)], &mut merged_bytes).unwrap();
+        let merged = AnnDiskIndex::open(OwnedBytes::new(merged_bytes), AnnKind::TqFlat, 3).unwrap();
+        let merged_sum = merged
+            .search_tq_combined_documents(1, &plan, crate::query::MultiValueCombiner::Sum)
+            .unwrap();
+        assert_eq!(merged_sum[0].doc_id, 2);
     }
 
     #[test]
@@ -1517,6 +2088,59 @@ mod tests {
     }
 
     #[test]
+    fn tq_parallel_fold_matches_a_sequential_scan() {
+        use crate::structures::vector::quantization::{
+            TQ_BLOCK_LANES, tq_block_bytes, tq_score_block,
+        };
+
+        // Exactly the production fan-out threshold exercises the parallel
+        // fold/reduce path without relying on a test-only configuration.
+        let dim = 8;
+        let count = TQ_PARALLEL_SCAN_MIN_VECTORS;
+        let (bytes, vectors) = build_tq_payload(dim, count, 87);
+        let disk =
+            AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::TqFlat, count as u32).unwrap();
+        let codec = crate::structures::TqCodec::new(dim);
+        let plan = crate::structures::TqQueryPlan::build(&codec, &vectors[count / 3]);
+        let k = 31;
+
+        let block_bytes = tq_block_bytes(disk.header().code_size);
+        assert_eq!(
+            disk.runs.len(),
+            1,
+            "the regression must parallelize chunks inside one run"
+        );
+        assert!(
+            disk.runs[0].codes.len() / block_bytes > TQ_PARALLEL_SCAN_CHUNK_BLOCKS,
+            "the single run must span multiple parallel chunks"
+        );
+        let raw = disk.raw.as_slice();
+        let mut reference = BoundedAnnCollector::<true, true>::new(k);
+        let mut scores = [0.0f32; TQ_BLOCK_LANES];
+        for run in &disk.runs {
+            let codes = &raw[run.codes.clone()];
+            for (block_index, block) in codes.chunks_exact(block_bytes).enumerate() {
+                tq_score_block(&plan, block, &mut scores);
+                let lane_base = block_index * TQ_BLOCK_LANES;
+                let lanes = TQ_BLOCK_LANES.min(run.count.saturating_sub(lane_base));
+                for (lane, &score) in scores.iter().enumerate().take(lanes) {
+                    let index = lane_base + lane;
+                    reference.insert(
+                        run_doc_id(raw, run, index).unwrap(),
+                        read_u16(raw, run.ordinals.start + index * 2),
+                        score,
+                    );
+                }
+            }
+        }
+
+        assert_eq!(
+            disk.search_tq_distinct(k, &plan).unwrap(),
+            reference.into_sorted_results(),
+        );
+    }
+
+    #[test]
     fn ivf_tq_scale_pruning_matches_the_unpruned_scan() {
         use crate::structures::vector::ivf::{CoarseCentroids, CoarseConfig};
         use crate::structures::vector::quantization::{
@@ -1542,7 +2166,8 @@ mod tests {
                 v
             })
             .collect();
-        let centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 8), &vectors);
+        let mut centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 8), &vectors);
+        centroids.version = crate::structures::mark_ivf_tq_cosine_generation(centroids.version);
         let mut index = IvfTqIndex::new(
             dim,
             crate::dsl::IvfRoutingMode::Flat,
@@ -1551,13 +2176,43 @@ mod tests {
         );
         let mut scratch = TqIvfEncodeScratch::default();
         for (i, vector) in vectors.iter().enumerate() {
-            index.add_vector(&centroids, i as u32, 0, vector, &mut scratch);
+            index.add_vector(
+                &centroids,
+                (i / 2) as u32,
+                (i % 2) as u16,
+                vector,
+                &mut scratch,
+            );
         }
         let mut bytes = Vec::new();
         write_built_ivf_tq(&index, centroids.num_clusters, &mut bytes).unwrap();
         let disk =
             AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::IvfTq, count as u32).unwrap();
 
+        // The supported cosine generation promises descending residual scales,
+        // enabling the reader to terminate the run at the first losing block.
+        let block_bytes = tq_ivf_block_bytes(disk.header().code_size);
+        let raw = disk.raw.as_slice();
+        for run in &disk.runs {
+            let codes = &raw[run.codes.clone()];
+            let mut previous_scale = f32::INFINITY;
+            for (block_index, block) in codes.chunks_exact(block_bytes).enumerate() {
+                let lane_base = block_index * TQ_BLOCK_LANES;
+                let lanes = TQ_BLOCK_LANES.min(run.count.saturating_sub(lane_base));
+                let mut block_scales = block[..TQ_BLOCK_LANES * size_of::<f32>()]
+                    .chunks_exact(size_of::<f32>())
+                    .take(lanes)
+                    .map(|lane| f32::from_le_bytes(lane.try_into().unwrap()));
+                let first_scale = block_scales.next().unwrap();
+                assert_eq!(tq_ivf_block_max_scale(block), first_scale);
+                assert!(first_scale <= previous_scale);
+                previous_scale = first_scale;
+                for scale in block_scales {
+                    assert!(scale <= previous_scale);
+                    previous_scale = scale;
+                }
+            }
+        }
         let k = 10;
         for query_seed in [1u64, 9, 42] {
             let mut qstate = query_seed;
@@ -1575,12 +2230,10 @@ mod tests {
                 8,
                 crate::dsl::IvfRoutingMode::Flat,
             );
-
             // Unpruned reference: score every block of every probed run with
             // the identical kernel and collector.
             let mut reference = BoundedAnnCollector::<true, true>::new(k);
-            let block_bytes = tq_ivf_block_bytes(disk.header().code_size);
-            let raw = disk.raw.as_slice();
+            let mut unpruned_scores = Vec::new();
             let mut scores = [0.0f32; TQ_BLOCK_LANES];
             for (cluster_id, cluster_dot) in plan.cluster_dots() {
                 for run in disk.cluster_runs(cluster_id) {
@@ -1596,17 +2249,40 @@ mod tests {
                                 read_u16(raw, run.ordinals.start + idx * 2),
                                 score,
                             );
+                            unpruned_scores.push((
+                                run_doc_id(raw, run, idx).unwrap(),
+                                read_u16(raw, run.ordinals.start + idx * 2),
+                                score,
+                            ));
                         }
                     }
                 }
             }
 
             let pruned = disk.search_ivf_tq_distinct(k, &plan).unwrap();
+            let reference = reference.into_sorted_results();
             assert_eq!(
-                pruned,
-                reference.into_sorted_results(),
+                pruned, reference,
                 "scale-bound pruning must not change the estimated top-k (seed {query_seed})"
             );
+            for combiner in [
+                crate::query::MultiValueCombiner::Max,
+                crate::query::MultiValueCombiner::Sum,
+                crate::query::MultiValueCombiner::Avg,
+                crate::query::MultiValueCombiner::default(),
+                crate::query::MultiValueCombiner::WeightedTopK { k: 3, decay: 0.7 },
+            ] {
+                let expected = combine_scored_ordinals(unpruned_scores.clone(), k, combiner);
+                let combined = disk
+                    .search_ivf_tq_combined_documents(k, &plan, combiner)
+                    .unwrap();
+                assert_eq!(
+                    combined, expected,
+                    "combined IVF-TQ scan diverged from the unpruned reference \
+                     for {combiner:?} (seed {query_seed})",
+                );
+                assert!(combined.len() <= k);
+            }
         }
     }
 

--- a/hermes-core/src/segment/builder/dense.rs
+++ b/hermes-core/src/segment/builder/dense.rs
@@ -1,12 +1,11 @@
 //! Dense vector streaming build (footer-based format).
 //!
 //! Streams each field's flat data directly to disk, then writes TOC + footer.
-//! Supports parallel segment-level IVF index building.
+//! ANN payloads are built and written one field at a time so large fields do
+//! not retain every packed index alongside every raw builder.
 
 use std::io::Write;
 
-#[cfg(feature = "native")]
-use rayon::prelude::*;
 use rustc_hash::FxHashMap;
 
 use crate::Result;
@@ -91,6 +90,55 @@ impl BinaryDenseVectorBuilder {
     pub fn len(&self) -> usize {
         self.doc_ids.len()
     }
+}
+
+#[cfg(feature = "native")]
+fn build_dense_ann_blob(
+    field_id: u32,
+    builder: &DenseVectorBuilder,
+    schema: &Schema,
+    trained: Option<&super::super::TrainedVectorStructures>,
+) -> Result<Option<(u8, Vec<u8>)>> {
+    let Some(config) = schema
+        .get_field_entry(Field(field_id))
+        .and_then(|entry| entry.dense_vector_config.as_ref())
+    else {
+        return Ok(None);
+    };
+
+    let dim = builder.dim;
+    let blob = match config.index_type {
+        VectorIndexType::Tq => {
+            super::super::ann_build::build_tq_flat(dim, &builder.doc_ids, &builder.vectors)
+                .map(|bytes| (super::super::ann_build::TQ_FLAT_TYPE, bytes))
+        }
+        VectorIndexType::IvfTq => {
+            // Only the coarse router is trained; segments stay flat until a
+            // compatible generation exists.
+            let Some(centroids) = trained.and_then(|trained| trained.centroids.get(&field_id))
+            else {
+                return Ok(None);
+            };
+            super::super::ann_build::build_ivf_tq(
+                dim,
+                config.ivf_routing,
+                centroids,
+                &builder.doc_ids,
+                &builder.vectors,
+            )
+            .map(|bytes| (super::super::ann_build::IVF_TQ_TYPE, bytes))
+        }
+        _ => return Ok(None),
+    };
+    let (index_type, bytes) = blob?;
+    log::info!(
+        "[dense_vector_build] built ANN(type={}) for field {} ({} vectors, {})",
+        index_type,
+        field_id,
+        builder.doc_ids.len(),
+        crate::format_bytes(bytes.len() as u64)
+    );
+    Ok(Some((index_type, bytes)))
 }
 
 /// Stream dense and binary dense vectors directly to disk (zero-buffer for vector data).
@@ -206,74 +254,12 @@ pub(super) fn build_vectors_streaming(
     let mut toc: Vec<DenseVectorTocEntry> = Vec::with_capacity(toc_capacity);
     let mut current_offset = 0u64;
 
-    // Pre-build ANN indexes across fields (native only). IVF-TQ requires
-    // trained coarse centroids; TQ is training-free and always builds.
-    #[cfg(feature = "native")]
-    let ann_blobs: Vec<(u32, u8, Vec<u8>)> = {
-        let ann_blob_fn = |(field_id, builder): &(u32, DenseVectorBuilder)|
-         -> Result<Option<(u32, u8, Vec<u8>)>> {
-                let Some(config) = schema
-                    .get_field_entry(Field(*field_id))
-                    .and_then(|e| e.dense_vector_config.as_ref())
-                else {
-                    return Ok(None);
-                };
-
-                let dim = builder.dim;
-                let blob = match config.index_type {
-                    VectorIndexType::Tq => super::super::ann_build::build_tq_flat(
-                        dim,
-                        &builder.doc_ids,
-                        &builder.vectors,
-                    )
-                    .map(|b| (super::super::ann_build::TQ_FLAT_TYPE, b)),
-                    VectorIndexType::IvfTq => {
-                        // Only the coarse router is trained; segments stay
-                        // flat until a generation exists (same as IVF-PQ).
-                        let Some(centroids) =
-                            trained.and_then(|trained| trained.centroids.get(field_id))
-                        else {
-                            return Ok(None);
-                        };
-                        super::super::ann_build::build_ivf_tq(
-                            dim,
-                            config.ivf_routing,
-                            centroids,
-                            &builder.doc_ids,
-                            &builder.vectors,
-                        )
-                        .map(|b| (super::super::ann_build::IVF_TQ_TYPE, b))
-                    }
-                    _ => return Ok(None),
-                };
-                let (index_type, bytes) = blob?;
-                log::info!(
-                    "[dense_vector_build] built ANN(type={}) for field {} ({} vectors, {})",
-                    index_type,
-                    field_id,
-                    builder.doc_ids.len(),
-                    crate::format_bytes(bytes.len() as u64)
-                );
-                Ok(Some((*field_id, index_type, bytes)))
-            };
-
-        fields
-            .par_iter()
-            .map(ann_blob_fn)
-            .collect::<Result<Vec<_>>>()?
-            .into_iter()
-            .flatten()
-            .collect()
-    };
-    // WASM: no ANN index building (requires trained structures from SegmentManager)
     #[cfg(not(feature = "native"))]
-    let ann_blobs: Vec<(u32, u8, Vec<u8>)> = {
-        let _ = trained; // suppress unused warning
-        Vec::new()
-    };
+    let _ = trained;
 
-    // Stream each field's flat data directly (builder → disk, no intermediate buffer)
-    for (i, (_field_id, builder)) in fields.into_iter().enumerate() {
+    // Stream each field's flat data, then build and immediately write its ANN
+    // payload. At most one final ANN blob is retained at a time.
+    for (i, (field_id, builder)) in fields.into_iter().enumerate() {
         let data_offset = current_offset;
         FlatVectorData::serialize_binary_from_flat_streaming(
             builder.dim,
@@ -289,7 +275,7 @@ pub(super) fn build_vectors_streaming(
             .checked_add(field_size)
             .ok_or_else(|| crate::Error::Internal("vector output offset exceeds u64".into()))?;
         toc.push(DenseVectorTocEntry {
-            field_id: _field_id,
+            field_id,
             index_type: super::super::ann_build::FLAT_TYPE,
             offset: data_offset,
             size: field_size,
@@ -302,31 +288,32 @@ pub(super) fn build_vectors_streaming(
                 crate::Error::Internal("vector output padding exceeds u64".into())
             })?;
         }
-        // builder dropped here, freeing vector memory before next field
-    }
 
-    // Write ANN blob entries after flat entries
-    for (field_id, index_type, blob) in ann_blobs {
-        let data_offset = current_offset;
-        let blob_len = u64::try_from(blob.len())
-            .map_err(|_| crate::Error::Internal("ANN blob size exceeds u64".into()))?;
-        writer.write_all(&blob)?;
-        current_offset = current_offset
-            .checked_add(blob_len)
-            .ok_or_else(|| crate::Error::Internal("vector output offset exceeds u64".into()))?;
-        toc.push(DenseVectorTocEntry {
-            field_id,
-            index_type,
-            offset: data_offset,
-            size: blob_len,
-        });
-        let pad = (8 - (current_offset % 8)) % 8;
-        if pad > 0 {
-            writer.write_all(&[0u8; 8][..pad as usize])?;
-            current_offset = current_offset.checked_add(pad).ok_or_else(|| {
-                crate::Error::Internal("vector output padding exceeds u64".into())
-            })?;
+        #[cfg(feature = "native")]
+        if let Some((index_type, blob)) = build_dense_ann_blob(field_id, &builder, schema, trained)?
+        {
+            let data_offset = current_offset;
+            let blob_len = u64::try_from(blob.len())
+                .map_err(|_| crate::Error::Internal("ANN blob size exceeds u64".into()))?;
+            writer.write_all(&blob)?;
+            current_offset = current_offset
+                .checked_add(blob_len)
+                .ok_or_else(|| crate::Error::Internal("vector output offset exceeds u64".into()))?;
+            toc.push(DenseVectorTocEntry {
+                field_id,
+                index_type,
+                offset: data_offset,
+                size: blob_len,
+            });
+            let pad = (8 - (current_offset % 8)) % 8;
+            if pad > 0 {
+                writer.write_all(&[0u8; 8][..pad as usize])?;
+                current_offset = current_offset.checked_add(pad).ok_or_else(|| {
+                    crate::Error::Internal("vector output padding exceeds u64".into())
+                })?;
+            }
         }
+        // Builder and its ANN blob are both dropped before the next field.
     }
 
     // Stream binary dense vector fields (packed bits, Hamming distance)

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -756,6 +756,13 @@ impl SegmentMerger {
             }
             return Ok(None);
         };
+        if !crate::structures::is_ivf_tq_cosine_generation(centroids.version) {
+            return Err(crate::Error::Corruption(format!(
+                "IVF-TQ field {} uses the removed legacy raw generation; \
+                 rebuild the index with a current Hermes version",
+                field.0,
+            )));
+        }
         let expected_fingerprint =
             crate::structures::vector::quantization::tq_expected_fingerprint(config.dim);
         let max_assignments = centroids
@@ -830,8 +837,8 @@ impl SegmentMerger {
     }
 
     /// Rebuild the IVF-TQ index for a vector-generation rewrite: re-assign
-    /// every flat vector against the supplied centroid generation and
-    /// re-encode residuals with the derived codec.
+    /// every raw flat vector against the supplied centroid generation and
+    /// re-encode normalized residuals with the derived codec.
     async fn rebuild_ivf_tq(
         &self,
         field: crate::dsl::Field,
@@ -847,6 +854,13 @@ impl SegmentMerger {
         let Some(centroids) = trained.and_then(|trained| trained.centroids.get(&field.0)) else {
             return Ok(None);
         };
+        if !crate::structures::is_ivf_tq_cosine_generation(centroids.version) {
+            return Err(crate::Error::Corruption(format!(
+                "IVF-TQ field {} uses the removed legacy raw generation; \
+                 rebuild the index with a current Hermes version",
+                field.0,
+            )));
+        }
 
         let codec = crate::structures::vector::quantization::tq_shared_codec(config.dim);
         let mut index = crate::structures::IvfTqIndex::new(

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -86,7 +86,7 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::sync::Arc;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::vector_data::LazyFlatVectorData;
 use crate::directories::{Directory, FileHandle};
@@ -295,6 +295,180 @@ struct DenseSearchParams {
     unit_norm: bool,
 }
 
+/// Query-derived state shared by every native-precision scoring batch in one
+/// flat scan or exact rerank operation.
+///
+/// Computing the query norm is O(dim), and f16 scoring additionally quantizes
+/// the query. Keeping both here avoids repeating that work for every bounded
+/// vector batch.
+struct PreparedDenseScoreQuery<'a> {
+    query: &'a [f32],
+    query_f16: Vec<u16>,
+    inv_norm_q: f32,
+    quantization: DenseVectorQuantization,
+    dim: usize,
+    unit_norm: bool,
+}
+
+impl<'a> PreparedDenseScoreQuery<'a> {
+    fn new(
+        query: &'a [f32],
+        quantization: DenseVectorQuantization,
+        dim: usize,
+        unit_norm: bool,
+    ) -> Result<Self> {
+        use crate::structures::simd;
+
+        if query.len() != dim {
+            return Err(Error::Query(format!(
+                "dense SIMD query dimension {} does not match vector dimension {dim}",
+                query.len()
+            )));
+        }
+        if quantization == DenseVectorQuantization::Binary {
+            return Err(Error::InvalidFieldType {
+                expected: "non-binary dense vector".to_string(),
+                got: "binary dense vector".to_string(),
+            });
+        }
+
+        let norm_q_sq = simd::dot_product_f32(query, query, dim);
+        let inv_norm_q = if norm_q_sq < f32::EPSILON {
+            0.0
+        } else {
+            simd::fast_inv_sqrt(norm_q_sq)
+        };
+        let query_f16 = if quantization == DenseVectorQuantization::F16 {
+            query.iter().map(|&value| simd::f32_to_f16(value)).collect()
+        } else {
+            Vec::new()
+        };
+
+        Ok(Self {
+            query,
+            query_f16,
+            inv_norm_q,
+            quantization,
+            dim,
+            unit_norm,
+        })
+    }
+
+    fn score_batch(&self, raw: &[u8], scores: &mut [f32]) -> Result<()> {
+        use crate::structures::simd;
+
+        let element_size = match self.quantization {
+            DenseVectorQuantization::F32 => std::mem::size_of::<f32>(),
+            DenseVectorQuantization::F16 => std::mem::size_of::<u16>(),
+            DenseVectorQuantization::UInt8 => 1,
+            DenseVectorQuantization::Binary => {
+                return Err(Error::InvalidFieldType {
+                    expected: "non-binary dense vector".to_string(),
+                    got: "binary dense vector".to_string(),
+                });
+            }
+        };
+        let required_bytes = scores
+            .len()
+            .checked_mul(self.dim)
+            .and_then(|elements| elements.checked_mul(element_size))
+            .ok_or_else(|| Error::Corruption("dense vector batch byte length overflow".into()))?;
+        if raw.len() < required_bytes {
+            return Err(Error::Corruption(format!(
+                "dense vector batch is truncated: need {required_bytes} bytes, got {}",
+                raw.len()
+            )));
+        }
+        if self.quantization == DenseVectorQuantization::F16
+            && required_bytes > 0
+            && !(raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<u16>())
+        {
+            return Err(Error::Corruption(
+                "f16 vector data is not 2-byte aligned".to_string(),
+            ));
+        }
+        if self.quantization == DenseVectorQuantization::F32
+            && !(raw.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>())
+        {
+            return Err(Error::Corruption(
+                "f32 vector data is not 4-byte aligned".to_string(),
+            ));
+        }
+
+        // The legacy batch scorers leave the destination untouched for empty
+        // dimensions or batches. Retain that boundary behavior before calling
+        // the precomputed kernels.
+        if self.dim == 0 || scores.is_empty() {
+            return Ok(());
+        }
+
+        match (self.quantization, self.unit_norm) {
+            (DenseVectorQuantization::F32, false) => {
+                let num_floats = scores.len() * self.dim;
+                let vectors: &[f32] =
+                    unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const f32, num_floats) };
+                simd::batch_cosine_scores_precomp(
+                    self.query,
+                    vectors,
+                    self.dim,
+                    scores,
+                    self.inv_norm_q,
+                );
+            }
+            (DenseVectorQuantization::F32, true) => {
+                let num_floats = scores.len() * self.dim;
+                let vectors: &[f32] =
+                    unsafe { std::slice::from_raw_parts(raw.as_ptr() as *const f32, num_floats) };
+                simd::batch_dot_scores_precomp(
+                    self.query,
+                    vectors,
+                    self.dim,
+                    scores,
+                    self.inv_norm_q,
+                );
+            }
+            (DenseVectorQuantization::F16, false) => {
+                simd::batch_cosine_scores_f16_precomp(
+                    &self.query_f16,
+                    raw,
+                    self.dim,
+                    scores,
+                    self.inv_norm_q,
+                );
+            }
+            (DenseVectorQuantization::F16, true) => {
+                simd::batch_dot_scores_f16_precomp(
+                    &self.query_f16,
+                    raw,
+                    self.dim,
+                    scores,
+                    self.inv_norm_q,
+                );
+            }
+            (DenseVectorQuantization::UInt8, false) => {
+                simd::batch_cosine_scores_u8_precomp(
+                    self.query,
+                    raw,
+                    self.dim,
+                    scores,
+                    self.inv_norm_q,
+                );
+            }
+            (DenseVectorQuantization::UInt8, true) => {
+                simd::batch_dot_scores_u8_precomp(
+                    self.query,
+                    raw,
+                    self.dim,
+                    scores,
+                    self.inv_norm_q,
+                );
+            }
+            (DenseVectorQuantization::Binary, _) => unreachable!("validated during preparation"),
+        }
+        Ok(())
+    }
+}
+
 /// Compute the ANN candidate count without relying on saturating float casts.
 fn checked_dense_fetch_k(k: usize, rerank_factor: f32) -> Result<usize> {
     if !rerank_factor.is_finite() || !(1.0..=MAX_DENSE_RERANK_FACTOR).contains(&rerank_factor) {
@@ -316,9 +490,30 @@ fn checked_dense_fetch_k(k: usize, rerank_factor: f32) -> Result<usize> {
     Ok(fetch.ceil() as usize)
 }
 
+/// Binary queries do not expose a configurable rerank factor. Use the shared
+/// query-level oversubscription policy while retaining the same hard
+/// per-segment candidate bound as float-vector reranking. Reject a result
+/// window larger than that bound instead of silently returning fewer than
+/// requested; candidate oversampling itself may safely clamp at the bound.
+#[inline]
+fn checked_binary_combined_fetch_k(k: usize) -> Result<usize> {
+    if k > MAX_DENSE_CANDIDATES_PER_SEGMENT {
+        return Err(Error::Query(format!(
+            "binary dense result count exceeds the per-segment maximum of \
+             {MAX_DENSE_CANDIDATES_PER_SEGMENT}: k={k}"
+        )));
+    }
+    Ok(crate::query::max_candidate_limit(k).min(MAX_DENSE_CANDIDATES_PER_SEGMENT))
+}
+
 #[inline]
 fn bounded_vector_score_batch(vector_byte_size: usize, preferred: usize) -> usize {
     preferred.min((MAX_VECTOR_SCORE_BATCH_BYTES / vector_byte_size.max(1)).max(1))
+}
+
+#[inline]
+fn bounded_rerank_batch(vector_byte_size: usize, preferred: usize, vector_count: usize) -> usize {
+    bounded_vector_score_batch(vector_byte_size, preferred).min(vector_count.max(1))
 }
 
 fn checked_file_range(
@@ -355,17 +550,24 @@ struct AnnCandidateDocuments {
 
 /// Resolve the document union returned by ANN to compact flat-vector ranges.
 ///
-/// The number of selected documents remains bounded by `fetch_k`, while the
-/// number of values those documents own is intentionally not capped. A valid
-/// multi-valued document may have many ordinals; materializing one result and
-/// one flat-index entry per ordinal used to turn that into a spurious query
-/// error at 20,000 vectors. Callers stream these ranges through a fixed-size
-/// score buffer instead.
+/// The document union is bounded by ANN document top-k, while the number of
+/// values those documents own is intentionally not capped. A valid
+/// multi-valued document may have many ordinals;
+/// materializing one result and one flat-index entry per ordinal used to turn
+/// that into a spurious query error at 20,000 vectors. Callers stream these
+/// ranges through a fixed-size score buffer instead.
 fn ann_candidate_document_ranges(
     ann_results: &[RawVectorCandidate],
     flat: &LazyFlatVectorData,
 ) -> Result<AnnCandidateDocuments> {
-    let mut candidate_docs: Vec<DocId> = ann_results.iter().map(|candidate| candidate.0).collect();
+    ann_candidate_document_ranges_from_ids(ann_results.iter().map(|candidate| candidate.0), flat)
+}
+
+fn ann_candidate_document_ranges_from_ids(
+    doc_ids: impl IntoIterator<Item = DocId>,
+    flat: &LazyFlatVectorData,
+) -> Result<AnnCandidateDocuments> {
+    let mut candidate_docs: Vec<DocId> = doc_ids.into_iter().collect();
     candidate_docs.sort_unstable();
     candidate_docs.dedup();
 
@@ -396,6 +598,49 @@ fn ann_candidate_document_ranges(
         ranges,
         vector_count,
     })
+}
+
+/// Validate the no-rerank binary IVF fast path against exact flat metadata.
+///
+/// Binary IVF stores the original packed codes, so a single-valued field does
+/// not need vector-data I/O to recompute scores. It still needs the same
+/// ANN/flat consistency checks the rerank path provided: every candidate must
+/// name the field's sole stored ordinal. Deduplicate by document as well so a
+/// malformed ANN payload cannot surface the same document more than once.
+fn validate_binary_single_value_ann_results(
+    ann_results: Vec<RawVectorCandidate>,
+    flat: &LazyFlatVectorData,
+) -> Result<Vec<RawVectorCandidate>> {
+    let mut seen_docs = FxHashSet::default();
+    let mut validated = Vec::with_capacity(ann_results.len());
+    for (doc_id, ordinal, score) in ann_results {
+        let (start, count) = flat.flat_indexes_for_doc_range(doc_id);
+        if count == 0 {
+            return Err(Error::Corruption(format!(
+                "ANN candidate document {doc_id} is missing from flat vector storage"
+            )));
+        }
+        if count != 1 {
+            return Err(Error::Corruption(format!(
+                "binary ANN single-valued candidate document {doc_id} has {count} flat vectors"
+            )));
+        }
+        let (stored_doc_id, stored_ordinal) = flat.get_doc_id(start);
+        if stored_doc_id != doc_id {
+            return Err(Error::Corruption(format!(
+                "flat vector doc map is not contiguous for document {doc_id}"
+            )));
+        }
+        if stored_ordinal != ordinal {
+            return Err(Error::Corruption(format!(
+                "binary ANN candidate document {doc_id} ordinal {ordinal} is missing from flat vector storage"
+            )));
+        }
+        if seen_docs.insert(doc_id) {
+            validated.push((doc_id, ordinal, score));
+        }
+    }
+    Ok(validated)
 }
 
 struct CandidateVectorCursor<'a> {
@@ -579,7 +824,8 @@ async fn exact_score_dense_candidate_documents(
         ..Default::default()
     };
     let vector_byte_size = flat.vector_byte_size();
-    let batch_len = bounded_vector_score_batch(vector_byte_size, DENSE_SCORE_BATCH);
+    let batch_len =
+        bounded_rerank_batch(vector_byte_size, DENSE_SCORE_BATCH, documents.vector_count);
     let raw_capacity = batch_len
         .checked_mul(vector_byte_size)
         .ok_or_else(|| Error::Query("dense rerank buffer size overflow".to_string()))?;
@@ -591,6 +837,8 @@ async fn exact_score_dense_candidate_documents(
     let mut cursor = CandidateVectorCursor::new(&documents.ranges);
     let mut collector = FlatDocumentCollector::new(limit, combiner);
     let mut scored = 0usize;
+    let prepared_query =
+        PreparedDenseScoreQuery::new(query, flat.quantization, flat.dim, unit_norm)?;
 
     while cursor.fill_batch(flat, &mut batch, batch_len)? {
         flat_indexes.clear();
@@ -606,14 +854,7 @@ async fn exact_score_dense_candidate_documents(
         stats.read_elapsed += read_started.elapsed();
 
         let score_started = std::time::Instant::now();
-        SegmentReader::score_quantized_batch(
-            query,
-            raw,
-            flat.quantization,
-            flat.dim,
-            &mut scores[..batch.len()],
-            unit_norm,
-        )?;
+        prepared_query.score_batch(raw, &mut scores[..batch.len()])?;
         stats.score_elapsed += score_started.elapsed();
         for (buffer_index, &(doc_id, ordinal, _)) in batch.iter().enumerate() {
             collector.push(doc_id, ordinal, scores[buffer_index]);
@@ -635,7 +876,8 @@ fn exact_score_dense_candidate_documents_sync(
 ) -> Result<Vec<VectorSearchResult>> {
     let documents = ann_candidate_document_ranges(ann_results, flat)?;
     let vector_byte_size = flat.vector_byte_size();
-    let batch_len = bounded_vector_score_batch(vector_byte_size, DENSE_SCORE_BATCH);
+    let batch_len =
+        bounded_rerank_batch(vector_byte_size, DENSE_SCORE_BATCH, documents.vector_count);
     let raw_capacity = batch_len
         .checked_mul(vector_byte_size)
         .ok_or_else(|| Error::Query("dense rerank buffer size overflow".to_string()))?;
@@ -647,6 +889,8 @@ fn exact_score_dense_candidate_documents_sync(
     let mut cursor = CandidateVectorCursor::new(&documents.ranges);
     let mut collector = FlatDocumentCollector::new(limit, combiner);
     let mut scored = 0usize;
+    let prepared_query =
+        PreparedDenseScoreQuery::new(query, flat.quantization, flat.dim, unit_norm)?;
 
     while cursor.fill_batch(flat, &mut batch, batch_len)? {
         flat_indexes.clear();
@@ -657,14 +901,7 @@ fn exact_score_dense_candidate_documents_sync(
             .ok_or_else(|| Error::Query("dense rerank buffer size overflow".to_string()))?;
         let raw = &mut raw[..raw_len];
         read_vector_runs_sync(flat, &flat_indexes, &mut read_runs, raw)?;
-        SegmentReader::score_quantized_batch(
-            query,
-            raw,
-            flat.quantization,
-            flat.dim,
-            &mut scores[..batch.len()],
-            unit_norm,
-        )?;
+        prepared_query.score_batch(raw, &mut scores[..batch.len()])?;
         for (buffer_index, &(doc_id, ordinal, _)) in batch.iter().enumerate() {
             collector.push(doc_id, ordinal, scores[buffer_index]);
         }
@@ -687,8 +924,52 @@ async fn exact_score_binary_candidate_documents(
         .iter()
         .map(|&(doc_id, ordinal, score)| ((doc_id, ordinal), score))
         .collect();
+    exact_score_binary_resolved_documents(
+        documents,
+        &probe_scores,
+        flat,
+        query,
+        dim_bits,
+        combiner,
+        limit,
+    )
+    .await
+}
+
+async fn exact_score_binary_candidate_document_ids(
+    candidate_doc_ids: Vec<DocId>,
+    flat: &LazyFlatVectorData,
+    query: &[u8],
+    dim_bits: usize,
+    combiner: crate::query::MultiValueCombiner,
+    limit: usize,
+) -> Result<Vec<VectorSearchResult>> {
+    let documents = ann_candidate_document_ranges_from_ids(candidate_doc_ids, flat)?;
+    let probe_scores = FxHashMap::default();
+    exact_score_binary_resolved_documents(
+        documents,
+        &probe_scores,
+        flat,
+        query,
+        dim_bits,
+        combiner,
+        limit,
+    )
+    .await
+}
+
+async fn exact_score_binary_resolved_documents(
+    documents: AnnCandidateDocuments,
+    probe_scores: &FxHashMap<(DocId, u16), f32>,
+    flat: &LazyFlatVectorData,
+    query: &[u8],
+    dim_bits: usize,
+    combiner: crate::query::MultiValueCombiner,
+    limit: usize,
+) -> Result<Vec<VectorSearchResult>> {
     let vector_byte_size = flat.vector_byte_size();
-    let batch_len = bounded_vector_score_batch(vector_byte_size, BINARY_SCORE_BATCH);
+    let batch_len =
+        bounded_rerank_batch(vector_byte_size, BINARY_SCORE_BATCH, documents.vector_count);
     let raw_capacity = batch_len
         .checked_mul(vector_byte_size)
         .ok_or_else(|| Error::Query("binary candidate buffer size overflow".to_string()))?;
@@ -753,8 +1034,52 @@ fn exact_score_binary_candidate_documents_sync(
         .iter()
         .map(|&(doc_id, ordinal, score)| ((doc_id, ordinal), score))
         .collect();
+    exact_score_binary_resolved_documents_sync(
+        documents,
+        &probe_scores,
+        flat,
+        query,
+        dim_bits,
+        combiner,
+        limit,
+    )
+}
+
+#[cfg(feature = "sync")]
+fn exact_score_binary_candidate_document_ids_sync(
+    candidate_doc_ids: Vec<DocId>,
+    flat: &LazyFlatVectorData,
+    query: &[u8],
+    dim_bits: usize,
+    combiner: crate::query::MultiValueCombiner,
+    limit: usize,
+) -> Result<Vec<VectorSearchResult>> {
+    let documents = ann_candidate_document_ranges_from_ids(candidate_doc_ids, flat)?;
+    let probe_scores = FxHashMap::default();
+    exact_score_binary_resolved_documents_sync(
+        documents,
+        &probe_scores,
+        flat,
+        query,
+        dim_bits,
+        combiner,
+        limit,
+    )
+}
+
+#[cfg(feature = "sync")]
+fn exact_score_binary_resolved_documents_sync(
+    documents: AnnCandidateDocuments,
+    probe_scores: &FxHashMap<(DocId, u16), f32>,
+    flat: &LazyFlatVectorData,
+    query: &[u8],
+    dim_bits: usize,
+    combiner: crate::query::MultiValueCombiner,
+    limit: usize,
+) -> Result<Vec<VectorSearchResult>> {
     let vector_byte_size = flat.vector_byte_size();
-    let batch_len = bounded_vector_score_batch(vector_byte_size, BINARY_SCORE_BATCH);
+    let batch_len =
+        bounded_rerank_batch(vector_byte_size, BINARY_SCORE_BATCH, documents.vector_count);
     let raw_capacity = batch_len
         .checked_mul(vector_byte_size)
         .ok_or_else(|| Error::Query("binary candidate buffer size overflow".to_string()))?;
@@ -838,23 +1163,54 @@ pub struct DensePlanCache {
 /// segments: the codec is a pure function of the schema dimension, so the
 /// LUTs are identical for every segment of the field (mirrors the IVF-PQ
 /// `probe_cache` hot-path rule — no repeated per-segment plan allocation).
+#[allow(clippy::too_many_arguments)]
 fn search_tq_segment(
     index: &crate::segment::ann_disk::AnnDiskIndex,
     codec: &crate::structures::TqCodec,
     query: &[f32],
     fetch_k: usize,
+    document_combiner: Option<crate::query::MultiValueCombiner>,
     field: Field,
     dim: usize,
     plan_cache: Option<&std::sync::Mutex<Option<std::sync::Arc<crate::structures::TqQueryPlan>>>>,
 ) -> Result<Vec<RawVectorCandidate>> {
     validate_tq_ann(index, codec, dim, field)?;
-    let plan = match plan_cache {
+    let plan = cached_tq_query_plan(codec, query, plan_cache)?;
+    match document_combiner {
+        Some(combiner) => index
+            .search_tq_combined_documents(fetch_k, &plan, combiner)
+            .map(|candidates| {
+                candidates
+                    .into_iter()
+                    // Exact dense reranking consumes only the document ID.
+                    // Use a zero placeholder so the document aggregate can
+                    // never be mistaken for an ordinal score.
+                    .map(|candidate| (candidate.doc_id, 0, 0.0))
+                    .collect()
+            }),
+        None => index.search_tq_distinct(fetch_k, &plan),
+    }
+    .map_err(|error| {
+        Error::Corruption(format!("invalid TQ payload for field {}: {error}", field.0))
+    })
+}
+
+/// Return the query-global flat-TQ plan, rebuilding it whenever either the
+/// codec generation or the exact query bits differ.
+fn cached_tq_query_plan(
+    codec: &crate::structures::TqCodec,
+    query: &[f32],
+    plan_cache: Option<&std::sync::Mutex<Option<std::sync::Arc<crate::structures::TqQueryPlan>>>>,
+) -> Result<std::sync::Arc<crate::structures::TqQueryPlan>> {
+    Ok(match plan_cache {
         Some(cache) => {
             let mut cached = cache
                 .lock()
                 .map_err(|_| Error::Internal("TQ plan cache is poisoned".into()))?;
             match cached.as_ref() {
-                Some(plan) if plan.fingerprint() == codec.fingerprint() => {
+                Some(plan)
+                    if plan.fingerprint() == codec.fingerprint() && plan.matches_query(query) =>
+                {
                     std::sync::Arc::clone(plan)
                 }
                 _ => {
@@ -866,9 +1222,6 @@ fn search_tq_segment(
             }
         }
         None => std::sync::Arc::new(crate::structures::TqQueryPlan::build(codec, query)),
-    };
-    index.search_tq_distinct(fetch_k, &plan).map_err(|error| {
-        Error::Corruption(format!("invalid TQ payload for field {}: {error}", field.0))
     })
 }
 
@@ -904,6 +1257,7 @@ fn search_ivf_tq_segment(
     codec: &crate::structures::TqCodec,
     query: &[f32],
     fetch_k: usize,
+    document_combiner: Option<crate::query::MultiValueCombiner>,
     field: Field,
     nprobe: usize,
     routing: crate::dsl::IvfRoutingMode,
@@ -912,7 +1266,8 @@ fn search_ivf_tq_segment(
     >,
 ) -> Result<Vec<RawVectorCandidate>> {
     let effective_nprobe = nprobe.clamp(1, centroids.num_clusters as usize);
-    let request_fingerprint = crate::structures::vector::ivf::routing::float_probe_fingerprint(
+    let request_fingerprint = crate::structures::TqIvfQueryPlan::request_fingerprint_for(
+        centroids,
         query,
         effective_nprobe,
         routing,
@@ -949,14 +1304,26 @@ fn search_ivf_tq_segment(
         }
         None => build(),
     };
-    index
-        .search_ivf_tq_distinct(fetch_k, &plan)
-        .map_err(|error| {
-            Error::Corruption(format!(
-                "invalid IVF-TQ payload for field {}: {error}",
-                field.0
-            ))
-        })
+    let candidates = match document_combiner {
+        Some(combiner) => index
+            .search_ivf_tq_combined_documents(fetch_k, &plan, combiner)
+            .map(|documents| {
+                documents
+                    .into_iter()
+                    // The compressed score aggregates a whole document. Exact
+                    // dense reranking consumes only its ID; a zero placeholder
+                    // prevents accidental reuse as an ordinal score.
+                    .map(|candidate| (candidate.doc_id, 0, 0.0))
+                    .collect()
+            }),
+        None => index.search_ivf_tq_distinct(fetch_k, &plan),
+    };
+    candidates.map_err(|error| {
+        Error::Corruption(format!(
+            "invalid IVF-TQ payload for field {}: {error}",
+            field.0
+        ))
+    })
 }
 
 fn validate_ivf_tq_ann(
@@ -968,6 +1335,16 @@ fn validate_ivf_tq_ann(
     field: Field,
 ) -> Result<()> {
     let header = index.header();
+    if !crate::structures::is_ivf_tq_cosine_generation(centroids.version)
+        || !crate::structures::is_ivf_tq_cosine_generation(header.quantizer_version)
+    {
+        return Err(Error::Corruption(format!(
+            "IVF-TQ field {} uses a legacy unmarked raw-vector generation that cannot \
+             preserve cosine candidate semantics; rebuild the index with a current \
+             Hermes version",
+            field.0,
+        )));
+    }
     if header.dim != dim
         || codec.dim() != dim
         || header.code_size != codec.code_size()
@@ -1884,12 +2261,9 @@ impl SegmentReader {
         Ok(config.dim)
     }
 
-    /// Batch cosine scoring on raw quantized bytes.
-    ///
-    /// Dispatches to the appropriate SIMD scorer based on quantization type.
-    /// Vectors file uses data-first layout (offset 0) with 8-byte padding between
-    /// fields, so mmap slices are always properly aligned for f32/f16/u8 access.
-    fn score_quantized_batch(
+    /// Previous per-batch preparation path retained as an equivalence oracle.
+    #[cfg(test)]
+    fn score_quantized_batch_legacy(
         query: &[f32],
         raw: &[u8],
         quant: crate::dsl::DenseVectorQuantization,
@@ -2036,14 +2410,14 @@ impl SegmentReader {
             return Ok(Vec::new());
         }
 
-        let ann_index = self.vector_indexes.get(&field.0);
+        let configured_ann_index = self.vector_indexes.get(&field.0);
         let lazy_flat = self.flat_vectors.get(&field.0);
         // No vectors at all for this field
-        if ann_index.is_none() && lazy_flat.is_none() {
+        if configured_ann_index.is_none() && lazy_flat.is_none() {
             return Ok(Vec::new());
         }
 
-        if ann_index.is_some() && lazy_flat.is_none() {
+        if configured_ann_index.is_some() && lazy_flat.is_none() {
             return Err(Error::Corruption(format!(
                 "dense ANN field {} is missing flat vector storage",
                 field.0
@@ -2059,6 +2433,15 @@ impl SegmentReader {
             )));
         }
 
+        let needs_document_aggregation = lazy_flat.is_some_and(|flat| {
+            flat.num_vectors != flat.num_docs_with_vectors()
+                && !matches!(combiner, crate::query::MultiValueCombiner::Max)
+        });
+        // Keep every configured ANN index active. Multi-value semantics are
+        // handled by bounded combiner-aware scans; IVF-TQ accepts only the
+        // cosine-normalized generation validated below.
+        let ann_index = configured_ann_index;
+
         // Results are (doc_id, ordinal, score) where score = similarity (higher = better)
         let t0 = std::time::Instant::now();
         let mut flat_results = None;
@@ -2073,6 +2456,7 @@ impl SegmentReader {
                         codec,
                         query,
                         fetch_k.min(flat.num_docs_with_vectors()),
+                        needs_document_aggregation.then_some(combiner),
                         field,
                         params.dim,
                         plan_cache.map(|cache| &cache.tq),
@@ -2106,6 +2490,7 @@ impl SegmentReader {
                         codec,
                         query,
                         fetch_k.min(flat.num_docs_with_vectors()),
+                        needs_document_aggregation.then_some(combiner),
                         field,
                         params.nprobe,
                         routing,
@@ -2135,6 +2520,7 @@ impl SegmentReader {
                 bounded_vector_score_batch(lazy_flat.vector_byte_size(), DENSE_SCORE_BATCH);
             let mut collector = FlatDocumentCollector::new(fetch_k.min(n), combiner);
             let mut scores = vec![0f32; batch_len];
+            let prepared_query = PreparedDenseScoreQuery::new(query, quant, dim, params.unit_norm)?;
 
             for batch_start in (0..n).step_by(batch_len) {
                 let batch_count = batch_len.min(n - batch_start);
@@ -2144,14 +2530,7 @@ impl SegmentReader {
                     .map_err(crate::Error::Io)?;
                 let raw = batch_bytes.as_slice();
 
-                Self::score_quantized_batch(
-                    query,
-                    raw,
-                    quant,
-                    dim,
-                    &mut scores[..batch_count],
-                    params.unit_norm,
-                )?;
+                prepared_query.score_batch(raw, &mut scores[..batch_count])?;
 
                 for (i, &score) in scores.iter().enumerate().take(batch_count) {
                     let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
@@ -2287,6 +2666,7 @@ impl SegmentReader {
                     field.0
                 ))
             })?;
+            let single_valued = flat.num_vectors == flat.num_docs_with_vectors();
             let clusters = binary_probe_clusters(
                 quantizer,
                 query,
@@ -2294,28 +2674,70 @@ impl SegmentReader {
                 config.ivf_routing,
                 probe_cache,
             )?;
-            let single_valued = flat.num_vectors == flat.num_docs_with_vectors();
-            let candidate_docs = k.min(flat.num_docs_with_vectors());
-            let ann_results = if single_valued {
-                ivf.search_binary_clusters::<false>(query, candidate_docs, &clusters)
+            let results = if !single_valued
+                && !matches!(combiner, crate::query::MultiValueCombiner::Max)
+            {
+                let candidate_limit =
+                    checked_binary_combined_fetch_k(k)?.min(flat.num_docs_with_vectors());
+                let candidate_documents = ivf
+                    .search_binary_combined_documents(candidate_limit, query, &clusters, combiner)
+                    .map_err(|error| {
+                        Error::Corruption(format!(
+                            "invalid binary IVF payload for field {}: {error}",
+                            field.0,
+                        ))
+                    })?;
+                exact_score_binary_candidate_document_ids(
+                    candidate_documents
+                        .into_iter()
+                        .map(|candidate| candidate.doc_id)
+                        .collect(),
+                    flat,
+                    query,
+                    schema_dim,
+                    combiner,
+                    k,
+                )
+                .await?
             } else {
-                ivf.search_binary_clusters::<true>(query, candidate_docs, &clusters)
-            }
-            .map_err(|error| {
-                Error::Corruption(format!(
-                    "invalid binary IVF payload for field {}: {error}",
-                    field.0,
-                ))
-            })?;
-            let results = exact_score_binary_candidate_documents(
-                &ann_results,
-                flat,
-                query,
-                schema_dim,
-                combiner,
-                k,
-            )
-            .await?;
+                let candidate_docs = if single_valued {
+                    k
+                } else {
+                    // Completing the selected documents from flat storage can
+                    // reorder a multi-value Max result when another ordinal
+                    // lives outside the probed leaves. Keep the same bounded
+                    // oversubscription used by combined binary reranking.
+                    checked_binary_combined_fetch_k(k)?
+                }
+                .min(flat.num_docs_with_vectors());
+                let ann_results = if single_valued {
+                    ivf.search_binary_clusters::<false>(query, candidate_docs, &clusters)
+                } else {
+                    ivf.search_binary_clusters::<true>(query, candidate_docs, &clusters)
+                }
+                .map_err(|error| {
+                    Error::Corruption(format!(
+                        "invalid binary IVF payload for field {}: {error}",
+                        field.0,
+                    ))
+                })?;
+                // Binary IVF stores the original packed codes, so its leaf
+                // scores are already exact for a single-valued field.
+                if single_valued {
+                    let ann_results = validate_binary_single_value_ann_results(ann_results, flat)?;
+                    combine_ordinal_results(ann_results, combiner, k)
+                } else {
+                    exact_score_binary_candidate_documents(
+                        &ann_results,
+                        flat,
+                        query,
+                        schema_dim,
+                        combiner,
+                        k,
+                    )
+                    .await?
+                }
+            };
             crate::observe::dense_l1(
                 self.schema.index_label(),
                 self.schema.get_field_name(field).unwrap_or("?"),
@@ -2671,13 +3093,13 @@ impl SegmentReader {
             return Ok(Vec::new());
         }
 
-        let ann_index = self.vector_indexes.get(&field.0);
+        let configured_ann_index = self.vector_indexes.get(&field.0);
         let lazy_flat = self.flat_vectors.get(&field.0);
-        if ann_index.is_none() && lazy_flat.is_none() {
+        if configured_ann_index.is_none() && lazy_flat.is_none() {
             return Ok(Vec::new());
         }
 
-        if ann_index.is_some() && lazy_flat.is_none() {
+        if configured_ann_index.is_some() && lazy_flat.is_none() {
             return Err(Error::Corruption(format!(
                 "dense ANN field {} is missing flat vector storage",
                 field.0
@@ -2693,6 +3115,14 @@ impl SegmentReader {
             )));
         }
 
+        let needs_document_aggregation = lazy_flat.is_some_and(|flat| {
+            flat.num_vectors != flat.num_docs_with_vectors()
+                && !matches!(combiner, crate::query::MultiValueCombiner::Max)
+        });
+        // Sync and async search share the same ANN candidate modes; neither
+        // silently substitutes a raw flat scan for an indexed field.
+        let ann_index = configured_ann_index;
+
         let results: Vec<(u32, u16, f32)> = if let Some(index) = ann_index {
             // ANN search (already sync)
             match index {
@@ -2703,6 +3133,7 @@ impl SegmentReader {
                         codec,
                         query,
                         fetch_k.min(flat.num_docs_with_vectors()),
+                        needs_document_aggregation.then_some(combiner),
                         field,
                         params.dim,
                         plan_cache.map(|cache| &cache.tq),
@@ -2736,6 +3167,7 @@ impl SegmentReader {
                         codec,
                         query,
                         fetch_k.min(flat.num_docs_with_vectors()),
+                        needs_document_aggregation.then_some(combiner),
                         field,
                         params.nprobe,
                         routing,
@@ -2756,6 +3188,7 @@ impl SegmentReader {
                 bounded_vector_score_batch(lazy_flat.vector_byte_size(), DENSE_SCORE_BATCH);
             let mut collector = FlatDocumentCollector::new(fetch_k.min(n), combiner);
             let mut scores = vec![0f32; batch_len];
+            let prepared_query = PreparedDenseScoreQuery::new(query, quant, dim, params.unit_norm)?;
 
             for batch_start in (0..n).step_by(batch_len) {
                 let batch_count = batch_len.min(n - batch_start);
@@ -2764,14 +3197,7 @@ impl SegmentReader {
                     .map_err(crate::Error::Io)?;
                 let raw = batch_bytes.as_slice();
 
-                Self::score_quantized_batch(
-                    query,
-                    raw,
-                    quant,
-                    dim,
-                    &mut scores[..batch_count],
-                    params.unit_norm,
-                )?;
+                prepared_query.score_batch(raw, &mut scores[..batch_count])?;
 
                 for (i, &score) in scores.iter().enumerate().take(batch_count) {
                     let (doc_id, ordinal) = lazy_flat.get_doc_id(batch_start + i);
@@ -2850,6 +3276,7 @@ impl SegmentReader {
                     field.0
                 ))
             })?;
+            let single_valued = flat.num_vectors == flat.num_docs_with_vectors();
             let clusters = binary_probe_clusters(
                 quantizer,
                 query,
@@ -2857,26 +3284,62 @@ impl SegmentReader {
                 config.ivf_routing,
                 probe_cache,
             )?;
-            let candidate_docs = k.min(flat.num_docs_with_vectors());
-            let ann_results = if flat.num_vectors == flat.num_docs_with_vectors() {
-                ivf.search_binary_clusters::<false>(query, candidate_docs, &clusters)
+            let results = if !single_valued
+                && !matches!(combiner, crate::query::MultiValueCombiner::Max)
+            {
+                let candidate_limit =
+                    checked_binary_combined_fetch_k(k)?.min(flat.num_docs_with_vectors());
+                let candidate_documents = ivf
+                    .search_binary_combined_documents(candidate_limit, query, &clusters, combiner)
+                    .map_err(|error| {
+                        Error::Corruption(format!(
+                            "invalid binary IVF payload for field {}: {error}",
+                            field.0,
+                        ))
+                    })?;
+                exact_score_binary_candidate_document_ids_sync(
+                    candidate_documents
+                        .into_iter()
+                        .map(|candidate| candidate.doc_id)
+                        .collect(),
+                    flat,
+                    query,
+                    schema_dim,
+                    combiner,
+                    k,
+                )?
             } else {
-                ivf.search_binary_clusters::<true>(query, candidate_docs, &clusters)
-            }
-            .map_err(|error| {
-                Error::Corruption(format!(
-                    "invalid binary IVF payload for field {}: {error}",
-                    field.0,
-                ))
-            })?;
-            let results = exact_score_binary_candidate_documents_sync(
-                &ann_results,
-                flat,
-                query,
-                schema_dim,
-                combiner,
-                k,
-            )?;
+                let candidate_docs = if single_valued {
+                    k
+                } else {
+                    checked_binary_combined_fetch_k(k)?
+                }
+                .min(flat.num_docs_with_vectors());
+                let ann_results = if single_valued {
+                    ivf.search_binary_clusters::<false>(query, candidate_docs, &clusters)
+                } else {
+                    ivf.search_binary_clusters::<true>(query, candidate_docs, &clusters)
+                }
+                .map_err(|error| {
+                    Error::Corruption(format!(
+                        "invalid binary IVF payload for field {}: {error}",
+                        field.0,
+                    ))
+                })?;
+                if single_valued {
+                    let ann_results = validate_binary_single_value_ann_results(ann_results, flat)?;
+                    combine_ordinal_results(ann_results, combiner, k)
+                } else {
+                    exact_score_binary_candidate_documents_sync(
+                        &ann_results,
+                        flat,
+                        query,
+                        schema_dim,
+                        combiner,
+                        k,
+                    )?
+                }
+            };
             crate::observe::dense_l1(
                 self.schema.index_label(),
                 self.schema.get_field_name(field).unwrap_or("?"),
@@ -2993,6 +3456,109 @@ mod dense_search_safety_tests {
         }
     }
 
+    fn values_as_bytes<T>(values: &[T]) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(values.as_ptr() as *const u8, std::mem::size_of_val(values))
+        }
+    }
+
+    fn assert_prepared_dense_scores_match_legacy(
+        quantization: DenseVectorQuantization,
+        raw: &[u8],
+        unit_norm: bool,
+    ) {
+        const DIM: usize = 4;
+        const VECTOR_COUNT: usize = 4;
+        let query = [0.25, -0.5, 0.75, 1.0];
+        let mut expected = [0.0; VECTOR_COUNT];
+        SegmentReader::score_quantized_batch_legacy(
+            &query,
+            raw,
+            quantization,
+            DIM,
+            &mut expected,
+            unit_norm,
+        )
+        .unwrap();
+
+        let prepared = PreparedDenseScoreQuery::new(&query, quantization, DIM, unit_norm).unwrap();
+        let vector_bytes = DIM
+            * match quantization {
+                DenseVectorQuantization::F32 => std::mem::size_of::<f32>(),
+                DenseVectorQuantization::F16 => std::mem::size_of::<u16>(),
+                DenseVectorQuantization::UInt8 => 1,
+                DenseVectorQuantization::Binary => unreachable!(),
+            };
+        let split = 2 * vector_bytes;
+        let mut actual = [0.0; VECTOR_COUNT];
+        prepared
+            .score_batch(&raw[..split], &mut actual[..2])
+            .unwrap();
+        prepared
+            .score_batch(&raw[split..], &mut actual[2..])
+            .unwrap();
+
+        assert_eq!(
+            actual.map(f32::to_bits),
+            expected.map(f32::to_bits),
+            "quantization={quantization:?}, unit_norm={unit_norm}"
+        );
+    }
+
+    #[test]
+    fn prepared_dense_query_matches_legacy_scoring_across_batches() {
+        let vectors_f32 = [
+            0.5, -0.25, 0.75, 1.0, -1.0, 0.5, 0.25, 0.125, 0.0, 0.0, 0.0, 0.0, 0.75, 0.5, -0.5,
+            -0.25,
+        ];
+        let vectors_f16: Vec<u16> = vectors_f32
+            .iter()
+            .map(|&value| crate::structures::simd::f32_to_f16(value))
+            .collect();
+        let vectors_u8 = [
+            255, 96, 224, 160, 0, 192, 144, 128, 128, 128, 128, 128, 224, 192, 64, 96,
+        ];
+
+        for unit_norm in [false, true] {
+            assert_prepared_dense_scores_match_legacy(
+                DenseVectorQuantization::F32,
+                values_as_bytes(&vectors_f32),
+                unit_norm,
+            );
+            assert_prepared_dense_scores_match_legacy(
+                DenseVectorQuantization::F16,
+                values_as_bytes(&vectors_f16),
+                unit_norm,
+            );
+            assert_prepared_dense_scores_match_legacy(
+                DenseVectorQuantization::UInt8,
+                &vectors_u8,
+                unit_norm,
+            );
+        }
+    }
+
+    #[test]
+    fn prepared_dense_query_preserves_scoring_validation_errors() {
+        assert!(matches!(
+            PreparedDenseScoreQuery::new(&[1.0], DenseVectorQuantization::F32, 2, false).err(),
+            Some(Error::Query(_))
+        ));
+        assert!(matches!(
+            PreparedDenseScoreQuery::new(&[1.0], DenseVectorQuantization::Binary, 1, false).err(),
+            Some(Error::InvalidFieldType { .. })
+        ));
+
+        let query = [1.0, 2.0];
+        let prepared =
+            PreparedDenseScoreQuery::new(&query, DenseVectorQuantization::F32, 2, false).unwrap();
+        let mut scores = [0.0];
+        assert!(matches!(
+            prepared.score_batch(&[0; 7], &mut scores),
+            Err(Error::Corruption(_))
+        ));
+    }
+
     #[test]
     fn flat_document_collector_does_not_let_one_multivalue_doc_crowd_out_others() {
         let mut collector = FlatDocumentCollector::new(2, crate::query::MultiValueCombiner::Max);
@@ -3042,10 +3608,93 @@ mod dense_search_safety_tests {
     }
 
     #[test]
+    fn binary_combined_fetch_count_uses_shared_bounded_oversampling() {
+        assert_eq!(checked_binary_combined_fetch_k(3).unwrap(), 6);
+        assert_eq!(checked_binary_combined_fetch_k(10_000).unwrap(), 20_000);
+        assert_eq!(checked_binary_combined_fetch_k(10_001).unwrap(), 20_000);
+        assert_eq!(checked_binary_combined_fetch_k(20_000).unwrap(), 20_000);
+        assert!(checked_binary_combined_fetch_k(20_001).is_err());
+        assert!(checked_binary_combined_fetch_k(usize::MAX).is_err());
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn legacy_ivf_tq_generation_is_rejected_while_opening() {
+        use crate::directories::OwnedBytes;
+        use crate::dsl::IvfRoutingMode;
+        use crate::segment::ann_disk::{AnnDiskIndex, AnnKind};
+
+        let centroids = CoarseCentroids {
+            num_clusters: 1,
+            dim: 2,
+            centroids: vec![1.0, 0.0],
+            version: 7,
+            soar_config: None,
+            routing_index: None,
+        };
+        let mut build_centroids = centroids.clone();
+        build_centroids.version =
+            crate::structures::mark_ivf_tq_cosine_generation(build_centroids.version);
+        let mut bytes = crate::segment::ann_build::build_ivf_tq(
+            2,
+            IvfRoutingMode::Flat,
+            &build_centroids,
+            &[(0, 0)],
+            &[1.0, 0.0],
+        )
+        .unwrap();
+        // Rewrite only the in-band centroid generation in the header to model
+        // a persisted pre-cosine artifact.
+        bytes[24..32].copy_from_slice(&centroids.version.to_le_bytes());
+        let error = AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::IvfTq, 1)
+            .err()
+            .expect("legacy IVF-TQ payload must fail while opening")
+            .to_string();
+        assert!(error.contains("unsupported legacy generation"), "{error}");
+    }
+
+    #[test]
+    fn rerank_batch_is_capped_by_actual_candidate_vectors() {
+        assert_eq!(bounded_rerank_batch(3_072, DENSE_SCORE_BATCH, 20), 20);
+        assert_eq!(
+            bounded_rerank_batch(3_072, DENSE_SCORE_BATCH, 10_000),
+            MAX_VECTOR_SCORE_BATCH_BYTES / 3_072
+        );
+        assert_eq!(bounded_rerank_batch(3_072, DENSE_SCORE_BATCH, 0), 1);
+    }
+
+    #[test]
     fn file_ranges_reject_overflow_and_truncation() {
         assert_eq!(checked_file_range(4, 3, 7, "test").unwrap(), 4..7);
         assert!(checked_file_range(u64::MAX, 1, u64::MAX, "test").is_err());
         assert!(checked_file_range(5, 3, 7, "test").is_err());
+    }
+
+    #[test]
+    fn shared_tq_plan_cache_rebuilds_for_divergent_query_clones() {
+        let codec = crate::structures::TqCodec::new(4);
+        let cache = std::sync::Mutex::new(None);
+        let original_query = vec![1.0, 2.0, 3.0, 4.0];
+
+        let original =
+            cached_tq_query_plan(&codec, &original_query, Some(&cache)).expect("build plan");
+        let reused =
+            cached_tq_query_plan(&codec, &original_query, Some(&cache)).expect("reuse plan");
+        assert!(
+            std::sync::Arc::ptr_eq(&original, &reused),
+            "unchanged queries must share their plan across segments"
+        );
+
+        let mut divergent_clone = original_query.clone();
+        divergent_clone[0] = -1.0;
+        let rebuilt =
+            cached_tq_query_plan(&codec, &divergent_clone, Some(&cache)).expect("rebuild plan");
+        assert!(
+            !std::sync::Arc::ptr_eq(&original, &rebuilt),
+            "a clone with a mutated vector must not reuse stale LUTs"
+        );
+        assert!(rebuilt.matches_query(&divergent_clone));
+        assert!(!rebuilt.matches_query(&original_query));
     }
 
     #[test]
@@ -3074,6 +3723,44 @@ mod dense_search_safety_tests {
             ]
         ));
         assert!(plan_vector_read_runs(&[3, 3], &mut runs).is_err());
+    }
+
+    #[tokio::test]
+    async fn binary_single_value_ann_fast_path_validates_and_deduplicates() {
+        use crate::directories::{FileHandle, OwnedBytes};
+        use crate::segment::FlatVectorData;
+
+        let mut encoded = Vec::new();
+        FlatVectorData::serialize_binary_from_bits_streaming(
+            8,
+            &[0x0f, 0xf0],
+            &[(1, 0), (3, 2)],
+            &mut encoded,
+        )
+        .unwrap();
+        let flat = LazyFlatVectorData::open_with_doc_limit(
+            FileHandle::from_bytes(OwnedBytes::new(encoded)),
+            Some(4),
+        )
+        .await
+        .unwrap();
+        assert_eq!(flat.num_vectors, flat.num_docs_with_vectors());
+
+        let validated = validate_binary_single_value_ann_results(
+            vec![(3, 2, 0.9), (1, 0, 0.8), (3, 2, 0.7)],
+            &flat,
+        )
+        .unwrap();
+        assert_eq!(validated, vec![(3, 2, 0.9), (1, 0, 0.8)]);
+
+        assert!(matches!(
+            validate_binary_single_value_ann_results(vec![(2, 0, 1.0)], &flat),
+            Err(Error::Corruption(_))
+        ));
+        assert!(matches!(
+            validate_binary_single_value_ann_results(vec![(3, 0, 1.0)], &flat),
+            Err(Error::Corruption(_))
+        ));
     }
 
     #[tokio::test]

--- a/hermes-core/src/structures/mod.rs
+++ b/hermes-core/src/structures/mod.rs
@@ -139,6 +139,8 @@ pub use vector::{
     TqIvfEncodeScratch,
     TqIvfQueryPlan,
     TqQueryPlan,
+    is_ivf_tq_cosine_generation,
+    mark_ivf_tq_cosine_generation,
 };
 
 // Re-export simd

--- a/hermes-core/src/structures/simd.rs
+++ b/hermes-core/src/structures/simd.rs
@@ -3470,10 +3470,42 @@ pub fn batch_hamming_scores(
 
     let inv_dim = 1.0 / dim_bits as f32;
 
-    for i in 0..n {
-        let vec = &db[i * byte_len..(i + 1) * byte_len];
-        let dist = hamming_distance(query, vec);
-        scores[i] = 1.0 - dist as f32 * inv_dim;
+    // Select the architecture kernel once for the whole batch. Calling
+    // `hamming_distance` here used to repeat runtime feature detection for
+    // every database vector in the hottest binary-scan loop.
+    #[cfg(target_arch = "x86_64")]
+    {
+        if avx2::is_available() {
+            for (i, score) in scores.iter_mut().enumerate() {
+                let vector = &db[i * byte_len..(i + 1) * byte_len];
+                let distance = unsafe { avx2::hamming_distance(query, vector) };
+                *score = 1.0 - distance as f32 * inv_dim;
+            }
+        } else {
+            for (i, score) in scores.iter_mut().enumerate() {
+                let vector = &db[i * byte_len..(i + 1) * byte_len];
+                let distance = hamming_distance_scalar(query, vector);
+                *score = 1.0 - distance as f32 * inv_dim;
+            }
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        for (i, score) in scores.iter_mut().enumerate() {
+            let vector = &db[i * byte_len..(i + 1) * byte_len];
+            let distance = unsafe { neon::hamming_distance(query, vector) };
+            *score = 1.0 - distance as f32 * inv_dim;
+        }
+    }
+
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    {
+        for (i, score) in scores.iter_mut().enumerate() {
+            let vector = &db[i * byte_len..(i + 1) * byte_len];
+            let distance = hamming_distance_scalar(query, vector);
+            *score = 1.0 - distance as f32 * inv_dim;
+        }
     }
 }
 

--- a/hermes-core/src/structures/vector/index/binary_ivf.rs
+++ b/hermes-core/src/structures/vector/index/binary_ivf.rs
@@ -19,8 +19,9 @@ use crate::dsl::IvfRoutingMode;
 use crate::structures::simd::{batch_hamming_scores, hamming_distance};
 use crate::structures::vector::ivf::routing::{
     HNSW_AUTO_THRESHOLD, HnswRoutingGraph, IvfProbePlan, IvfRoutingTopology,
-    allocate_child_clusters, binary_probe_fingerprint, effective_routing_mode, parent_probe_count,
-    routing_parent_count, select_best, select_best_candidates,
+    allocate_child_clusters, binary_probe_fingerprint, effective_routing_mode,
+    routing_parent_count, select_best, select_best_candidates, select_parent_beam,
+    select_parent_beam_for_build,
 };
 
 fn argmax_score_lowest_index(scores: &[f32]) -> usize {
@@ -50,8 +51,25 @@ fn nearest_binary_centroid(
     argmax_score_lowest_index(scores) as u32
 }
 
+#[inline]
+fn nearest_binary_centroid_with_distance(
+    code: &[u8],
+    centroids: &[u8],
+    byte_len: usize,
+    dim_bits: usize,
+    scores: &mut [f32],
+) -> (u32, u32) {
+    let centroid = nearest_binary_centroid(code, centroids, byte_len, dim_bits, scores);
+    let offset = centroid as usize * byte_len;
+    (
+        centroid,
+        hamming_distance(code, &centroids[offset..offset + byte_len]),
+    )
+}
+
 const MAX_BINARY_IVF_CLUSTERS: usize = 1_048_576;
 const BINARY_IVF_SCORE_BATCH: usize = 8_192;
+const BUILD_ASSIGNMENT_CANDIDATES: usize = 128;
 
 /// Global Hamming coarse quantizer shared by every segment of a field.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -242,8 +260,19 @@ impl BinaryCoarseQuantizer {
 
     pub fn assign(&self, code: &[u8], mode: IvfRoutingMode) -> u32 {
         match effective_routing_mode(mode, self.num_clusters as usize) {
-            IvfRoutingMode::Hnsw => self.find_nearest_hnsw(code),
-            IvfRoutingMode::TwoLevel => self.find_k_nearest_two_level(code, 1)[0],
+            IvfRoutingMode::Hnsw => self
+                .find_k_nearest_hnsw_for_build(code, 1)
+                .first()
+                .copied()
+                .unwrap_or(0),
+            IvfRoutingMode::TwoLevel => self
+                .find_k_nearest_two_level_for_build(
+                    code,
+                    BUILD_ASSIGNMENT_CANDIDATES.min(self.num_clusters as usize),
+                )
+                .first()
+                .copied()
+                .unwrap_or(0),
             IvfRoutingMode::Flat | IvfRoutingMode::Auto => self.find_nearest(code),
         }
     }
@@ -273,6 +302,18 @@ impl BinaryCoarseQuantizer {
     }
 
     fn find_k_nearest_two_level(&self, query: &[u8], k: usize) -> Vec<u32> {
+        self.find_k_nearest_two_level_impl::<false>(query, k)
+    }
+
+    fn find_k_nearest_two_level_for_build(&self, query: &[u8], k: usize) -> Vec<u32> {
+        self.find_k_nearest_two_level_impl::<true>(query, k)
+    }
+
+    fn find_k_nearest_two_level_impl<const FOR_BUILD: bool>(
+        &self,
+        query: &[u8],
+        k: usize,
+    ) -> Vec<u32> {
         let Some(BinaryCentroidRouter::TwoLevel {
             parent_centroids,
             topology,
@@ -291,9 +332,11 @@ impl BinaryCoarseQuantizer {
             self.dim_bits,
             &mut parent_scores,
         );
-        let parent_take =
-            parent_probe_count(k, self.num_clusters as usize, topology.parent_count());
-        let parents = select_best::<true>(&parent_scores, parent_take);
+        let parents = if FOR_BUILD {
+            select_parent_beam_for_build::<true>(&parent_scores, topology, k)
+        } else {
+            select_parent_beam::<true>(&parent_scores, topology, k)
+        };
         let candidate_count = parents
             .iter()
             .map(|&parent| topology.children(parent as usize).len())
@@ -332,17 +375,20 @@ impl BinaryCoarseQuantizer {
         )
     }
 
-    fn find_nearest_hnsw(&self, query: &[u8]) -> u32 {
+    fn find_k_nearest_hnsw_for_build(&self, query: &[u8], k: usize) -> Vec<u32> {
         let Some(BinaryCentroidRouter::Hnsw(graph)) = self.routing_index.as_ref() else {
-            return self.find_nearest(query);
+            return self.find_k_nearest(query, k);
         };
         let byte_len = self.byte_len();
-        graph.search_one(|leaf| {
-            hamming_distance(
-                query,
-                &self.centroids[leaf as usize * byte_len..(leaf as usize + 1) * byte_len],
-            ) as f32
-        })
+        graph.search_for_build(
+            |leaf| {
+                hamming_distance(
+                    query,
+                    &self.centroids[leaf as usize * byte_len..(leaf as usize + 1) * byte_len],
+                ) as f32
+            },
+            k,
+        )
     }
 }
 
@@ -686,28 +732,30 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
     // to duplicate/near-duplicate cells on skewed embedding distributions.
     let first = rng.random_range(0..n);
     centroids[..byte_len].copy_from_slice(vec_at(first));
-    let mut min_dist_sq = vec![f64::INFINITY; n];
+    let mut minimum_weights = vec![f64::INFINITY; n];
     for centroid_id in 1..k {
         let previous = &centroids[(centroid_id - 1) * byte_len..centroid_id * byte_len];
         #[cfg(feature = "native")]
         {
             use rayon::prelude::*;
-            min_dist_sq
+            minimum_weights
                 .par_iter_mut()
                 .enumerate()
-                .for_each(|(index, min_distance)| {
+                .for_each(|(index, minimum_weight)| {
                     let distance = hamming_distance(vec_at(index), previous);
-                    *min_distance = min_distance.min((distance as f64) * (distance as f64));
+                    // Hamming distance is already squared Euclidean distance
+                    // for vectors in {0,1}^d, so D² sampling uses it directly.
+                    *minimum_weight = minimum_weight.min(distance as f64);
                 });
         }
         #[cfg(not(feature = "native"))]
-        for (index, min_distance) in min_dist_sq.iter_mut().enumerate() {
+        for (index, minimum_weight) in minimum_weights.iter_mut().enumerate() {
             let distance = hamming_distance(vec_at(index), previous);
-            *min_distance = min_distance.min((distance as f64) * (distance as f64));
+            *minimum_weight = minimum_weight.min(distance as f64);
         }
 
         let chosen = if let Some(chosen) = crate::structures::vector::kmeans::weighted_sample_index(
-            &min_dist_sq,
+            &minimum_weights,
             rng.random::<f64>(),
         ) {
             chosen
@@ -719,6 +767,7 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
     }
 
     let mut assignment = vec![u32::MAX; n];
+    let mut assignment_distances = vec![u32::MAX; n];
     let mut members: Vec<Vec<usize>> = (0..k).map(|_| Vec::new()).collect();
 
     for _iter in 0..config.train_iters {
@@ -730,17 +779,19 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
             use rayon::prelude::*;
             assignment
                 .par_iter_mut()
+                .zip(assignment_distances.par_iter_mut())
                 .enumerate()
                 .map_init(
                     || vec![0f32; k],
-                    |scores, (i, slot)| {
-                        let best = nearest_binary_centroid(
+                    |scores, (i, (slot, assignment_distance))| {
+                        let (best, distance) = nearest_binary_centroid_with_distance(
                             vec_at(i),
                             &centroids,
                             byte_len,
                             dim_bits,
                             scores,
                         );
+                        *assignment_distance = distance;
                         usize::from(std::mem::replace(slot, best) != best)
                     },
                 )
@@ -751,15 +802,17 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
             let mut scores = vec![0f32; k];
             assignment
                 .iter_mut()
+                .zip(&mut assignment_distances)
                 .enumerate()
-                .map(|(i, slot)| {
-                    let best = nearest_binary_centroid(
+                .map(|(i, (slot, assignment_distance))| {
+                    let (best, distance) = nearest_binary_centroid_with_distance(
                         vec_at(i),
                         &centroids,
                         byte_len,
                         dim_bits,
                         &mut scores,
                     );
+                    *assignment_distance = distance;
                     usize::from(std::mem::replace(slot, best) != best)
                 })
                 .sum()
@@ -777,6 +830,16 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
         for (i, &slot) in assignment.iter().enumerate().take(n) {
             members[slot as usize].push(i);
         }
+
+        reseed_empty_binary_centroids(
+            &mut centroids,
+            &mut members,
+            &mut assignment,
+            &mut assignment_distances,
+            sample.as_deref(),
+            codes,
+            byte_len,
+        );
 
         #[cfg(feature = "native")]
         {
@@ -807,19 +870,82 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
                 );
             }
         }
-
-        // Re-seed empty clusters serially so RNG consumption and the resulting
-        // model remain deterministic across thread counts.
-        for (c, cluster_members) in members.iter().enumerate() {
-            if cluster_members.is_empty() {
-                // Re-seed empty cluster with a random sampled vector
-                let sample_index = rng.random_range(0..n);
-                centroids[c * byte_len..(c + 1) * byte_len].copy_from_slice(vec_at(sample_index));
-            }
-        }
     }
 
     centroids
+}
+
+/// Re-seed empty cells from the represented points with the largest assignment
+/// error. One closest point is retained in every donor cell, so each selected
+/// point is unique and re-assignment cannot create a new empty cell. Empty IDs
+/// and equal-distance candidates are resolved in ascending order.
+fn reseed_empty_binary_centroids(
+    centroids: &mut [u8],
+    members: &mut [Vec<usize>],
+    assignment: &mut [u32],
+    assignment_distances: &mut [u32],
+    sample: Option<&[usize]>,
+    codes: &[u8],
+    byte_len: usize,
+) {
+    let empty_clusters: Vec<usize> = members
+        .iter()
+        .enumerate()
+        .filter_map(|(cluster, cluster_members)| cluster_members.is_empty().then_some(cluster))
+        .collect();
+    if empty_clusters.is_empty() {
+        return;
+    }
+
+    // Retain the closest (then lowest-index) represented point in each donor
+    // cell. Every other point is safe to move without emptying its donor.
+    let mut candidates = Vec::with_capacity(
+        assignment
+            .len()
+            .saturating_sub(members.len() - empty_clusters.len()),
+    );
+    for cluster_members in members.iter().filter(|members| !members.is_empty()) {
+        let keeper = *cluster_members
+            .iter()
+            .min_by_key(|&&point| (assignment_distances[point], point))
+            .expect("non-empty binary cluster must have a represented point");
+        candidates.extend(
+            cluster_members
+                .iter()
+                .copied()
+                .filter(|&point| point != keeper),
+        );
+    }
+    debug_assert!(candidates.len() >= empty_clusters.len());
+
+    let farthest_first = |left: &usize, right: &usize| {
+        assignment_distances[*right]
+            .cmp(&assignment_distances[*left])
+            .then_with(|| left.cmp(right))
+    };
+    if empty_clusters.len() < candidates.len() {
+        candidates.select_nth_unstable_by(empty_clusters.len(), farthest_first);
+        candidates.truncate(empty_clusters.len());
+    }
+    candidates.sort_unstable_by(farthest_first);
+
+    for (empty_cluster, point) in empty_clusters.into_iter().zip(candidates) {
+        assignment[point] = empty_cluster as u32;
+        assignment_distances[point] = 0;
+        let vector_index = sample.map_or(point, |sample| sample[point]);
+        centroids[empty_cluster * byte_len..(empty_cluster + 1) * byte_len]
+            .copy_from_slice(&codes[vector_index * byte_len..(vector_index + 1) * byte_len]);
+    }
+
+    // Keep the membership view consistent with the assignments before the
+    // centroid-update phase. In particular, donor modes must not retain points
+    // that were moved into newly seeded cells.
+    for cluster_members in members.iter_mut() {
+        cluster_members.clear();
+    }
+    for (point, &cluster) in assignment.iter().enumerate() {
+        members[cluster as usize].push(point);
+    }
 }
 
 /// Compute one Hamming-space centroid using a per-byte bit histogram. Member
@@ -843,13 +969,18 @@ fn update_binary_centroid(
         }
     }
 
-    let half = members.len() / 2;
     for (byte, counts) in centroid.iter_mut().zip(bit_counts) {
+        let previous = *byte;
         *byte = counts
             .into_iter()
             .enumerate()
             .fold(0u8, |packed, (bit, count)| {
-                packed | (u8::from(count > half) << bit)
+                let value = match count.cmp(&(members.len() - count)) {
+                    std::cmp::Ordering::Greater => 1,
+                    std::cmp::Ordering::Less => 0,
+                    std::cmp::Ordering::Equal => (previous >> bit) & 1,
+                };
+                packed | (value << bit)
             });
     }
 }
@@ -1019,6 +1150,84 @@ mod tests {
     }
 
     #[test]
+    fn k_majority_seeding_uses_raw_hamming_d2_weights() {
+        let codes = [0x00, 0x01, 0x03, 0x0f, 0x3f, 0x7f, 0xff];
+        let (seed, first, raw_choice, squared_choice) = (0u64..10_000)
+            .find_map(|seed| {
+                let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+                let first = rng.random_range(0..codes.len());
+                let draw = rng.random::<f64>();
+                let raw_weights: Vec<f64> = codes
+                    .iter()
+                    .map(|code| {
+                        f64::from(hamming_distance(
+                            std::slice::from_ref(code),
+                            std::slice::from_ref(&codes[first]),
+                        ))
+                    })
+                    .collect();
+                let squared_weights: Vec<f64> =
+                    raw_weights.iter().map(|weight| weight * weight).collect();
+                let raw_choice =
+                    crate::structures::vector::kmeans::weighted_sample_index(&raw_weights, draw)?;
+                let squared_choice = crate::structures::vector::kmeans::weighted_sample_index(
+                    &squared_weights,
+                    draw,
+                )?;
+                (raw_choice != squared_choice).then_some((seed, first, raw_choice, squared_choice))
+            })
+            .expect("test data must distinguish Hamming from Hamming-squared sampling");
+
+        let mut config = BinaryIvfConfig::new(8, 2);
+        config.seed = seed;
+        config.train_iters = 0;
+        config.max_train_samples = codes.len();
+        let centroids = train_k_majority(&config, &codes, codes.len());
+
+        assert_eq!(centroids[0], codes[first]);
+        assert_eq!(centroids[1], codes[raw_choice]);
+        assert_ne!(centroids[1], codes[squared_choice]);
+    }
+
+    #[test]
+    fn empty_binary_centroids_take_farthest_movable_points_deterministically() {
+        let codes = [0x0f, 0x01, 0xf0, 0xf1, 0xfe];
+        let mut centroids = vec![0x00, 0xff, 0x55, 0xaa];
+        let mut members = vec![vec![0, 1], vec![2, 3, 4], vec![], vec![]];
+        let mut assignment = vec![0, 0, 1, 1, 1];
+        let mut assignment_distances = vec![4, 1, 4, 3, 1];
+
+        reseed_empty_binary_centroids(
+            &mut centroids,
+            &mut members,
+            &mut assignment,
+            &mut assignment_distances,
+            None,
+            &codes,
+            1,
+        );
+
+        // Points 0 and 2 have the largest movable distance. The equal-distance
+        // tie and empty cluster IDs are both resolved from lowest to highest.
+        assert_eq!(centroids, vec![0x00, 0xff, 0x0f, 0xf0]);
+        assert_eq!(assignment, vec![2, 0, 3, 1, 1]);
+        assert_eq!(assignment_distances, vec![0, 1, 0, 3, 1]);
+        assert_eq!(members, vec![vec![1], vec![3, 4], vec![0], vec![2]]);
+    }
+
+    #[test]
+    fn binary_centroid_majority_ties_keep_previous_bits() {
+        let codes = [0b1010_1010, 0b0101_0101];
+        let mut centroid = [0b1100_0011];
+        update_binary_centroid(&mut centroid, &[0, 1], None, &codes, 1);
+        assert_eq!(centroid, [0b1100_0011]);
+
+        let decisive_codes = [0b1111_0000, 0b1111_0000, 0b0000_1111];
+        update_binary_centroid(&mut centroid, &[0, 1, 2], None, &decisive_codes, 1);
+        assert_eq!(centroid, [0b1111_0000]);
+    }
+
+    #[test]
     fn streaming_builder_appends_batches_without_retaining_inputs() {
         let codes = [0x00, 0x01, 0x02, 0xf0, 0xf1, 0xf2];
         let labels = [(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)];
@@ -1061,6 +1270,43 @@ mod tests {
                 .all(|(&cells, size)| cells <= size)
         );
         assert_eq!(allocation[2], 0);
+    }
+
+    #[test]
+    fn binary_two_level_build_assignment_checks_four_parents() {
+        let leaves_per_parent = 512;
+        let children: Vec<Vec<u32>> = (0..4)
+            .map(|parent| {
+                let first = parent * leaves_per_parent;
+                (first..first + leaves_per_parent)
+                    .map(|leaf| leaf as u32)
+                    .collect()
+            })
+            .collect();
+        let mut leaf_centroids = vec![0x01; 4 * leaves_per_parent];
+        let best_leaf = 3 * leaves_per_parent;
+        leaf_centroids[best_leaf] = 0x00;
+        let quantizer = BinaryCoarseQuantizer {
+            dim_bits: 8,
+            num_clusters: leaf_centroids.len() as u32,
+            centroids: leaf_centroids,
+            version: 1,
+            routing_index: Some(BinaryCentroidRouter::TwoLevel {
+                parent_centroids: vec![0x00, 0xff, 0xff, 0xff],
+                topology: IvfRoutingTopology::from_children(&children),
+            }),
+        };
+
+        assert_eq!(
+            &*quantizer
+                .probe(&[0x00], 1, IvfRoutingMode::TwoLevel)
+                .cluster_ids,
+            &[0]
+        );
+        assert_eq!(
+            quantizer.assign(&[0x00], IvfRoutingMode::TwoLevel),
+            best_leaf as u32
+        );
     }
 
     #[test]

--- a/hermes-core/src/structures/vector/index/ivf_tq.rs
+++ b/hermes-core/src/structures/vector/index/ivf_tq.rs
@@ -2,8 +2,9 @@
 //!
 //! Two-level index (design: `docs/turboquant-quantization.md`):
 //! - Level 1: the trained global coarse quantizer (same router as IVF-PQ).
-//! - Level 2: per-leaf TQ codes of `vector − centroid` residuals plus a
-//!   per-vector residual scale, so `⟨q̂, x⟩ = ⟨q̂, c⟩ + scale · ⟨q̂, r̂⟩`.
+//! - Level 2: per-leaf TQ codes of `normalized(vector) − centroid` residuals
+//!   plus a per-vector residual scale, so
+//!   `⟨q̂, x̂⟩ = ⟨q̂, c⟩ + scale · ⟨q̂, r̂⟩`.
 //!
 //! Unlike IVF-PQ, the leaf codec is training-free and the residual estimate
 //! uses one query-wide LUT: probed clusters differ only by the scalar
@@ -12,8 +13,38 @@
 //! `segment::ann_disk`; this type is build-only.
 
 use crate::dsl::IvfRoutingMode;
+use crate::structures::vector::ivf::routing::{
+    cosine_probe_fingerprint, normalize_cosine_in_place, normalized_cosine_query,
+};
 use crate::structures::vector::ivf::{CoarseCentroids, IvfProbePlan};
 use crate::structures::vector::quantization::{TqCodec, TqEncodeScratch, TqQueryPlan};
+
+// Preserve the serialized centroid and ANN-header layouts by carrying the
+// cosine-generation format in the existing u64 version. Timestamp-generated
+// legacy versions cannot reach this prefix for centuries; the mixed 52-bit
+// payload retains ample generation entropy without exposing timestamp bits.
+const IVF_TQ_COSINE_VERSION_MASK: u64 = 0xfff0_0000_0000_0000;
+const IVF_TQ_COSINE_VERSION_TAG: u64 = 0xc050_0000_0000_0000;
+
+/// Mark an IVF-TQ centroid version whose centroids and residuals use normalized
+/// cosine-space vectors. The transformation is idempotent.
+pub fn mark_ivf_tq_cosine_generation(version: u64) -> u64 {
+    if is_ivf_tq_cosine_generation(version) {
+        return version;
+    }
+    let mut mixed = version;
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    mixed ^= mixed >> 31;
+    IVF_TQ_COSINE_VERSION_TAG | (mixed & !IVF_TQ_COSINE_VERSION_MASK)
+}
+
+/// Whether a persisted IVF-TQ generation was trained and encoded in normalized
+/// cosine space. Readers use this marker to reject incompatible artifacts.
+#[inline]
+pub fn is_ivf_tq_cosine_generation(version: u64) -> bool {
+    version & IVF_TQ_COSINE_VERSION_MASK == IVF_TQ_COSINE_VERSION_TAG
+}
 
 /// Struct-of-arrays payload for one non-empty IVF-TQ leaf. `rows` holds one
 /// unpacked nibble value (0..=15) per padded coordinate per vector; blocks
@@ -69,30 +100,53 @@ impl TqIvfQueryPlan {
         nprobe: usize,
         routing: IvfRoutingMode,
     ) -> Self {
-        let route: IvfProbePlan = coarse_centroids.probe(query, nprobe, routing);
-        let norm = crate::structures::simd::dot_product_f32(query, query, query.len()).sqrt();
-        let inverse_norm = if norm.is_finite() && norm > 0.0 {
-            1.0 / norm
-        } else {
-            0.0
-        };
+        assert!(
+            is_ivf_tq_cosine_generation(coarse_centroids.version),
+            "legacy raw IVF-TQ generations cannot build a query plan; rebuild the index"
+        );
+        let normalized_query = normalized_cosine_query(query);
+        let route: IvfProbePlan = coarse_centroids.probe(&normalized_query, nprobe, routing);
+        let effective_nprobe = nprobe.clamp(1, coarse_centroids.num_clusters as usize);
         let cluster_dots = route
             .cluster_ids
             .iter()
             .map(|&cluster_id| {
                 let centroid = coarse_centroids.get_centroid(cluster_id);
-                crate::structures::simd::dot_product_f32(query, centroid, query.len())
-                    * inverse_norm
+                crate::structures::simd::dot_product_f32(
+                    &normalized_query,
+                    centroid,
+                    normalized_query.len(),
+                )
             })
             .collect();
         Self {
             quantizer_version: route.quantizer_version,
             fingerprint: codec.fingerprint(),
-            request_fingerprint: route.request_fingerprint,
+            request_fingerprint: Self::request_fingerprint_for(
+                coarse_centroids,
+                query,
+                effective_nprobe,
+                routing,
+            ),
             cluster_ids: route.cluster_ids,
             cluster_dots,
-            tq: TqQueryPlan::build(codec, query),
+            tq: TqQueryPlan::build(codec, &normalized_query),
         }
+    }
+
+    /// Cache identity matching normalized cosine routing geometry.
+    pub fn request_fingerprint_for(
+        coarse_centroids: &CoarseCentroids,
+        query: &[f32],
+        nprobe: usize,
+        routing: IvfRoutingMode,
+    ) -> u64 {
+        assert!(
+            is_ivf_tq_cosine_generation(coarse_centroids.version),
+            "legacy raw IVF-TQ generations cannot build a query fingerprint; rebuild the index"
+        );
+        let effective_nprobe = nprobe.clamp(1, coarse_centroids.num_clusters as usize);
+        cosine_probe_fingerprint(query, effective_nprobe, routing)
     }
 
     #[inline]
@@ -128,6 +182,10 @@ impl IvfTqIndex {
         codec: std::sync::Arc<TqCodec>,
     ) -> Self {
         assert_eq!(codec.dim(), dim, "IVF-TQ codec/config dimension mismatch");
+        assert!(
+            is_ivf_tq_cosine_generation(centroids_version),
+            "legacy raw IVF-TQ generations cannot encode vectors; rebuild the index"
+        );
         Self {
             dim,
             routing,
@@ -146,6 +204,26 @@ impl IvfTqIndex {
     /// Add a single vector: assign to the trained router (with SOAR when
     /// configured) and TQ-encode the residual against every assigned leaf.
     pub fn add_vector(
+        &mut self,
+        coarse_centroids: &CoarseCentroids,
+        doc_id: u32,
+        ordinal: u16,
+        vector: &[f32],
+        scratch: &mut TqIvfEncodeScratch,
+    ) {
+        assert_eq!(
+            coarse_centroids.version, self.centroids_version,
+            "IVF-TQ centroid generation mismatch"
+        );
+        let mut normalized = std::mem::take(&mut scratch.normalized);
+        normalized.clear();
+        normalized.extend_from_slice(vector);
+        normalize_cosine_in_place(&mut normalized);
+        self.add_prepared_vector(coarse_centroids, doc_id, ordinal, &normalized, scratch);
+        scratch.normalized = normalized;
+    }
+
+    fn add_prepared_vector(
         &mut self,
         coarse_centroids: &CoarseCentroids,
         doc_id: u32,
@@ -224,6 +302,9 @@ impl IvfTqIndex {
             .ok_or("IVF-TQ input size overflow")?;
         if vectors.len() != expected {
             return Err("IVF-TQ vector and label matrices are inconsistent");
+        }
+        if coarse_centroids.version != self.centroids_version {
+            return Err("IVF-TQ centroid generation mismatch");
         }
         if vector_count == 0 {
             return Ok(());
@@ -313,6 +394,7 @@ impl IvfTqIndex {
 /// Reusable per-thread IVF-TQ encode buffers.
 #[derive(Debug, Default)]
 pub struct TqIvfEncodeScratch {
+    normalized: Vec<f32>,
     residual: Vec<f32>,
     nibbles: Vec<u8>,
     tq: TqEncodeScratch,
@@ -344,13 +426,14 @@ mod tests {
     }
 
     /// The scaled residual estimator must approximate the true inner product
-    /// of the raw (unnormalized-residual) decomposition.
+    /// of the normalized-vector residual decomposition.
     #[test]
     fn scaled_residual_estimator_tracks_true_dot() {
         let dim = 64;
         let codec = std::sync::Arc::new(TqCodec::new(dim));
         let vectors: Vec<Vec<f32>> = (0..64).map(|i| seeded_unit_vector(dim, 100 + i)).collect();
-        let centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 4), &vectors);
+        let mut centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 4), &vectors);
+        centroids.version = mark_ivf_tq_cosine_generation(centroids.version);
 
         let mut index = IvfTqIndex::new(
             dim,
@@ -403,5 +486,99 @@ mod tests {
         assert!(checked >= vectors.len(), "every vector must be scored");
         let rmse = (squared_error / checked as f64).sqrt();
         assert!(rmse < 0.08, "IVF-TQ estimator RMSE too large: {rmse}");
+    }
+
+    #[test]
+    fn query_plans_are_scale_invariant() {
+        let dim = 2;
+        let codec = TqCodec::new(dim);
+        let query = vec![1.0, 0.0];
+        let scaled_query: Vec<f32> = query.iter().map(|value| value * 100.0).collect();
+        for routing in [IvfRoutingMode::Auto, IvfRoutingMode::Flat] {
+            let centroids = CoarseCentroids {
+                num_clusters: 2,
+                dim,
+                // An intentionally non-unit fixture makes accidental raw-L2
+                // routing select a different leaf for the scaled query.
+                centroids: vec![1.0, 0.0, 10.0, 0.0],
+                version: mark_ivf_tq_cosine_generation(7),
+                soar_config: None,
+                routing_index: None,
+            };
+            let plan = TqIvfQueryPlan::build(&centroids, &codec, &query, 1, routing);
+            let scaled_plan = TqIvfQueryPlan::build(&centroids, &codec, &scaled_query, 1, routing);
+
+            assert_eq!(&*plan.cluster_ids, &[0]);
+            assert_eq!(plan.cluster_ids, scaled_plan.cluster_ids);
+            assert_eq!(plan.request_fingerprint, scaled_plan.request_fingerprint);
+            assert_eq!(plan.cluster_dots, scaled_plan.cluster_dots);
+        }
+    }
+
+    #[test]
+    fn vector_encoding_always_normalizes_input() {
+        let codec = std::sync::Arc::new(TqCodec::new(2));
+        let centroids = CoarseCentroids {
+            num_clusters: 1,
+            dim: 2,
+            centroids: vec![1.0, 0.0],
+            version: mark_ivf_tq_cosine_generation(7),
+            soar_config: None,
+            routing_index: None,
+        };
+        let mut index = IvfTqIndex::new(
+            2,
+            IvfRoutingMode::Flat,
+            centroids.version,
+            std::sync::Arc::clone(&codec),
+        );
+        let mut scratch = TqIvfEncodeScratch::default();
+
+        index.add_vector(&centroids, 0, 0, &[2.0, 0.0], &mut scratch);
+        index.add_vector(&centroids, 1, 0, &[128.0, 0.0], &mut scratch);
+
+        let cluster = &index.clusters[&0];
+        assert_eq!(cluster.doc_ids, [0, 1]);
+        assert_eq!(cluster.scales, [0.0, 0.0]);
+        assert_eq!(cluster.gammas[0], cluster.gammas[1]);
+        assert_eq!(
+            &cluster.rows[..index.codec.padded_dim()],
+            &cluster.rows[index.codec.padded_dim()..]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "legacy raw IVF-TQ generations cannot build a query plan")]
+    fn query_plan_rejects_legacy_generation() {
+        let centroids = CoarseCentroids {
+            num_clusters: 1,
+            dim: 2,
+            centroids: vec![1.0, 0.0],
+            version: 7,
+            soar_config: None,
+            routing_index: None,
+        };
+        let codec = TqCodec::new(2);
+        let _ = TqIvfQueryPlan::build(&centroids, &codec, &[1.0, 0.0], 1, IvfRoutingMode::Flat);
+    }
+
+    #[test]
+    #[should_panic(expected = "legacy raw IVF-TQ generations cannot encode vectors")]
+    fn index_builder_rejects_legacy_generation() {
+        let _ = IvfTqIndex::new(
+            2,
+            IvfRoutingMode::Flat,
+            7,
+            std::sync::Arc::new(TqCodec::new(2)),
+        );
+    }
+
+    #[test]
+    fn cosine_generation_marker_is_stable_and_distinct_from_unmarked() {
+        let marked = mark_ivf_tq_cosine_generation(7);
+        assert!(!is_ivf_tq_cosine_generation(7));
+        assert!(is_ivf_tq_cosine_generation(marked));
+        assert_eq!(mark_ivf_tq_cosine_generation(marked), marked);
+        assert_ne!(marked, mark_ivf_tq_cosine_generation(8));
     }
 }

--- a/hermes-core/src/structures/vector/index/mod.rs
+++ b/hermes-core/src/structures/vector/index/mod.rs
@@ -9,7 +9,10 @@ mod ivf_tq;
 #[cfg(feature = "native")]
 pub(crate) use binary_ivf::BinaryIvfBuilder;
 pub use binary_ivf::{BinaryCoarseQuantizer, BinaryIvfConfig, BinaryIvfIndex};
-pub use ivf_tq::{IvfTqIndex, TqIvfEncodeScratch, TqIvfQueryPlan};
+pub use ivf_tq::{
+    IvfTqIndex, TqIvfEncodeScratch, TqIvfQueryPlan, is_ivf_tq_cosine_generation,
+    mark_ivf_tq_cosine_generation,
+};
 
 #[derive(Clone, Copy)]
 struct RankedEntry {
@@ -54,6 +57,73 @@ pub(crate) struct BoundedAnnCollector<const BY_DOCUMENT: bool, const HIGHER_IS_B
     k: usize,
     heap: std::collections::BinaryHeap<RankedEntry>,
     best: rustc_hash::FxHashMap<u64, RankedEntry>,
+}
+
+/// Heap-only top-k collector for streams whose `(doc_id, ordinal)` keys are
+/// guaranteed unique by construction.
+///
+/// Unlike `BoundedAnnCollector`, this deliberately performs no deduplication
+/// and therefore avoids an O(k) hash map plus a hash-table lookup on every
+/// competitive insertion.
+pub(crate) struct BoundedUniqueAnnCollector<const HIGHER_IS_BETTER: bool> {
+    k: usize,
+    heap: std::collections::BinaryHeap<RankedEntry>,
+}
+
+impl<const HIGHER_IS_BETTER: bool> BoundedUniqueAnnCollector<HIGHER_IS_BETTER> {
+    pub(crate) fn new(k: usize) -> Self {
+        Self {
+            k,
+            heap: std::collections::BinaryHeap::with_capacity(k.min(8_192)),
+        }
+    }
+
+    #[inline]
+    fn rank(value: f32) -> f32 {
+        if HIGHER_IS_BETTER { -value } else { value }
+    }
+
+    #[inline]
+    fn value(rank: f32) -> f32 {
+        if HIGHER_IS_BETTER { -rank } else { rank }
+    }
+
+    #[inline]
+    pub(crate) fn insert(&mut self, doc_id: u32, ordinal: u16, value: f32) {
+        if self.k == 0 || !value.is_finite() {
+            return;
+        }
+        let candidate = RankedEntry {
+            doc_id,
+            ordinal,
+            rank: Self::rank(value),
+        };
+        if self.heap.len() < self.k {
+            self.heap.push(candidate);
+        } else if self.heap.peek().is_some_and(|worst| candidate < *worst) {
+            self.heap.pop();
+            self.heap.push(candidate);
+        }
+    }
+
+    pub(crate) fn into_sorted_results(self) -> Vec<(u32, u16, f32)> {
+        let mut results: Vec<_> = self
+            .heap
+            .into_iter()
+            .map(|entry| (entry.doc_id, entry.ordinal, Self::value(entry.rank)))
+            .collect();
+        results.sort_unstable_by(|a, b| {
+            let order = if HIGHER_IS_BETTER {
+                b.2.total_cmp(&a.2)
+            } else {
+                a.2.total_cmp(&b.2)
+            };
+            order
+                .then_with(|| a.0.cmp(&b.0))
+                .then_with(|| a.1.cmp(&b.1))
+        });
+        results
+    }
 }
 
 impl<const BY_DOCUMENT: bool, const HIGHER_IS_BETTER: bool>
@@ -159,6 +229,16 @@ impl<const BY_DOCUMENT: bool, const HIGHER_IS_BETTER: bool>
         self.heap.peek().map(|entry| Self::value(entry.rank))
     }
 
+    /// Merge another bounded collector without sorting or materializing its
+    /// retained entries. This is used by parallel scans to reduce worker-local
+    /// top-k state while keeping temporary memory bounded by the workers.
+    #[cfg(any(feature = "native", test))]
+    pub(crate) fn merge_from(&mut self, other: Self) {
+        for entry in other.best.into_values() {
+            self.insert(entry.doc_id, entry.ordinal, Self::value(entry.rank));
+        }
+    }
+
     pub(crate) fn into_sorted_results(self) -> Vec<(u32, u16, f32)> {
         let mut results: Vec<_> = self
             .best
@@ -181,7 +261,7 @@ impl<const BY_DOCUMENT: bool, const HIGHER_IS_BETTER: bool>
 
 #[cfg(test)]
 mod tests {
-    use super::BoundedAnnCollector;
+    use super::{BoundedAnnCollector, BoundedUniqueAnnCollector};
     use rand::{Rng, SeedableRng};
 
     type BoundedDistanceCollector = BoundedAnnCollector<false, false>;
@@ -255,6 +335,37 @@ mod tests {
             collector.into_sorted_results(),
             vec![(3, 0, 0.75), (4, 0, 0.75)]
         );
+    }
+
+    #[test]
+    fn bounded_collectors_merge_without_changing_top_k() {
+        let mut left = BoundedDocumentScoreCollector::new(3);
+        left.insert(1, 0, 0.5);
+        left.insert(2, 0, 0.8);
+        left.insert(3, 0, 0.6);
+
+        let mut right = BoundedDocumentScoreCollector::new(3);
+        right.insert(1, 1, 0.9);
+        right.insert(4, 0, 0.7);
+        right.insert(5, 0, 0.4);
+
+        left.merge_from(right);
+        assert_eq!(
+            left.into_sorted_results(),
+            vec![(1, 1, 0.9), (2, 0, 0.8), (4, 0, 0.7)]
+        );
+    }
+
+    #[test]
+    fn heap_only_collector_matches_deduplicating_collector_for_unique_keys() {
+        let mut bounded = BoundedDocumentScoreCollector::new(17);
+        let mut unique = BoundedUniqueAnnCollector::<true>::new(17);
+        for doc_id in 0..1_000 {
+            let score = ((doc_id * 37) % 211) as f32 / 211.0;
+            bounded.insert(doc_id, 0, score);
+            unique.insert(doc_id, 0, score);
+        }
+        assert_eq!(unique.into_sorted_results(), bounded.into_sorted_results(),);
     }
 
     #[test]

--- a/hermes-core/src/structures/vector/ivf/coarse.rs
+++ b/hermes-core/src/structures/vector/ivf/coarse.rs
@@ -7,11 +7,28 @@ use serde::{Deserialize, Serialize};
 
 use super::routing::{
     HNSW_AUTO_THRESHOLD, HnswRoutingGraph, IvfProbePlan, IvfRoutingTopology,
-    allocate_child_clusters, effective_routing_mode, float_probe_fingerprint, parent_probe_count,
-    routing_parent_count, select_best, select_best_candidates,
+    allocate_child_clusters, effective_routing_mode, float_probe_fingerprint, routing_parent_count,
+    select_best_candidates, select_parent_beam, select_parent_beam_for_build,
 };
 use super::soar::{MultiAssignment, SoarConfig};
 use crate::dsl::IvfRoutingMode;
+
+// The SOAR paper evaluates lambda = 1. Keep it private until a different
+// value has recall/latency evidence and can be added without changing the
+// serialized public configuration.
+const SOAR_LAMBDA: f32 = 1.0;
+/// Selective spilling is intended for boundary vectors, whose primary and
+/// secondary residuals have comparable distortion. Encoding a residual to a
+/// much farther secondary centroid both wastes a posting and amplifies TQ
+/// estimation error enough to crowd better exact-rerank candidates out.
+///
+/// Compare squared distances, so `4` permits a secondary residual up to twice
+/// the primary residual norm. Full spilling remains unconditional.
+const MAX_SELECTIVE_SECONDARY_TO_PRIMARY_DISTANCE_RATIO_SQ: f32 = 4.0;
+/// Construction is offline, so expand more of a hierarchical router than a
+/// latency-sensitive one-leaf query. This reduces permanent misassignment
+/// without returning to an O(K) centroid scan for large codebooks.
+const BUILD_ASSIGNMENT_CANDIDATES: usize = 128;
 
 /// Configuration for coarse quantizer
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,28 +106,59 @@ pub(crate) enum FloatCentroidRouter {
     Hnsw(HnswRoutingGraph),
 }
 
+struct FlatClusterMemberships {
+    offsets: Vec<usize>,
+    members: Vec<usize>,
+}
+
+impl FlatClusterMemberships {
+    fn cluster(&self, cluster: usize) -> &[usize] {
+        &self.members[self.offsets[cluster]..self.offsets[cluster + 1]]
+    }
+}
+
 impl CoarseCentroids {
     /// Train coarse centroids using k-means algorithm
     ///
-    /// Uses deterministic k-means++ seeding and Lloyd refinement.
+    /// Uses deterministic adaptive D² seeding and Lloyd refinement.
     pub fn train(config: &CoarseConfig, vectors: &[Vec<f32>]) -> Self {
         assert!(!vectors.is_empty(), "Cannot train on empty vector set");
         assert!(config.num_clusters > 0, "Need at least 1 cluster");
         assert!(vectors.iter().all(|vector| vector.len() == config.dim));
 
-        let actual_clusters = config.num_clusters.min(vectors.len());
+        // Keep the public row-oriented API for callers and tests, but funnel
+        // production training through one contiguous matrix so the build path
+        // does not allocate one heap object per sampled vector.
+        let flat = vectors
+            .iter()
+            .flat_map(|vector| vector.iter().copied())
+            .collect::<Vec<_>>();
+        Self::train_contiguous(config, &flat, vectors.len())
+    }
+
+    /// Train directly from a contiguous row-major matrix.
+    pub(crate) fn train_contiguous(
+        config: &CoarseConfig,
+        vectors: &[f32],
+        vector_count: usize,
+    ) -> Self {
+        assert!(vector_count > 0, "Cannot train on empty vector set");
+        assert!(config.num_clusters > 0, "Need at least 1 cluster");
+        assert_eq!(vectors.len(), vector_count.saturating_mul(config.dim));
+
+        let actual_clusters = config.num_clusters.min(vector_count);
         let (centroids, routing_index) =
             match effective_routing_mode(config.routing, actual_clusters) {
                 IvfRoutingMode::TwoLevel => {
                     let (leaves, router) =
-                        Self::train_hierarchical(config, vectors, actual_clusters);
+                        Self::train_hierarchical(config, vectors, vector_count, actual_clusters);
                     (leaves, Some(router))
                 }
                 IvfRoutingMode::Hnsw => {
                     let leaves = if actual_clusters >= HNSW_AUTO_THRESHOLD {
-                        Self::train_hierarchical(config, vectors, actual_clusters).0
+                        Self::train_hierarchical(config, vectors, vector_count, actual_clusters).0
                     } else {
-                        Self::train_flat(config, vectors, actual_clusters).0
+                        Self::train_flat(config, vectors, vector_count, actual_clusters)
                     };
                     let graph = HnswRoutingGraph::build(
                         actual_clusters,
@@ -126,9 +174,10 @@ impl CoarseCentroids {
                     );
                     (leaves, Some(FloatCentroidRouter::Hnsw(graph)))
                 }
-                IvfRoutingMode::Flat | IvfRoutingMode::Auto => {
-                    (Self::train_flat(config, vectors, actual_clusters).0, None)
-                }
+                IvfRoutingMode::Flat | IvfRoutingMode::Auto => (
+                    Self::train_flat(config, vectors, vector_count, actual_clusters),
+                    None,
+                ),
             };
 
         let version = std::time::SystemTime::now()
@@ -136,68 +185,186 @@ impl CoarseCentroids {
             .unwrap_or_default()
             .as_nanos() as u64;
 
-        Self {
+        let mut soar_config = config.soar.clone();
+        if let Some(soar) = &mut soar_config
+            && soar.num_secondary > 1
+        {
+            log::warn!(
+                "SOAR currently implements the published primary + one-secondary objective; \
+                 clamping {} requested secondary assignments to one",
+                soar.num_secondary,
+            );
+            soar.num_secondary = 1;
+        }
+        let calibration_target = soar_config
+            .as_ref()
+            .and_then(SoarConfig::calibration_target);
+        let mut trained = Self {
             num_clusters: actual_clusters as u32,
             dim: config.dim,
             centroids,
             version,
-            soar_config: config.soar.clone(),
+            // Install the SOAR policy after calibration so primary assignment
+            // below cannot recursively request secondary leaves.
+            soar_config: None,
             routing_index,
+        };
+        if let Some(target) = calibration_target {
+            let threshold = trained.calibrate_selective_spill_threshold(
+                vectors,
+                vector_count,
+                config.routing,
+                target,
+            );
+            if let Some(soar) = &mut soar_config {
+                soar.spill_threshold = threshold;
+            }
+            log::info!(
+                "Calibrated SOAR selective spilling to at most {:.1}% of the training sample \
+                 (residual threshold {:.6})",
+                target * 100.0,
+                threshold,
+            );
+        }
+        trained.soar_config = soar_config;
+        trained
+    }
+
+    fn calibrate_selective_spill_threshold(
+        &self,
+        vectors: &[f32],
+        vector_count: usize,
+        routing: IvfRoutingMode,
+        target_fraction: f32,
+    ) -> f32 {
+        // Bound calibration independently of the caller's raw training
+        // sample. Flat routing pays O(KD) per selected vector; hierarchical
+        // routers can afford a larger validation slice.
+        let routing = effective_routing_mode(routing, self.num_clusters as usize);
+        let sample_limit = match routing {
+            IvfRoutingMode::Flat | IvfRoutingMode::Auto => {
+                let work_per_vector = (self.num_clusters as usize).saturating_mul(self.dim).max(1);
+                (64_000_000usize / work_per_vector).clamp(32, 4_096)
+            }
+            IvfRoutingMode::TwoLevel | IvfRoutingMode::Hnsw => 8_192,
+        }
+        .min(vector_count);
+        let mut residual_norms = Vec::with_capacity(sample_limit);
+        for sample in 0..sample_limit {
+            let vector_index = sample.saturating_mul(vector_count) / sample_limit;
+            let offset = vector_index * self.dim;
+            let vector = &vectors[offset..offset + self.dim];
+            let primary = self.assign_with_routing(vector, routing).primary_cluster;
+            residual_norms.push(squared_l2(vector, self.get_centroid(primary)).sqrt());
+        }
+        residual_norms.sort_unstable_by(f32::total_cmp);
+        if residual_norms.is_empty() {
+            return 0.0;
+        }
+        let spill_count = ((residual_norms.len() as f32 * target_fraction.clamp(0.0, 1.0)).round()
+            as usize)
+            .min(residual_norms.len());
+        if spill_count == 0 {
+            let largest = residual_norms.last().copied().unwrap_or(0.0);
+            return threshold_strictly_above(largest);
+        }
+        let boundary = residual_norms[residual_norms.len() - spill_count];
+        let at_or_above =
+            residual_norms.len() - residual_norms.partition_point(|&norm| norm < boundary);
+        if at_or_above > spill_count {
+            // Equality spills, so a quantile that lands in a tie could exceed
+            // the configured storage budget—up to 100% for identical
+            // residuals. Move strictly above the tied value; underfilling is
+            // preferable to an unbounded posting expansion.
+            threshold_strictly_above(boundary)
+        } else {
+            boundary
         }
     }
 
     fn train_flat(
         config: &CoarseConfig,
-        vectors: &[Vec<f32>],
+        vectors: &[f32],
+        vector_count: usize,
         clusters: usize,
-    ) -> (Vec<f32>, Vec<Vec<usize>>) {
-        let dim = config.dim;
-        let flat: Vec<f32> = vectors.iter().flat_map(|v| v.iter().copied()).collect();
-        let trained = crate::structures::vector::kmeans::train_euclidean_kmeans(
-            &flat,
-            vectors.len(),
-            dim,
+    ) -> Vec<f32> {
+        Self::run_kmeans(config, vectors, vector_count, clusters).centroids
+    }
+
+    fn train_flat_with_memberships(
+        config: &CoarseConfig,
+        vectors: &[f32],
+        vector_count: usize,
+        clusters: usize,
+    ) -> (Vec<f32>, FlatClusterMemberships) {
+        let trained = Self::run_kmeans(config, vectors, vector_count, clusters);
+        (
+            trained.centroids,
+            FlatClusterMemberships {
+                offsets: trained.member_offsets,
+                members: trained.members,
+            },
+        )
+    }
+
+    fn run_kmeans(
+        config: &CoarseConfig,
+        vectors: &[f32],
+        vector_count: usize,
+        clusters: usize,
+    ) -> crate::structures::vector::kmeans::EuclideanKMeans {
+        crate::structures::vector::kmeans::train_euclidean_kmeans(
+            vectors,
+            vector_count,
+            config.dim,
             clusters,
             config.max_iters,
             config.seed,
-        );
-        let mut groups = vec![Vec::new(); clusters];
-        for (point, cluster) in trained.assignments.into_iter().enumerate() {
-            groups[cluster].push(point);
-        }
-        (trained.centroids, groups)
+        )
     }
 
     fn train_hierarchical(
         config: &CoarseConfig,
-        vectors: &[Vec<f32>],
+        vectors: &[f32],
+        vector_count: usize,
         leaf_count: usize,
     ) -> (Vec<f32>, FloatCentroidRouter) {
-        let parent_count = routing_parent_count(leaf_count).min(vectors.len());
+        let parent_count = routing_parent_count(leaf_count).min(vector_count);
         let mut parent_config = config.clone();
         parent_config.routing = IvfRoutingMode::Flat;
         parent_config.num_clusters = parent_count;
-        let (parent_centroids, groups) = Self::train_flat(&parent_config, vectors, parent_count);
-        let group_sizes: Vec<usize> = groups.iter().map(Vec::len).collect();
+        let (parent_centroids, groups) =
+            Self::train_flat_with_memberships(&parent_config, vectors, vector_count, parent_count);
+        let group_sizes: Vec<usize> = (0..parent_count)
+            .map(|parent| groups.cluster(parent).len())
+            .collect();
         let child_counts = allocate_child_clusters(&group_sizes, leaf_count);
         let mut leaves = Vec::with_capacity(leaf_count.saturating_mul(config.dim));
         let mut children = vec![Vec::new(); parent_count];
+        let mut group_vectors = Vec::new();
 
-        for (parent, (indices, &child_count)) in groups.iter().zip(&child_counts).enumerate() {
+        for (parent, &child_count) in child_counts.iter().enumerate() {
             if child_count == 0 {
                 continue;
             }
-            let group_vectors: Vec<Vec<f32>> = indices
-                .iter()
-                .map(|&index| vectors[index].clone())
-                .collect();
+            let indices = groups.cluster(parent);
+            group_vectors.clear();
+            group_vectors.reserve(indices.len().saturating_mul(config.dim));
+            for &index in indices {
+                let offset = index * config.dim;
+                group_vectors.extend_from_slice(&vectors[offset..offset + config.dim]);
+            }
             let mut child_config = config.clone();
             child_config.routing = IvfRoutingMode::Flat;
             child_config.num_clusters = child_count;
             child_config.seed = config.seed ^ (parent as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15);
             let first_leaf = leaves.len() / config.dim;
-            leaves
-                .extend_from_slice(&Self::train_flat(&child_config, &group_vectors, child_count).0);
+            leaves.extend_from_slice(&Self::train_flat(
+                &child_config,
+                &group_vectors,
+                indices.len(),
+                child_count,
+            ));
             children[parent].extend((first_leaf..first_leaf + child_count).map(|leaf| leaf as u32));
         }
         debug_assert_eq!(leaves.len(), leaf_count * config.dim);
@@ -320,6 +487,18 @@ impl CoarseCentroids {
     }
 
     fn find_k_nearest_two_level(&self, vector: &[f32], k: usize) -> Vec<u32> {
+        self.find_k_nearest_two_level_impl::<false>(vector, k)
+    }
+
+    fn find_k_nearest_two_level_for_build(&self, vector: &[f32], k: usize) -> Vec<u32> {
+        self.find_k_nearest_two_level_impl::<true>(vector, k)
+    }
+
+    fn find_k_nearest_two_level_impl<const FOR_BUILD: bool>(
+        &self,
+        vector: &[f32],
+        k: usize,
+    ) -> Vec<u32> {
         let Some(FloatCentroidRouter::TwoLevel {
             parent_centroids,
             topology,
@@ -336,9 +515,11 @@ impl CoarseCentroids {
             let offset = parent_id * self.dim;
             *score = squared_l2(vector, &parent_centroids[offset..offset + self.dim]);
         }
-        let parent_take =
-            parent_probe_count(k, self.num_clusters as usize, topology.parent_count());
-        let parents = select_best::<false>(&parent_scores, parent_take);
+        let parents = if FOR_BUILD {
+            select_parent_beam_for_build::<false>(&parent_scores, topology, k)
+        } else {
+            select_parent_beam::<false>(&parent_scores, topology, k)
+        };
         let candidate_capacity = parents
             .iter()
             .map(|&parent| topology.children(parent as usize).len())
@@ -357,13 +538,6 @@ impl CoarseCentroids {
             return self.find_k_nearest(vector, k);
         };
         graph.search(|leaf| squared_l2(vector, self.get_centroid(leaf)), k)
-    }
-
-    fn find_nearest_hnsw(&self, vector: &[f32]) -> u32 {
-        let Some(FloatCentroidRouter::Hnsw(graph)) = self.routing_index.as_ref() else {
-            return self.find_nearest(vector);
-        };
-        graph.search_one(|leaf| squared_l2(vector, self.get_centroid(leaf)))
     }
 
     /// Find k nearest clusters with their distances
@@ -403,8 +577,15 @@ impl CoarseCentroids {
         } else {
             let primary_cluster = match effective_routing_mode(routing, self.num_clusters as usize)
             {
-                IvfRoutingMode::Hnsw => self.find_nearest_hnsw(vector),
-                IvfRoutingMode::TwoLevel => self.find_k_nearest_two_level(vector, 1)[0],
+                IvfRoutingMode::Hnsw => self.find_k_nearest_hnsw_for_build(vector, 1)[0],
+                IvfRoutingMode::TwoLevel => self
+                    .find_k_nearest_two_level_for_build(
+                        vector,
+                        BUILD_ASSIGNMENT_CANDIDATES.min(self.num_clusters as usize),
+                    )
+                    .first()
+                    .copied()
+                    .unwrap_or(0),
                 IvfRoutingMode::Flat | IvfRoutingMode::Auto => self.find_nearest(vector),
             };
             MultiAssignment {
@@ -414,7 +595,7 @@ impl CoarseCentroids {
         }
     }
 
-    /// SOAR-style assignment: find secondary clusters with orthogonal residuals
+    /// SOAR-style assignment: balance secondary distortion and residual orthogonality
     pub fn assign_with_soar(&self, vector: &[f32], config: &SoarConfig) -> MultiAssignment {
         self.assign_with_soar_and_routing(vector, config, IvfRoutingMode::Flat)
     }
@@ -425,27 +606,33 @@ impl CoarseCentroids {
         config: &SoarConfig,
         routing: IvfRoutingMode,
     ) -> MultiAssignment {
+        // The implemented SOAR loss is the published primary + one-secondary
+        // objective. Treat larger manually constructed values the same as the
+        // trained/config-parsed path instead of pretending repeated independent
+        // minimization implements the generalized multi-spill objective.
+        let num_secondary = config.num_secondary.min(1);
+        // Secondary assignment needs a meaningfully larger candidate pool
+        // than the number of requested spills; otherwise a skewed two-level
+        // topology can leave the SOAR loss no alternatives to rank.
+        let candidate_budget =
+            soar_build_candidate_budget(num_secondary, self.num_clusters as usize);
         let leaf_ids: Vec<u32> = match effective_routing_mode(routing, self.num_clusters as usize) {
             IvfRoutingMode::TwoLevel => {
-                self.two_level_candidate_leaves(vector, config.num_secondary + 1)
+                self.two_level_candidate_leaves_for_build(vector, candidate_budget)
             }
-            IvfRoutingMode::Hnsw => self.find_k_nearest_hnsw(
-                vector,
-                (config.num_secondary + 1)
-                    .saturating_mul(16)
-                    .max(32)
-                    .min(self.num_clusters as usize),
-            ),
+            IvfRoutingMode::Hnsw => self.find_k_nearest_hnsw_for_build(vector, candidate_budget),
             IvfRoutingMode::Flat | IvfRoutingMode::Auto => (0..self.num_clusters).collect(),
         };
-        let primary = leaf_ids
+        // Compute every candidate distance once. Reuse it both for primary
+        // selection and as the distortion term in the secondary SOAR loss.
+        let leaf_distances: Vec<(u32, f32)> = leaf_ids
+            .into_iter()
+            .map(|cluster| (cluster, squared_l2(vector, self.get_centroid(cluster))))
+            .collect();
+        let primary = leaf_distances
             .iter()
-            .copied()
-            .min_by(|&left, &right| {
-                squared_l2(vector, self.get_centroid(left))
-                    .total_cmp(&squared_l2(vector, self.get_centroid(right)))
-                    .then_with(|| left.cmp(&right))
-            })
+            .min_by(|left, right| scored_cluster_order(left, right))
+            .map(|&(cluster, _)| cluster)
             .unwrap_or(0);
         let primary_centroid = self.get_centroid(primary);
 
@@ -466,42 +653,56 @@ impl CoarseCentroids {
             };
         }
 
-        // 4. Find secondary clusters that MINIMIZE |⟨r, r'⟩| (orthogonal residuals)
-        let mut candidates: Vec<(u32, f32)> = leaf_ids
+        // 4. Minimize the published lambda=1 SOAR objective:
+        //
+        //      ||r'||² + lambda * ||proj_r(r')||²
+        //
+        // This retains ordinary secondary quantization quality while penalizing
+        // correlation with the primary residual. Optimizing only the projection
+        // term can otherwise select an arbitrarily distant orthogonal centroid.
+        let mut candidates: Vec<(u32, f32)> = leaf_distances
             .into_iter()
-            .filter(|&c| c != primary)
-            .map(|c| {
-                let centroid = self.get_centroid(c);
-                // Compute r' = x - c'
-                // Then compute |⟨r, r'⟩| - we want this SMALL (orthogonal)
-                let dot: f32 = vector
-                    .iter()
-                    .zip(centroid)
-                    .zip(&residual)
-                    .map(|((v, c), r)| (v - c) * r)
-                    .sum();
-                (c, dot.abs())
+            .filter(|&(cluster, secondary_residual_norm_sq)| {
+                cluster != primary
+                    && (!config.selective
+                        || secondary_residual_norm_sq
+                            <= MAX_SELECTIVE_SECONDARY_TO_PRIMARY_DISTANCE_RATIO_SQ
+                                * residual_norm_sq)
+            })
+            .map(|(cluster, secondary_residual_norm_sq)| {
+                (
+                    cluster,
+                    soar_secondary_loss(
+                        vector,
+                        self.get_centroid(cluster),
+                        &residual,
+                        residual_norm_sq,
+                        secondary_residual_norm_sq,
+                    ),
+                )
             })
             .collect();
 
-        // Partial sort by orthogonality (smallest dot product first)
-        let take = config.num_secondary.min(candidates.len());
+        // Select by loss, then sort the retained prefix so ties and assignment
+        // order are deterministic across platforms and repeated builds.
+        let take = num_secondary.min(candidates.len());
         if candidates.len() > take {
-            candidates.select_nth_unstable_by(take, |a, b| a.1.total_cmp(&b.1));
+            candidates.select_nth_unstable_by(take, scored_cluster_order);
             candidates.truncate(take);
         }
+        candidates.sort_unstable_by(scored_cluster_order);
 
         MultiAssignment {
             primary_cluster: primary,
             secondary_clusters: candidates
                 .iter()
-                .take(config.num_secondary)
+                .take(num_secondary)
                 .map(|(c, _)| *c)
                 .collect(),
         }
     }
 
-    fn two_level_candidate_leaves(&self, vector: &[f32], k: usize) -> Vec<u32> {
+    fn two_level_candidate_leaves_for_build(&self, vector: &[f32], k: usize) -> Vec<u32> {
         let Some(FloatCentroidRouter::TwoLevel {
             parent_centroids,
             topology,
@@ -514,10 +715,7 @@ impl CoarseCentroids {
             let offset = parent_id * self.dim;
             *score = squared_l2(vector, &parent_centroids[offset..offset + self.dim]);
         }
-        let parents = select_best::<false>(
-            &parent_scores,
-            parent_probe_count(k, self.num_clusters as usize, topology.parent_count()),
-        );
+        let parents = select_parent_beam_for_build::<false>(&parent_scores, topology, k);
         let capacity = parents
             .iter()
             .map(|&parent| topology.children(parent as usize).len())
@@ -527,6 +725,13 @@ impl CoarseCentroids {
             leaves.extend_from_slice(topology.children(parent as usize));
         }
         leaves
+    }
+
+    fn find_k_nearest_hnsw_for_build(&self, vector: &[f32], k: usize) -> Vec<u32> {
+        let Some(FloatCentroidRouter::Hnsw(graph)) = self.routing_index.as_ref() else {
+            return self.find_k_nearest(vector, k);
+        };
+        graph.search_for_build(|leaf| squared_l2(vector, self.get_centroid(leaf)), k)
     }
 
     /// Get centroid for a cluster
@@ -607,6 +812,60 @@ fn squared_l2(left: &[f32], right: &[f32]) -> f32 {
         .sum()
 }
 
+#[inline]
+fn threshold_strictly_above(value: f32) -> f32 {
+    if !value.is_finite() {
+        return f32::INFINITY;
+    }
+    // A single ULP is not sufficient near zero because the assignment path
+    // compares squared norms and a subnormal threshold can square back to
+    // zero. A small relative-or-absolute margin remains negligible for
+    // normalized vectors while guaranteeing a strictly larger squared bound.
+    let next = value + value.abs().max(1.0) * (4.0 * f32::EPSILON);
+    if next > value { next } else { f32::INFINITY }
+}
+
+#[inline]
+fn soar_build_candidate_budget(num_secondary: usize, num_clusters: usize) -> usize {
+    num_secondary
+        .saturating_add(1)
+        .saturating_mul(64)
+        .max(BUILD_ASSIGNMENT_CANDIDATES)
+        .min(num_clusters)
+}
+
+#[inline]
+fn soar_secondary_loss(
+    vector: &[f32],
+    secondary_centroid: &[f32],
+    primary_residual: &[f32],
+    primary_residual_norm_sq: f32,
+    secondary_residual_norm_sq: f32,
+) -> f32 {
+    let residual_dot = vector
+        .iter()
+        .zip(secondary_centroid)
+        .zip(primary_residual)
+        .map(|((&value, &centroid), &primary)| primary * (value - centroid))
+        .sum::<f32>();
+
+    // A zero primary residual already has no correlated score error. Define
+    // its projection penalty as zero rather than producing 0/0.
+    let projection_norm_sq = if primary_residual_norm_sq > 0.0 {
+        residual_dot * residual_dot / primary_residual_norm_sq
+    } else {
+        0.0
+    };
+    secondary_residual_norm_sq + SOAR_LAMBDA * projection_norm_sq
+}
+
+#[inline]
+fn scored_cluster_order(left: &(u32, f32), right: &(u32, f32)) -> std::cmp::Ordering {
+    left.1
+        .total_cmp(&right.1)
+        .then_with(|| left.0.cmp(&right.0))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -631,6 +890,33 @@ mod tests {
     }
 
     #[test]
+    fn contiguous_training_matches_row_wrapper() {
+        let dim = 8;
+        let vectors: Vec<Vec<f32>> = (0..128)
+            .map(|row| {
+                (0..dim)
+                    .map(|column| ((row * 31 + column * 17) % 101) as f32 / 101.0)
+                    .collect()
+            })
+            .collect();
+        let flat = vectors.iter().flatten().copied().collect::<Vec<_>>();
+        let config = CoarseConfig::new(dim, 12)
+            .with_seed(91)
+            .with_routing(IvfRoutingMode::TwoLevel);
+
+        let rows = CoarseCentroids::train(&config, &vectors);
+        let contiguous = CoarseCentroids::train_contiguous(&config, &flat, vectors.len());
+
+        assert_eq!(rows.centroids, contiguous.centroids);
+        assert_eq!(
+            bincode::serde::encode_to_vec(&rows.routing_index, bincode::config::standard())
+                .unwrap(),
+            bincode::serde::encode_to_vec(&contiguous.routing_index, bincode::config::standard())
+                .unwrap(),
+        );
+    }
+
+    #[test]
     fn test_find_nearest() {
         let dim = 32;
         let n = 500;
@@ -649,6 +935,25 @@ mod tests {
             let cluster = centroids.find_nearest(v);
             assert!(cluster < centroids.num_clusters);
         }
+    }
+
+    #[test]
+    fn scaled_l2_probes_keep_distinct_cache_identities() {
+        let centroids = CoarseCentroids {
+            num_clusters: 2,
+            dim: 2,
+            centroids: vec![1.0, 0.0, 10.0, 0.0],
+            version: 7,
+            soar_config: None,
+            routing_index: None,
+        };
+
+        let near = centroids.probe(&[1.0, 0.0], 1, IvfRoutingMode::Flat);
+        let scaled = centroids.probe(&[100.0, 0.0], 1, IvfRoutingMode::Flat);
+
+        assert_eq!(&*near.cluster_ids, &[0]);
+        assert_eq!(&*scaled.cluster_ids, &[1]);
+        assert_ne!(near.request_fingerprint, scaled.request_fingerprint);
     }
 
     #[test]
@@ -673,12 +978,400 @@ mod tests {
         // Test SOAR assignment
         let assignment = centroids.assign(&vectors[0]);
         assert!(assignment.primary_cluster < centroids.num_clusters);
-        assert_eq!(assignment.secondary_clusters.len(), 2);
+        assert_eq!(centroids.soar_config.as_ref().unwrap().num_secondary, 1);
+        assert_eq!(assignment.secondary_clusters.len(), 1);
 
         // Secondary clusters should be different from primary
         for &sec in &assignment.secondary_clusters {
             assert_ne!(sec, assignment.primary_cluster);
         }
+    }
+
+    #[test]
+    fn soar_loss_includes_distortion_and_normalized_projection() {
+        let vector = [0.0, 0.0];
+        let primary_residual = [2.0, 0.0];
+        let secondary_centroid = [-3.0, -4.0];
+
+        // r' = [3, 4], so ||r'||² = 25 and
+        // ||proj_r(r')||² = <r,r'>² / ||r||² = 36 / 4 = 9.
+        let loss = soar_secondary_loss(&vector, &secondary_centroid, &primary_residual, 4.0, 25.0);
+        assert!((loss - 34.0).abs() <= f32::EPSILON);
+    }
+
+    #[test]
+    fn soar_routing_keeps_an_oversampled_secondary_candidate_pool() {
+        assert_eq!(soar_build_candidate_budget(1, 1_000), 128);
+        assert_eq!(soar_build_candidate_budget(2, 1_000), 192);
+        assert_eq!(soar_build_candidate_budget(8, 64), 64);
+    }
+
+    #[test]
+    fn two_level_build_assignment_checks_four_parents_for_primary_and_soar() {
+        let leaves_per_parent = 512;
+        let children: Vec<Vec<u32>> = (0..4)
+            .map(|parent| {
+                let first = parent * leaves_per_parent;
+                (first..first + leaves_per_parent)
+                    .map(|leaf| leaf as u32)
+                    .collect()
+            })
+            .collect();
+        let mut leaf_centroids = vec![1.0; 4 * leaves_per_parent];
+        let best_leaf = 3 * leaves_per_parent;
+        leaf_centroids[best_leaf] = 0.0;
+        let centroids = CoarseCentroids {
+            num_clusters: leaf_centroids.len() as u32,
+            dim: 1,
+            centroids: leaf_centroids,
+            version: 1,
+            soar_config: None,
+            routing_index: Some(FloatCentroidRouter::TwoLevel {
+                parent_centroids: vec![0.0, 10.0, 20.0, 30.0],
+                topology: IvfRoutingTopology::from_children(&children),
+            }),
+        };
+
+        let query = [0.0];
+        assert_eq!(
+            &*centroids
+                .probe(&query, 1, IvfRoutingMode::TwoLevel)
+                .cluster_ids,
+            &[0]
+        );
+        assert_eq!(
+            centroids
+                .assign_with_routing(&query, IvfRoutingMode::TwoLevel)
+                .primary_cluster,
+            best_leaf as u32
+        );
+        assert_eq!(
+            centroids
+                .assign_with_soar_and_routing(
+                    &query,
+                    &SoarConfig::full(),
+                    IvfRoutingMode::TwoLevel,
+                )
+                .primary_cluster,
+            best_leaf as u32
+        );
+    }
+
+    #[test]
+    fn selective_soar_calibrates_to_a_storage_budget() {
+        let centroids = CoarseCentroids {
+            num_clusters: 2,
+            dim: 2,
+            centroids: vec![0.0, 0.0, 10.0, 0.0],
+            version: 1,
+            soar_config: None,
+            routing_index: None,
+        };
+        let vectors: Vec<Vec<f32>> = (0..100)
+            .map(|index| vec![index as f32 / 100.0, 0.0])
+            .collect();
+        let flat = vectors.iter().flatten().copied().collect::<Vec<_>>();
+        let threshold = centroids.calibrate_selective_spill_threshold(
+            &flat,
+            vectors.len(),
+            IvfRoutingMode::Flat,
+            0.30,
+        );
+        let spilled = vectors
+            .iter()
+            .filter(|vector| squared_l2(vector, centroids.get_centroid(0)).sqrt() >= threshold)
+            .count();
+        assert!((29..=31).contains(&spilled), "{spilled}");
+    }
+
+    #[test]
+    fn selective_soar_never_exceeds_budget_when_residuals_tie() {
+        let centroids = CoarseCentroids {
+            num_clusters: 2,
+            dim: 2,
+            centroids: vec![0.0, 0.0, 10.0, 0.0],
+            version: 1,
+            soar_config: None,
+            routing_index: None,
+        };
+        let vectors = [1.0f32, 0.0].repeat(100);
+        let threshold = centroids.calibrate_selective_spill_threshold(
+            &vectors,
+            100,
+            IvfRoutingMode::Flat,
+            0.30,
+        );
+        let config = SoarConfig::new().threshold(threshold);
+        let spilled = vectors
+            .chunks_exact(2)
+            .filter(|vector| centroids.assign_with_soar(vector, &config).is_spilled())
+            .count();
+
+        assert!(threshold > 1.0);
+        assert!(spilled <= 30, "{spilled}");
+    }
+
+    #[test]
+    fn selective_soar_preserves_boundary_query_candidate_recall_with_bounded_postings() {
+        const DIM: usize = 16;
+        const CLUSTERS: usize = 16;
+        const MEMBERS_PER_CLUSTER: usize = 128;
+        const TOP_K: usize = 20;
+        const TARGET_SPILL: f32 = 0.30;
+
+        fn normalize(values: &mut [f32]) {
+            let norm = values.iter().map(|value| value * value).sum::<f32>().sqrt();
+            for value in values {
+                *value /= norm;
+            }
+        }
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0x50a4_5eed);
+        let source_centers: Vec<Vec<f32>> = (0..CLUSTERS)
+            .map(|_| {
+                let mut center: Vec<f32> = (0..DIM).map(|_| rng.random::<f32>() - 0.5).collect();
+                normalize(&mut center);
+                center
+            })
+            .collect();
+        let corpus: Vec<Vec<f32>> = source_centers
+            .iter()
+            .flat_map(|center| {
+                (0..MEMBERS_PER_CLUSTER)
+                    .map(|_| {
+                        let mut noise: Vec<f32> =
+                            (0..DIM).map(|_| rng.random::<f32>() - 0.5).collect();
+                        normalize(&mut noise);
+                        let mut vector: Vec<f32> = center
+                            .iter()
+                            .zip(noise)
+                            .map(|(&value, noise)| value + 0.75 * noise)
+                            .collect();
+                        normalize(&mut vector);
+                        vector
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        let selective = CoarseCentroids::train(
+            &CoarseConfig::new(DIM, CLUSTERS)
+                .with_seed(0x1f4)
+                .with_routing(IvfRoutingMode::Flat)
+                .with_soar(SoarConfig::new().target_spill_fraction(TARGET_SPILL)),
+            &corpus,
+        );
+        // Share the exact trained codebook so the only variable is whether
+        // documents receive selective secondary postings.
+        let mut primary_only = selective.clone();
+        primary_only.soar_config = None;
+
+        let primary_assignments: Vec<MultiAssignment> = corpus
+            .iter()
+            .map(|vector| primary_only.assign(vector))
+            .collect();
+        let selective_assignments: Vec<MultiAssignment> = corpus
+            .iter()
+            .map(|vector| selective.assign(vector))
+            .collect();
+        for (primary, spilled) in primary_assignments.iter().zip(&selective_assignments) {
+            assert_eq!(
+                primary.primary_cluster, spilled.primary_cluster,
+                "SOAR policy must not change the primary posting"
+            );
+        }
+
+        let spilled = selective_assignments
+            .iter()
+            .filter(|assignment| assignment.is_spilled())
+            .count();
+        let posting_factor = selective_assignments
+            .iter()
+            .map(MultiAssignment::num_assignments)
+            .sum::<usize>() as f32
+            / corpus.len() as f32;
+        let spill_budget = (corpus.len() as f32 * TARGET_SPILL).round() as usize;
+        assert!(
+            spilled > 0,
+            "the smoke corpus must exercise selective spilling"
+        );
+        assert!(
+            spilled <= spill_budget,
+            "{spilled} spilled vectors exceeded the calibrated budget of {spill_budget}"
+        );
+        assert!(
+            posting_factor <= 1.0 + TARGET_SPILL + f32::EPSILON,
+            "posting amplification {posting_factor:.4} exceeded the 1.30 calibration target"
+        );
+
+        // Midpoints between each learned centroid and its nearest peer stress
+        // the exact partition boundaries where a single probe loses the most
+        // candidates and selective secondary postings should help.
+        let queries: Vec<Vec<f32>> = (0..selective.num_clusters)
+            .map(|left| {
+                let left_centroid = selective.get_centroid(left);
+                let right = (0..selective.num_clusters)
+                    .filter(|&candidate| candidate != left)
+                    .min_by(|&a, &b| {
+                        squared_l2(left_centroid, selective.get_centroid(a))
+                            .total_cmp(&squared_l2(left_centroid, selective.get_centroid(b)))
+                            .then_with(|| a.cmp(&b))
+                    })
+                    .unwrap();
+                let mut query: Vec<f32> = left_centroid
+                    .iter()
+                    .zip(selective.get_centroid(right))
+                    .map(|(&a, &b)| 0.51 * a + 0.49 * b)
+                    .collect();
+                normalize(&mut query);
+                query
+            })
+            .collect();
+
+        let mut gained_queries = 0usize;
+        for nprobe in [1, 2] {
+            let mut primary_hits = 0usize;
+            let mut selective_hits = 0usize;
+            for query in &queries {
+                let primary_plan = primary_only.probe(query, nprobe, IvfRoutingMode::Flat);
+                let selective_plan = selective.probe(query, nprobe, IvfRoutingMode::Flat);
+                assert_eq!(
+                    primary_plan.cluster_ids, selective_plan.cluster_ids,
+                    "SOAR must not alter query routing"
+                );
+
+                let mut truth: Vec<(usize, f32)> = corpus
+                    .iter()
+                    .enumerate()
+                    .map(|(document, vector)| (document, squared_l2(query, vector)))
+                    .collect();
+                truth.select_nth_unstable_by(TOP_K, |left, right| {
+                    left.1
+                        .total_cmp(&right.1)
+                        .then_with(|| left.0.cmp(&right.0))
+                });
+                truth.truncate(TOP_K);
+
+                let query_primary_hits = truth
+                    .iter()
+                    .filter(|&&(document, _)| {
+                        primary_assignments[document]
+                            .all_clusters()
+                            .any(|cluster| primary_plan.cluster_ids.contains(&cluster))
+                    })
+                    .count();
+                let query_selective_hits = truth
+                    .iter()
+                    .filter(|&&(document, _)| {
+                        selective_assignments[document]
+                            .all_clusters()
+                            .any(|cluster| selective_plan.cluster_ids.contains(&cluster))
+                    })
+                    .count();
+                primary_hits += query_primary_hits;
+                selective_hits += query_selective_hits;
+                gained_queries += usize::from(query_selective_hits > query_primary_hits);
+            }
+
+            let denominator = (queries.len() * TOP_K) as f32;
+            let primary_recall = primary_hits as f32 / denominator;
+            let selective_recall = selective_hits as f32 / denominator;
+            assert!(
+                selective_recall + 0.005 >= primary_recall,
+                "selective SOAR candidate recall regressed at nprobe={nprobe}: \
+                 {selective_recall:.4} vs {primary_recall:.4}"
+            );
+            if nprobe == 1 {
+                assert!(
+                    selective_recall >= primary_recall + 0.01,
+                    "selective SOAR must recover boundary candidates at nprobe=1: \
+                     {selective_recall:.4} vs {primary_recall:.4}"
+                );
+            }
+        }
+        assert!(
+            gained_queries > 0,
+            "boundary-query smoke did not exercise a selective SOAR recall gain"
+        );
+    }
+
+    #[test]
+    fn soar_does_not_choose_an_arbitrarily_distant_orthogonal_centroid() {
+        let centroids = CoarseCentroids {
+            num_clusters: 3,
+            dim: 2,
+            // For x=[0,0], cluster 0 is primary with r=[1,0].
+            // Cluster 1 is perfectly orthogonal but extremely distant.
+            // Cluster 2 is slightly farther than the primary and parallel:
+            // its complete SOAR loss is 1.21 + 1.21 = 2.42.
+            centroids: vec![-1.0, 0.0, 0.0, -100.0, 1.1, 0.0],
+            version: 1,
+            soar_config: None,
+            routing_index: None,
+        };
+
+        let assignment = centroids.assign_with_soar(&[0.0, 0.0], &SoarConfig::full());
+        assert_eq!(assignment.primary_cluster, 0);
+        assert_eq!(assignment.secondary_clusters, vec![2]);
+    }
+
+    #[test]
+    fn selective_soar_rejects_a_far_secondary_residual() {
+        let centroids = CoarseCentroids {
+            num_clusters: 2,
+            dim: 2,
+            centroids: vec![0.0, 0.0, 10.0, 0.0],
+            version: 1,
+            soar_config: None,
+            routing_index: None,
+        };
+        let config = SoarConfig::new().threshold(0.0);
+
+        // Primary squared distance is 1; the only secondary is 81 away.
+        // Selective SOAR must not create a low-quality far-leaf posting.
+        let assignment = centroids.assign_with_soar(&[1.0, 0.0], &config);
+        assert_eq!(assignment.primary_cluster, 0);
+        assert!(assignment.secondary_clusters.is_empty());
+    }
+
+    #[test]
+    fn selective_soar_keeps_a_comparable_boundary_secondary() {
+        let centroids = CoarseCentroids {
+            num_clusters: 2,
+            dim: 2,
+            centroids: vec![0.0, 0.0, 2.0, 0.0],
+            version: 1,
+            soar_config: None,
+            routing_index: None,
+        };
+        let config = SoarConfig::new().threshold(0.0);
+
+        // The point is close to the Voronoi boundary: primary and secondary
+        // squared distances are 0.82 and 1.22, comfortably within the gate.
+        let assignment = centroids.assign_with_soar(&[0.9, 0.1], &config);
+        assert_eq!(assignment.primary_cluster, 0);
+        assert_eq!(assignment.secondary_clusters, vec![1]);
+    }
+
+    #[test]
+    fn soar_secondary_ties_are_ordered_by_cluster_id_and_capped_to_one() {
+        let centroids = CoarseCentroids {
+            num_clusters: 3,
+            dim: 2,
+            centroids: vec![0.0, 0.0, 1.0, 0.0, -1.0, 0.0],
+            version: 1,
+            soar_config: None,
+            routing_index: None,
+        };
+        let config = SoarConfig {
+            num_secondary: 2,
+            selective: false,
+            spill_threshold: 0.0,
+        };
+
+        let assignment = centroids.assign_with_soar(&[0.0, 0.0], &config);
+        assert_eq!(assignment.primary_cluster, 0);
+        assert_eq!(assignment.secondary_clusters, vec![1]);
     }
 
     #[test]

--- a/hermes-core/src/structures/vector/ivf/routing.rs
+++ b/hermes-core/src/structures/vector/ivf/routing.rs
@@ -22,11 +22,20 @@ pub const HNSW_AUTO_THRESHOLD: usize = 4_096;
 /// the minimum parent count avoids the recall cliff of greedy one-parent
 /// hierarchical routing while keeping parent/leaf scoring sublinear.
 const PARENT_BEAM_OVERSAMPLE: usize = 4;
+/// Construction assignments become permanent, so inspect multiple populated
+/// parent cells even when the query-time leaf budget fits under one parent.
+const MIN_BUILD_PARENT_BEAM: usize = 4;
 
 const HNSW_M: usize = 32;
 const HNSW_EF_CONSTRUCTION: usize = 200;
 const HNSW_QUERY_OVERSAMPLE: usize = 4;
 const HNSW_MIN_EF_SEARCH: usize = 128;
+/// Index construction happens once per vector generation and can afford a
+/// wider centroid search than latency-sensitive queries. Keeping the budgets
+/// separate prevents an approximate query-router miss from permanently
+/// assigning a vector to a needlessly distant leaf.
+const HNSW_BUILD_OVERSAMPLE: usize = 8;
+const HNSW_MIN_EF_BUILD: usize = 512;
 
 #[derive(Clone, Copy, Debug)]
 struct GraphCandidate {
@@ -279,14 +288,40 @@ impl HnswRoutingGraph {
         if take == 0 {
             return Vec::new();
         }
-        let mut entry = self.entry_point;
-        for level in (1..=self.max_level as usize).rev() {
-            entry = greedy_search_compact(self, entry, level, &query_distance);
-        }
         let ef_search = take
             .saturating_mul(HNSW_QUERY_OVERSAMPLE)
             .max(HNSW_MIN_EF_SEARCH)
             .min(self.node_levels.len());
+        self.search_with_budget(query_distance, take, ef_search)
+    }
+
+    /// Higher-recall centroid search used only while constructing postings.
+    pub(crate) fn search_for_build(
+        &self,
+        query_distance: impl Fn(u32) -> f32,
+        take: usize,
+    ) -> Vec<u32> {
+        let take = take.min(self.node_levels.len());
+        if take == 0 {
+            return Vec::new();
+        }
+        let ef_search = take
+            .saturating_mul(HNSW_BUILD_OVERSAMPLE)
+            .max(HNSW_MIN_EF_BUILD)
+            .min(self.node_levels.len());
+        self.search_with_budget(query_distance, take, ef_search)
+    }
+
+    fn search_with_budget(
+        &self,
+        query_distance: impl Fn(u32) -> f32,
+        take: usize,
+        ef_search: usize,
+    ) -> Vec<u32> {
+        let mut entry = self.entry_point;
+        for level in (1..=self.max_level as usize).rev() {
+            entry = greedy_search_compact(self, entry, level, &query_distance);
+        }
         HNSW_QUERY_SCRATCH.with(|scratch| {
             let mut scratch = scratch.borrow_mut();
             search_compact_layer_reusing(self, entry, ef_search, &query_distance, &mut scratch);
@@ -296,22 +331,6 @@ impl HnswRoutingGraph {
                 .take(take)
                 .map(|candidate| candidate.node)
                 .collect()
-        })
-    }
-
-    pub fn search_one(&self, query_distance: impl Fn(u32) -> f32) -> u32 {
-        let mut entry = self.entry_point;
-        for level in (1..=self.max_level as usize).rev() {
-            entry = greedy_search_compact(self, entry, level, &query_distance);
-        }
-        let ef_search = HNSW_MIN_EF_SEARCH.min(self.node_levels.len());
-        HNSW_QUERY_SCRATCH.with(|scratch| {
-            let mut scratch = scratch.borrow_mut();
-            search_compact_layer_reusing(self, entry, ef_search, &query_distance, &mut scratch);
-            scratch
-                .ordered
-                .first()
-                .map_or(entry, |candidate| candidate.node)
         })
     }
 
@@ -655,40 +674,101 @@ pub fn routing_parent_count(num_leaves: usize) -> usize {
         .min(num_leaves)
 }
 
-/// Allocate exactly `total_clusters` child cells proportionally to populated
-/// parent groups, without assigning more cells than training points.
+/// Allocate `total_clusters` child cells proportionally to populated parent
+/// groups, or one per training point when fewer points are available.
 pub fn allocate_child_clusters(group_sizes: &[usize], total_clusters: usize) -> Vec<usize> {
-    let mut allocated: Vec<usize> = group_sizes
-        .iter()
-        .map(|&size| usize::from(size > 0))
-        .collect();
-    let mut remaining = total_clusters.saturating_sub(allocated.iter().sum());
-    let total_points: usize = group_sizes.iter().sum();
-    if remaining == 0 || total_points == 0 {
+    let total_points: u128 = group_sizes.iter().map(|&size| size as u128).sum();
+    let target = (total_clusters as u128).min(total_points) as usize;
+    if target == 0 {
+        return vec![0; group_sizes.len()];
+    }
+
+    let populated = group_sizes.iter().filter(|&&size| size > 0).count();
+    let guarantee_populated = target >= populated;
+    let mut allocated = vec![0usize; group_sizes.len()];
+    let mut fixed = vec![false; group_sizes.len()];
+    let mut fixed_cells = 0usize;
+
+    if guarantee_populated {
+        // Solve the lower-bounded proportional allocation
+        //
+        //     allocation_i = max(1, lambda * group_size_i)
+        //
+        // by successively fixing cells whose unconstrained quota is at most
+        // one. This avoids letting the one-per-parent guarantee distort a
+        // 90/10 population into an 80/20 child split.
+        loop {
+            let active_weight: u128 = group_sizes
+                .iter()
+                .enumerate()
+                .filter(|(index, size)| **size > 0 && !fixed[*index])
+                .map(|(_, &size)| size as u128)
+                .sum();
+            let active_target = target - fixed_cells;
+            if active_weight == 0 || active_target == 0 {
+                break;
+            }
+            let newly_fixed = group_sizes
+                .iter()
+                .enumerate()
+                .filter_map(|(index, &size)| {
+                    (size > 0
+                        && !fixed[index]
+                        && (size as u128) * (active_target as u128) <= active_weight)
+                        .then_some(index)
+                })
+                .collect::<Vec<_>>();
+            if newly_fixed.is_empty() {
+                break;
+            }
+            for index in newly_fixed {
+                fixed[index] = true;
+                allocated[index] = 1;
+                fixed_cells += 1;
+            }
+        }
+    }
+
+    let remaining = target - fixed_cells;
+    if remaining == 0 {
         return allocated;
     }
-    for (allocation, &size) in allocated.iter_mut().zip(group_sizes) {
-        let capacity = size.saturating_sub(*allocation);
-        let share = remaining
-            .saturating_mul(size)
-            .checked_div(total_points)
-            .unwrap_or(0)
-            .min(capacity);
-        *allocation += share;
+    let active_weight: u128 = group_sizes
+        .iter()
+        .enumerate()
+        .filter(|(index, size)| **size > 0 && !fixed[*index])
+        .map(|(_, &size)| size as u128)
+        .sum();
+    debug_assert!(active_weight > 0);
+
+    let mut remainders = Vec::with_capacity(group_sizes.len());
+    for (index, &size) in group_sizes.iter().enumerate() {
+        if size == 0 || fixed[index] {
+            continue;
+        }
+        let numerator = (remaining as u128) * (size as u128);
+        let whole = (numerator / active_weight) as usize;
+        allocated[index] = whole;
+        if whole < size {
+            remainders.push((index, numerator % active_weight));
+        }
     }
-    remaining = total_clusters.saturating_sub(allocated.iter().sum());
-    while remaining > 0 {
-        let Some((index, _)) = group_sizes
-            .iter()
-            .enumerate()
-            .filter(|(index, size)| allocated[*index] < **size)
-            .max_by_key(|(index, size)| (**size, std::cmp::Reverse(allocated[*index])))
-        else {
-            break;
-        };
+
+    let remainder_cells = target - allocated.iter().sum::<usize>();
+    remainders.sort_unstable_by(|(left_index, left), (right_index, right)| {
+        right.cmp(left).then_with(|| left_index.cmp(right_index))
+    });
+    debug_assert!(remainder_cells <= remainders.len());
+    for (index, _) in remainders.into_iter().take(remainder_cells) {
         allocated[index] += 1;
-        remaining -= 1;
     }
+    debug_assert_eq!(allocated.iter().sum::<usize>(), target);
+    debug_assert!(
+        allocated
+            .iter()
+            .zip(group_sizes)
+            .all(|(&cells, &size)| cells <= size)
+    );
     allocated
 }
 
@@ -746,6 +826,38 @@ pub fn float_probe_fingerprint(query: &[f32], nprobe: usize, mode: IvfRoutingMod
     )
 }
 
+pub(crate) fn normalize_cosine_in_place(vector: &mut [f32]) {
+    let norm = crate::structures::simd::dot_product_f32(vector, vector, vector.len()).sqrt();
+    let inverse_norm = if norm.is_finite() && norm > 0.0 {
+        1.0 / norm
+    } else {
+        0.0
+    };
+    vector.iter_mut().for_each(|value| *value *= inverse_norm);
+}
+
+pub(crate) fn normalized_cosine_query(query: &[f32]) -> Vec<f32> {
+    let mut normalized = query.to_vec();
+    normalize_cosine_in_place(&mut normalized);
+    normalized
+}
+
+pub(crate) fn cosine_probe_fingerprint(query: &[f32], nprobe: usize, mode: IvfRoutingMode) -> u64 {
+    let norm = crate::structures::simd::dot_product_f32(query, query, query.len()).sqrt();
+    let inverse_norm = if norm.is_finite() && norm > 0.0 {
+        1.0 / norm
+    } else {
+        0.0
+    };
+    fingerprint_words(
+        mode,
+        nprobe,
+        query
+            .iter()
+            .map(|value| (value * inverse_norm).to_bits() as u64),
+    )
+}
+
 pub fn binary_probe_fingerprint(query: &[u8], nprobe: usize, mode: IvfRoutingMode) -> u64 {
     fingerprint_words(mode, nprobe, query.iter().map(|&value| value as u64))
 }
@@ -769,6 +881,82 @@ pub fn parent_probe_count(nprobe: usize, num_leaves: usize, num_parents: usize) 
         .saturating_mul(PARENT_BEAM_OVERSAMPLE)
         .div_ceil(leaves_per_parent)
         .clamp(1, num_parents)
+}
+
+/// Select the closest parent beam while guaranteeing enough child leaves to
+/// satisfy the requested leaf budget. The usual oversubscribed beam remains
+/// the fast path; only an uneven topology that underfills the budget pays for
+/// ranking additional parents.
+pub fn select_parent_beam<const HIGHER_IS_BETTER: bool>(
+    scores: &[f32],
+    topology: &IvfRoutingTopology,
+    requested_leaves: usize,
+) -> Vec<u32> {
+    let parent_count = scores.len().min(topology.parent_count());
+    let leaf_count = topology.leaf_ids.len();
+    let requested_leaves = requested_leaves.min(leaf_count);
+    if parent_count == 0 || requested_leaves == 0 {
+        return Vec::new();
+    }
+
+    let initial_take =
+        parent_probe_count(requested_leaves, leaf_count, parent_count).min(parent_count);
+    let scores = &scores[..parent_count];
+    let initial = select_best::<HIGHER_IS_BETTER>(scores, initial_take);
+    let initial_coverage: usize = initial
+        .iter()
+        .map(|&parent| topology.children(parent as usize).len())
+        .sum();
+    if initial_coverage >= requested_leaves || initial_take == parent_count {
+        return initial;
+    }
+
+    let mut ranked = select_best::<HIGHER_IS_BETTER>(scores, parent_count);
+    let mut coverage = 0usize;
+    let mut take = parent_count;
+    for (index, &parent) in ranked.iter().enumerate() {
+        coverage = coverage.saturating_add(topology.children(parent as usize).len());
+        if index + 1 >= initial_take && coverage >= requested_leaves {
+            take = index + 1;
+            break;
+        }
+    }
+    ranked.truncate(take);
+    ranked
+}
+
+/// Select a construction-time parent beam without narrowing query routing.
+///
+/// The query beam remains the lower bound for leaf coverage, while offline
+/// construction inspects at least four populated parents when available. Empty
+/// parents are removed because they contribute no leaf candidates.
+pub fn select_parent_beam_for_build<const HIGHER_IS_BETTER: bool>(
+    scores: &[f32],
+    topology: &IvfRoutingTopology,
+    requested_leaves: usize,
+) -> Vec<u32> {
+    if requested_leaves == 0 {
+        return Vec::new();
+    }
+    let parent_count = scores.len().min(topology.parent_count());
+    if parent_count == 0 {
+        return Vec::new();
+    }
+
+    let query_parents = select_parent_beam::<HIGHER_IS_BETTER>(scores, topology, requested_leaves);
+    let query_populated = query_parents
+        .iter()
+        .filter(|&&parent| !topology.children(parent as usize).is_empty())
+        .count();
+
+    let scores = &scores[..parent_count];
+    let mut ranked = select_best::<HIGHER_IS_BETTER>(scores, parent_count);
+    ranked.retain(|&parent| !topology.children(parent as usize).is_empty());
+    let take = query_populated
+        .max(MIN_BUILD_PARENT_BEAM.min(ranked.len()))
+        .min(ranked.len());
+    ranked.truncate(take);
+    ranked
 }
 
 /// Deterministically select the best score indexes without fully sorting the
@@ -846,6 +1034,111 @@ mod tests {
     }
 
     #[test]
+    fn two_level_beam_expands_until_skewed_parents_cover_leaf_budget() {
+        let mut children: Vec<Vec<u32>> = (0..9).map(|leaf| vec![leaf]).collect();
+        children.push((9..100).collect());
+        let topology = IvfRoutingTopology::from_children(&children);
+
+        // The average-size heuristic initially chooses two parents. The four
+        // closest parents contain only one leaf each, so the beam must expand
+        // to four to honor nprobe=4.
+        let lower_is_better: Vec<f32> = (0..10).map(|score| score as f32).collect();
+        assert_eq!(
+            select_parent_beam::<false>(&lower_is_better, &topology, 4),
+            vec![0, 1, 2, 3]
+        );
+
+        let higher_is_better: Vec<f32> = (0..10).rev().map(|score| score as f32).collect();
+        assert_eq!(
+            select_parent_beam::<true>(&higher_is_better, &topology, 4),
+            vec![0, 1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn build_parent_beam_uses_four_populated_parents_when_query_uses_one() {
+        let children: Vec<Vec<u32>> = (0..4)
+            .map(|parent| {
+                let first = parent * 512;
+                (first..first + 512).map(|leaf| leaf as u32).collect()
+            })
+            .collect();
+        let topology = IvfRoutingTopology::from_children(&children);
+
+        let lower_is_better = [0.0, 1.0, 2.0, 3.0];
+        assert_eq!(
+            select_parent_beam::<false>(&lower_is_better, &topology, 128),
+            vec![0]
+        );
+        assert_eq!(
+            select_parent_beam_for_build::<false>(&lower_is_better, &topology, 128),
+            vec![0, 1, 2, 3]
+        );
+
+        let higher_is_better = [4.0, 3.0, 2.0, 1.0];
+        assert_eq!(
+            select_parent_beam::<true>(&higher_is_better, &topology, 128),
+            vec![0]
+        );
+        assert_eq!(
+            select_parent_beam_for_build::<true>(&higher_is_better, &topology, 128),
+            vec![0, 1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn build_parent_beam_uses_every_available_populated_parent() {
+        let children = vec![vec![0], vec![], vec![1], vec![], vec![2]];
+        let topology = IvfRoutingTopology::from_children(&children);
+        let scores = [1.0, 0.0, 2.0, -1.0, 3.0];
+
+        assert_eq!(
+            select_parent_beam_for_build::<false>(&scores, &topology, 1),
+            vec![0, 2, 4]
+        );
+    }
+
+    #[test]
+    fn child_allocation_uses_largest_remainders_instead_of_largest_parent() {
+        assert_eq!(allocate_child_clusters(&[100, 90], 4), vec![2, 2]);
+        assert_eq!(allocate_child_clusters(&[5, 5, 5], 5), vec![2, 2, 1]);
+        assert_eq!(allocate_child_clusters(&[90, 10], 10), vec![9, 1]);
+    }
+
+    #[test]
+    fn child_allocation_is_exact_capacity_bounded_and_deterministic() {
+        assert_eq!(
+            allocate_child_clusters(&[1, 100, 7, 0], 100),
+            vec![1, 93, 6, 0]
+        );
+        assert_eq!(allocate_child_clusters(&[1, 2, 0], 10), vec![1, 2, 0]);
+        assert_eq!(allocate_child_clusters(&[10, 9, 8], 2), vec![1, 1, 0]);
+
+        for target in 0..=140 {
+            let sizes = [100, 30, 0, 7];
+            let allocation = allocate_child_clusters(&sizes, target);
+            assert_eq!(
+                allocation.iter().sum::<usize>(),
+                target.min(sizes.iter().sum())
+            );
+            assert!(
+                allocation
+                    .iter()
+                    .zip(sizes)
+                    .all(|(&cells, size)| cells <= size)
+            );
+            if target >= sizes.iter().filter(|&&size| size > 0).count() {
+                assert!(
+                    allocation
+                        .iter()
+                        .zip(sizes)
+                        .all(|(&cells, size)| size == 0 || cells > 0)
+                );
+            }
+        }
+    }
+
+    #[test]
     fn compact_hnsw_routes_without_copying_points() {
         let points: Vec<[f32; 2]> = (0..512)
             .map(|index| {
@@ -863,8 +1156,10 @@ mod tests {
         assert!(graph.size_bytes() < points.len() * 512);
 
         let query = [0.37f32, -0.91];
+        let query_distance_calls = std::cell::Cell::new(0usize);
         let routed = graph.search(
             |node| {
+                query_distance_calls.set(query_distance_calls.get() + 1);
                 let [x, y] = points[node as usize];
                 (x - query[0]).powi(2) + (y - query[1]).powi(2)
             },
@@ -881,6 +1176,21 @@ mod tests {
                 .then_with(|| left.cmp(&right))
         });
         assert_eq!(routed, exact[..10]);
+
+        let build_distance_calls = std::cell::Cell::new(0usize);
+        let build_routed = graph.search_for_build(
+            |node| {
+                build_distance_calls.set(build_distance_calls.get() + 1);
+                let [x, y] = points[node as usize];
+                (x - query[0]).powi(2) + (y - query[1]).powi(2)
+            },
+            10,
+        );
+        assert_eq!(build_routed, exact[..10]);
+        assert!(
+            build_distance_calls.get() > query_distance_calls.get(),
+            "offline construction should spend its wider search budget"
+        );
 
         let bytes = bincode::serde::encode_to_vec(&graph, bincode::config::standard()).unwrap();
         let (decoded, consumed): (HnswRoutingGraph, usize) =

--- a/hermes-core/src/structures/vector/ivf/soar.rs
+++ b/hermes-core/src/structures/vector/ivf/soar.rs
@@ -10,14 +10,21 @@
 
 use serde::{Deserialize, Serialize};
 
+const DEFAULT_SELECTIVE_SPILL_FRACTION: f32 = 0.30;
+
 /// Configuration for SOAR (Spilling with Orthogonality-Amplified Residuals)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SoarConfig {
-    /// Number of secondary cluster assignments (typically 1-2)
+    /// Number of secondary cluster assignments. Current trained generations
+    /// use the published two-assignment objective, so builders clamp this to
+    /// one secondary.
     pub num_secondary: usize,
     /// Use selective spilling (only spill vectors near cluster boundaries)
     pub selective: bool,
-    /// Threshold for selective spilling (residual norm must exceed this)
+    /// Positive values are calibrated residual-norm thresholds. A negative
+    /// value requests build-time calibration to the corresponding spill
+    /// fraction; trained artifacts always persist a positive threshold. This
+    /// tagged representation preserves the serialized structure layout.
     pub spill_threshold: f32,
 }
 
@@ -26,7 +33,7 @@ impl Default for SoarConfig {
         Self {
             num_secondary: 1,
             selective: true,
-            spill_threshold: 0.5,
+            spill_threshold: -DEFAULT_SELECTIVE_SPILL_FRACTION,
         }
     }
 }
@@ -40,7 +47,7 @@ impl SoarConfig {
     /// Create SOAR config with specified number of secondary assignments
     pub fn with_secondary(num_secondary: usize) -> Self {
         Self {
-            num_secondary,
+            num_secondary: num_secondary.min(1),
             ..Default::default()
         }
     }
@@ -53,7 +60,15 @@ impl SoarConfig {
 
     /// Set spill threshold for selective spilling
     pub fn threshold(mut self, threshold: f32) -> Self {
-        self.spill_threshold = threshold;
+        self.spill_threshold = threshold.max(0.0);
+        self
+    }
+
+    /// Calibrate selective spilling during training to at most a target
+    /// fraction of vectors receiving one secondary assignment.
+    pub fn target_spill_fraction(mut self, fraction: f32) -> Self {
+        self.selective = true;
+        self.spill_threshold = -fraction.clamp(0.0, 1.0);
         self
     }
 
@@ -66,13 +81,20 @@ impl SoarConfig {
         }
     }
 
-    /// Aggressive spilling with 2 secondary clusters
+    /// Compatibility alias for full one-secondary spilling. The generalized
+    /// multi-secondary objective is intentionally not exposed until it is
+    /// implemented and validated.
     pub fn aggressive() -> Self {
         Self {
-            num_secondary: 2,
+            num_secondary: 1,
             selective: false,
             spill_threshold: 0.0,
         }
+    }
+
+    pub(crate) fn calibration_target(&self) -> Option<f32> {
+        (self.selective && self.spill_threshold.is_sign_negative())
+            .then(|| (-self.spill_threshold).clamp(0.0, 1.0))
     }
 }
 
@@ -170,6 +192,17 @@ mod tests {
         let config = SoarConfig::default();
         assert_eq!(config.num_secondary, 1);
         assert!(config.selective);
+        assert_eq!(config.calibration_target(), Some(0.30));
+    }
+
+    #[test]
+    fn explicit_threshold_and_target_budget_have_distinct_tags() {
+        let threshold = SoarConfig::new().threshold(0.42);
+        assert_eq!(threshold.calibration_target(), None);
+        assert_eq!(threshold.spill_threshold, 0.42);
+
+        let target = SoarConfig::new().target_spill_fraction(0.25);
+        assert_eq!(target.calibration_target(), Some(0.25));
     }
 
     #[test]

--- a/hermes-core/src/structures/vector/kmeans.rs
+++ b/hermes-core/src/structures/vector/kmeans.rs
@@ -1,16 +1,74 @@
 //! Deterministic Euclidean k-means shared by coarse and product quantizers.
 //!
-//! k-means++ seeding avoids the unstable random-first-k initialization that
-//! previously existed in the native path. Lloyd assignment is parallel on
-//! native builds, while centroid reduction stays deterministic.
+//! k-means|| seeding reduces the number of full-data synchronization passes
+//! needed to initialize large codebooks. Lloyd assignment is parallel on
+//! native builds, while candidate selection, objective reduction, and centroid
+//! reduction stay deterministic.
 
 use rand::prelude::*;
 
 const WEIGHT_REDUCTION_BLOCK: usize = 16 * 1024;
+const KMEANS_PARALLEL_ROUNDS: usize = 5;
+const KMEANS_PARALLEL_TOTAL_OVERSAMPLING: usize = 2;
+const KMEANS_PLUS_PLUS_MAX_CLUSTERS: usize = 256;
+const RELATIVE_OBJECTIVE_TOLERANCE: f64 = 1.0e-5;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InitializationStrategy {
+    KMeansPlusPlus,
+    KMeansParallel,
+}
 
 pub(crate) struct EuclideanKMeans {
     pub centroids: Vec<f32>,
+    #[cfg(test)]
     pub assignments: Vec<usize>,
+    /// Cluster-major ranges into `members`; length is `clusters + 1`.
+    pub member_offsets: Vec<usize>,
+    /// Every training point exactly once, grouped by final cluster.
+    pub members: Vec<usize>,
+}
+
+#[inline]
+fn initialization_strategy(clusters: usize) -> InitializationStrategy {
+    if clusters <= KMEANS_PLUS_PLUS_MAX_CLUSTERS {
+        InitializationStrategy::KMeansPlusPlus
+    } else {
+        InitializationStrategy::KMeansParallel
+    }
+}
+
+/// Conservative full-Lloyd-pass equivalent for build-work admission control.
+///
+/// One unit is `points * clusters` point/centroid distance evaluations.
+/// Small codebooks spend one such unit in k-means++ initialization; large
+/// codebooks spend up to two units comparing points to the total 2K candidate
+/// budget, plus `ceil(candidate_count / points)` for weighted candidate
+/// reduction. Candidate weights reuse the oversampling assignments, so there
+/// is no second points-by-candidates scan. The final unit keeps returned
+/// assignments synchronized with the returned centroids.
+#[cfg(any(feature = "native", test))]
+pub(crate) fn estimated_euclidean_kmeans_distance_multiplier(
+    points: usize,
+    clusters: usize,
+    max_iters: usize,
+) -> usize {
+    if points == 0 || clusters == 0 {
+        return 0;
+    }
+    debug_assert!(clusters <= points);
+    let initialization = match initialization_strategy(clusters) {
+        InitializationStrategy::KMeansPlusPlus => 1,
+        InitializationStrategy::KMeansParallel => {
+            let candidates = kmeans_parallel_candidate_budget(points, clusters);
+            candidates
+                .div_ceil(clusters)
+                .saturating_add(candidates.div_ceil(points))
+        }
+    };
+    initialization
+        .saturating_add(max_iters.max(1))
+        .saturating_add(1)
 }
 
 #[inline]
@@ -49,26 +107,32 @@ fn update_centroid(centroid: &mut [f32], members: &[usize], data: &[f32], dim: u
     }
 }
 
-/// Draw from non-negative weights with a fixed reduction topology. Parallel
-/// block sums remove the serial O(N) bottleneck from every k-means++ seed while
-/// producing the same choice for every rayon thread count.
-pub(crate) fn weighted_sample_index(weights: &[f64], draw: f64) -> Option<usize> {
-    if weights.is_empty() {
-        return None;
-    }
+fn fixed_weight_block_totals(weights: &[f64]) -> Vec<f64> {
     #[cfg(feature = "native")]
-    let block_totals: Vec<f64> = {
+    {
         use rayon::prelude::*;
         weights
             .par_chunks(WEIGHT_REDUCTION_BLOCK)
             .map(|block| block.iter().sum())
             .collect()
-    };
+    }
     #[cfg(not(feature = "native"))]
-    let block_totals: Vec<f64> = weights
-        .chunks(WEIGHT_REDUCTION_BLOCK)
-        .map(|block| block.iter().sum())
-        .collect();
+    {
+        weights
+            .chunks(WEIGHT_REDUCTION_BLOCK)
+            .map(|block| block.iter().sum())
+            .collect()
+    }
+}
+
+/// Draw from non-negative weights with a fixed reduction topology. Parallel
+/// block sums avoid a serial O(N) reduction while producing the same choice
+/// for every rayon thread count.
+pub(crate) fn weighted_sample_index(weights: &[f64], draw: f64) -> Option<usize> {
+    if weights.is_empty() {
+        return None;
+    }
+    let block_totals = fixed_weight_block_totals(weights);
 
     let total: f64 = block_totals.iter().sum();
     if !total.is_finite() || total <= 0.0 {
@@ -134,18 +198,403 @@ fn initialize_kmeans_plus_plus(
             *minimum = minimum.min(squared_l2(point, latest) as f64);
         }
 
-        let selected = if let Some(selected) =
-            weighted_sample_index(&minimum_distances, rng.random::<f64>())
-        {
-            selected
-        } else {
-            // All points are identical (or all remaining distances underflow).
-            // A deterministic duplicate is the only representable centroid.
-            (centroids.len() / dim) % points
-        };
+        let selected = weighted_sample_index(&minimum_distances, rng.random::<f64>())
+            .unwrap_or((centroids.len() / dim) % points);
         centroids.extend_from_slice(&data[selected * dim..(selected + 1) * dim]);
     }
     centroids
+}
+
+fn update_point_minimum_distances(
+    data: &[f32],
+    points: usize,
+    dim: usize,
+    center_indices: &[usize],
+    center_offset: usize,
+    minimum_distances: &mut [f64],
+    nearest_centers: &mut [usize],
+) {
+    debug_assert_eq!(minimum_distances.len(), points);
+    debug_assert_eq!(nearest_centers.len(), points);
+    #[cfg(feature = "native")]
+    {
+        use rayon::prelude::*;
+        minimum_distances
+            .par_iter_mut()
+            .zip(nearest_centers.par_iter_mut())
+            .enumerate()
+            .for_each(|(index, (minimum, nearest_center))| {
+                let point = &data[index * dim..(index + 1) * dim];
+                for (offset, &center_index) in center_indices.iter().enumerate() {
+                    let center = &data[center_index * dim..(center_index + 1) * dim];
+                    let distance = squared_l2(point, center) as f64;
+                    let candidate = center_offset + offset;
+                    if distance < *minimum || (distance == *minimum && candidate < *nearest_center)
+                    {
+                        *minimum = distance;
+                        *nearest_center = candidate;
+                    }
+                }
+            });
+    }
+    #[cfg(not(feature = "native"))]
+    for (index, (minimum, nearest_center)) in minimum_distances
+        .iter_mut()
+        .zip(nearest_centers)
+        .enumerate()
+    {
+        let point = &data[index * dim..(index + 1) * dim];
+        for (offset, &center_index) in center_indices.iter().enumerate() {
+            let center = &data[center_index * dim..(center_index + 1) * dim];
+            let distance = squared_l2(point, center) as f64;
+            let candidate = center_offset + offset;
+            if distance < *minimum || (distance == *minimum && candidate < *nearest_center) {
+                *minimum = distance;
+                *nearest_center = candidate;
+            }
+        }
+    }
+}
+
+fn update_candidate_minimum_distances(
+    data: &[f32],
+    dim: usize,
+    candidate_indices: &[usize],
+    selected_candidate: usize,
+    minimum_distances: &mut [f64],
+) {
+    let center_index = candidate_indices[selected_candidate];
+    let center = &data[center_index * dim..(center_index + 1) * dim];
+    #[cfg(feature = "native")]
+    {
+        use rayon::prelude::*;
+        minimum_distances
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(candidate, minimum)| {
+                let point_index = candidate_indices[candidate];
+                let point = &data[point_index * dim..(point_index + 1) * dim];
+                *minimum = minimum.min(squared_l2(point, center) as f64);
+            });
+    }
+    #[cfg(not(feature = "native"))]
+    for (candidate, minimum) in minimum_distances.iter_mut().enumerate() {
+        let point_index = candidate_indices[candidate];
+        let point = &data[point_index * dim..(point_index + 1) * dim];
+        *minimum = minimum.min(squared_l2(point, center) as f64);
+    }
+}
+
+fn reduce_kmeans_parallel_candidates(
+    data: &[f32],
+    dim: usize,
+    clusters: usize,
+    candidate_indices: &[usize],
+    candidate_assignments: &[usize],
+    rng: &mut rand::rngs::StdRng,
+) -> Vec<f32> {
+    debug_assert!(candidate_indices.len() >= clusters);
+    debug_assert_eq!(candidate_assignments.len(), data.len() / dim);
+    if candidate_indices.len() == clusters {
+        return candidate_indices
+            .iter()
+            .flat_map(|&index| data[index * dim..(index + 1) * dim].iter().copied())
+            .collect();
+    }
+
+    let mut candidate_weights = vec![0usize; candidate_indices.len()];
+    for &candidate in candidate_assignments {
+        candidate_weights[candidate] += 1;
+    }
+    let mut sampling_weights: Vec<f64> = candidate_weights
+        .iter()
+        .map(|&weight| weight as f64)
+        .collect();
+    let first = weighted_sample_index(&sampling_weights, rng.random::<f64>()).unwrap_or_default();
+    let mut selected = vec![false; candidate_indices.len()];
+    selected[first] = true;
+    let mut selected_candidates = Vec::with_capacity(clusters);
+    selected_candidates.push(first);
+    let mut minimum_distances = vec![f64::INFINITY; candidate_indices.len()];
+
+    while selected_candidates.len() < clusters {
+        let latest = *selected_candidates.last().unwrap();
+        update_candidate_minimum_distances(
+            data,
+            dim,
+            candidate_indices,
+            latest,
+            &mut minimum_distances,
+        );
+        for (candidate, weight) in sampling_weights.iter_mut().enumerate() {
+            *weight = if selected[candidate] {
+                0.0
+            } else {
+                candidate_weights[candidate] as f64 * minimum_distances[candidate]
+            };
+        }
+        let next = weighted_sample_index(&sampling_weights, rng.random::<f64>()).or_else(|| {
+            // Identical candidates have zero D² weight. Retain deterministic
+            // multiplicity by selecting the heaviest remaining candidate,
+            // breaking ties by its stable candidate position.
+            let mut best = None;
+            for (candidate, &weight) in candidate_weights.iter().enumerate() {
+                if selected[candidate] {
+                    continue;
+                }
+                if best.is_none_or(|best_candidate| {
+                    weight > candidate_weights[best_candidate]
+                        || (weight == candidate_weights[best_candidate]
+                            && candidate < best_candidate)
+                }) {
+                    best = Some(candidate);
+                }
+            }
+            best
+        });
+        let Some(next) = next else {
+            break;
+        };
+        selected[next] = true;
+        selected_candidates.push(next);
+    }
+
+    selected_candidates
+        .iter()
+        .flat_map(|&candidate| {
+            let point_index = candidate_indices[candidate];
+            data[point_index * dim..(point_index + 1) * dim]
+                .iter()
+                .copied()
+        })
+        .collect()
+}
+
+#[inline]
+fn kmeans_parallel_candidate_budget(points: usize, clusters: usize) -> usize {
+    points.min(
+        clusters
+            .saturating_mul(KMEANS_PARALLEL_TOTAL_OVERSAMPLING)
+            .max(clusters),
+    )
+}
+
+fn initialize_kmeans_parallel(
+    data: &[f32],
+    points: usize,
+    dim: usize,
+    clusters: usize,
+    seed: u64,
+) -> (Vec<f32>, usize) {
+    if clusters == points {
+        return (data.to_vec(), clusters);
+    }
+
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let first = rng.random_range(0..points);
+    let candidate_budget = kmeans_parallel_candidate_budget(points, clusters);
+    let mut candidate_indices = Vec::with_capacity(candidate_budget);
+    candidate_indices.push(first);
+    let mut selected = vec![false; points];
+    selected[first] = true;
+    let mut minimum_distances = vec![f64::INFINITY; points];
+    let mut nearest_candidates = vec![usize::MAX; points];
+    update_point_minimum_distances(
+        data,
+        points,
+        dim,
+        &[first],
+        0,
+        &mut minimum_distances,
+        &mut nearest_candidates,
+    );
+    for round in 0..KMEANS_PARALLEL_ROUNDS {
+        if candidate_indices.len() >= candidate_budget {
+            break;
+        }
+        let potential: f64 = fixed_weight_block_totals(&minimum_distances)
+            .into_iter()
+            .sum();
+        if !potential.is_finite() || potential <= 0.0 {
+            break;
+        }
+        let remaining_rounds = KMEANS_PARALLEL_ROUNDS - round;
+        let round_budget = (candidate_budget - candidate_indices.len()).div_ceil(remaining_rounds);
+        let mut sampled = Vec::new();
+        for (point, &distance) in minimum_distances.iter().enumerate() {
+            if selected[point] {
+                continue;
+            }
+            let probability = (round_budget as f64 * distance / potential).min(1.0);
+            let draw = rng.random::<f64>();
+            if probability > 0.0 && draw < probability {
+                // Conditional on acceptance, draw / probability is uniform.
+                // It provides an order-independent deterministic cap when a
+                // Bernoulli round samples more than its allotted work.
+                sampled.push((point, draw / probability));
+            }
+        }
+        if sampled.len() > round_budget {
+            sampled.sort_unstable_by(|left, right| {
+                left.1
+                    .total_cmp(&right.1)
+                    .then_with(|| left.0.cmp(&right.0))
+            });
+            sampled.truncate(round_budget);
+        }
+        let mut round_candidates: Vec<usize> =
+            sampled.into_iter().map(|(point, _)| point).collect();
+        if round_candidates.is_empty()
+            && let Some(point) = weighted_sample_index(&minimum_distances, rng.random::<f64>())
+            && !selected[point]
+        {
+            round_candidates.push(point);
+        }
+        if round_candidates.is_empty() {
+            break;
+        }
+        round_candidates.sort_unstable();
+        for &point in &round_candidates {
+            selected[point] = true;
+        }
+        let candidate_offset = candidate_indices.len();
+        update_point_minimum_distances(
+            data,
+            points,
+            dim,
+            &round_candidates,
+            candidate_offset,
+            &mut minimum_distances,
+            &mut nearest_candidates,
+        );
+        candidate_indices.extend(round_candidates);
+    }
+
+    if candidate_indices.len() < clusters {
+        // Oversampling is probabilistic. Guarantee enough distinct source
+        // points for the weighted reduction in one deterministic recovery pass.
+        let mut remaining: Vec<usize> = (0..points).filter(|&point| !selected[point]).collect();
+        remaining.sort_unstable_by(|&left, &right| {
+            minimum_distances[right]
+                .total_cmp(&minimum_distances[left])
+                .then_with(|| left.cmp(&right))
+        });
+        let recovered: Vec<usize> = remaining
+            .into_iter()
+            .take(clusters - candidate_indices.len())
+            .collect();
+        let candidate_offset = candidate_indices.len();
+        update_point_minimum_distances(
+            data,
+            points,
+            dim,
+            &recovered,
+            candidate_offset,
+            &mut minimum_distances,
+            &mut nearest_candidates,
+        );
+        candidate_indices.extend(recovered);
+    }
+    debug_assert!(candidate_indices.len() <= candidate_budget);
+
+    drop(minimum_distances);
+    drop(selected);
+    let candidate_count = candidate_indices.len();
+    let centroids = reduce_kmeans_parallel_candidates(
+        data,
+        dim,
+        clusters,
+        &candidate_indices,
+        &nearest_candidates,
+        &mut rng,
+    );
+    (centroids, candidate_count)
+}
+
+fn initialize_euclidean_centroids(
+    data: &[f32],
+    points: usize,
+    dim: usize,
+    clusters: usize,
+    seed: u64,
+) -> Vec<f32> {
+    match initialization_strategy(clusters) {
+        InitializationStrategy::KMeansPlusPlus => {
+            initialize_kmeans_plus_plus(data, points, dim, clusters, seed)
+        }
+        InitializationStrategy::KMeansParallel => {
+            initialize_kmeans_parallel(data, points, dim, clusters, seed).0
+        }
+    }
+}
+
+fn assign_nearest_points(
+    data: &[f32],
+    dim: usize,
+    centroids: &[f32],
+    nearest_points: &mut [(usize, f32)],
+) {
+    debug_assert_eq!(data.len(), nearest_points.len().saturating_mul(dim));
+    #[cfg(feature = "native")]
+    {
+        use rayon::prelude::*;
+        nearest_points
+            .par_iter_mut()
+            .zip(data.par_chunks_exact(dim))
+            .for_each(|(result, point)| *result = nearest(centroids, point, dim));
+    }
+    #[cfg(not(feature = "native"))]
+    for (result, point) in nearest_points.iter_mut().zip(data.chunks_exact(dim)) {
+        *result = nearest(centroids, point, dim);
+    }
+}
+
+fn deterministic_objective(nearest_points: &[(usize, f32)]) -> f64 {
+    #[cfg(feature = "native")]
+    let block_totals: Vec<f64> = {
+        use rayon::prelude::*;
+        nearest_points
+            .par_chunks(WEIGHT_REDUCTION_BLOCK)
+            .map(|block| block.iter().map(|&(_, distance)| distance as f64).sum())
+            .collect()
+    };
+    #[cfg(not(feature = "native"))]
+    let block_totals: Vec<f64> = nearest_points
+        .chunks(WEIGHT_REDUCTION_BLOCK)
+        .map(|block| block.iter().map(|&(_, distance)| distance as f64).sum())
+        .collect();
+    block_totals.into_iter().sum()
+}
+
+#[inline]
+fn objective_has_converged(previous: f64, current: f64) -> bool {
+    previous.is_finite()
+        && current.is_finite()
+        && current <= previous
+        && previous - current <= RELATIVE_OBJECTIVE_TOLERANCE * previous.max(f64::MIN_POSITIVE)
+}
+
+fn rebuild_flat_memberships(
+    assignments: &[usize],
+    counts: &mut [usize],
+    offsets: &mut [usize],
+    members: &mut [usize],
+) {
+    debug_assert_eq!(offsets.len(), counts.len() + 1);
+    debug_assert_eq!(members.len(), assignments.len());
+    counts.fill(0);
+    for &cluster in assignments {
+        counts[cluster] += 1;
+    }
+    offsets[0] = 0;
+    for cluster in 0..counts.len() {
+        offsets[cluster + 1] = offsets[cluster] + counts[cluster];
+    }
+    counts.fill(0);
+    for (point, &cluster) in assignments.iter().enumerate() {
+        members[offsets[cluster] + counts[cluster]] = point;
+        counts[cluster] += 1;
+    }
 }
 
 pub(crate) fn train_euclidean_kmeans(
@@ -160,23 +609,17 @@ pub(crate) fn train_euclidean_kmeans(
     assert_eq!(data.len(), points.saturating_mul(dim));
     assert!(data.iter().all(|value| value.is_finite()));
 
-    let mut centroids = initialize_kmeans_plus_plus(data, points, dim, clusters, seed);
+    let mut centroids = initialize_euclidean_centroids(data, points, dim, clusters, seed);
     let mut assignments = vec![usize::MAX; points];
-    let mut members: Vec<Vec<usize>> = (0..clusters).map(|_| Vec::new()).collect();
+    let mut nearest_points = vec![(0usize, f32::INFINITY); points];
+    let mut counts = vec![0usize; clusters];
+    let mut offsets = vec![0usize; clusters + 1];
+    let mut members = vec![0usize; points];
+    let mut next_centroids = vec![0.0f32; clusters * dim];
+    let mut previous_objective = None;
 
     for _ in 0..max_iters.max(1) {
-        #[cfg(feature = "native")]
-        let nearest_points: Vec<(usize, f32)> = {
-            use rayon::prelude::*;
-            data.par_chunks_exact(dim)
-                .map(|point| nearest(&centroids, point, dim))
-                .collect()
-        };
-        #[cfg(not(feature = "native"))]
-        let nearest_points: Vec<(usize, f32)> = data
-            .chunks_exact(dim)
-            .map(|point| nearest(&centroids, point, dim))
-            .collect();
+        assign_nearest_points(data, dim, &centroids, &mut nearest_points);
 
         let changed = assignments
             .iter()
@@ -186,40 +629,54 @@ pub(crate) fn train_euclidean_kmeans(
         if changed == 0 {
             break;
         }
+        let objective = deterministic_objective(&nearest_points);
         for (assignment, &(next, _)) in assignments.iter_mut().zip(&nearest_points) {
             *assignment = next;
         }
 
-        for cluster_members in &mut members {
-            cluster_members.clear();
+        rebuild_flat_memberships(&assignments, &mut counts, &mut offsets, &mut members);
+        let has_empty_cluster = counts.contains(&0);
+        if !has_empty_cluster
+            && previous_objective
+                .is_some_and(|previous| objective_has_converged(previous, objective))
+        {
+            break;
         }
-        for (point_index, &cluster) in assignments.iter().enumerate() {
-            members[cluster].push(point_index);
-        }
+        previous_objective = Some(objective);
 
-        let mut next_centroids = vec![0.0f32; clusters * dim];
+        next_centroids.fill(0.0);
         #[cfg(feature = "native")]
         {
             use rayon::prelude::*;
             next_centroids
                 .par_chunks_mut(dim)
-                .zip(members.par_iter())
-                .filter(|(_, cluster_members)| !cluster_members.is_empty())
-                .for_each(|(centroid, cluster_members)| {
-                    update_centroid(centroid, cluster_members, data, dim);
+                .enumerate()
+                .filter(|(cluster, _)| counts[*cluster] != 0)
+                .for_each(|(cluster, centroid)| {
+                    update_centroid(
+                        centroid,
+                        &members[offsets[cluster]..offsets[cluster + 1]],
+                        data,
+                        dim,
+                    );
                 });
         }
         #[cfg(not(feature = "native"))]
-        for (centroid, cluster_members) in next_centroids.chunks_mut(dim).zip(&members) {
-            if cluster_members.is_empty() {
+        for (cluster, centroid) in next_centroids.chunks_mut(dim).enumerate() {
+            if counts[cluster] == 0 {
                 continue;
             }
-            update_centroid(centroid, cluster_members, data, dim);
+            update_centroid(
+                centroid,
+                &members[offsets[cluster]..offsets[cluster + 1]],
+                data,
+                dim,
+            );
         }
 
         // Empty cells are re-seeded from the currently worst represented
         // points, a standard Lloyd recovery that avoids zero-vector cells.
-        if members.iter().any(Vec::is_empty) {
+        if has_empty_cluster {
             let mut farthest: Vec<usize> = (0..points).collect();
             farthest.sort_unstable_by(|&left, &right| {
                 nearest_points[right]
@@ -228,8 +685,8 @@ pub(crate) fn train_euclidean_kmeans(
                     .then_with(|| left.cmp(&right))
             });
             let mut replacement = 0usize;
-            for (cluster, cluster_members) in members.iter().enumerate() {
-                if cluster_members.is_empty() {
+            for (cluster, &count) in counts.iter().enumerate() {
+                if count == 0 {
                     let point = farthest[replacement % farthest.len()];
                     replacement += 1;
                     next_centroids[cluster * dim..(cluster + 1) * dim]
@@ -237,36 +694,48 @@ pub(crate) fn train_euclidean_kmeans(
                 }
             }
         }
-        centroids = next_centroids;
+        std::mem::swap(&mut centroids, &mut next_centroids);
     }
 
     // Ensure assignments correspond to the returned centroids when the
     // iteration budget, rather than convergence, stopped training.
-    #[cfg(feature = "native")]
-    {
-        use rayon::prelude::*;
-        assignments = data
-            .par_chunks_exact(dim)
-            .map(|point| nearest(&centroids, point, dim).0)
-            .collect();
+    assign_nearest_points(data, dim, &centroids, &mut nearest_points);
+    for (assignment, &(cluster, _)) in assignments.iter_mut().zip(&nearest_points) {
+        *assignment = cluster;
     }
-    #[cfg(not(feature = "native"))]
-    {
-        assignments = data
-            .chunks_exact(dim)
-            .map(|point| nearest(&centroids, point, dim).0)
-            .collect();
-    }
+    rebuild_flat_memberships(&assignments, &mut counts, &mut offsets, &mut members);
 
     EuclideanKMeans {
         centroids,
+        #[cfg(test)]
         assignments,
+        member_offsets: offsets,
+        members,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_memberships_match(trained: &EuclideanKMeans, clusters: usize) {
+        assert_eq!(trained.member_offsets.len(), clusters + 1);
+        assert_eq!(trained.member_offsets.first(), Some(&0));
+        assert_eq!(
+            trained.member_offsets.last(),
+            Some(&trained.assignments.len())
+        );
+        let mut seen = vec![false; trained.assignments.len()];
+        for cluster in 0..clusters {
+            for &point in &trained.members
+                [trained.member_offsets[cluster]..trained.member_offsets[cluster + 1]]
+            {
+                assert_eq!(trained.assignments[point], cluster);
+                assert!(!std::mem::replace(&mut seen[point], true));
+            }
+        }
+        assert!(seen.into_iter().all(|point| point));
+    }
 
     #[test]
     fn weighted_sampling_selects_across_fixed_reduction_blocks() {
@@ -294,18 +763,118 @@ mod tests {
         let second = train_euclidean_kmeans(&data, 6, 1, 2, 20, 42);
         assert_eq!(first.centroids, second.centroids);
         assert_eq!(first.assignments, second.assignments);
+        assert_memberships_match(&first, 2);
+        for (point, &assignment) in data.iter().zip(&first.assignments) {
+            assert_eq!(
+                assignment,
+                nearest(&first.centroids, std::slice::from_ref(point), 1).0
+            );
+        }
         let mut centroids = first.centroids;
         centroids.sort_unstable_by(f32::total_cmp);
         assert!((centroids[0] - 0.0).abs() < 0.01);
         assert!((centroids[1] - 10.0).abs() < 0.01);
     }
 
+    #[test]
+    fn initialization_strategy_and_distance_work_are_bounded() {
+        assert_eq!(
+            initialization_strategy(KMEANS_PLUS_PLUS_MAX_CLUSTERS),
+            InitializationStrategy::KMeansPlusPlus
+        );
+        assert_eq!(
+            initialization_strategy(KMEANS_PLUS_PLUS_MAX_CLUSTERS + 1),
+            InitializationStrategy::KMeansParallel
+        );
+        assert_eq!(
+            kmeans_parallel_candidate_budget(10_000, 300),
+            300 * KMEANS_PARALLEL_TOTAL_OVERSAMPLING
+        );
+        assert_eq!(kmeans_parallel_candidate_budget(350, 300), 350);
+        assert_eq!(
+            estimated_euclidean_kmeans_distance_multiplier(
+                10_000,
+                KMEANS_PLUS_PLUS_MAX_CLUSTERS,
+                25
+            ),
+            27
+        );
+        assert_eq!(
+            estimated_euclidean_kmeans_distance_multiplier(
+                10_000,
+                KMEANS_PLUS_PLUS_MAX_CLUSTERS + 1,
+                25
+            ),
+            29
+        );
+    }
+
+    #[test]
+    fn large_k_parallel_candidates_respect_total_budget_and_preserve_quality() {
+        let clusters = KMEANS_PLUS_PLUS_MAX_CLUSTERS + 1;
+        let mut data = Vec::with_capacity(clusters * 2);
+        for cluster in 0..clusters {
+            let center = cluster as f32 * 10.0;
+            data.extend([center - 0.01, center + 0.01]);
+        }
+        let points = data.len();
+        let (first, first_candidates) = initialize_kmeans_parallel(&data, points, 1, clusters, 42);
+        let (second, second_candidates) =
+            initialize_kmeans_parallel(&data, points, 1, clusters, 42);
+        assert_eq!(first, second);
+        assert_eq!(first_candidates, second_candidates);
+        assert!(first_candidates >= clusters);
+        assert!(first_candidates <= kmeans_parallel_candidate_budget(points, clusters));
+
+        let trained = train_euclidean_kmeans(&data, points, 1, clusters, 10, 42);
+        let objective: f32 = data
+            .iter()
+            .enumerate()
+            .map(|(point, &value)| {
+                let centroid = trained.centroids[trained.assignments[point]];
+                (value - centroid) * (value - centroid)
+            })
+            .sum();
+        assert!(objective < 0.1, "unexpected large-K objective {objective}");
+        assert_memberships_match(&trained, clusters);
+    }
+
+    #[test]
+    fn flat_memberships_are_cluster_major_and_stable() {
+        let assignments = [2, 0, 2, 1, 0, 2];
+        let mut counts = vec![0; 3];
+        let mut offsets = vec![0; 4];
+        let mut members = vec![usize::MAX; assignments.len()];
+        rebuild_flat_memberships(&assignments, &mut counts, &mut offsets, &mut members);
+
+        assert_eq!(counts, [2, 1, 3]);
+        assert_eq!(offsets, [0, 2, 3, 6]);
+        assert_eq!(members, [1, 4, 3, 0, 2, 5]);
+    }
+
+    #[test]
+    fn farthest_recovery_keeps_identical_empty_centroids_representable() {
+        let data = [7.0; 8];
+        let trained = train_euclidean_kmeans(&data, data.len(), 1, 4, 1, 7);
+        assert_eq!(trained.centroids, [7.0; 4]);
+        assert!(trained.assignments.iter().all(|&cluster| cluster == 0));
+        assert_memberships_match(&trained, 4);
+    }
+
+    #[test]
+    fn objective_stopping_is_relative_and_never_accepts_regression() {
+        assert!(objective_has_converged(100.0, 99.9995));
+        assert!(!objective_has_converged(100.0, 99.9));
+        assert!(!objective_has_converged(100.0, 100.0001));
+        assert!(!objective_has_converged(f64::INFINITY, 1.0));
+    }
+
     #[cfg(feature = "native")]
     #[test]
     fn training_is_deterministic_across_thread_counts() {
-        let points = 2_048;
-        let dim = 16;
-        let clusters = 32;
+        let points = 1_024;
+        let dim = 4;
+        let clusters = KMEANS_PLUS_PLUS_MAX_CLUSTERS + 1;
         let data: Vec<f32> = (0..points * dim)
             .map(|index| {
                 let mixed = (index as u64)
@@ -319,14 +888,16 @@ mod tests {
             .num_threads(1)
             .build()
             .unwrap()
-            .install(|| train_euclidean_kmeans(&data, points, dim, clusters, 4, 42));
+            .install(|| train_euclidean_kmeans(&data, points, dim, clusters, 3, 42));
         let four_threads = rayon::ThreadPoolBuilder::new()
             .num_threads(4)
             .build()
             .unwrap()
-            .install(|| train_euclidean_kmeans(&data, points, dim, clusters, 4, 42));
+            .install(|| train_euclidean_kmeans(&data, points, dim, clusters, 3, 42));
 
         assert_eq!(one_thread.centroids, four_threads.centroids);
         assert_eq!(one_thread.assignments, four_threads.assignments);
+        assert_eq!(one_thread.member_offsets, four_threads.member_offsets);
+        assert_eq!(one_thread.members, four_threads.members);
     }
 }

--- a/hermes-core/src/structures/vector/mod.rs
+++ b/hermes-core/src/structures/vector/mod.rs
@@ -27,6 +27,9 @@ pub mod ivf;
 mod kmeans;
 pub mod quantization;
 
+#[cfg(feature = "native")]
+pub(crate) use kmeans::estimated_euclidean_kmeans_distance_multiplier;
+
 // IVF core
 pub use ivf::{CoarseCentroids, CoarseConfig, IvfProbePlan, MultiAssignment, SoarConfig};
 
@@ -38,5 +41,5 @@ pub use quantization::{TqCodec, TqQueryPlan};
 // Indexes
 pub use index::{
     BinaryCoarseQuantizer, BinaryIvfConfig, BinaryIvfIndex, IvfTqIndex, TqIvfEncodeScratch,
-    TqIvfQueryPlan,
+    TqIvfQueryPlan, is_ivf_tq_cosine_generation, mark_ivf_tq_cosine_generation,
 };

--- a/hermes-core/src/structures/vector/quantization/tq.rs
+++ b/hermes-core/src/structures/vector/quantization/tq.rs
@@ -515,6 +515,13 @@ fn tq_fingerprint(dim: usize, padded_dim: usize) -> u64 {
 pub struct TqQueryPlan {
     padded_dim: usize,
     fingerprint: u64,
+    /// Exact query identity used to validate query-global plan caches.
+    ///
+    /// Keep the IEEE-754 bits rather than a hash: a `DenseVectorQuery` is
+    /// cloneable and its public vector may be mutated while clones continue
+    /// sharing the same cache. Exact bits make stale LUT reuse impossible,
+    /// including for distinct NaN payloads and signed zero.
+    query_bits: Box<[u32]>,
     base_lut_i8: Vec<i8>,
     qjl_lut_i8: Vec<i8>,
     base_dequant: f32,
@@ -530,6 +537,7 @@ impl std::fmt::Debug for TqQueryPlan {
             .debug_struct("TqQueryPlan")
             .field("padded_dim", &self.padded_dim)
             .field("fingerprint", &self.fingerprint)
+            .field("query_dim", &self.query_bits.len())
             .finish()
     }
 }
@@ -570,6 +578,11 @@ impl TqQueryPlan {
         Self {
             padded_dim,
             fingerprint: codec.fingerprint,
+            query_bits: query
+                .iter()
+                .map(|value| value.to_bits())
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
             base_lut_i8,
             qjl_lut_i8,
             base_dequant,
@@ -587,6 +600,17 @@ impl TqQueryPlan {
     #[inline]
     pub fn fingerprint(&self) -> u64 {
         self.fingerprint
+    }
+
+    /// Whether these LUTs were built for this exact query.
+    #[inline]
+    pub(crate) fn matches_query(&self, query: &[f32]) -> bool {
+        self.query_bits.len() == query.len()
+            && self
+                .query_bits
+                .iter()
+                .zip(query)
+                .all(|(&bits, value)| bits == value.to_bits())
     }
 
     /// Reference f32 estimator over one unpacked nibble row (test oracle for
@@ -1400,6 +1424,24 @@ mod tests {
             "TQ fingerprint for dim 768 changed; existing segments would be \
              rejected. Bump TQ_CODEC_VERSION deliberately instead."
         );
+    }
+
+    #[test]
+    fn query_plan_identity_uses_exact_float_bits() {
+        let codec = TqCodec::new(4);
+        let query = [0.0, -0.0, 1.0, f32::from_bits(0x7fc0_0001)];
+        let plan = TqQueryPlan::build(&codec, &query);
+
+        assert!(plan.matches_query(&query));
+        assert!(!plan.matches_query(&query[..3]));
+
+        let mut different_zero = query;
+        different_zero[1] = 0.0;
+        assert!(!plan.matches_query(&different_zero));
+
+        let mut different_nan = query;
+        different_nan[3] = f32::from_bits(0x7fc0_0002);
+        assert!(!plan.matches_query(&different_nan));
     }
 
     const GOLDEN_FINGERPRINT_768: u64 = 7026088428300072418;


### PR DESCRIPTION
## Summary

- make cosine-normalized, version-marked IVF-TQ the only supported ANN generation and reject legacy unmarked artifacts
- replace expensive coarse initialization with bounded adaptive k-means++/k-means||, contiguous sampling, flat memberships, held-out seed selection, proportional hierarchy allocation, and wider build-only routing
- improve binary IVF empty-cluster/tie correctness and keep production query probing bounded
- enable selective one-secondary SOAR by default for IVF-TQ, calibrated to at most a 30% spill budget; preserve explicit `soar: off` and reject far, low-quality secondary residuals
- add deterministic recall/storage benchmarks and focused routing-quality gates

## Quality and performance evidence

- SOAR-off vs default end-to-end: recall@10 0.9810 -> 0.9880
- persisted postings/vector: 1.000 -> 1.190 after the far-secondary quality gate
- boundary candidate recall at nprobe=1: 0.4219 -> 0.4688; unchanged at nprobe=2
- coarse training Criterion point estimates: K=64 ~12.1 ms, K=257 ~53.0 ms with comparable per-vector throughput
- production query probe budgets remain unchanged; wider/exact work is construction/evaluation only

## Validation

- `cargo test -p hermes-core`: 1,025 unit passed, 6 ignored; all 9 integration tests and doctests passed
- `cargo clippy -p hermes-core --all-targets -- -D warnings`
- no-default and all-feature library builds
- release SOAR quality benchmark, full benchmark compilation, formatting, and diff checks
- two independent P0/P1 integration reviews

## Compatibility

This intentionally does not load or migrate legacy unmarked IVF-TQ trained generations or ANN payloads. Existing legacy indexes must be rebuilt/reindexed with the current cosine-normalized format.