### PR TITLE
perf(core): optimize the binary embeddings path

### DIFF
--- a/hermes-core/Cargo.toml
+++ b/hermes-core/Cargo.toml
@@ -98,6 +98,10 @@ name = "vector_indexing"
 harness = false
 
 [[bench]]
+name = "binary_vectors"
+harness = false
+
+[[bench]]
 name = "bmp_vs_maxscore"
 harness = false
 

--- a/hermes-core/benches/binary_vectors.rs
+++ b/hermes-core/benches/binary_vectors.rs
@@ -1,0 +1,311 @@
+//! Binary dense-vector microbenchmarks: Hamming kernels, coarse routing and
+//! build-time assignment.
+//!
+//! The binary path had no benchmark coverage at all, which is how a 4x wider
+//! construction beam and a per-row SIMD dispatch pattern shipped as "quality
+//! improvements" with an unmeasured cost. Each group here pairs the current
+//! implementation against the shape it replaced, so the win (or its absence) is
+//! reproducible rather than asserted.
+//!
+//! Prod-shaped defaults: 2,560-bit codes (320 bytes) at ~16k leaves.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use hermes_core::dsl::IvfRoutingMode;
+use hermes_core::structures::simd::{
+    HammingKernel, batch_hamming_scores, hamming_distance, scores_from_hamming,
+};
+use hermes_core::structures::{BinaryCoarseQuantizer, BinaryIvfConfig};
+use rand::prelude::*;
+
+/// Prod field width: 2,560-bit codes.
+const CODE_BYTES: usize = 320;
+/// Rows per scan measured by the kernel group.
+const SCAN_ROWS: usize = 1_024;
+
+fn random_codes(rows: usize, byte_len: usize, seed: u64) -> Vec<u8> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let mut codes = vec![0u8; rows * byte_len];
+    rng.fill_bytes(&mut codes);
+    codes
+}
+
+/// Clustered corpus: `groups` anchors, each with `per_group` near-duplicates.
+/// Uniform noise would make every routing budget look equally good.
+fn clustered_codes(
+    byte_len: usize,
+    groups: usize,
+    per_group: usize,
+    flips: usize,
+    seed: u64,
+) -> Vec<u8> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let mut codes = Vec::with_capacity(groups * per_group * byte_len);
+    for _ in 0..groups {
+        let mut anchor = vec![0u8; byte_len];
+        rng.fill_bytes(&mut anchor);
+        for _ in 0..per_group {
+            let mut code = anchor.clone();
+            for _ in 0..flips {
+                let bit = rng.random_range(0..byte_len * 8);
+                code[bit / 8] ^= 1 << (bit % 8);
+            }
+            codes.extend_from_slice(&code);
+        }
+    }
+    codes
+}
+
+/// Scanning one query against many stored codes.
+///
+/// `dispatch_per_row` reproduces the previous inner loop: one `hamming_distance`
+/// call per row, each repeating runtime feature detection and rebuilding the
+/// AVX2 nibble table. `resolved_batch` and `resolved_gather` dispatch once for
+/// the whole run and score four rows per kernel invocation.
+fn bench_hamming_kernels(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("binary_hamming_scan");
+    let kernel = HammingKernel::resolve();
+    for byte_len in [8usize, 32, 128, CODE_BYTES] {
+        let query = random_codes(1, byte_len, 1);
+        let db = random_codes(SCAN_ROWS, byte_len, 2);
+        let ids: Vec<u32> = (0..SCAN_ROWS as u32).rev().collect();
+        let mut distances = vec![0u32; SCAN_ROWS];
+        let mut scores = vec![0f32; SCAN_ROWS];
+
+        group.throughput(Throughput::Bytes((SCAN_ROWS * byte_len) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("dispatch_per_row", byte_len),
+            &byte_len,
+            |bencher, &byte_len| {
+                bencher.iter(|| {
+                    for (row, slot) in distances.iter_mut().enumerate() {
+                        *slot = hamming_distance(&query, &db[row * byte_len..(row + 1) * byte_len]);
+                    }
+                    black_box(distances[0])
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("resolved_batch", byte_len),
+            &byte_len,
+            |bencher, &byte_len| {
+                bencher.iter(|| {
+                    kernel.distances(&query, &db, byte_len, &mut distances);
+                    black_box(distances[0])
+                });
+            },
+        );
+        // Graph routing visits scattered rows; this is the gather path's cost.
+        group.bench_with_input(
+            BenchmarkId::new("resolved_gather", byte_len),
+            &byte_len,
+            |bencher, &byte_len| {
+                bencher.iter(|| {
+                    kernel.gather_distances(&query, &db, byte_len, &ids, &mut distances);
+                    black_box(distances[0])
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("scores_resolved", byte_len),
+            &byte_len,
+            |bencher, &byte_len| {
+                bencher.iter(|| {
+                    scores_from_hamming(kernel, &query, &db, byte_len, byte_len * 8, &mut scores);
+                    black_box(scores[0])
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Per-leaf versus per-parent scoring for two-level routing.
+///
+/// The old probe loop called the batch kernel once per leaf on a single-row
+/// slice, paying argument validation, a reciprocal divide and feature detection
+/// per centroid. Children of a parent are contiguous, so one call covers them
+/// all.
+fn bench_leaf_scoring_shape(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("binary_leaf_scoring");
+    let leaves = 338; // routing_parent_count(114_309) children per parent
+    let query = random_codes(1, CODE_BYTES, 3);
+    let centroids = random_codes(leaves, CODE_BYTES, 4);
+    let kernel = HammingKernel::resolve();
+    let dim_bits = CODE_BYTES * 8;
+
+    group.throughput(Throughput::Elements(leaves as u64));
+    group.bench_function("one_call_per_leaf", |bencher| {
+        let mut score = [0f32];
+        let mut candidates: Vec<(u32, f32)> = Vec::with_capacity(leaves);
+        bencher.iter(|| {
+            candidates.clear();
+            for leaf in 0..leaves {
+                let offset = leaf * CODE_BYTES;
+                batch_hamming_scores(
+                    &query,
+                    &centroids[offset..offset + CODE_BYTES],
+                    CODE_BYTES,
+                    dim_bits,
+                    &mut score,
+                );
+                candidates.push((leaf as u32, score[0]));
+            }
+            black_box(candidates.len())
+        });
+    });
+    group.bench_function("one_call_per_parent", |bencher| {
+        let mut scores = vec![0f32; leaves];
+        let mut candidates: Vec<(u32, f32)> = Vec::with_capacity(leaves);
+        bencher.iter(|| {
+            scores_from_hamming(
+                kernel,
+                &query,
+                &centroids,
+                CODE_BYTES,
+                dim_bits,
+                &mut scores,
+            );
+            candidates.clear();
+            candidates.extend((0..leaves as u32).zip(scores.iter().copied()));
+            black_box(candidates.len())
+        });
+    });
+    group.finish();
+}
+
+fn trained_quantizer(
+    clusters: usize,
+    routing: IvfRoutingMode,
+    codes: &[u8],
+    byte_len: usize,
+) -> BinaryCoarseQuantizer {
+    let points = codes.len() / byte_len;
+    let mut config = BinaryIvfConfig::new(byte_len * 8, clusters);
+    config.train_iters = 3;
+    config.max_train_samples = points;
+    config.routing = routing;
+    BinaryCoarseQuantizer::train(config, codes, points).expect("binary coarse training")
+}
+
+/// Query-time probing and build-time assignment against a realistic codebook.
+///
+/// `assign` is the operation every vector of a rebuilt segment pays once; its
+/// cost is linear in the construction beam, which is why the beam floor is set
+/// from measured recall rather than from "construction can afford it".
+fn bench_routing(criterion: &mut Criterion) {
+    // One anchor per leaf (plus slack): fewer distinct anchors than leaves
+    // produces near-duplicate centroids, and greedy descent then tie-walks
+    // through equidistant nodes instead of measuring realistic routing.
+    let clusters = 16_384;
+    let corpus = clustered_codes(CODE_BYTES, 20_000, 3, 32, 7);
+    let probes = clustered_codes(CODE_BYTES, 64, 1, 40, 11);
+
+    let mut group = criterion.benchmark_group("binary_routing");
+    group.sample_size(20);
+    for routing in [
+        IvfRoutingMode::Flat,
+        IvfRoutingMode::TwoLevel,
+        IvfRoutingMode::Hnsw,
+    ] {
+        let quantizer = trained_quantizer(clusters, routing, &corpus, CODE_BYTES);
+        let label = format!("{routing:?}");
+
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(
+            BenchmarkId::new("probe_nprobe64", &label),
+            &routing,
+            |bencher, &routing| {
+                let mut cursor = 0usize;
+                bencher.iter(|| {
+                    let start = cursor * CODE_BYTES;
+                    cursor = (cursor + 1) % (probes.len() / CODE_BYTES);
+                    let plan = quantizer.probe(&probes[start..start + CODE_BYTES], 64, routing);
+                    black_box(plan.cluster_ids.len())
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("assign", &label),
+            &routing,
+            |bencher, &routing| {
+                let mut cursor = 0usize;
+                bencher.iter(|| {
+                    let start = cursor * CODE_BYTES;
+                    cursor = (cursor + 1) % (probes.len() / CODE_BYTES);
+                    black_box(quantizer.assign(&probes[start..start + CODE_BYTES], routing))
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Where graph routing actually starts beating an exact flat scan.
+///
+/// A base-layer search with beam `ef` and degree `2M` touches roughly
+/// `ef * 2M` adjacency slots, so below about that many leaves it visits the
+/// whole codebook anyway — with random access and heap traffic instead of one
+/// sequential SIMD pass, and approximately instead of exactly. Both modes are
+/// probed on the *same* centroids here, so the crossing point is a property of
+/// the codebook size alone.
+fn bench_routing_crossover(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("binary_routing_crossover");
+    group.sample_size(10);
+    for clusters in [4_096usize, 16_384, 32_768, 65_536] {
+        let corpus = clustered_codes(CODE_BYTES, clusters + clusters / 4, 3, 32, 17);
+        let quantizer = trained_quantizer(clusters, IvfRoutingMode::Hnsw, &corpus, CODE_BYTES);
+        let probes = clustered_codes(CODE_BYTES, 32, 1, 40, 19);
+        for mode in [IvfRoutingMode::Flat, IvfRoutingMode::Hnsw] {
+            group.bench_with_input(
+                BenchmarkId::new(format!("probe_{mode:?}"), clusters),
+                &mode,
+                |bencher, &mode| {
+                    let mut cursor = 0usize;
+                    bencher.iter(|| {
+                        let start = cursor * CODE_BYTES;
+                        cursor = (cursor + 1) % (probes.len() / CODE_BYTES);
+                        let plan = quantizer.probe(&probes[start..start + CODE_BYTES], 64, mode);
+                        black_box(plan.cluster_ids.len())
+                    });
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+/// k-majority training: seeding, Lloyd assignment and the majority update that
+/// used to allocate and zero a 20 KiB counter block per centroid per iteration.
+fn bench_training(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("binary_coarse_training");
+    group.sample_size(10);
+    let corpus = clustered_codes(CODE_BYTES, 512, 16, 24, 13);
+    let points = corpus.len() / CODE_BYTES;
+    group.throughput(Throughput::Elements(points as u64));
+    for clusters in [256usize, 1_024] {
+        group.bench_with_input(
+            BenchmarkId::new("k_majority", clusters),
+            &clusters,
+            |bencher, &clusters| {
+                bencher.iter(|| {
+                    let quantizer =
+                        trained_quantizer(clusters, IvfRoutingMode::Flat, &corpus, CODE_BYTES);
+                    black_box(quantizer.num_clusters)
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_hamming_kernels,
+    bench_leaf_scoring_shape,
+    bench_routing,
+    bench_routing_crossover,
+    bench_training
+);
+criterion_main!(benches);

--- a/hermes-core/src/index/tests/vector.rs
+++ b/hermes-core/src/index/tests/vector.rs
@@ -1282,6 +1282,125 @@ async fn test_binary_ivf_end_to_end() {
     );
 }
 
+/// Partial probing with a non-`Max` combiner: reusing the probe's exact scores
+/// must not lose the ordinals that live *outside* the probed leaves.
+///
+/// With `nprobe < num_clusters` a retained document usually has some ordinals in
+/// probed leaves (scored during the scan) and some elsewhere (which still have
+/// to be read from flat storage). Dropping the latter would silently shrink an
+/// additive combiner's score, so the returned score is checked against the exact
+/// combination over *every* ordinal of that document.
+#[tokio::test]
+async fn test_binary_ivf_partial_probe_combines_unprobed_ordinals() {
+    use crate::dsl::BinaryDenseVectorConfig;
+    use crate::query::{BinaryDenseVectorQuery, MultiValueCombiner};
+
+    let dim_bits = 64;
+    let byte_len = dim_bits / 8;
+
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    // 8 leaves, probe only one of them.
+    let cfg = BinaryDenseVectorConfig::new(dim_bits).with_ivf(Some(8), 1);
+    let bvec = sb.add_binary_dense_vector_field_with_config("bvec", true, true, cfg);
+    sb.set_multi(bvec, true);
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+
+    // Every document pairs a vector near one "corner" of the space with a
+    // vector near a different corner, so a single probed leaf can only ever
+    // hold part of a document.
+    let corner = |index: usize| -> Vec<u8> {
+        let mut vector = vec![0u8; byte_len];
+        vector[index % byte_len] = 0xFF;
+        vector[(index * 3 + 1) % byte_len] = 0x0F;
+        vector
+    };
+    let mut vectors_by_title = std::collections::HashMap::new();
+    for doc_index in 0usize..40 {
+        let ordinals = vec![corner(doc_index), corner(doc_index + 17)];
+        let name = format!("doc {doc_index}");
+        let mut doc = Document::new();
+        doc.add_text(title, name.clone());
+        for vector in &ordinals {
+            doc.add_binary_dense_vector(bvec, vector.clone());
+        }
+        writer.add_document(doc).unwrap();
+        vectors_by_title.insert(name, ordinals);
+    }
+    writer.commit().await.unwrap();
+    writer.build_vector_index().await.unwrap();
+    let mut merge_trigger = Document::new();
+    merge_trigger.add_text(title, "merge trigger");
+    merge_trigger.add_binary_dense_vector(bvec, vec![0; byte_len]);
+    writer.add_document(merge_trigger).unwrap();
+    writer.commit().await.unwrap();
+    writer.force_merge().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    let segments = index.segment_readers().await.unwrap();
+    assert!(
+        matches!(
+            segments[0].get_vector_index(bvec),
+            Some(crate::segment::VectorIndex::BinaryIvf(_))
+        ),
+        "binary IVF payload expected for a partial-probe test"
+    );
+
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let query_vector = corner(3);
+    for combiner in [
+        MultiValueCombiner::Sum,
+        MultiValueCombiner::Avg,
+        MultiValueCombiner::default(),
+    ] {
+        let results = searcher
+            .search(
+                &BinaryDenseVectorQuery::new(bvec, query_vector.clone()).with_combiner(combiner),
+                3,
+            )
+            .await
+            .unwrap();
+        assert!(!results.is_empty(), "{combiner:?} returned nothing");
+        for result in &results {
+            let document = searcher
+                .doc(result.segment_id, result.doc_id)
+                .await
+                .unwrap()
+                .unwrap();
+            let name = document
+                .get_first(title)
+                .unwrap()
+                .as_text()
+                .unwrap()
+                .to_string();
+            let Some(ordinals) = vectors_by_title.get(&name) else {
+                continue; // the merge trigger has a single ordinal
+            };
+            let exact: Vec<(u32, f32)> = ordinals
+                .iter()
+                .enumerate()
+                .map(|(ordinal, vector)| {
+                    let distance = crate::structures::simd::hamming_distance(&query_vector, vector);
+                    (ordinal as u32, 1.0 - distance as f32 / dim_bits as f32)
+                })
+                .collect();
+            let expected = combiner.combine(&exact);
+            assert!(
+                (result.score - expected).abs() < 1e-6,
+                "{combiner:?} score for {name} dropped an unprobed ordinal: got {}, exact {expected}",
+                result.score,
+            );
+        }
+    }
+}
+
 /// Multi-valued binary IVF: the IVF probe's exact Hamming scores are reused
 /// for the ordinals it returned, remaining ordinals are exact-scored from
 /// flat storage, and the document combiner sees every ordinal exactly once —

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -26,6 +26,10 @@ use crate::dsl::IvfRoutingMode;
 use crate::structures::BinaryIvfIndex;
 use crate::structures::vector::index::{BoundedAnnCollector, BoundedUniqueAnnCollector};
 
+/// Combined binary candidates: the retained documents, plus the exact
+/// per-ordinal `(doc_id, ordinal, score)` scores behind them.
+type CombinedBinaryCandidates = (Vec<AnnDocumentCandidate>, Vec<(u32, u16, f32)>);
+
 const ANN_HEADER_MAGIC: u32 = 0x3152_4e41; // "ANR1"
 const ANN_FOOTER_MAGIC: u32 = 0x3146_4e41; // "ANF1"
 const ANN_DISK_VERSION: u16 = 1;
@@ -514,13 +518,18 @@ impl AnnDiskIndex {
     /// Score packed codes in the selected binary-IVF leaves, deduplicate
     /// repeated `(doc_id, ordinal)` assignments, combine per document, and
     /// retain at most `k` approximate document candidates.
+    ///
+    /// The second return value carries the per-ordinal scores behind the
+    /// retained documents. Binary leaves store the original packed codes, so
+    /// those scores are *exact*, and reranking can reuse them instead of
+    /// re-reading the same codes from flat storage.
     pub(crate) fn search_binary_combined_documents(
         &self,
         k: usize,
         query: &[u8],
         cluster_ids: &[u32],
         combiner: crate::query::MultiValueCombiner,
-    ) -> io::Result<Vec<AnnDocumentCandidate>> {
+    ) -> io::Result<CombinedBinaryCandidates> {
         validate_combined_search(combiner)?;
         if query.len() != self.header.code_size {
             return Err(io::Error::new(
@@ -529,7 +538,7 @@ impl AnnDiskIndex {
             ));
         }
         if k == 0 {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), Vec::new()));
         }
         #[cfg(feature = "native")]
         self.prefetch_cluster_runs(cluster_ids);
@@ -548,7 +557,11 @@ impl AnnDiskIndex {
             &mut score_batch,
             &mut ordinal_scores,
         )?;
-        Ok(combine_scored_ordinals(ordinal_scores, k, combiner))
+        Ok(combine_scored_ordinals_retaining(
+            ordinal_scores,
+            k,
+            combiner,
+        ))
     }
 
     /// Score every TQ block against the query plan and keep the top `k`
@@ -918,12 +931,25 @@ fn validate_combined_search(combiner: crate::query::MultiValueCombiner) -> io::R
 /// tuple per probed posting and never expands to unprobed leaves or raw
 /// vectors; final retained state is O(k).
 fn combine_scored_ordinals(
-    mut scores: Vec<(u32, u16, f32)>,
+    scores: Vec<(u32, u16, f32)>,
     k: usize,
     combiner: crate::query::MultiValueCombiner,
 ) -> Vec<AnnDocumentCandidate> {
+    combine_scored_ordinals_retaining(scores, k, combiner).0
+}
+
+/// As [`combine_scored_ordinals`], additionally returning the deduplicated
+/// per-ordinal scores of the retained documents, sorted by `(doc_id, ordinal)`.
+///
+/// Only callers whose leaf scores are exact may reuse those numbers; TQ block
+/// scores are estimates and must still be reranked against raw vectors.
+fn combine_scored_ordinals_retaining(
+    mut scores: Vec<(u32, u16, f32)>,
+    k: usize,
+    combiner: crate::query::MultiValueCombiner,
+) -> CombinedBinaryCandidates {
     if k == 0 || scores.is_empty() {
-        return Vec::new();
+        return (Vec::new(), Vec::new());
     }
     scores.retain(|entry| entry.2.is_finite());
     scores.sort_unstable_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
@@ -952,7 +978,7 @@ fn combine_scored_ordinals(
     let mut top_documents = BoundedAnnCollector::<true, true>::new(k);
     let mut current_doc = None;
     let mut ordinal_scores = Vec::new();
-    for (doc_id, ordinal, score) in scores {
+    for &(doc_id, ordinal, score) in &scores {
         if current_doc.is_some_and(|current| current != doc_id) {
             retain_combined_document(
                 &mut top_documents,
@@ -969,11 +995,31 @@ fn combine_scored_ordinals(
         retain_combined_document(&mut top_documents, doc_id, &ordinal_scores, combiner);
     }
 
-    top_documents
+    let candidates: Vec<AnnDocumentCandidate> = top_documents
         .into_sorted_results()
         .into_iter()
         .map(|(doc_id, _, score)| AnnDocumentCandidate { doc_id, score })
-        .collect()
+        .collect();
+
+    // Narrow the per-ordinal scores to the retained documents. `scores` is
+    // already sorted by document, so this is one pass over a sorted ID set
+    // rather than a hash lookup per posting.
+    let mut retained_ids: Vec<u32> = candidates
+        .iter()
+        .map(|candidate| candidate.doc_id)
+        .collect();
+    retained_ids.sort_unstable();
+    let mut retained = Vec::with_capacity(scores.len().min(retained_ids.len().saturating_mul(4)));
+    let mut cursor = 0usize;
+    for entry in scores {
+        while cursor < retained_ids.len() && retained_ids[cursor] < entry.0 {
+            cursor += 1;
+        }
+        if retained_ids.get(cursor) == Some(&entry.0) {
+            retained.push(entry);
+        }
+    }
+    (candidates, retained)
 }
 
 #[cfg(feature = "native")]
@@ -1897,7 +1943,7 @@ mod tests {
             crate::query::MultiValueCombiner::Sum,
             crate::query::MultiValueCombiner::default(),
         ] {
-            let result = disk
+            let (result, probed) = disk
                 .search_binary_combined_documents(1, &[0], &[0, 1], combiner)
                 .unwrap();
             assert_eq!(result.len(), 1, "combined search must honor k");
@@ -1905,9 +1951,19 @@ mod tests {
                 result[0].doc_id, 1,
                 "SOAR duplicate changed {combiner:?} ranking: {result:?}",
             );
+            // Exact leaf scores are handed back only for the retained document,
+            // deduplicated and sorted, so reranking can skip re-reading them.
+            assert_eq!(
+                probed
+                    .iter()
+                    .map(|&(doc_id, ordinal, _)| (doc_id, ordinal))
+                    .collect::<Vec<_>>(),
+                vec![(1, 0), (1, 1)],
+                "{combiner:?}",
+            );
         }
 
-        let top_two = disk
+        let (top_two, probed) = disk
             .search_binary_combined_documents(
                 2,
                 &[0],
@@ -1923,6 +1979,15 @@ mod tests {
             vec![1, 0],
         );
         assert_eq!(top_two.len(), 2, "full probing must still return at most k");
+        // doc 0 ordinal 0 was probed twice (a SOAR duplicate) and must appear
+        // once, with the two retained documents in ascending order.
+        assert_eq!(
+            probed
+                .iter()
+                .map(|&(doc_id, ordinal, _)| (doc_id, ordinal))
+                .collect::<Vec<_>>(),
+            vec![(0, 0), (0, 1), (1, 0), (1, 1)],
+        );
     }
 
     #[test]

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -938,6 +938,7 @@ async fn exact_score_binary_candidate_documents(
 
 async fn exact_score_binary_candidate_document_ids(
     candidate_doc_ids: Vec<DocId>,
+    probed_ordinal_scores: &[(u32, u16, f32)],
     flat: &LazyFlatVectorData,
     query: &[u8],
     dim_bits: usize,
@@ -945,7 +946,9 @@ async fn exact_score_binary_candidate_document_ids(
     limit: usize,
 ) -> Result<Vec<VectorSearchResult>> {
     let documents = ann_candidate_document_ranges_from_ids(candidate_doc_ids, flat)?;
-    let probe_scores = FxHashMap::default();
+    // Binary leaves hold the original packed codes, so probed ordinals already
+    // have exact scores; only ordinals outside the probed leaves are read back.
+    let probe_scores = binary_probe_score_map(probed_ordinal_scores);
     exact_score_binary_resolved_documents(
         documents,
         &probe_scores,
@@ -956,6 +959,15 @@ async fn exact_score_binary_candidate_document_ids(
         limit,
     )
     .await
+}
+
+fn binary_probe_score_map(
+    probed_ordinal_scores: &[(u32, u16, f32)],
+) -> FxHashMap<(DocId, u16), f32> {
+    probed_ordinal_scores
+        .iter()
+        .map(|&(doc_id, ordinal, score)| ((doc_id, ordinal), score))
+        .collect()
 }
 
 async fn exact_score_binary_resolved_documents(
@@ -1048,6 +1060,7 @@ fn exact_score_binary_candidate_documents_sync(
 #[cfg(feature = "sync")]
 fn exact_score_binary_candidate_document_ids_sync(
     candidate_doc_ids: Vec<DocId>,
+    probed_ordinal_scores: &[(u32, u16, f32)],
     flat: &LazyFlatVectorData,
     query: &[u8],
     dim_bits: usize,
@@ -1055,7 +1068,7 @@ fn exact_score_binary_candidate_document_ids_sync(
     limit: usize,
 ) -> Result<Vec<VectorSearchResult>> {
     let documents = ann_candidate_document_ranges_from_ids(candidate_doc_ids, flat)?;
-    let probe_scores = FxHashMap::default();
+    let probe_scores = binary_probe_score_map(probed_ordinal_scores);
     exact_score_binary_resolved_documents_sync(
         documents,
         &probe_scores,
@@ -2679,7 +2692,7 @@ impl SegmentReader {
             {
                 let candidate_limit =
                     checked_binary_combined_fetch_k(k)?.min(flat.num_docs_with_vectors());
-                let candidate_documents = ivf
+                let (candidate_documents, probed_ordinal_scores) = ivf
                     .search_binary_combined_documents(candidate_limit, query, &clusters, combiner)
                     .map_err(|error| {
                         Error::Corruption(format!(
@@ -2692,6 +2705,7 @@ impl SegmentReader {
                         .into_iter()
                         .map(|candidate| candidate.doc_id)
                         .collect(),
+                    &probed_ordinal_scores,
                     flat,
                     query,
                     schema_dim,
@@ -3289,7 +3303,7 @@ impl SegmentReader {
             {
                 let candidate_limit =
                     checked_binary_combined_fetch_k(k)?.min(flat.num_docs_with_vectors());
-                let candidate_documents = ivf
+                let (candidate_documents, probed_ordinal_scores) = ivf
                     .search_binary_combined_documents(candidate_limit, query, &clusters, combiner)
                     .map_err(|error| {
                         Error::Corruption(format!(
@@ -3302,6 +3316,7 @@ impl SegmentReader {
                         .into_iter()
                         .map(|candidate| candidate.doc_id)
                         .collect(),
+                    &probed_ordinal_scores,
                     flat,
                     query,
                     schema_dim,

--- a/hermes-core/src/structures/simd.rs
+++ b/hermes-core/src/structures/simd.rs
@@ -346,6 +346,49 @@ mod neon {
         total
     }
 
+    /// Four-row NEON Hamming distance.
+    ///
+    /// The query chunk load and the horizontal reduction are shared across the
+    /// rows, and the four accumulator chains overlap instead of serialising on
+    /// `vcntq_u8`/`vaddq_u8` latency.
+    #[target_feature(enable = "neon")]
+    pub unsafe fn hamming_distance_x4(query: &[u8], rows: [&[u8]; 4]) -> [u32; 4] {
+        let len = query.len();
+        let chunks16 = len / 16;
+        let mut total = [0u32; 4];
+
+        let mut i = 0;
+        while i < chunks16 {
+            let batch_end = (i + 31).min(chunks16);
+            let mut acc = [vdupq_n_u8(0); 4];
+            for j in i..batch_end {
+                let off = j * 16;
+                let vq = vld1q_u8(query.as_ptr().add(off));
+                for r in 0..4 {
+                    let vr = vld1q_u8(rows[r].as_ptr().add(off));
+                    acc[r] = vaddq_u8(acc[r], vcntq_u8(veorq_u8(vq, vr)));
+                }
+            }
+            for r in 0..4 {
+                let sum64 = vpaddlq_u32(vpaddlq_u16(vpaddlq_u8(acc[r])));
+                total[r] += vgetq_lane_u64(sum64, 0) as u32 + vgetq_lane_u64(sum64, 1) as u32;
+            }
+            i = batch_end;
+        }
+
+        // Remainder through the u64 scalar path: a per-byte tail would dominate
+        // for code widths narrower than one vector (e.g. 64-bit fields).
+        let base = chunks16 * 16;
+        if base < len {
+            let tail = &query[base..];
+            for r in 0..4 {
+                total[r] += super::hamming_distance_scalar(tail, &rows[r][base..]);
+            }
+        }
+
+        total
+    }
+
     /// Check if NEON is available (always true on aarch64)
     #[inline]
     pub fn is_available() -> bool {
@@ -949,6 +992,71 @@ mod avx2 {
         }
 
         total as u32
+    }
+
+    /// Four-row AVX2 Hamming distance.
+    ///
+    /// The query chunk load, the nibble lookup table and the horizontal
+    /// reduction are shared across the rows, and the four accumulator chains
+    /// overlap instead of serialising on popcount latency.
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn hamming_distance_x4(query: &[u8], rows: [&[u8]; 4]) -> [u32; 4] {
+        let len = query.len();
+        let chunks32 = len / 32;
+        let low_mask = _mm256_set1_epi8(0x0f);
+        let lookup = _mm256_setr_epi8(
+            0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2,
+            3, 3, 4,
+        );
+        let mut total = [0u64; 4];
+
+        let mut i = 0;
+        while i < chunks32 {
+            let batch_end = (i + 31).min(chunks32);
+            let mut acc = [_mm256_setzero_si256(); 4];
+            for j in i..batch_end {
+                let off = j * 32;
+                let vq = _mm256_loadu_si256(query.as_ptr().add(off) as *const __m256i);
+                for r in 0..4 {
+                    let vr = _mm256_loadu_si256(rows[r].as_ptr().add(off) as *const __m256i);
+                    let xored = _mm256_xor_si256(vq, vr);
+                    let lo = _mm256_and_si256(xored, low_mask);
+                    let hi = _mm256_and_si256(_mm256_srli_epi16(xored, 4), low_mask);
+                    acc[r] = _mm256_add_epi8(
+                        acc[r],
+                        _mm256_add_epi8(
+                            _mm256_shuffle_epi8(lookup, lo),
+                            _mm256_shuffle_epi8(lookup, hi),
+                        ),
+                    );
+                }
+            }
+            for r in 0..4 {
+                let sad = _mm256_sad_epu8(acc[r], _mm256_setzero_si256());
+                total[r] += _mm256_extract_epi64(sad, 0) as u64
+                    + _mm256_extract_epi64(sad, 1) as u64
+                    + _mm256_extract_epi64(sad, 2) as u64
+                    + _mm256_extract_epi64(sad, 3) as u64;
+            }
+            i = batch_end;
+        }
+
+        // Remainder through the u64 scalar path: a per-byte tail would dominate
+        // for code widths narrower than one vector (e.g. 64-bit fields).
+        let base = chunks32 * 32;
+        if base < len {
+            let tail = &query[base..];
+            for r in 0..4 {
+                total[r] += u64::from(super::hamming_distance_scalar(tail, &rows[r][base..]));
+            }
+        }
+
+        [
+            total[0] as u32,
+            total[1] as u32,
+            total[2] as u32,
+            total[3] as u32,
+        ]
     }
 
     /// Check if AVX2 is available at runtime
@@ -3391,29 +3499,243 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 // Hamming distance for binary dense vectors
 // ============================================================================
 
+/// AVX-512 Hamming distance using `VPOPCNTDQ`.
+///
+/// Processes 64 bytes per iteration with a single hardware popcount per lane
+/// group, which removes the nibble-lookup shuffles the AVX2 path needs.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f,avx512vpopcntdq")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn hamming_distance_avx512(a: &[u8], b: &[u8]) -> u32 {
+    use std::arch::x86_64::*;
+
+    let len = a.len();
+    let chunks64 = len / 64;
+    let mut acc = _mm512_setzero_si512();
+
+    for c in 0..chunks64 {
+        let off = c * 64;
+        let va = _mm512_loadu_si512(a.as_ptr().add(off) as *const __m512i);
+        let vb = _mm512_loadu_si512(b.as_ptr().add(off) as *const __m512i);
+        acc = _mm512_add_epi64(acc, _mm512_popcnt_epi64(_mm512_xor_si512(va, vb)));
+    }
+
+    let base = chunks64 * 64;
+    _mm512_reduce_add_epi64(acc) as u32 + hamming_distance_scalar(&a[base..], &b[base..])
+}
+
+/// Four-row AVX-512 Hamming distance sharing the query load across rows.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f,avx512vpopcntdq")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn hamming_distance_x4_avx512(query: &[u8], rows: [&[u8]; 4]) -> [u32; 4] {
+    use std::arch::x86_64::*;
+
+    let len = query.len();
+    let chunks64 = len / 64;
+    let mut acc = [_mm512_setzero_si512(); 4];
+
+    for c in 0..chunks64 {
+        let off = c * 64;
+        let vq = _mm512_loadu_si512(query.as_ptr().add(off) as *const __m512i);
+        for r in 0..4 {
+            let vr = _mm512_loadu_si512(rows[r].as_ptr().add(off) as *const __m512i);
+            acc[r] = _mm512_add_epi64(acc[r], _mm512_popcnt_epi64(_mm512_xor_si512(vq, vr)));
+        }
+    }
+
+    let base = chunks64 * 64;
+    let tail = &query[base..];
+    [
+        _mm512_reduce_add_epi64(acc[0]) as u32 + hamming_distance_scalar(tail, &rows[0][base..]),
+        _mm512_reduce_add_epi64(acc[1]) as u32 + hamming_distance_scalar(tail, &rows[1][base..]),
+        _mm512_reduce_add_epi64(acc[2]) as u32 + hamming_distance_scalar(tail, &rows[2][base..]),
+        _mm512_reduce_add_epi64(acc[3]) as u32 + hamming_distance_scalar(tail, &rows[3][base..]),
+    ]
+}
+
+/// Four-row scalar Hamming distance sharing the query load across rows.
+#[inline]
+fn hamming_distance_x4_scalar(query: &[u8], rows: [&[u8]; 4]) -> [u32; 4] {
+    let len = query.len();
+    let chunks = len / 8;
+    let mut total = [0u32; 4];
+
+    for i in 0..chunks {
+        let off = i * 8;
+        let vq = unsafe { std::ptr::read_unaligned(query.as_ptr().add(off) as *const u64) };
+        for r in 0..4 {
+            let vr = unsafe { std::ptr::read_unaligned(rows[r].as_ptr().add(off) as *const u64) };
+            total[r] += (vq ^ vr).count_ones();
+        }
+    }
+
+    let base = chunks * 8;
+    for k in base..len {
+        let q = query[k];
+        for r in 0..4 {
+            total[r] += (q ^ rows[r][k]).count_ones();
+        }
+    }
+
+    total
+}
+
+/// Rows scored per kernel invocation. Sharing the query load, the AVX2 nibble
+/// lookup table and the horizontal reduction across four rows amortises the
+/// non-inlinable `#[target_feature]` call and overlaps the popcount chains.
+const HAMMING_ROWS_PER_KERNEL: usize = 4;
+
+/// Architecture kernel resolved once for a whole scan.
+///
+/// Hot binary paths — HNSW centroid routing, k-majority assignment, leaf
+/// scanning — score millions of code pairs against one query. Resolving the
+/// kernel up front keeps runtime feature detection out of the inner loop, and
+/// the row-batched entry points let one dispatch cover a whole neighbour list.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HammingKernel {
+    #[cfg(target_arch = "x86_64")]
+    Avx512,
+    #[cfg(target_arch = "x86_64")]
+    Avx2,
+    #[cfg(target_arch = "aarch64")]
+    Neon,
+    Scalar,
+}
+
+impl HammingKernel {
+    /// Detect the widest kernel this CPU supports.
+    #[inline]
+    pub fn resolve() -> Self {
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vpopcntdq") {
+                return Self::Avx512;
+            }
+            if avx2::is_available() {
+                return Self::Avx2;
+            }
+            Self::Scalar
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            Self::Neon
+        }
+
+        #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+        {
+            Self::Scalar
+        }
+    }
+
+    /// Hamming distance between two equal-length packed-bit vectors.
+    #[inline]
+    pub fn distance(self, a: &[u8], b: &[u8]) -> u32 {
+        debug_assert_eq!(a.len(), b.len(), "Hamming vector byte length mismatch");
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx512 => unsafe { hamming_distance_avx512(a, b) },
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx2 => unsafe { avx2::hamming_distance(a, b) },
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon => unsafe { neon::hamming_distance(a, b) },
+            Self::Scalar => hamming_distance_scalar(a, b),
+        }
+    }
+
+    /// `out[i]` receives the distance from `query` to row `i` of `db`.
+    pub fn distances(self, query: &[u8], db: &[u8], byte_len: usize, out: &mut [u32]) {
+        self.score_rows(query, db, byte_len, out, |index| index);
+    }
+
+    /// `out[i]` receives the distance from `query` to row `ids[i]` of `db`.
+    ///
+    /// Graph routing visits scattered centroid rows; gathering them through one
+    /// dispatch keeps the batched kernel usable there.
+    pub fn gather_distances(
+        self,
+        query: &[u8],
+        db: &[u8],
+        byte_len: usize,
+        ids: &[u32],
+        out: &mut [u32],
+    ) {
+        assert_eq!(
+            ids.len(),
+            out.len(),
+            "Hamming gather needs one output slot per row id"
+        );
+        self.score_rows(query, db, byte_len, out, |index| ids[index] as usize);
+    }
+
+    #[inline]
+    fn score_rows(
+        self,
+        query: &[u8],
+        db: &[u8],
+        byte_len: usize,
+        out: &mut [u32],
+        index_of: impl Fn(usize) -> usize,
+    ) {
+        assert_eq!(query.len(), byte_len, "Hamming query byte length mismatch");
+        if byte_len == 0 || out.is_empty() {
+            return;
+        }
+        let row = |index: usize| -> &[u8] {
+            let start = index * byte_len;
+            &db[start..start + byte_len]
+        };
+        macro_rules! score_with {
+            ($one:expr, $four:expr) => {{
+                let mut i = 0;
+                while i + HAMMING_ROWS_PER_KERNEL <= out.len() {
+                    let quad = [
+                        row(index_of(i)),
+                        row(index_of(i + 1)),
+                        row(index_of(i + 2)),
+                        row(index_of(i + 3)),
+                    ];
+                    out[i..i + HAMMING_ROWS_PER_KERNEL].copy_from_slice(&$four(query, quad));
+                    i += HAMMING_ROWS_PER_KERNEL;
+                }
+                while i < out.len() {
+                    out[i] = $one(query, row(index_of(i)));
+                    i += 1;
+                }
+            }};
+        }
+        match self {
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx512 => score_with!(
+                |query, row| unsafe { hamming_distance_avx512(query, row) },
+                |query, rows| unsafe { hamming_distance_x4_avx512(query, rows) }
+            ),
+            #[cfg(target_arch = "x86_64")]
+            Self::Avx2 => score_with!(
+                |query, row| unsafe { avx2::hamming_distance(query, row) },
+                |query, rows| unsafe { avx2::hamming_distance_x4(query, rows) }
+            ),
+            #[cfg(target_arch = "aarch64")]
+            Self::Neon => score_with!(
+                |query, row| unsafe { neon::hamming_distance(query, row) },
+                |query, rows| unsafe { neon::hamming_distance_x4(query, rows) }
+            ),
+            Self::Scalar => score_with!(hamming_distance_scalar, hamming_distance_x4_scalar),
+        }
+    }
+}
+
 /// Compute Hamming distance between two packed-bit vectors.
 /// Returns the number of differing bits.
 ///
-/// Uses NEON intrinsics on aarch64, POPCNT on x86_64, scalar fallback otherwise.
+/// Uses NEON on aarch64 and VPOPCNTDQ/AVX2 on x86_64, with a scalar fallback.
+/// Loops over many pairs should resolve a [`HammingKernel`] once instead of
+/// paying feature detection here per pair.
 #[inline]
 pub fn hamming_distance(a: &[u8], b: &[u8]) -> u32 {
     assert_eq!(a.len(), b.len(), "Hamming vector byte length mismatch");
-
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        neon::hamming_distance(a, b)
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    {
-        if avx2::is_available() {
-            return unsafe { avx2::hamming_distance(a, b) };
-        }
-        hamming_distance_scalar(a, b)
-    }
-
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-    hamming_distance_scalar(a, b)
+    HammingKernel::resolve().distance(a, b)
 }
 
 /// Scalar Hamming distance using u64 chunks + count_ones().
@@ -3468,45 +3790,58 @@ pub fn batch_hamming_scores(
         return;
     }
 
+    scores_from_hamming(
+        HammingKernel::resolve(),
+        query,
+        db,
+        byte_len,
+        dim_bits,
+        scores,
+    );
+}
+
+/// Batch Hamming scoring with a caller-resolved kernel.
+///
+/// Scans that already hold a [`HammingKernel`] (leaf scanning, Lloyd
+/// assignment) use this to keep feature detection out of the loop entirely.
+pub fn scores_from_hamming(
+    kernel: HammingKernel,
+    query: &[u8],
+    db: &[u8],
+    byte_len: usize,
+    dim_bits: usize,
+    scores: &mut [f32],
+) {
+    if byte_len == 0 || scores.is_empty() || dim_bits == 0 {
+        return;
+    }
     let inv_dim = 1.0 / dim_bits as f32;
-
-    // Select the architecture kernel once for the whole batch. Calling
-    // `hamming_distance` here used to repeat runtime feature detection for
-    // every database vector in the hottest binary-scan loop.
-    #[cfg(target_arch = "x86_64")]
-    {
-        if avx2::is_available() {
-            for (i, score) in scores.iter_mut().enumerate() {
-                let vector = &db[i * byte_len..(i + 1) * byte_len];
-                let distance = unsafe { avx2::hamming_distance(query, vector) };
-                *score = 1.0 - distance as f32 * inv_dim;
-            }
-        } else {
-            for (i, score) in scores.iter_mut().enumerate() {
-                let vector = &db[i * byte_len..(i + 1) * byte_len];
-                let distance = hamming_distance_scalar(query, vector);
-                *score = 1.0 - distance as f32 * inv_dim;
-            }
-        }
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    {
-        for (i, score) in scores.iter_mut().enumerate() {
-            let vector = &db[i * byte_len..(i + 1) * byte_len];
-            let distance = unsafe { neon::hamming_distance(query, vector) };
+    // Distances stay integral until the very last step; the stack block keeps
+    // the row-batched kernel reachable without a per-scan allocation.
+    let mut distances = [0u32; HAMMING_DISTANCE_BLOCK];
+    for (block_index, block) in scores.chunks_mut(HAMMING_DISTANCE_BLOCK).enumerate() {
+        let rows = &mut distances[..block.len()];
+        kernel.distances(
+            query,
+            &db[block_index * HAMMING_DISTANCE_BLOCK * byte_len..],
+            byte_len,
+            rows,
+        );
+        for (score, &distance) in block.iter_mut().zip(rows.iter()) {
             *score = 1.0 - distance as f32 * inv_dim;
         }
     }
+}
 
-    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
-    {
-        for (i, score) in scores.iter_mut().enumerate() {
-            let vector = &db[i * byte_len..(i + 1) * byte_len];
-            let distance = hamming_distance_scalar(query, vector);
-            *score = 1.0 - distance as f32 * inv_dim;
-        }
-    }
+/// Rows per stack block when converting batched distances into scores.
+const HAMMING_DISTANCE_BLOCK: usize = 64;
+
+/// Batch Hamming distances (exact bit counts) for `out.len()` rows of `db`.
+///
+/// Callers that rank by distance — coarse assignment, routing — avoid the
+/// float round-trip entirely.
+pub fn batch_hamming_distances(query: &[u8], db: &[u8], byte_len: usize, out: &mut [u32]) {
+    HammingKernel::resolve().distances(query, db, byte_len, out);
 }
 
 #[cfg(test)]
@@ -4240,6 +4575,97 @@ mod tests {
         batch_hamming_scores(&query, &db, 0, 0, &mut scores);
         // Should return early without modifying scores
         assert_eq!(scores[0], 0.0);
+    }
+
+    // ================================================================
+    // Resolved-kernel and row-batched Hamming tests
+    // ================================================================
+
+    fn hamming_matrix(rows: usize, byte_len: usize) -> (Vec<u8>, Vec<u8>) {
+        let query: Vec<u8> = (0..byte_len).map(|i| (i * 31 + 5) as u8).collect();
+        let db: Vec<u8> = (0..rows * byte_len)
+            .map(|i| (i * 97 + i / byte_len * 11 + 3) as u8)
+            .collect();
+        (query, db)
+    }
+
+    /// The row-batched kernels share query loads and accumulators across four
+    /// rows; every width must still agree bit-for-bit with the scalar loop.
+    #[test]
+    fn batched_hamming_distances_match_scalar_for_every_row_count() {
+        let kernel = HammingKernel::resolve();
+        // Cover both multiples of the quad width and every tail remainder, and
+        // byte lengths that exercise 16/32/64-byte chunking plus odd tails.
+        for byte_len in [1, 7, 8, 15, 16, 31, 32, 33, 63, 64, 65, 128, 320] {
+            for rows in [1, 2, 3, 4, 5, 7, 8, 9, 64, 70] {
+                let (query, db) = hamming_matrix(rows, byte_len);
+                let mut got = vec![0u32; rows];
+                kernel.distances(&query, &db, byte_len, &mut got);
+                for (row, &distance) in got.iter().enumerate() {
+                    let expected =
+                        hamming_distance_scalar(&query, &db[row * byte_len..(row + 1) * byte_len]);
+                    assert_eq!(
+                        distance, expected,
+                        "row {row} of {rows} at byte_len {byte_len}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn gathered_hamming_distances_follow_row_ids() {
+        let kernel = HammingKernel::resolve();
+        let byte_len = 320;
+        let rows = 37;
+        let (query, db) = hamming_matrix(rows, byte_len);
+        // Scattered, repeated and reversed ids: routing visits rows in graph
+        // order, not storage order.
+        let ids: Vec<u32> = [36, 0, 17, 17, 5, 31, 2, 9, 9, 36, 1].into_iter().collect();
+        let mut got = vec![0u32; ids.len()];
+        kernel.gather_distances(&query, &db, byte_len, &ids, &mut got);
+        for (slot, &id) in ids.iter().enumerate() {
+            let start = id as usize * byte_len;
+            let expected = hamming_distance_scalar(&query, &db[start..start + byte_len]);
+            assert_eq!(got[slot], expected, "slot {slot} for row {id}");
+        }
+    }
+
+    #[test]
+    fn resolved_kernel_matches_scalar_pairwise() {
+        let kernel = HammingKernel::resolve();
+        for byte_len in [1, 8, 32, 64, 65, 320, 4096] {
+            let (query, db) = hamming_matrix(1, byte_len);
+            assert_eq!(
+                kernel.distance(&query, &db),
+                hamming_distance_scalar(&query, &db),
+                "byte_len {byte_len}"
+            );
+        }
+    }
+
+    #[test]
+    fn scores_from_hamming_matches_batch_scores_across_blocks() {
+        let kernel = HammingKernel::resolve();
+        let byte_len = 320;
+        let dim_bits = byte_len * 8;
+        // More rows than one stack block so the block seam is covered.
+        let rows = HAMMING_DISTANCE_BLOCK * 2 + 3;
+        let (query, db) = hamming_matrix(rows, byte_len);
+        let mut expected = vec![0f32; rows];
+        for (row, score) in expected.iter_mut().enumerate() {
+            let distance =
+                hamming_distance_scalar(&query, &db[row * byte_len..(row + 1) * byte_len]);
+            *score = 1.0 - distance as f32 / dim_bits as f32;
+        }
+        let mut got = vec![0f32; rows];
+        scores_from_hamming(kernel, &query, &db, byte_len, dim_bits, &mut got);
+        for (row, (&got, &want)) in got.iter().zip(expected.iter()).enumerate() {
+            assert!((got - want).abs() < 1e-6, "row {row}: {got} vs {want}");
+        }
+        let mut public = vec![0f32; rows];
+        batch_hamming_scores(&query, &db, byte_len, dim_bits, &mut public);
+        assert_eq!(got, public);
     }
 }
 

--- a/hermes-core/src/structures/vector/index/binary_ivf.rs
+++ b/hermes-core/src/structures/vector/index/binary_ivf.rs
@@ -13,61 +13,133 @@
 
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
 use std::io;
 
 use crate::dsl::IvfRoutingMode;
+use crate::structures::simd::{HammingKernel, scores_from_hamming};
+#[cfg(test)]
 use crate::structures::simd::{batch_hamming_scores, hamming_distance};
 use crate::structures::vector::ivf::routing::{
-    HNSW_AUTO_THRESHOLD, HnswRoutingGraph, IvfProbePlan, IvfRoutingTopology,
-    allocate_child_clusters, binary_probe_fingerprint, effective_routing_mode,
-    routing_parent_count, select_best, select_best_candidates, select_parent_beam,
-    select_parent_beam_for_build,
+    HIERARCHICAL_TRAINING_THRESHOLD, HnswRoutingGraph, IvfProbePlan, IvfRoutingTopology,
+    PairDistance, QueryDistance, allocate_child_clusters, binary_probe_fingerprint,
+    effective_binary_routing_mode, routing_parent_count, select_best, select_best_candidates,
+    select_parent_beam, select_parent_beam_for_build,
 };
 
-fn argmax_score_lowest_index(scores: &[f32]) -> usize {
-    scores
-        .iter()
-        .enumerate()
-        .max_by(|(left_index, left), (right_index, right)| {
-            left.total_cmp(right)
-                // `max_by` keeps the greater element; reverse the index
-                // comparison so equal scores consistently prefer the lowest
-                // cluster ID, matching query-time centroid ordering.
-                .then_with(|| right_index.cmp(left_index))
-        })
-        .map(|(index, _)| index)
-        .unwrap_or(0)
-}
-
-#[inline]
-fn nearest_binary_centroid(
-    code: &[u8],
-    centroids: &[u8],
+/// Hamming distance from one query code to graph nodes backed by a packed
+/// centroid matrix.
+///
+/// Routing visits scattered centroid rows, so the batched form gathers a whole
+/// neighbour list through one SIMD dispatch instead of one call per node.
+struct BinaryCentroidDistance<'a> {
+    query: &'a [u8],
+    centroids: &'a [u8],
     byte_len: usize,
-    dim_bits: usize,
-    scores: &mut [f32],
-) -> u32 {
-    batch_hamming_scores(code, centroids, byte_len, dim_bits, scores);
-    argmax_score_lowest_index(scores) as u32
+    kernel: HammingKernel,
 }
 
+impl<'a> BinaryCentroidDistance<'a> {
+    #[inline]
+    fn new(query: &'a [u8], centroids: &'a [u8], byte_len: usize) -> Self {
+        Self {
+            query,
+            centroids,
+            byte_len,
+            kernel: HammingKernel::resolve(),
+        }
+    }
+}
+
+impl QueryDistance for BinaryCentroidDistance<'_> {
+    #[inline]
+    fn distance(&self, node: u32) -> f32 {
+        let offset = node as usize * self.byte_len;
+        self.kernel
+            .distance(self.query, &self.centroids[offset..offset + self.byte_len]) as f32
+    }
+
+    fn distances(&self, nodes: &[u32], out: &mut [f32]) {
+        let mut distances = [0u32; ROUTING_GATHER_BLOCK];
+        for (block, scores) in nodes
+            .chunks(ROUTING_GATHER_BLOCK)
+            .zip(out.chunks_mut(ROUTING_GATHER_BLOCK))
+        {
+            let gathered = &mut distances[..block.len()];
+            self.kernel.gather_distances(
+                self.query,
+                self.centroids,
+                self.byte_len,
+                block,
+                gathered,
+            );
+            for (slot, &distance) in scores.iter_mut().zip(gathered.iter()) {
+                *slot = distance as f32;
+            }
+        }
+    }
+}
+
+/// Pairwise centroid distance used while building the routing graph.
+struct BinaryCentroidPairDistance<'a> {
+    centroids: &'a [u8],
+    byte_len: usize,
+    kernel: HammingKernel,
+}
+
+impl PairDistance for BinaryCentroidPairDistance<'_> {
+    #[inline]
+    fn distance(&self, left: u32, right: u32) -> f32 {
+        let left_offset = left as usize * self.byte_len;
+        let right_offset = right as usize * self.byte_len;
+        self.kernel.distance(
+            &self.centroids[left_offset..left_offset + self.byte_len],
+            &self.centroids[right_offset..right_offset + self.byte_len],
+        ) as f32
+    }
+
+    fn distances_from(&self, left: u32, rights: &[u32], out: &mut [f32]) {
+        let offset = left as usize * self.byte_len;
+        BinaryCentroidDistance {
+            query: &self.centroids[offset..offset + self.byte_len],
+            centroids: self.centroids,
+            byte_len: self.byte_len,
+            kernel: self.kernel,
+        }
+        .distances(rights, out);
+    }
+}
+
+/// Rows gathered per kernel dispatch while routing. Covers a full level-0
+/// neighbour list (`2 * HNSW_M`) without touching the allocator.
+const ROUTING_GATHER_BLOCK: usize = 128;
+
+/// Nearest centroid and its exact Hamming distance.
+///
+/// Ranking stays integral: the winner's distance falls out of the same scan
+/// rather than costing a second full-width distance, and equal distances keep
+/// the lowest cluster ID to match query-time centroid ordering.
 #[inline]
 fn nearest_binary_centroid_with_distance(
+    kernel: HammingKernel,
     code: &[u8],
     centroids: &[u8],
     byte_len: usize,
-    dim_bits: usize,
-    scores: &mut [f32],
+    distances: &mut [u32],
 ) -> (u32, u32) {
-    let centroid = nearest_binary_centroid(code, centroids, byte_len, dim_bits, scores);
-    let offset = centroid as usize * byte_len;
-    (
-        centroid,
-        hamming_distance(code, &centroids[offset..offset + byte_len]),
-    )
+    kernel.distances(code, centroids, byte_len, distances);
+    let mut best = (u32::MAX, 0u32);
+    for (cluster, &distance) in distances.iter().enumerate() {
+        if distance < best.0 {
+            best = (distance, cluster as u32);
+        }
+    }
+    (best.1, best.0)
 }
 
 const MAX_BINARY_IVF_CLUSTERS: usize = 1_048_576;
+#[cfg(test)]
 const BINARY_IVF_SCORE_BATCH: usize = 8_192;
 const BUILD_ASSIGNMENT_CANDIDATES: usize = 128;
 
@@ -111,14 +183,14 @@ impl BinaryCoarseQuantizer {
         }
         config.num_clusters = config.num_clusters.clamp(1, num_vectors);
         let (centroids, routing_index) =
-            match effective_routing_mode(config.routing, config.num_clusters) {
+            match effective_binary_routing_mode(config.routing, config.num_clusters) {
                 IvfRoutingMode::TwoLevel => {
                     let (leaves, router) =
                         train_k_majority_hierarchical(&config, codes, num_vectors);
                     (leaves, Some(router))
                 }
                 IvfRoutingMode::Hnsw => {
-                    let leaves = if config.num_clusters >= HNSW_AUTO_THRESHOLD {
+                    let leaves = if config.num_clusters >= HIERARCHICAL_TRAINING_THRESHOLD {
                         train_k_majority_hierarchical(&config, codes, num_vectors).0
                     } else {
                         train_k_majority(&config, codes, num_vectors)
@@ -126,11 +198,10 @@ impl BinaryCoarseQuantizer {
                     let byte_len = config.byte_len();
                     let graph = HnswRoutingGraph::build(
                         config.num_clusters,
-                        |left, right| {
-                            hamming_distance(
-                                &leaves[left as usize * byte_len..(left as usize + 1) * byte_len],
-                                &leaves[right as usize * byte_len..(right as usize + 1) * byte_len],
-                            ) as f32
+                        BinaryCentroidPairDistance {
+                            centroids: &leaves,
+                            byte_len,
+                            kernel: HammingKernel::resolve(),
                         },
                         config.seed,
                     );
@@ -195,7 +266,7 @@ impl BinaryCoarseQuantizer {
     }
 
     pub fn validate_routing(&self, mode: IvfRoutingMode) -> Result<(), String> {
-        match effective_routing_mode(mode, self.num_clusters as usize) {
+        match effective_binary_routing_mode(mode, self.num_clusters as usize) {
             IvfRoutingMode::Flat | IvfRoutingMode::Auto => {}
             IvfRoutingMode::TwoLevel
                 if !matches!(
@@ -246,7 +317,7 @@ impl BinaryCoarseQuantizer {
 
     pub fn probe(&self, query: &[u8], k: usize, mode: IvfRoutingMode) -> IvfProbePlan {
         let take = k.clamp(1, self.num_clusters as usize);
-        let cluster_ids = match effective_routing_mode(mode, self.num_clusters as usize) {
+        let cluster_ids = match effective_binary_routing_mode(mode, self.num_clusters as usize) {
             IvfRoutingMode::Flat | IvfRoutingMode::Auto => self.find_k_nearest(query, take),
             IvfRoutingMode::TwoLevel => self.find_k_nearest_two_level(query, take),
             IvfRoutingMode::Hnsw => self.find_k_nearest_hnsw(query, take),
@@ -258,13 +329,13 @@ impl BinaryCoarseQuantizer {
         )
     }
 
+    /// Assign one code to its leaf.
+    ///
+    /// Segment construction routes every vector through here, so this path must
+    /// stay allocation-free.
     pub fn assign(&self, code: &[u8], mode: IvfRoutingMode) -> u32 {
-        match effective_routing_mode(mode, self.num_clusters as usize) {
-            IvfRoutingMode::Hnsw => self
-                .find_k_nearest_hnsw_for_build(code, 1)
-                .first()
-                .copied()
-                .unwrap_or(0),
+        match effective_binary_routing_mode(mode, self.num_clusters as usize) {
+            IvfRoutingMode::Hnsw => self.find_nearest_hnsw_for_build(code).unwrap_or(0),
             IvfRoutingMode::TwoLevel => self
                 .find_k_nearest_two_level_for_build(
                     code,
@@ -278,27 +349,51 @@ impl BinaryCoarseQuantizer {
     }
 
     fn find_nearest(&self, query: &[u8]) -> u32 {
-        (0..self.num_clusters)
-            .min_by_key(|&cluster| {
-                let offset = cluster as usize * self.byte_len();
-                hamming_distance(query, &self.centroids[offset..offset + self.byte_len()])
-            })
-            .unwrap_or(0)
+        let byte_len = self.byte_len();
+        if query.len() != byte_len {
+            return 0;
+        }
+        let kernel = HammingKernel::resolve();
+        let mut distances = [0u32; BINARY_CENTROID_SCAN_BLOCK];
+        let mut best = (u32::MAX, 0u32);
+        for (block_index, block) in self
+            .centroids
+            .chunks(BINARY_CENTROID_SCAN_BLOCK * byte_len)
+            .enumerate()
+        {
+            let rows = block.len() / byte_len;
+            let scored = &mut distances[..rows];
+            kernel.distances(query, block, byte_len, scored);
+            for (row, &distance) in scored.iter().enumerate() {
+                // Ties keep the lowest cluster ID, matching query-time ordering.
+                if distance < best.0 {
+                    best = (
+                        distance,
+                        (block_index * BINARY_CENTROID_SCAN_BLOCK + row) as u32,
+                    );
+                }
+            }
+        }
+        best.1
     }
 
     fn find_k_nearest(&self, query: &[u8], k: usize) -> Vec<u32> {
         if query.len() != self.byte_len() {
             return Vec::new();
         }
-        let mut scores = vec![0.0; self.num_clusters as usize];
-        batch_hamming_scores(
-            query,
-            &self.centroids,
-            self.byte_len(),
-            self.dim_bits,
-            &mut scores,
-        );
-        select_best::<true>(&scores, k)
+        // A flat probe scores every centroid; at production cluster counts the
+        // score buffer is hundreds of KiB, so it comes from reusable scratch.
+        with_centroid_score_scratch(self.num_clusters as usize, |scores| {
+            scores_from_hamming(
+                HammingKernel::resolve(),
+                query,
+                &self.centroids,
+                self.byte_len(),
+                self.dim_bits,
+                scores,
+            );
+            select_best::<true>(scores, k)
+        })
     }
 
     fn find_k_nearest_two_level(&self, query: &[u8], k: usize) -> Vec<u32> {
@@ -324,11 +419,14 @@ impl BinaryCoarseQuantizer {
         if topology.parent_count() <= 1 {
             return self.find_k_nearest(query, k);
         }
+        let byte_len = self.byte_len();
+        let kernel = HammingKernel::resolve();
         let mut parent_scores = vec![0.0; topology.parent_count()];
-        batch_hamming_scores(
+        scores_from_hamming(
+            kernel,
             query,
             parent_centroids,
-            self.byte_len(),
+            byte_len,
             self.dim_bits,
             &mut parent_scores,
         );
@@ -342,18 +440,37 @@ impl BinaryCoarseQuantizer {
             .map(|&parent| topology.children(parent as usize).len())
             .sum();
         let mut candidates = Vec::with_capacity(candidate_count);
-        let mut score = [0.0];
+        // Each parent owns a contiguous leaf run, so its children are one
+        // batched pass over the centroid matrix rather than one kernel call
+        // (and one runtime feature detection) per leaf.
+        let mut leaf_scores = vec![0.0f32; 0];
         for parent in parents {
-            for &leaf in topology.children(parent as usize) {
-                let offset = leaf as usize * self.byte_len();
-                batch_hamming_scores(
-                    query,
-                    &self.centroids[offset..offset + self.byte_len()],
-                    self.byte_len(),
-                    self.dim_bits,
-                    &mut score,
-                );
-                candidates.push((leaf, score[0]));
+            let children = topology.children(parent as usize);
+            match topology.children_run(parent as usize) {
+                Some((first_leaf, count)) => {
+                    leaf_scores.clear();
+                    leaf_scores.resize(count, 0.0);
+                    let start = first_leaf as usize * byte_len;
+                    scores_from_hamming(
+                        kernel,
+                        query,
+                        &self.centroids[start..start + count * byte_len],
+                        byte_len,
+                        self.dim_bits,
+                        &mut leaf_scores,
+                    );
+                    candidates.extend(
+                        (first_leaf..first_leaf + count as u32).zip(leaf_scores.iter().copied()),
+                    );
+                }
+                None => {
+                    for &leaf in children {
+                        let offset = leaf as usize * byte_len;
+                        let distance =
+                            kernel.distance(query, &self.centroids[offset..offset + byte_len]);
+                        candidates.push((leaf, 1.0 - distance as f32 / self.dim_bits as f32));
+                    }
+                }
             }
         }
         select_best_candidates::<true>(&mut candidates, k)
@@ -363,33 +480,41 @@ impl BinaryCoarseQuantizer {
         let Some(BinaryCentroidRouter::Hnsw(graph)) = self.routing_index.as_ref() else {
             return self.find_k_nearest(query, k);
         };
-        let byte_len = self.byte_len();
         graph.search(
-            |leaf| {
-                hamming_distance(
-                    query,
-                    &self.centroids[leaf as usize * byte_len..(leaf as usize + 1) * byte_len],
-                ) as f32
-            },
+            BinaryCentroidDistance::new(query, &self.centroids, self.byte_len()),
             k,
         )
     }
 
-    fn find_k_nearest_hnsw_for_build(&self, query: &[u8], k: usize) -> Vec<u32> {
+    fn find_nearest_hnsw_for_build(&self, query: &[u8]) -> Option<u32> {
         let Some(BinaryCentroidRouter::Hnsw(graph)) = self.routing_index.as_ref() else {
-            return self.find_k_nearest(query, k);
+            return Some(self.find_nearest(query));
         };
-        let byte_len = self.byte_len();
-        graph.search_for_build(
-            |leaf| {
-                hamming_distance(
-                    query,
-                    &self.centroids[leaf as usize * byte_len..(leaf as usize + 1) * byte_len],
-                ) as f32
-            },
-            k,
-        )
+        graph.search_best_for_build(BinaryCentroidDistance::new(
+            query,
+            &self.centroids,
+            self.byte_len(),
+        ))
     }
+}
+
+/// Centroid rows scored per stack block during a flat scan.
+const BINARY_CENTROID_SCAN_BLOCK: usize = 64;
+
+thread_local! {
+    /// Flat probing scores every centroid; at production cluster counts that
+    /// buffer is hundreds of KiB per query, so it is retained per thread.
+    static CENTROID_SCORE_SCRATCH: std::cell::RefCell<Vec<f32>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+fn with_centroid_score_scratch<T>(len: usize, scope: impl FnOnce(&mut [f32]) -> T) -> T {
+    CENTROID_SCORE_SCRATCH.with(|scratch| {
+        let mut scores = scratch.borrow_mut();
+        scores.clear();
+        scores.resize(len, 0.0);
+        scope(&mut scores)
+    })
 }
 
 fn default_max_train_samples() -> usize {
@@ -464,6 +589,7 @@ pub(crate) struct BinaryCluster {
     pub(crate) codes: Vec<u8>,
 }
 
+#[cfg(test)]
 fn visit_binary_cluster(
     cluster: &BinaryCluster,
     dim_bits: usize,
@@ -575,13 +701,34 @@ impl BinaryIvfBuilder {
             .map(|code| quantizer.assign(code, self.routing))
             .collect();
 
-        for (index, &(doc_id, ordinal)) in doc_id_ordinals.iter().enumerate() {
-            let cluster = self.clusters.entry(assignments[index]).or_default();
-            cluster.doc_ids.push(doc_id);
-            cluster.ordinals.push(ordinal);
-            cluster
-                .codes
-                .extend_from_slice(&codes[index * byte_len..(index + 1) * byte_len]);
+        // Insert grouped by leaf: one map lookup and one reservation per
+        // distinct leaf in the batch instead of per code. Sorting by
+        // `(cluster, index)` keeps each leaf's entries in ascending batch order,
+        // so the serialized payload is byte-identical to per-code insertion.
+        let mut order: Vec<u32> = (0..assignments.len() as u32).collect();
+        order.sort_unstable_by_key(|&index| (assignments[index as usize], index));
+        let mut run_start = 0usize;
+        while run_start < order.len() {
+            let cluster_id = assignments[order[run_start] as usize];
+            let mut run_end = run_start + 1;
+            while run_end < order.len() && assignments[order[run_end] as usize] == cluster_id {
+                run_end += 1;
+            }
+            let run = &order[run_start..run_end];
+            let cluster = self.clusters.entry(cluster_id).or_default();
+            cluster.doc_ids.reserve(run.len());
+            cluster.ordinals.reserve(run.len());
+            cluster.codes.reserve(run.len() * byte_len);
+            for &index in run {
+                let index = index as usize;
+                let (doc_id, ordinal) = doc_id_ordinals[index];
+                cluster.doc_ids.push(doc_id);
+                cluster.ordinals.push(ordinal);
+                cluster
+                    .codes
+                    .extend_from_slice(&codes[index * byte_len..(index + 1) * byte_len]);
+            }
+            run_start = run_end;
         }
         self.len = self.len.checked_add(doc_id_ordinals.len()).ok_or_else(|| {
             io::Error::new(io::ErrorKind::InvalidInput, "binary IVF count overflows")
@@ -646,31 +793,20 @@ impl BinaryIvfIndex {
         Ok(())
     }
 
+    /// Score the requested clusters of the in-memory build product.
+    ///
+    /// Queries never reach this: they scan the mmap-backed `AnnDiskIndex` this
+    /// structure serialises into. It exists so build-side tests can assert the
+    /// partitioning directly, and is therefore test-only — production scanning
+    /// lives in `ann_disk::score_binary_cluster_runs`.
+    #[cfg(test)]
     pub fn search_in_clusters(
         &self,
         query: &[u8],
         k: usize,
         cluster_ids: &[u32],
     ) -> Vec<(u32, u16, f32)> {
-        self.search_impl::<false>(query, k, cluster_ids)
-    }
-
-    pub fn search_distinct_documents_in_clusters(
-        &self,
-        query: &[u8],
-        k: usize,
-        cluster_ids: &[u32],
-    ) -> Vec<(u32, u16, f32)> {
-        self.search_impl::<true>(query, k, cluster_ids)
-    }
-
-    fn search_impl<const BY_DOCUMENT: bool>(
-        &self,
-        query: &[u8],
-        k: usize,
-        cluster_ids: &[u32],
-    ) -> Vec<(u32, u16, f32)> {
-        let mut collector = super::BoundedAnnCollector::<BY_DOCUMENT, true>::new(k);
+        let mut collector = super::BoundedAnnCollector::<false, true>::new(k);
         if query.len() == self.dim_bits.div_ceil(8) && self.len > 0 {
             let mut scores = vec![0.0; BINARY_IVF_SCORE_BATCH.min(self.len)];
             for &cluster_id in cluster_ids {
@@ -711,8 +847,11 @@ impl BinaryIvfIndex {
 fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8> {
     let byte_len = config.byte_len();
     let k = config.num_clusters;
-    let dim_bits = config.dim_bits;
     let mut rng = rand::rngs::StdRng::seed_from_u64(config.seed);
+    // Seeding and Lloyd assignment together dominate training; resolve the
+    // architecture kernel once instead of re-detecting CPU features for every
+    // one of the O(N*K) code pairs.
+    let kernel = HammingKernel::resolve();
 
     // Bound training cost: iterate over a sample, assign everything later. Do
     // not materialize a random permutation when the complete input is used:
@@ -742,7 +881,7 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
                 .par_iter_mut()
                 .enumerate()
                 .for_each(|(index, minimum_weight)| {
-                    let distance = hamming_distance(vec_at(index), previous);
+                    let distance = kernel.distance(vec_at(index), previous);
                     // Hamming distance is already squared Euclidean distance
                     // for vectors in {0,1}^d, so D² sampling uses it directly.
                     *minimum_weight = minimum_weight.min(distance as f64);
@@ -750,7 +889,7 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
         }
         #[cfg(not(feature = "native"))]
         for (index, minimum_weight) in minimum_weights.iter_mut().enumerate() {
-            let distance = hamming_distance(vec_at(index), previous);
+            let distance = kernel.distance(vec_at(index), previous);
             *minimum_weight = minimum_weight.min(distance as f64);
         }
 
@@ -782,14 +921,14 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
                 .zip(assignment_distances.par_iter_mut())
                 .enumerate()
                 .map_init(
-                    || vec![0f32; k],
-                    |scores, (i, (slot, assignment_distance))| {
+                    || vec![0u32; k],
+                    |distances, (i, (slot, assignment_distance))| {
                         let (best, distance) = nearest_binary_centroid_with_distance(
+                            kernel,
                             vec_at(i),
                             &centroids,
                             byte_len,
-                            dim_bits,
-                            scores,
+                            distances,
                         );
                         *assignment_distance = distance;
                         usize::from(std::mem::replace(slot, best) != best)
@@ -799,18 +938,18 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
         };
         #[cfg(not(feature = "native"))]
         let changed: usize = {
-            let mut scores = vec![0f32; k];
+            let mut distances = vec![0u32; k];
             assignment
                 .iter_mut()
                 .zip(&mut assignment_distances)
                 .enumerate()
                 .map(|(i, (slot, assignment_distance))| {
                     let (best, distance) = nearest_binary_centroid_with_distance(
+                        kernel,
                         vec_at(i),
                         &centroids,
                         byte_len,
-                        dim_bits,
-                        &mut scores,
+                        &mut distances,
                     );
                     *assignment_distance = distance;
                     usize::from(std::mem::replace(slot, best) != best)
@@ -848,32 +987,43 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
                 .par_chunks_mut(byte_len)
                 .zip(members.par_iter())
                 .filter(|(_, cluster_members)| !cluster_members.is_empty())
-                .for_each(|(centroid, cluster_members)| {
+                .for_each_init(
+                    BinaryMajorityScratch::default,
+                    |scratch, (centroid, cluster_members)| {
+                        update_binary_centroid(
+                            centroid,
+                            cluster_members,
+                            sample.as_deref(),
+                            codes,
+                            byte_len,
+                            scratch,
+                        );
+                    },
+                );
+        }
+        #[cfg(not(feature = "native"))]
+        {
+            let mut scratch = BinaryMajorityScratch::default();
+            for (centroid, cluster_members) in centroids.chunks_mut(byte_len).zip(&members) {
+                if !cluster_members.is_empty() {
                     update_binary_centroid(
                         centroid,
                         cluster_members,
                         sample.as_deref(),
                         codes,
                         byte_len,
+                        &mut scratch,
                     );
-                });
-        }
-        #[cfg(not(feature = "native"))]
-        for (centroid, cluster_members) in centroids.chunks_mut(byte_len).zip(&members) {
-            if !cluster_members.is_empty() {
-                update_binary_centroid(
-                    centroid,
-                    cluster_members,
-                    sample.as_deref(),
-                    codes,
-                    byte_len,
-                );
+                }
             }
         }
     }
 
     centroids
 }
+
+/// Re-seed preference: farthest assignment distance first, then lowest point ID.
+type ReseedPriority = (u32, Reverse<usize>);
 
 /// Re-seed empty cells from the represented points with the largest assignment
 /// error. One closest point is retained in every donor cell, so each selected
@@ -899,52 +1049,103 @@ fn reseed_empty_binary_centroids(
 
     // Retain the closest (then lowest-index) represented point in each donor
     // cell. Every other point is safe to move without emptying its donor.
-    let mut candidates = Vec::with_capacity(
-        assignment
-            .len()
-            .saturating_sub(members.len() - empty_clusters.len()),
-    );
+    //
+    // Only `empty_clusters.len()` of those points are ever used, so selection
+    // runs through a bounded heap: the previous full candidate list was an
+    // allocation proportional to the whole training sample, on every Lloyd
+    // iteration that had even one empty cell.
+    let wanted = empty_clusters.len();
+    let priority =
+        |point: usize| -> ReseedPriority { (assignment_distances[point], Reverse(point)) };
+    // The heap keeps the *least* preferred survivor on top, so a bounded push/pop
+    // retains exactly the `wanted` most preferred points.
+    let mut selected: BinaryHeap<Reverse<ReseedPriority>> = BinaryHeap::with_capacity(wanted + 1);
     for cluster_members in members.iter().filter(|members| !members.is_empty()) {
         let keeper = *cluster_members
             .iter()
             .min_by_key(|&&point| (assignment_distances[point], point))
             .expect("non-empty binary cluster must have a represented point");
-        candidates.extend(
-            cluster_members
-                .iter()
-                .copied()
-                .filter(|&point| point != keeper),
-        );
+        for &point in cluster_members.iter().filter(|&&point| point != keeper) {
+            selected.push(Reverse(priority(point)));
+            if selected.len() > wanted {
+                selected.pop();
+            }
+        }
     }
-    debug_assert!(candidates.len() >= empty_clusters.len());
+    debug_assert!(selected.len() >= wanted.min(selected.capacity()));
 
-    let farthest_first = |left: &usize, right: &usize| {
-        assignment_distances[*right]
-            .cmp(&assignment_distances[*left])
-            .then_with(|| left.cmp(right))
-    };
-    if empty_clusters.len() < candidates.len() {
-        candidates.select_nth_unstable_by(empty_clusters.len(), farthest_first);
-        candidates.truncate(empty_clusters.len());
-    }
-    candidates.sort_unstable_by(farthest_first);
+    let mut candidates: Vec<usize> = selected
+        .into_iter()
+        .map(|Reverse((_, Reverse(point)))| point)
+        .collect();
+    candidates.sort_unstable_by_key(|&point| Reverse(priority(point)));
 
-    for (empty_cluster, point) in empty_clusters.into_iter().zip(candidates) {
+    for (&empty_cluster, &point) in empty_clusters.iter().zip(candidates.iter()) {
+        let donor = assignment[point] as usize;
         assignment[point] = empty_cluster as u32;
         assignment_distances[point] = 0;
         let vector_index = sample.map_or(point, |sample| sample[point]);
         centroids[empty_cluster * byte_len..(empty_cluster + 1) * byte_len]
             .copy_from_slice(&codes[vector_index * byte_len..(vector_index + 1) * byte_len]);
+
+        // Keep the membership view consistent with the assignments before the
+        // centroid-update phase: a donor cell must not retain a point that
+        // moved into a newly seeded cell. Only moved points are touched, so
+        // this costs one donor scan each instead of rebuilding every cell.
+        if let Some(position) = members[donor].iter().position(|&member| member == point) {
+            members[donor].remove(position);
+        }
+        members[empty_cluster].push(point);
+    }
+}
+
+/// Per-worker counters for Hamming-majority centroid updates.
+///
+/// Counts live as eight bit-planes of one byte-counter per code byte, so the
+/// accumulation loop is a flat `u8` add over a contiguous plane and vectorises.
+/// The narrow planes are folded into wide counters before they can overflow,
+/// which keeps one 20 KiB-scale allocation per worker instead of one per
+/// centroid per Lloyd iteration.
+#[derive(Default)]
+struct BinaryMajorityScratch {
+    planes: Vec<u8>,
+    counts: Vec<u32>,
+}
+
+/// Members accumulated into `u8` planes before folding. A plane slot counts one
+/// bit per member, so 255 members is the overflow bound.
+const MAJORITY_PLANE_FLUSH: usize = 255;
+
+impl BinaryMajorityScratch {
+    fn reset(&mut self, byte_len: usize) {
+        let slots = byte_len * 8;
+        self.planes.clear();
+        self.planes.resize(slots, 0);
+        self.counts.clear();
+        self.counts.resize(slots, 0);
     }
 
-    // Keep the membership view consistent with the assignments before the
-    // centroid-update phase. In particular, donor modes must not retain points
-    // that were moved into newly seeded cells.
-    for cluster_members in members.iter_mut() {
-        cluster_members.clear();
+    #[inline]
+    fn accumulate(&mut self, vector: &[u8], byte_len: usize) {
+        for bit in 0..8 {
+            let plane = &mut self.planes[bit * byte_len..(bit + 1) * byte_len];
+            for (slot, &byte) in plane.iter_mut().zip(vector) {
+                *slot += (byte >> bit) & 1;
+            }
+        }
     }
-    for (point, &cluster) in assignment.iter().enumerate() {
-        members[cluster as usize].push(point);
+
+    #[inline]
+    fn fold(&mut self) {
+        for (count, plane) in self.counts.iter_mut().zip(self.planes.iter_mut()) {
+            *count += u32::from(*plane);
+            *plane = 0;
+        }
+    }
+
+    #[inline]
+    fn count(&self, bit: usize, byte_index: usize, byte_len: usize) -> u32 {
+        self.counts[bit * byte_len + byte_index]
     }
 }
 
@@ -957,31 +1158,34 @@ fn update_binary_centroid(
     sample: Option<&[usize]>,
     codes: &[u8],
     byte_len: usize,
+    scratch: &mut BinaryMajorityScratch,
 ) {
-    let mut bit_counts = vec![[0usize; 8]; centroid.len()];
-    for &member in members {
+    scratch.reset(byte_len);
+    for (position, &member) in members.iter().enumerate() {
         let vector_index = sample.map_or(member, |sample| sample[member]);
         let vector = &codes[vector_index * byte_len..(vector_index + 1) * byte_len];
-        for (&byte, counts) in vector.iter().zip(&mut bit_counts) {
-            for (bit, count) in counts.iter_mut().enumerate() {
-                *count += usize::from((byte >> bit) & 1);
-            }
+        scratch.accumulate(vector, byte_len);
+        if (position + 1).is_multiple_of(MAJORITY_PLANE_FLUSH) {
+            scratch.fold();
         }
     }
+    scratch.fold();
 
-    for (byte, counts) in centroid.iter_mut().zip(bit_counts) {
+    let total = members.len() as u32;
+    for (byte_index, byte) in centroid.iter_mut().enumerate() {
         let previous = *byte;
-        *byte = counts
-            .into_iter()
-            .enumerate()
-            .fold(0u8, |packed, (bit, count)| {
-                let value = match count.cmp(&(members.len() - count)) {
-                    std::cmp::Ordering::Greater => 1,
-                    std::cmp::Ordering::Less => 0,
-                    std::cmp::Ordering::Equal => (previous >> bit) & 1,
-                };
-                packed | (value << bit)
-            });
+        let mut packed = 0u8;
+        for bit in 0..8 {
+            let ones = scratch.count(bit, byte_index, byte_len);
+            let value = match ones.cmp(&(total - ones)) {
+                std::cmp::Ordering::Greater => 1,
+                std::cmp::Ordering::Less => 0,
+                // Majority ties keep the previous bit rather than biasing to 0.
+                std::cmp::Ordering::Equal => (previous >> bit) & 1,
+            };
+            packed |= value << bit;
+        }
+        *byte = packed;
     }
 }
 
@@ -1003,33 +1207,36 @@ fn train_k_majority_hierarchical(
 
     let mut assignments = vec![0u32; n];
     let mut group_sizes = vec![0usize; parent_count];
+    let kernel = HammingKernel::resolve();
     #[cfg(feature = "native")]
     {
         use rayon::prelude::*;
         assignments.par_iter_mut().enumerate().for_each_init(
-            || vec![0.0; parent_count],
-            |scores, (index, assignment)| {
-                *assignment = nearest_binary_centroid(
+            || vec![0u32; parent_count],
+            |distances, (index, assignment)| {
+                *assignment = nearest_binary_centroid_with_distance(
+                    kernel,
                     &codes[index * byte_len..(index + 1) * byte_len],
                     &parents,
                     byte_len,
-                    config.dim_bits,
-                    scores,
-                );
+                    distances,
+                )
+                .0;
             },
         );
     }
     #[cfg(not(feature = "native"))]
     {
-        let mut scores = vec![0.0; parent_count];
+        let mut distances = vec![0u32; parent_count];
         for (index, assignment) in assignments.iter_mut().enumerate() {
-            *assignment = nearest_binary_centroid(
+            *assignment = nearest_binary_centroid_with_distance(
+                kernel,
                 &codes[index * byte_len..(index + 1) * byte_len],
                 &parents,
                 byte_len,
-                config.dim_bits,
-                &mut scores,
-            );
+                &mut distances,
+            )
+            .0;
         }
     }
     for &assignment in &assignments {
@@ -1120,6 +1327,137 @@ mod tests {
         });
         expected.truncate(20);
         assert_eq!(actual, expected);
+    }
+
+    /// Build a clustered binary corpus: `groups` random anchors, each with
+    /// `per_group` codes at a small Hamming radius. Real embedding corpora are
+    /// clustered, and uniform noise would make every routing budget look alike.
+    fn clustered_binary_codes(
+        byte_len: usize,
+        groups: usize,
+        per_group: usize,
+        flips: usize,
+        seed: u64,
+    ) -> Vec<u8> {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let mut codes = Vec::with_capacity(groups * per_group * byte_len);
+        for _ in 0..groups {
+            let mut anchor = vec![0u8; byte_len];
+            rng.fill_bytes(&mut anchor);
+            for _ in 0..per_group {
+                let mut code = anchor.clone();
+                for _ in 0..flips {
+                    let bit = rng.random_range(0..byte_len * 8);
+                    code[bit / 8] ^= 1 << (bit % 8);
+                }
+                codes.extend_from_slice(&code);
+            }
+        }
+        codes
+    }
+
+    /// The construction beam is a *floor* paid by every assigned vector, so its
+    /// value has to be justified by assignment quality rather than by "build can
+    /// afford more". Assignment recall against exact centroid scan saturates
+    /// well below the floor: widening past it only multiplies the distance work
+    /// each rebuilt segment pays per vector.
+    ///
+    /// Referenced by `HNSW_MIN_EF_BUILD` in `ivf/routing.rs`.
+    #[cfg(feature = "native")]
+    #[test]
+    fn hnsw_build_beam_recall_saturates_before_the_floor() {
+        use crate::structures::vector::ivf::routing::HNSW_MIN_EF_BUILD;
+
+        let dim_bits = 256;
+        let byte_len = dim_bits / 8;
+        let codes = clustered_binary_codes(byte_len, 512, 24, 12, 0x5eed_1234);
+        let points = codes.len() / byte_len;
+
+        let mut config = BinaryIvfConfig::new(dim_bits, 4_096);
+        config.train_iters = 3;
+        config.max_train_samples = points;
+        config.routing = IvfRoutingMode::Hnsw;
+        let quantizer = BinaryCoarseQuantizer::train(config, &codes, points).unwrap();
+        let Some(BinaryCentroidRouter::Hnsw(graph)) = quantizer.routing_index.as_ref() else {
+            panic!("HNSW routing expected at 4096 clusters");
+        };
+
+        let probes = clustered_binary_codes(byte_len, 64, 4, 14, 0x9ab_cdef);
+        let exact: Vec<u32> = probes
+            .chunks_exact(byte_len)
+            .map(|code| quantizer.find_nearest(code))
+            .collect();
+
+        let recall_at = |ef: usize| -> f64 {
+            let hits = probes
+                .chunks_exact(byte_len)
+                .zip(exact.iter())
+                .filter(|&(code, &want)| {
+                    graph.search_best_with_ef(
+                        BinaryCentroidDistance::new(code, &quantizer.centroids, byte_len),
+                        ef,
+                    ) == Some(want)
+                })
+                .count();
+            hits as f64 / exact.len() as f64
+        };
+
+        let (narrow, floor, wide) = (recall_at(32), recall_at(HNSW_MIN_EF_BUILD), recall_at(512));
+
+        // Cost side of the same comparison: count centroid distance
+        // evaluations, which is deterministic where wall-clock is not.
+        struct CountingDistance<'a> {
+            inner: BinaryCentroidDistance<'a>,
+            calls: &'a std::cell::Cell<usize>,
+        }
+        impl QueryDistance for CountingDistance<'_> {
+            fn distance(&self, node: u32) -> f32 {
+                self.calls.set(self.calls.get() + 1);
+                self.inner.distance(node)
+            }
+
+            fn distances(&self, nodes: &[u32], out: &mut [f32]) {
+                self.calls.set(self.calls.get() + nodes.len());
+                self.inner.distances(nodes, out);
+            }
+        }
+        let work_at = |ef: usize| -> usize {
+            let calls = std::cell::Cell::new(0usize);
+            for code in probes.chunks_exact(byte_len) {
+                graph.search_best_with_ef(
+                    CountingDistance {
+                        inner: BinaryCentroidDistance::new(code, &quantizer.centroids, byte_len),
+                        calls: &calls,
+                    },
+                    ef,
+                );
+            }
+            calls.get()
+        };
+        let (floor_work, wide_work) = (work_at(HNSW_MIN_EF_BUILD), work_at(512));
+        println!(
+            "assignment recall@1: ef=32 {narrow:.4}, ef={HNSW_MIN_EF_BUILD} {floor:.4}, ef=512 {wide:.4}\n\
+             assignment distance evaluations: ef={HNSW_MIN_EF_BUILD} {floor_work}, ef=512 {wide_work} \
+             ({:.2}x)",
+            wide_work as f64 / floor_work as f64
+        );
+        assert!(
+            wide_work > floor_work,
+            "a wider beam must cost more work: {wide_work} vs {floor_work}"
+        );
+
+        // The floor must be worth paying for over a clearly narrow beam...
+        assert!(
+            floor >= narrow,
+            "floor beam {HNSW_MIN_EF_BUILD} must not route worse than ef=32: {floor:.4} vs {narrow:.4}"
+        );
+        // ...and 4x more work than the floor must not be buying recall, which is
+        // what makes the previous 512 floor pure overhead.
+        assert!(
+            wide - floor <= 0.005,
+            "ef=512 bought {:.4} recall over ef={HNSW_MIN_EF_BUILD}; the floor is too low",
+            wide - floor
+        );
     }
 
     #[cfg(feature = "native")]
@@ -1217,14 +1555,65 @@ mod tests {
 
     #[test]
     fn binary_centroid_majority_ties_keep_previous_bits() {
+        let mut scratch = BinaryMajorityScratch::default();
         let codes = [0b1010_1010, 0b0101_0101];
         let mut centroid = [0b1100_0011];
-        update_binary_centroid(&mut centroid, &[0, 1], None, &codes, 1);
+        update_binary_centroid(&mut centroid, &[0, 1], None, &codes, 1, &mut scratch);
         assert_eq!(centroid, [0b1100_0011]);
 
         let decisive_codes = [0b1111_0000, 0b1111_0000, 0b0000_1111];
-        update_binary_centroid(&mut centroid, &[0, 1, 2], None, &decisive_codes, 1);
+        update_binary_centroid(
+            &mut centroid,
+            &[0, 1, 2],
+            None,
+            &decisive_codes,
+            1,
+            &mut scratch,
+        );
         assert_eq!(centroid, [0b1111_0000]);
+    }
+
+    /// Bit counts accumulate in `u8` planes that must be folded into the wide
+    /// counters before 256 members can overflow them, and the scratch is reused
+    /// across centroids so it must not carry counts between calls.
+    #[test]
+    fn binary_centroid_majority_survives_plane_overflow_and_scratch_reuse() {
+        let byte_len = 3;
+        let members: Vec<usize> = (0..MAJORITY_PLANE_FLUSH * 2 + 7).collect();
+        // Every member is all-ones, so the majority must be all-ones however
+        // many times the planes were folded.
+        let ones = vec![0xffu8; members.len() * byte_len];
+        let mut scratch = BinaryMajorityScratch::default();
+        let mut centroid = vec![0x00u8; byte_len];
+        update_binary_centroid(&mut centroid, &members, None, &ones, byte_len, &mut scratch);
+        assert_eq!(centroid, vec![0xff; byte_len]);
+
+        // Reusing the same scratch for an all-zero cluster must yield zeros.
+        let zeros = vec![0x00u8; members.len() * byte_len];
+        let mut next = vec![0xffu8; byte_len];
+        update_binary_centroid(&mut next, &members, None, &zeros, byte_len, &mut scratch);
+        assert_eq!(next, vec![0x00; byte_len]);
+
+        // A per-bit split just past the fold boundary resolves by true majority.
+        let split_members: Vec<usize> = (0..MAJORITY_PLANE_FLUSH + 3).collect();
+        let mut split_codes = vec![0x00u8; split_members.len() * byte_len];
+        let ones_majority = MAJORITY_PLANE_FLUSH / 2 + 3;
+        for (position, chunk) in split_codes.chunks_mut(byte_len).enumerate() {
+            if position < ones_majority {
+                chunk.fill(0b0000_1111);
+            }
+        }
+        assert!(ones_majority * 2 > split_members.len());
+        let mut split = vec![0x00u8; byte_len];
+        update_binary_centroid(
+            &mut split,
+            &split_members,
+            None,
+            &split_codes,
+            byte_len,
+            &mut scratch,
+        );
+        assert_eq!(split, vec![0b0000_1111; byte_len]);
     }
 
     #[test]
@@ -1247,6 +1636,24 @@ mod tests {
             index.search_in_clusters(&[0xf0], 1, &plan.cluster_ids)[0].0,
             3
         );
+
+        // Batched inserts group by leaf, so pin the payload layout: one batch
+        // must produce the same columns as two, and each leaf must keep its
+        // entries in ascending input order.
+        let single =
+            BinaryIvfIndex::build(&quantizer, IvfRoutingMode::Flat, &codes, &labels).unwrap();
+        assert_eq!(index.clusters.len(), single.clusters.len());
+        for ((left_id, left), (right_id, right)) in index.clusters.iter().zip(&single.clusters) {
+            assert_eq!(left_id, right_id);
+            assert_eq!(left.doc_ids, right.doc_ids);
+            assert_eq!(left.ordinals, right.ordinals);
+            assert_eq!(left.codes, right.codes);
+            assert!(
+                left.doc_ids.windows(2).all(|pair| pair[0] < pair[1]),
+                "leaf {left_id} lost input order: {:?}",
+                left.doc_ids
+            );
+        }
     }
 
     #[test]

--- a/hermes-core/src/structures/vector/ivf/coarse.rs
+++ b/hermes-core/src/structures/vector/ivf/coarse.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::routing::{
-    HNSW_AUTO_THRESHOLD, HnswRoutingGraph, IvfProbePlan, IvfRoutingTopology,
+    HIERARCHICAL_TRAINING_THRESHOLD, HnswRoutingGraph, IvfProbePlan, IvfRoutingTopology,
     allocate_child_clusters, effective_routing_mode, float_probe_fingerprint, routing_parent_count,
     select_best_candidates, select_parent_beam, select_parent_beam_for_build,
 };
@@ -155,7 +155,7 @@ impl CoarseCentroids {
                     (leaves, Some(router))
                 }
                 IvfRoutingMode::Hnsw => {
-                    let leaves = if actual_clusters >= HNSW_AUTO_THRESHOLD {
+                    let leaves = if actual_clusters >= HIERARCHICAL_TRAINING_THRESHOLD {
                         Self::train_hierarchical(config, vectors, vector_count, actual_clusters).0
                     } else {
                         Self::train_flat(config, vectors, vector_count, actual_clusters)
@@ -577,7 +577,7 @@ impl CoarseCentroids {
         } else {
             let primary_cluster = match effective_routing_mode(routing, self.num_clusters as usize)
             {
-                IvfRoutingMode::Hnsw => self.find_k_nearest_hnsw_for_build(vector, 1)[0],
+                IvfRoutingMode::Hnsw => self.find_nearest_hnsw_for_build(vector),
                 IvfRoutingMode::TwoLevel => self
                     .find_k_nearest_two_level_for_build(
                         vector,
@@ -732,6 +732,17 @@ impl CoarseCentroids {
             return self.find_k_nearest(vector, k);
         };
         graph.search_for_build(|leaf| squared_l2(vector, self.get_centroid(leaf)), k)
+    }
+
+    /// Single-leaf assignment. Construction routes every vector through here,
+    /// so it avoids the one-element result `Vec` the ranked form allocates.
+    fn find_nearest_hnsw_for_build(&self, vector: &[f32]) -> u32 {
+        let Some(FloatCentroidRouter::Hnsw(graph)) = self.routing_index.as_ref() else {
+            return self.find_nearest(vector);
+        };
+        graph
+            .search_best_for_build(|leaf| squared_l2(vector, self.get_centroid(leaf)))
+            .unwrap_or(0)
     }
 
     /// Get centroid for a cluster

--- a/hermes-core/src/structures/vector/ivf/mod.rs
+++ b/hermes-core/src/structures/vector/ivf/mod.rs
@@ -11,5 +11,7 @@ pub(crate) mod routing;
 mod soar;
 
 pub use coarse::{CoarseCentroids, CoarseConfig};
-pub use routing::{HNSW_AUTO_THRESHOLD, IvfProbePlan};
+pub use routing::{
+    BINARY_HNSW_AUTO_THRESHOLD, HIERARCHICAL_TRAINING_THRESHOLD, HNSW_AUTO_THRESHOLD, IvfProbePlan,
+};
 pub use soar::{MultiAssignment, SoarConfig};

--- a/hermes-core/src/structures/vector/ivf/routing.rs
+++ b/hermes-core/src/structures/vector/ivf/routing.rs
@@ -13,10 +13,46 @@ use crate::dsl::IvfRoutingMode;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 
-/// Automatic routing switches to a centroid index at this leaf count. Below
-/// it, a SIMD-friendly flat pass is normally cheaper than another level of
-/// indirection.
+/// Automatic routing switches to a centroid graph at this leaf count.
+///
+/// Float centroids are wide (a 768-dim leaf is 3 KiB), so a flat pass over them
+/// gets expensive at far fewer leaves than for packed binary codes. This value
+/// is the historical one and is *not* backed by a crossover measurement; see
+/// [`BINARY_HNSW_AUTO_THRESHOLD`] for the measured binary counterpart, and
+/// measure the float case the same way before changing this.
 pub const HNSW_AUTO_THRESHOLD: usize = 4_096;
+
+/// Automatic routing switch for packed binary centroids.
+///
+/// A base-layer search with beam `ef` and degree `2 * HNSW_M` touches on the
+/// order of `ef * 2M` adjacency slots, so below roughly that many leaves it
+/// visits the whole codebook anyway — by random access with heap traffic, and
+/// approximately, where the flat pass is one sequential SIMD scan that is
+/// *exact*. Measured on 2,560-bit binary centroids at `nprobe = 64`
+/// (`benches/binary_vectors.rs`, `binary_routing_crossover`, aarch64/NEON):
+///
+/// | leaves | flat probe | graph probe |
+/// |-------:|-----------:|------------:|
+/// |  4,096 |    28.6 µs |    116.3 µs |
+/// | 16,384 |   126.0 µs |    212.9 µs |
+/// | 32,768 |   249.3 µs |    255.1 µs |
+/// | 65,536 |   513.3 µs |    444.6 µs |
+///
+/// The graph only starts paying off past ~32k leaves, so that is the switch.
+/// Explicit `hnsw` routing is still honoured at any size.
+///
+/// Hierarchical *training* has its own threshold — see
+/// [`HIERARCHICAL_TRAINING_THRESHOLD`] — because O(N·K) seeding becomes
+/// unaffordable long before graph routing becomes profitable.
+pub const BINARY_HNSW_AUTO_THRESHOLD: usize = 32_768;
+
+/// Codebook size past which coarse training becomes hierarchical.
+///
+/// Direct k-means/k-majority seeding costs one full pass over the sample per
+/// centroid; beyond a few thousand centroids that dominates training, so large
+/// codebooks train as `sqrt(K)` parents plus per-parent child codebooks
+/// regardless of which router is used at query time.
+pub const HIERARCHICAL_TRAINING_THRESHOLD: usize = 4_096;
 
 /// Extra leaf coverage requested from the parent level. A beam of four times
 /// the minimum parent count avoids the recall cliff of greedy one-parent
@@ -35,7 +71,85 @@ const HNSW_MIN_EF_SEARCH: usize = 128;
 /// separate prevents an approximate query-router miss from permanently
 /// assigning a vector to a needlessly distant leaf.
 const HNSW_BUILD_OVERSAMPLE: usize = 8;
-const HNSW_MIN_EF_BUILD: usize = 512;
+/// Floor for the construction beam.
+///
+/// This is a *floor*, so it is what single-candidate assignment actually pays:
+/// every vector in a rebuilt segment routes with `take = 1`. Recall@1 against
+/// exact centroid assignment saturates well before 512 at `M = 32` — see
+/// `hnsw_build_beam_recall_saturates_before_the_floor` — while the cost is
+/// linear in the beam, so a 512 floor spent ~4x the distance work of a 128 one
+/// for no measurable assignment gain. Multi-candidate build routing still
+/// widens through `HNSW_BUILD_OVERSAMPLE`.
+pub(crate) const HNSW_MIN_EF_BUILD: usize = 128;
+
+/// Neighbour lists are capped at `2 * HNSW_M`; one stack block therefore covers
+/// a whole expansion, letting the batched distance form run without touching
+/// the allocator.
+const NEIGHBOR_BLOCK: usize = HNSW_M * 4;
+
+/// Distance from one query to graph nodes.
+///
+/// Float centroids vectorise across the dimension, so the pairwise form is
+/// already efficient there. Binary centroids are single-row popcounts: scoring
+/// a whole neighbour list per call is what keeps the SIMD kernel fed and pays
+/// the `#[target_feature]` dispatch once per expansion instead of per node.
+pub trait QueryDistance {
+    fn distance(&self, node: u32) -> f32;
+
+    /// Score a whole neighbour list. Defaults to repeated pairwise calls.
+    fn distances(&self, nodes: &[u32], out: &mut [f32]) {
+        debug_assert_eq!(nodes.len(), out.len());
+        for (slot, &node) in out.iter_mut().zip(nodes) {
+            *slot = self.distance(node);
+        }
+    }
+}
+
+impl<F: Fn(u32) -> f32> QueryDistance for F {
+    #[inline]
+    fn distance(&self, node: u32) -> f32 {
+        self(node)
+    }
+}
+
+/// Distance between two graph nodes, used while constructing the graph.
+pub trait PairDistance {
+    fn distance(&self, left: u32, right: u32) -> f32;
+
+    /// Score `left` against a whole node list. Defaults to pairwise calls.
+    fn distances_from(&self, left: u32, rights: &[u32], out: &mut [f32]) {
+        debug_assert_eq!(rights.len(), out.len());
+        for (slot, &right) in out.iter_mut().zip(rights) {
+            *slot = self.distance(left, right);
+        }
+    }
+}
+
+impl<F: Fn(u32, u32) -> f32> PairDistance for F {
+    #[inline]
+    fn distance(&self, left: u32, right: u32) -> f32 {
+        self(left, right)
+    }
+}
+
+/// One inserted node's view of a [`PairDistance`], so construction reuses the
+/// same batched search as queries.
+struct PairQueryDistance<'a, P: ?Sized> {
+    pair: &'a P,
+    left: u32,
+}
+
+impl<P: PairDistance + ?Sized> QueryDistance for PairQueryDistance<'_, P> {
+    #[inline]
+    fn distance(&self, node: u32) -> f32 {
+        self.pair.distance(self.left, node)
+    }
+
+    #[inline]
+    fn distances(&self, nodes: &[u32], out: &mut [f32]) {
+        self.pair.distances_from(self.left, nodes, out);
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 struct GraphCandidate {
@@ -108,6 +222,10 @@ struct HnswQueryScratch {
     candidates: BinaryHeap<Reverse<GraphCandidate>>,
     best: BinaryHeap<GraphCandidate>,
     ordered: Vec<GraphCandidate>,
+    /// Unvisited neighbours of the node being expanded, plus their distances,
+    /// so one expansion is one batched distance call.
+    pending: Vec<u32>,
+    pending_distances: Vec<f32>,
 }
 
 impl HnswQueryScratch {
@@ -117,6 +235,8 @@ impl HnswQueryScratch {
             candidates: BinaryHeap::new(),
             best: BinaryHeap::new(),
             ordered: Vec::new(),
+            pending: Vec::new(),
+            pending_distances: Vec::new(),
         }
     }
 }
@@ -147,7 +267,7 @@ pub struct HnswRoutingGraph {
 }
 
 impl HnswRoutingGraph {
-    pub fn build(node_count: usize, distance: impl Fn(u32, u32) -> f32, seed: u64) -> Self {
+    pub fn build(node_count: usize, distance: impl PairDistance, seed: u64) -> Self {
         assert!(node_count > 0 && node_count <= u32::MAX as usize);
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         let level_multiplier = 1.0 / (HNSW_M as f64).ln();
@@ -170,7 +290,10 @@ impl HnswRoutingGraph {
         for &node in insertion_order.iter().skip(1) {
             let node_level = node_levels[node as usize];
             let mut entry = entry_point;
-            let node_distance = |candidate| distance(node, candidate);
+            let node_distance = PairQueryDistance {
+                pair: &distance,
+                left: node,
+            };
 
             for level in ((node_level as usize + 1)..=max_level as usize).rev() {
                 entry = greedy_search_level(&links, entry, level, &node_distance);
@@ -203,7 +326,7 @@ impl HnswRoutingGraph {
                             .copied()
                             .map(|candidate| GraphCandidate {
                                 node: candidate,
-                                distance: distance(neighbor, candidate),
+                                distance: distance.distance(neighbor, candidate),
                             })
                             .collect();
                         *adjacency = select_diverse_neighbors(
@@ -283,7 +406,7 @@ impl HnswRoutingGraph {
         &self.neighbors[start..end]
     }
 
-    pub fn search(&self, query_distance: impl Fn(u32) -> f32, take: usize) -> Vec<u32> {
+    pub fn search(&self, query_distance: impl QueryDistance, take: usize) -> Vec<u32> {
         let take = take.min(self.node_levels.len());
         if take == 0 {
             return Vec::new();
@@ -298,23 +421,83 @@ impl HnswRoutingGraph {
     /// Higher-recall centroid search used only while constructing postings.
     pub(crate) fn search_for_build(
         &self,
-        query_distance: impl Fn(u32) -> f32,
+        query_distance: impl QueryDistance,
         take: usize,
     ) -> Vec<u32> {
         let take = take.min(self.node_levels.len());
         if take == 0 {
             return Vec::new();
         }
-        let ef_search = take
-            .saturating_mul(HNSW_BUILD_OVERSAMPLE)
+        self.search_with_budget(query_distance, take, self.build_budget(take))
+    }
+
+    /// Single nearest node, for the assignment of one vector to one leaf.
+    ///
+    /// Construction routes every vector in a segment through here, so it avoids
+    /// both the result `Vec` and the full ranking of the beam that
+    /// [`Self::search_for_build`] needs — the minimum of the bounded heap is
+    /// the same node the ranked list would have put first.
+    pub(crate) fn search_best_for_build(&self, query_distance: impl QueryDistance) -> Option<u32> {
+        if self.node_levels.is_empty() {
+            return None;
+        }
+        let ef_search = self.build_budget(1);
+        let mut entry = self.entry_point;
+        for level in (1..=self.max_level as usize).rev() {
+            entry = greedy_search_compact(self, entry, level, &query_distance);
+        }
+        HNSW_QUERY_SCRATCH.with(|scratch| {
+            let mut scratch = scratch.borrow_mut();
+            search_compact_layer_reusing(self, entry, ef_search, &query_distance, &mut scratch);
+            Some(
+                scratch
+                    .best
+                    .iter()
+                    .min()
+                    .map_or(entry, |candidate| candidate.node),
+            )
+        })
+    }
+
+    #[inline]
+    fn build_budget(&self, take: usize) -> usize {
+        take.saturating_mul(HNSW_BUILD_OVERSAMPLE)
             .max(HNSW_MIN_EF_BUILD)
-            .min(self.node_levels.len());
-        self.search_with_budget(query_distance, take, ef_search)
+            .min(self.node_levels.len())
+    }
+
+    /// Nearest node under an explicit beam, so tests can measure how assignment
+    /// recall responds to the budget instead of asserting a constant.
+    #[cfg(test)]
+    pub(crate) fn search_best_with_ef(
+        &self,
+        query_distance: impl QueryDistance,
+        ef: usize,
+    ) -> Option<u32> {
+        if self.node_levels.is_empty() {
+            return None;
+        }
+        let ef_search = ef.clamp(1, self.node_levels.len());
+        let mut entry = self.entry_point;
+        for level in (1..=self.max_level as usize).rev() {
+            entry = greedy_search_compact(self, entry, level, &query_distance);
+        }
+        HNSW_QUERY_SCRATCH.with(|scratch| {
+            let mut scratch = scratch.borrow_mut();
+            search_compact_layer_reusing(self, entry, ef_search, &query_distance, &mut scratch);
+            Some(
+                scratch
+                    .best
+                    .iter()
+                    .min()
+                    .map_or(entry, |candidate| candidate.node),
+            )
+        })
     }
 
     fn search_with_budget(
         &self,
-        query_distance: impl Fn(u32) -> f32,
+        query_distance: impl QueryDistance,
         take: usize,
         ef_search: usize,
     ) -> Vec<u32> {
@@ -325,6 +508,7 @@ impl HnswRoutingGraph {
         HNSW_QUERY_SCRATCH.with(|scratch| {
             let mut scratch = scratch.borrow_mut();
             search_compact_layer_reusing(self, entry, ef_search, &query_distance, &mut scratch);
+            order_scratch_candidates(&mut scratch);
             scratch
                 .ordered
                 .iter()
@@ -402,18 +586,23 @@ fn greedy_search_level(
     links: &[Vec<Vec<u32>>],
     mut current: u32,
     level: usize,
-    query_distance: &impl Fn(u32) -> f32,
+    query_distance: &impl QueryDistance,
 ) -> u32 {
-    let mut current_distance = query_distance(current);
+    let mut current_distance = query_distance.distance(current);
+    let mut scores = [0f32; NEIGHBOR_BLOCK];
     loop {
         let mut changed = false;
-        for &candidate in &links[current as usize][level] {
-            let distance = query_distance(candidate);
-            if distance < current_distance || (distance == current_distance && candidate < current)
-            {
-                current = candidate;
-                current_distance = distance;
-                changed = true;
+        for chunk in links[current as usize][level].chunks(NEIGHBOR_BLOCK) {
+            let scored = &mut scores[..chunk.len()];
+            query_distance.distances(chunk, scored);
+            for (&candidate, &distance) in chunk.iter().zip(scored.iter()) {
+                if distance < current_distance
+                    || (distance == current_distance && candidate < current)
+                {
+                    current = candidate;
+                    current_distance = distance;
+                    changed = true;
+                }
             }
         }
         if !changed {
@@ -426,18 +615,23 @@ fn greedy_search_compact(
     graph: &HnswRoutingGraph,
     mut current: u32,
     level: usize,
-    query_distance: &impl Fn(u32) -> f32,
+    query_distance: &impl QueryDistance,
 ) -> u32 {
-    let mut current_distance = query_distance(current);
+    let mut current_distance = query_distance.distance(current);
+    let mut scores = [0f32; NEIGHBOR_BLOCK];
     loop {
         let mut changed = false;
-        for &candidate in graph.neighbors(current, level) {
-            let distance = query_distance(candidate);
-            if distance < current_distance || (distance == current_distance && candidate < current)
-            {
-                current = candidate;
-                current_distance = distance;
-                changed = true;
+        for chunk in graph.neighbors(current, level).chunks(NEIGHBOR_BLOCK) {
+            let scored = &mut scores[..chunk.len()];
+            query_distance.distances(chunk, scored);
+            for (&candidate, &distance) in chunk.iter().zip(scored.iter()) {
+                if distance < current_distance
+                    || (distance == current_distance && candidate < current)
+                {
+                    current = candidate;
+                    current_distance = distance;
+                    changed = true;
+                }
             }
         }
         if !changed {
@@ -451,7 +645,7 @@ fn search_graph_layer(
     entry: u32,
     level: usize,
     ef: usize,
-    query_distance: &impl Fn(u32) -> f32,
+    query_distance: &impl QueryDistance,
     visited: &mut VisitedNodes,
 ) -> Vec<GraphCandidate> {
     search_layer_impl(entry, ef, query_distance, visited, |node| {
@@ -459,11 +653,15 @@ fn search_graph_layer(
     })
 }
 
+/// Expand the base layer into `scratch.best`, leaving `scratch.ordered` empty.
+///
+/// Callers that need a ranked list finish with [`order_scratch_candidates`];
+/// single-candidate assignment skips that and scans the bounded heap instead.
 fn search_compact_layer_reusing(
     graph: &HnswRoutingGraph,
     entry: u32,
     ef: usize,
-    query_distance: &impl Fn(u32) -> f32,
+    query_distance: &impl QueryDistance,
     scratch: &mut HnswQueryScratch,
 ) {
     scratch.visited.ensure_nodes(graph.node_levels.len());
@@ -474,7 +672,7 @@ fn search_compact_layer_reusing(
     scratch.visited.insert(entry);
     let first = GraphCandidate {
         node: entry,
-        distance: query_distance(entry),
+        distance: query_distance.distance(entry),
     };
     scratch.candidates.push(Reverse(first));
     scratch.best.push(first);
@@ -488,14 +686,24 @@ fn search_compact_layer_reusing(
         {
             break;
         }
+        // Score the whole unvisited frontier of this node in one call. The
+        // accept test below still runs in adjacency order, so results are
+        // identical to scoring node by node.
+        scratch.pending.clear();
         for &neighbor in graph.neighbors(current.node, 0) {
-            if !scratch.visited.insert(neighbor) {
-                continue;
+            if scratch.visited.insert(neighbor) {
+                scratch.pending.push(neighbor);
             }
-            let candidate = GraphCandidate {
-                node: neighbor,
-                distance: query_distance(neighbor),
-            };
+        }
+        if scratch.pending.is_empty() {
+            continue;
+        }
+        scratch.pending_distances.clear();
+        scratch.pending_distances.resize(scratch.pending.len(), 0.0);
+        query_distance.distances(&scratch.pending, &mut scratch.pending_distances);
+
+        for (&node, &distance) in scratch.pending.iter().zip(scratch.pending_distances.iter()) {
+            let candidate = GraphCandidate { node, distance };
             if scratch.best.len() < ef
                 || scratch.best.peek().is_some_and(|worst| candidate < *worst)
             {
@@ -507,6 +715,9 @@ fn search_compact_layer_reusing(
             }
         }
     }
+}
+
+fn order_scratch_candidates(scratch: &mut HnswQueryScratch) {
     scratch.ordered.extend(scratch.best.drain());
     scratch.ordered.sort_unstable();
 }
@@ -514,7 +725,7 @@ fn search_compact_layer_reusing(
 fn search_layer_impl<'a>(
     entry: u32,
     ef: usize,
-    query_distance: &impl Fn(u32) -> f32,
+    query_distance: &impl QueryDistance,
     visited: &mut VisitedNodes,
     neighbors: impl Fn(u32) -> &'a [u32],
 ) -> Vec<GraphCandidate> {
@@ -522,12 +733,14 @@ fn search_layer_impl<'a>(
     visited.insert(entry);
     let first = GraphCandidate {
         node: entry,
-        distance: query_distance(entry),
+        distance: query_distance.distance(entry),
     };
     let mut candidates = BinaryHeap::new();
     let mut best = BinaryHeap::new();
     candidates.push(Reverse(first));
     best.push(first);
+    let mut pending: Vec<u32> = Vec::new();
+    let mut pending_distances: Vec<f32> = Vec::new();
 
     while let Some(Reverse(current)) = candidates.pop() {
         if best.len() >= ef
@@ -537,14 +750,21 @@ fn search_layer_impl<'a>(
         {
             break;
         }
+        pending.clear();
         for &neighbor in neighbors(current.node) {
-            if !visited.insert(neighbor) {
-                continue;
+            if visited.insert(neighbor) {
+                pending.push(neighbor);
             }
-            let candidate = GraphCandidate {
-                node: neighbor,
-                distance: query_distance(neighbor),
-            };
+        }
+        if pending.is_empty() {
+            continue;
+        }
+        pending_distances.clear();
+        pending_distances.resize(pending.len(), 0.0);
+        query_distance.distances(&pending, &mut pending_distances);
+
+        for (&node, &distance) in pending.iter().zip(pending_distances.iter()) {
+            let candidate = GraphCandidate { node, distance };
             if best.len() < ef || best.peek().is_some_and(|worst| candidate < *worst) {
                 candidates.push(Reverse(candidate));
                 best.push(candidate);
@@ -561,7 +781,7 @@ fn select_diverse_neighbors(
     query_node: u32,
     mut candidates: Vec<GraphCandidate>,
     limit: usize,
-    distance: &impl Fn(u32, u32) -> f32,
+    distance: &impl PairDistance,
 ) -> Vec<u32> {
     candidates.sort_unstable();
     candidates.dedup_by_key(|candidate| candidate.node);
@@ -573,7 +793,7 @@ fn select_diverse_neighbors(
         }
         if selected
             .iter()
-            .all(|&neighbor| distance(candidate.node, neighbor) > candidate.distance)
+            .all(|&neighbor| distance.distance(candidate.node, neighbor) > candidate.distance)
         {
             selected.push(candidate.node);
             if selected.len() == limit {
@@ -590,6 +810,12 @@ fn select_diverse_neighbors(
         selected.push(candidate);
     }
     selected
+}
+
+fn contiguous_leaf_run(children: &[u32]) -> bool {
+    children
+        .windows(2)
+        .all(|pair| pair[1] == pair[0].saturating_add(1))
 }
 
 /// Compact parent-to-leaf adjacency shared by float and binary quantizers.
@@ -626,6 +852,19 @@ impl IvfRoutingTopology {
         &self.leaf_ids[start..end]
     }
 
+    /// Children of `parent` as a `(first_leaf, count)` run.
+    ///
+    /// Both trainers append each parent's leaves as one contiguous block, which
+    /// lets a caller score a whole parent with a single batched pass over the
+    /// centroid matrix instead of one kernel call per leaf. Returns `None` for
+    /// an empty parent, and — defensively — for any non-contiguous list, so the
+    /// scoring path stays correct even if the invariant is ever relaxed.
+    pub fn children_run(&self, parent: usize) -> Option<(u32, usize)> {
+        let children = self.children(parent);
+        let first = *children.first()?;
+        contiguous_leaf_run(children).then_some((first, children.len()))
+    }
+
     pub fn validate(&self, num_leaves: usize) -> bool {
         if self.parent_count() == 0 {
             return self.child_offsets.is_empty() && self.leaf_ids.is_empty();
@@ -635,6 +874,10 @@ impl IvfRoutingTopology {
             && self.child_offsets.windows(2).all(|pair| pair[0] <= pair[1])
             && self.leaf_ids.len() == num_leaves
             && self.leaf_ids.iter().all(|&leaf| leaf < num_leaves as u32)
+            // Contiguity is a build invariant of both trainers; a topology
+            // without it did not come from this codebase, so refuse it rather
+            // than silently routing through a slower path.
+            && (0..self.parent_count()).all(|parent| contiguous_leaf_run(self.children(parent)))
             && {
                 let mut leaves = self.leaf_ids.clone();
                 leaves.sort_unstable();
@@ -862,10 +1105,31 @@ pub fn binary_probe_fingerprint(query: &[u8], nprobe: usize, mode: IvfRoutingMod
     fingerprint_words(mode, nprobe, query.iter().map(|&value| value as u64))
 }
 
+/// Resolve `Auto` for float centroids.
 #[inline]
 pub fn effective_routing_mode(mode: IvfRoutingMode, num_leaves: usize) -> IvfRoutingMode {
+    resolve_auto_routing(mode, num_leaves, HNSW_AUTO_THRESHOLD)
+}
+
+/// Resolve `Auto` for packed binary centroids, whose flat pass stays cheap much
+/// further up the leaf-count range.
+///
+/// Every binary site — training, validation, probing and assignment — must use
+/// this, or a codebook trained without a graph would be asked to route through
+/// one.
+#[inline]
+pub fn effective_binary_routing_mode(mode: IvfRoutingMode, num_leaves: usize) -> IvfRoutingMode {
+    resolve_auto_routing(mode, num_leaves, BINARY_HNSW_AUTO_THRESHOLD)
+}
+
+#[inline]
+fn resolve_auto_routing(
+    mode: IvfRoutingMode,
+    num_leaves: usize,
+    auto_threshold: usize,
+) -> IvfRoutingMode {
     match mode {
-        IvfRoutingMode::Auto if num_leaves >= HNSW_AUTO_THRESHOLD => IvfRoutingMode::Hnsw,
+        IvfRoutingMode::Auto if num_leaves >= auto_threshold => IvfRoutingMode::Hnsw,
         IvfRoutingMode::Auto => IvfRoutingMode::Flat,
         explicit => explicit,
     }
@@ -1018,6 +1282,52 @@ pub fn select_best_candidates<const HIGHER_IS_BETTER: bool>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// For binary centroids, `Auto` must not pick the graph where an exact flat
+    /// scan is both faster and more accurate; the switch point comes from the
+    /// measured crossover documented on `BINARY_HNSW_AUTO_THRESHOLD`. The float
+    /// threshold is separate because float leaves are ~10x wider per centroid.
+    #[test]
+    fn auto_routing_prefers_exact_flat_probing_below_the_measured_crossover() {
+        for leaves in [1usize, 4_096, 16_384, BINARY_HNSW_AUTO_THRESHOLD - 1] {
+            assert_eq!(
+                effective_binary_routing_mode(IvfRoutingMode::Auto, leaves),
+                IvfRoutingMode::Flat,
+                "{leaves} binary leaves"
+            );
+        }
+        for leaves in [BINARY_HNSW_AUTO_THRESHOLD, 114_309] {
+            assert_eq!(
+                effective_binary_routing_mode(IvfRoutingMode::Auto, leaves),
+                IvfRoutingMode::Hnsw,
+                "{leaves} binary leaves"
+            );
+        }
+        // Float routing keeps its own, lower threshold.
+        assert_eq!(
+            effective_routing_mode(IvfRoutingMode::Auto, HNSW_AUTO_THRESHOLD),
+            IvfRoutingMode::Hnsw
+        );
+        assert_eq!(
+            effective_routing_mode(IvfRoutingMode::Auto, HNSW_AUTO_THRESHOLD - 1),
+            IvfRoutingMode::Flat
+        );
+        // Explicit modes are honoured at any size, and large codebooks still
+        // train hierarchically even when routing stays flat.
+        for leaves in [64usize, 1_000_000] {
+            assert_eq!(
+                effective_binary_routing_mode(IvfRoutingMode::Hnsw, leaves),
+                IvfRoutingMode::Hnsw
+            );
+            assert_eq!(
+                effective_binary_routing_mode(IvfRoutingMode::TwoLevel, leaves),
+                IvfRoutingMode::TwoLevel
+            );
+        }
+        const {
+            assert!(HIERARCHICAL_TRAINING_THRESHOLD <= BINARY_HNSW_AUTO_THRESHOLD);
+        }
+    }
 
     #[test]
     fn deterministic_selection_supports_both_metric_directions() {
@@ -1187,10 +1497,43 @@ mod tests {
             10,
         );
         assert_eq!(build_routed, exact[..10]);
-        assert!(
-            build_distance_calls.get() > query_distance_calls.get(),
-            "offline construction should spend its wider search budget"
+        // Both budgets share the same floor, so a small take costs the same
+        // either way; construction only widens once its oversample exceeds the
+        // floor. The floor is what per-vector assignment pays, and it is set
+        // from measured recall (see
+        // `index::binary_ivf::tests::hnsw_build_beam_recall_saturates_before_the_floor`).
+        assert_eq!(build_distance_calls.get(), query_distance_calls.get());
+
+        let wide_query_calls = std::cell::Cell::new(0usize);
+        graph.search(
+            |node| {
+                wide_query_calls.set(wide_query_calls.get() + 1);
+                let [x, y] = points[node as usize];
+                (x - query[0]).powi(2) + (y - query[1]).powi(2)
+            },
+            64,
         );
+        let wide_build_calls = std::cell::Cell::new(0usize);
+        graph.search_for_build(
+            |node| {
+                wide_build_calls.set(wide_build_calls.get() + 1);
+                let [x, y] = points[node as usize];
+                (x - query[0]).powi(2) + (y - query[1]).powi(2)
+            },
+            64,
+        );
+        assert!(
+            wide_build_calls.get() > wide_query_calls.get(),
+            "multi-candidate construction should spend its wider search budget"
+        );
+
+        // Single-candidate assignment returns the same leaf the ranked search
+        // would have put first, without allocating a result list.
+        let assigned = graph.search_best_for_build(|node| {
+            let [x, y] = points[node as usize];
+            (x - query[0]).powi(2) + (y - query[1]).powi(2)
+        });
+        assert_eq!(assigned, Some(exact[0]));
 
         let bytes = bincode::serde::encode_to_vec(&graph, bincode::config::standard()).unwrap();
         let (decoded, consumed): (HnswRoutingGraph, usize) =


### PR DESCRIPTION
The binary path had **no benchmark coverage at all**, which is how ec52653 shipped a 4× wider construction beam plus a per-vector allocation as a "quality improvement" with an unmeasured cost — the regression showed up as slow production rebuilds of 2,560-bit binary IVF fields.

Every change here is paired against the shape it replaced in the new `benches/binary_vectors.rs`.

## Build-time assignment (the acute regression)

- `HNSW_MIN_EF_BUILD` 512 → **128**. Measured assignment recall@1 against an exact centroid scan: **0.8867 @ ef=32, 1.0000 @ ef=128, 1.0000 @ ef=512** — the 512 floor bought no accuracy. Distance evaluations drop 1.46× at 4,096 leaves; the gap widens with codebook size.
- New `search_best_for_build` removes the one-element result `Vec` and the full beam ranking every assigned vector paid (~5.7M malloc/free pairs per field in the observed segment). Also applied to the float IVF assignment path.

## Hamming kernels

1,024-row scan, aarch64/NEON, per-row dispatch → batched:

| code width | before | after | speedup |
|---|---:|---:|---:|
| 64-bit | 2.55 µs | 0.87 µs | 2.9× |
| 256-bit | 2.52 µs | 1.06 µs | 2.4× |
| 1024-bit | 4.32 µs | 2.29 µs | 1.9× |
| 2560-bit (prod) | 8.28 µs | 4.83 µs | 1.7× |

`HammingKernel` is resolved once per scan; four rows share the query load, the AVX2 nibble table and the horizontal reduce; tails use the u64 scalar path; a gather form keeps scattered graph rows on the batched kernel. Adds an AVX-512 `VPOPCNTDQ` path.

## Routing

- Two-level leaf scoring batches each parent's contiguous child run: **4.39 → 1.64 µs (2.7×)** for 338 leaves. Contiguity is now a validated invariant with a correct per-leaf fallback.
- **Binary `Auto` switches to the graph at 32,768 leaves, not 4,096.** Measured probe cost (2,560-bit centroids, nprobe=64, flat vs graph): 4,096 → 28.6/116.3 µs; 16,384 → 126.0/212.9 µs; 32,768 → 249.3/255.1 µs; 65,536 → 513.3/444.6 µs. Below ~32k the graph was slower *and* approximate where the flat SIMD pass is exact. The float threshold stays 4,096 (float leaves are ~10× wider; that crossover was not measured). Hierarchical training gets its own threshold so large codebooks don't regress to O(N·K) seeding.

## Training and allocations

- `update_binary_centroid` allocated and zeroed a 20 KiB counter block per centroid per Lloyd iteration and accumulated bit-serially → reusable per-worker bit-plane scratch with a vectorizable inner loop.
- Empty-cell reseeding replaced a training-sample-sized candidate buffer plus two full membership rebuilds with a bounded heap and surgical updates.
- Feature detection hoisted out of k-means++ seeding and Lloyd assignment; distances stay integral (the winner's distance falls out of the same scan); flat probing uses thread-local scratch instead of ~912 KB of per-query `Vec`s at 114k leaves.
- Batch inserts group by leaf with reserved columns; payload stays byte-identical (pinned by test).

## Query correctness

Non-`Max` multi-value binary rerank reused nothing — it discarded the probe's exact leaf scores and re-read every ordinal from flat storage. It now reuses them; ordinals outside the probed leaves are still read and combined, pinned by `test_binary_ivf_partial_probe_combines_unprobed_ordinals`.

Also removes dead `search_distinct_documents_in_clusters` and gates the build-side scanner only tests use.

## Validation

- 1,035 lib + all integration tests on aarch64; 1,033 on x86_64 under Rosetta (exercises the AVX2 four-row kernel)
- clippy `--all-targets --all-features -D warnings`; no-default-features and WASM-feature checks

**Caveat:** the AVX-512 `VPOPCNTDQ` path compiles and is dispatch-guarded but has **not been executed** — no AVX-512 hardware in the dev environment. The AVX2 fallback is what's tested; worth confirming on a prod Xeon/EPYC.

No on-disk format change. Existing binary quantizers stay readable; codebooks in the 4k–32k range simply route flat (exact) until retrained.