### PR TITLE
feat(core): vector training progress, index-attributed logs, zero-vector guards

### DIFF
--- a/hermes-core/benches/binary_vectors.rs
+++ b/hermes-core/benches/binary_vectors.rs
@@ -186,7 +186,7 @@ fn trained_quantizer(
     config.train_iters = 3;
     config.max_train_samples = points;
     config.routing = routing;
-    BinaryCoarseQuantizer::train(config, codes, points).expect("binary coarse training")
+    BinaryCoarseQuantizer::train(config, codes, points, "bench").expect("binary coarse training")
 }
 
 /// Query-time probing and build-time assignment against a realistic codebook.
@@ -292,6 +292,23 @@ fn bench_training(criterion: &mut Criterion) {
                 bencher.iter(|| {
                     let quantizer =
                         trained_quantizer(clusters, IvfRoutingMode::Flat, &corpus, CODE_BYTES);
+                    black_box(quantizer.num_clusters)
+                });
+            },
+        );
+    }
+
+    // Hierarchical training: sqrt(K) parent cells plus one child codebook per
+    // parent. This is what every production-sized codebook uses, and the child
+    // codebooks are the level that parallelises.
+    for clusters in [1_024usize, 4_096] {
+        group.bench_with_input(
+            BenchmarkId::new("hierarchical", clusters),
+            &clusters,
+            |bencher, &clusters| {
+                bencher.iter(|| {
+                    let quantizer =
+                        trained_quantizer(clusters, IvfRoutingMode::TwoLevel, &corpus, CODE_BYTES);
                     black_box(quantizer.num_clusters)
                 });
             },

--- a/hermes-core/benches/vector_indexing.rs
+++ b/hermes-core/benches/vector_indexing.rs
@@ -86,6 +86,7 @@ fn bench_ivf_tq_plan(c: &mut Criterion) {
     let mut coarse = CoarseCentroids::train(
         &CoarseConfig::new(DIM, 256).with_routing(IvfRoutingMode::Flat),
         &vectors,
+        "bench",
     );
     coarse.version = hermes_core::structures::mark_ivf_tq_cosine_generation(coarse.version);
     let codec = tq_shared_codec(DIM);
@@ -129,6 +130,7 @@ fn bench_ivf_coarse_training(c: &mut Criterion) {
                 black_box(CoarseCentroids::train(
                     black_box(&config),
                     black_box(&vectors),
+                    "bench",
                 ))
             })
         });

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -425,13 +425,15 @@ impl IndexMetadata {
         built_fields.sort_unstable_by_key(|(field_id, _)| **field_id);
 
         log::debug!(
-            "[trained] loading trained structures, dense_vector_fields={:?}",
+            "[trained] index={} loading trained structures, dense_vector_fields={:?}",
+            schema.index_label(),
             vector_fields.keys().collect::<Vec<_>>()
         );
 
         for (field_id, field_meta) in built_fields {
             log::debug!(
-                "[trained] field {} state={:?} centroids_file={:?} codebook_file={:?}",
+                "[trained] index={} field {} state={:?} centroids_file={:?} codebook_file={:?}",
+                schema.index_label(),
                 field_id,
                 field_meta.state,
                 field_meta.centroids_file,

--- a/hermes-core/src/index/reader.rs
+++ b/hermes-core/src/index/reader.rs
@@ -185,7 +185,8 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
             let old_count = self.state.load().segment_ids.len();
             let new_count = new_segment_ids.len();
             log::info!(
-                "[index_reload] old_count={} new_count={}",
+                "[index_reload] index={} old_count={} new_count={}",
+                self.schema.index_label(),
                 old_count,
                 new_count
             );
@@ -226,7 +227,10 @@ impl<D: DirectoryWriter + 'static> IndexReader<D> {
         if segments_changed {
             self.reload_with_segments(new_segment_ids).await
         } else {
-            log::debug!("[reload] segments unchanged, skipping");
+            log::debug!(
+                "[reload] index={} segments unchanged, skipping",
+                self.schema.index_label()
+            );
             Ok(())
         }
     }

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -344,7 +344,8 @@ impl<D: Directory + 'static> Searcher<D> {
 
         if !existing_segments.is_empty() {
             log::info!(
-                "[searcher] reusing {} segment readers, loading {} new",
+                "[searcher] index={} reusing {} segment readers, loading {} new",
+                schema.index_label(),
                 reused.len(),
                 to_load.len(),
             );
@@ -424,11 +425,12 @@ impl<D: Directory + 'static> Searcher<D> {
             total_pinned = total_pinned.saturating_add(stats.pinned_metadata_bytes);
             total_pin_intended = total_pin_intended.saturating_add(stats.pin_intended_bytes);
             log::info!(
-                "[searcher] segment {:016x}: docs={}, heap_estimate={} \
+                "[searcher] index={} segment {:016x}: docs={}, heap_estimate={} \
                  (term_cache={}, store_cache={}, sparse_vectors={}, dense_vectors={}), \
                  file_backed={} (term_bloom={}, sparse_vectors={}, dense_vectors={}), \
                  pinned_metadata={} of {} eligible \
                  (sparse_vectors={} of {}, dense_vectors={} of {})",
+                schema.index_label(),
                 stats.segment_id,
                 stats.num_docs,
                 crate::format_bytes(heap as u64),
@@ -451,9 +453,10 @@ impl<D: Directory + 'static> Searcher<D> {
         // Log process RSS if available (helps diagnose OOM)
         let rss_bytes = process_rss_bytes();
         log::info!(
-            "[searcher] loaded {} segments: total_docs={}, heap_estimate={}, \
+            "[searcher] index={} loaded {} segments: total_docs={}, heap_estimate={}, \
              file_backed={}, pinned_metadata={} of {} eligible, \
              shared_store_cache={} in {} blocks, process_rss={}",
+            schema.index_label(),
             segments.len(),
             total_docs,
             crate::format_bytes(total_heap as u64),
@@ -804,7 +807,8 @@ impl<D: Directory + 'static> Searcher<D> {
             selection.evaluated_superblocks,
         );
         log::debug!(
-            "BMP hierarchical LSP: field={}, coarse_groups={}/{}, E_superblocks={}/{}, gamma={}",
+            "[searcher] BMP hierarchical LSP: index={}, field={}, coarse_groups={}/{}, E_superblocks={}/{}, gamma={}",
+            self.schema.index_label(),
             field_label,
             selection.expanded_groups,
             coarse_bounds

--- a/hermes-core/src/index/tests/vector.rs
+++ b/hermes-core/src/index/tests/vector.rs
@@ -1282,6 +1282,58 @@ async fn test_binary_ivf_end_to_end() {
     );
 }
 
+/// An all-zero query carries no information: Hamming distance from it is
+/// `popcount(candidate)` for every candidate, so it ranks by bit count rather
+/// than similarity. Almost always a caller that failed to embed, so it is
+/// refused rather than silently answered with nonsense.
+#[tokio::test]
+async fn test_all_zero_binary_query_is_refused() {
+    use crate::dsl::BinaryDenseVectorConfig;
+    use crate::query::BinaryDenseVectorQuery;
+
+    let dim_bits = 64;
+    let byte_len = dim_bits / 8;
+    let mut sb = SchemaBuilder::default();
+    let title = sb.add_text_field("title", true, true);
+    let cfg = BinaryDenseVectorConfig::new(dim_bits);
+    let bvec = sb.add_binary_dense_vector_field_with_config("bvec", true, true, cfg);
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+    for i in 0u8..8 {
+        let mut doc = Document::new();
+        doc.add_text(title, format!("doc {i}"));
+        doc.add_binary_dense_vector(bvec, vec![i | 0x0f; byte_len]);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    let error = searcher
+        .search(&BinaryDenseVectorQuery::new(bvec, vec![0u8; byte_len]), 5)
+        .await
+        .expect_err("an all-zero binary query must be refused");
+    let message = error.to_string();
+    assert!(
+        message.contains("all-zero"),
+        "error should name the cause, got: {message}"
+    );
+
+    // A real query on the same field still works.
+    let results = searcher
+        .search(&BinaryDenseVectorQuery::new(bvec, vec![0x0f; byte_len]), 5)
+        .await
+        .unwrap();
+    assert!(!results.is_empty(), "non-zero queries must still be served");
+}
+
 /// Partial probing with a non-`Max` combiner: reusing the probe's exact scores
 /// must not lose the ordinals that live *outside* the probed leaves.
 ///

--- a/hermes-core/src/index/vector_builder.rs
+++ b/hermes-core/src/index/vector_builder.rs
@@ -593,7 +593,10 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     async fn build_vector_generation(&self, mode: VectorGenerationMode) -> Result<()> {
         let dense_fields = self.get_ivf_vector_fields();
         if dense_fields.is_empty() {
-            log::info!("No dense vector fields configured for ANN indexing");
+            log::info!(
+                "[vector_training] no dense vector fields configured for ANN indexing: index={}",
+                self.schema.index_label()
+            );
             return Ok(());
         }
 
@@ -702,8 +705,9 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             .await?;
         self.cleanup_unreferenced_vector_artifacts().await;
         log::info!(
-            "Dense vector ANN generation {:?} complete for {} field(s)",
+            "[vector_training] ANN generation {:?} complete: index={} {} field(s)",
             mode,
+            self.schema.index_label(),
             target_field_ids.len(),
         );
         Ok(())
@@ -717,6 +721,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         artifact_generation: &str,
     ) -> Result<Vec<TrainedFieldUpdate>> {
         let training_pool = self.segment_manager.background_cpu_pool();
+        let index_label = self.schema.index_label();
         let mut missing = Vec::new();
         let mut updates = Vec::with_capacity(fields.len());
         for (field, config) in fields {
@@ -739,6 +744,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                         &mut sample,
                         corpus_count,
                         artifact_generation,
+                        index_label,
                     )
                 })
             })?;
@@ -754,7 +760,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         }
         if !missing.is_empty() {
             log::info!(
-                "Skipping dense vector field(s) {missing:?}: the current corpus contains no vectors"
+                "[vector_training] skipping dense vector field(s) {missing:?}: index={index_label} has no vectors in the current corpus"
             );
         }
         Ok(updates)
@@ -784,7 +790,10 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let files = match self.directory.list_files(std::path::Path::new("")).await {
             Ok(files) => files,
             Err(error) => {
-                log::warn!("[trained] failed listing abandoned dense vector artifacts: {error}");
+                log::warn!(
+                    "[trained] index={} failed listing abandoned dense vector artifacts: {error}",
+                    self.schema.index_label()
+                );
                 return;
             }
         };
@@ -800,7 +809,10 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             if let Err(error) = self.directory.delete(&path).await
                 && error.kind() != std::io::ErrorKind::NotFound
             {
-                log::warn!("[trained] failed deleting abandoned artifact {path:?}: {error}");
+                log::warn!(
+                    "[trained] index={} failed deleting abandoned artifact {path:?}: {error}",
+                    self.schema.index_label()
+                );
             }
         }
     }
@@ -981,6 +993,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             )),
         };
         let max_read_vectors = (MAX_SAMPLE_READ_BYTES / bytes_per_sample.max(1)).max(1);
+        let mut zero_codes = 0usize;
         let mut global_offset = 0usize;
         let mut cursor = 0usize;
         let field_ids = [field.0];
@@ -1036,9 +1049,16 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                         for &ordinal in &selected[run_start..run_end] {
                             let relative = ordinal - selected[run_start];
                             let offset = relative * bytes_per_sample;
-                            codes.extend_from_slice(
-                                &bytes.as_slice()[offset..offset + bytes_per_sample],
-                            );
+                            let code = &bytes.as_slice()[offset..offset + bytes_per_sample];
+                            // All-zero codes are never indexed, so training on
+                            // them only spends centroids that can never be
+                            // assigned: a production field turned ~30% of a
+                            // 163k codebook into duplicate zero centroids.
+                            if code.iter().all(|&byte| byte == 0) {
+                                zero_codes += 1;
+                                continue;
+                            }
+                            codes.extend_from_slice(code);
                         }
                     }
                     TrainingSample::Float(values) => {
@@ -1066,17 +1086,45 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         }
 
         let collected = sample.len(config.dim());
-        if global_offset != total || cursor != take || collected != take {
+        // Coverage is checked against what was *selected*; withheld all-zero
+        // codes are subtracted explicitly so a real traversal bug still trips.
+        if global_offset != total || cursor != take || collected + zero_codes != take {
             return Err(Error::Corruption(format!(
-                "training sample coverage mismatch for field {}: counted={total}, traversed={global_offset}, selected={cursor}, collected={collected}",
+                "training sample coverage mismatch for field {}: counted={total}, traversed={global_offset}, selected={cursor}, collected={collected}, zero={zero_codes}",
                 field.0,
             )));
         }
+        if zero_codes > 0 {
+            log::warn!(
+                "[vector_training] index={} field={}: {zero_codes} of {take} sampled vectors \
+                 ({:.1}%) are all-zero and were excluded from training — they cannot be assigned \
+                 to any leaf, so training on them only wastes centroids",
+                self.schema.index_label(),
+                field.0,
+                100.0 * zero_codes as f64 / take.max(1) as f64,
+            );
+            crate::observe::binary_zero_vectors(
+                self.schema.index_label(),
+                field.0,
+                zero_codes,
+                take,
+            );
+        }
+        if collected == 0 {
+            log::warn!(
+                "[vector_training] index={} field={}: every sampled vector is all-zero; \
+                 skipping ANN training for this field",
+                self.schema.index_label(),
+                field.0,
+            );
+            return Ok(None);
+        }
         if collected < total {
             log::info!(
-                "Sampled {} / {} dense vectors for field {} (max {} vectors / {} resident)",
+                "[vector_training] sampled {} / {} dense vectors: index={} field={} (max {} vectors / {} resident)",
                 collected,
                 total,
+                self.schema.index_label(),
                 field.0,
                 self.config.vector_training_max_samples,
                 crate::format_bytes(self.config.vector_training_memory_bytes as u64),
@@ -1093,6 +1141,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         sample: &mut TrainingSample,
         corpus_count: usize,
         artifact_generation: &str,
+        index_label: &str,
     ) -> Result<TrainedFieldModel> {
         let field_id = field.0;
         let dim = config.dim();
@@ -1105,7 +1154,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let num_clusters = effective_field_num_clusters(config, corpus_count, sample_count)?;
 
         log::info!(
-            "Training dense vector index for field {} with {} sampled / {} total vectors, {} clusters (dim={})",
+            "[vector_training] training model: index={} field={} with {} sampled / {} total vectors, {} clusters (dim={})",
+            index_label,
             field_id,
             sample_count,
             corpus_count,
@@ -1149,14 +1199,14 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 let validation_count = validation.len() / dim;
                 if seeds.len() > 1 {
                     log::info!(
-                        "Field {field_id}: {} training + {} held-out vectors; evaluating {} deterministic centroid seed(s)",
+                        "[vector_training] model selection: index={index_label} field={field_id}, {} training + {} held-out vectors, {} deterministic centroid seed(s)",
                         training_count,
                         validation_count,
                         seeds.len(),
                     );
                 } else {
                     log::info!(
-                        "Field {field_id}: training all {} sampled vectors with one deterministic \
+                        "[vector_training] model selection: index={index_label} field={field_id}, all {} sampled vectors with one deterministic \
                          centroid seed; model-selection holdout disabled",
                         training_count,
                     );
@@ -1178,12 +1228,13 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                         &base_config.clone().with_seed(seed),
                         training_values,
                         training_count,
+                        index_label,
                     );
                     let quality =
                         evaluate_float_build_quality(&candidate, validation, config.ivf_routing);
                     if let Some(quality) = quality {
                         log::info!(
-                            "Field {field_id} IVF candidate seed={seed}: objective={:.6}, \
+                            "[vector_training] IVF candidate: index={index_label} field={field_id} seed={seed}, objective={:.6}, \
                              exact/routed_mean_distortion={:.6}/{:.6}, router_recall@1={:.4}, \
                              construction_postings/vector={:.3}, \
                              residual_scale[p50/p95/p99]={:.4}/{:.4}/{:.4}, \
@@ -1221,14 +1272,14 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     selected.expect("the fixed centroid seed bank is non-empty");
                 if let Some(quality) = quality {
                     log::info!(
-                        "Field {field_id}: selected IVF seed {seed} with held-out objective {:.6} \
+                        "[vector_training] selected IVF seed: index={index_label} field={field_id} seed={seed}, held-out objective {:.6} \
                          (occupancy penalty {:.4})",
                         quality.objective,
                         quality.occupancy.penalty,
                     );
                 } else {
                     log::info!(
-                        "Field {field_id}: selected IVF seed {seed} without a model-selection \
+                        "[vector_training] selected IVF seed: index={index_label} field={field_id} seed={seed}, without a model-selection \
                          holdout",
                     );
                 }
@@ -1246,6 +1297,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     binary_config,
                     codes,
                     training_count,
+                    index_label,
                 )
                 .map_err(Error::Io)?;
                 TrainedFieldArtifacts::Binary(quantizer)
@@ -1281,7 +1333,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 self.save_trained_artifact(&centroids, &update.centroids_file)
                     .await?;
                 log::info!(
-                    "Saved IVF-TQ coarse artifact for field {} ({} clusters; leaf codec is derived)",
+                    "[vector_training] saved IVF-TQ coarse artifact: index={} field={} ({} clusters; leaf codec is derived)",
+                    self.schema.index_label(),
                     update.field_id,
                     centroids.num_clusters,
                 );
@@ -1290,7 +1343,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 self.save_trained_artifact(&quantizer, &update.centroids_file)
                     .await?;
                 log::info!(
-                    "Saved binary IVF artifact for field {} ({} clusters)",
+                    "[vector_training] saved binary IVF artifact: index={} field={} ({} clusters)",
+                    self.schema.index_label(),
                     update.field_id,
                     quantizer.num_clusters,
                 );
@@ -1497,7 +1551,12 @@ mod tests {
     fn float_quality_reports_exact_query_router_recall() {
         let training = [0.0, 0.0, 0.1, 0.0, 10.0, 10.0, 10.1, 10.0];
         let config = crate::structures::CoarseConfig::new(2, 2);
-        let centroids = crate::structures::CoarseCentroids::train_contiguous(&config, &training, 4);
+        let centroids = crate::structures::CoarseCentroids::train_contiguous(
+            &config,
+            &training,
+            4,
+            "test-index",
+        );
         for routing in [
             crate::dsl::IvfRoutingMode::Flat,
             crate::dsl::IvfRoutingMode::Auto,
@@ -1522,7 +1581,12 @@ mod tests {
         let config = crate::structures::CoarseConfig::new(2, 2)
             .with_routing(crate::dsl::IvfRoutingMode::Flat)
             .with_soar(crate::structures::SoarConfig::full());
-        let centroids = crate::structures::CoarseCentroids::train_contiguous(&config, &training, 4);
+        let centroids = crate::structures::CoarseCentroids::train_contiguous(
+            &config,
+            &training,
+            4,
+            "test-index",
+        );
         let quality = evaluate_float_build_quality(
             &centroids,
             &[0.05, 0.0, 10.05, 10.0],
@@ -1554,6 +1618,7 @@ mod tests {
             &mut sample,
             3,
             "test",
+            "test-index",
         )
         .unwrap();
         let TrainedFieldArtifacts::FloatCentroids(centroids) = model.artifacts else {
@@ -1588,6 +1653,7 @@ mod tests {
             &mut sample,
             3,
             "test-no-soar",
+            "test-index",
         )
         .unwrap();
         let TrainedFieldArtifacts::FloatCentroids(centroids) = model.artifacts else {

--- a/hermes-core/src/index/wasm_writer.rs
+++ b/hermes-core/src/index/wasm_writer.rs
@@ -344,8 +344,9 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             let buffered = self.builder.take().map(|b| b.num_docs()).unwrap_or(0);
             let lost = buffered.saturating_sub(1);
             log::warn!(
-                "[wasm_writer] segment builder poisoned by failed add_document ({e}); \
-                 discarding {lost} buffered document(s)"
+                "[wasm_writer] index={} segment builder poisoned by failed add_document ({e}); \
+                 discarding {lost} buffered document(s)",
+                self.schema.index_label()
             );
             return Err(crate::Error::Internal(format!(
                 "document failed mid-indexing and poisoned the segment builder: {e}; \
@@ -380,7 +381,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 let doc_count = builder.num_docs();
 
                 log::info!(
-                    "[wasm_writer] building segment: id={} docs={}",
+                    "[wasm_writer] index={} building segment: id={} docs={}",
+                    self.schema.index_label(),
                     segment_hex,
                     doc_count
                 );

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -912,8 +912,9 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         match try_acquire_writer_lock(self.directory.as_ref())? {
             acquired @ (WriterLock::Held { .. } | WriterLock::NotApplicable) => {
                 log::info!(
-                    "[writer_lock] single-writer lock acquired after retry; \
-                     the previous holder has released it — resuming writes"
+                    "[writer_lock] index={} single-writer lock acquired after retry; \
+                     the previous holder has released it — resuming writes",
+                    self.schema.index_label()
                 );
                 *lock = acquired;
                 Ok(())
@@ -937,9 +938,10 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     fn clear_uncommitted_pk_reservations(&self) {
         if self.pk_reservations_retained.load(Ordering::Acquire) {
             log::warn!(
-                "[primary_key] keeping uncommitted reservations through abort: a \
+                "[primary_key] index={} keeping uncommitted reservations through abort: a \
                  failed post-commit refresh left them as the only record of \
-                 committed keys; they are cleared by the next successful commit"
+                 committed keys; they are cleared by the next successful commit",
+                self.schema.index_label()
             );
             return;
         }
@@ -1101,6 +1103,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 super::primary_key::PrimaryKeyIndex::from_persisted(field, bloom, pk_data, snapshot)
             } else {
                 // Incremental: only iterate new segments' keys.
+                let index_label = self.schema.index_label().to_owned();
                 tokio::task::spawn_blocking(move || {
                     // Insert new segments' keys into the bloom, then construct
                     // PrimaryKeyIndex with the pre-populated bloom.
@@ -1119,7 +1122,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     }
                     if added > 0 {
                         log::info!(
-                            "[primary_key] bloom: added {} keys from {} new segment(s)",
+                            "[primary_key] index={index_label} bloom: added {} keys from {} new segment(s)",
                             added,
                             num_new,
                         );
@@ -1174,7 +1177,11 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         {
             Ok(writer) => writer,
             Err(error) => {
-                log::warn!("[primary_key] failed to open bloom cache: {}", error);
+                log::warn!(
+                    "[primary_key] index={} failed to open bloom cache: {}",
+                    self.schema.index_label(),
+                    error
+                );
                 return;
             }
         };
@@ -1182,7 +1189,11 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             write_pk_bloom_stream(pk_index, segment_ids, writer)
         });
         if let Err(e) = result {
-            log::warn!("[primary_key] failed to persist bloom cache: {}", e);
+            log::warn!(
+                "[primary_key] index={} failed to persist bloom cache: {}",
+                self.schema.index_label(),
+                e
+            );
         }
     }
 
@@ -1320,7 +1331,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
                     if b.num_docs() & 0x3FFF == 0 {
                         log::debug!(
-                            "[indexing] docs={}, memory={}, budget={}",
+                            "[indexing] index={} docs={}, memory={}, budget={}",
+                            state.schema.index_label(),
                             b.num_docs(),
                             crate::format_bytes(builder_memory as u64),
                             crate::format_bytes(state.memory_budget_per_worker as u64)
@@ -1338,8 +1350,9 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                         )
                     {
                         log::info!(
-                            "[indexing] memory budget reached, building segment: \
+                            "[indexing] index={} memory budget reached, building segment: \
                              worker={}, docs={}, memory={}, soft_budget={}, hard_budget={}",
+                            state.schema.index_label(),
                             worker_id,
                             b.num_docs(),
                             crate::format_bytes(builder_memory as u64),
@@ -1363,7 +1376,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
             if build_result.is_err() {
                 log::error!(
-                    "[worker] panic during indexing cycle — documents in this cycle may be lost"
+                    "[worker] index={} panic during indexing cycle — documents in this cycle may be lost",
+                    state.schema.index_label()
                 );
                 state.record_cycle_error("indexing worker panicked while building the batch");
             }
@@ -1424,7 +1438,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             Ok(operation) => operation,
             Err(e) => {
                 log::error!(
-                    "[segment_build_failed] segment_id={} lifecycle_error={}",
+                    "[segment_build_failed] index={} segment_id={} lifecycle_error={}",
+                    state.schema.index_label(),
                     segment_hex,
                     e,
                 );
@@ -1439,7 +1454,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         let build_start = std::time::Instant::now();
 
         log::info!(
-            "[segment_build] segment_id={} doc_count={} ann={}",
+            "[segment_build] index={} segment_id={} doc_count={} ann={}",
+            state.schema.index_label(),
             segment_hex,
             doc_count,
             trained.is_some()
@@ -1467,7 +1483,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             Ok(meta) if meta.num_docs == doc_count && meta.num_docs > 0 => {
                 let duration_ms = build_start.elapsed().as_millis() as u64;
                 log::info!(
-                    "[segment_build_done] segment_id={} doc_count={} duration_ms={}",
+                    "[segment_build_done] index={} segment_id={} doc_count={} duration_ms={}",
+                    state.schema.index_label(),
                     segment_hex,
                     meta.num_docs,
                     duration_ms,
@@ -1480,12 +1497,16 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                     "segment {segment_hex} built {} docs from a {doc_count}-document builder",
                     meta.num_docs
                 );
-                log::error!("[segment_build_failed] {error}");
+                log::error!(
+                    "[segment_build_failed] index={} {error}",
+                    state.schema.index_label()
+                );
                 state.record_cycle_error(error);
             }
             Err(e) => {
                 log::error!(
-                    "[segment_build_failed] segment_id={} error={:?}",
+                    "[segment_build_failed] index={} segment_id={} error={:?}",
+                    state.schema.index_label(),
                     segment_hex,
                     e
                 );
@@ -1536,7 +1557,11 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         .await
         .map_err(|error| Error::Internal(format!("failed to join index workers: {}", error)))?;
         if panicked > 0 {
-            log::error!("[index_shutdown] {} indexing worker(s) panicked", panicked);
+            log::error!(
+                "[index_shutdown] index={} {} indexing worker(s) panicked",
+                self.schema.index_label(),
+                panicked
+            );
         }
 
         // No commit is possible after shutdown. Dropping these RAII values
@@ -1616,6 +1641,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         // 2. Wait for all workers to complete their flush (via spawn_blocking
         //    to avoid blocking the tokio runtime)
         let state = Arc::clone(&self.worker_state);
+        let index_label = self.schema.index_label().to_owned();
         let all_flushed = tokio::task::spawn_blocking(move || {
             let mut lock = state.flush_mutex.lock();
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(300);
@@ -1623,7 +1649,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 let remaining = deadline.saturating_duration_since(std::time::Instant::now());
                 if remaining.is_zero() {
                     log::error!(
-                        "[prepare_commit] timed out waiting for workers: {}/{} flushed",
+                        "[prepare_commit] index={index_label} timed out waiting for workers: {}/{} flushed",
                         state.flush_count.load(Ordering::Acquire),
                         state.num_workers
                     );
@@ -1985,7 +2011,11 @@ async fn refresh_primary_key_snapshot<D: DirectoryWriter + 'static>(
         {
             Ok(writer) => writer,
             Err(error) => {
-                log::warn!("[primary_key] failed to open bloom cache: {}", error);
+                log::warn!(
+                    "[primary_key] index={} failed to open bloom cache: {}",
+                    schema.index_label(),
+                    error
+                );
                 return Ok(());
             }
         };
@@ -1997,7 +2027,11 @@ async fn refresh_primary_key_snapshot<D: DirectoryWriter + 'static>(
                 write_pk_bloom_stream(pk_index, &seg_ids, writer)
             })
         {
-            log::warn!("[primary_key] failed to persist bloom cache: {}", error);
+            log::warn!(
+                "[primary_key] index={} failed to persist bloom cache: {}",
+                schema.index_label(),
+                error
+            );
         }
     }
     Ok(())
@@ -2093,7 +2127,10 @@ impl<'a, D: DirectoryWriter + 'static> PreparedCommit<'a, D> {
 
         // Fast path: nothing to commit
         if segments.is_empty() {
-            log::debug!("[commit] no segments to commit, skipping");
+            log::debug!(
+                "[commit] index={} no segments to commit, skipping",
+                self.writer.schema.index_label()
+            );
             self.is_resolved = true;
             self.writer.resume_workers();
             return Ok(false);

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -280,10 +280,13 @@ struct ActiveSegmentOperations {
     idle: Notify,
     shutdown: Notify,
     shutdown_requested: Arc<AtomicBool>,
+    /// Owning index, so lifecycle decisions are attributable when several
+    /// indexes register and defer operations concurrently.
+    index_label: Arc<str>,
 }
 
 impl ActiveSegmentOperations {
-    fn new() -> Self {
+    fn new(index_label: Arc<str>) -> Self {
         Self {
             inner: parking_lot::Mutex::new(ActiveOperationState {
                 segment_ids: HashSet::new(),
@@ -296,6 +299,7 @@ impl ActiveSegmentOperations {
             idle: Notify::new(),
             shutdown: Notify::new(),
             shutdown_requested: Arc::new(AtomicBool::new(false)),
+            index_label,
         }
     }
 
@@ -332,18 +336,25 @@ impl ActiveSegmentOperations {
     ) -> Option<SegmentOperationGuard> {
         let mut inner = self.inner.lock();
         if !inner.accepting {
-            log::debug!("[segment_lifecycle] rejected operation during shutdown");
+            log::debug!(
+                "[segment_lifecycle] index={} rejected operation during shutdown",
+                self.index_label
+            );
             return None;
         }
         if !indexing && !vector_update && inner.non_indexing_paused {
-            log::debug!("[segment_lifecycle] deferred operation during dense vector retraining");
+            log::debug!(
+                "[segment_lifecycle] index={} deferred operation during dense vector retraining",
+                self.index_label
+            );
             return None;
         }
         // Check for overlap with any active lifecycle operation.
         for id in &segment_ids {
             if inner.segment_ids.contains(id) {
                 log::debug!(
-                    "[segment_lifecycle] rejected: {} overlaps with an active operation ({} active IDs)",
+                    "[segment_lifecycle] index={} rejected: {} overlaps with an active operation ({} active IDs)",
+                    self.index_label,
                     id,
                     inner.segment_ids.len()
                 );
@@ -351,7 +362,8 @@ impl ActiveSegmentOperations {
             }
         }
         log::debug!(
-            "[segment_lifecycle] registered {} IDs (total active: {})",
+            "[segment_lifecycle] index={} registered {} IDs (total active: {})",
+            self.index_label,
             segment_ids.len(),
             inner.segment_ids.len() + segment_ids.len()
         );
@@ -645,7 +657,7 @@ type ReplacementRefresh = Arc<
 /// Reconcile a long-lived consumer after a durable segment replacement.
 /// This runs inside the same lifecycle-owned task as metadata publication, so
 /// cancelling the caller cannot leave the replacement published but unannounced.
-async fn refresh_replacement_topology(refresh: Option<ReplacementRefresh>) {
+async fn refresh_replacement_topology(refresh: Option<ReplacementRefresh>, index_label: &str) {
     let Some(refresh) = refresh else {
         return;
     };
@@ -663,7 +675,7 @@ async fn refresh_replacement_topology(refresh: Option<ReplacementRefresh>) {
     }
     if let Some(error) = last_error {
         log::warn!(
-            "[segment_lifecycle] replacement topology refresh failed after 3 attempts: {}",
+            "[segment_lifecycle] index={index_label} replacement topology refresh failed after 3 attempts: {}",
             error,
         );
     }
@@ -915,7 +927,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         // at index creation. Absent = disabled (merges block-copy).
         let reorder_on_merge = schema.reorder_on_merge();
         if reorder_on_merge {
-            log::info!("[merge] reorder-on-merge enabled by index schema");
+            log::info!(
+                "[merge] index={} reorder-on-merge enabled by index schema",
+                schema.index_label()
+            );
         }
 
         let tracker = Arc::new(SegmentTracker::new());
@@ -929,6 +944,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             let dir = Arc::clone(&directory);
             let tracker = Arc::clone(&tracker);
             let lifecycle_handles = Arc::clone(&lifecycle_handles);
+            let cleanup_index_label: Arc<str> = schema.index_label().into();
             Arc::new(move |segment_ids| {
                 // Guard: if the tokio runtime is gone (program exit), skip async
                 // deletion. Segment files become orphans cleaned up on next startup.
@@ -940,18 +956,21 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 };
                 let dir = Arc::clone(&dir);
                 let task_tracker = Arc::clone(&tracker);
+                let task_index_label = Arc::clone(&cleanup_index_label);
                 let cleanup_ids = segment_ids.clone();
                 let future = async move {
                     for &segment_id in &segment_ids {
                         log::info!(
-                            "[segment_cleanup] deleting deferred segment {}",
+                            "[segment_cleanup] index={} deleting deferred segment {}",
+                            task_index_label,
                             segment_id.to_hex()
                         );
                         if let Err(error) =
                             crate::segment::delete_segment(dir.as_ref(), segment_id).await
                         {
                             log::warn!(
-                                "[segment_cleanup] deferred delete failed for {}: {}",
+                                "[segment_cleanup] index={} deferred delete failed for {}: {}",
+                                task_index_label,
                                 segment_id.to_hex(),
                                 error,
                             );
@@ -965,7 +984,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     // retry; crash recovery handles a process exit.
                     tracker.complete_deletion(&cleanup_ids);
                     log::warn!(
-                        "[segment_cleanup] runtime rejected deferred deletion; files will be swept later"
+                        "[segment_cleanup] index={} runtime rejected deferred deletion; files will be swept later",
+                        cleanup_index_label
                     );
                 }
             })
@@ -976,7 +996,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 metadata,
                 merge_policy,
             })),
-            active_operations: Arc::new(ActiveSegmentOperations::new()),
+            active_operations: Arc::new(ActiveSegmentOperations::new(schema.index_label().into())),
             quarantined_segments: parking_lot::Mutex::new(HashSet::new()),
             merge_retry: parking_lot::Mutex::new(MergeRetryState::default()),
             reorder_retries: parking_lot::Mutex::new(HashMap::new()),
@@ -1078,7 +1098,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let cleanup: Arc<dyn Fn(SegmentId) + Send + Sync> = Arc::new(move |segment_id| {
             let Ok(handle) = tokio::runtime::Handle::try_current() else {
                 log::warn!(
-                    "[segment_cleanup] runtime unavailable; partial output {} will be swept on startup",
+                    "[segment_cleanup] index={} runtime unavailable; partial output {} will be swept on startup",
+                    manager.schema.index_label(),
                     segment_id.to_hex(),
                 );
                 return;
@@ -1092,7 +1113,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             };
             if !try_spawn_lifecycle(&manager.lifecycle_handles, &handle, future) {
                 log::warn!(
-                    "[segment_cleanup] runtime rejected output cleanup; {} will be swept on startup",
+                    "[segment_cleanup] index={} runtime rejected output cleanup; {} will be swept on startup",
+                    manager.schema.index_label(),
                     segment_id.to_hex(),
                 );
             }
@@ -1123,7 +1145,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             // The dropped future releases operation ownership. Startup sweep
             // handles its output if the runtime is already tearing down.
             log::warn!(
-                "[segment_cleanup] runtime unavailable; indexing output {} will be swept on startup",
+                "[segment_cleanup] index={} runtime unavailable; indexing output {} will be swept on startup",
+                self.schema.index_label(),
                 output_hex,
             );
         }
@@ -1203,8 +1226,9 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             .insert(segment_id.to_string());
         if inserted {
             log::error!(
-                "[merge] quarantined metadata-live segment {} after deterministic source/validation failure: {}. \
+                "[merge] index={} quarantined metadata-live segment {} after deterministic source/validation failure: {}. \
                  It remains metadata-live for explicit repair but is excluded from merges until restart",
+                self.schema.index_label(),
                 segment_id,
                 error,
             );
@@ -1217,7 +1241,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let delay = merge_retry_delay(retry.consecutive_failures);
         retry.retry_after = std::time::Instant::now().checked_add(delay);
         log::warn!(
-            "[merge] pausing background merge scheduling for {:.0}s after consecutive failure #{}: {}",
+            "[merge] index={} pausing background merge scheduling for {:.0}s after consecutive failure #{}: {}",
+            self.schema.index_label(),
             delay.as_secs_f64(),
             retry.consecutive_failures,
             error,
@@ -1248,7 +1273,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let delay = merge_retry_delay(retry.consecutive_failures);
         retry.retry_after = std::time::Instant::now().checked_add(delay);
         log::warn!(
-            "[reorder] pausing optimizer retries for segment {} for {:.0}s after failure #{}: {}",
+            "[reorder] index={} pausing optimizer retries for segment {} for {:.0}s after failure #{}: {}",
+            self.schema.index_label(),
             segment_id,
             delay.as_secs_f64(),
             retry.consecutive_failures,
@@ -1311,7 +1337,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         if !try_spawn_lifecycle(&self.lifecycle_handles, &runtime, future) {
             self.global_merge_wakeup_pending
                 .store(false, Ordering::Release);
-            log::warn!("[merge] runtime rejected global-capacity wakeup task");
+            log::warn!(
+                "[merge] index={} runtime rejected global-capacity wakeup task",
+                self.schema.index_label()
+            );
         }
     }
 
@@ -1337,14 +1366,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         // publisher after this check. Never hold the metadata mutex while a
         // multi-GB filesystem deletion runs.
         log::info!(
-            "[segment_cleanup] deleting uncommitted output {} after {}",
+            "[segment_cleanup] index={} deleting uncommitted output {} after {}",
+            self.schema.index_label(),
             output_hex,
             reason,
         );
         if let Err(error) = crate::segment::delete_segment(self.directory.as_ref(), output_id).await
         {
             log::warn!(
-                "[segment_cleanup] failed deleting uncommitted output {}: {}",
+                "[segment_cleanup] index={} failed deleting uncommitted output {}: {}",
+                self.schema.index_label(),
                 output_hex,
                 error,
             );
@@ -1510,6 +1541,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         // after the metadata transaction has been detached. The last guard
         // clone drops only after durable metadata and ArcSwap state agree.
         let artifact_update = artifact_update.clone();
+        let index_label = self.schema.index_label().to_owned();
         self.run_lifecycle_transaction(async move {
             let _artifact_update = artifact_update;
             next.save(directory.as_ref()).await?;
@@ -1536,14 +1568,14 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     crate::segment::delete_segment(directory.as_ref(), segment_id).await
                 {
                     log::warn!(
-                        "[segment_cleanup] immediate dense-vector generation delete failed for {}: {}",
+                        "[segment_cleanup] index={index_label} immediate dense-vector generation delete failed for {}: {}",
                         segment_id.to_hex(),
                         error,
                     );
                 }
             }
             tracker.complete_deletion(&ready_to_delete);
-            refresh_replacement_topology(replacement_refresh).await;
+            refresh_replacement_topology(replacement_refresh, &index_label).await;
             Ok(())
         })
         .await
@@ -1658,11 +1690,17 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
     /// concurrent triggers cannot exceed configured merge capacity.
     pub async fn maybe_merge(self: &Arc<Self>) {
         if !self.active_operations.is_accepting() {
-            log::debug!("[maybe_merge] manager is shutting down, skipping");
+            log::debug!(
+                "[maybe_merge] index={} manager is shutting down, skipping",
+                self.schema.index_label()
+            );
             return;
         }
         if self.merge_retry_is_paused() {
-            log::debug!("[maybe_merge] retry backoff active, skipping");
+            log::debug!(
+                "[maybe_merge] index={} retry backoff active, skipping",
+                self.schema.index_label()
+            );
             return;
         }
 
@@ -1710,7 +1748,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 .cloned()
                 .collect();
 
-            log::debug!("[maybe_merge] {} eligible segments", segments.len());
+            log::debug!(
+                "[maybe_merge] index={} {} eligible segments",
+                self.schema.index_label(),
+                segments.len()
+            );
 
             let candidates = st.merge_policy.find_merges(&segments);
 
@@ -1725,12 +1767,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 if local_slots > 0 && global_slots == 0 {
                     self.schedule_global_merge_wakeup();
                 }
-                log::debug!("[maybe_merge] at max concurrent merges, skipping");
+                log::debug!(
+                    "[maybe_merge] index={} at max concurrent merges, skipping",
+                    self.schema.index_label()
+                );
                 return;
             }
 
             log::debug!(
-                "[maybe_merge] {} merge candidates, {} slots available",
+                "[maybe_merge] index={} {} merge candidates, {} slots available",
+                self.schema.index_label(),
                 candidates.len(),
                 slots_available
             );
@@ -1753,8 +1799,9 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             if !handles.is_empty() {
                 if severe_backlog && self.reorder_on_merge {
                     log::info!(
-                        "[maybe_merge] severe backlog: {} live segments; started {} fast \
+                        "[maybe_merge] index={} severe backlog: {} live segments; started {} fast \
                          block-copy merge(s), deferring BP to the optimizer",
+                        self.schema.index_label(),
                         live_segments.len(),
                         handles.len(),
                     );
@@ -1782,13 +1829,19 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         reorder_bmp: bool,
     ) -> Option<JoinHandle<()>> {
         if self.force_merge_active.load(Ordering::Acquire) > 0 {
-            log::debug!("[spawn_merge] skipped: explicit force merge has priority");
+            log::debug!(
+                "[spawn_merge] index={} skipped: explicit force merge has priority",
+                self.schema.index_label()
+            );
             return None;
         }
         let global_merge_permit = match Arc::clone(&self.global_merge_permits).try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => {
-                log::debug!("[spawn_merge] skipped: global merge capacity is full");
+                log::debug!(
+                    "[spawn_merge] index={} skipped: global merge capacity is full",
+                    self.schema.index_label()
+                );
                 self.schedule_global_merge_wakeup();
                 return None;
             }
@@ -1796,7 +1849,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let merge_permit = match Arc::clone(&self.merge_permits).try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => {
-                log::debug!("[spawn_merge] skipped: no merge permit available");
+                log::debug!(
+                    "[spawn_merge] index={} skipped: no merge permit available",
+                    self.schema.index_label()
+                );
                 return None;
             }
         };
@@ -1809,7 +1865,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let guard = match self.active_operations.try_register(all_ids) {
             Some(g) => g,
             None => {
-                log::debug!("[spawn_merge] skipped: segments overlap with an active operation");
+                log::debug!(
+                    "[spawn_merge] index={} skipped: segments overlap with an active operation",
+                    self.schema.index_label()
+                );
                 return None;
             }
         };
@@ -1817,6 +1876,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let sm = Arc::clone(self);
         let ids = segment_ids_to_merge;
 
+        let index_label = self.schema.index_label().to_owned();
         Some(tokio::spawn(async move {
             let mut reevaluate = false;
             let mut retry_delay = None;
@@ -1840,7 +1900,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     ..
                 }) => {
                     log::debug!(
-                        "[merge] background merge for segments {:?} cancelled during shutdown",
+                        "[merge] index={index_label} background merge for segments {:?} cancelled during shutdown",
                         ids,
                     );
                 }
@@ -1849,7 +1909,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     unavailable_segments,
                 }) => {
                     log::error!(
-                        "[merge] background merge failed for segments {:?}: {}",
+                        "[merge] index={index_label} background merge failed for segments {:?}: {}",
                         ids,
                         error
                     );
@@ -1971,8 +2031,9 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let runtime = tokio::runtime::Handle::current();
         if !try_spawn_lifecycle(&self.lifecycle_handles, &runtime, future) {
             log::warn!(
-                "[merge] runtime rejected merge-retry wakeup task; eligible segments may stay \
-                 unmerged until the next commit re-runs merge policy evaluation"
+                "[merge] index={} runtime rejected merge-retry wakeup task; eligible segments may stay \
+                 unmerged until the next commit re-runs merge policy evaluation",
+                self.schema.index_label()
             );
         }
     }
@@ -2094,6 +2155,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let directory = Arc::clone(&self.directory);
         let tracker = Arc::clone(&self.tracker);
         let replacement_refresh = self.replacement_refresh.read().clone();
+        let index_label = self.schema.index_label().to_owned();
         self.run_lifecycle_transaction(async move {
             // Durable-before-visible. If persistence fails, old metadata and
             // tracker ownership stay intact and source deletion is never armed.
@@ -2111,14 +2173,14 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     crate::segment::delete_segment(directory.as_ref(), segment_id).await
                 {
                     log::warn!(
-                        "[segment_cleanup] immediate delete failed for {}: {}",
+                        "[segment_cleanup] index={index_label} immediate delete failed for {}: {}",
                         segment_id.to_hex(),
                         error,
                     );
                 }
             }
             tracker.complete_deletion(&ready_to_delete);
-            refresh_replacement_topology(replacement_refresh).await;
+            refresh_replacement_topology(replacement_refresh, &index_label).await;
             Ok(())
         })
         .await
@@ -2212,7 +2274,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 }
                 Err(e) => {
                     log::error!(
-                        "[merge] Failed to open segment {}: {:?}",
+                        "[merge] index={} Failed to open segment {}: {:?}",
+                        schema.index_label(),
                         segment_ids_to_merge[i],
                         e
                     );
@@ -2246,7 +2309,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         }
 
         log::info!(
-            "[merge] loaded {} segment readers in {:.1}s",
+            "[merge] index={} loaded {} segment readers in {:.1}s",
+            schema.index_label(),
             readers.len(),
             load_start.elapsed().as_secs_f64()
         );
@@ -2265,7 +2329,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             .with_background_pool(bg_cpu_pool);
 
         log::info!(
-            "[merge] {} segments -> {} (trained={})",
+            "[merge] index={} {} segments -> {} (trained={})",
+            schema.index_label(),
             segment_ids_to_merge.len(),
             output_hex,
             trained.map_or(0, |t| t.centroids.len()),
@@ -2289,13 +2354,15 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let bp_converged = merge_stats.bp_converged;
         if !bp_converged {
             log::info!(
-                "[merge] merge-time BP hit its wall-clock budget — output marked unconverged; \
+                "[merge] index={} merge-time BP hit its wall-clock budget — output marked unconverged; \
                  the background optimizer deepens it later",
+                schema.index_label(),
             );
         }
 
         log::info!(
-            "[merge] total wall-clock: {:.1}s ({} segments, {} docs)",
+            "[merge] index={} total wall-clock: {:.1}s ({} segments, {} docs)",
+            schema.index_label(),
             load_start.elapsed().as_secs_f64(),
             readers.len(),
             total_docs,
@@ -2323,7 +2390,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 if let Err(error) = result
                     && error.is_panic()
                 {
-                    log::error!("[merge] background task panicked while draining: {}", error);
+                    log::error!(
+                        "[merge] index={} background task panicked while draining: {}",
+                        self.schema.index_label(),
+                        error
+                    );
                 }
             }
         }
@@ -2372,7 +2443,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 if let Err(error) = handle.await
                     && error.is_panic()
                 {
-                    log::error!("[segment_cleanup] task panicked while draining: {}", error);
+                    log::error!(
+                        "[segment_cleanup] index={} task panicked while draining: {}",
+                        self.schema.index_label(),
+                        error
+                    );
                 }
             }
         }
@@ -2441,7 +2516,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             .count();
         if background_merges > 0 {
             log::info!(
-                "[force_merge] waiting for {} in-flight background merge(s) before planning",
+                "[force_merge] index={} waiting for {} in-flight background merge(s) before planning",
+                self.schema.index_label(),
                 background_merges,
             );
         }
@@ -2449,7 +2525,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         self.wait_for_all_merges().await;
         if drain_start.elapsed() >= std::time::Duration::from_secs(1) {
             log::info!(
-                "[force_merge] drained background merges in {:.1}s",
+                "[force_merge] index={} drained background merges in {:.1}s",
+                self.schema.index_label(),
                 drain_start.elapsed().as_secs_f64(),
             );
         }
@@ -2462,7 +2539,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         refresh_snapshots().await?;
         if refresh_start.elapsed() >= std::time::Duration::from_secs(1) {
             log::info!(
-                "[force_merge] initial snapshot refresh took {:.1}s",
+                "[force_merge] index={} initial snapshot refresh took {:.1}s",
+                self.schema.index_label(),
                 refresh_start.elapsed().as_secs_f64(),
             );
         }
@@ -2534,13 +2612,18 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 }
                 if !logged_held_wait {
                     log::info!(
-                        "[force_merge] waiting: {} segment(s) held by active \
+                        "[force_merge] index={} waiting: {} segment(s) held by active \
                          merge/reorder operations, no free group can merge",
+                        self.schema.index_label(),
                         held
                     );
                     logged_held_wait = true;
                 } else {
-                    log::debug!("[force_merge] still waiting on {} held segment(s)", held);
+                    log::debug!(
+                        "[force_merge] index={} still waiting on {} held segment(s)",
+                        self.schema.index_label(),
+                        held
+                    );
                 }
                 #[cfg(test)]
                 self.force_merge_conflict_retries
@@ -2583,7 +2666,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     #[cfg(test)]
                     self.force_merge_conflict_retries
                         .fetch_add(1, Ordering::Relaxed);
-                    log::debug!("[force_merge] group lost a registration race, replanning");
+                    log::debug!(
+                        "[force_merge] index={} group lost a registration race, replanning",
+                        self.schema.index_label()
+                    );
                     let had_tracked_merges = !self.merge_handles.lock().is_empty();
                     self.wait_for_merging_thread().await;
                     if !had_tracked_merges {
@@ -2594,7 +2680,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             };
 
             log::info!(
-                "[force_merge] planned final group: {} segments, {} docs, {} merge pass(es)",
+                "[force_merge] index={} planned final group: {} segments, {} docs, {} merge pass(es)",
+                self.schema.index_label(),
                 group.segments.len(),
                 group.total_docs,
                 output_ids.len(),
@@ -2626,7 +2713,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 };
                 if capacity_start.elapsed() >= std::time::Duration::from_secs(1) {
                     log::info!(
-                        "[force_merge] waited {:.1}s for foreground global merge capacity",
+                        "[force_merge] index={} waited {:.1}s for foreground global merge capacity",
+                        self.schema.index_label(),
                         capacity_start.elapsed().as_secs_f64(),
                     );
                 }
@@ -2636,7 +2724,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             };
             let _foreground_reorder = if self.reorder_on_merge {
                 log::info!(
-                    "[force_merge] prioritizing BP capacity ({} total pass slot(s))",
+                    "[force_merge] index={} prioritizing BP capacity ({} total pass slot(s))",
+                    self.schema.index_label(),
                     self.reorder_permits.limit(),
                 );
                 let admission_start = std::time::Instant::now();
@@ -2648,7 +2737,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     })?;
                 if admission_start.elapsed() >= std::time::Duration::from_secs(1) {
                     log::info!(
-                        "[force_merge] acquired foreground BP capacity in {:.1}s",
+                        "[force_merge] index={} acquired foreground BP capacity in {:.1}s",
+                        self.schema.index_label(),
                         admission_start.elapsed().as_secs_f64(),
                     );
                 }
@@ -2695,7 +2785,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 };
                 if capacity_start.elapsed() >= std::time::Duration::from_secs(1) {
                     log::info!(
-                        "[force_merge] waited {:.1}s for global merge capacity",
+                        "[force_merge] index={} waited {:.1}s for global merge capacity",
+                        self.schema.index_label(),
                         capacity_start.elapsed().as_secs_f64(),
                     );
                 }
@@ -2705,7 +2796,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 // tiny sources never reorders the same documents repeatedly.
                 let reorder_bmp = final_pass && self.reorder_on_merge;
                 log::info!(
-                    "[force_merge] {} pass: {} segments ({} docs, bp={})",
+                    "[force_merge] index={} {} pass: {} segments ({} docs, bp={})",
+                    self.schema.index_label(),
                     if final_pass {
                         "final"
                     } else {
@@ -2732,7 +2824,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 refresh_snapshots().await?;
                 if refresh_start.elapsed() >= std::time::Duration::from_secs(1) {
                     log::info!(
-                        "[force_merge] post-replacement snapshot refresh took {:.1}s",
+                        "[force_merge] index={} post-replacement snapshot refresh took {:.1}s",
+                        self.schema.index_label(),
                         refresh_start.elapsed().as_secs_f64(),
                     );
                 }
@@ -3130,7 +3223,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             }
             if !conflicted && !changed {
                 log::info!(
-                    "[dense_vector_rewrite] ANN finalization complete ({} segment(s) rewritten)",
+                    "[dense_vector_rewrite] index={} ANN finalization complete ({} segment(s) rewritten)",
+                    self.schema.index_label(),
                     rewritten,
                 );
                 return Ok(rewritten);
@@ -3178,7 +3272,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                         Ok(_) => break,
                         Err(error) => {
                             log::error!(
-                                "[dense_vector_rewrite] failed to upgrade newly committed segment {}: {}",
+                                "[dense_vector_rewrite] index={} failed to upgrade newly committed segment {}: {}",
+                                manager.schema.index_label(),
                                 segment_id,
                                 error,
                             );
@@ -3190,13 +3285,15 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         };
         let Ok(runtime) = tokio::runtime::Handle::try_current() else {
             log::warn!(
-                "[dense_vector_rewrite] runtime unavailable; newly committed flat segment upgrade deferred"
+                "[dense_vector_rewrite] index={} runtime unavailable; newly committed flat segment upgrade deferred",
+                self.schema.index_label()
             );
             return;
         };
         if !try_spawn_lifecycle(&self.lifecycle_handles, &runtime, future) {
             log::warn!(
-                "[dense_vector_rewrite] runtime rejected newly committed flat segment upgrade"
+                "[dense_vector_rewrite] index={} runtime rejected newly committed flat segment upgrade",
+                self.schema.index_label()
             );
         }
     }
@@ -3227,11 +3324,18 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         let segment_ids = self.get_segment_ids().await;
 
         if segment_ids.is_empty() {
-            log::info!("[reorder] no segments to reorder");
+            log::info!(
+                "[reorder] index={} no segments to reorder",
+                self.schema.index_label()
+            );
             return Ok(());
         }
 
-        log::info!("[reorder] reordering {} segments", segment_ids.len());
+        log::info!(
+            "[reorder] index={} reordering {} segments",
+            self.schema.index_label(),
+            segment_ids.len()
+        );
 
         for seg_id in segment_ids {
             match self
@@ -3239,7 +3343,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 .await
             {
                 Ok(true) => refresh_snapshots().await?,
-                Ok(false) => log::warn!("[reorder] segment {} skipped (in merge)", seg_id),
+                Ok(false) => log::warn!(
+                    "[reorder] index={} segment {} skipped (in merge)",
+                    self.schema.index_label(),
+                    seg_id
+                ),
                 Err(e) => return Err(e),
             }
         }
@@ -3247,7 +3355,10 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         // A segment skipped because another lifecycle owner held it may have
         // been replaced after the preceding callback.
         refresh_snapshots().await?;
-        log::info!("[reorder] all segments reordered");
+        log::info!(
+            "[reorder] index={} all segments reordered",
+            self.schema.index_label()
+        );
         Ok(())
     }
 
@@ -3339,7 +3450,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         drop(st);
         if deepening {
             log::info!(
-                "[reorder] source BP lineage unconverged — forcing record-level BP (deepening pass)",
+                "[reorder] index={} source BP lineage unconverged — forcing record-level BP (deepening pass)",
+                self.schema.index_label(),
             );
             crate::segment::reorder::BpGranularity::Records
         } else {
@@ -3367,7 +3479,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         }
         if self.force_merge_active.load(Ordering::Acquire) > 0 {
             log::debug!(
-                "[optimizer] explicit force merge active, skipping reorder of {}",
+                "[optimizer] index={} explicit force merge active, skipping reorder of {}",
+                self.schema.index_label(),
                 seg_id,
             );
             return Ok(false);
@@ -3408,14 +3521,16 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             // above and prevents optimizer starvation between final groups.
             if self.force_merge_active.load(Ordering::Acquire) > 0 {
                 log::debug!(
-                    "[optimizer] explicit force merge active, skipping reorder of {}",
+                    "[optimizer] index={} explicit force merge active, skipping reorder of {}",
+                    self.schema.index_label(),
                     seg_id,
                 );
                 return Ok(false);
             }
             let Some(source_meta) = st.metadata.segment_metas.get(seg_id) else {
                 log::info!(
-                    "[optimizer] segment {} no longer in metadata (merged away), skipping reorder",
+                    "[optimizer] index={} segment {} no longer in metadata (merged away), skipping reorder",
+                    self.schema.index_label(),
                     seg_id
                 );
                 self.clear_reorder_retry(seg_id);
@@ -3428,7 +3543,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     return Err(Error::IndexClosed);
                 }
                 None => {
-                    log::debug!("[optimizer] segment {} in active merge, skipping", seg_id);
+                    log::debug!(
+                        "[optimizer] index={} segment {} in active merge, skipping",
+                        self.schema.index_label(),
+                        seg_id
+                    );
                     return Ok(false);
                 }
             }
@@ -3576,7 +3695,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => true,
                 Err(error) => {
                     log::warn!(
-                        "[segment_cleanup] failed sweeping orphan segment {}: {}",
+                        "[segment_cleanup] index={} failed sweeping orphan segment {}: {}",
+                        self.schema.index_label(),
                         hex_id,
                         error,
                     );
@@ -3588,7 +3708,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             drop(deletion_guard);
             if removed {
                 deleted += 1;
-                log::info!("[segment_cleanup] swept orphan segment {}", hex_id);
+                log::info!(
+                    "[segment_cleanup] index={} swept orphan segment {}",
+                    self.schema.index_label(),
+                    hex_id
+                );
             }
         }
 
@@ -3939,7 +4063,7 @@ mod tests {
 
     #[test]
     fn test_active_operation_guard_releases_ownership() {
-        let active = Arc::new(ActiveSegmentOperations::new());
+        let active = Arc::new(ActiveSegmentOperations::new("test".into()));
         {
             let _guard = active.try_register(vec!["a".into(), "b".into()]).unwrap();
             let snap = active.snapshot();
@@ -3951,7 +4075,7 @@ mod tests {
 
     #[test]
     fn test_non_overlapping_operations_can_run_concurrently() {
-        let active = Arc::new(ActiveSegmentOperations::new());
+        let active = Arc::new(ActiveSegmentOperations::new("test".into()));
         let first = active.try_register(vec!["a".into(), "b".into()]).unwrap();
         let _second = active.try_register(vec!["c".into(), "d".into()]).unwrap();
         let snap = active.snapshot();
@@ -3966,7 +4090,7 @@ mod tests {
 
     #[test]
     fn test_overlapping_operation_is_rejected_until_release() {
-        let active = Arc::new(ActiveSegmentOperations::new());
+        let active = Arc::new(ActiveSegmentOperations::new("test".into()));
         let first = active.try_register(vec!["a".into(), "b".into()]).unwrap();
         assert!(active.try_register(vec!["b".into(), "c".into()]).is_none());
         drop(first);
@@ -3975,7 +4099,7 @@ mod tests {
 
     #[test]
     fn test_active_operation_snapshot() {
-        let active = Arc::new(ActiveSegmentOperations::new());
+        let active = Arc::new(ActiveSegmentOperations::new("test".into()));
         let _guard = active.try_register(vec!["x".into(), "y".into()]).unwrap();
         let snap = active.snapshot();
         assert!(snap.contains("x"));
@@ -3985,7 +4109,7 @@ mod tests {
 
     #[tokio::test]
     async fn operation_barrier_ignores_producers_started_after_snapshot() {
-        let active = Arc::new(ActiveSegmentOperations::new());
+        let active = Arc::new(ActiveSegmentOperations::new("test".into()));
         let before_gate = active.try_register(vec!["old".into()]).unwrap();
         let (barrier, parked_indexing) = active.draining_operation_tokens_snapshot();
         assert_eq!(parked_indexing, 0);
@@ -4067,7 +4191,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_rejects_new_work_and_waits_for_existing_guard() {
-        let active = Arc::new(ActiveSegmentOperations::new());
+        let active = Arc::new(ActiveSegmentOperations::new("test".into()));
         let guard = active.try_register(vec!["live".into()]).unwrap();
         let cancellation = active.cancellation_flag();
         active.stop_accepting();

--- a/hermes-core/src/observe.rs
+++ b/hermes-core/src/observe.rs
@@ -254,6 +254,19 @@ mod imp {
             .record(coherence_norm as f64);
     }
 
+    /// Vectors withheld from a binary ANN payload for carrying no information.
+    ///
+    /// A counter rather than a log-only warning: the rate matters (it tracks an
+    /// upstream producer regressing) and it has to be visible per index/field.
+    pub fn binary_zero_vectors(index: &str, field: u32, skipped: usize, total: usize) {
+        let index = shared_label(index);
+        let field = field.to_string();
+        metrics::counter!("hermes_binary_zero_vectors_total", "index" => index.clone(), "field" => field.clone())
+            .increment(skipped as u64);
+        metrics::counter!("hermes_binary_indexed_vectors_total", "index" => index, "field" => field)
+            .increment(total as u64);
+    }
+
     pub fn reorder_bp_started(index: &str, field: &str, entity_kind: &'static str) {
         metrics::gauge!("hermes_reorder_bp_active_passes", "index" => shared_label(index), "field" => shared_label(field), "entity_kind" => entity_kind)
             .increment(1.0);
@@ -355,6 +368,9 @@ mod imp {
     pub fn maxscore_query(_: &str, _: &str, _: f64, _: usize) {}
     #[inline(always)]
     pub fn dense_l1(_: &str, _: &str, _: &'static str, _: f64, _: usize) {}
+    #[inline(always)]
+    #[allow(dead_code)]
+    pub fn binary_zero_vectors(_: &str, _: u32, _: usize, _: usize) {}
     #[inline(always)]
     pub fn dense_rerank(_: &str, _: &str, _: f64, _: f64, _: f64, _: usize) {}
     #[inline(always)]

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -2231,7 +2231,7 @@ mod tests {
                 v
             })
             .collect();
-        let mut centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 8), &vectors);
+        let mut centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 8), &vectors, "test");
         centroids.version = crate::structures::mark_ivf_tq_cosine_generation(centroids.version);
         let mut index = IvfTqIndex::new(
             dim,

--- a/hermes-core/src/segment/bmp_adaptive.rs
+++ b/hermes-core/src/segment/bmp_adaptive.rs
@@ -17,6 +17,14 @@
 //! chosen exactly when it is no larger than the sparse pairs and slots are
 //! unique, so the representation never grows because of adaptation.
 
+// The encode half of this module — scratch, stats, block inspection and term
+// iteration — exists for segment building (`segment::builder`, gated on
+// `native`/`wasm`) and reordering (`native`). The featureless library build
+// compiles neither, so those items have no caller there. Silence dead-code
+// analysis for exactly that configuration and leave it fully active for the
+// ones that ship.
+#![cfg_attr(not(any(feature = "native", feature = "wasm")), allow(dead_code))]
+
 const WIDE_BLOCK_FLAG: u32 = 1 << 31;
 const NARROW_DENSE_FLAG: u16 = 1 << 15;
 const WIDE_DENSE_FLAG: u32 = 1 << 31;

--- a/hermes-core/src/segment/builder/dense.rs
+++ b/hermes-core/src/segment/builder/dense.rs
@@ -132,7 +132,8 @@ fn build_dense_ann_blob(
     };
     let (index_type, bytes) = blob?;
     log::info!(
-        "[dense_vector_build] built ANN(type={}) for field {} ({} vectors, {})",
+        "[dense_vector_build] index={} built ANN(type={}) for field {} ({} vectors, {})",
+        schema.index_label(),
         index_type,
         field_id,
         builder.doc_ids.len(),
@@ -368,6 +369,11 @@ pub(super) fn build_vectors_streaming(
                     &builder.doc_ids,
                 )
                 .map_err(crate::Error::Io)?;
+                crate::structures::vector::index::report_binary_build_quality(
+                    schema.index_label(),
+                    field_id,
+                    &index,
+                );
                 let blob_offset = current_offset;
                 let mut output = &mut *writer;
                 let blob_len = crate::segment::ann_disk::write_built_binary_ivf(
@@ -394,7 +400,8 @@ pub(super) fn build_vectors_streaming(
                     })?;
                 }
                 log::debug!(
-                    "[dense_vector_build] field {}: binary IVF built ({} vectors, {} clusters, {})",
+                    "[dense_vector_build] index={} field {}: binary IVF built ({} vectors, {} clusters, {})",
+                    schema.index_label(),
                     field_id,
                     num_vectors,
                     quantizer.num_clusters,

--- a/hermes-core/src/segment/builder/mod.rs
+++ b/hermes-core/src/segment/builder/mod.rs
@@ -959,10 +959,11 @@ impl SegmentBuilder {
         if !self.position_saturation_warned {
             self.position_saturation_warned = true;
             log::warn!(
-                "[segment_builder] {what} {value} exceeds the position-encoding limit {max}; \
+                "[segment_builder] index={} {what} {value} exceeds the position-encoding limit {max}; \
                  saturating — phrase/ordinal matching degrades for the overflowing \
                  elements/tokens instead of corrupting other documents' matches \
-                 (further occurrences in this segment are not logged)"
+                 (further occurrences in this segment are not logged)",
+                self.schema.index_label()
             );
         }
     }
@@ -1425,7 +1426,8 @@ impl SegmentBuilder {
         drop(sparse_vectors);
 
         log::info!(
-            "[segment_build] docs={}: term_dict={}, postings={}, store={}, dense_vectors={}, sparse_vectors={}, fast_fields={}",
+            "[segment_build] index={} docs={}: term_dict={}, postings={}, store={}, dense_vectors={}, sparse_vectors={}, fast_fields={}",
+            self.schema.index_label(),
             num_docs,
             crate::format_bytes(term_dict_bytes as u64),
             crate::format_bytes(postings_bytes as u64),

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -421,7 +421,8 @@ impl SegmentMerger {
         let output_size = writer.offset() as usize;
         super::block_in_place_if_multithread(move || writer.finish())?;
         log::info!(
-            "[dense_vector_merge] file written: {} ({} fields) in {:.1}s",
+            "[dense_vector_merge] index={} file written: {} ({} fields) in {:.1}s",
+            self.schema.index_label(),
             crate::format_bytes(output_size as u64),
             toc.len(),
             write_start.elapsed().as_secs_f64()
@@ -552,7 +553,8 @@ impl SegmentMerger {
         result.map_err(crate::Error::Io)?;
         let data_size = writer.offset() - data_offset;
         log::debug!(
-            "[dense_vector_merge] field {}: copied {} compatible ANN run source(s), {}",
+            "[dense_vector_merge] index={} field {}: copied {} compatible ANN run source(s), {}",
+            self.schema.index_label(),
             field.0,
             sources.len(),
             crate::format_bytes(data_size),
@@ -635,7 +637,8 @@ impl SegmentMerger {
             result.map_err(crate::Error::Io)?;
             let data_size = writer.offset() - data_offset;
             log::debug!(
-                "[merge_vectors] field {}: copied {} compatible TQ run source(s), {} bytes",
+                "[merge_vectors] index={} field {}: copied {} compatible TQ run source(s), {} bytes",
+                self.schema.index_label(),
                 field.0,
                 sources.len(),
                 data_size,
@@ -650,8 +653,9 @@ impl SegmentMerger {
         // Payload-less sources (pre-TQ builds or a schema switch to `tq`)
         // are re-encoded; every compatible source is still byte-copied.
         log::info!(
-            "[merge_vectors] field {}: {}/{} TQ source(s) have no payload; re-encoding only \
+            "[merge_vectors] index={} field {}: {}/{} TQ source(s) have no payload; re-encoding only \
              those from flat vectors (training-free), byte-copying the rest",
+            self.schema.index_label(),
             field.0,
             missing_segments.len(),
             segments_with_vectors,
@@ -688,8 +692,9 @@ impl SegmentMerger {
         let vector_count = builder.len();
         if sources.is_empty() && vector_count == 0 {
             log::warn!(
-                "[merge_vectors] field {}: TQ re-encode found no vectors in any source; \
+                "[merge_vectors] index={} field {}: TQ re-encode found no vectors in any source; \
                  the merged segment will carry no TQ payload and fall back to exact scan",
+                self.schema.index_label(),
                 field.0,
             );
             return Ok(None);
@@ -719,7 +724,8 @@ impl SegmentMerger {
             result.map_err(crate::Error::Io)?;
         }
         log::info!(
-            "[merge_vectors] field {}: TQ re-encoded {} vectors in {:.1}s ({} sources copied)",
+            "[merge_vectors] index={} field {}: TQ re-encoded {} vectors in {:.1}s ({} sources copied)",
+            self.schema.index_label(),
             field.0,
             vector_count,
             encode_start.elapsed().as_secs_f64(),
@@ -824,7 +830,8 @@ impl SegmentMerger {
         result.map_err(crate::Error::Io)?;
         let data_size = writer.offset() - data_offset;
         log::debug!(
-            "[merge_vectors] field {}: copied {} compatible IVF-TQ run source(s), {} bytes",
+            "[merge_vectors] index={} field {}: copied {} compatible IVF-TQ run source(s), {} bytes",
+            self.schema.index_label(),
             field.0,
             sources.len(),
             data_size,
@@ -906,7 +913,8 @@ impl SegmentMerger {
             return Ok(None);
         }
         log::info!(
-            "[merge_vectors] field {} IVF-TQ rebuilt from {} vectors into {} assignments ({:.1}s)",
+            "[merge_vectors] index={} field {} IVF-TQ rebuilt from {} vectors into {} assignments ({:.1}s)",
+            self.schema.index_label(),
             field.0,
             total_fed,
             index.len(),
@@ -990,8 +998,14 @@ impl SegmentMerger {
         }
         let num_clusters = quantizer.num_clusters;
         let index = builder.finish().map_err(crate::Error::Io)?;
+        crate::structures::vector::index::report_binary_build_quality(
+            self.schema.index_label(),
+            field.0,
+            &index,
+        );
         log::debug!(
-            "[dense_vector_merge] field {}: binary IVF rebuilt ({} vectors, {} clusters, estimated {})",
+            "[dense_vector_merge] index={} field {}: binary IVF rebuilt ({} vectors, {} clusters, estimated {})",
+            self.schema.index_label(),
             field.0,
             vector_count,
             num_clusters,

--- a/hermes-core/src/segment/merger/fast_fields.rs
+++ b/hermes-core/src/segment/merger/fast_fields.rs
@@ -143,7 +143,8 @@ impl SegmentMerger {
         let total_bytes = toc_offset as usize + toc_entries.len() * 38 + 16;
 
         log::info!(
-            "[merge] fast-fields: {} columns, {} docs, {} (raw block stacking)",
+            "[merge] index={} fast-fields: {} columns, {} docs, {} (raw block stacking)",
+            self.schema.index_label(),
             toc_entries.len(),
             total_docs,
             crate::format_bytes(total_bytes as u64)

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -230,6 +230,7 @@ pub(crate) async fn append_and_delete_temp<D: DirectoryWriter>(
     path: &std::path::Path,
     expected_bytes: u64,
     writer: &mut OffsetWriter,
+    index_label: &str,
 ) -> Result<()> {
     use std::io::Write as _;
 
@@ -270,7 +271,8 @@ pub(crate) async fn append_and_delete_temp<D: DirectoryWriter>(
         // scratch file is safe for the startup orphan sweep and must not
         // invalidate an otherwise successful multi-hour merge.
         log::warn!(
-            "[merge] failed to remove temporary sparse section {:?}: {}",
+            "[merge] index={} failed to remove temporary sparse section {:?}: {}",
+            index_label,
             path,
             error,
         );
@@ -596,7 +598,8 @@ impl SegmentMerger {
                 let _ = dir.delete(&files.positions).await;
             }
             log::info!(
-                "[merge] postings done: {} terms, term_dict={}, postings={}, positions={}",
+                "[merge] index={} postings done: {} terms, term_dict={}, postings={}, positions={}",
+                self.schema.index_label(),
                 terms_processed,
                 crate::format_bytes(term_dict_bytes as u64),
                 crate::format_bytes(postings_bytes as u64),
@@ -625,7 +628,8 @@ impl SegmentMerger {
         self.ensure_not_cancelled()?;
 
         log::info!(
-            "[merge] stage 1 done in {:.1}s (postings + store + fast)",
+            "[merge] index={} stage 1 done in {:.1}s (postings + store + fast)",
+            self.schema.index_label(),
             merge_start.elapsed().as_secs_f64()
         );
 
@@ -660,7 +664,8 @@ impl SegmentMerger {
         stats.bp_converged = bp_converged;
         stats.fast_bytes = fast_bytes;
         log::info!(
-            "[merge] all phases done in {:.1}s: {}",
+            "[merge] index={} all phases done in {:.1}s: {}",
+            self.schema.index_label(),
             merge_start.elapsed().as_secs_f64(),
             stats
         );
@@ -697,8 +702,9 @@ impl SegmentMerger {
         // source segment metadata disagrees with its store.
         if store_num_docs != total_docs {
             log::error!(
-                "[merge] STORE/META MISMATCH: store has {} docs but metadata expects {}. \
+                "[merge] index={} STORE/META MISMATCH: store has {} docs but metadata expects {}. \
                  Per-segment: {:?}",
+                self.schema.index_label(),
                 store_num_docs,
                 total_docs,
                 segments
@@ -734,7 +740,12 @@ impl SegmentMerger {
         // wall-clock timer also includes postings, store, sparse BP and any BP
         // scheduler wait. Calling this an "ANN merge" made long sparse waits
         // look like ANN construction in production logs.
-        log::info!("[merge] complete: {} docs, {}", total_docs, stats);
+        log::info!(
+            "[merge] index={} complete: {} docs, {}",
+            self.schema.index_label(),
+            total_docs,
+            stats
+        );
 
         Ok((meta, stats))
     }

--- a/hermes-core/src/segment/merger/postings.rs
+++ b/hermes-core/src/segment/merger/postings.rs
@@ -74,12 +74,18 @@ impl SegmentMerger {
         let results = futures::future::join_all(futs).await;
         for (i, res) in results.into_iter().enumerate() {
             res.map_err(|e| {
-                log::error!("Prefetch failed for segment {}: {}", i, e);
+                log::error!(
+                    "[merge] index={} prefetch failed for segment {}: {}",
+                    self.schema.index_label(),
+                    i,
+                    e
+                );
                 e
             })?;
         }
         log::debug!(
-            "Prefetched {} term dicts in {:.1}s",
+            "[merge] index={} prefetched {} term dicts in {:.1}s",
+            self.schema.index_label(),
             segments.len(),
             prefetch_start.elapsed().as_secs_f64()
         );
@@ -174,7 +180,11 @@ impl SegmentMerger {
 
             // Log progress every 100k terms
             if terms_processed.is_multiple_of(100_000) {
-                log::debug!("Merge progress: {} terms processed", terms_processed);
+                log::debug!(
+                    "[merge] index={} progress: {} terms processed",
+                    self.schema.index_label(),
+                    terms_processed
+                );
             }
         }
 

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -154,7 +154,8 @@ impl SegmentMerger {
                         // its schema — fall through to block-copy. Loud so an
                         // operator can see why the merged field stays unordered.
                         log::info!(
-                            "[merge_bmp] field {}: `reorder` schema attribute not set — block-copy merge",
+                            "[merge_bmp] index={} field {}: `reorder` schema attribute not set — block-copy merge",
+                            self.schema.index_label(),
                             field.0,
                         );
                     }
@@ -174,7 +175,8 @@ impl SegmentMerger {
                         let pool = self.background_pool.clone();
                         let granularity = self.granularity;
                         log::info!(
-                            "[merge_bmp] field {}: reorder-on-merge enabled — running BP over {} source(s)",
+                            "[merge_bmp] index={} field {}: reorder-on-merge enabled — running BP over {} source(s)",
+                            self.schema.index_label(),
                             fid,
                             sources.len(),
                         );
@@ -198,7 +200,8 @@ impl SegmentMerger {
                         let permit_wait = permit_wait_start.elapsed();
                         if permit_wait >= std::time::Duration::from_secs(1) {
                             log::info!(
-                                "[merge_bmp] field {}: waited {:.1}s for the BP scheduler",
+                                "[merge_bmp] index={} field {}: waited {:.1}s for the BP scheduler",
+                                self.schema.index_label(),
                                 fid,
                                 permit_wait.as_secs_f64(),
                             );
@@ -251,6 +254,7 @@ impl SegmentMerger {
                             &doc_offs,
                             &source_sparse_paths,
                             field.0,
+                            self.schema.index_label(),
                             dims,
                             bmp_block_size,
                             grid_bits,
@@ -303,7 +307,8 @@ impl SegmentMerger {
                 })?;
 
             log::debug!(
-                "[sparse_vector_merge] field {}: {} unique dims across {} segments, total_vectors={}",
+                "[sparse_vector_merge] index={} field {}: {} unique dims across {} segments, total_vectors={}",
+                self.schema.index_label(),
                 field.0,
                 all_dims.len(),
                 segments.len(),
@@ -488,7 +493,14 @@ impl SegmentMerger {
         // Phase 2: Stream-copy skip entries from temp file to main writer.
         let skip_offset = writer.offset();
         let skip_size = skip_count as u64 * SparseSkipEntry::SIZE as u64;
-        super::append_and_delete_temp(dir, &skip_tmp, skip_size, &mut writer).await?;
+        super::append_and_delete_temp(
+            dir,
+            &skip_tmp,
+            skip_size,
+            &mut writer,
+            self.schema.index_label(),
+        )
+        .await?;
 
         // Phase 3 + 4: Write TOC + footer
         let toc_offset = writer.offset();
@@ -500,7 +512,8 @@ impl SegmentMerger {
 
         let total_dims: usize = field_tocs.iter().map(|f| f.dims.len()).sum();
         log::info!(
-            "[sparse_vector_merge] file written: {} ({} fields, {} dims, {} skip entries)",
+            "[sparse_vector_merge] index={} file written: {} ({} fields, {} dims, {} skip entries)",
+            self.schema.index_label(),
             crate::format_bytes(output_size as u64),
             field_tocs.len(),
             total_dims,
@@ -615,6 +628,7 @@ fn merge_bmp_field(
     doc_offs: &[u32],
     source_sparse_paths: &[Option<std::path::PathBuf>],
     field_id: u32,
+    index_label: &str,
     dims: u32,
     bmp_block_size: u32,
     grid_bits: u8,
@@ -704,8 +718,9 @@ fn merge_bmp_field(
         total_postings = total_postings.saturating_add(bmp.total_postings());
     }
     log::debug!(
-        "[merge_bmp_v18] field {}: dims={}, {} sources, {} total_blocks, \
+        "[merge_bmp_v18] index={} field {}: dims={}, {} sources, {} total_blocks, \
          block_size={}, max_weight_scale={:.4}",
+        index_label,
         field_id,
         dims,
         sources.len(),

--- a/hermes-core/src/segment/merger/store.rs
+++ b/hermes-core/src/segment/merger/store.rs
@@ -29,7 +29,8 @@ impl SegmentMerger {
             let store_docs = segment.store().num_docs();
             if meta_docs != store_docs {
                 log::error!(
-                    "[merge_store] SOURCE MISMATCH segment {:016x}: meta.num_docs={}, store.num_docs={}",
+                    "[merge_store] index={} SOURCE MISMATCH segment {:016x}: meta.num_docs={}, store.num_docs={}",
+                    self.schema.index_label(),
                     segment.meta().id,
                     meta_docs,
                     store_docs

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -725,6 +725,10 @@ impl BmpIndex {
     }
 
     /// Iterate `(dimension, conservative maximum, postings)` for one block.
+    ///
+    /// Only the build/reorder paths walk a block term by term, and those are
+    /// gated on `native`/`wasm`.
+    #[cfg_attr(not(any(feature = "native", feature = "wasm")), allow(dead_code))]
     pub(crate) fn iter_block_terms(
         &self,
         block_id: u32,

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -1681,8 +1681,9 @@ impl SegmentReader {
         };
         if report.skipped_budget_bytes > 0 || report.failed_bytes > 0 {
             log::warn!(
-                "[pin] segment {:016x}: pinned {}/{} (budget skipped {}, mlock failed {}) — \
+                "[pin] index={} segment {:016x}: pinned {}/{} (budget skipped {}, mlock failed {}) — \
                  raise HERMES_PIN_METADATA_BUDGET_MB or RLIMIT_MEMLOCK for full coverage",
+                self.schema.index_label(),
                 self.meta.id,
                 crate::format_bytes(report.pinned_bytes),
                 crate::format_bytes(report.intended_bytes),
@@ -1691,7 +1692,8 @@ impl SegmentReader {
             );
         } else if report.pinned_bytes > 0 {
             log::info!(
-                "[pin] segment {:016x}: pinned {} of hot metadata ({:?})",
+                "[pin] index={} segment {:016x}: pinned {} of hot metadata ({:?})",
+                self.schema.index_label(),
                 self.meta.id,
                 crate::format_bytes(report.pinned_bytes),
                 policy.mode,
@@ -2271,6 +2273,17 @@ impl SegmentReader {
                 config.byte_len()
             )));
         }
+        if query.iter().all(|&byte| byte == 0) {
+            // Hamming distance from an all-zero query is `popcount(candidate)`
+            // for every candidate, so the ranking it produces is "fewest bits
+            // set" — not similarity. Almost always a caller that failed to
+            // embed and sent a zero-filled buffer.
+            return Err(Error::Query(format!(
+                "binary query for field '{}' is all-zero: it carries no information and would \
+                 rank candidates by bit count rather than similarity",
+                entry.name,
+            )));
+        }
         Ok(config.dim)
     }
 
@@ -2520,7 +2533,8 @@ impl SegmentReader {
             // Combine every value of a document before document-level top-k;
             // vector-level top-k loses documents on multi-valued fields.
             log::debug!(
-                "[dense_vector_search] field {}: brute-force on {} vectors (dim={}, quant={:?})",
+                "[dense_vector_search] index={} field {}: brute-force on {} vectors (dim={}, quant={:?})",
+                self.schema.index_label(),
                 field.0,
                 lazy_flat.num_vectors,
                 lazy_flat.dim,
@@ -2573,7 +2587,8 @@ impl SegmentReader {
             );
         }
         log::debug!(
-            "[dense_vector_search] field {}: L1 returned {} candidates in {:.1}ms",
+            "[dense_vector_search] index={} field {}: L1 returned {} candidates in {:.1}ms",
+            self.schema.index_label(),
             field.0,
             flat_results.as_ref().map_or(results.len(), Vec::len),
             l1_elapsed.as_secs_f64() * 1000.0
@@ -2610,7 +2625,8 @@ impl SegmentReader {
                 stats.vector_count,
             );
             log::debug!(
-                "[dense_vector_search] field {}: rerank {} vectors (dim={}, quant={:?}, bytes_per_vector={}): resolve={:.1}ms read={:.1}ms score={:.1}ms",
+                "[dense_vector_search] index={} field {}: rerank {} vectors (dim={}, quant={:?}, bytes_per_vector={}): resolve={:.1}ms read={:.1}ms score={:.1}ms",
+                self.schema.index_label(),
                 field.0,
                 stats.vector_count,
                 lazy_flat.dim,
@@ -2622,7 +2638,8 @@ impl SegmentReader {
             );
 
             log::debug!(
-                "[dense_vector_search] field {}: rerank total={:.1}ms",
+                "[dense_vector_search] index={} field {}: rerank total={:.1}ms",
+                self.schema.index_label(),
                 field.0,
                 t_rerank.elapsed().as_secs_f64() * 1000.0
             );

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -152,7 +152,7 @@ impl Drop for GridScratchFiles {
             if let Err(error) = std::fs::remove_file(path)
                 && error.kind() != std::io::ErrorKind::NotFound
             {
-                log::warn!("[reorder_bmp] failed to remove spill {:?}: {}", path, error);
+                log::warn!("[reorder_bmp] failed to remove spill {path:?}: {error}");
             }
         }
     }
@@ -191,6 +191,7 @@ fn spill_grid_entries(
     entries: &mut Vec<BmpGridEntry>,
     scratch: &mut GridScratchFiles,
     field_id: u32,
+    index_label: &str,
     rayon_pool: Option<&rayon::ThreadPool>,
 ) -> Result<()> {
     if entries.is_empty() {
@@ -202,7 +203,8 @@ fn spill_grid_entries(
     crate::segment::builder::bmp::write_grid_run(entries, &path).map_err(crate::Error::Io)?;
     entries.clear();
     log::debug!(
-        "[reorder_bmp] field {}: spilled grid run {} to disk",
+        "[reorder_bmp] index={} field {}: spilled grid run {} to disk",
+        index_label,
         field_id,
         scratch.num_runs(),
     );
@@ -214,6 +216,7 @@ fn write_reorder_grids(
     mut entries: Vec<BmpGridEntry>,
     scratch: &mut GridScratchFiles,
     field_id: u32,
+    index_label: &str,
     dims: usize,
     num_blocks: usize,
     grid_bits: u8,
@@ -244,7 +247,7 @@ fn write_reorder_grids(
         if cancellation_requested(cancellation) {
             return Err(crate::Error::IndexClosed);
         }
-        spill_grid_entries(&mut entries, scratch, field_id, rayon_pool)?;
+        spill_grid_entries(&mut entries, scratch, field_id, index_label, rayon_pool)?;
     }
     drop(entries);
     // Bound both file descriptors and BufReader memory. Extremely large
@@ -511,6 +514,7 @@ fn write_sorted_routed_block(
     grid_run_entries: usize,
     run_files: &mut GridScratchFiles,
     field_id: u32,
+    index_label: &str,
     rayon_pool: Option<&rayon::ThreadPool>,
     scratch: &mut RoutedBlockEncodeScratch,
     encoded_block: &mut Vec<u8>,
@@ -553,7 +557,7 @@ fn write_sorted_routed_block(
             })?);
         scratch.maxima.push(max_impact);
         if grid_entries.len() == grid_run_entries {
-            spill_grid_entries(grid_entries, run_files, field_id, rayon_pool)?;
+            spill_grid_entries(grid_entries, run_files, field_id, index_label, rayon_pool)?;
         }
         grid_entries.push((dimension, out_block, max_impact));
         term_start = term_end;
@@ -959,10 +963,11 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
     let dst_files = SegmentFiles::new(output_id.0);
 
     log::info!(
-        "[reorder] segment {} → {} ({} docs)",
+        "[reorder] segment {} → {} ({} docs) index={}",
         source_id.to_hex(),
         output_id.to_hex(),
         num_docs,
+        schema.index_label(),
     );
 
     // Copy unchanged segment files
@@ -990,10 +995,19 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
         if cancellation_requested(cancellation.as_deref()) {
             return Err(crate::Error::IndexClosed);
         }
-        clone_segment_file(dir, src, dst, required, cancellation.as_deref()).await?;
+        clone_segment_file(
+            dir,
+            schema.index_label(),
+            src,
+            dst,
+            required,
+            cancellation.as_deref(),
+        )
+        .await?;
     }
     log::info!(
-        "[reorder] copied files in {:.1}s",
+        "[reorder] index={} copied files in {:.1}s",
+        schema.index_label(),
         copy_start.elapsed().as_secs_f64(),
     );
 
@@ -1044,8 +1058,13 @@ pub async fn rewrite_vector_segment<D: Directory + DirectoryWriter>(
     let src_files = SegmentFiles::new(source_id.0);
     let dst_files = SegmentFiles::new(output_id.0);
 
+    // Logged when the rewrite *starts*: the ANN payload rebuild that follows
+    // runs for minutes on a large segment, and a line that reads like a
+    // completion made a working rebuild look hung.
+    let rewrite_started = std::time::Instant::now();
     log::info!(
-        "[dense_vector_rewrite] finalizing segment {} → {} ({} docs)",
+        "[dense_vector_rewrite] started: index={} segment {} → {} ({} docs)",
+        schema.index_label(),
         source_id.to_hex(),
         output_id.to_hex(),
         num_docs,
@@ -1071,7 +1090,7 @@ pub async fn rewrite_vector_segment<D: Directory + DirectoryWriter>(
             !reader.sparse_indexes().is_empty() || !reader.bmp_indexes().is_empty(),
         ),
     ] {
-        clone_segment_file(dir, src, dst, required, None).await?;
+        clone_segment_file(dir, schema.index_label(), src, dst, required, None).await?;
     }
 
     let merger = SegmentMerger::new(Arc::clone(schema)).with_background_pool(rayon_pool);
@@ -1100,6 +1119,16 @@ pub async fn rewrite_vector_segment<D: Directory + DirectoryWriter>(
     dir.write_durable(&dst_files.meta, &meta.serialize()?)
         .await?;
 
+    log::info!(
+        "[dense_vector_rewrite] completed: index={} segment {} → {} ({} docs, {} vector payload) in {:.1}s",
+        schema.index_label(),
+        source_id.to_hex(),
+        output_id.to_hex(),
+        num_docs,
+        crate::format_bytes(vector_bytes as u64),
+        rewrite_started.elapsed().as_secs_f64(),
+    );
+
     Ok((output_id.to_hex(), num_docs))
 }
 
@@ -1112,6 +1141,7 @@ pub async fn rewrite_vector_segment<D: Directory + DirectoryWriter>(
 /// Empty files are still created (SegmentReader requires their existence).
 async fn clone_segment_file<D: Directory + DirectoryWriter>(
     dir: &D,
+    index_label: &str,
     src: &Path,
     dst: &Path,
     required: bool,
@@ -1130,7 +1160,8 @@ async fn clone_segment_file<D: Directory + DirectoryWriter>(
         }
         Err(error) => {
             log::debug!(
-                "[segment_clone] link {:?} → {:?} unavailable ({}), streaming instead",
+                "[segment_clone] index={} link {:?} → {:?} unavailable ({}), streaming instead",
+                index_label,
                 src,
                 dst,
                 error,
@@ -1242,12 +1273,14 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
     if !has_bmp_data {
         // No BMP field wants reordering — just copy the sparse file as-is
         log::info!(
-            "[reorder] segment {:x}: no BMP field has the `reorder` schema attribute — sparse file copied unchanged",
+            "[reorder] index={} segment {:x}: no BMP field has the `reorder` schema attribute — sparse file copied unchanged",
+            schema.index_label(),
             reader.meta().id,
         );
         let src_files = SegmentFiles::new(reader.meta().id);
         clone_segment_file(
             dir,
+            schema.index_label(),
             &src_files.sparse,
             &dst_files.sparse,
             true,
@@ -1295,7 +1328,8 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
                 if !*reorder {
                     // Field opted out of BP: copy its blob byte-identically.
                     log::info!(
-                        "[reorder] field {}: `reorder` attribute not set — blob copied unchanged",
+                        "[reorder] index={} field {}: `reorder` attribute not set — blob copied unchanged",
+                        schema.index_label(),
                         field.0,
                     );
                     copy_bmp_blob(
@@ -1392,7 +1426,14 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
     let skip_bytes = u64::from(skip_count)
         .checked_mul(crate::structures::SparseSkipEntry::SIZE as u64)
         .ok_or_else(|| crate::Error::Internal("sparse skip section exceeds u64::MAX".into()))?;
-    super::merger::append_and_delete_temp(dir, &skip_tmp, skip_bytes, &mut writer).await?;
+    super::merger::append_and_delete_temp(
+        dir,
+        &skip_tmp,
+        skip_bytes,
+        &mut writer,
+        schema.index_label(),
+    )
+    .await?;
 
     // Write TOC + footer
     let toc_offset = writer.offset();
@@ -1403,7 +1444,8 @@ async fn reorder_sparse_file<D: Directory + DirectoryWriter>(
 
     let total_dims: usize = field_tocs.iter().map(|f| f.dims.len()).sum();
     log::info!(
-        "[reorder] sparse file written: {} fields, {} dims, {} skip entries (bp_converged={})",
+        "[reorder] index={} sparse file written: {} fields, {} dims, {} skip entries (bp_converged={})",
+        schema.index_label(),
         field_tocs.len(),
         total_dims,
         skip_count,
@@ -1557,7 +1599,8 @@ fn reorder_bmp_field_blockwise(
         .collect();
     drop(perm);
     log::info!(
-        "[reorder_bmp] field {}: blockwise BP over {} blocks in {:.1}ms (converged={})",
+        "[reorder_bmp] index={} field {}: blockwise BP over {} blocks in {:.1}ms (converged={})",
+        index_label,
         field_id,
         num_blocks_total,
         bp_start.elapsed().as_secs_f64() * 1000.0,
@@ -1616,6 +1659,7 @@ fn reorder_bmp_field_blockwise(
                     &mut grid_entries,
                     &mut run_files,
                     field_id,
+                    index_label,
                     rayon_pool.as_deref(),
                 )?;
             }
@@ -1645,6 +1689,7 @@ fn reorder_bmp_field_blockwise(
         grid_entries,
         &mut run_files,
         field_id,
+        index_label,
         dims as usize,
         num_blocks_total,
         grid_bits,
@@ -1711,7 +1756,8 @@ fn reorder_bmp_field_blockwise(
     ));
 
     log::info!(
-        "[reorder_bmp] field {}: blockwise reorder done — {} blocks, {}, phases: data+offsets={:.1}s grids={:.1}s doc_maps={:.1}s total={:.1}s",
+        "[reorder_bmp] index={} field {}: blockwise reorder done — {} blocks, {}, phases: data+offsets={:.1}s grids={:.1}s doc_maps={:.1}s total={:.1}s",
+        index_label,
         field_id,
         num_blocks_total,
         crate::format_bytes(blob_len),
@@ -1913,7 +1959,8 @@ pub(crate) fn reorder_bmp_field(
         })?;
     }
     log::info!(
-        "[reorder_bmp] field {}: validated {} source block(s) in {:.1}ms",
+        "[reorder_bmp] index={} field {}: validated {} source block(s) in {:.1}ms",
+        index_label,
         field_id,
         sources
             .iter()
@@ -1936,7 +1983,8 @@ pub(crate) fn reorder_bmp_field(
                 BpGranularity::Records
             };
             log::info!(
-                "[reorder_bmp] field {}: coherence norm={:.3} (d={:.2}, rand={:.2}, max={:.2}, threshold {:.2}, {}/{} blocks scanned in {:.1}ms) → {:?} granularity",
+                "[reorder_bmp] index={} field {}: coherence norm={:.3} (d={:.2}, rand={:.2}, max={:.2}, threshold {:.2}, {}/{} blocks scanned in {:.1}ms) → {:?} granularity",
+                index_label,
                 field_id,
                 coherence.norm,
                 coherence.d,
@@ -1953,7 +2001,8 @@ pub(crate) fn reorder_bmp_field(
         }
         explicit => {
             log::info!(
-                "[reorder_bmp] field {}: {:?} granularity (explicit, coherence scan skipped)",
+                "[reorder_bmp] index={} field {}: {:?} granularity (explicit, coherence scan skipped)",
+                index_label,
                 field_id,
                 explicit,
             );
@@ -2013,7 +2062,8 @@ pub(crate) fn reorder_bmp_field(
     const MIN_RECORD_WORKSPACE: usize = 16 * 1024 * 1024;
     if record_fixed_peak > memory_budget.saturating_sub(MIN_RECORD_WORKSPACE) {
         log::warn!(
-            "[reorder_bmp] field {}: record maps need {} of the {} total budget; falling back to blockwise order",
+            "[reorder_bmp] index={} field {}: record maps need {} of the {} total budget; falling back to blockwise order",
+            index_label,
             field_id,
             crate::format_bytes(record_fixed_peak as u64),
             crate::format_bytes(memory_budget as u64),
@@ -2082,7 +2132,8 @@ pub(crate) fn reorder_bmp_field(
     }
 
     log::info!(
-        "[reorder_bmp] field {}: running BP on {} real docs from {} source(s)",
+        "[reorder_bmp] index={} field {}: running BP on {} real docs from {} source(s)",
+        index_label,
         field_id,
         num_real_docs,
         sources.len(),
@@ -2103,7 +2154,8 @@ pub(crate) fn reorder_bmp_field(
             *virtual_to_real = Vec::new();
         }
         log::info!(
-            "[reorder_bmp] field {}: zero time budget — identity re-block, forward index skipped",
+            "[reorder_bmp] index={} field {}: zero time budget — identity re-block, forward index skipped",
+            index_label,
             field_id,
         );
         ((0..num_real_docs as u32).collect(), false)
@@ -2134,7 +2186,8 @@ pub(crate) fn reorder_bmp_field(
         };
 
         log::info!(
-            "[reorder_bmp] field {}: forward index built in {:.1}ms ({} terms, {} postings)",
+            "[reorder_bmp] index={} field {}: forward index built in {:.1}ms ({} terms, {} postings)",
+            index_label,
             field_id,
             bp_start.elapsed().as_secs_f64() * 1000.0,
             fwd.num_terms,
@@ -2176,7 +2229,8 @@ pub(crate) fn reorder_bmp_field(
                 run_graph()
             };
             log::info!(
-                "[reorder_bmp] field {}: BP completed in {:.1}ms (converged={})",
+                "[reorder_bmp] index={} field {}: BP completed in {:.1}ms (converged={})",
+                index_label,
                 field_id,
                 graph_start.elapsed().as_secs_f64() * 1000.0,
                 converged,
@@ -2197,7 +2251,8 @@ pub(crate) fn reorder_bmp_field(
     let real_to_virtual: Vec<Vec<u32>> = vid_maps.into_iter().map(|(_, real)| real).collect();
 
     log::info!(
-        "[reorder_bmp] field {}: writing reordered blob ({} blocks)",
+        "[reorder_bmp] index={} field {}: writing reordered blob ({} blocks)",
+        index_label,
         field_id,
         num_real_docs.div_ceil(effective_block_size),
     );
@@ -2341,7 +2396,8 @@ pub(crate) fn reorder_bmp_field(
         };
         if window_end < initial_end {
             log::debug!(
-                "[reorder_bmp] field {}: record window reduced from {} to {} blocks ({} admitted of {} budget)",
+                "[reorder_bmp] index={} field {}: record window reduced from {} to {} blocks ({} admitted of {} budget)",
+                index_label,
                 field_id,
                 initial_end - window_start,
                 window_end - window_start,
@@ -2402,6 +2458,7 @@ pub(crate) fn reorder_bmp_field(
                 grid_run_entries,
                 &mut run_files,
                 field_id,
+                index_label,
                 rayon_pool.as_deref(),
                 &mut block_encode_scratch,
                 &mut encoded_block,
@@ -2448,6 +2505,7 @@ pub(crate) fn reorder_bmp_field(
         grid_entries,
         &mut run_files,
         field_id,
+        index_label,
         dims as usize,
         new_num_blocks,
         grid_bits,
@@ -2510,7 +2568,8 @@ pub(crate) fn reorder_bmp_field(
     ));
 
     log::info!(
-        "[reorder_bmp] field {}: done — {} blocks, {} terms, {} postings, {}, source-block scans={}, phases: transpose+data+offsets={:.1}s grids={:.1}s doc_maps={:.1}s total={:.1}s",
+        "[reorder_bmp] index={} field {}: done — {} blocks, {} terms, {} postings, {}, source-block scans={}, phases: transpose+data+offsets={:.1}s grids={:.1}s doc_maps={:.1}s total={:.1}s",
+        index_label,
         field_id,
         new_num_blocks,
         total_terms,
@@ -2536,12 +2595,12 @@ mod grid_run_prefix_tests {
         let missing = std::path::Path::new("missing");
         let output = std::path::Path::new("output");
 
-        super::clone_segment_file(&dir, missing, output, false, None)
+        super::clone_segment_file(&dir, "test", missing, output, false, None)
             .await
             .unwrap();
         assert!(!dir.exists(output).await.unwrap());
 
-        let error = super::clone_segment_file(&dir, missing, output, true, None)
+        let error = super::clone_segment_file(&dir, "test", missing, output, true, None)
             .await
             .unwrap_err();
         assert!(matches!(error, crate::Error::Corruption(_)));
@@ -2555,7 +2614,7 @@ mod grid_run_prefix_tests {
         let data = vec![0x5a; 4 * 1024 * 1024 + 17];
         dir.write(source, &data).await.unwrap();
 
-        super::clone_segment_file(&dir, source, output, true, None)
+        super::clone_segment_file(&dir, "test", source, output, true, None)
             .await
             .unwrap();
 

--- a/hermes-core/src/segment/types.rs
+++ b/hermes-core/src/segment/types.rs
@@ -337,6 +337,7 @@ mod ann_pin_tests {
         let centroids = CoarseCentroids::train(
             &CoarseConfig::new(2, 2).with_routing(IvfRoutingMode::Flat),
             &vectors,
+            "test",
         );
         let mut trained = TrainedVectorStructures::default();
         trained.centroids.insert(7, Arc::new(centroids));

--- a/hermes-core/src/structures/vector/index/binary_ivf.rs
+++ b/hermes-core/src/structures/vector/index/binary_ivf.rs
@@ -27,6 +27,7 @@ use crate::structures::vector::ivf::routing::{
     effective_binary_routing_mode, routing_parent_count, select_best, select_best_candidates,
     select_parent_beam, select_parent_beam_for_build,
 };
+use crate::structures::vector::progress::PhaseProgress;
 
 /// Hamming distance from one query code to graph nodes backed by a packed
 /// centroid matrix.
@@ -143,6 +144,33 @@ const MAX_BINARY_IVF_CLUSTERS: usize = 1_048_576;
 const BINARY_IVF_SCORE_BATCH: usize = 8_192;
 const BUILD_ASSIGNMENT_CANDIDATES: usize = 128;
 
+/// A code with no set bits carries no information: its Hamming distance to any
+/// query is a constant `popcount(query)`, so it scores mid-range against
+/// *everything* while matching nothing.
+///
+/// It is also a latency cliff. Equal distances resolve to the lowest cluster
+/// ID, so every zero code lands in the same leaf: one production field
+/// accumulated 31% of its vectors — 20.1M codes, 6.0 GiB — in leaf 0, and any
+/// query probing that leaf scanned all of it.
+///
+/// They are still indexed, because the byte-copy merge path requires an ANN
+/// payload to hold exactly as many vectors as flat storage; withholding them
+/// needs a versioned header field and is deliberately not done here. What the
+/// build does instead is count and report them, so a producer regression is
+/// loud rather than a silent scan cliff.
+#[inline]
+fn is_zero_code(code: &[u8]) -> bool {
+    code.iter().all(|&byte| byte == 0)
+}
+
+/// A leaf this many times larger than the average is a scan cliff regardless of
+/// what produced it, so segment builds report it.
+#[cfg(feature = "native")]
+const LEAF_SKEW_WARN_RATIO: usize = 100;
+/// Below this many vectors a skewed leaf cannot cost enough to be worth a line.
+#[cfg(feature = "native")]
+const LEAF_SKEW_WARN_MINIMUM: usize = 10_000;
+
 /// Global Hamming coarse quantizer shared by every segment of a field.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BinaryCoarseQuantizer {
@@ -168,6 +196,7 @@ impl BinaryCoarseQuantizer {
         mut config: BinaryIvfConfig,
         codes: &[u8],
         num_vectors: usize,
+        index_label: &str,
     ) -> io::Result<Self> {
         config
             .validate()
@@ -186,14 +215,14 @@ impl BinaryCoarseQuantizer {
             match effective_binary_routing_mode(config.routing, config.num_clusters) {
                 IvfRoutingMode::TwoLevel => {
                     let (leaves, router) =
-                        train_k_majority_hierarchical(&config, codes, num_vectors);
+                        train_k_majority_hierarchical(&config, codes, num_vectors, index_label);
                     (leaves, Some(router))
                 }
                 IvfRoutingMode::Hnsw => {
                     let leaves = if config.num_clusters >= HIERARCHICAL_TRAINING_THRESHOLD {
-                        train_k_majority_hierarchical(&config, codes, num_vectors).0
+                        train_k_majority_hierarchical(&config, codes, num_vectors, index_label).0
                     } else {
-                        train_k_majority(&config, codes, num_vectors)
+                        train_k_majority(&config, codes, num_vectors, index_label)
                     };
                     let byte_len = config.byte_len();
                     let graph = HnswRoutingGraph::build(
@@ -204,12 +233,14 @@ impl BinaryCoarseQuantizer {
                             kernel: HammingKernel::resolve(),
                         },
                         config.seed,
+                        index_label,
                     );
                     (leaves, Some(BinaryCentroidRouter::Hnsw(graph)))
                 }
-                IvfRoutingMode::Flat | IvfRoutingMode::Auto => {
-                    (train_k_majority(&config, codes, num_vectors), None)
-                }
+                IvfRoutingMode::Flat | IvfRoutingMode::Auto => (
+                    train_k_majority(&config, codes, num_vectors, index_label),
+                    None,
+                ),
             };
         let version = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -630,6 +661,8 @@ pub struct BinaryIvfIndex {
     /// leaves.
     pub(crate) clusters: Vec<(u32, BinaryCluster)>,
     len: usize,
+    /// Indexed codes that carry no information (all bits clear).
+    zero_codes: usize,
 }
 
 /// Streaming build state used by vector-generation rewrites. Only the exact
@@ -642,6 +675,7 @@ pub(crate) struct BinaryIvfBuilder {
     routing: IvfRoutingMode,
     clusters: rustc_hash::FxHashMap<u32, BinaryCluster>,
     len: usize,
+    zero_codes: usize,
 }
 
 impl BinaryIvfBuilder {
@@ -659,6 +693,7 @@ impl BinaryIvfBuilder {
             routing,
             clusters: rustc_hash::FxHashMap::default(),
             len: 0,
+            zero_codes: 0,
         })
     }
 
@@ -705,6 +740,10 @@ impl BinaryIvfBuilder {
         // distinct leaf in the batch instead of per code. Sorting by
         // `(cluster, index)` keeps each leaf's entries in ascending batch order,
         // so the serialized payload is byte-identical to per-code insertion.
+        self.zero_codes += codes
+            .chunks_exact(byte_len)
+            .filter(|code| is_zero_code(code))
+            .count();
         let mut order: Vec<u32> = (0..assignments.len() as u32).collect();
         order.sort_unstable_by_key(|&index| (assignments[index as usize], index));
         let mut run_start = 0usize;
@@ -730,7 +769,7 @@ impl BinaryIvfBuilder {
             }
             run_start = run_end;
         }
-        self.len = self.len.checked_add(doc_id_ordinals.len()).ok_or_else(|| {
+        self.len = self.len.checked_add(order.len()).ok_or_else(|| {
             io::Error::new(io::ErrorKind::InvalidInput, "binary IVF count overflows")
         })?;
         Ok(())
@@ -745,6 +784,7 @@ impl BinaryIvfBuilder {
             num_clusters: self.num_clusters,
             clusters,
             len: self.len,
+            zero_codes: self.zero_codes,
         };
         index
             .validate()
@@ -835,6 +875,19 @@ impl BinaryIvfIndex {
         self.len == 0
     }
 
+    /// Indexed codes that were all-zero.
+    pub fn zero_codes(&self) -> usize {
+        self.zero_codes
+    }
+
+    /// Largest leaf as `(cluster_id, count)`, for skew reporting.
+    pub fn largest_cluster(&self) -> Option<(u32, usize)> {
+        self.clusters
+            .iter()
+            .map(|(cluster_id, cluster)| (*cluster_id, cluster.doc_ids.len()))
+            .max_by_key(|&(cluster_id, count)| (count, std::cmp::Reverse(cluster_id)))
+    }
+
     pub fn estimated_memory_bytes(&self) -> usize {
         self.clusters
             .iter()
@@ -843,8 +896,61 @@ impl BinaryIvfIndex {
     }
 }
 
+/// Report build-quality problems for one segment's binary payload.
+///
+/// Both are silent-degradation modes that cost search latency and recall long
+/// before anything looks broken, so they are surfaced at every build, merge and
+/// rewrite rather than left to be discovered from disk.
+#[cfg(feature = "native")]
+pub(crate) fn report_binary_build_quality(
+    index_label: &str,
+    field_id: u32,
+    index: &BinaryIvfIndex,
+) {
+    let indexed = index.len();
+    let zero = index.zero_codes();
+    if zero > 0 {
+        log::warn!(
+            "[binary_ivf] index={index_label} field={field_id}: {zero} of {indexed} indexed \
+             vectors ({:.1}%) are all-zero — they match nothing, collapse into a single leaf, \
+             and every query probing that leaf scans them; check the embedding producer",
+            100.0 * zero as f64 / indexed.max(1) as f64,
+        );
+        crate::observe::binary_zero_vectors(index_label, field_id, zero, indexed);
+    }
+    if let Some((cluster_id, count)) = index.largest_cluster()
+        && count >= LEAF_SKEW_WARN_MINIMUM
+        && index.num_clusters > 1
+        && count.saturating_mul(index.num_clusters as usize)
+            > indexed.saturating_mul(LEAF_SKEW_WARN_RATIO)
+    {
+        log::warn!(
+            "[binary_ivf] index={index_label} field={field_id}: leaf {cluster_id} holds {count}              of {indexed} vectors ({:.1}%, {:.0}x the average) — every query probing it scans              that leaf in full",
+            100.0 * count as f64 / indexed.max(1) as f64,
+            count as f64 * index.num_clusters as f64 / indexed.max(1) as f64,
+        );
+    }
+}
+
 /// Lloyd-style k-majority clustering in Hamming space.
-fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8> {
+fn train_k_majority(
+    config: &BinaryIvfConfig,
+    codes: &[u8],
+    n: usize,
+    index_label: &str,
+) -> Vec<u8> {
+    train_k_majority_reporting(config, codes, n, index_label, true)
+}
+
+/// As [`train_k_majority`], with progress reporting suppressed for the hundreds
+/// of small child codebooks a hierarchical build trains.
+fn train_k_majority_reporting(
+    config: &BinaryIvfConfig,
+    codes: &[u8],
+    n: usize,
+    index_label: &str,
+    report: bool,
+) -> Vec<u8> {
     let byte_len = config.byte_len();
     let k = config.num_clusters;
     let mut rng = rand::rngs::StdRng::seed_from_u64(config.seed);
@@ -872,7 +978,17 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
     let first = rng.random_range(0..n);
     centroids[..byte_len].copy_from_slice(vec_at(first));
     let mut minimum_weights = vec![f64::INFINITY; n];
+    // Seeding is one full pass over the sample per centroid, so it is O(N*K)
+    // and by far the longest silent stretch of a large codebook.
+    let mut seeding = PhaseProgress::start_if(
+        report,
+        index_label,
+        "k-majority seeding",
+        format!("{k} centroids over {n} samples"),
+        k,
+    );
     for centroid_id in 1..k {
+        seeding.advance(centroid_id);
         let previous = &centroids[(centroid_id - 1) * byte_len..centroid_id * byte_len];
         #[cfg(feature = "native")]
         {
@@ -905,11 +1021,24 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
             .copy_from_slice(vec_at(chosen));
     }
 
+    seeding.finish();
+
     let mut assignment = vec![u32::MAX; n];
     let mut assignment_distances = vec![u32::MAX; n];
     let mut members: Vec<Vec<usize>> = (0..k).map(|_| Vec::new()).collect();
 
+    let mut lloyd = PhaseProgress::start_if(
+        report,
+        index_label,
+        "k-majority refinement",
+        format!(
+            "{k} centroids, {n} samples, <= {} iters",
+            config.train_iters
+        ),
+        config.train_iters,
+    );
     for _iter in 0..config.train_iters {
+        lloyd.advance(_iter);
         // Assignment is point-independent. Give every rayon worker its own
         // score buffer so the O(N*K) scan uses all available training CPUs
         // without synchronization or per-point allocation.
@@ -1018,6 +1147,7 @@ fn train_k_majority(config: &BinaryIvfConfig, codes: &[u8], n: usize) -> Vec<u8>
             }
         }
     }
+    lloyd.finish();
 
     centroids
 }
@@ -1197,13 +1327,14 @@ fn train_k_majority_hierarchical(
     config: &BinaryIvfConfig,
     codes: &[u8],
     n: usize,
+    index_label: &str,
 ) -> (Vec<u8>, BinaryCentroidRouter) {
     let byte_len = config.byte_len();
     let parent_count = routing_parent_count(config.num_clusters).min(n);
     let mut parent_config = config.clone();
     parent_config.num_clusters = parent_count;
     parent_config.max_train_samples = config.max_train_samples.min(n);
-    let parents = train_k_majority(&parent_config, codes, n);
+    let parents = train_k_majority(&parent_config, codes, n, index_label);
 
     let mut assignments = vec![0u32; n];
     let mut group_sizes = vec![0usize; parent_count];
@@ -1253,22 +1384,68 @@ fn train_k_majority_hierarchical(
     }
     drop(assignments);
 
-    let mut leaves = Vec::with_capacity(config.num_clusters.saturating_mul(byte_len));
-    let mut children = vec![Vec::new(); parent_count];
-    for (parent, (group, &child_count)) in groups.iter().zip(&child_counts).enumerate() {
+    // Child codebooks share nothing: each trains from its own parent's group
+    // with its own derived seed. Training them concurrently is the level that
+    // actually fills the machine — one child covers only a few tens of
+    // thousands of codes, far too little work for its internal rayon loops to
+    // saturate a 48-core box, so a sequential loop over parents left most of
+    // the machine idle for the bulk of a large codebook's build.
+    let populated = child_counts.iter().filter(|&&count| count > 0).count();
+    let child_phase = PhaseProgress::start(
+        index_label,
+        "child codebooks",
+        format!("{populated} parents -> {} leaves", config.num_clusters),
+        populated,
+    );
+    let shared = child_phase.shared();
+    let train_child = |(parent, (group, &child_count)): (usize, (&Vec<u8>, &usize))| -> Vec<u8> {
         if child_count == 0 {
-            continue;
+            return Vec::new();
         }
         let mut child_config = config.clone();
         child_config.num_clusters = child_count;
         child_config.max_train_samples = group.len() / byte_len;
         child_config.seed = config.seed ^ (parent as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15);
-        let first_leaf = leaves.len() / byte_len;
-        leaves.extend_from_slice(&train_k_majority(
+        let trained = train_k_majority_reporting(
             &child_config,
             group,
             group.len() / byte_len,
-        ));
+            index_label,
+            false,
+        );
+        shared.complete_one();
+        trained
+    };
+    #[cfg(feature = "native")]
+    let trained_children: Vec<Vec<u8>> = {
+        use rayon::prelude::*;
+        groups
+            .par_iter()
+            .zip(child_counts.par_iter())
+            .enumerate()
+            .map(train_child)
+            .collect()
+    };
+    #[cfg(not(feature = "native"))]
+    let trained_children: Vec<Vec<u8>> = groups
+        .iter()
+        .zip(child_counts.iter())
+        .enumerate()
+        .map(train_child)
+        .collect();
+    child_phase.finish();
+
+    // Assemble in parent order, so the leaf matrix is byte-identical to the
+    // sequential build and every parent still owns one contiguous leaf run.
+    let mut leaves = Vec::with_capacity(config.num_clusters.saturating_mul(byte_len));
+    let mut children = vec![Vec::new(); parent_count];
+    for (parent, (trained, &child_count)) in trained_children.iter().zip(&child_counts).enumerate()
+    {
+        if child_count == 0 {
+            continue;
+        }
+        let first_leaf = leaves.len() / byte_len;
+        leaves.extend_from_slice(trained);
         children[parent].extend((first_leaf..first_leaf + child_count).map(|leaf| leaf as u32));
     }
     debug_assert_eq!(leaves.len(), config.num_clusters * byte_len);
@@ -1294,7 +1471,7 @@ mod tests {
         let mut config = BinaryIvfConfig::new(dim_bits, clusters);
         config.train_iters = 4;
         config.max_train_samples = labels.len();
-        let quantizer = BinaryCoarseQuantizer::train(config, codes, labels.len()).unwrap();
+        let quantizer = BinaryCoarseQuantizer::train(config, codes, labels.len(), "test").unwrap();
         let index = BinaryIvfIndex::build(&quantizer, IvfRoutingMode::Flat, codes, labels).unwrap();
         (quantizer, index)
     }
@@ -1377,7 +1554,7 @@ mod tests {
         config.train_iters = 3;
         config.max_train_samples = points;
         config.routing = IvfRoutingMode::Hnsw;
-        let quantizer = BinaryCoarseQuantizer::train(config, &codes, points).unwrap();
+        let quantizer = BinaryCoarseQuantizer::train(config, &codes, points, "test").unwrap();
         let Some(BinaryCentroidRouter::Hnsw(graph)) = quantizer.routing_index.as_ref() else {
             panic!("HNSW routing expected at 4096 clusters");
         };
@@ -1460,6 +1637,47 @@ mod tests {
         );
     }
 
+    /// Child codebooks train concurrently, so the leaf matrix and topology must
+    /// still be byte-identical whatever the pool width — the quantizer is a
+    /// shared artifact and every segment's postings are keyed to its leaf IDs.
+    #[cfg(feature = "native")]
+    #[test]
+    fn hierarchical_training_is_deterministic_across_thread_counts() {
+        let dim_bits = 64;
+        let byte_len = dim_bits / 8;
+        let points = 4_000;
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0x1234_5678);
+        let mut codes = vec![0u8; points * byte_len];
+        rng.fill_bytes(&mut codes);
+
+        let mut config = BinaryIvfConfig::new(dim_bits, 96);
+        config.train_iters = 3;
+        config.max_train_samples = points;
+
+        let train = |threads: usize| {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .unwrap()
+                .install(|| train_k_majority_hierarchical(&config, &codes, points, "test"))
+        };
+        let (one_leaves, one_router) = train(1);
+        let (eight_leaves, eight_router) = train(8);
+
+        assert_eq!(one_leaves, eight_leaves, "leaf centroids diverged");
+        let (
+            BinaryCentroidRouter::TwoLevel { topology: one, .. },
+            BinaryCentroidRouter::TwoLevel {
+                topology: eight, ..
+            },
+        ) = (&one_router, &eight_router)
+        else {
+            panic!("hierarchical training must produce a two-level router");
+        };
+        assert_eq!(one, eight, "parent topology diverged");
+        assert!(one.validate(config.num_clusters), "topology invalid");
+    }
+
     #[cfg(feature = "native")]
     #[test]
     fn k_majority_is_deterministic_across_thread_counts() {
@@ -1477,12 +1695,12 @@ mod tests {
             .num_threads(1)
             .build()
             .unwrap()
-            .install(|| train_k_majority(&config, &codes, points));
+            .install(|| train_k_majority(&config, &codes, points, "test"));
         let four_threads = rayon::ThreadPoolBuilder::new()
             .num_threads(4)
             .build()
             .unwrap()
-            .install(|| train_k_majority(&config, &codes, points));
+            .install(|| train_k_majority(&config, &codes, points, "test"));
 
         assert_eq!(one_thread, four_threads);
     }
@@ -1520,7 +1738,7 @@ mod tests {
         config.seed = seed;
         config.train_iters = 0;
         config.max_train_samples = codes.len();
-        let centroids = train_k_majority(&config, &codes, codes.len());
+        let centroids = train_k_majority(&config, &codes, codes.len(), "test");
 
         assert_eq!(centroids[0], codes[first]);
         assert_eq!(centroids[1], codes[raw_choice]);
@@ -1621,7 +1839,7 @@ mod tests {
         let codes = [0x00, 0x01, 0x02, 0xf0, 0xf1, 0xf2];
         let labels = [(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)];
         let config = BinaryIvfConfig::new(8, 2);
-        let quantizer = BinaryCoarseQuantizer::train(config, &codes, codes.len()).unwrap();
+        let quantizer = BinaryCoarseQuantizer::train(config, &codes, codes.len(), "test").unwrap();
         let mut builder = BinaryIvfBuilder::new(&quantizer, IvfRoutingMode::Flat).unwrap();
         builder
             .add_batch(&quantizer, &codes[..3], &labels[..3])
@@ -1654,6 +1872,63 @@ mod tests {
                 left.doc_ids
             );
         }
+    }
+
+    /// All-zero codes are counted and reported. They are still indexed —
+    /// the byte-copy merge requires the payload to hold exactly as many
+    /// vectors as flat storage — so the guard is detection, not removal.
+    #[test]
+    fn all_zero_codes_are_counted_and_reported() {
+        let codes = [0x00u8, 0xf0, 0x00, 0x00, 0x0f, 0x00];
+        let labels = [(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)];
+        let mut config = BinaryIvfConfig::new(8, 2);
+        config.train_iters = 2;
+        config.max_train_samples = labels.len();
+        let quantizer = BinaryCoarseQuantizer::train(config, &codes, labels.len(), "test").unwrap();
+        let index =
+            BinaryIvfIndex::build(&quantizer, IvfRoutingMode::Flat, &codes, &labels).unwrap();
+
+        assert_eq!(index.zero_codes(), 4, "four zero codes must be counted");
+        assert_eq!(index.len(), labels.len(), "every vector stays indexed");
+        // Ties resolve to the lowest cluster ID, so the zeros share one leaf:
+        // this is exactly the collapse the report warns about.
+        let (_, largest) = index.largest_cluster().expect("a populated leaf");
+        assert!(
+            largest >= 4,
+            "all-zero codes should share one leaf, got {largest}"
+        );
+        report_binary_build_quality("test-index", 7, &index);
+    }
+
+    /// A field that is entirely zero still produces a payload, so merges that
+    /// require one keep working.
+    #[test]
+    fn an_entirely_zero_field_still_produces_a_payload() {
+        let codes = [0x00u8; 4];
+        let labels = [(0, 0), (1, 0), (2, 0), (3, 0)];
+        let mut config = BinaryIvfConfig::new(8, 2);
+        config.train_iters = 1;
+        config.max_train_samples = labels.len();
+        let quantizer = BinaryCoarseQuantizer::train(config, &codes, labels.len(), "test").unwrap();
+        let index =
+            BinaryIvfIndex::build(&quantizer, IvfRoutingMode::Flat, &codes, &labels).unwrap();
+        assert!(!index.is_empty(), "payload must cover every flat vector");
+        assert_eq!(index.len(), labels.len());
+        assert_eq!(index.zero_codes(), 4);
+    }
+
+    #[test]
+    fn largest_cluster_reports_the_dominant_leaf() {
+        let codes = [0x0fu8, 0x0f, 0x0e, 0x0f, 0x0d, 0x0f, 0xf0];
+        let labels = [(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0)];
+        let mut config = BinaryIvfConfig::new(8, 2);
+        config.train_iters = 4;
+        config.max_train_samples = labels.len();
+        let quantizer = BinaryCoarseQuantizer::train(config, &codes, labels.len(), "test").unwrap();
+        let index =
+            BinaryIvfIndex::build(&quantizer, IvfRoutingMode::Flat, &codes, &labels).unwrap();
+        let (_, count) = index.largest_cluster().expect("a populated leaf");
+        assert_eq!(count, 6, "the dominant leaf holds every near-duplicate");
     }
 
     #[test]
@@ -1725,7 +2000,7 @@ mod tests {
             config.routing = routing;
             config.train_iters = 3;
             config.max_train_samples = 256;
-            let quantizer = BinaryCoarseQuantizer::train(config, &codes, 256).unwrap();
+            let quantizer = BinaryCoarseQuantizer::train(config, &codes, 256, "test").unwrap();
             quantizer.validate_routing(routing).unwrap();
             let plan = quantizer.probe(&codes[..8], 8, routing);
             assert_eq!(plan.cluster_ids.len(), 8);

--- a/hermes-core/src/structures/vector/index/ivf_tq.rs
+++ b/hermes-core/src/structures/vector/index/ivf_tq.rs
@@ -432,7 +432,7 @@ mod tests {
         let dim = 64;
         let codec = std::sync::Arc::new(TqCodec::new(dim));
         let vectors: Vec<Vec<f32>> = (0..64).map(|i| seeded_unit_vector(dim, 100 + i)).collect();
-        let mut centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 4), &vectors);
+        let mut centroids = CoarseCentroids::train(&CoarseConfig::new(dim, 4), &vectors, "test");
         centroids.version = mark_ivf_tq_cosine_generation(centroids.version);
 
         let mut index = IvfTqIndex::new(

--- a/hermes-core/src/structures/vector/index/mod.rs
+++ b/hermes-core/src/structures/vector/index/mod.rs
@@ -8,6 +8,8 @@ mod ivf_tq;
 
 #[cfg(feature = "native")]
 pub(crate) use binary_ivf::BinaryIvfBuilder;
+#[cfg(feature = "native")]
+pub(crate) use binary_ivf::report_binary_build_quality;
 pub use binary_ivf::{BinaryCoarseQuantizer, BinaryIvfConfig, BinaryIvfIndex};
 pub use ivf_tq::{
     IvfTqIndex, TqIvfEncodeScratch, TqIvfQueryPlan, is_ivf_tq_cosine_generation,

--- a/hermes-core/src/structures/vector/ivf/coarse.rs
+++ b/hermes-core/src/structures/vector/ivf/coarse.rs
@@ -121,7 +121,7 @@ impl CoarseCentroids {
     /// Train coarse centroids using k-means algorithm
     ///
     /// Uses deterministic adaptive D² seeding and Lloyd refinement.
-    pub fn train(config: &CoarseConfig, vectors: &[Vec<f32>]) -> Self {
+    pub fn train(config: &CoarseConfig, vectors: &[Vec<f32>], index_label: &str) -> Self {
         assert!(!vectors.is_empty(), "Cannot train on empty vector set");
         assert!(config.num_clusters > 0, "Need at least 1 cluster");
         assert!(vectors.iter().all(|vector| vector.len() == config.dim));
@@ -133,7 +133,7 @@ impl CoarseCentroids {
             .iter()
             .flat_map(|vector| vector.iter().copied())
             .collect::<Vec<_>>();
-        Self::train_contiguous(config, &flat, vectors.len())
+        Self::train_contiguous(config, &flat, vectors.len(), index_label)
     }
 
     /// Train directly from a contiguous row-major matrix.
@@ -141,6 +141,7 @@ impl CoarseCentroids {
         config: &CoarseConfig,
         vectors: &[f32],
         vector_count: usize,
+        index_label: &str,
     ) -> Self {
         assert!(vector_count > 0, "Cannot train on empty vector set");
         assert!(config.num_clusters > 0, "Need at least 1 cluster");
@@ -171,6 +172,7 @@ impl CoarseCentroids {
                             )
                         },
                         config.seed,
+                        index_label,
                     );
                     (leaves, Some(FloatCentroidRouter::Hnsw(graph)))
                 }
@@ -894,7 +896,7 @@ mod tests {
             .collect();
 
         let config = CoarseConfig::new(dim, num_clusters);
-        let centroids = CoarseCentroids::train(&config, &vectors);
+        let centroids = CoarseCentroids::train(&config, &vectors, "test");
 
         assert_eq!(centroids.num_clusters, num_clusters as u32);
         assert_eq!(centroids.dim, dim);
@@ -915,8 +917,8 @@ mod tests {
             .with_seed(91)
             .with_routing(IvfRoutingMode::TwoLevel);
 
-        let rows = CoarseCentroids::train(&config, &vectors);
-        let contiguous = CoarseCentroids::train_contiguous(&config, &flat, vectors.len());
+        let rows = CoarseCentroids::train(&config, &vectors, "test");
+        let contiguous = CoarseCentroids::train_contiguous(&config, &flat, vectors.len(), "test");
 
         assert_eq!(rows.centroids, contiguous.centroids);
         assert_eq!(
@@ -939,7 +941,7 @@ mod tests {
             .collect();
 
         let config = CoarseConfig::new(dim, num_clusters);
-        let centroids = CoarseCentroids::train(&config, &vectors);
+        let centroids = CoarseCentroids::train(&config, &vectors, "test");
 
         // Test that find_nearest returns valid cluster IDs
         for v in &vectors {
@@ -984,7 +986,7 @@ mod tests {
             spill_threshold: 0.0,
         };
         let config = CoarseConfig::new(dim, num_clusters).with_soar(soar_config);
-        let centroids = CoarseCentroids::train(&config, &vectors);
+        let centroids = CoarseCentroids::train(&config, &vectors, "test");
 
         // Test SOAR assignment
         let assignment = centroids.assign(&vectors[0]);
@@ -1171,6 +1173,7 @@ mod tests {
                 .with_routing(IvfRoutingMode::Flat)
                 .with_soar(SoarConfig::new().target_spill_fraction(TARGET_SPILL)),
             &corpus,
+            "test",
         );
         // Share the exact trained codebook so the only variable is whether
         // documents receive selective secondary postings.
@@ -1397,7 +1400,7 @@ mod tests {
             .collect();
 
         let config = CoarseConfig::new(dim, num_clusters);
-        let centroids = CoarseCentroids::train(&config, &vectors);
+        let centroids = CoarseCentroids::train(&config, &vectors, "test");
 
         // Serialize and deserialize
         let bytes = bincode::serde::encode_to_vec(&centroids, bincode::config::standard()).unwrap();
@@ -1419,8 +1422,11 @@ mod tests {
             .collect();
 
         for routing in [IvfRoutingMode::Hnsw, IvfRoutingMode::TwoLevel] {
-            let trained =
-                CoarseCentroids::train(&CoarseConfig::new(dim, 16).with_routing(routing), &vectors);
+            let trained = CoarseCentroids::train(
+                &CoarseConfig::new(dim, 16).with_routing(routing),
+                &vectors,
+                "test",
+            );
             trained.validate_routing(routing).unwrap();
             let plan = trained.probe(&vectors[0], 8, routing);
             assert_eq!(plan.cluster_ids.len(), 8);

--- a/hermes-core/src/structures/vector/ivf/routing.rs
+++ b/hermes-core/src/structures/vector/ivf/routing.rs
@@ -10,6 +10,7 @@ use std::collections::BinaryHeap;
 use std::sync::Arc;
 
 use crate::dsl::IvfRoutingMode;
+use crate::structures::vector::progress::PhaseProgress;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -267,7 +268,12 @@ pub struct HnswRoutingGraph {
 }
 
 impl HnswRoutingGraph {
-    pub fn build(node_count: usize, distance: impl PairDistance, seed: u64) -> Self {
+    pub fn build(
+        node_count: usize,
+        distance: impl PairDistance,
+        seed: u64,
+        index_label: &str,
+    ) -> Self {
         assert!(node_count > 0 && node_count <= u32::MAX as usize);
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         let level_multiplier = 1.0 / (HNSW_M as f64).ln();
@@ -287,7 +293,14 @@ impl HnswRoutingGraph {
         let mut entry_point = insertion_order[0];
         let mut max_level = node_levels[entry_point as usize];
 
-        for &node in insertion_order.iter().skip(1) {
+        let mut progress = PhaseProgress::start(
+            index_label,
+            "hnsw graph build",
+            format!("{node_count} centroids, M={HNSW_M}, ef={HNSW_EF_CONSTRUCTION}"),
+            node_count,
+        );
+        for (inserted, &node) in insertion_order.iter().enumerate().skip(1) {
+            progress.advance(inserted);
             let node_level = node_levels[node as usize];
             let mut entry = entry_point;
             let node_distance = PairQueryDistance {
@@ -344,6 +357,7 @@ impl HnswRoutingGraph {
                 max_level = node_level;
             }
         }
+        progress.finish();
 
         Self::compact(
             HNSW_M,
@@ -1461,7 +1475,7 @@ mod tests {
             let [rx, ry] = points[right as usize];
             (lx - rx).powi(2) + (ly - ry).powi(2)
         };
-        let graph = HnswRoutingGraph::build(points.len(), distance, 42);
+        let graph = HnswRoutingGraph::build(points.len(), distance, 42, "test");
         assert!(graph.validate(points.len()));
         assert!(graph.size_bytes() < points.len() * 512);
 

--- a/hermes-core/src/structures/vector/mod.rs
+++ b/hermes-core/src/structures/vector/mod.rs
@@ -25,6 +25,7 @@
 pub mod index;
 pub mod ivf;
 mod kmeans;
+pub(crate) mod progress;
 pub mod quantization;
 
 #[cfg(feature = "native")]

--- a/hermes-core/src/structures/vector/progress.rs
+++ b/hermes-core/src/structures/vector/progress.rs
@@ -1,0 +1,245 @@
+//! Progress reporting for long, otherwise silent training phases.
+//!
+//! Production codebook training runs for tens of minutes — a 163,342-cluster
+//! binary field spent 1h24m between "training started" and "artifact saved"
+//! with no output at all, which is indistinguishable from a hang. Every phase
+//! that can run longer than a few seconds reports here, rate-limited so a long
+//! phase produces a steady trickle rather than a flood.
+
+#[cfg(feature = "native")]
+use std::time::{Duration, Instant};
+
+/// Minimum gap between progress lines within one phase.
+#[cfg(feature = "native")]
+const PROGRESS_INTERVAL: Duration = Duration::from_secs(30);
+
+/// One named training phase with a known amount of work.
+pub(crate) struct PhaseProgress {
+    index: String,
+    label: &'static str,
+    detail: String,
+    total: usize,
+    report: bool,
+    #[cfg(feature = "native")]
+    started: Instant,
+    #[cfg(feature = "native")]
+    last_report: Instant,
+}
+
+impl PhaseProgress {
+    /// Announce a phase. `total` is the unit count `advance` counts toward.
+    ///
+    /// `index` names the index being trained: several indexes train at once in
+    /// production, and without it their interleaved lines are unattributable.
+    pub(crate) fn start(index: &str, label: &'static str, detail: String, total: usize) -> Self {
+        Self::start_if(true, index, label, detail, total)
+    }
+
+    /// As [`Self::start`], but silent when `report` is false.
+    ///
+    /// Hierarchical training runs hundreds of small child codebooks through the
+    /// same code as one large one; only the outer phase should be logged.
+    pub(crate) fn start_if(
+        report: bool,
+        index: &str,
+        label: &'static str,
+        detail: String,
+        total: usize,
+    ) -> Self {
+        if report {
+            log::info!("[vector_training] {label} started: index={index} {detail}");
+        }
+        Self {
+            index: index.to_owned(),
+            label,
+            detail,
+            total,
+            report,
+            #[cfg(feature = "native")]
+            started: Instant::now(),
+            #[cfg(feature = "native")]
+            last_report: Instant::now(),
+        }
+    }
+
+    /// Report cumulative progress, at most once per [`PROGRESS_INTERVAL`].
+    ///
+    /// Called from sequential outer loops only, so it never contends.
+    #[allow(unused_variables)]
+    pub(crate) fn advance(&mut self, done: usize) {
+        if !self.report {
+            return;
+        }
+        #[cfg(feature = "native")]
+        {
+            let now = Instant::now();
+            if now.duration_since(self.last_report) < PROGRESS_INTERVAL || done == 0 {
+                return;
+            }
+            self.last_report = now;
+            let elapsed = now.duration_since(self.started);
+            let percent = if self.total == 0 {
+                0.0
+            } else {
+                100.0 * done as f64 / self.total as f64
+            };
+            // Extrapolate from the completed fraction; the remaining work is
+            // homogeneous in every phase reporting here.
+            let remaining = if done == 0 || done >= self.total {
+                Duration::ZERO
+            } else {
+                elapsed.mul_f64((self.total - done) as f64 / done as f64)
+            };
+            log::info!(
+                "[vector_training] {} index={} {}/{} ({percent:.1}%) in {:.1}s, ~{:.0}s left: {}",
+                self.label,
+                self.index,
+                done,
+                self.total,
+                elapsed.as_secs_f64(),
+                remaining.as_secs_f64(),
+                self.detail,
+            );
+        }
+    }
+
+    /// Progress counter for a phase whose units complete on worker threads.
+    ///
+    /// Reporting is gated on completion count rather than elapsed time so it
+    /// stays lock-free; the phase emits at most [`SHARED_PROGRESS_STEPS`] lines.
+    pub(crate) fn shared(&self) -> SharedProgress {
+        SharedProgress {
+            index: self.index.clone(),
+            label: self.label,
+            total: self.total,
+            done: std::sync::atomic::AtomicUsize::new(0),
+            step: self.total.div_ceil(SHARED_PROGRESS_STEPS).max(1),
+        }
+    }
+
+    /// Close the phase with its total wall time.
+    pub(crate) fn finish(self) {
+        if !self.report {
+            return;
+        }
+        #[cfg(feature = "native")]
+        log::info!(
+            "[vector_training] {} complete in {:.1}s: index={} {}",
+            self.label,
+            self.started.elapsed().as_secs_f64(),
+            self.index,
+            self.detail,
+        );
+        #[cfg(not(feature = "native"))]
+        log::info!(
+            "[vector_training] {} complete: index={} {}",
+            self.label,
+            self.index,
+            self.detail
+        );
+    }
+}
+
+/// Lines emitted by a [`SharedProgress`] over a whole phase.
+const SHARED_PROGRESS_STEPS: usize = 20;
+
+/// Completion counter safe to advance from worker threads.
+pub(crate) struct SharedProgress {
+    index: String,
+    label: &'static str,
+    total: usize,
+    done: std::sync::atomic::AtomicUsize,
+    step: usize,
+}
+
+impl SharedProgress {
+    /// Record one completed unit, logging on every `step`-th completion.
+    pub(crate) fn complete_one(&self) {
+        let done = self.done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+        if done.is_multiple_of(self.step) && done < self.total {
+            log::info!(
+                "[vector_training] {} index={} {done}/{} ({:.0}%)",
+                self.label,
+                self.index,
+                self.total,
+                100.0 * done as f64 / self.total as f64,
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    static CAPTURED: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+    struct CaptureLogger;
+
+    impl log::Log for CaptureLogger {
+        fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+            true
+        }
+        fn log(&self, record: &log::Record<'_>) {
+            CAPTURED
+                .get_or_init(Default::default)
+                .lock()
+                .unwrap()
+                .push(record.args().to_string());
+        }
+        fn flush(&self) {}
+    }
+
+    /// Every training line must name its index: production runs several
+    /// retrains at once and their output interleaves.
+    #[test]
+    fn training_progress_lines_carry_the_index_name() {
+        let _ = log::set_boxed_logger(Box::new(CaptureLogger));
+        log::set_max_level(log::LevelFilter::Info);
+
+        let phase = PhaseProgress::start(
+            "documents_20260724",
+            "k-majority seeding",
+            "163342 centroids".into(),
+            4,
+        );
+        phase.shared().complete_one();
+        phase.finish();
+        let silent = PhaseProgress::start_if(
+            false,
+            "social_20260724",
+            "child codebooks",
+            "quiet".into(),
+            1,
+        );
+        silent.finish();
+
+        let lines = CAPTURED
+            .get_or_init(Default::default)
+            .lock()
+            .unwrap()
+            .clone();
+        assert!(
+            lines
+                .iter()
+                .all(|line| line.contains("index=documents_20260724")),
+            "unlabelled training line: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|line| line
+                .contains("k-majority seeding started: index=documents_20260724 163342 centroids")),
+            "start line shape changed: {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("k-majority seeding complete in")),
+            "missing completion line: {lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|line| line.contains("social")),
+            "suppressed phase must stay silent: {lines:?}"
+        );
+    }
+}

--- a/hermes-tool/src/vector_ops.rs
+++ b/hermes-tool/src/vector_ops.rs
@@ -78,7 +78,7 @@ pub fn train_centroids(
     let coarse_config = hermes_core::structures::CoarseConfig::new(dim, num_clusters)
         .with_max_iters(max_iters)
         .with_seed(seed);
-    let centroids = CoarseCentroids::train(&coarse_config, &vectors);
+    let centroids = CoarseCentroids::train(&coarse_config, &vectors, "hermes-tool");
     let elapsed = start.elapsed();
 
     info!(
@@ -163,7 +163,7 @@ pub async fn retrain_centroids(
     let coarse_config = hermes_core::structures::CoarseConfig::new(dim, num_clusters)
         .with_max_iters(max_iters)
         .with_seed(seed);
-    let centroids = CoarseCentroids::train(&coarse_config, &vectors);
+    let centroids = CoarseCentroids::train(&coarse_config, &vectors, "hermes-tool");
 
     // Save centroids to index directory
     let centroids_path = index_path.join("coarse_centroids.bin");


### PR DESCRIPTION
Found while diagnosing why `documents_20260724` dense queries run ~1 s and `social_20260724` runs ~15 ms. Three separate blind spots, plus the guard that would have caught the root cause months earlier.

## 1. Training was silent

A 163,342-cluster binary field spent **1h24m** between "training started" and "artifact saved" with no output — indistinguishable from a hang, and we spent real time deciding whether prod was stuck.

Every long phase now reports through `PhaseProgress`: start, rate-limited progress with an extrapolated ETA, completion with elapsed.

```
[vector_training] k-majority seeding started: index=documents_20260724 163342 centroids over 10000000 samples
[vector_training] k-majority seeding index=documents_20260724 41000/163342 (25.1%) in 300.0s, ~896s left: …
[vector_training] child codebooks index=documents_20260724 81/405 (20%)
[vector_training] hnsw graph build complete in 412.7s: index=documents_20260724 163342 centroids, M=32, ef=200
```

The rendered output is pinned by a test that installs a capturing `log::Log`, not by asserting on a format string.

## 2. The serial phase wasn't where I'd have guessed

Instrumenting first paid off: the bottleneck is **not** the HNSW graph build but the loop over ~405 parents training child codebooks. One child covers a few tens of thousands of codes — far too little for its internal rayon loops to fill 48 cores.

Children are independent (own group, own derived seed), so they now train concurrently and assemble in parent order, leaving the leaf matrix **byte-identical**. Pinned by `hierarchical_training_is_deterministic_across_thread_counts` (1 vs 8 threads → identical leaves *and* topology).

I did **not** parallelise HNSW insertion — it's inherently sequential and a batch-parallel variant changes graph quality. It's measurable now, so it can be judged on evidence.

## 3. Logs couldn't be attributed to an index

Two indexes retrain concurrently in production and their output interleaves. Before this, exactly **three** log lines in the whole workspace carried an index name.

~170 index-scoped sites now carry `index=<name>`, following the existing `[reorder][bp] started: index=… field=…` convention. Most were reachable via `self.schema.index_label()`; ~15 needed a threaded `index_label` parameter; two needed a struct field (`PhaseProgress`, `ActiveSegmentOperations`).

Deliberately left alone: `pin.rs`/`tracker.rs`/`segment/types.rs`, whose types hold no index context and whose messages already carry a segment ID or a path under `/data/<index>/`, plus genuinely process-wide lines.

Also: `[dense_vector_rewrite] finalizing segment …` is logged when a rewrite **starts**, which made a working rebuild look hung. It's now a started/completed pair with elapsed and payload size.

## 4. Zero-vector guards

31% of one production field's vectors are all-zero embeddings (an upstream producer regression). Ties resolve to the lowest cluster ID, so **20.1M codes — 6.0 GiB — collapsed into leaf 0**, and ~48,600 of 163,342 centroids became all-zero duplicates that can never be assigned. Every query probing that leaf scanned all of it. None of this was observable.

- Build, merge and rewrite count all-zero codes and report them per index/field, plus `hermes_binary_zero_vectors_total`.
- Any leaf holding >100× the average (and ≥10k vectors) is reported — catches a collapse from *any* cause.
- Coarse training excludes all-zero codes from the sample so they stop consuming centroids; sample-coverage accounting subtracts them explicitly, so a real traversal bug still trips.
- All-zero **queries** are refused: Hamming distance from them is `popcount(candidate)`, so they rank by bit count rather than similarity — almost always a caller that failed to embed.

**These guards detect rather than remove.** Withholding zero codes from the ANN payload breaks the byte-copy merge, which requires `header.vector_count == flat.num_vectors` — an on-disk integrity invariant. Doing it safely needs a versioned header field and belongs in its own change.

## 5. Warnings

Silences dead-code analysis **only** in the featureless library build, where the encode half of `bmp_adaptive` and `BmpIndex::iter_block_terms` have no caller because `segment::builder` and `segment::reorder` are gated on `native`/`wasm`. Detection stays fully active in every shipping configuration.

## Validation

- 1,041 lib + all integration tests on aarch64; 1,039 on x86_64 under Rosetta
- `cargo clippy --all-targets -- -D warnings` (the exact CI command) clean
- hermes-core / hermes-tool / hermes-server clippy with all features clean
- WASM-feature and no-default-features library checks: zero warnings

No on-disk format change.