### PR TITLE
perf(core): compact binary ANN runs at merge and reorder

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -84,6 +84,31 @@ headroom; both would have fired months early):
 - `fragmentation ≥ 8` → warn (a rebuilt segment is 1.0; 32-way merges can
   reach 32 in one step)
 
+## Run compaction
+
+Fragmentation now heals itself instead of only being reported:
+
+- **Merges** compact binary ANN runs when the byte-copy output would reach
+  fragmentation ≥ 4 (`ANN_COMPACTION_FRAGMENTATION_THRESHOLD`): the payload is
+  rewritten cluster-major — one extent per cluster, document IDs made absolute
+  — restoring the freshly-built layout. Below the threshold, merges keep the
+  cheap byte-copy, so shallow merge trees pay nothing.
+- **The external `reorder` API** (the optimize pass) compacts at _any_
+  fragmentation above 1.0, alongside its BP reorder of sparse fields. It
+  requires the trained artifacts to be loaded; without them the vectors file
+  is cloned unchanged and a warning names why.
+
+Compaction streams the same payload bytes the byte-copy merge already
+writes; the only extra work is one `u32` add per posting for the doc-ID
+rewrite. Peak extra memory is a 256 KiB scratch buffer plus one 48-byte
+directory record per non-empty cluster — nothing scales with vectors.
+Measured on 0.32 GiB across 4 sources (aarch64, warm cache): byte-copy
+9.8 GiB/s, compaction 20.1 GiB/s — the cluster-major writer is _faster_
+because it streams larger sequential extents. TQ payloads are exempt: their
+codes are block-packed and cannot be concatenated without re-packing.
+
+`hermes_ann_fragmentation` and `hermes-tool diagnose` observe the outcome.
+
 ## Tiers
 
 ### Passive: segment open (always on)

--- a/hermes-core/src/index/tests/vector.rs
+++ b/hermes-core/src/index/tests/vector.rs
@@ -1334,6 +1334,105 @@ async fn test_all_zero_binary_query_is_refused() {
     assert!(!results.is_empty(), "non-zero queries must still be served");
 }
 
+/// The merge and reorder compaction policies together: a 2-way byte-copy
+/// merge stays below the merge threshold and carries fragmentation 2.0, and
+/// the explicit reorder pass — the external `reorder` API — then compacts the
+/// binary ANN payload back to one extent per cluster with identical results.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reorder_compacts_fragmented_binary_ann_runs() {
+    use crate::dsl::BinaryDenseVectorConfig;
+    use crate::query::BinaryDenseVectorQuery;
+
+    let dim_bits = 64;
+    let byte_len = dim_bits / 8;
+    let mut sb = SchemaBuilder::default();
+    sb.set_index_name("reorder-compaction");
+    let title = sb.add_text_field("title", true, true);
+    let cfg = BinaryDenseVectorConfig::new(dim_bits).with_ivf(Some(8), 8);
+    let bvec = sb.add_binary_dense_vector_field_with_config("bvec", true, true, cfg);
+    // A reorder-enabled BMP sparse field so the reorder pass has its usual
+    // BP work to do alongside the ANN compaction.
+    let sparse = sb.add_sparse_vector_field_with_config(
+        "sparse",
+        true,
+        false,
+        crate::structures::SparseVectorConfig::splade_bmp(),
+    );
+    sb.set_reorder(sparse, true);
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+        .await
+        .unwrap();
+    let add_batch = |writer: &mut IndexWriter<RamDirectory>, offset: u32| {
+        for i in 0u32..60 {
+            let mut doc = Document::new();
+            doc.add_text(title, format!("doc {} hemoglobin", offset + i));
+            let value = (offset + i) as u8 | 0x01;
+            doc.add_binary_dense_vector(bvec, vec![value; byte_len]);
+            doc.add_sparse_vector(sparse, vec![(0, 1.0), (1 + (i % 5), 0.5)]);
+            writer.add_document(doc).unwrap();
+        }
+    };
+    add_batch(&mut writer, 0);
+    writer.commit().await.unwrap();
+    writer.build_vector_index().await.unwrap();
+    add_batch(&mut writer, 100);
+    writer.commit().await.unwrap();
+    // Merge the two ANN-bearing segments: 2 sources is below the merge
+    // compaction threshold, so byte-copy preserves both extents per cluster.
+    writer.force_merge().await.unwrap();
+
+    let fragmentation_of = |segments: &[std::sync::Arc<crate::segment::SegmentReader>]| {
+        segments
+            .iter()
+            .filter_map(|segment| segment.ann_health(bvec))
+            .map(|health| health.fragmentation())
+            .fold(0.0f64, f64::max)
+    };
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    let before = fragmentation_of(&index.segment_readers().await.unwrap());
+    assert!(
+        before > 1.5,
+        "byte-copy merge must leave multi-extent clusters, got {before}"
+    );
+    let needle = vec![0x0f_u8 | 0x01; byte_len];
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let before_results = searcher
+        .search(&BinaryDenseVectorQuery::new(bvec, needle.clone()), 10)
+        .await
+        .unwrap();
+    drop(searcher);
+
+    // The external reorder API: BP-reorders the sparse field AND compacts
+    // the fragmented binary ANN payload.
+    writer.reorder().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir, config).await.unwrap();
+    let after = fragmentation_of(&index.segment_readers().await.unwrap());
+    assert!(
+        (after - 1.0).abs() < 1e-9,
+        "reorder must compact ANN runs to one extent per cluster, got {after}"
+    );
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let after_results = searcher
+        .search(&BinaryDenseVectorQuery::new(bvec, needle), 10)
+        .await
+        .unwrap();
+    assert_eq!(before_results.len(), after_results.len());
+    for (before_hit, after_hit) in before_results.iter().zip(&after_results) {
+        assert!(
+            (before_hit.score - after_hit.score).abs() < 1e-6,
+            "scores must be identical after compaction"
+        );
+    }
+}
+
 /// Partial probing with a non-`Max` combiner: reusing the probe's exact scores
 /// must not lose the ordinals that live *outside* the probed leaves.
 ///

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -3579,6 +3579,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             granularity,
             rayon_pool,
             Some(self.active_operations.cancellation_flag()),
+            self.trained_for_segment_build(),
         )
         .await;
         let (new_id, total_docs, bp_converged) = match reorder_result {

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -466,7 +466,8 @@ impl AnnDiskIndex {
             log::warn!(
                 "[ann_health] index={index_label} field={field_id} segment={segment_id:016x}: \
                  {fragmentation:.1} extents per probed cluster ({} runs / {} clusters) — \
-                 cold probes pay that many seeks; a vector-generation rewrite compacts to 1.0",
+                 cold probes pay that many seeks; the next merge or vector-generation rewrite \
+                 compacts to 1.0",
                 health.runs,
                 health.clusters_nonempty,
             );
@@ -1457,6 +1458,261 @@ pub(crate) fn write_merged_ann_cancellable(
     write_merged_ann_impl(sources, &[], writer, cancellation)
 }
 
+/// Physical extents per non-empty cluster the byte-copy merge of `sources`
+/// would produce.
+///
+/// Byte-copy preserves every source run, so the merged fragmentation is
+/// `total runs / distinct non-empty clusters` — computable exactly from the
+/// in-memory directories before writing a byte. The merge policy compacts
+/// when this crosses its threshold instead of letting probe read
+/// amplification grow another generation.
+#[cfg(feature = "native")]
+pub(crate) fn predicted_merge_fragmentation(sources: &[(&AnnDiskIndex, u32)]) -> f64 {
+    let mut total_runs = 0usize;
+    // Distinct clusters via a k-way sorted walk over the (already
+    // cluster-sorted) directories — no allocation proportional to clusters.
+    let mut cursors: Vec<std::iter::Peekable<std::slice::Iter<'_, AnnRun>>> = sources
+        .iter()
+        .map(|(source, _)| {
+            total_runs += source.runs.len();
+            source.runs.iter().peekable()
+        })
+        .collect();
+    let mut distinct = 0usize;
+    while let Some(cluster) = cursors
+        .iter_mut()
+        .filter_map(|cursor| cursor.peek().map(|run| run.cluster_id))
+        .min()
+    {
+        distinct += 1;
+        for cursor in &mut cursors {
+            while cursor.peek().is_some_and(|run| run.cluster_id == cluster) {
+                cursor.next();
+            }
+        }
+    }
+    if distinct == 0 {
+        0.0
+    } else {
+        total_runs as f64 / distinct as f64
+    }
+}
+
+/// Cluster-major compacting merge for binary IVF payloads.
+///
+/// The byte-copy merge keeps each source payload as one physical extent, so a
+/// logical cluster's postings scatter across up to `sources.len()` extents —
+/// and another factor per earlier merge generation. Every extent is a
+/// potential seek when the index is cold; production measured the array
+/// IOPS-bound at 32 KB/read from exactly this. This writer instead gathers
+/// each cluster's runs from all sources and emits **one contiguous run per
+/// cluster**, restoring the freshly-built layout (fragmentation 1.0).
+///
+/// Cost: the same total payload bytes the byte-copy merge already streams,
+/// plus one `u32` add per posting — document IDs are rewritten absolute
+/// (`doc_base = 0`) because runs from different sources cannot share a single
+/// directory entry otherwise. Codes and ordinals are copied verbatim.
+///
+/// Binary only: binary code columns are exactly `count × code_size`, so
+/// concatenating runs is trivially valid. TQ payloads pack codes into
+/// fixed-lane blocks with per-run tail padding; concatenating those without
+/// re-packing would corrupt block boundaries, so TQ merges stay byte-copy.
+/// Compact binary ANN runs when a byte-copy merge would leave this many
+/// physical extents per probed cluster.
+///
+/// A rebuilt segment is 1.0 and each byte-copy merge multiplies by its source
+/// count, so 4 permits roughly two cheap 2-way generations before a merge
+/// pays the compaction pass. Explicit reorder/optimize passes compact at any
+/// fragmentation above 1.0 instead — an optimize command should hand back the
+/// freshly-built layout.
+#[cfg(feature = "native")]
+pub(crate) const ANN_COMPACTION_FRAGMENTATION_THRESHOLD: f64 = 4.0;
+
+/// Doc IDs rewritten per scratch flush during compaction (256 KiB of u32s).
+#[cfg(feature = "native")]
+const DOC_ID_REWRITE_CHUNK: usize = 64 * 1024;
+
+#[cfg(feature = "native")]
+pub(crate) fn write_compacted_ann_cancellable(
+    sources: &[(&AnnDiskIndex, u32)],
+    writer: &mut (impl Write + ?Sized),
+    cancellation: Option<&std::sync::atomic::AtomicBool>,
+) -> io::Result<u64> {
+    let Some((first, _)) = sources.first() else {
+        return Err(invalid_data("cannot compact an empty ANN source list"));
+    };
+    if first.header.kind != AnnKind::BinaryIvf {
+        return Err(invalid_data(
+            "ANN run compaction is only defined for binary IVF payloads",
+        ));
+    }
+    let mut header = first.header.clone();
+    header.vector_count = 0;
+    for &(source, _) in sources {
+        if !headers_compatible(&first.header, &source.header) {
+            return Err(invalid_data(
+                "ANN compaction sources use incompatible generations",
+            ));
+        }
+        header.vector_count = header
+            .vector_count
+            .checked_add(source.header.vector_count)
+            .ok_or_else(|| invalid_data("compacted ANN vector count overflows usize"))?;
+    }
+    validate_header(&header)?;
+    write_header(writer, &header)?;
+
+    let code_size = header.code_size;
+    let mut offset = ANN_HEADER_SIZE as u64;
+    let mut records: Vec<RunRecord> = Vec::new();
+    let mut scratch = Vec::new();
+    let mut cursors: Vec<usize> = vec![0; sources.len()];
+
+    loop {
+        if cancellation.is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Relaxed)) {
+            return Err(io::Error::new(
+                io::ErrorKind::Interrupted,
+                "ANN compaction cancelled",
+            ));
+        }
+        // Next cluster = minimum un-consumed cluster ID across sources.
+        let Some(cluster_id) = sources
+            .iter()
+            .zip(&cursors)
+            .filter_map(|((source, _), &cursor)| source.runs.get(cursor).map(|run| run.cluster_id))
+            .min()
+        else {
+            break;
+        };
+
+        // Pass 1: doc IDs, rewritten absolute. Sources are visited in
+        // segment order and each source's same-cluster runs in directory
+        // order, which is ascending document ranges — so the output column
+        // stays sorted like a built segment's.
+        let mut count = 0usize;
+        let mut max_doc_id = 0u32;
+        let doc_ids_offset = offset;
+        for (source_index, &(source, segment_base)) in sources.iter().enumerate() {
+            let mut cursor = cursors[source_index];
+            while let Some(run) = source
+                .runs
+                .get(cursor)
+                .filter(|run| run.cluster_id == cluster_id)
+            {
+                let base = run
+                    .doc_base
+                    .checked_add(segment_base)
+                    .ok_or_else(|| invalid_data("compacted ANN document base overflows u32"))?;
+                let bytes = source.raw.as_slice();
+                // Chunked rewrite: peak scratch stays at 256 KiB no matter how
+                // large the run — the production incident had a single run of
+                // 20M postings, and buffering it whole would be an 80 MB spike
+                // in the middle of a merge.
+                for chunk_start in (0..run.count).step_by(DOC_ID_REWRITE_CHUNK) {
+                    let chunk_end = (chunk_start + DOC_ID_REWRITE_CHUNK).min(run.count);
+                    scratch.clear();
+                    scratch.reserve((chunk_end - chunk_start) * 4);
+                    for index in chunk_start..chunk_end {
+                        let doc_id = run_doc_id_with_base(bytes, run, index, base)?;
+                        max_doc_id = max_doc_id.max(doc_id);
+                        scratch.extend_from_slice(&doc_id.to_le_bytes());
+                    }
+                    writer.write_all(&scratch)?;
+                    if cancellation
+                        .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Relaxed))
+                    {
+                        return Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "ANN compaction cancelled",
+                        ));
+                    }
+                }
+                offset = checked_advance(offset, run.count * 4)?;
+                count = count
+                    .checked_add(run.count)
+                    .ok_or_else(|| invalid_data("compacted ANN run count overflows usize"))?;
+                cursor += 1;
+            }
+        }
+
+        // Pass 2: ordinals, verbatim.
+        let ordinals_offset = offset;
+        for (source_index, &(source, _)) in sources.iter().enumerate() {
+            let mut cursor = cursors[source_index];
+            while let Some(run) = source
+                .runs
+                .get(cursor)
+                .filter(|run| run.cluster_id == cluster_id)
+            {
+                copy_range(writer, &source.raw, run.ordinals.clone(), cancellation)?;
+                offset = checked_advance(offset, run.ordinals.len())?;
+                cursor += 1;
+            }
+        }
+
+        // Pass 3: codes, verbatim — the dominant bytes.
+        let codes_offset = offset;
+        for (source_index, &(source, _)) in sources.iter().enumerate() {
+            let mut cursor = cursors[source_index];
+            while let Some(run) = source
+                .runs
+                .get(cursor)
+                .filter(|run| run.cluster_id == cluster_id)
+            {
+                copy_range(writer, &source.raw, run.codes.clone(), cancellation)?;
+                offset = checked_advance(offset, run.codes.len())?;
+                cursor += 1;
+            }
+        }
+
+        // Consume this cluster's runs from every cursor.
+        for (source_index, &(source, _)) in sources.iter().enumerate() {
+            while source
+                .runs
+                .get(cursors[source_index])
+                .is_some_and(|run| run.cluster_id == cluster_id)
+            {
+                cursors[source_index] += 1;
+            }
+        }
+
+        records.push(RunRecord {
+            cluster_id,
+            doc_base: 0,
+            count: u32::try_from(count)
+                .map_err(|_| invalid_data("compacted ANN run exceeds u32 vectors"))?,
+            max_doc_id,
+            doc_ids_offset,
+            ordinals_offset,
+            codes_offset,
+            codes_len: u64::try_from(expected_codes_column_len(
+                AnnKind::BinaryIvf,
+                count,
+                code_size,
+            )?)
+            .map_err(|_| invalid_data("compacted ANN code length exceeds u64"))?,
+        });
+    }
+
+    if records.is_empty() {
+        return Err(invalid_data("cannot compact an ANN payload with no runs"));
+    }
+    finish_layout(writer, offset, &records)
+}
+
+/// [`run_doc_id`] against an explicit base, for rewriting IDs absolute.
+#[cfg(feature = "native")]
+fn run_doc_id_with_base(bytes: &[u8], run: &AnnRun, index: usize, base: u32) -> io::Result<u32> {
+    let local_doc_id = read_u32(bytes, run.doc_ids.start + index * 4);
+    if local_doc_id > run.max_doc_id {
+        return Err(invalid_data(
+            "ANN run contains a document above its declared maximum",
+        ));
+    }
+    base.checked_add(local_doc_id)
+        .ok_or_else(|| invalid_data("compacted ANN document ID overflows u32"))
+}
+
 /// [`write_merged_ann`] plus freshly built runs appended to the payload —
 /// used when some merge sources predate the field's current format and were
 /// re-encoded while every compatible source is still byte-copied.
@@ -1904,6 +2160,261 @@ fn invalid_data(message: impl Into<String>) -> io::Error {
 #[cfg(all(test, feature = "native"))]
 mod tests {
     use super::*;
+
+    /// Compaction must produce a payload indistinguishable from a fresh
+    /// build: one run per cluster, fragmentation 1.0, absolute doc IDs — and
+    /// return exactly the results the byte-copy merge of the same sources
+    /// returns, for every cluster.
+    #[test]
+    fn compacted_merge_matches_byte_copy_and_resets_fragmentation() {
+        // Segment A: clusters {0: 3 docs, 5: 2 docs}. Segment B: {0: 2, 2: 1}.
+        // Merging A+B and then merging that result with A again produces
+        // multi-generation fragmentation (cluster 0 in three extents).
+        let a0_docs = [0u32, 1, 2];
+        let a0_ords = [0u16, 0, 1];
+        let a0_codes = [0x11u8, 0x22, 0x33];
+        let a5_docs = [3u32, 4];
+        let a5_ords = [0u16; 2];
+        let a5_codes = [0x44u8, 0x55];
+        let a_runs = [
+            BuildRun {
+                cluster_id: 0,
+                doc_ids: &a0_docs,
+                ordinals: &a0_ords,
+                codes: &a0_codes,
+            },
+            BuildRun {
+                cluster_id: 5,
+                doc_ids: &a5_docs,
+                ordinals: &a5_ords,
+                codes: &a5_codes,
+            },
+        ];
+        let mut header = binary_header(5);
+        header.num_clusters = 8;
+        let mut a_bytes = Vec::new();
+        write_built_runs(header.clone(), &a_runs, &mut a_bytes).unwrap();
+        let a = AnnDiskIndex::open(OwnedBytes::new(a_bytes), AnnKind::BinaryIvf, 5).unwrap();
+
+        let b0_docs = [0u32, 2];
+        let b0_ords = [1u16, 0];
+        let b0_codes = [0x66u8, 0x77];
+        let b2_docs = [1u32];
+        let b2_ords = [0u16];
+        let b2_codes = [0x88u8];
+        let b_runs = [
+            BuildRun {
+                cluster_id: 0,
+                doc_ids: &b0_docs,
+                ordinals: &b0_ords,
+                codes: &b0_codes,
+            },
+            BuildRun {
+                cluster_id: 2,
+                doc_ids: &b2_docs,
+                ordinals: &b2_ords,
+                codes: &b2_codes,
+            },
+        ];
+        let mut header_b = binary_header(3);
+        header_b.num_clusters = 8;
+        let mut b_bytes = Vec::new();
+        write_built_runs(header_b, &b_runs, &mut b_bytes).unwrap();
+        let b = AnnDiskIndex::open(OwnedBytes::new(b_bytes), AnnKind::BinaryIvf, 3).unwrap();
+
+        // Generation 1: byte-copy A (docs 0..5) + B (docs 5..8).
+        let mut gen1_bytes = Vec::new();
+        write_merged_ann(&[(&a, 0), (&b, 5)], &mut gen1_bytes).unwrap();
+        let gen1 = AnnDiskIndex::open(OwnedBytes::new(gen1_bytes), AnnKind::BinaryIvf, 8).unwrap();
+
+        // Generation 2 sources: gen1 (docs 0..8) + A again (docs 8..13).
+        let sources: [(&AnnDiskIndex, u32); 2] = [(&gen1, 0), (&a, 8)];
+        let predicted = predicted_merge_fragmentation(&sources);
+        // 4 runs (gen1) + 2 runs (a) over 3 distinct clusters {0, 2, 5}.
+        assert!((predicted - 2.0).abs() < 1e-9, "{predicted}");
+
+        let mut copied_bytes = Vec::new();
+        write_merged_ann(&sources, &mut copied_bytes).unwrap();
+        let copied =
+            AnnDiskIndex::open(OwnedBytes::new(copied_bytes), AnnKind::BinaryIvf, 13).unwrap();
+        let mut compacted_bytes = Vec::new();
+        write_compacted_ann_cancellable(&sources, &mut compacted_bytes, None).unwrap();
+        let compacted =
+            AnnDiskIndex::open(OwnedBytes::new(compacted_bytes), AnnKind::BinaryIvf, 13).unwrap();
+
+        // Byte-copy carries the fragmentation forward; compaction resets it.
+        let copied_health = copied.health();
+        let compacted_health = compacted.health();
+        assert!((copied_health.fragmentation() - 2.0).abs() < 1e-9);
+        assert!((compacted_health.fragmentation() - 1.0).abs() < 1e-9);
+        assert_eq!(compacted_health.runs, 3, "one run per non-empty cluster");
+        assert_eq!(copied_health.vectors, compacted_health.vectors);
+        assert_eq!(copied_health.payload_bytes, compacted_health.payload_bytes);
+        assert_eq!(
+            copied_health.largest_cluster_vectors,
+            compacted_health.largest_cluster_vectors
+        );
+
+        // Every cluster returns identical (doc, ordinal, score) results.
+        for cluster in 0..8u32 {
+            let query = [0x5Au8];
+            let from_copy = copied
+                .search_binary_clusters::<false>(&query, 16, &[cluster])
+                .unwrap();
+            let from_compact = compacted
+                .search_binary_clusters::<false>(&query, 16, &[cluster])
+                .unwrap();
+            assert_eq!(from_copy, from_compact, "cluster {cluster} diverged");
+        }
+
+        // Doc IDs are absolute now: every directory entry has doc_base 0.
+        assert!(compacted.runs.iter().all(|run| run.doc_base == 0));
+
+        // A compacted payload is indistinguishable from a built one, so it
+        // must remain a valid source for future ordinary byte-copy merges.
+        let mut generation3 = Vec::new();
+        write_merged_ann(&[(&compacted, 0), (&b, 13)], &mut generation3).unwrap();
+        let generation3 =
+            AnnDiskIndex::open(OwnedBytes::new(generation3), AnnKind::BinaryIvf, 16).unwrap();
+        assert_eq!(generation3.health().vectors, 16);
+        // And the third A copy's docs landed at offset 8.
+        let all: Vec<(u32, u16, f32)> = compacted
+            .search_binary_clusters::<false>(&[0x5A], 32, &[0, 2, 5])
+            .unwrap();
+        let mut docs: Vec<u32> = all.iter().map(|&(doc, _, _)| doc).collect();
+        docs.sort_unstable();
+        assert_eq!(docs, (0..=12).collect::<Vec<u32>>());
+    }
+
+    /// Throughput comparison, prod-shaped: 320-byte codes, 4 sources.
+    /// Ignored: run with `cargo test --release -- --ignored ann_merge_throughput --nocapture`.
+    #[test]
+    #[ignore]
+    fn ann_merge_throughput_byte_copy_vs_compaction() {
+        let code_size = 320usize;
+        let clusters = 4_096u32;
+        let vectors_per_source = 262_144usize;
+        let sources_count = 4usize;
+
+        let mut sources_bytes = Vec::new();
+        for source_index in 0..sources_count {
+            let mut per_cluster: Vec<(Vec<u32>, Vec<u16>, Vec<u8>)> = Vec::new();
+            let vectors_per_cluster = vectors_per_source / clusters as usize;
+            let mut doc = 0u32;
+            for cluster in 0..clusters {
+                let mut docs = Vec::with_capacity(vectors_per_cluster);
+                let mut ords = Vec::with_capacity(vectors_per_cluster);
+                let mut codes = Vec::with_capacity(vectors_per_cluster * code_size);
+                for _ in 0..vectors_per_cluster {
+                    docs.push(doc);
+                    ords.push(0u16);
+                    codes.extend(std::iter::repeat_n(
+                        (doc ^ cluster ^ source_index as u32) as u8,
+                        code_size,
+                    ));
+                    doc += 1;
+                }
+                per_cluster.push((docs, ords, codes));
+            }
+            let runs: Vec<BuildRun<'_>> = per_cluster
+                .iter()
+                .enumerate()
+                .map(|(cluster, (docs, ords, codes))| BuildRun {
+                    cluster_id: cluster as u32,
+                    doc_ids: docs,
+                    ordinals: ords,
+                    codes,
+                })
+                .collect();
+            let header = AnnDiskHeader {
+                kind: AnnKind::BinaryIvf,
+                routing: IvfRoutingMode::Hnsw,
+                dim: code_size * 8,
+                code_size,
+                num_clusters: clusters,
+                quantizer_version: 42,
+                codebook_version: 0,
+                vector_count: vectors_per_source,
+            };
+            let mut bytes = Vec::new();
+            write_built_runs(header, &runs, &mut bytes).unwrap();
+            sources_bytes.push(bytes);
+        }
+        let sources_open: Vec<AnnDiskIndex> = sources_bytes
+            .iter()
+            .map(|bytes| {
+                AnnDiskIndex::open(
+                    OwnedBytes::new(bytes.clone()),
+                    AnnKind::BinaryIvf,
+                    (vectors_per_source * sources_count) as u32,
+                )
+                .unwrap()
+            })
+            .collect();
+        let sources: Vec<(&AnnDiskIndex, u32)> = sources_open
+            .iter()
+            .enumerate()
+            .map(|(index, source)| (source, (index * vectors_per_source) as u32))
+            .collect();
+        let payload_bytes = sources_bytes.iter().map(Vec::len).sum::<usize>();
+
+        let mut out = Vec::with_capacity(payload_bytes + (1 << 20));
+        let start = std::time::Instant::now();
+        write_merged_ann(&sources, &mut out).unwrap();
+        let copy_secs = start.elapsed().as_secs_f64();
+
+        out.clear();
+        let start = std::time::Instant::now();
+        write_compacted_ann_cancellable(&sources, &mut out, None).unwrap();
+        let compact_secs = start.elapsed().as_secs_f64();
+        let compacted = AnnDiskIndex::open(
+            OwnedBytes::new(out),
+            AnnKind::BinaryIvf,
+            (vectors_per_source * sources_count) as u32,
+        )
+        .unwrap();
+        assert!((compacted.health().fragmentation() - 1.0).abs() < 1e-9);
+
+        let gib = payload_bytes as f64 / (1u64 << 30) as f64;
+        println!(
+            "ann merge {:.2} GiB: byte-copy {:.3}s ({:.2} GiB/s), compaction {:.3}s \
+             ({:.2} GiB/s), overhead {:.1}%",
+            gib,
+            copy_secs,
+            gib / copy_secs,
+            compact_secs,
+            gib / compact_secs,
+            100.0 * (compact_secs - copy_secs) / copy_secs,
+        );
+    }
+
+    /// Compaction is undefined for block-packed TQ codes and must refuse.
+    #[test]
+    fn compaction_refuses_non_binary_payloads() {
+        // A binary payload whose header is rewritten to the TQ kind would not
+        // validate, so exercise the guard through the real gate: any source
+        // list whose first header is not BinaryIvf is refused before a byte
+        // is written. Reuse a TQ payload from the flat-TQ writer used by the
+        // pruning tests.
+        let codec = std::sync::Arc::new(crate::structures::TqCodec::new(8));
+        let mut builder = crate::structures::TqFlatBuilder::new(codec);
+        builder
+            .add_batch(
+                &[(0, 0), (1, 0)],
+                &[
+                    1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, //
+                    0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+                ],
+            )
+            .unwrap();
+        builder.finish();
+        let mut bytes = Vec::new();
+        write_built_tq_flat(&builder, &mut bytes).unwrap();
+        let disk = AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::TqFlat, 2).unwrap();
+        let error = write_compacted_ann_cancellable(&[(&disk, 0)], &mut Vec::new(), None)
+            .expect_err("TQ payloads must not compact");
+        assert!(error.to_string().contains("binary"), "{error}");
+    }
 
     /// Health math on a hand-built payload: two runs of one cluster (a
     /// byte-copy merge shape) plus one dominant leaf, checked against the

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -541,24 +541,56 @@ impl SegmentMerger {
         if sources.is_empty() {
             return Ok(None);
         }
+        // Byte-copy preserves every source extent, so fragmentation (extents
+        // per probed cluster) multiplies with each merge generation and every
+        // extent is a potential seek on a cold index. When the merged output
+        // would cross the threshold, compact instead: same payload bytes
+        // streamed, plus one u32 add per posting, and the result is
+        // indistinguishable from a freshly built segment (fragmentation 1.0).
+        // Only binary payloads compact — TQ codes are block-packed and cannot
+        // be concatenated without re-packing.
+        let predicted_fragmentation =
+            crate::segment::ann_disk::predicted_merge_fragmentation(&sources);
+        let compact = index_type == crate::segment::ann_build::BINARY_IVF_TYPE
+            && (self.force_ann_compaction && predicted_fragmentation > 1.0 + 1e-9
+                || predicted_fragmentation
+                    >= crate::segment::ann_disk::ANN_COMPACTION_FRAGMENTATION_THRESHOLD);
         let data_offset = writer.offset();
         let result = super::block_in_place_if_multithread(|| {
-            crate::segment::ann_disk::write_merged_ann_cancellable(
-                &sources,
-                writer,
-                self.cancellation.as_deref(),
-            )
+            if compact {
+                crate::segment::ann_disk::write_compacted_ann_cancellable(
+                    &sources,
+                    writer,
+                    self.cancellation.as_deref(),
+                )
+            } else {
+                crate::segment::ann_disk::write_merged_ann_cancellable(
+                    &sources,
+                    writer,
+                    self.cancellation.as_deref(),
+                )
+            }
         });
         self.ensure_not_cancelled()?;
         result.map_err(crate::Error::Io)?;
         let data_size = writer.offset() - data_offset;
-        log::debug!(
-            "[dense_vector_merge] index={} field {}: copied {} compatible ANN run source(s), {}",
-            self.schema.index_label(),
-            field.0,
-            sources.len(),
-            crate::format_bytes(data_size),
-        );
+        if compact {
+            log::info!(
+                "[dense_vector_merge] index={} field {}: compacted {} ANN source(s) at predicted                  fragmentation {predicted_fragmentation:.1} ({}) — one extent per cluster again",
+                self.schema.index_label(),
+                field.0,
+                sources.len(),
+                crate::format_bytes(data_size),
+            );
+        } else {
+            log::debug!(
+                "[dense_vector_merge] index={} field {}: copied {} compatible ANN run source(s),                  {} (predicted fragmentation {predicted_fragmentation:.1})",
+                self.schema.index_label(),
+                field.0,
+                sources.len(),
+                crate::format_bytes(data_size),
+            );
+        }
         Ok(Some((index_type, data_offset, data_size)))
     }
 

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -291,6 +291,10 @@ pub struct SegmentMerger {
     /// the SegmentManager always passes its background pool so BP cannot
     /// starve query scoring.
     background_pool: Option<Arc<rayon::ThreadPool>>,
+    /// Compact binary ANN runs regardless of the fragmentation threshold.
+    /// The explicit reorder/optimize pass sets this: an optimize command
+    /// should hand back the freshly-built one-extent-per-cluster layout.
+    pub(crate) force_ann_compaction: bool,
     /// Granularity for merge-time BP. `Auto` by default; the SegmentManager
     /// forces `Records` when any merge source is an unconverged partial
     /// reorder.
@@ -319,6 +323,7 @@ impl SegmentMerger {
             schema,
             reorder_bmp: false,
             background_pool: None,
+            force_ann_compaction: false,
             granularity: crate::segment::reorder::BpGranularity::Auto,
             bp_budget: crate::segment::BpBudget::full(),
             cancellation: None,
@@ -335,6 +340,12 @@ impl SegmentMerger {
     }
 
     /// Run merge-time BP on this bounded pool instead of the global one.
+    /// Compact binary ANN runs even below the merge fragmentation threshold.
+    pub fn with_forced_ann_compaction(mut self, force: bool) -> Self {
+        self.force_ann_compaction = force;
+        self
+    }
+
     pub fn with_background_pool(mut self, pool: Option<Arc<rayon::ThreadPool>>) -> Self {
         self.background_pool = pool;
         self

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -955,6 +955,7 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
     granularity: BpGranularity,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
     cancellation: Option<Arc<std::sync::atomic::AtomicBool>>,
+    trained: Option<Arc<crate::segment::TrainedVectorStructures>>,
 ) -> Result<(String, u32, bool)> {
     let reader = SegmentReader::open(dir, source_id, Arc::clone(schema), term_cache_blocks).await?;
     let num_docs = reader.num_docs();
@@ -972,6 +973,43 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
 
     // Copy unchanged segment files
     let copy_start = std::time::Instant::now();
+    // Reorder is the explicit optimize pass, so it also un-does the extent
+    // fragmentation byte-copy merges accumulate: any binary ANN field above
+    // fragmentation 1.0 gets its vectors file rewritten cluster-major instead
+    // of cloned. This needs the trained artifacts (the copy path validates
+    // payloads against their quantizer generation); without them the file is
+    // cloned unchanged, loudly.
+    let max_binary_fragmentation = reader
+        .vector_indexes()
+        .iter()
+        .filter(|(_, index)| matches!(index, crate::segment::VectorIndex::BinaryIvf(_)))
+        .filter_map(|(&field_id, _)| reader.ann_health(crate::dsl::Field(field_id)))
+        .map(|health| health.fragmentation())
+        .fold(0.0f64, f64::max);
+    let artifacts_available = trained.as_ref().is_some_and(|trained| {
+        reader
+            .vector_indexes()
+            .iter()
+            .all(|(&field_id, index)| match index {
+                crate::segment::VectorIndex::BinaryIvf(_) => {
+                    trained.binary_quantizers.contains_key(&field_id)
+                }
+                crate::segment::VectorIndex::IvfTq { .. } => {
+                    trained.centroids.contains_key(&field_id)
+                }
+                crate::segment::VectorIndex::Tq { .. } => true,
+            })
+    });
+    let compact_vectors = max_binary_fragmentation > 1.0 + 1e-9 && artifacts_available;
+    if max_binary_fragmentation > 1.0 + 1e-9 && !artifacts_available {
+        log::warn!(
+            "[reorder] index={} segment {}: binary ANN fragmentation {max_binary_fragmentation:.1} \
+             but trained artifacts are unavailable — vectors file cloned unchanged",
+            schema.index_label(),
+            source_id.to_hex(),
+        );
+    }
+
     for (src, dst, required) in [
         (&src_files.term_dict, &dst_files.term_dict, true),
         (&src_files.postings, &dst_files.postings, true),
@@ -989,7 +1027,8 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
         (
             &src_files.vectors,
             &dst_files.vectors,
-            !reader.vector_indexes().is_empty() || !reader.flat_vectors().is_empty(),
+            !compact_vectors
+                && (!reader.vector_indexes().is_empty() || !reader.flat_vectors().is_empty()),
         ),
     ] {
         if cancellation_requested(cancellation.as_deref()) {
@@ -1004,6 +1043,33 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
             cancellation.as_deref(),
         )
         .await?;
+    }
+    if compact_vectors {
+        // Single-source copy "merge": flat and TQ sections are byte-copied,
+        // and the binary ANN payload goes through the compaction policy —
+        // with one fragmented source its predicted fragmentation is its own,
+        // and reorder compacts at any value above 1.0.
+        let compaction_started = std::time::Instant::now();
+        let merger = super::merger::SegmentMerger::new(Arc::clone(schema))
+            .with_background_pool(rayon_pool.clone())
+            .with_forced_ann_compaction(true);
+        let trained_ref = trained.as_deref().expect("gated on artifacts_available");
+        merger
+            .merge_dense_vectors(
+                dir,
+                std::slice::from_ref(&reader),
+                &dst_files,
+                Some(trained_ref),
+                super::merger::AnnWriteMode::Copy,
+            )
+            .await?;
+        log::info!(
+            "[reorder] index={} segment {}: compacted binary ANN runs \
+             (fragmentation {max_binary_fragmentation:.1} → 1.0) in {:.1}s",
+            schema.index_label(),
+            source_id.to_hex(),
+            compaction_started.elapsed().as_secs_f64(),
+        );
     }
     log::info!(
         "[reorder] index={} copied files in {:.1}s",


### PR DESCRIPTION
Fixes the fragmentation half of "it degrades quite fast": byte-copy merges preserve each source payload as one physical extent, so a logical IVF cluster's postings scatter across up to source-count extents per merge generation. Every extent ≈ one seek on a cold index — production measured the array IOPS-bound at 5,541 reads/s × 32.8 KB from exactly this, and only a multi-hour vector-generation rewrite reset the layout.

## What it does

`write_compacted_ann_cancellable` gathers each cluster's runs from all sources and writes **one contiguous run per cluster** — the freshly-built layout, fragmentation 1.0. Doc IDs are rewritten absolute (`doc_base = 0`); ordinals and codes copy verbatim. **Binary payloads only**: TQ codes are block-packed with per-run tail padding and can't be concatenated without re-packing.

## Policy

| trigger | behavior |
|---|---|
| ordinary merge | compact when predicted fragmentation ≥ 4 (computed exactly from in-memory directories before writing a byte); below that, cheap byte-copy — shallow merge trees pay nothing |
| **`reorder` API** (the explicit optimize pass) | compacts at *any* fragmentation > 1.0, alongside the BP sparse reorder |

During the transient retrain window `trained_for_segment_build` gates artifacts off; reorder then clones the vectors file unchanged with a warning — harmless, since the retrain ends by rewriting every segment at 1.0 anyway.

## Integrity

No new lifecycle machinery. Both sites write into a **brand-new segment** and ride the existing durable-replace path: `replace_segments` validates mandatory files, **fully re-opens the output** (so `AnnDiskIndex::open`'s structural validation runs over the compacted payload — a corrupt compaction cannot be published), checks doc counts, then does the durable-before-visible metadata swap. Failures/crashes leave the source segment live; the orphan output is swept. Cancellation checked per cluster, per 256 KiB doc-ID chunk, per 8 MB copy window.

## Measured

- **Throughput** (0.32 GiB, 4 sources, prod-shaped 320-B codes, aarch64, warm cache): byte-copy 9.8 GiB/s, **compaction 20.1 GiB/s** — cluster-major output streams larger sequential extents than the per-record directory merge.
- **Memory**: 256 KiB doc-ID scratch (chunked — a prod-sized 20M-posting run would otherwise spike 80 MB) + 48 B per non-empty cluster. Nothing scales with vector count.

## Tests

- Parity vs byte-copy on a two-generation fragmented payload: identical per-cluster results, 2.0 → 1.0, absolute doc IDs, and the compacted output stays a **valid source for future byte-copy merges**.
- TQ payloads refused.
- E2E through the real `writer.reorder()` API (same path as the server RPC): merge to fragmentation 2.0, reorder, assert 1.0 with byte-identical search scores.
- Ignored throughput benchmark pins the numbers.

`hermes_ann_fragmentation` and `hermes-tool diagnose` (PR #119) observe the outcome. No on-disk format change — compacted payloads are indistinguishable from freshly built ones.

Validation: CI clippy command clean; 1,046 core tests aarch64 + compaction suite on x86_64; featureless and WASM checks clean.