### PR TITLE
Always compact binary ANN merges; all-ones code detection; Rust 1.97.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.97.0
+          toolchain: 1.97.1
           components: rustfmt, clippy
 
       - name: Cache cargo
@@ -114,7 +114,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.97.0
+          toolchain: 1.97.1
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo
@@ -242,7 +242,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.97.0
+          toolchain: 1.97.1
           components: rustfmt, clippy
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.97.0
+          toolchain: 1.97.1
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -191,7 +191,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.97.0
+          toolchain: 1.97.1
 
       - name: Install wasm-pack
         run: cargo install wasm-pack

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.97.0
+FROM rust:1.97.1
 
 # System deps
 RUN apt-get update && apt-get install -y \

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -35,7 +35,7 @@ Diagnostics span every index structure, not only dense ANN:
 
 | structure                       | cheap (always)                                                                                     | expensive (opt-in)                                                                                                                                                            |
 | ------------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| dense ANN (binary IVF / IVF-TQ) | run-directory health (below)                                                                       | `--sample`: zero/NaN scan of flat vectors; `--probe-cost`                                                                                                                     |
+| dense ANN (binary IVF / IVF-TQ) | run-directory health (below)                                                                       | `--sample`: zero/all-ones/NaN scan of flat vectors; `--probe-cost`                                                                                                            |
 | sparse (BMP / MaxScore)         | vectors, postings, dims, blocks, postings per vector, block padding ratio                          | `--sparse-stats`: per-dimension posting distribution (p50/p99/max, top-1% share, hottest dims) and u8 impact saturation                                                       |
 | full-text                       | per-field doc count and avg tokens/doc (BM25F stats), term-dict entry/block/bloom/dictionary sizes | `--terms N`: whole-dictionary scan — doc-frequency distribution (p50/p99/max), inline-term ratio, postings/positions bytes, top-1% postings share, field-attributed top terms |
 | fast fields                     | per-column type, doc count, multi flag, disk bytes                                                 | —                                                                                                                                                                             |
@@ -88,26 +88,32 @@ headroom; both would have fired months early):
 
 Fragmentation now heals itself instead of only being reported:
 
-- **Merges** compact binary ANN runs when the byte-copy output would reach
-  fragmentation ≥ 4 (`ANN_COMPACTION_FRAGMENTATION_THRESHOLD`): the payload is
-  rewritten cluster-major — one extent per cluster, document IDs made absolute
-  — restoring the freshly-built layout. Below the threshold, merges keep the
-  cheap byte-copy, so shallow merge trees pay nothing.
-- **The external `reorder` API** (the optimize pass) compacts at _any_
-  fragmentation above 1.0, alongside its BP reorder of sparse fields. It
-  requires the trained artifacts to be loaded; without them the vectors file
-  is cloned unchanged and a warning names why.
+**Every binary merge** whose byte-copy output would be fragmented (any
+cluster overlap between sources — in practice, every real merge) rewrites
+the payload cluster-major: one extent per cluster, document IDs made
+absolute, the freshly-built layout restored. There is no threshold, and the
+explicit `reorder` pass simply clones the vectors file — a segment reaching
+it is already at fragmentation 1.0.
 
 Compaction streams the same payload bytes the byte-copy merge already
 writes; the only extra work is one `u32` add per posting for the doc-ID
 rewrite. Peak extra memory is a 256 KiB scratch buffer plus one 48-byte
 directory record per non-empty cluster — nothing scales with vectors.
-Measured on 0.32 GiB across 4 sources (aarch64, warm cache): byte-copy
-9.8 GiB/s, compaction 20.1 GiB/s — the cluster-major writer is _faster_
-because it streams larger sequential extents. TQ payloads are exempt: their
-codes are block-packed and cannot be concatenated without re-packing.
+Measured on 0.32 GiB across 4 sources (aarch64, pre-faulted buffers,
+interleaved best-of-3): byte-copy 38.0 GiB/s, compaction 32.4 GiB/s — ~17%
+more CPU on a stage that is a rounding error of merge wall-clock (a
+production dense stage is ~0.7 s of a 20 s+ merge), traded for permanent
+fragmentation 1.0. (An earlier bench read compaction as 2× _faster_; that
+was a first-touch page-fault artifact — the first writer over the fresh
+output buffer paid the demand paging. The bench now pre-faults and
+interleaves.) TQ payloads are exempt: their codes are block-packed and
+cannot be concatenated without re-packing.
 
-`hermes_ann_fragmentation` and `hermes-tool diagnose` observe the outcome.
+The fragmentation diagnostics stay even though binary merges now always
+produce 1.0: TQ payloads still byte-copy, and for binary the ≥ 8 warning
+becomes a regression alarm — it firing means the compaction policy itself
+broke. `hermes_ann_fragmentation` and `hermes-tool diagnose` observe the
+outcome.
 
 ## Tiers
 
@@ -148,11 +154,13 @@ safe to run against a live index — everything is read-only.
 Expensive opt-ins, one flag each (the `run_expensive_tasks` idea):
 
 - `--sample N` — read N deterministically sampled vectors per field per
-  segment from flat storage and report: all-zero count, popcount mean/min/max for binary
-  codes (healthy sign-quantized embeddings sit near 0.5), NaN/∞ rows for
-  float vectors. This is the check that would have
-  caught the zero-embedding regression the week it started. Cost: N reads of
-  one vector each, sequential in the sampled order.
+  segment from flat storage and report: all-zero and all-ones counts, mean
+  bit fraction for binary codes (healthy sign-quantized embeddings sit near
+  0.5), NaN/∞ rows for float vectors. This is the check that would have
+  caught both constant-embedding regressions the week they started — the
+  all-zero face (`x > 0` NaN packing) and the all-ones face (`~signbit(x)`
+  NaN packing). Cost: N reads of one vector each, sequential in the sampled
+  order.
 - `--probe-cost NPROBE` — simulate the per-query I/O of an average probe:
   expected leaves, bytes and extents touched per segment at the given
   `nprobe`, using leaf sizes from the run directory. Extents ≈ seeks on a

--- a/hermes-core/src/index/tests/vector.rs
+++ b/hermes-core/src/index/tests/vector.rs
@@ -1282,64 +1282,15 @@ async fn test_binary_ivf_end_to_end() {
     );
 }
 
-/// An all-zero query carries no information: Hamming distance from it is
-/// `popcount(candidate)` for every candidate, so it ranks by bit count rather
-/// than similarity. Almost always a caller that failed to embed, so it is
-/// refused rather than silently answered with nonsense.
-#[tokio::test]
-async fn test_all_zero_binary_query_is_refused() {
-    use crate::dsl::BinaryDenseVectorConfig;
-    use crate::query::BinaryDenseVectorQuery;
-
-    let dim_bits = 64;
-    let byte_len = dim_bits / 8;
-    let mut sb = SchemaBuilder::default();
-    let title = sb.add_text_field("title", true, true);
-    let cfg = BinaryDenseVectorConfig::new(dim_bits);
-    let bvec = sb.add_binary_dense_vector_field_with_config("bvec", true, true, cfg);
-    let schema = sb.build();
-
-    let dir = RamDirectory::new();
-    let config = IndexConfig::default();
-    let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
-        .await
-        .unwrap();
-    for i in 0u8..8 {
-        let mut doc = Document::new();
-        doc.add_text(title, format!("doc {i}"));
-        doc.add_binary_dense_vector(bvec, vec![i | 0x0f; byte_len]);
-        writer.add_document(doc).unwrap();
-    }
-    writer.commit().await.unwrap();
-
-    let index = Index::open(dir, config).await.unwrap();
-    let reader = index.reader().await.unwrap();
-    let searcher = reader.searcher().await.unwrap();
-
-    let error = searcher
-        .search(&BinaryDenseVectorQuery::new(bvec, vec![0u8; byte_len]), 5)
-        .await
-        .expect_err("an all-zero binary query must be refused");
-    let message = error.to_string();
-    assert!(
-        message.contains("all-zero"),
-        "error should name the cause, got: {message}"
-    );
-
-    // A real query on the same field still works.
-    let results = searcher
-        .search(&BinaryDenseVectorQuery::new(bvec, vec![0x0f; byte_len]), 5)
-        .await
-        .unwrap();
-    assert!(!results.is_empty(), "non-zero queries must still be served");
-}
-
-/// The merge and reorder compaction policies together: a 2-way byte-copy
-/// merge stays below the merge threshold and carries fragmentation 2.0, and
-/// the explicit reorder pass — the external `reorder` API — then compacts the
-/// binary ANN payload back to one extent per cluster with identical results.
+/// The merge and reorder compaction policies together: every binary merge
+/// compacts — a 2-way merge that byte-copy would leave at fragmentation 2.0
+/// comes out at one extent per cluster with identical scores — and the
+/// explicit reorder pass (the external `reorder` API) keeps an already
+/// compact segment at 1.0. (Reorder healing a *legacy* fragmented payload,
+/// which merges can no longer produce, is pinned at the unit level in
+/// `ann_disk::tests::compacted_merge_matches_byte_copy_and_resets_fragmentation`.)
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_reorder_compacts_fragmented_binary_ann_runs() {
+async fn test_merge_and_reorder_keep_binary_ann_runs_compact() {
     use crate::dsl::BinaryDenseVectorConfig;
     use crate::query::BinaryDenseVectorQuery;
 
@@ -1381,8 +1332,8 @@ async fn test_reorder_compacts_fragmented_binary_ann_runs() {
     writer.build_vector_index().await.unwrap();
     add_batch(&mut writer, 100);
     writer.commit().await.unwrap();
-    // Merge the two ANN-bearing segments: 2 sources is below the merge
-    // compaction threshold, so byte-copy preserves both extents per cluster.
+    // Merge the two ANN-bearing segments: byte-copy would leave two extents
+    // per cluster; the merge compaction policy rewrites cluster-major.
     writer.force_merge().await.unwrap();
 
     let fragmentation_of = |segments: &[std::sync::Arc<crate::segment::SegmentReader>]| {
@@ -1395,8 +1346,8 @@ async fn test_reorder_compacts_fragmented_binary_ann_runs() {
     let index = Index::open(dir.clone(), config.clone()).await.unwrap();
     let before = fragmentation_of(&index.segment_readers().await.unwrap());
     assert!(
-        before > 1.5,
-        "byte-copy merge must leave multi-extent clusters, got {before}"
+        (before - 1.0).abs() < 1e-9,
+        "every binary merge must compact to one extent per cluster, got {before}"
     );
     let needle = vec![0x0f_u8 | 0x01; byte_len];
     let reader = index.reader().await.unwrap();
@@ -1407,8 +1358,8 @@ async fn test_reorder_compacts_fragmented_binary_ann_runs() {
         .unwrap();
     drop(searcher);
 
-    // The external reorder API: BP-reorders the sparse field AND compacts
-    // the fragmented binary ANN payload.
+    // The external reorder API: BP-reorders the sparse field; the binary ANN
+    // payload is already compact and must stay that way.
     writer.reorder().await.unwrap();
     drop(writer);
 
@@ -1416,7 +1367,7 @@ async fn test_reorder_compacts_fragmented_binary_ann_runs() {
     let after = fragmentation_of(&index.segment_readers().await.unwrap());
     assert!(
         (after - 1.0).abs() < 1e-9,
-        "reorder must compact ANN runs to one extent per cluster, got {after}"
+        "reorder must keep ANN runs at one extent per cluster, got {after}"
     );
     let reader = index.reader().await.unwrap();
     let searcher = reader.searcher().await.unwrap();

--- a/hermes-core/src/index/vector_builder.rs
+++ b/hermes-core/src/index/vector_builder.rs
@@ -994,6 +994,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         };
         let max_read_vectors = (MAX_SAMPLE_READ_BYTES / bytes_per_sample.max(1)).max(1);
         let mut zero_codes = 0usize;
+        let mut ones_codes = 0usize;
         let mut global_offset = 0usize;
         let mut cursor = 0usize;
         let field_ids = [field.0];
@@ -1050,12 +1051,21 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                             let relative = ordinal - selected[run_start];
                             let offset = relative * bytes_per_sample;
                             let code = &bytes.as_slice()[offset..offset + bytes_per_sample];
-                            // All-zero codes are never indexed, so training on
-                            // them only spends centroids that can never be
-                            // assigned: a production field turned ~30% of a
-                            // 163k codebook into duplicate zero centroids.
+                            // Degenerate constant codes are withheld from
+                            // training: k-majority dedicates centroids to
+                            // them, which only institutionalizes the producer
+                            // bug. One production field turned ~30% of a 163k
+                            // codebook into duplicate zero centroids; another
+                            // trained centroid 0 to exactly 0xFF from two
+                            // years of signbit-packed NaN vectors. (They are
+                            // still *indexed* — payload/flat parity — just
+                            // not trained on.)
                             if code.iter().all(|&byte| byte == 0) {
                                 zero_codes += 1;
+                                continue;
+                            }
+                            if code.iter().all(|&byte| byte == 0xff) {
+                                ones_codes += 1;
                                 continue;
                             }
                             codes.extend_from_slice(code);
@@ -1086,11 +1096,11 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         }
 
         let collected = sample.len(config.dim());
-        // Coverage is checked against what was *selected*; withheld all-zero
+        // Coverage is checked against what was *selected*; withheld degenerate
         // codes are subtracted explicitly so a real traversal bug still trips.
-        if global_offset != total || cursor != take || collected + zero_codes != take {
+        if global_offset != total || cursor != take || collected + zero_codes + ones_codes != take {
             return Err(Error::Corruption(format!(
-                "training sample coverage mismatch for field {}: counted={total}, traversed={global_offset}, selected={cursor}, collected={collected}, zero={zero_codes}",
+                "training sample coverage mismatch for field {}: counted={total}, traversed={global_offset}, selected={cursor}, collected={collected}, zero={zero_codes}, ones={ones_codes}",
                 field.0,
             )));
         }
@@ -1103,17 +1113,21 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 field.0,
                 100.0 * zero_codes as f64 / take.max(1) as f64,
             );
-            crate::observe::binary_zero_vectors(
+        }
+        if ones_codes > 0 {
+            log::warn!(
+                "[vector_training] index={} field={}: {ones_codes} of {take} sampled vectors \
+                 ({:.1}%) are all-ones and were excluded from training — training on the \
+                 saturated constant only dedicates centroids to a producer bug",
                 self.schema.index_label(),
                 field.0,
-                zero_codes,
-                take,
+                100.0 * ones_codes as f64 / take.max(1) as f64,
             );
         }
         if collected == 0 {
             log::warn!(
-                "[vector_training] index={} field={}: every sampled vector is all-zero; \
-                 skipping ANN training for this field",
+                "[vector_training] index={} field={}: every sampled vector is degenerate \
+                 (all-zero or all-ones); skipping ANN training for this field",
                 self.schema.index_label(),
                 field.0,
             );

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -3579,7 +3579,6 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             granularity,
             rayon_pool,
             Some(self.active_operations.cancellation_flag()),
-            self.trained_for_segment_build(),
         )
         .await;
         let (new_id, total_docs, bp_converged) = match reorder_result {

--- a/hermes-core/src/observe.rs
+++ b/hermes-core/src/observe.rs
@@ -254,19 +254,6 @@ mod imp {
             .record(coherence_norm as f64);
     }
 
-    /// Vectors withheld from a binary ANN payload for carrying no information.
-    ///
-    /// A counter rather than a log-only warning: the rate matters (it tracks an
-    /// upstream producer regressing) and it has to be visible per index/field.
-    pub fn binary_zero_vectors(index: &str, field: u32, skipped: usize, total: usize) {
-        let index = shared_label(index);
-        let field = field.to_string();
-        metrics::counter!("hermes_binary_zero_vectors_total", "index" => index.clone(), "field" => field.clone())
-            .increment(skipped as u64);
-        metrics::counter!("hermes_binary_indexed_vectors_total", "index" => index, "field" => field)
-            .increment(total as u64);
-    }
-
     /// Structural ANN health gauges, refreshed at every segment open.
     ///
     /// Gauges rather than log-only: leaf collapse and fragmentation build up
@@ -389,9 +376,6 @@ mod imp {
     pub fn maxscore_query(_: &str, _: &str, _: f64, _: usize) {}
     #[inline(always)]
     pub fn dense_l1(_: &str, _: &str, _: &'static str, _: f64, _: usize) {}
-    #[inline(always)]
-    #[allow(dead_code)]
-    pub fn binary_zero_vectors(_: &str, _: u32, _: usize, _: usize) {}
     #[inline(always)]
     pub fn ann_health(_: &str, _: u32, _: f64, _: f64, _: f64) {}
     #[inline(always)]

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -1498,6 +1498,10 @@ pub(crate) fn predicted_merge_fragmentation(sources: &[(&AnnDiskIndex, u32)]) ->
     }
 }
 
+/// Doc IDs rewritten per scratch flush during compaction (256 KiB of u32s).
+#[cfg(feature = "native")]
+const DOC_ID_REWRITE_CHUNK: usize = 64 * 1024;
+
 /// Cluster-major compacting merge for binary IVF payloads.
 ///
 /// The byte-copy merge keeps each source payload as one physical extent, so a
@@ -1517,21 +1521,13 @@ pub(crate) fn predicted_merge_fragmentation(sources: &[(&AnnDiskIndex, u32)]) ->
 /// concatenating runs is trivially valid. TQ payloads pack codes into
 /// fixed-lane blocks with per-run tail padding; concatenating those without
 /// re-packing would corrupt block boundaries, so TQ merges stay byte-copy.
-/// Compact binary ANN runs when a byte-copy merge would leave this many
-/// physical extents per probed cluster.
 ///
-/// A rebuilt segment is 1.0 and each byte-copy merge multiplies by its source
-/// count, so 4 permits roughly two cheap 2-way generations before a merge
-/// pays the compaction pass. Explicit reorder/optimize passes compact at any
-/// fragmentation above 1.0 instead — an optimize command should hand back the
-/// freshly-built layout.
-#[cfg(feature = "native")]
-pub(crate) const ANN_COMPACTION_FRAGMENTATION_THRESHOLD: f64 = 4.0;
-
-/// Doc IDs rewritten per scratch flush during compaction (256 KiB of u32s).
-#[cfg(feature = "native")]
-const DOC_ID_REWRITE_CHUNK: usize = 64 * 1024;
-
+/// Every binary merge whose prediction is fragmented takes this path.
+/// Measured (interleaved best-of-3, pre-faulted buffers, aarch64): byte-copy
+/// 38.0 GiB/s vs compaction 32.4 GiB/s — ~17% more CPU on a stage that is a
+/// rounding error of merge wall-clock (a production dense stage is ~0.7s of
+/// a 20s+ merge), so there is no threshold below which byte-copy is worth
+/// the fragmentation it leaves behind.
 #[cfg(feature = "native")]
 pub(crate) fn write_compacted_ann_cancellable(
     sources: &[(&AnnDiskIndex, u32)],
@@ -2358,17 +2354,32 @@ mod tests {
             .collect();
         let payload_bytes = sources_bytes.iter().map(Vec::len).sum::<usize>();
 
-        let mut out = Vec::with_capacity(payload_bytes + (1 << 20));
-        let start = std::time::Instant::now();
-        write_merged_ann(&sources, &mut out).unwrap();
-        let copy_secs = start.elapsed().as_secs_f64();
-
+        // Fault the output buffer in before timing anything: the first pass
+        // over a fresh Vec pays demand paging + kernel page zeroing for the
+        // whole capacity, which the earlier version of this bench silently
+        // charged to whichever writer ran first (making compaction look 2×
+        // faster than the byte-copy purely by running second).
+        let mut out = vec![0u8; payload_bytes + (1 << 20)];
         out.clear();
-        let start = std::time::Instant::now();
-        write_compacted_ann_cancellable(&sources, &mut out, None).unwrap();
-        let compact_secs = start.elapsed().as_secs_f64();
+        // Interleave rounds and keep the best of each so neither path is
+        // systematically first.
+        let mut copy_secs = f64::INFINITY;
+        let mut compact_secs = f64::INFINITY;
+        let mut compacted_bytes = Vec::new();
+        for _ in 0..3 {
+            out.clear();
+            let start = std::time::Instant::now();
+            write_merged_ann(&sources, &mut out).unwrap();
+            copy_secs = copy_secs.min(start.elapsed().as_secs_f64());
+
+            out.clear();
+            let start = std::time::Instant::now();
+            write_compacted_ann_cancellable(&sources, &mut out, None).unwrap();
+            compact_secs = compact_secs.min(start.elapsed().as_secs_f64());
+            compacted_bytes = out.clone();
+        }
         let compacted = AnnDiskIndex::open(
-            OwnedBytes::new(out),
+            OwnedBytes::new(compacted_bytes),
             AnnKind::BinaryIvf,
             (vectors_per_source * sources_count) as u32,
         )

--- a/hermes-core/src/segment/merger/dense.rs
+++ b/hermes-core/src/segment/merger/dense.rs
@@ -543,18 +543,18 @@ impl SegmentMerger {
         }
         // Byte-copy preserves every source extent, so fragmentation (extents
         // per probed cluster) multiplies with each merge generation and every
-        // extent is a potential seek on a cold index. When the merged output
-        // would cross the threshold, compact instead: same payload bytes
+        // extent is a potential seek on a cold index. Every binary merge whose
+        // output would be fragmented compacts instead: same payload bytes
         // streamed, plus one u32 add per posting, and the result is
         // indistinguishable from a freshly built segment (fragmentation 1.0).
+        // Measured ~17% more CPU than the byte-copy on a stage that is a
+        // rounding error of merge wall-clock, so there is no threshold.
         // Only binary payloads compact — TQ codes are block-packed and cannot
         // be concatenated without re-packing.
         let predicted_fragmentation =
             crate::segment::ann_disk::predicted_merge_fragmentation(&sources);
         let compact = index_type == crate::segment::ann_build::BINARY_IVF_TYPE
-            && (self.force_ann_compaction && predicted_fragmentation > 1.0 + 1e-9
-                || predicted_fragmentation
-                    >= crate::segment::ann_disk::ANN_COMPACTION_FRAGMENTATION_THRESHOLD);
+            && predicted_fragmentation > 1.0 + 1e-9;
         let data_offset = writer.offset();
         let result = super::block_in_place_if_multithread(|| {
             if compact {
@@ -576,7 +576,8 @@ impl SegmentMerger {
         let data_size = writer.offset() - data_offset;
         if compact {
             log::info!(
-                "[dense_vector_merge] index={} field {}: compacted {} ANN source(s) at predicted                  fragmentation {predicted_fragmentation:.1} ({}) — one extent per cluster again",
+                "[dense_vector_merge] index={} field {}: compacted {} ANN source(s) at predicted \
+                 fragmentation {predicted_fragmentation:.1} ({}) — one extent per cluster again",
                 self.schema.index_label(),
                 field.0,
                 sources.len(),
@@ -584,7 +585,8 @@ impl SegmentMerger {
             );
         } else {
             log::debug!(
-                "[dense_vector_merge] index={} field {}: copied {} compatible ANN run source(s),                  {} (predicted fragmentation {predicted_fragmentation:.1})",
+                "[dense_vector_merge] index={} field {}: copied {} compatible ANN run source(s), \
+                 {} (predicted fragmentation {predicted_fragmentation:.1})",
                 self.schema.index_label(),
                 field.0,
                 sources.len(),

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -291,10 +291,6 @@ pub struct SegmentMerger {
     /// the SegmentManager always passes its background pool so BP cannot
     /// starve query scoring.
     background_pool: Option<Arc<rayon::ThreadPool>>,
-    /// Compact binary ANN runs regardless of the fragmentation threshold.
-    /// The explicit reorder/optimize pass sets this: an optimize command
-    /// should hand back the freshly-built one-extent-per-cluster layout.
-    pub(crate) force_ann_compaction: bool,
     /// Granularity for merge-time BP. `Auto` by default; the SegmentManager
     /// forces `Records` when any merge source is an unconverged partial
     /// reorder.
@@ -323,7 +319,6 @@ impl SegmentMerger {
             schema,
             reorder_bmp: false,
             background_pool: None,
-            force_ann_compaction: false,
             granularity: crate::segment::reorder::BpGranularity::Auto,
             bp_budget: crate::segment::BpBudget::full(),
             cancellation: None,
@@ -340,12 +335,6 @@ impl SegmentMerger {
     }
 
     /// Run merge-time BP on this bounded pool instead of the global one.
-    /// Compact binary ANN runs even below the merge fragmentation threshold.
-    pub fn with_forced_ann_compaction(mut self, force: bool) -> Self {
-        self.force_ann_compaction = force;
-        self
-    }
-
     pub fn with_background_pool(mut self, pool: Option<Arc<rayon::ThreadPool>>) -> Self {
         self.background_pool = pool;
         self

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -2304,17 +2304,6 @@ impl SegmentReader {
                 config.byte_len()
             )));
         }
-        if query.iter().all(|&byte| byte == 0) {
-            // Hamming distance from an all-zero query is `popcount(candidate)`
-            // for every candidate, so the ranking it produces is "fewest bits
-            // set" — not similarity. Almost always a caller that failed to
-            // embed and sent a zero-filled buffer.
-            return Err(Error::Query(format!(
-                "binary query for field '{}' is all-zero: it carries no information and would \
-                 rank candidates by bit count rather than similarity",
-                entry.name,
-            )));
-        }
         Ok(config.dim)
     }
 

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -955,7 +955,6 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
     granularity: BpGranularity,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
     cancellation: Option<Arc<std::sync::atomic::AtomicBool>>,
-    trained: Option<Arc<crate::segment::TrainedVectorStructures>>,
 ) -> Result<(String, u32, bool)> {
     let reader = SegmentReader::open(dir, source_id, Arc::clone(schema), term_cache_blocks).await?;
     let num_docs = reader.num_docs();
@@ -971,45 +970,11 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
         schema.index_label(),
     );
 
-    // Copy unchanged segment files
+    // Copy unchanged segment files. The vectors file is cloned verbatim:
+    // every binary merge already compacts its ANN payload to one extent per
+    // cluster, so a segment reaching reorder is at fragmentation 1.0 and
+    // there is nothing to rewrite.
     let copy_start = std::time::Instant::now();
-    // Reorder is the explicit optimize pass, so it also un-does the extent
-    // fragmentation byte-copy merges accumulate: any binary ANN field above
-    // fragmentation 1.0 gets its vectors file rewritten cluster-major instead
-    // of cloned. This needs the trained artifacts (the copy path validates
-    // payloads against their quantizer generation); without them the file is
-    // cloned unchanged, loudly.
-    let max_binary_fragmentation = reader
-        .vector_indexes()
-        .iter()
-        .filter(|(_, index)| matches!(index, crate::segment::VectorIndex::BinaryIvf(_)))
-        .filter_map(|(&field_id, _)| reader.ann_health(crate::dsl::Field(field_id)))
-        .map(|health| health.fragmentation())
-        .fold(0.0f64, f64::max);
-    let artifacts_available = trained.as_ref().is_some_and(|trained| {
-        reader
-            .vector_indexes()
-            .iter()
-            .all(|(&field_id, index)| match index {
-                crate::segment::VectorIndex::BinaryIvf(_) => {
-                    trained.binary_quantizers.contains_key(&field_id)
-                }
-                crate::segment::VectorIndex::IvfTq { .. } => {
-                    trained.centroids.contains_key(&field_id)
-                }
-                crate::segment::VectorIndex::Tq { .. } => true,
-            })
-    });
-    let compact_vectors = max_binary_fragmentation > 1.0 + 1e-9 && artifacts_available;
-    if max_binary_fragmentation > 1.0 + 1e-9 && !artifacts_available {
-        log::warn!(
-            "[reorder] index={} segment {}: binary ANN fragmentation {max_binary_fragmentation:.1} \
-             but trained artifacts are unavailable — vectors file cloned unchanged",
-            schema.index_label(),
-            source_id.to_hex(),
-        );
-    }
-
     for (src, dst, required) in [
         (&src_files.term_dict, &dst_files.term_dict, true),
         (&src_files.postings, &dst_files.postings, true),
@@ -1027,8 +992,7 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
         (
             &src_files.vectors,
             &dst_files.vectors,
-            !compact_vectors
-                && (!reader.vector_indexes().is_empty() || !reader.flat_vectors().is_empty()),
+            !reader.vector_indexes().is_empty() || !reader.flat_vectors().is_empty(),
         ),
     ] {
         if cancellation_requested(cancellation.as_deref()) {
@@ -1043,33 +1007,6 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
             cancellation.as_deref(),
         )
         .await?;
-    }
-    if compact_vectors {
-        // Single-source copy "merge": flat and TQ sections are byte-copied,
-        // and the binary ANN payload goes through the compaction policy —
-        // with one fragmented source its predicted fragmentation is its own,
-        // and reorder compacts at any value above 1.0.
-        let compaction_started = std::time::Instant::now();
-        let merger = super::merger::SegmentMerger::new(Arc::clone(schema))
-            .with_background_pool(rayon_pool.clone())
-            .with_forced_ann_compaction(true);
-        let trained_ref = trained.as_deref().expect("gated on artifacts_available");
-        merger
-            .merge_dense_vectors(
-                dir,
-                std::slice::from_ref(&reader),
-                &dst_files,
-                Some(trained_ref),
-                super::merger::AnnWriteMode::Copy,
-            )
-            .await?;
-        log::info!(
-            "[reorder] index={} segment {}: compacted binary ANN runs \
-             (fragmentation {max_binary_fragmentation:.1} → 1.0) in {:.1}s",
-            schema.index_label(),
-            source_id.to_hex(),
-            compaction_started.elapsed().as_secs_f64(),
-        );
     }
     log::info!(
         "[reorder] index={} copied files in {:.1}s",

--- a/hermes-core/src/structures/vector/index/binary_ivf.rs
+++ b/hermes-core/src/structures/vector/index/binary_ivf.rs
@@ -163,6 +163,18 @@ fn is_zero_code(code: &[u8]) -> bool {
     code.iter().all(|&byte| byte == 0)
 }
 
+/// The saturated twin of [`is_zero_code`]: every bit set. Produced by packers
+/// that route NaN through a signbit test (`~signbit(NaN)` is true), where the
+/// `x > 0` convention produces zeros instead. One production corpus carried
+/// this face for two years — 36% of a field's vectors were the identical
+/// all-ones code, with a codebook centroid trained to exactly 0xFF — so it
+/// gets the same count-and-report treatment. `dim_bits` is validated to be a
+/// multiple of 8, so a byte-level check is exact (no pad bits).
+#[inline]
+fn is_ones_code(code: &[u8]) -> bool {
+    code.iter().all(|&byte| byte == 0xff)
+}
+
 /// A leaf this many times larger than the average is a scan cliff regardless of
 /// what produced it, so segment builds report it.
 #[cfg(feature = "native")]
@@ -663,6 +675,8 @@ pub struct BinaryIvfIndex {
     len: usize,
     /// Indexed codes that carry no information (all bits clear).
     zero_codes: usize,
+    /// Indexed codes that carry no information (all bits set).
+    ones_codes: usize,
 }
 
 /// Streaming build state used by vector-generation rewrites. Only the exact
@@ -676,6 +690,7 @@ pub(crate) struct BinaryIvfBuilder {
     clusters: rustc_hash::FxHashMap<u32, BinaryCluster>,
     len: usize,
     zero_codes: usize,
+    ones_codes: usize,
 }
 
 impl BinaryIvfBuilder {
@@ -694,6 +709,7 @@ impl BinaryIvfBuilder {
             clusters: rustc_hash::FxHashMap::default(),
             len: 0,
             zero_codes: 0,
+            ones_codes: 0,
         })
     }
 
@@ -740,10 +756,13 @@ impl BinaryIvfBuilder {
         // distinct leaf in the batch instead of per code. Sorting by
         // `(cluster, index)` keeps each leaf's entries in ascending batch order,
         // so the serialized payload is byte-identical to per-code insertion.
-        self.zero_codes += codes
-            .chunks_exact(byte_len)
-            .filter(|code| is_zero_code(code))
-            .count();
+        for code in codes.chunks_exact(byte_len) {
+            if is_zero_code(code) {
+                self.zero_codes += 1;
+            } else if is_ones_code(code) {
+                self.ones_codes += 1;
+            }
+        }
         let mut order: Vec<u32> = (0..assignments.len() as u32).collect();
         order.sort_unstable_by_key(|&index| (assignments[index as usize], index));
         let mut run_start = 0usize;
@@ -785,6 +804,7 @@ impl BinaryIvfBuilder {
             clusters,
             len: self.len,
             zero_codes: self.zero_codes,
+            ones_codes: self.ones_codes,
         };
         index
             .validate()
@@ -880,6 +900,11 @@ impl BinaryIvfIndex {
         self.zero_codes
     }
 
+    /// Indexed codes that were all-ones.
+    pub fn ones_codes(&self) -> usize {
+        self.ones_codes
+    }
+
     /// Largest leaf as `(cluster_id, count)`, for skew reporting.
     pub fn largest_cluster(&self) -> Option<(u32, usize)> {
         self.clusters
@@ -916,7 +941,16 @@ pub(crate) fn report_binary_build_quality(
              and every query probing that leaf scans them; check the embedding producer",
             100.0 * zero as f64 / indexed.max(1) as f64,
         );
-        crate::observe::binary_zero_vectors(index_label, field_id, zero, indexed);
+    }
+    let ones = index.ones_codes();
+    if ones > 0 {
+        log::warn!(
+            "[binary_ivf] index={index_label} field={field_id}: {ones} of {indexed} indexed \
+             vectors ({:.1}%) are all-ones — the saturated twin of the zero code (NaN packed \
+             through a signbit test): they match nothing, collapse into a single leaf, and \
+             every query probing that leaf scans them; check the embedding producer",
+            100.0 * ones as f64 / indexed.max(1) as f64,
+        );
     }
     if let Some((cluster_id, count)) = index.largest_cluster()
         && count >= LEAF_SKEW_WARN_MINIMUM
@@ -1896,6 +1930,37 @@ mod tests {
         assert!(
             largest >= 4,
             "all-zero codes should share one leaf, got {largest}"
+        );
+        report_binary_build_quality("test-index", 7, &index);
+    }
+
+    /// All-ones codes — signbit-packed NaN — are counted and reported the
+    /// same way as zeros, and separately from them: the two faces attribute
+    /// to different producer revisions.
+    #[test]
+    fn all_ones_codes_are_counted_and_reported() {
+        let codes = [0xffu8, 0xf0, 0xff, 0xff, 0x0f, 0x00];
+        let labels = [(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (5, 0)];
+        let mut config = BinaryIvfConfig::new(8, 2);
+        config.train_iters = 2;
+        config.max_train_samples = labels.len();
+        let quantizer = BinaryCoarseQuantizer::train(config, &codes, labels.len(), "test").unwrap();
+        let index =
+            BinaryIvfIndex::build(&quantizer, IvfRoutingMode::Flat, &codes, &labels).unwrap();
+
+        assert_eq!(
+            index.ones_codes(),
+            3,
+            "three all-ones codes must be counted"
+        );
+        assert_eq!(index.zero_codes(), 1, "the zero code is counted on its own");
+        assert_eq!(index.len(), labels.len(), "every vector stays indexed");
+        // Identical codes share a nearest centroid, so the constant collapses
+        // into one leaf: the same topology the ann_health warning names.
+        let (_, largest) = index.largest_cluster().expect("a populated leaf");
+        assert!(
+            largest >= 3,
+            "all-ones codes should share one leaf, got {largest}"
         );
         report_binary_build_quality("test-index", 7, &index);
     }

--- a/hermes-server/Dockerfile
+++ b/hermes-server/Dockerfile
@@ -5,7 +5,7 @@
 # trixie (glibc 2.38), the binary stopped loading on the bookworm runtime
 # ("GLIBC_2.38 not found", prod CrashLoopBackOff 2026-07-15). The server
 # needs no nightly features; it builds on stable.
-FROM rust:1.97.0-slim-bookworm AS builder
+FROM rust:1.97.1-slim-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \

--- a/hermes-tool/src/diagnose.rs
+++ b/hermes-tool/src/diagnose.rs
@@ -179,13 +179,16 @@ impl From<AnnHealth> for AnnReport {
 
 /// Degenerate-vector scan over a deterministic sample of flat storage.
 ///
-/// This is the check that catches the zero-embedding failure mode: an
-/// upstream producer emitting all-zero vectors that carry no signal and
-/// collapse into a single IVF leaf.
+/// This is the check that catches the constant-embedding failure modes: an
+/// upstream producer emitting all-zero (or, from signbit-packed NaN,
+/// all-ones) vectors that carry no signal and collapse into a single IVF
+/// leaf.
 #[derive(Serialize)]
 pub struct SampleReport {
     pub sampled: usize,
     pub all_zero: usize,
+    /// Binary codes with every bit set — the saturated twin of `all_zero`.
+    pub all_ones: usize,
     /// Binary codes: fraction of bits set, averaged over the sample. Healthy
     /// sign-quantized embeddings sit near 0.5.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -220,6 +223,7 @@ pub struct FieldAggregate {
     pub clusters_nonempty: u64,
     pub worst_leaf_share: f64,
     pub all_zero_sampled: usize,
+    pub all_ones_sampled: usize,
     pub sampled: usize,
 }
 
@@ -427,6 +431,7 @@ async fn diagnose_segment(
         if let Some(sample_report) = &sample {
             aggregate.sampled += sample_report.sampled;
             aggregate.all_zero_sampled += sample_report.all_zero;
+            aggregate.all_ones_sampled += sample_report.all_ones;
         }
 
         dense_fields.push(DenseFieldReport {
@@ -515,6 +520,7 @@ async fn sample_flat_vectors(
     let is_binary = matches!(flat.quantization, DenseVectorQuantization::Binary);
 
     let mut all_zero = 0usize;
+    let mut all_ones = 0usize;
     let mut bits_set = 0u64;
     let mut non_finite = 0usize;
     let mut raw = vec![0u8; byte_size];
@@ -535,6 +541,11 @@ async fn sample_flat_vectors(
         if raw.iter().all(|&byte| byte == 0) {
             all_zero += 1;
         }
+        // Saturated codes only mean something for binary quantization; a
+        // float row of 0xff bytes is NaN garbage the non-finite check owns.
+        if is_binary && raw.iter().all(|&byte| byte == 0xff) {
+            all_ones += 1;
+        }
         if is_binary {
             bits_set += raw
                 .iter()
@@ -550,6 +561,7 @@ async fn sample_flat_vectors(
     Ok(SampleReport {
         sampled: take,
         all_zero,
+        all_ones,
         mean_bit_fraction: is_binary.then(|| {
             if take == 0 {
                 0.0
@@ -805,8 +817,8 @@ fn print_human(report: &Report) {
             println!();
             if let Some(sample) = &dense.sample {
                 print!(
-                    "        sample: {} vectors, {} all-zero",
-                    sample.sampled, sample.all_zero
+                    "        sample: {} vectors, {} all-zero, {} all-ones",
+                    sample.sampled, sample.all_zero, sample.all_ones
                 );
                 if let Some(fraction) = sample.mean_bit_fraction {
                     print!(", mean bit fraction {fraction:.3}");
@@ -888,10 +900,12 @@ fn print_human(report: &Report) {
             );
             if aggregate.sampled > 0 {
                 print!(
-                    " sampled={} all_zero={} ({:.1}%)",
+                    " sampled={} all_zero={} ({:.1}%) all_ones={} ({:.1}%)",
                     aggregate.sampled,
                     aggregate.all_zero_sampled,
                     100.0 * aggregate.all_zero_sampled as f64 / aggregate.sampled as f64,
+                    aggregate.all_ones_sampled,
+                    100.0 * aggregate.all_ones_sampled as f64 / aggregate.sampled as f64,
                 );
             }
             println!();
@@ -938,6 +952,9 @@ mod tests {
             doc.add_text(title, format!("document {i} about hemoglobin"));
             let code: Vec<u8> = if i % 4 == 0 {
                 vec![0u8; byte_len]
+            } else if i % 8 == 1 {
+                // The saturated face: signbit-packed NaN from the producer.
+                vec![0xffu8; byte_len]
             } else {
                 (0..byte_len)
                     .map(|_| {
@@ -1024,6 +1041,16 @@ mod tests {
         assert!(
             (0.15..=0.35).contains(&zero_rate),
             "sample must recover the ~25% zero rate, got {zero_rate:.2}"
+        );
+        let ones: usize = dense
+            .iter()
+            .filter_map(|f| f.sample.as_ref())
+            .map(|s| s.all_ones)
+            .sum();
+        let ones_rate = ones as f64 / sampled as f64;
+        assert!(
+            (0.06..=0.25).contains(&ones_rate),
+            "sample must recover the ~12.5% all-ones rate, got {ones_rate:.2}"
         );
 
         // Cheap tier covers the other structures too.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97.0"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Follow-up to the all-ones incident investigation (the Feb-2024→Mar-2026 signbit-NaN cohort: 36% of fresh documents vectors were the identical 0xFF code, codebook centroid 0 trained to the constant).

- Binary IVF builds count **all-ones codes** alongside all-zero and warn identically; **training excludes both constant faces** so the codebook stops absorbing producer bugs.
- `diagnose --sample` reports `all_zero` and `all_ones`.
- Query-side degenerate gates and `hermes_binary_*` counters **removed** per operator call — upstream fixed; build/training warnings cover detection.
- **Every binary merge compacts** (threshold + force flag removed); reorder clones vectors again (legacy-heal path removed). Honest bench after fixing a first-touch page-fault artifact: byte-copy 38.0 GiB/s vs compaction 32.4 GiB/s (~17% CPU on a ~0.7s stage of a 20s+ merge) for permanent fragmentation 1.0.
- **Rust 1.97.1** across toolchain, Dockerfiles, CI, publish.

Validated: clippy -D warnings (core/tool/server), WASM feature check, binary/reorder/compaction suites + diagnose E2E green on 1.97.1.