### PR TITLE
Make LogSumExp combiner a count-invariant smooth maximum

### DIFF
--- a/hermes-client-typescript/src/generated/hermes.ts
+++ b/hermes-client-typescript/src/generated/hermes.ts
@@ -47,7 +47,7 @@ export function fusionMethodToJSON(object: FusionMethod): string {
 
 /** How to combine scores for multi-valued documents */
 export enum MultiValueCombiner {
-  /** COMBINER_LOG_SUM_EXP - Log-sum-exp smooth maximum (default) */
+  /** COMBINER_LOG_SUM_EXP - Softmax-weighted smooth maximum (default); count-invariant */
   COMBINER_LOG_SUM_EXP = 0,
   /** COMBINER_MAX - Take maximum score */
   COMBINER_MAX = 1,

--- a/hermes-core/src/query/fusion.rs
+++ b/hermes-core/src/query/fusion.rs
@@ -155,9 +155,10 @@ pub fn fuse_ranked_lists(
 /// - Fused results carry per-chunk `positions`, so `ordinal_scores` survive
 ///   fusion (chunk attribution for snippets / chunk selection).
 ///
-/// `MultiValueCombiner::Max` is the recommended combiner: RRF contributions
-/// are small in magnitude, which makes `LogSumExp` degenerate (temperature
-/// far exceeds the score scale).
+/// `MultiValueCombiner::Max` is the recommended combiner. `LogSumExp` is
+/// also safe now that it is a softmax-weighted maximum — at RRF's small
+/// score scale it degrades toward a mean rather than growing with chunk
+/// count — but `Max` states the intent directly.
 pub fn fuse_ranked_lists_chunked(
     lists: Vec<(Vec<SearchResult>, f32)>,
     method: FusionMethod,

--- a/hermes-core/src/query/vector/combiner.rs
+++ b/hermes-core/src/query/vector/combiner.rs
@@ -9,9 +9,17 @@ pub enum MultiValueCombiner {
     Max,
     /// Take the average score
     Avg,
-    /// Log-Sum-Exp: smooth maximum approximation (default)
-    /// `score = (1/t) * log(Σ exp(t * sᵢ))`
-    /// Higher temperature → closer to max; lower → closer to mean
+    /// Softmax-weighted smooth maximum (default)
+    /// `score = Σ softmax(t * sᵢ) * sᵢ`
+    /// Higher temperature → closer to max; lower → closer to mean.
+    ///
+    /// Deliberately NOT the raw `(1/t)·log(Σ exp(t·sᵢ))`: that form adds
+    /// `ln(n)/t` per document, so chunk *count* outranked chunk quality —
+    /// a 300-chunk compendium of mediocre matches beat every focused paper
+    /// (score 0.55 + ln(300)/1.5 ≈ 4.3 vs 0.72 + ln(3)/1.5 ≈ 1.4). The
+    /// softmax weighting is count-invariant (n identical scores combine to
+    /// that score), bounded by the max, and still tracks a dominant score
+    /// at any scale.
     LogSumExp {
         /// Temperature parameter (default: 1.5)
         temperature: f32,
@@ -94,8 +102,9 @@ impl MultiValueCombiner {
                 sum / scores.len() as f32
             }
             MultiValueCombiner::LogSumExp { temperature } => {
-                // Numerically stable log-sum-exp:
-                // LSE(x) = max(x) + log(Σ exp(xᵢ - max(x)))
+                // Softmax-weighted average, numerically stabilized by
+                // subtracting the max before exponentiation. The max's own
+                // weight is exp(0) = 1, so the denominator is never zero.
                 let t = *temperature;
                 let max_score = scores
                     .iter()
@@ -103,12 +112,14 @@ impl MultiValueCombiner {
                     .max_by(|a, b| a.total_cmp(b))
                     .unwrap_or(0.0);
 
-                let sum_exp: f32 = scores
-                    .iter()
-                    .map(|(_, s)| (t * (s - max_score)).exp())
-                    .sum();
-
-                max_score + sum_exp.ln() / t
+                let mut weight_sum = 0.0f32;
+                let mut weighted = 0.0f32;
+                for (_, s) in scores {
+                    let weight = (t * (s - max_score)).exp();
+                    weight_sum += weight;
+                    weighted += weight * s;
+                }
+                weighted / weight_sum
             }
             MultiValueCombiner::WeightedTopK { k, decay } => {
                 // Sort scores descending and take top k
@@ -167,9 +178,57 @@ mod tests {
         let scores = vec![(0, 1.0), (1, 2.0), (2, 3.0)];
         let combiner = MultiValueCombiner::log_sum_exp();
         let result = combiner.combine(&scores);
-        // LogSumExp should be between max (3.0) and max + log(n)/t
-        assert!(result >= 3.0);
-        assert!(result <= 3.0 + (3.0_f32).ln() / 1.5);
+        // A smooth maximum lives between the mean and the max, weighted
+        // toward the max.
+        assert!(result > 2.0, "must exceed the mean, got {result}");
+        assert!(result <= 3.0, "must never exceed the max, got {result}");
+    }
+
+    /// The production incident this pins: a 300-chunk compendium whose chunks
+    /// all score ~0.5 must not outrank a 3-chunk paper whose chunks score
+    /// ~0.7. The additive `ln(n)/t` count term of the raw log-sum-exp did
+    /// exactly that (0.55 + ln(300)/1.5 ≈ 4.3 vs 0.72 + ln(3)/1.5 ≈ 1.4),
+    /// which buried every relevant result for "off-label aripiprazole usage"
+    /// under generic long documents.
+    #[test]
+    fn log_sum_exp_is_count_invariant_and_bounded_by_max() {
+        let combiner = MultiValueCombiner::log_sum_exp();
+
+        // n identical scores combine to that score, regardless of n.
+        let identical: Vec<(u32, f32)> = (0..300).map(|i| (i, 0.7)).collect();
+        let combined = combiner.combine(&identical);
+        assert!(
+            (combined - 0.7).abs() < 1e-3,
+            "300 identical 0.7 chunks must combine to 0.7, got {combined}"
+        );
+
+        // Many mediocre chunks never outrank a few strong ones.
+        let mut compendium: Vec<(u32, f32)> = (0..300).map(|i| (i, 0.5)).collect();
+        compendium.push((300, 0.55));
+        let paper = vec![(0, 0.72), (1, 0.70), (2, 0.65)];
+        let compendium_score = combiner.combine(&compendium);
+        let paper_score = combiner.combine(&paper);
+        assert!(
+            paper_score > compendium_score,
+            "3 strong chunks ({paper_score}) must beat 301 mediocre ones ({compendium_score})"
+        );
+    }
+
+    /// The reason the fix is a softmax-weighted average rather than
+    /// `LSE - ln(n)/t`: subtracting the count term turns the combiner into a
+    /// near-average in the peaked regime, collapsing a document whose single
+    /// chunk scores 15 among 299 zeros to ~6.4. The softmax weighting keeps
+    /// it at the dominant score.
+    #[test]
+    fn log_sum_exp_tracks_a_dominant_score_at_sparse_scale() {
+        let combiner = MultiValueCombiner::log_sum_exp_with_temperature(0.7);
+        let mut scores: Vec<(u32, f32)> = (0..299).map(|i| (i, 0.0)).collect();
+        scores.push((299, 15.0));
+        let combined = combiner.combine(&scores);
+        assert!(
+            (combined - 15.0).abs() < 0.3,
+            "one dominant sparse chunk must keep its score, got {combined}"
+        );
     }
 
     #[test]

--- a/hermes-core/src/query/vector/sparse.rs
+++ b/hermes-core/src/query/vector/sparse.rs
@@ -78,10 +78,10 @@ impl std::fmt::Display for SparseVectorQuery {
 impl SparseVectorQuery {
     /// Create a new sparse vector query
     ///
-    /// Default combiner is `LogSumExp { temperature: 0.7 }` which provides
-    /// saturation for documents with many sparse vectors (e.g., 100+ ordinals).
-    /// This prevents over-weighting from multiple matches while still allowing
-    /// additional matches to contribute to the score.
+    /// Default combiner is `LogSumExp { temperature: 0.7 }` — a
+    /// softmax-weighted smooth maximum. A document's score follows its
+    /// strongest ordinals; ordinal *count* contributes nothing on its own,
+    /// so many-chunk documents cannot outrank a focused strong match.
     pub fn new(field: Field, vector: Vec<(u32, f32)>) -> Self {
         let mut q = Self {
             field,

--- a/hermes-core/src/segment/ann_disk.rs
+++ b/hermes-core/src/segment/ann_disk.rs
@@ -2711,29 +2711,54 @@ mod tests {
         write_built_runs(binary_header(6), &runs, &mut bytes).unwrap();
         let disk = AnnDiskIndex::open(OwnedBytes::new(bytes), AnnKind::BinaryIvf, 3).unwrap();
 
-        for combiner in [
-            crate::query::MultiValueCombiner::Sum,
-            crate::query::MultiValueCombiner::default(),
-        ] {
-            let (result, probed) = disk
-                .search_binary_combined_documents(1, &[0], &[0, 1], combiner)
-                .unwrap();
-            assert_eq!(result.len(), 1, "combined search must honor k");
-            assert_eq!(
-                result[0].doc_id, 1,
-                "SOAR duplicate changed {combiner:?} ranking: {result:?}",
-            );
-            // Exact leaf scores are handed back only for the retained document,
-            // deduplicated and sorted, so reranking can skip re-reading them.
-            assert_eq!(
-                probed
-                    .iter()
-                    .map(|&(doc_id, ordinal, _)| (doc_id, ordinal))
-                    .collect::<Vec<_>>(),
-                vec![(1, 0), (1, 1)],
-                "{combiner:?}",
-            );
-        }
+        // Under Sum the SOAR duplicate decides the winner outright: doc 0
+        // counted twice (2.0) would beat doc 1's two distinct values (1.5);
+        // deduplicated, doc 1 wins.
+        let sum = crate::query::MultiValueCombiner::Sum;
+        let (result, probed) = disk
+            .search_binary_combined_documents(1, &[0], &[0, 1], sum)
+            .unwrap();
+        assert_eq!(result.len(), 1, "combined search must honor k");
+        assert_eq!(
+            result[0].doc_id, 1,
+            "SOAR duplicate changed {sum:?} ranking: {result:?}",
+        );
+        // Exact leaf scores are handed back only for the retained document,
+        // deduplicated and sorted, so reranking can skip re-reading them.
+        assert_eq!(
+            probed
+                .iter()
+                .map(|&(doc_id, ordinal, _)| (doc_id, ordinal))
+                .collect::<Vec<_>>(),
+            vec![(1, 0), (1, 1)],
+            "{sum:?}",
+        );
+
+        // Under the default smooth-max combiner doc 0's perfect ordinal wins
+        // regardless of the duplicate, so dedup is pinned through the exact
+        // score instead: it must equal the combiner over the two *distinct*
+        // ordinals (1.0 and 0.0) — a double-counted (doc 0, ordinal 0) would
+        // inflate it.
+        let smooth_max = crate::query::MultiValueCombiner::default();
+        let (result, probed) = disk
+            .search_binary_combined_documents(1, &[0], &[0, 1], smooth_max)
+            .unwrap();
+        assert_eq!(result.len(), 1, "combined search must honor k");
+        assert_eq!(result[0].doc_id, 0, "{result:?}");
+        let expected = smooth_max.combine(&[(0, 1.0), (1, 0.0)]);
+        assert!(
+            (result[0].score - expected).abs() < 1e-6,
+            "SOAR duplicate leaked into {smooth_max:?}: got {}, expected {expected}",
+            result[0].score,
+        );
+        assert_eq!(
+            probed
+                .iter()
+                .map(|&(doc_id, ordinal, _)| (doc_id, ordinal))
+                .collect::<Vec<_>>(),
+            vec![(0, 0), (0, 1)],
+            "{smooth_max:?}",
+        );
 
         let (top_two, probed) = disk
             .search_binary_combined_documents(
@@ -2856,9 +2881,12 @@ mod tests {
             sum[0].doc_id, 1,
             "two complete values must make doc 1 win by Sum: {sum:?}"
         );
+        // The default combiner is a smooth maximum: doc 0's single best value
+        // (1.0) outranks doc 1's two 0.8 values — value count alone no longer
+        // wins. Sum above is what pins that both of doc 1's values were seen.
         assert_eq!(
-            default_combiner[0].doc_id, 1,
-            "default LogSumExp must aggregate complete documents: {default_combiner:?}"
+            default_combiner[0].doc_id, 0,
+            "default smooth-max must follow the best value: {default_combiner:?}"
         );
         assert!(sum[0].score > max[0].2);
 

--- a/hermes-proto/hermes.proto
+++ b/hermes-proto/hermes.proto
@@ -91,7 +91,7 @@ message FusionQuery {
 
 // How to combine scores for multi-valued documents
 enum MultiValueCombiner {
-  COMBINER_LOG_SUM_EXP = 0;  // Log-sum-exp smooth maximum (default)
+  COMBINER_LOG_SUM_EXP = 0;  // Softmax-weighted smooth maximum (default); count-invariant
   COMBINER_MAX = 1;          // Take maximum score
   COMBINER_AVG = 2;          // Average all scores
   COMBINER_SUM = 3;          // Sum all scores


### PR DESCRIPTION
Fixes the relevance failure behind "off-label aripiprazole usage": the raw log-sum-exp added `ln(n)/t` per document, so chunk **count** outranked chunk quality — a 300-chunk compendium of ~0.5 matches (score ≈ 4.3) buried every focused paper (≈ 1.4) in the hybrid fusion's dense channel.

**LogSumExp is now the softmax-weighted average** `Σ softmax(t·sᵢ)·sᵢ`:
- n identical scores → that score (count-invariant)
- always bounded by the max
- tracks a dominant score at any scale (naive `LSE − ln(n)/t` would collapse a single 15-score sparse chunk among 299 zeros to ~6.4; softmax keeps ≈14.9)

Verified live on `documents_20260726`: `COMBINER_MAX` (the t→∞ limit of the new form) returns the aripiprazole papers at 0.70–0.72 where the old default returned 280–470k-char compendia.

Tests written failing-first (`log_sum_exp_is_count_invariant_and_bounded_by_max`, `log_sum_exp_tracks_a_dominant_score_at_sparse_scale`); SOAR-dedup and TQ-completeness tests re-pinned to their true invariants. 1051 tests green, clippy clean, TS binding regenerated (comment-only), Python bindings unchanged.

⚠️ Score scale changes for multi-value fields (now bounded by max) — downstream absolute-score thresholds should be re-checked.