### PR TITLE
Run hybrid fusion sub-queries in parallel

### DIFF
--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -1227,19 +1227,28 @@ impl<D: Directory + 'static> Searcher<D> {
         }
         combiner.validate().map_err(crate::Error::Query)?;
 
-        // Each sub-query already fans out across every segment. Keep fusion
-        // sequential at the outer level so queries do not contend for the
-        // same rayon pool, mmap pages, and memory bandwidth, and so each
-        // query's shared threshold converges as early as possible.
+        // A hybrid query's sub-queries are independent (different fields and
+        // scorers), so run them concurrently instead of one after another. Each
+        // still fans out across every segment; rayon work-stealing overlaps the
+        // branches' I/O stalls and fills the cores one branch leaves idle, so a
+        // hybrid costs ~max(branch) rather than the sum. Sequential execution
+        // left that on the table — measured 10–40% over max on production.
+        //
+        // Safe to nest: sub-query parallelism sits over segment parallelism on
+        // the same shared pool (bounded by its thread count, not multiplied),
+        // and the sparse BMP random-I/O gate is acquired per branch — hybrid's
+        // binary branch never takes it, so the two cannot serialize on it.
+        // `par_iter` preserves input order for deterministic rank ties.
         #[cfg(feature = "sync")]
         if !self.segments.is_empty()
             && tokio::runtime::Handle::current().runtime_flavor()
                 == tokio::runtime::RuntimeFlavor::MultiThread
         {
+            use rayon::prelude::*;
             let lists: Vec<(Vec<crate::query::SearchResult>, f32, u32)> =
                 tokio::task::block_in_place(|| {
                     queries
-                        .iter()
+                        .par_iter()
                         .map(|&(query, weight)| {
                             let (results, seen) =
                                 self.search_internal_sync(query, fetch_limit, 0, true)?;
@@ -1261,13 +1270,14 @@ impl<D: Directory + 'static> Searcher<D> {
             return Ok((fused, total_seen));
         }
 
-        // Async/current-thread fallback uses the same outer execution shape
-        // and preserves input list order for deterministic rank ties.
-        let mut lists = Vec::with_capacity(queries.len());
-        for &(query, weight) in queries {
-            let (results, seen) = self.search_with_positions(query, fetch_limit).await?;
-            lists.push((results, weight, seen));
-        }
+        // Async/current-thread fallback: run the sub-queries concurrently so
+        // their awaits overlap, preserving input order for deterministic ties.
+        let lists: Vec<(Vec<crate::query::SearchResult>, f32, u32)> =
+            futures::future::try_join_all(queries.iter().map(|&(query, weight)| async move {
+                let (results, seen) = self.search_with_positions(query, fetch_limit).await?;
+                Ok::<_, crate::Error>((results, weight, seen))
+            }))
+            .await?;
         let mut total_seen = 0u32;
         let ranked_lists = lists
             .into_iter()
@@ -1823,7 +1833,7 @@ mod search_window_tests {
 #[cfg(test)]
 mod fusion_parallelism_tests {
     #[test]
-    fn fusion_keeps_parallelism_at_the_segment_level() {
+    fn fusion_runs_subqueries_concurrently() {
         let source = include_str!("searcher.rs");
         let body = source
             .split("pub async fn search_fused_with_count")
@@ -1831,13 +1841,16 @@ mod fusion_parallelism_tests {
             .and_then(|tail| tail.split("/// Two-stage search").next())
             .expect("bounded fusion search implementation");
 
+        // Independent hybrid branches run concurrently — rayon over the shared
+        // pool in the multi-thread sync path, joined futures in the async
+        // fallback — so a hybrid query costs ~max(branch) instead of the sum.
         assert!(
-            !body.contains(".par_iter()"),
-            "sub-query parallelism nests over segment parallelism"
+            body.contains(".par_iter()"),
+            "sync fusion path must run sub-queries in parallel over the rayon pool"
         );
         assert!(
-            !body.contains(".buffered("),
-            "async fusion fallback must preserve the same bounded execution shape"
+            body.contains("try_join_all"),
+            "async fusion fallback must run sub-queries concurrently"
         );
     }
 }


### PR DESCRIPTION
Hybrid queries ran their sub-queries (sparse BMP + binary dense) **sequentially**, so a hybrid cost ~`sparse+binary` — reliably slower than either branch alone. Measured on `documents_20260726`: **+4–24 ms over max(branch), 10–40% overhead**.

The branches are independent (different fields/scorers), so this runs them concurrently — rayon `par_iter` over the shared pool (multi-thread sync path), `try_join_all` (async fallback). Each branch still fans out across every segment; work-stealing overlaps their I/O stalls and fills idle cores → targets ~`max(branch)`.

**Safe to nest:** sub-query parallelism sits over segment parallelism on the same pool (bounded by thread count, not multiplied); the sparse BMP random-I/O gate is per-branch and hybrid's binary branch never takes it, so they can't serialize on it. Order preserved for deterministic ties; **fusion output unchanged** (1061 tests pass, clippy clean).

⚠️ **Tradeoff:** raises per-query rayon task pressure under heavy concurrent load (why it was sequential originally). Bounded by pool size so throughput isn't multiplied, but worth watching p99 under load after deploy.