### PR TITLE
feat(train): build exact multi-billion-token curriculum

### DIFF
--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -55,7 +55,9 @@ profile from 1980 onward. Their subject-specific hybrid queries provide the
 positive relevance gate; canonical document type, language, negative-title,
 and text-quality checks remain mandatory. Foundation and school stages also
 require positive title patterns, where educational level cannot be inferred
-safely from a broad subject query alone.
+safely from a broad subject query alone. Advanced searches run once per
+canonical document type so one high-volume type cannot consume the complete
+500-hit fusion window for a subject and year.
 
 Install the live-only dependencies, set the standard libpq environment
 variables (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD`), and

--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -41,23 +41,64 @@ hybrid discovery and returns IDs plus lightweight metadata;
 copy for only those IDs. Search-result text can never enter the output. URI
 scheme and prefix do not affect selection; URIs are metadata only. The builder
 requires Search API's `hybrid` mode, which fuses sparse and dense retrieval.
+Both reranking paths are explicitly disabled: discovery sends `rerank: false`
+and `cross_rerank: false`.
+The example uses focused English and Russian subject queries rather than one
+generic result window. Each query runs once without a date constraint and again
+across publication-time buckets, always using the Search API's complete 500-hit
+window; IDs are then globally deduplicated. This broadens coverage without
+offset pagination beyond the API's `offset + limit <= 500` contract. Discovery
+is constrained by each stage's document types, while language is verified
+against the canonical AlloyDB record instead of adding an expensive search-time
+language scan. University and research stages use a named yearly partition
+profile from 1980 onward, exposing enough distinct high-quality results to meet
+the corpus token contract without weakening title or text-quality filters.
 
 Install the live-only dependencies, set the standard libpq environment
 variables (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD`), and
 run:
 
 ```bash
-python -m pip install asyncpg zstandard
+python -m pip install asyncpg zstandard gigatoken==0.10.0
 python hermes-train/scripts/build_education_curriculum.py \
   --config hermes-train/education-curriculum.example.json \
+  --tokenizer tokenizer.json \
   --output /data/education-curriculum
 ```
 
-Use `--search-limit 10` for a live smoke build. The output includes the staged
-JSONL files, validation splits, a directly consumable `curriculum.json`, and a
-checksummed `manifest.json` with Search API query and rejection counts. Selection
-and replay are covered without live services by
+Use `--search-limit 10` for a live smoke build; an explicit search cap is
+recorded in the manifest and skips the production minimum-token gate. The
+output includes the staged JSONL files, validation splits, a directly
+consumable `curriculum.json`, and a checksummed `manifest.json` with Search API
+query and rejection counts. The manifest embeds the complete non-secret build
+configuration and its canonical hash for deterministic reproduction. An
+ID/score/URI-only cache under `.discovery-cache/` makes interrupted discovery
+resumable without retaining Search API snippets or other enriched fields.
+The manifest also records canonical character counts plus language and document
+type distributions so a completed corpus can be sized and audited without
+opening document bodies. Documents with concentrated extraction-control or
+Unicode replacement characters are rejected; isolated parser controls are
+normalized before shard writing.
+Large builds use a bounded-memory streaming path: canonical bodies are fetched
+from AlloyDB with deterministic multi-connection prefetch, written immediately,
+and never retained beyond the bounded prefetch/tokenization windows. A SQLite
+build catalog plus atomic tier files makes discovery and completed tiers
+restartable. GigaToken counts every emitted chunk with the exact deployed
+`tokenizer.json`; the example refuses to finish below 10 billion unique causal
+tokens and records both unique tokens and replay-adjusted curriculum exposure in
+the manifest. The final advanced stage stops after the exact count crosses the
+15-billion target (with at most one prefetched-batch overshoot); hard document
+caps keep the result in the requested 10–20B range.
+Selection and replay are covered without live services by
 `python3 hermes-train/scripts/test_education_curriculum.py`.
+After a production build, independently re-read every shard, verify checksums,
+split isolation, text hygiene, and all stored token counts with:
+
+```bash
+python hermes-train/scripts/audit_education_curriculum.py \
+  --output /data/education-curriculum \
+  --tokenizer tokenizer.json
+```
 
 Training is defined by a versioned JSON curriculum; stage geometry is not split
 between CLI flags and a data manifest. Start from

--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -51,8 +51,11 @@ offset pagination beyond the API's `offset + limit <= 500` contract. Discovery
 is constrained by each stage's document types, while language is verified
 against the canonical AlloyDB record instead of adding an expensive search-time
 language scan. University and research stages use a named yearly partition
-profile from 1980 onward, exposing enough distinct high-quality results to meet
-the corpus token contract without weakening title or text-quality filters.
+profile from 1980 onward. Their subject-specific hybrid queries provide the
+positive relevance gate; canonical document type, language, negative-title,
+and text-quality checks remain mandatory. Foundation and school stages also
+require positive title patterns, where educational level cannot be inferred
+safely from a broad subject query alone.
 
 Install the live-only dependencies, set the standard libpq environment
 variables (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, and `PGPASSWORD`), and

--- a/hermes-train/education-curriculum.example.json
+++ b/hermes-train/education-curriculum.example.json
@@ -4,18 +4,331 @@
     "url": "http://search-api/internal/v2/search/",
     "index": "documents",
     "mode": "hybrid",
-    "page_size": 250,
-    "limit_per_search": 2000,
+    "page_size": 500,
+    "limit_per_search": 500,
+    "concurrency": 8,
     "deduplicate": true,
-    "timeout_seconds": 60,
-    "max_retries": 6,
-    "retry_initial_seconds": 1,
-    "retry_max_seconds": 15
+    "filter_language": false,
+    "filter_document_types": true,
+    "heap_factor": 0.2,
+    "cross_rerank": false,
+    "timeout_seconds": 180,
+    "max_retries": 3,
+    "retry_initial_seconds": 5,
+    "retry_max_seconds": 60,
+    "minimum_page_retries": 12,
+    "minimum_page_retry_seconds": 30,
+    "minimum_page_retry_max_seconds": 180,
+    "time_partitions": [
+      { "name": "all" },
+      { "name": "pre-1800", "issued_before": -5364662400 },
+      {
+        "name": "1800-1899",
+        "issued_after": -5364662400,
+        "issued_before": -2208988800
+      },
+      {
+        "name": "1900-1949",
+        "issued_after": -2208988800,
+        "issued_before": -631152000
+      },
+      {
+        "name": "1950-1979",
+        "issued_after": -631152000,
+        "issued_before": 315532800
+      },
+      {
+        "name": "1980-1999",
+        "issued_after": 315532800,
+        "issued_before": 946684800
+      },
+      {
+        "name": "2000-2009",
+        "issued_after": 946684800,
+        "issued_before": 1262304000
+      },
+      {
+        "name": "2010-2015",
+        "issued_after": 1262304000,
+        "issued_before": 1451606400
+      },
+      {
+        "name": "2016-2020",
+        "issued_after": 1451606400,
+        "issued_before": 1609459200
+      },
+      {
+        "name": "2021-2026",
+        "issued_after": 1609459200,
+        "issued_before": 1798761600
+      }
+    ],
+    "time_partition_profiles": {
+      "research-yearly": [
+        { "name": "all" },
+        { "name": "pre-1800", "issued_before": -5364662400 },
+        {
+          "name": "1800-1899",
+          "issued_after": -5364662400,
+          "issued_before": -2208988800
+        },
+        {
+          "name": "1900-1949",
+          "issued_after": -2208988800,
+          "issued_before": -631152000
+        },
+        {
+          "name": "1950-1979",
+          "issued_after": -631152000,
+          "issued_before": 315532800
+        },
+        {
+          "name": "1980",
+          "issued_after": 315532800,
+          "issued_before": 347155200
+        },
+        {
+          "name": "1981",
+          "issued_after": 347155200,
+          "issued_before": 378691200
+        },
+        {
+          "name": "1982",
+          "issued_after": 378691200,
+          "issued_before": 410227200
+        },
+        {
+          "name": "1983",
+          "issued_after": 410227200,
+          "issued_before": 441763200
+        },
+        {
+          "name": "1984",
+          "issued_after": 441763200,
+          "issued_before": 473385600
+        },
+        {
+          "name": "1985",
+          "issued_after": 473385600,
+          "issued_before": 504921600
+        },
+        {
+          "name": "1986",
+          "issued_after": 504921600,
+          "issued_before": 536457600
+        },
+        {
+          "name": "1987",
+          "issued_after": 536457600,
+          "issued_before": 567993600
+        },
+        {
+          "name": "1988",
+          "issued_after": 567993600,
+          "issued_before": 599616000
+        },
+        {
+          "name": "1989",
+          "issued_after": 599616000,
+          "issued_before": 631152000
+        },
+        {
+          "name": "1990",
+          "issued_after": 631152000,
+          "issued_before": 662688000
+        },
+        {
+          "name": "1991",
+          "issued_after": 662688000,
+          "issued_before": 694224000
+        },
+        {
+          "name": "1992",
+          "issued_after": 694224000,
+          "issued_before": 725846400
+        },
+        {
+          "name": "1993",
+          "issued_after": 725846400,
+          "issued_before": 757382400
+        },
+        {
+          "name": "1994",
+          "issued_after": 757382400,
+          "issued_before": 788918400
+        },
+        {
+          "name": "1995",
+          "issued_after": 788918400,
+          "issued_before": 820454400
+        },
+        {
+          "name": "1996",
+          "issued_after": 820454400,
+          "issued_before": 852076800
+        },
+        {
+          "name": "1997",
+          "issued_after": 852076800,
+          "issued_before": 883612800
+        },
+        {
+          "name": "1998",
+          "issued_after": 883612800,
+          "issued_before": 915148800
+        },
+        {
+          "name": "1999",
+          "issued_after": 915148800,
+          "issued_before": 946684800
+        },
+        {
+          "name": "2000",
+          "issued_after": 946684800,
+          "issued_before": 978307200
+        },
+        {
+          "name": "2001",
+          "issued_after": 978307200,
+          "issued_before": 1009843200
+        },
+        {
+          "name": "2002",
+          "issued_after": 1009843200,
+          "issued_before": 1041379200
+        },
+        {
+          "name": "2003",
+          "issued_after": 1041379200,
+          "issued_before": 1072915200
+        },
+        {
+          "name": "2004",
+          "issued_after": 1072915200,
+          "issued_before": 1104537600
+        },
+        {
+          "name": "2005",
+          "issued_after": 1104537600,
+          "issued_before": 1136073600
+        },
+        {
+          "name": "2006",
+          "issued_after": 1136073600,
+          "issued_before": 1167609600
+        },
+        {
+          "name": "2007",
+          "issued_after": 1167609600,
+          "issued_before": 1199145600
+        },
+        {
+          "name": "2008",
+          "issued_after": 1199145600,
+          "issued_before": 1230768000
+        },
+        {
+          "name": "2009",
+          "issued_after": 1230768000,
+          "issued_before": 1262304000
+        },
+        {
+          "name": "2010",
+          "issued_after": 1262304000,
+          "issued_before": 1293840000
+        },
+        {
+          "name": "2011",
+          "issued_after": 1293840000,
+          "issued_before": 1325376000
+        },
+        {
+          "name": "2012",
+          "issued_after": 1325376000,
+          "issued_before": 1356998400
+        },
+        {
+          "name": "2013",
+          "issued_after": 1356998400,
+          "issued_before": 1388534400
+        },
+        {
+          "name": "2014",
+          "issued_after": 1388534400,
+          "issued_before": 1420070400
+        },
+        {
+          "name": "2015",
+          "issued_after": 1420070400,
+          "issued_before": 1451606400
+        },
+        {
+          "name": "2016",
+          "issued_after": 1451606400,
+          "issued_before": 1483228800
+        },
+        {
+          "name": "2017",
+          "issued_after": 1483228800,
+          "issued_before": 1514764800
+        },
+        {
+          "name": "2018",
+          "issued_after": 1514764800,
+          "issued_before": 1546300800
+        },
+        {
+          "name": "2019",
+          "issued_after": 1546300800,
+          "issued_before": 1577836800
+        },
+        {
+          "name": "2020",
+          "issued_after": 1577836800,
+          "issued_before": 1609459200
+        },
+        {
+          "name": "2021",
+          "issued_after": 1609459200,
+          "issued_before": 1640995200
+        },
+        {
+          "name": "2022",
+          "issued_after": 1640995200,
+          "issued_before": 1672531200
+        },
+        {
+          "name": "2023",
+          "issued_after": 1672531200,
+          "issued_before": 1704067200
+        },
+        {
+          "name": "2024",
+          "issued_after": 1704067200,
+          "issued_before": 1735689600
+        },
+        {
+          "name": "2025",
+          "issued_after": 1735689600,
+          "issued_before": 1767225600
+        },
+        {
+          "name": "2026",
+          "issued_after": 1767225600,
+          "issued_before": 1798761600
+        }
+      ]
+    }
   },
   "alloydb": {
-    "batch_size": 500,
+    "batch_size": 128,
     "connections": 4,
+    "prefetch_batches": 4,
     "timeout_seconds": 120
+  },
+  "quality": {
+    "max_control_character_fraction": 0.01,
+    "max_replacement_character_fraction": 0.001
   },
   "output": {
     "compression": "zstd",
@@ -24,7 +337,12 @@
     "max_chunk_chars": 24000,
     "min_chunk_chars": 300,
     "max_chunks_per_document": 256,
-    "hard_negatives": 2
+    "hard_negatives": 2,
+    "streaming": true,
+    "token_batch_characters": 16000000,
+    "cleanup_build_artifacts": true,
+    "minimum_causal_tokens": 10000000000,
+    "target_causal_tokens": 15000000000
   },
   "stages": [
     {
@@ -37,37 +355,119 @@
       "max_duplicate_line_fraction": 0.35,
       "max_documents": 8000,
       "max_documents_per_language": 6000,
-      "min_documents": 2,
+      "min_documents": 150,
       "title_allow_patterns": [
-        "\\b(alphabet|abc|primer|phonics|spelling|grammar|reader|reading|language arts)\\b",
-        "(буквар|азбук|грамматик|чтени|русский язык)"
+        "\\b(alphabet|abc|primer|phonics|spelling|grammar|reader|reading|language arts|vocabulary|punctuation|sentence|composition|word families)\\b",
+        "(буквар|азбук|грамматик|чтени|русский язык|обучение грамоте|развитие речи|орфограф|пунктуац|словар)"
       ],
       "title_deny_patterns": [
         "proceedings",
         "journal",
         "conference",
-        "dissertation"
+        "dissertation",
+        "\\b(curriculum|syllabus|teacher evaluation)\\b",
+        "(конференц|диссертац|оценочные средства|рабочая программа)"
       ],
       "searches": [
         {
-          "name": "english-alphabet-and-phonics",
+          "name": "en-alphabet-phonics",
           "language": "en",
-          "query": "beginner English alphabet and phonics book"
+          "query": "English alphabet phonics primer for beginning readers"
         },
         {
-          "name": "english-grammar-foundations",
+          "name": "en-decodable-readers",
+          "language": "en",
+          "query": "decodable phonics reader book for children"
+        },
+        {
+          "name": "en-early-reading",
+          "language": "en",
+          "query": "early reading primer with simple sentences and stories"
+        },
+        {
+          "name": "en-basic-grammar",
           "language": "en",
           "query": "basic English grammar and sentence structure textbook"
         },
         {
-          "name": "russian-alphabet-and-reading",
-          "language": "ru",
-          "query": "букварь азбука обучение чтению"
+          "name": "en-grammar-workbook",
+          "language": "en",
+          "query": "beginner English grammar exercises workbook"
         },
         {
-          "name": "russian-basic-grammar",
+          "name": "en-spelling-punctuation",
+          "language": "en",
+          "query": "elementary spelling and punctuation practice book"
+        },
+        {
+          "name": "en-vocabulary-word-families",
+          "language": "en",
+          "query": "children vocabulary and word families workbook"
+        },
+        {
+          "name": "en-reading-comprehension",
+          "language": "en",
+          "query": "elementary reading comprehension passages and questions"
+        },
+        {
+          "name": "en-language-arts",
+          "language": "en",
+          "query": "primary school English language arts textbook"
+        },
+        {
+          "name": "en-writing-composition",
+          "language": "en",
+          "query": "elementary sentence writing and composition workbook"
+        },
+        {
+          "name": "ru-alphabet-primer",
+          "language": "ru",
+          "query": "букварь азбука обучение чтению для детей"
+        },
+        {
+          "name": "ru-literacy-first-grade",
+          "language": "ru",
+          "query": "обучение грамоте русский язык 1 класс учебник"
+        },
+        {
+          "name": "ru-early-reading",
+          "language": "ru",
+          "query": "книга для первого чтения простые рассказы детям"
+        },
+        {
+          "name": "ru-primary-language",
+          "language": "ru",
+          "query": "русский язык начальная школа 2 3 4 класс учебник"
+        },
+        {
+          "name": "ru-basic-grammar",
           "language": "ru",
           "query": "основы грамматики русского языка для детей"
+        },
+        {
+          "name": "ru-grammar-exercises",
+          "language": "ru",
+          "query": "грамматика русского языка упражнения для школьников"
+        },
+        {
+          "name": "ru-spelling-punctuation",
+          "language": "ru",
+          "query": "орфография и пунктуация начальная школа упражнения"
+        },
+        {
+          "name": "ru-reading-comprehension",
+          "language": "ru",
+          "query": "литературное чтение начальная школа учебник вопросы"
+        },
+        {
+          "name": "ru-speech-development",
+          "language": "ru",
+          "query": "развитие речи словарного запаса для детей пособие"
+        },
+        {
+          "name": "ru-beginner-second-language",
+          "language": "ru",
+          "query": "русский язык как иностранный начальный уровень учебник"
         }
       ],
       "training": {
@@ -95,40 +495,184 @@
       "name": "school-fundamentals",
       "languages": ["en", "ru"],
       "allow_unknown_language": false,
-      "document_types": ["book", "wiki", "report"],
+      "document_types": ["book", "wiki"],
       "min_content_chars": 1000,
       "max_content_chars": 4000000,
       "max_duplicate_line_fraction": 0.35,
       "max_documents": 16000,
       "max_documents_per_language": 12000,
-      "min_documents": 2,
+      "min_documents": 250,
       "title_allow_patterns": [
-        "\\b(grade|school|elementary|middle school|arithmetic|science|history|geography|algebra|geometry|textbook|workbook)\\b",
-        "(школ|учебник|арифметик|естествозн|истори|географ|алгебр|геометр)"
+        "\\b(grade|school|elementary|middle school|secondary school|arithmetic|mathematics|science|history|geography|algebra|geometry|biology|chemistry|physics|astronomy|civics|economics|computer science|logic|textbook|workbook)\\b",
+        "(школ|учебник|арифметик|математик|естествозн|истори|географ|алгебр|геометр|биолог|хими|физик|астроном|обществозн|экономик|информатик|логик)"
+      ],
+      "title_deny_patterns": [
+        "\\b(conference|proceedings|seminar|curriculum|syllabus|teacher guide)\\b",
+        "(конференц|семинар|рабочая программа|примерная программа|методические рекомендации)"
       ],
       "replay": {
         "language-foundations": 0.2
       },
       "searches": [
         {
-          "name": "english-school-math-reasoning",
+          "name": "en-arithmetic",
           "language": "en",
-          "query": "school mathematics and reasoning textbook"
+          "query": "elementary arithmetic textbook with worked problems"
         },
         {
-          "name": "english-school-science-and-facts",
+          "name": "en-fractions-decimals",
           "language": "en",
-          "query": "school science history and geography textbook"
+          "query": "school fractions decimals percentages workbook"
         },
         {
-          "name": "russian-school-math",
-          "language": "ru",
-          "query": "школьный учебник математики с задачами"
+          "name": "en-algebra",
+          "language": "en",
+          "query": "middle school algebra textbook with exercises"
         },
         {
-          "name": "russian-school-science",
+          "name": "en-geometry",
+          "language": "en",
+          "query": "school geometry textbook with proofs and problems"
+        },
+        {
+          "name": "en-math-reasoning",
+          "language": "en",
+          "query": "school mathematics problem solving and reasoning book"
+        },
+        {
+          "name": "en-biology",
+          "language": "en",
+          "query": "secondary school biology textbook"
+        },
+        {
+          "name": "en-chemistry",
+          "language": "en",
+          "query": "secondary school chemistry textbook with experiments"
+        },
+        {
+          "name": "en-physics",
+          "language": "en",
+          "query": "secondary school physics textbook with problems"
+        },
+        {
+          "name": "en-earth-science",
+          "language": "en",
+          "query": "school earth science and environmental science textbook"
+        },
+        {
+          "name": "en-astronomy",
+          "language": "en",
+          "query": "introductory astronomy textbook for school students"
+        },
+        {
+          "name": "en-world-history",
+          "language": "en",
+          "query": "world history school textbook"
+        },
+        {
+          "name": "en-geography",
+          "language": "en",
+          "query": "school geography textbook with maps"
+        },
+        {
+          "name": "en-civics",
+          "language": "en",
+          "query": "school civics government and society textbook"
+        },
+        {
+          "name": "en-economics",
+          "language": "en",
+          "query": "high school economics textbook"
+        },
+        {
+          "name": "en-computer-science",
+          "language": "en",
+          "query": "school computer science and programming textbook"
+        },
+        {
+          "name": "en-logic-critical-thinking",
+          "language": "en",
+          "query": "logic and critical thinking workbook for students"
+        },
+        {
+          "name": "ru-arithmetic",
           "language": "ru",
-          "query": "школьный учебник естествознания истории и географии"
+          "query": "арифметика начальная школа учебник задачи"
+        },
+        {
+          "name": "ru-fractions-decimals",
+          "language": "ru",
+          "query": "дроби десятичные числа проценты школьные задачи"
+        },
+        {
+          "name": "ru-algebra",
+          "language": "ru",
+          "query": "алгебра 7 8 9 класс учебник задачи"
+        },
+        {
+          "name": "ru-geometry",
+          "language": "ru",
+          "query": "геометрия школьный учебник доказательства задачи"
+        },
+        {
+          "name": "ru-math-reasoning",
+          "language": "ru",
+          "query": "школьная математика логические задачи с решениями"
+        },
+        {
+          "name": "ru-biology",
+          "language": "ru",
+          "query": "биология 6 7 8 9 класс учебник"
+        },
+        {
+          "name": "ru-chemistry",
+          "language": "ru",
+          "query": "химия 8 9 класс учебник задачи опыты"
+        },
+        {
+          "name": "ru-physics",
+          "language": "ru",
+          "query": "физика 7 8 9 класс учебник задачи"
+        },
+        {
+          "name": "ru-earth-science",
+          "language": "ru",
+          "query": "естествознание экология школьный учебник"
+        },
+        {
+          "name": "ru-astronomy",
+          "language": "ru",
+          "query": "астрономия школьный учебник"
+        },
+        {
+          "name": "ru-world-history",
+          "language": "ru",
+          "query": "всемирная история школьный учебник"
+        },
+        {
+          "name": "ru-geography",
+          "language": "ru",
+          "query": "география 5 6 7 8 9 класс учебник"
+        },
+        {
+          "name": "ru-civics",
+          "language": "ru",
+          "query": "обществознание право государство школьный учебник"
+        },
+        {
+          "name": "ru-economics",
+          "language": "ru",
+          "query": "экономика для школьников учебник"
+        },
+        {
+          "name": "ru-computer-science",
+          "language": "ru",
+          "query": "информатика программирование школьный учебник"
+        },
+        {
+          "name": "ru-logic-critical-thinking",
+          "language": "ru",
+          "query": "логика критическое мышление задачи для школьников"
         }
       ],
       "training": {
@@ -154,18 +698,25 @@
     },
     {
       "name": "university-core",
+      "time_partition_profile": "research-yearly",
       "languages": ["en", "ru"],
       "allow_unknown_language": false,
-      "document_types": ["book", "wiki", "report"],
+      "document_types": ["book", "report"],
       "min_content_chars": 1500,
       "max_content_chars": 5000000,
       "max_duplicate_line_fraction": 0.35,
-      "max_documents": 20000,
-      "max_documents_per_language": 15000,
-      "min_documents": 2,
+      "max_documents": 30000,
+      "max_documents_per_language": 24000,
+      "min_documents": 250,
       "title_allow_patterns": [
-        "\\b(university|college|undergraduate|textbook|handbook|lecture notes|calculus|linear algebra|computer science)\\b",
-        "(университет|учебник|курс лекц|высшая математик|линейная алгебр)"
+        "\\b(textbook|handbook|lecture notes|course|foundations|principles|calculus|linear algebra|discrete mathematics|probability|statistics|differential equations|mechanics|electrodynamics|chemistry|biology|genetics|algorithms|data structures|operating systems|databases|networks|software engineering|economics|philosophy|logic|psychology|linguistics|research methods)\\b",
+        "(учебник|учебное пособие|задачник|курс лекц|высшая математик|математический анализ|линейная алгебр|дискретн|теори.*вероятност|статистик|дифференциальн|механик|электродинамик|хими|биолог|генетик|алгоритм|структур.*данн|операционн.*систем|баз.*данн|сетев|программирован|экономик|философ|логик|психолог|лингвист|метод.*исследован)"
+      ],
+      "title_deny_patterns": [
+        "^\\s*(the\\s+)?[\\w .'-]+\\b(university|college)\\s*$",
+        "^\\s*[\\w .«»\"'-]+\\b(университет|институт|академия)\\s*$",
+        "\\b(conference|proceedings|course catalog)\\b",
+        "(конференц|сборник трудов)"
       ],
       "replay": {
         "language-foundations": 0.1,
@@ -173,19 +724,204 @@
       },
       "searches": [
         {
-          "name": "english-university-stem",
+          "name": "en-calculus",
           "language": "en",
-          "query": "undergraduate STEM textbook with worked examples"
+          "query": "undergraduate calculus textbook with worked examples"
         },
         {
-          "name": "english-university-computing-and-humanities",
+          "name": "en-linear-algebra",
           "language": "en",
-          "query": "university computer science social science and humanities textbook"
+          "query": "undergraduate linear algebra textbook with exercises"
         },
         {
-          "name": "russian-university-textbooks",
+          "name": "en-discrete-mathematics",
+          "language": "en",
+          "query": "discrete mathematics textbook proofs and problems"
+        },
+        {
+          "name": "en-probability-statistics",
+          "language": "en",
+          "query": "undergraduate probability and statistics textbook"
+        },
+        {
+          "name": "en-differential-equations",
+          "language": "en",
+          "query": "ordinary differential equations textbook with solutions"
+        },
+        {
+          "name": "en-classical-mechanics",
+          "language": "en",
+          "query": "undergraduate classical mechanics textbook problems"
+        },
+        {
+          "name": "en-electromagnetism",
+          "language": "en",
+          "query": "undergraduate electricity magnetism electrodynamics textbook"
+        },
+        {
+          "name": "en-general-chemistry",
+          "language": "en",
+          "query": "university general chemistry textbook"
+        },
+        {
+          "name": "en-organic-chemistry",
+          "language": "en",
+          "query": "undergraduate organic chemistry textbook"
+        },
+        {
+          "name": "en-cell-biology-genetics",
+          "language": "en",
+          "query": "university cell biology molecular biology genetics textbook"
+        },
+        {
+          "name": "en-algorithms-data-structures",
+          "language": "en",
+          "query": "algorithms and data structures university textbook"
+        },
+        {
+          "name": "en-operating-systems",
+          "language": "en",
+          "query": "operating systems computer architecture textbook"
+        },
+        {
+          "name": "en-databases-networks",
+          "language": "en",
+          "query": "database systems and computer networks textbook"
+        },
+        {
+          "name": "en-software-engineering",
+          "language": "en",
+          "query": "software engineering programming languages textbook"
+        },
+        {
+          "name": "en-economics",
+          "language": "en",
+          "query": "undergraduate microeconomics macroeconomics textbook"
+        },
+        {
+          "name": "en-philosophy-logic",
+          "language": "en",
+          "query": "introduction to philosophy and formal logic textbook"
+        },
+        {
+          "name": "en-psychology",
+          "language": "en",
+          "query": "undergraduate cognitive psychology textbook"
+        },
+        {
+          "name": "en-linguistics",
+          "language": "en",
+          "query": "introduction to linguistics textbook phonology syntax semantics"
+        },
+        {
+          "name": "en-history-politics",
+          "language": "en",
+          "query": "undergraduate history political science textbook"
+        },
+        {
+          "name": "en-research-methods",
+          "language": "en",
+          "query": "university research methods and experimental design textbook"
+        },
+        {
+          "name": "ru-calculus",
           "language": "ru",
-          "query": "университетский учебник с примерами и упражнениями"
+          "query": "математический анализ учебник для вузов задачи"
+        },
+        {
+          "name": "ru-linear-algebra",
+          "language": "ru",
+          "query": "линейная алгебра аналитическая геометрия учебник задачи"
+        },
+        {
+          "name": "ru-discrete-mathematics",
+          "language": "ru",
+          "query": "дискретная математика учебник для вузов"
+        },
+        {
+          "name": "ru-probability-statistics",
+          "language": "ru",
+          "query": "теория вероятностей математическая статистика учебник"
+        },
+        {
+          "name": "ru-differential-equations",
+          "language": "ru",
+          "query": "дифференциальные уравнения учебник задачи решения"
+        },
+        {
+          "name": "ru-classical-mechanics",
+          "language": "ru",
+          "query": "теоретическая классическая механика учебник для вузов"
+        },
+        {
+          "name": "ru-electromagnetism",
+          "language": "ru",
+          "query": "электродинамика электричество магнетизм учебник задачи"
+        },
+        {
+          "name": "ru-general-chemistry",
+          "language": "ru",
+          "query": "общая химия учебник для вузов"
+        },
+        {
+          "name": "ru-organic-chemistry",
+          "language": "ru",
+          "query": "органическая химия учебник для вузов"
+        },
+        {
+          "name": "ru-cell-biology-genetics",
+          "language": "ru",
+          "query": "молекулярная биология генетика учебник"
+        },
+        {
+          "name": "ru-algorithms-data-structures",
+          "language": "ru",
+          "query": "алгоритмы структуры данных учебник задачи"
+        },
+        {
+          "name": "ru-operating-systems",
+          "language": "ru",
+          "query": "операционные системы архитектура компьютера учебник"
+        },
+        {
+          "name": "ru-databases-networks",
+          "language": "ru",
+          "query": "базы данных компьютерные сети учебник"
+        },
+        {
+          "name": "ru-software-engineering",
+          "language": "ru",
+          "query": "программная инженерия языки программирования учебник"
+        },
+        {
+          "name": "ru-economics",
+          "language": "ru",
+          "query": "микроэкономика макроэкономика учебник для вузов"
+        },
+        {
+          "name": "ru-philosophy-logic",
+          "language": "ru",
+          "query": "философия формальная логика учебник для вузов"
+        },
+        {
+          "name": "ru-psychology",
+          "language": "ru",
+          "query": "когнитивная психология учебник для вузов"
+        },
+        {
+          "name": "ru-linguistics",
+          "language": "ru",
+          "query": "общее языкознание лингвистика учебник"
+        },
+        {
+          "name": "ru-history-politics",
+          "language": "ru",
+          "query": "история политология учебник для вузов"
+        },
+        {
+          "name": "ru-research-methods",
+          "language": "ru",
+          "query": "методы научного исследования экспериментальный дизайн учебник"
         }
       ],
       "training": {
@@ -211,18 +947,23 @@
     },
     {
       "name": "advanced-scholarship",
+      "time_partition_profile": "research-yearly",
       "languages": ["en", "ru"],
       "allow_unknown_language": false,
       "document_types": ["journal-article", "book", "report"],
       "min_content_chars": 1500,
       "max_content_chars": 5000000,
       "max_duplicate_line_fraction": 0.35,
-      "max_documents": 30000,
-      "max_documents_per_language": 24000,
-      "min_documents": 2,
+      "max_documents": 50000,
+      "max_documents_per_language": 40000,
+      "min_documents": 300,
       "title_allow_patterns": [
-        "\\b(advanced|graduate|monograph|handbook|review|proceedings|journal|thesis|dissertation|analysis|theory)\\b",
-        "(монограф|диссертац|научн|теори|анализ|аспирант)"
+        "\\b(advanced|graduate|monograph|handbook|review|proceedings|journal|thesis|dissertation|analysis|theory|algebra|geometry|topology|probability|statistics|optimization|algorithms|complexity|machine learning|information retrieval|language model|distributed systems|database|cryptography|quantum|astrophysics|materials science|catalysis|genomics|molecular biology|neuroscience|clinical|climate|econometrics|linguistics|robotics|control systems)\\b",
+        "(монограф|диссертац|научн|теори|анализ|аспирант|алгебр|геометр|тополог|вероятност|статистик|оптимизац|алгоритм|сложност|машинн.*обучен|информационн.*поиск|языков.*модел|распределенн.*систем|баз.*данн|криптограф|квантов|астрофиз|материаловед|катализ|геном|молекулярн.*биолог|нейро|клиническ|климат|эконометр|лингвист|робот|теори.*управлен)"
+      ],
+      "title_deny_patterns": [
+        "\\b(how to write|getting .* published|publication guide|literature review organizer|research agenda for graduate education|for beginners|introductory|introduction to|basics of|fundamentals of|book review)\\b",
+        "(как написать|подготовка презентации|организация работы студентов|публикационная активность|для начинающих|введение в|основы|рецензия на)"
       ],
       "replay": {
         "language-foundations": 0.05,
@@ -231,19 +972,204 @@
       },
       "searches": [
         {
-          "name": "english-advanced-textbooks-and-monographs",
+          "name": "en-pure-mathematics",
           "language": "en",
-          "query": "advanced graduate textbook handbook or research monograph"
+          "query": "research monograph advanced algebra geometry topology number theory"
         },
         {
-          "name": "english-scholarly-papers",
+          "name": "en-probability-statistics",
           "language": "en",
-          "query": "scholarly review paper with methods results and references"
+          "query": "advanced probability statistics stochastic processes monograph review"
         },
         {
-          "name": "russian-advanced-scholarship",
+          "name": "en-optimization-numerical",
+          "language": "en",
+          "query": "optimization numerical analysis scientific computing research monograph"
+        },
+        {
+          "name": "en-theoretical-computer-science",
+          "language": "en",
+          "query": "theoretical computer science algorithms complexity research monograph"
+        },
+        {
+          "name": "en-machine-learning",
+          "language": "en",
+          "query": "machine learning deep learning advanced textbook research review"
+        },
+        {
+          "name": "en-nlp-retrieval",
+          "language": "en",
+          "query": "natural language processing information retrieval language models research"
+        },
+        {
+          "name": "en-distributed-databases",
+          "language": "en",
+          "query": "distributed systems database systems research monograph review"
+        },
+        {
+          "name": "en-security-cryptography",
+          "language": "en",
+          "query": "cryptography computer security advanced textbook research monograph"
+        },
+        {
+          "name": "en-quantum-physics",
+          "language": "en",
+          "query": "quantum physics condensed matter advanced monograph review"
+        },
+        {
+          "name": "en-astrophysics",
+          "language": "en",
+          "query": "astrophysics cosmology advanced textbook research monograph"
+        },
+        {
+          "name": "en-materials-engineering",
+          "language": "en",
+          "query": "materials science chemical engineering advanced handbook review"
+        },
+        {
+          "name": "en-chemistry-catalysis",
+          "language": "en",
+          "query": "organic synthesis catalysis chemistry research monograph review"
+        },
+        {
+          "name": "en-genomics-molecular-biology",
+          "language": "en",
+          "query": "genomics molecular biology advanced textbook research review"
+        },
+        {
+          "name": "en-neuroscience",
+          "language": "en",
+          "query": "neuroscience cognition advanced handbook research review"
+        },
+        {
+          "name": "en-clinical-medicine",
+          "language": "en",
+          "query": "clinical medicine evidence systematic review advanced handbook"
+        },
+        {
+          "name": "en-climate-geoscience",
+          "language": "en",
+          "query": "climate science geoscience advanced monograph research review"
+        },
+        {
+          "name": "en-econometrics",
+          "language": "en",
+          "query": "econometrics economic theory advanced textbook research monograph"
+        },
+        {
+          "name": "en-social-political-science",
+          "language": "en",
+          "query": "political science sociology advanced research monograph"
+        },
+        {
+          "name": "en-linguistics",
+          "language": "en",
+          "query": "theoretical computational linguistics research monograph review"
+        },
+        {
+          "name": "en-control-robotics",
+          "language": "en",
+          "query": "control systems robotics advanced textbook research monograph"
+        },
+        {
+          "name": "ru-pure-mathematics",
           "language": "ru",
-          "query": "научная монография диссертация или обзорная статья"
+          "query": "современная алгебра геометрия топология теория чисел монография"
+        },
+        {
+          "name": "ru-probability-statistics",
+          "language": "ru",
+          "query": "теория вероятностей статистика случайные процессы научная монография"
+        },
+        {
+          "name": "ru-optimization-numerical",
+          "language": "ru",
+          "query": "оптимизация численные методы научные вычисления монография"
+        },
+        {
+          "name": "ru-theoretical-computer-science",
+          "language": "ru",
+          "query": "теоретическая информатика алгоритмы сложность научная монография"
+        },
+        {
+          "name": "ru-machine-learning",
+          "language": "ru",
+          "query": "машинное обучение глубокое обучение научная монография обзор"
+        },
+        {
+          "name": "ru-nlp-retrieval",
+          "language": "ru",
+          "query": "обработка естественного языка информационный поиск языковые модели"
+        },
+        {
+          "name": "ru-distributed-databases",
+          "language": "ru",
+          "query": "распределенные системы базы данных научная монография"
+        },
+        {
+          "name": "ru-security-cryptography",
+          "language": "ru",
+          "query": "криптография информационная безопасность научная монография"
+        },
+        {
+          "name": "ru-quantum-physics",
+          "language": "ru",
+          "query": "квантовая физика физика конденсированного состояния монография"
+        },
+        {
+          "name": "ru-astrophysics",
+          "language": "ru",
+          "query": "астрофизика космология научная монография"
+        },
+        {
+          "name": "ru-materials-engineering",
+          "language": "ru",
+          "query": "материаловедение химическая технология научная монография"
+        },
+        {
+          "name": "ru-chemistry-catalysis",
+          "language": "ru",
+          "query": "органический синтез катализ химия научная монография"
+        },
+        {
+          "name": "ru-genomics-molecular-biology",
+          "language": "ru",
+          "query": "геномика молекулярная биология научная монография обзор"
+        },
+        {
+          "name": "ru-neuroscience",
+          "language": "ru",
+          "query": "нейробиология когнитивные науки научная монография"
+        },
+        {
+          "name": "ru-clinical-medicine",
+          "language": "ru",
+          "query": "клиническая медицина систематический обзор научная монография"
+        },
+        {
+          "name": "ru-climate-geoscience",
+          "language": "ru",
+          "query": "климатология науки о Земле научная монография"
+        },
+        {
+          "name": "ru-econometrics",
+          "language": "ru",
+          "query": "эконометрика экономическая теория научная монография"
+        },
+        {
+          "name": "ru-social-political-science",
+          "language": "ru",
+          "query": "политология социология научная монография"
+        },
+        {
+          "name": "ru-linguistics",
+          "language": "ru",
+          "query": "теоретическая компьютерная лингвистика научная монография"
+        },
+        {
+          "name": "ru-control-robotics",
+          "language": "ru",
+          "query": "теория управления робототехника научная монография"
         }
       ],
       "training": {

--- a/hermes-train/education-curriculum.example.json
+++ b/hermes-train/education-curriculum.example.json
@@ -705,13 +705,9 @@
       "min_content_chars": 1500,
       "max_content_chars": 5000000,
       "max_duplicate_line_fraction": 0.35,
-      "max_documents": 30000,
-      "max_documents_per_language": 24000,
+      "max_documents": 50000,
+      "max_documents_per_language": 40000,
       "min_documents": 250,
-      "title_allow_patterns": [
-        "\\b(textbook|handbook|lecture notes|course|foundations|principles|calculus|linear algebra|discrete mathematics|probability|statistics|differential equations|mechanics|electrodynamics|chemistry|biology|genetics|algorithms|data structures|operating systems|databases|networks|software engineering|economics|philosophy|logic|psychology|linguistics|research methods)\\b",
-        "(учебник|учебное пособие|задачник|курс лекц|высшая математик|математический анализ|линейная алгебр|дискретн|теори.*вероятност|статистик|дифференциальн|механик|электродинамик|хими|биолог|генетик|алгоритм|структур.*данн|операционн.*систем|баз.*данн|сетев|программирован|экономик|философ|логик|психолог|лингвист|метод.*исследован)"
-      ],
       "title_deny_patterns": [
         "^\\s*(the\\s+)?[\\w .'-]+\\b(university|college)\\s*$",
         "^\\s*[\\w .«»\"'-]+\\b(университет|институт|академия)\\s*$",
@@ -954,13 +950,9 @@
       "min_content_chars": 1500,
       "max_content_chars": 5000000,
       "max_duplicate_line_fraction": 0.35,
-      "max_documents": 50000,
-      "max_documents_per_language": 40000,
+      "max_documents": 200000,
+      "max_documents_per_language": 160000,
       "min_documents": 300,
-      "title_allow_patterns": [
-        "\\b(advanced|graduate|monograph|handbook|review|proceedings|journal|thesis|dissertation|analysis|theory|algebra|geometry|topology|probability|statistics|optimization|algorithms|complexity|machine learning|information retrieval|language model|distributed systems|database|cryptography|quantum|astrophysics|materials science|catalysis|genomics|molecular biology|neuroscience|clinical|climate|econometrics|linguistics|robotics|control systems)\\b",
-        "(монограф|диссертац|научн|теори|анализ|аспирант|алгебр|геометр|тополог|вероятност|статистик|оптимизац|алгоритм|сложност|машинн.*обучен|информационн.*поиск|языков.*модел|распределенн.*систем|баз.*данн|криптограф|квантов|астрофиз|материаловед|катализ|геном|молекулярн.*биолог|нейро|клиническ|климат|эконометр|лингвист|робот|теори.*управлен)"
-      ],
       "title_deny_patterns": [
         "\\b(how to write|getting .* published|publication guide|literature review organizer|research agenda for graduate education|for beginners|introductory|introduction to|basics of|fundamentals of|book review)\\b",
         "(как написать|подготовка презентации|организация работы студентов|публикационная активность|для начинающих|введение в|основы|рецензия на)"

--- a/hermes-train/education-curriculum.example.json
+++ b/hermes-train/education-curriculum.example.json
@@ -944,6 +944,7 @@
     {
       "name": "advanced-scholarship",
       "time_partition_profile": "research-yearly",
+      "search_document_types_separately": true,
       "languages": ["en", "ru"],
       "allow_unknown_language": false,
       "document_types": ["journal-article", "book", "report"],

--- a/hermes-train/scripts/audit_education_curriculum.py
+++ b/hermes-train/scripts/audit_education_curriculum.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Verify checksums, splits, text hygiene, and exact tokens in a built corpus."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from curriculum_streaming import GigaTokenCounter, _payload_characters
+from education_curriculum import CONTROL_CHARACTER_RE
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--tokenizer",
+        type=Path,
+        help="re-encode every causal record and verify its stored exact count",
+    )
+    parser.add_argument(
+        "--token-batch-characters",
+        type=int,
+        default=16_000_000,
+    )
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def records(path: Path) -> Iterator[tuple[int, str, dict[str, Any]]]:
+    raw = path.open("rb")
+    try:
+        if path.suffix == ".zst":
+            try:
+                import zstandard  # type: ignore[import-not-found]
+            except ImportError as error:
+                raise RuntimeError(
+                    "zstd input requires `pip install zstandard`"
+                ) from error
+            binary = zstandard.ZstdDecompressor().stream_reader(raw)
+        else:
+            binary = raw
+        with io.TextIOWrapper(binary, encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, start=1):
+                if not line.strip():
+                    continue
+                value = json.loads(line)
+                if not isinstance(value, dict):
+                    raise ValueError(f"non-object JSON at {path}:{line_number}")
+                yield line_number, line, value
+    finally:
+        if not raw.closed:
+            raw.close()
+
+
+def text_values(record: dict[str, Any]) -> Iterator[str]:
+    for key in (
+        "text",
+        "document",
+        "summary",
+        "request",
+        "plan",
+        "context",
+        "query",
+        "positive",
+    ):
+        value = record.get(key)
+        if isinstance(value, str):
+            yield value
+    negatives = record.get("negatives")
+    if isinstance(negatives, list):
+        yield from (value for value in negatives if isinstance(value, str))
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise RuntimeError(message)
+
+
+def verify_token_batch(
+    counter: GigaTokenCounter,
+    path: Path,
+    texts: list[str],
+    expected: list[tuple[int, int]],
+) -> None:
+    actual = counter.count_batch(texts)
+    for measured, (line_number, stored) in zip(actual, expected, strict=True):
+        require(
+            measured == stored,
+            f"token mismatch at {path}:{line_number}: stored {stored}, measured {measured}",
+        )
+
+
+def audit(args: argparse.Namespace) -> dict[str, Any]:
+    manifest_path = args.output / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    embedded_config = manifest.get("config")
+    require(isinstance(embedded_config, dict), "manifest is missing its build config")
+    config_hash = hashlib.sha256(
+        json.dumps(
+            embedded_config,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+    ).hexdigest()
+    require(
+        config_hash == manifest.get("config_sha256"),
+        "embedded build config does not match config_sha256",
+    )
+    counter = GigaTokenCounter(args.tokenizer) if args.tokenizer else None
+    if counter is not None:
+        expected_tokenizer = manifest.get("tokenizer", {})
+        measured_tokenizer = counter.metadata
+        for key in ("engine", "version", "tokenizer_sha256", "vocab_size"):
+            require(
+                measured_tokenizer.get(key) == expected_tokenizer.get(key),
+                f"audit tokenizer {key} does not match the build manifest",
+            )
+    train_documents: set[str] = set()
+    eval_documents: set[str] = set()
+    unique_causal: dict[tuple[str, int], int] = {}
+    total_train_causal_tokens = 0
+    total_train_causal_with_eos = 0
+    total_records = 0
+    file_results: list[dict[str, Any]] = []
+
+    for expected in manifest["files"]:
+        path = args.output / expected["path"]
+        logging.info("auditing file=%s", path.name)
+        require(path.exists(), f"missing manifest file {path}")
+        require(
+            path.stat().st_size == expected["bytes"], f"byte size mismatch for {path}"
+        )
+        require(
+            sha256_file(path) == expected["sha256"], f"checksum mismatch for {path}"
+        )
+        is_causal = "-causal.jsonl" in path.name
+        is_eval = "-eval-" in path.name
+        record_count = 0
+        uncompressed_bytes = 0
+        payload_characters = 0
+        content_tokens = 0
+        pending_texts: list[str] = []
+        pending_expected: list[tuple[int, int]] = []
+        pending_characters = 0
+
+        for line_number, line, record in records(path):
+            record_count += 1
+            if record_count % 100_000 == 0:
+                logging.info(
+                    "auditing file=%s records=%d",
+                    path.name,
+                    record_count,
+                )
+            uncompressed_bytes += len(line.encode("utf-8"))
+            payload_characters += _payload_characters(record)
+            document_id = record.get("document_id")
+            require(
+                isinstance(document_id, str) and document_id,
+                f"missing document_id at {path}:{line_number}",
+            )
+            (eval_documents if is_eval else train_documents).add(document_id)
+            for text in text_values(record):
+                require(
+                    "\ufffd" not in text,
+                    f"replacement character at {path}:{line_number}",
+                )
+                require(
+                    CONTROL_CHARACTER_RE.search(text) is None,
+                    f"control character at {path}:{line_number}",
+                )
+            if is_causal:
+                text = record.get("text")
+                token_count = record.get("token_count")
+                chunk = record.get("chunk")
+                require(
+                    isinstance(text, str) and text,
+                    f"missing text at {path}:{line_number}",
+                )
+                require(
+                    isinstance(token_count, int) and token_count > 0,
+                    f"missing token_count at {path}:{line_number}",
+                )
+                require(
+                    isinstance(chunk, int) and chunk >= 0,
+                    f"missing chunk index at {path}:{line_number}",
+                )
+                content_tokens += token_count
+                if not is_eval:
+                    total_train_causal_tokens += token_count
+                    total_train_causal_with_eos += token_count + 1
+                    unique_causal.setdefault((document_id, chunk), token_count)
+                if counter is not None:
+                    pending_texts.append(text)
+                    pending_expected.append((line_number, token_count))
+                    pending_characters += len(text)
+                    if pending_characters >= args.token_batch_characters:
+                        verify_token_batch(
+                            counter, path, pending_texts, pending_expected
+                        )
+                        pending_texts.clear()
+                        pending_expected.clear()
+                        pending_characters = 0
+        if pending_texts and counter is not None:
+            verify_token_batch(counter, path, pending_texts, pending_expected)
+        require(
+            record_count == expected["records"], f"record count mismatch for {path}"
+        )
+        require(
+            uncompressed_bytes == expected["uncompressed_bytes"],
+            f"uncompressed byte mismatch for {path}",
+        )
+        require(
+            payload_characters == expected["payload_characters"],
+            f"payload character mismatch for {path}",
+        )
+        if is_causal:
+            require(
+                content_tokens == expected.get("content_tokens", 0),
+                f"content token mismatch for {path}",
+            )
+        total_records += record_count
+        logging.info(
+            "verified file=%s records=%d content_tokens=%d",
+            path.name,
+            record_count,
+            content_tokens,
+        )
+        file_results.append(
+            {
+                "path": path.name,
+                "records": record_count,
+                "content_tokens": content_tokens if is_causal else None,
+            }
+        )
+
+    overlap = train_documents & eval_documents
+    require(not overlap, f"train/eval document overlap: {len(overlap)} IDs")
+    unique_tokens = sum(unique_causal.values())
+    tokens = manifest["tokens"]
+    require(
+        unique_tokens == tokens["unique_train_causal"],
+        "unique causal token total does not match manifest",
+    )
+    require(
+        total_train_causal_tokens == tokens["curriculum_train_causal"],
+        "curriculum causal token total does not match manifest",
+    )
+    require(
+        total_train_causal_with_eos == tokens["curriculum_train_causal_with_eos"],
+        "curriculum causal-with-EOS total does not match manifest",
+    )
+    minimum = tokens.get("minimum_required")
+    if tokens.get("minimum_enforced", True) and minimum is not None:
+        require(unique_tokens >= minimum, "corpus is below its minimum token contract")
+    return {
+        "files": file_results,
+        "records": total_records,
+        "train_documents": len(train_documents),
+        "eval_documents": len(eval_documents),
+        "train_eval_overlap": 0,
+        "unique_train_causal_tokens": unique_tokens,
+        "curriculum_train_causal_tokens": total_train_causal_tokens,
+        "curriculum_train_causal_tokens_with_eos": total_train_causal_with_eos,
+        "tokenizer_recounted": counter is not None,
+        "config_verified": True,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    if args.token_batch_characters <= 0:
+        raise SystemExit("--token-batch-characters must be positive")
+    print(json.dumps(audit(args), ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes-train/scripts/build_education_curriculum.py
+++ b/hermes-train/scripts/build_education_curriculum.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -13,7 +14,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-from education_curriculum import build_live, load_config
+from curriculum_streaming import GigaTokenCounter, build_live_streaming
+from education_curriculum import SearchPageCapacityError, build_live, load_config
 
 
 class SearchApiClient:
@@ -21,7 +23,12 @@ class SearchApiClient:
 
     RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 
-    def __init__(self, config: dict, url_override: str | None = None):
+    def __init__(
+        self,
+        config: dict,
+        url_override: str | None = None,
+        cache_dir: Path | None = None,
+    ):
         url = url_override or config["url"]
         self.base_url = url.rstrip("/") + "/"
         self.timeout = float(config.get("timeout_seconds", 60))
@@ -29,6 +36,61 @@ class SearchApiClient:
         self.max_retries = int(config.get("max_retries", 6))
         self.retry_initial_seconds = float(config.get("retry_initial_seconds", 1))
         self.retry_max_seconds = float(config.get("retry_max_seconds", 15))
+        self.filter_language = bool(config.get("filter_language", True))
+        self.filter_document_types = bool(config.get("filter_document_types", False))
+        self.heap_factor = config.get("heap_factor")
+        self.cache_dir = cache_dir
+        if cache_dir is not None:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _cache_path(self, payload: dict) -> Path | None:
+        if self.cache_dir is None:
+            return None
+        canonical = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        digest = hashlib.sha256(canonical).hexdigest()
+        return self.cache_dir / f"search-{digest}.json"
+
+    def _load_cached(self, payload: dict) -> dict | None:
+        payloads = [payload]
+        if payload.get("return_documents") is False:
+            # ID-only caches contain the same sanitized fields as older
+            # hydrated requests. Reuse them so deploying the Search API fix
+            # does not invalidate a multi-hour discovery pass.
+            legacy = dict(payload)
+            legacy.pop("return_documents")
+            payloads.append(legacy)
+        for candidate in payloads:
+            path = self._cache_path(candidate)
+            if path is None or not path.exists():
+                continue
+            try:
+                cached = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as error:
+                logging.warning(
+                    "ignoring unreadable discovery cache %s: %s", path, error
+                )
+                continue
+            if not isinstance(cached, dict) or not isinstance(cached.get("hits"), list):
+                logging.warning("ignoring invalid discovery cache %s", path)
+                continue
+            return cached
+        return None
+
+    def _store_cached(self, payload: dict, result: dict) -> None:
+        path = self._cache_path(payload)
+        if path is None:
+            return
+        temporary = path.with_suffix(".json.tmp")
+        temporary.write_text(
+            json.dumps(result, ensure_ascii=False, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
 
     def _request_once(self, url: str, payload: dict | None = None) -> dict:
         body = None if payload is None else json.dumps(payload).encode("utf-8")
@@ -52,17 +114,32 @@ class SearchApiClient:
             try:
                 return await asyncio.to_thread(self._request_once, url, payload)
             except HTTPError as error:
-                retryable = error.code in self.RETRYABLE_STATUS
-                reason = f"HTTP {error.code}"
+                response_body = (
+                    error.read(4096).lower() if error.fp is not None else b""
+                )
+                hydration_budget_exceeded = b"hydration budget" in response_body
+                retryable = (
+                    error.code in self.RETRYABLE_STATUS
+                    and not hydration_budget_exceeded
+                )
+                reason = (
+                    f"HTTP {error.code} (hydration budget)"
+                    if hydration_budget_exceeded
+                    else f"HTTP {error.code}"
+                )
                 error.close()
-                if not retryable or attempt == self.max_retries:
-                    raise RuntimeError(
-                        f"Search API request failed: {reason}"
+                if hydration_budget_exceeded:
+                    raise SearchPageCapacityError(
+                        "Search API hydration budget exceeded; reduce "
+                        "search_api.page_size or the per-query search limit"
                     ) from error
+                if not retryable or attempt == self.max_retries:
+                    error_type = SearchPageCapacityError if retryable else RuntimeError
+                    raise error_type(f"Search API request failed: {reason}") from error
             except (URLError, TimeoutError) as error:
                 reason = type(error).__name__
                 if attempt == self.max_retries:
-                    raise RuntimeError(
+                    raise SearchPageCapacityError(
                         f"Search API request failed: {reason}"
                     ) from error
 
@@ -93,6 +170,9 @@ class SearchApiClient:
         limit: int,
         offset: int,
         language: str | None,
+        document_types: tuple[str, ...] = (),
+        issued_after: int | None = None,
+        issued_before: int | None = None,
     ) -> dict:
         payload = {
             "query": query,
@@ -101,10 +181,25 @@ class SearchApiClient:
             "limit": limit,
             "offset": offset,
             "rerank": False,
+            "cross_rerank": False,
             "deduplicate": self.deduplicate,
+            "return_documents": False,
         }
-        if language:
+        if language and self.filter_language:
             payload["possible_languages"] = [language]
+        if document_types and self.filter_document_types:
+            payload["filter_types"] = list(document_types)
+        if issued_after is not None:
+            payload["filter_issued_after"] = issued_after
+        if issued_before is not None:
+            payload["filter_issued_before"] = issued_before
+        if self.heap_factor is not None:
+            payload["heap_factor"] = self.heap_factor
+
+        cached = self._load_cached(payload)
+        if cached is not None:
+            return cached
+
         response = await self._request(self.base_url, payload)
         if response.get("embed_ms") is None:
             raise RuntimeError(
@@ -123,7 +218,9 @@ class SearchApiClient:
                     "uris": document.get("uris", []),
                 }
             )
-        return {"hits": hits, "total_hits": int(response.get("total_hits", 0))}
+        result = {"hits": hits, "total_hits": int(response.get("total_hits", 0))}
+        self._store_cached(payload, result)
+        return result
 
 
 def parse_args() -> argparse.Namespace:
@@ -136,9 +233,19 @@ def parse_args() -> argparse.Namespace:
         help="override search_api.url (for example, an SSH tunnel)",
     )
     parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        help="ID-only discovery cache (defaults to OUTPUT/.discovery-cache)",
+    )
+    parser.add_argument(
         "--search-limit",
         type=int,
         help="cap each configured Search API query (useful for a smoke build)",
+    )
+    parser.add_argument(
+        "--tokenizer",
+        type=Path,
+        help="Hermes tokenizer.json used for exact multi-billion-token sizing",
     )
     parser.add_argument("--log-level", default="INFO")
     return parser.parse_args()
@@ -153,7 +260,12 @@ async def run(args: argparse.Namespace) -> None:
         ) from error
 
     config = load_config(args.config)
-    search_client = SearchApiClient(config["search_api"], args.search_api_url)
+    cache_dir = args.cache_dir or args.output / ".discovery-cache"
+    search_client = SearchApiClient(
+        config["search_api"],
+        args.search_api_url,
+        cache_dir=cache_dir,
+    )
     alloydb = config.get("alloydb", {})
     pool = await asyncpg.create_pool(
         min_size=1,
@@ -161,13 +273,25 @@ async def run(args: argparse.Namespace) -> None:
         command_timeout=alloydb.get("timeout_seconds", 120),
     )
     try:
-        manifest = await build_live(
-            search_client,
-            pool,
-            config,
-            args.output,
-            search_limit_override=args.search_limit,
-        )
+        if config.get("output", {}).get("streaming", False):
+            if args.tokenizer is None:
+                raise SystemExit("streaming curriculum builds require --tokenizer")
+            manifest = await build_live_streaming(
+                search_client,
+                pool,
+                config,
+                args.output,
+                GigaTokenCounter(args.tokenizer),
+                search_limit_override=args.search_limit,
+            )
+        else:
+            manifest = await build_live(
+                search_client,
+                pool,
+                config,
+                args.output,
+                search_limit_override=args.search_limit,
+            )
     finally:
         await pool.close()
 
@@ -178,6 +302,12 @@ async def run(args: argparse.Namespace) -> None:
         args.output,
         args.output / manifest["curriculum"],
     )
+    if "tokens" in manifest:
+        logging.info(
+            "unique causal tokens=%d curriculum causal tokens=%d",
+            manifest["tokens"]["unique_train_causal"],
+            manifest["tokens"]["curriculum_train_causal"],
+        )
 
 
 def main() -> None:

--- a/hermes-train/scripts/curriculum_streaming.py
+++ b/hermes-train/scripts/curriculum_streaming.py
@@ -1,0 +1,1040 @@
+"""Bounded-memory writer for multi-billion-token education curricula.
+
+Discovery metadata stays in memory, but canonical document bodies never do.
+AlloyDB rows are validated, tokenized, and written in bounded batches.  A small
+SQLite catalog retains only selection metadata and the first chunk needed for
+hard-negative construction.  Completed tiers are restartable; an interrupted
+tier is discarded and rebuilt atomically from the ID-only discovery cache.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.metadata
+import io
+import json
+import logging
+import math
+import os
+import shutil
+import sqlite3
+from collections import Counter
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol
+
+from education_curriculum import (
+    Candidate,
+    Discovery,
+    SelectedDocument,
+    _content_fingerprint,
+    _curriculum_stage,
+    _eligible,
+    _first_language,
+    _open_jsonl,
+    _sanitize_training_text,
+    _slug,
+    _validation_member,
+    chunk_document,
+    discover_with_search_api,
+    resolve_from_alloydb,
+)
+
+
+class TokenCounter(Protocol):
+    """Exact tokenizer used to size causal data before training."""
+
+    @property
+    def metadata(self) -> dict[str, Any]: ...
+
+    def count_batch(self, texts: list[str]) -> list[int]: ...
+
+
+class GigaTokenCounter:
+    """Exact, batched token counts from a local Hermes ``tokenizer.json``."""
+
+    def __init__(self, tokenizer_path: Path):
+        try:
+            import awkward as ak  # type: ignore[import-not-found]
+            import gigatoken as gt  # type: ignore[import-not-found]
+        except ImportError as error:
+            raise RuntimeError(
+                "exact corpus sizing requires `pip install gigatoken==0.10.0`"
+            ) from error
+        self._ak = ak
+        self._tokenizer = gt.Tokenizer(tokenizer_path)
+        self._metadata = {
+            "engine": "gigatoken",
+            "version": importlib.metadata.version("gigatoken"),
+            "tokenizer_path": str(tokenizer_path),
+            "tokenizer_sha256": _sha256_file(tokenizer_path),
+            "vocab_size": int(self._tokenizer.vocab_size),
+        }
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return dict(self._metadata)
+
+    def count_batch(self, texts: list[str]) -> list[int]:
+        if not texts:
+            return []
+        encoded = self._tokenizer.encode_batch(texts)
+        lengths = self._ak.to_list(self._ak.num(encoded, axis=1))
+        return [int(length) for length in lengths]
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _payload_characters(record: dict[str, Any]) -> int:
+    total = 0
+    for key in (
+        "text",
+        "document",
+        "summary",
+        "request",
+        "plan",
+        "context",
+        "query",
+        "positive",
+    ):
+        value = record.get(key)
+        if isinstance(value, str):
+            total += len(value)
+    negatives = record.get("negatives")
+    if isinstance(negatives, list):
+        total += sum(len(value) for value in negatives if isinstance(value, str))
+    return total
+
+
+class JsonlWriter:
+    """Atomic JSONL writer with manifest and exact-token accounting."""
+
+    def __init__(self, path: Path, compression: str):
+        self.path = path
+        self.compression = compression
+        self.temporary = path.with_name(f".{path.name}.tmp")
+        self.records = 0
+        self.uncompressed_bytes = 0
+        self.payload_characters = 0
+        self.content_tokens = 0
+        self._stream: io.TextIOBase | None = None
+
+    def __enter__(self) -> JsonlWriter:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.temporary.unlink(missing_ok=True)
+        self._stream = _open_jsonl(self.temporary, self.compression)
+        return self
+
+    def write(self, record: dict[str, Any]) -> None:
+        if self._stream is None:
+            raise RuntimeError("JSONL writer is not open")
+        serialized = json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+        line = f"{serialized}\n"
+        self._stream.write(line)
+        self.records += 1
+        self.uncompressed_bytes += len(line.encode("utf-8"))
+        self.payload_characters += _payload_characters(record)
+        token_count = record.get("token_count", 0)
+        if isinstance(token_count, int) and token_count >= 0:
+            self.content_tokens += token_count
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        assert self._stream is not None
+        try:
+            self._stream.close()
+        finally:
+            self._stream = None
+        if exc_type is None:
+            os.replace(self.temporary, self.path)
+        else:
+            self.temporary.unlink(missing_ok=True)
+        return False
+
+    def stats(self, *, manifest_path: str | None = None) -> dict[str, Any]:
+        result = {
+            "path": manifest_path or self.path.name,
+            "records": self.records,
+            "bytes": self.path.stat().st_size,
+            "uncompressed_bytes": self.uncompressed_bytes,
+            "payload_characters": self.payload_characters,
+            "sha256": _sha256_file(self.path),
+        }
+        if self.content_tokens:
+            result["content_tokens"] = self.content_tokens
+            result["trainer_tokens_with_eos"] = self.content_tokens + self.records
+        return result
+
+
+def _open_records(path: Path) -> Iterator[dict[str, Any]]:
+    raw = path.open("rb")
+    try:
+        if path.suffix == ".zst":
+            try:
+                import zstandard  # type: ignore[import-not-found]
+            except ImportError as error:
+                raise RuntimeError(
+                    "zstd input requires `pip install zstandard`"
+                ) from error
+            binary = zstandard.ZstdDecompressor().stream_reader(raw)
+        else:
+            binary = raw
+        with io.TextIOWrapper(binary, encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, start=1):
+                if not line.strip():
+                    continue
+                value = json.loads(line)
+                if not isinstance(value, dict):
+                    raise ValueError(f"non-object JSON at {path}:{line_number}")
+                yield value
+    finally:
+        if not raw.closed:
+            raw.close()
+
+
+def _sampled_records(
+    path: Path,
+    source_count: int,
+    requested: int,
+    *,
+    seed: int,
+    namespace: str,
+) -> Iterator[dict[str, Any]]:
+    """Select exactly ``requested`` records with a constant-memory permutation."""
+    requested = min(requested, source_count)
+    if requested <= 0:
+        return
+    if requested == source_count:
+        yield from _open_records(path)
+        return
+    digest = hashlib.sha256(f"{seed}:{namespace}".encode()).digest()
+    multiplier = int.from_bytes(digest[:8], "big") % source_count
+    while math.gcd(multiplier, source_count) != 1:
+        multiplier = (multiplier + 1) % source_count
+    offset = int.from_bytes(digest[8:16], "big") % source_count
+    emitted = 0
+    seen = 0
+    for index, record in enumerate(_open_records(path)):
+        seen = index + 1
+        if (multiplier * index + offset) % source_count < requested:
+            emitted += 1
+            yield record
+    if emitted != requested:
+        raise RuntimeError(
+            f"replay source {path} contained {seen} records; expected {source_count}"
+        )
+
+
+def _state_connection(
+    path: Path, config_hash: str, tokenizer_hash: str
+) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("PRAGMA synchronous=NORMAL")
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS selected (
+            document_id TEXT PRIMARY KEY,
+            stage TEXT NOT NULL,
+            validation INTEGER NOT NULL,
+            language TEXT NOT NULL,
+            document_type TEXT NOT NULL,
+            title TEXT NOT NULL,
+            first_chunk TEXT NOT NULL,
+            query TEXT NOT NULL,
+            searches_json TEXT NOT NULL,
+            fingerprint TEXT NOT NULL UNIQUE,
+            canonical_content_characters INTEGER NOT NULL,
+            causal_records INTEGER NOT NULL,
+            causal_tokens INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS selected_stage_split
+            ON selected(stage, validation, document_id);
+        CREATE TABLE IF NOT EXISTS matches (
+            stage TEXT NOT NULL,
+            search TEXT NOT NULL,
+            document_id TEXT NOT NULL REFERENCES selected(document_id) ON DELETE CASCADE,
+            rank INTEGER NOT NULL,
+            PRIMARY KEY(stage, search, document_id)
+        );
+        CREATE INDEX IF NOT EXISTS matches_negative_lookup
+            ON matches(stage, search, rank, document_id);
+        CREATE TABLE IF NOT EXISTS stage_stats (
+            stage TEXT PRIMARY KEY,
+            stage_index INTEGER NOT NULL,
+            stats_json TEXT NOT NULL
+        );
+        """
+    )
+    expected = {
+        "format": "1",
+        "config_sha256": config_hash,
+        "tokenizer_sha256": tokenizer_hash,
+    }
+    existing = {
+        row["key"]: row["value"]
+        for row in connection.execute("SELECT key, value FROM metadata")
+    }
+    if existing and any(existing.get(key) != value for key, value in expected.items()):
+        connection.close()
+        raise RuntimeError(
+            "streaming build state belongs to a different config or tokenizer; use a new output directory"
+        )
+    connection.executemany(
+        "INSERT OR REPLACE INTO metadata(key, value) VALUES (?, ?)",
+        expected.items(),
+    )
+    connection.commit()
+    return connection
+
+
+def _suffix(compression: str) -> str:
+    return ".jsonl.zst" if compression == "zstd" else ".jsonl"
+
+
+def _raw_paths(
+    build_dir: Path, stage_index: int, stage_name: str, compression: str
+) -> dict[str, Path]:
+    slug = f"{stage_index:02d}-{_slug(stage_name)}"
+    suffix = _suffix(compression)
+    raw = build_dir / "raw"
+    return {
+        "train_causal": raw / f"{slug}-causal{suffix}",
+        "eval_causal": raw / f"{slug}-eval-causal{suffix}",
+        "train_retrieval": raw / f"{slug}-retrieval{suffix}",
+        "eval_retrieval": raw / f"{slug}-eval-retrieval{suffix}",
+    }
+
+
+def _completed_prefix(
+    connection: sqlite3.Connection,
+    config: dict[str, Any],
+    build_dir: Path,
+) -> dict[str, dict[str, Any]]:
+    compression = config.get("output", {}).get("compression", "zstd")
+    completed: dict[str, dict[str, Any]] = {}
+    incomplete = False
+    for index, stage in enumerate(config["stages"], start=1):
+        name = stage["name"]
+        row = connection.execute(
+            "SELECT stats_json FROM stage_stats WHERE stage = ?", (name,)
+        ).fetchone()
+        paths = _raw_paths(build_dir, index, name, compression)
+        if (
+            not incomplete
+            and row is not None
+            and all(path.exists() for path in paths.values())
+        ):
+            completed[name] = json.loads(row["stats_json"])
+            continue
+        incomplete = True
+        connection.execute("DELETE FROM selected WHERE stage = ?", (name,))
+        connection.execute("DELETE FROM stage_stats WHERE stage = ?", (name,))
+        for path in paths.values():
+            path.unlink(missing_ok=True)
+            path.with_name(f".{path.name}.tmp").unlink(missing_ok=True)
+    connection.commit()
+    return completed
+
+
+@dataclass
+class PendingDocument:
+    selected: SelectedDocument
+    chunks: list[str]
+    fingerprint: str
+
+
+def _match_map(candidate: Candidate) -> dict[str, tuple[int, str]]:
+    matches: dict[str, tuple[int, str]] = {}
+    for match in candidate.matches:
+        current = matches.get(match.search)
+        if current is None or match.rank < current[0]:
+            matches[match.search] = (match.rank, match.retrieval_query)
+    return matches
+
+
+def _write_pending(
+    pending: list[PendingDocument],
+    counter: TokenCounter,
+    train_writer: JsonlWriter,
+    eval_writer: JsonlWriter,
+    connection: sqlite3.Connection,
+) -> None:
+    if not pending:
+        return
+    texts = [chunk for item in pending for chunk in item.chunks]
+    token_counts = counter.count_batch(texts)
+    if len(token_counts) != len(texts):
+        raise RuntimeError("token counter returned the wrong number of rows")
+    token_offset = 0
+    for pending_document in pending:
+        item = pending_document.selected
+        chunks = pending_document.chunks
+        counts = token_counts[token_offset : token_offset + len(chunks)]
+        token_offset += len(chunks)
+        writer = eval_writer if item.validation else train_writer
+        for chunk_index, (chunk, token_count) in enumerate(
+            zip(chunks, counts, strict=True)
+        ):
+            writer.write(
+                {
+                    "text": chunk,
+                    "document_id": item.document.document_id,
+                    "chunk": chunk_index,
+                    "curriculum_stage": item.stage,
+                    "language": item.language,
+                    "token_count": token_count,
+                }
+            )
+        matches = _match_map(item.candidate)
+        _primary_search, (_primary_rank, primary_query) = min(
+            matches.items(), key=lambda value: (value[1][0], value[0])
+        )
+        title = _sanitize_training_text(item.document.title)
+        query = title if len(title.split()) >= 2 else primary_query
+        connection.execute(
+            """
+            INSERT INTO selected(
+                document_id, stage, validation, language, document_type,
+                title, first_chunk, query, searches_json, fingerprint,
+                canonical_content_characters, causal_records, causal_tokens
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                item.document.document_id,
+                item.stage,
+                int(item.validation),
+                item.language,
+                item.document.document_type,
+                title,
+                chunks[0],
+                query,
+                json.dumps(sorted(matches), ensure_ascii=False),
+                pending_document.fingerprint,
+                len(item.document.content),
+                len(chunks),
+                sum(counts),
+            ),
+        )
+        connection.executemany(
+            """
+            INSERT INTO matches(stage, search, document_id, rank)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(stage, search, document_id)
+            DO UPDATE SET rank = MIN(rank, excluded.rank)
+            """,
+            (
+                (item.stage, search, item.document.document_id, rank)
+                for search, (rank, _query) in matches.items()
+            ),
+        )
+    connection.commit()
+
+
+def _negative_rows(
+    connection: sqlite3.Connection,
+    *,
+    stage: str,
+    validation: bool,
+    document_id: str,
+    searches: list[str],
+    count: int,
+) -> list[sqlite3.Row]:
+    negatives: list[sqlite3.Row] = []
+    seen = {document_id}
+    for search in searches:
+        rows = connection.execute(
+            """
+            SELECT s.document_id, s.first_chunk
+            FROM matches AS m
+            JOIN selected AS s ON s.document_id = m.document_id
+            WHERE m.stage = ? AND m.search = ? AND s.validation = ?
+              AND s.document_id <> ?
+            ORDER BY m.rank, s.document_id
+            LIMIT ?
+            """,
+            (stage, search, int(validation), document_id, max(count * 4, 8)),
+        )
+        for row in rows:
+            if row["document_id"] in seen:
+                continue
+            seen.add(row["document_id"])
+            negatives.append(row)
+            if len(negatives) >= count:
+                return negatives
+    if len(negatives) < count:
+        rows = connection.execute(
+            """
+            SELECT document_id, first_chunk
+            FROM selected
+            WHERE stage = ? AND validation = ? AND document_id <> ?
+            ORDER BY document_id
+            LIMIT ?
+            """,
+            (stage, int(validation), document_id, max(count * 4, 8)),
+        )
+        for row in rows:
+            if row["document_id"] in seen:
+                continue
+            seen.add(row["document_id"])
+            negatives.append(row)
+            if len(negatives) >= count:
+                break
+    return negatives
+
+
+def _write_retrieval_split(
+    connection: sqlite3.Connection,
+    path: Path,
+    compression: str,
+    *,
+    stage: str,
+    validation: bool,
+    negative_count: int,
+) -> dict[str, Any]:
+    with JsonlWriter(path, compression) as writer:
+        rows = connection.execute(
+            """
+            SELECT document_id, language, query, first_chunk, searches_json
+            FROM selected
+            WHERE stage = ? AND validation = ?
+            ORDER BY document_id
+            """,
+            (stage, int(validation)),
+        )
+        for row in rows:
+            searches = json.loads(row["searches_json"])
+            negatives = _negative_rows(
+                connection,
+                stage=stage,
+                validation=validation,
+                document_id=row["document_id"],
+                searches=searches,
+                count=negative_count,
+            )
+            record: dict[str, Any] = {
+                "query": row["query"],
+                "positive": row["first_chunk"],
+                "document_id": row["document_id"],
+                "curriculum_stage": stage,
+                "language": row["language"],
+                "discovery_searches": searches,
+            }
+            if negatives:
+                record["negatives"] = [row["first_chunk"] for row in negatives]
+                record["negative_document_ids"] = [
+                    row["document_id"] for row in negatives
+                ]
+            writer.write(record)
+    return writer.stats(manifest_path=path.name)
+
+
+async def _select_stage(
+    pool: Any,
+    config: dict[str, Any],
+    stage: dict[str, Any],
+    stage_index: int,
+    discovery: Discovery,
+    connection: sqlite3.Connection,
+    counter: TokenCounter,
+    build_dir: Path,
+    assigned_ids: set[str],
+    fingerprints: set[str],
+    target_train_tokens: int | None = None,
+) -> dict[str, Any]:
+    output = config.get("output", {})
+    compression = output.get("compression", "zstd")
+    paths = _raw_paths(build_dir, stage_index, stage["name"], compression)
+    rejection_stats: Counter[str] = Counter()
+    language_counts: Counter[str] = Counter()
+    document_types: Counter[str] = Counter()
+    accepted = 0
+    train_documents = 0
+    validation_documents = 0
+    canonical_content_characters = 0
+    candidates = sorted(
+        discovery.candidates[stage["name"]].values(),
+        key=lambda candidate: (
+            -candidate.best_score,
+            candidate.best_rank,
+            candidate.document_id,
+        ),
+    )
+    maximum = int(stage.get("max_documents", len(candidates)))
+    minimum = int(stage.get("min_documents", 2))
+    per_language = stage.get("max_documents_per_language")
+    alloydb = config.get("alloydb", {})
+    batch_size = int(alloydb.get("batch_size", 128))
+    prefetch_batches = int(
+        alloydb.get("prefetch_batches", alloydb.get("connections", 1))
+    )
+    token_batch_characters = int(output.get("token_batch_characters", 16_000_000))
+    pending: list[PendingDocument] = []
+    pending_characters = 0
+    available_candidates: list[Candidate] = []
+    for candidate in candidates:
+        if candidate.document_id in assigned_ids:
+            rejection_stats["assigned_to_earlier_stage"] += 1
+        else:
+            available_candidates.append(candidate)
+    processed_candidates = 0
+
+    with (
+        JsonlWriter(paths["train_causal"], compression) as train_writer,
+        JsonlWriter(paths["eval_causal"], compression) as eval_writer,
+    ):
+        window_size = batch_size * prefetch_batches
+        stop_reason: str | None = None
+        for window_offset in range(0, len(available_candidates), window_size):
+            window = available_candidates[window_offset : window_offset + window_size]
+            batches = [
+                window[offset : offset + batch_size]
+                for offset in range(0, len(window), batch_size)
+            ]
+            resolved_batches = await asyncio.gather(
+                *(
+                    resolve_from_alloydb(
+                        pool,
+                        [candidate.document_id for candidate in batch],
+                        batch_size=batch_size,
+                    )
+                    for batch in batches
+                )
+            )
+            for batch, documents in zip(batches, resolved_batches, strict=True):
+                if accepted >= maximum:
+                    stop_reason = "stage_quota"
+                    break
+                if (
+                    target_train_tokens is not None
+                    and accepted >= minimum
+                    and train_writer.content_tokens >= target_train_tokens
+                ):
+                    stop_reason = "token_target"
+                    break
+                for candidate in batch:
+                    if accepted >= maximum:
+                        rejection_stats["stage_quota"] += 1
+                        continue
+                    document = documents.get(candidate.document_id)
+                    if document is None:
+                        rejection_stats["missing_in_alloydb"] += 1
+                        continue
+                    reason = _eligible(
+                        stage, candidate, document, config.get("quality", {})
+                    )
+                    if reason is not None:
+                        rejection_stats[reason] += 1
+                        continue
+                    language = _first_language(document, candidate, stage)
+                    if (
+                        per_language is not None
+                        and language_counts[language] >= per_language
+                    ):
+                        rejection_stats["language_quota"] += 1
+                        continue
+                    fingerprint = _content_fingerprint(document)
+                    if fingerprint in fingerprints:
+                        rejection_stats["duplicate_content"] += 1
+                        continue
+                    selected = SelectedDocument(
+                        stage=stage["name"],
+                        candidate=candidate,
+                        document=document,
+                        language=language,
+                        validation=_validation_member(
+                            candidate.document_id,
+                            int(output.get("seed", 17)),
+                            float(output.get("validation_fraction", 0.01)),
+                        ),
+                    )
+                    chunks = chunk_document(
+                        selected,
+                        max_chars=int(output.get("max_chunk_chars", 24_000)),
+                        min_chars=int(output.get("min_chunk_chars", 300)),
+                        max_chunks=int(output.get("max_chunks_per_document", 256)),
+                    )
+                    if not chunks:
+                        rejection_stats["no_training_chunks"] += 1
+                        continue
+                    assigned_ids.add(candidate.document_id)
+                    fingerprints.add(fingerprint)
+                    language_counts[language] += 1
+                    document_types[document.document_type] += 1
+                    accepted += 1
+                    if selected.validation:
+                        validation_documents += 1
+                    else:
+                        train_documents += 1
+                    canonical_content_characters += len(document.content)
+                    pending.append(PendingDocument(selected, chunks, fingerprint))
+                    pending_characters += sum(map(len, chunks))
+                    if pending_characters >= token_batch_characters:
+                        _write_pending(
+                            pending, counter, train_writer, eval_writer, connection
+                        )
+                        pending.clear()
+                        pending_characters = 0
+                processed_candidates += len(batch)
+                logging.info(
+                    "resolved stage=%s candidates=%d/%d accepted=%d",
+                    stage["name"],
+                    len(candidates) - len(available_candidates) + processed_candidates,
+                    len(candidates),
+                    accepted,
+                )
+            if stop_reason is not None:
+                rejection_stats[stop_reason] += (
+                    len(available_candidates) - processed_candidates
+                )
+                break
+        _write_pending(pending, counter, train_writer, eval_writer, connection)
+
+    if accepted < minimum:
+        raise ValueError(
+            f"stage {stage['name']!r} selected {accepted} documents, below min_documents {minimum}"
+        )
+    train_causal_stats = train_writer.stats(manifest_path=paths["train_causal"].name)
+    eval_causal_stats = eval_writer.stats(manifest_path=paths["eval_causal"].name)
+    train_retrieval_stats = _write_retrieval_split(
+        connection,
+        paths["train_retrieval"],
+        compression,
+        stage=stage["name"],
+        validation=False,
+        negative_count=int(output.get("hard_negatives", 2)),
+    )
+    eval_retrieval_stats = _write_retrieval_split(
+        connection,
+        paths["eval_retrieval"],
+        compression,
+        stage=stage["name"],
+        validation=True,
+        negative_count=int(output.get("hard_negatives", 2)),
+    )
+    if train_retrieval_stats["records"] < 2:
+        raise ValueError(
+            f"stage {stage['name']!r} produced fewer than two retrieval records"
+        )
+    stats = {
+        "selected_documents": accepted,
+        "training_documents": train_documents,
+        "validation_documents": validation_documents,
+        "languages": dict(sorted(language_counts.items())),
+        "document_types": dict(sorted(document_types.items())),
+        "canonical_content_characters": canonical_content_characters,
+        "unique_train_causal_tokens": train_causal_stats.get("content_tokens", 0),
+        "rejections": dict(sorted(rejection_stats.items())),
+        "raw_files": {
+            "train_causal": train_causal_stats,
+            "eval_causal": eval_causal_stats,
+            "train_retrieval": train_retrieval_stats,
+            "eval_retrieval": eval_retrieval_stats,
+        },
+    }
+    connection.execute(
+        "INSERT OR REPLACE INTO stage_stats(stage, stage_index, stats_json) VALUES (?, ?, ?)",
+        (stage["name"], stage_index, json.dumps(stats, ensure_ascii=False)),
+    )
+    connection.commit()
+    logging.info(
+        "selected stage=%s accepted=%d candidates=%d causal_tokens=%d rejected=%s",
+        stage["name"],
+        accepted,
+        len(candidates),
+        stats["unique_train_causal_tokens"],
+        json.dumps(stats["rejections"], sort_keys=True),
+    )
+    return stats
+
+
+def _finalize_training_file(
+    output_path: Path,
+    compression: str,
+    current_path: Path,
+    current_count: int,
+    prior: dict[str, tuple[Path, int]],
+    replay: dict[str, float],
+    *,
+    seed: int,
+    namespace: str,
+) -> dict[str, Any]:
+    with JsonlWriter(output_path, compression) as writer:
+        for record in _open_records(current_path):
+            writer.write(record)
+        if replay:
+            current_fraction = 1.0 - sum(replay.values())
+            target_total = math.ceil(current_count / current_fraction)
+            for source, fraction in replay.items():
+                source_path, source_count = prior[source]
+                requested = min(round(target_total * fraction), source_count)
+                for record in _sampled_records(
+                    source_path,
+                    source_count,
+                    requested,
+                    seed=seed,
+                    namespace=f"{namespace}:{source}",
+                ):
+                    writer.write(record)
+    return writer.stats(manifest_path=output_path.name)
+
+
+def _copy_file_with_stats(
+    source: Path,
+    destination: Path,
+    raw_stats: dict[str, Any],
+) -> dict[str, Any]:
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    shutil.copyfile(source, temporary)
+    os.replace(temporary, destination)
+    stats = dict(raw_stats)
+    stats["path"] = destination.name
+    stats["bytes"] = destination.stat().st_size
+    stats["sha256"] = _sha256_file(destination)
+    return stats
+
+
+def _write_curriculum_and_manifest(
+    config: dict[str, Any],
+    output_dir: Path,
+    build_dir: Path,
+    discovery: Discovery,
+    stage_stats: dict[str, dict[str, Any]],
+    counter: TokenCounter,
+    config_hash: str,
+    *,
+    enforce_minimum: bool,
+) -> dict[str, Any]:
+    output = config.get("output", {})
+    compression = output.get("compression", "zstd")
+    suffix = _suffix(compression)
+    seed = int(output.get("seed", 17))
+    files: list[dict[str, Any]] = []
+    curriculum_stages: list[dict[str, Any]] = []
+    prior_causal: dict[str, tuple[Path, int]] = {}
+    prior_retrieval: dict[str, tuple[Path, int]] = {}
+
+    for index, stage in enumerate(config["stages"], start=1):
+        name = stage["name"]
+        slug = f"{index:02d}-{_slug(name)}"
+        raw_paths = _raw_paths(build_dir, index, name, compression)
+        replay = {key: float(value) for key, value in stage.get("replay", {}).items()}
+        causal_path = output_dir / f"{slug}-causal{suffix}"
+        retrieval_path = output_dir / f"{slug}-retrieval{suffix}"
+        eval_causal_path = output_dir / f"{slug}-eval-causal{suffix}"
+        eval_retrieval_path = output_dir / f"{slug}-eval-retrieval{suffix}"
+        raw = stage_stats[name]["raw_files"]
+        causal_stats = _finalize_training_file(
+            causal_path,
+            compression,
+            raw_paths["train_causal"],
+            int(raw["train_causal"]["records"]),
+            prior_causal,
+            replay,
+            seed=seed,
+            namespace=f"{name}:causal",
+        )
+        retrieval_stats = _finalize_training_file(
+            retrieval_path,
+            compression,
+            raw_paths["train_retrieval"],
+            int(raw["train_retrieval"]["records"]),
+            prior_retrieval,
+            replay,
+            seed=seed,
+            namespace=f"{name}:retrieval",
+        )
+        files.extend(
+            [
+                causal_stats,
+                retrieval_stats,
+                _copy_file_with_stats(
+                    raw_paths["eval_causal"], eval_causal_path, raw["eval_causal"]
+                ),
+                _copy_file_with_stats(
+                    raw_paths["eval_retrieval"],
+                    eval_retrieval_path,
+                    raw["eval_retrieval"],
+                ),
+            ]
+        )
+        training = stage["training"]
+        curriculum_stages.append(
+            _curriculum_stage(
+                f"{name}-causal",
+                causal_path.name,
+                {"type": "causal_lm"},
+                training["causal"],
+            )
+        )
+        curriculum_stages.append(
+            _curriculum_stage(
+                f"{name}-retrieval",
+                retrieval_path.name,
+                {
+                    "type": "contrastive_retrieval",
+                    "temperature": training["retrieval"].get("temperature", 0.05),
+                    "layer": training["retrieval"].get("layer", 24),
+                },
+                training["retrieval"],
+            )
+        )
+        prior_causal[name] = (
+            raw_paths["train_causal"],
+            int(raw["train_causal"]["records"]),
+        )
+        prior_retrieval[name] = (
+            raw_paths["train_retrieval"],
+            int(raw["train_retrieval"]["records"]),
+        )
+
+    curriculum = {"version": 1, "stages": curriculum_stages}
+    curriculum_path = output_dir / "curriculum.json"
+    temporary = output_dir / ".curriculum.json.tmp"
+    temporary.write_text(
+        json.dumps(curriculum, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, curriculum_path)
+    unique_tokens = sum(
+        int(stats["unique_train_causal_tokens"]) for stats in stage_stats.values()
+    )
+    final_causal_files = [
+        file
+        for file in files
+        if file["path"].endswith(f"-causal{suffix}") and "-eval-" not in file["path"]
+    ]
+    training_tokens = sum(
+        int(file.get("content_tokens", 0)) for file in final_causal_files
+    )
+    training_tokens_with_eos = sum(
+        int(file.get("trainer_tokens_with_eos", 0)) for file in final_causal_files
+    )
+    manifest = {
+        "version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "contract": "Search API discovery IDs -> AlloyDB documents_assembled full copies",
+        "search_index": discovery.index,
+        "searches": discovery.searches,
+        "stages": stage_stats,
+        "files": files,
+        "curriculum": curriculum_path.name,
+        "tokenizer": counter.metadata,
+        "tokens": {
+            "unique_train_causal": unique_tokens,
+            "curriculum_train_causal": training_tokens,
+            "curriculum_train_causal_with_eos": training_tokens_with_eos,
+            "minimum_required": output.get("minimum_causal_tokens"),
+            "minimum_enforced": enforce_minimum,
+            "target": output.get("target_causal_tokens"),
+        },
+        "config": config,
+        "config_sha256": config_hash,
+    }
+    manifest_path = output_dir / "manifest.json"
+    temporary = output_dir / ".manifest.json.tmp"
+    temporary.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, manifest_path)
+    minimum = int(output.get("minimum_causal_tokens", 0))
+    if enforce_minimum and unique_tokens < minimum:
+        raise RuntimeError(
+            f"corpus contains {unique_tokens:,} unique causal tokens, below the required {minimum:,}"
+        )
+    return manifest
+
+
+async def build_live_streaming(
+    client: Any,
+    pool: Any,
+    config: dict[str, Any],
+    output_dir: Path,
+    counter: TokenCounter,
+    *,
+    search_limit_override: int | None = None,
+) -> dict[str, Any]:
+    """Build a restartable corpus without retaining canonical bodies in memory."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    config_hash = hashlib.sha256(
+        json.dumps(config, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    build_dir = output_dir / ".build"
+    connection = _state_connection(
+        build_dir / "state.sqlite3",
+        config_hash,
+        str(counter.metadata["tokenizer_sha256"]),
+    )
+    try:
+        completed = _completed_prefix(connection, config, build_dir)
+        discovery = await discover_with_search_api(
+            client,
+            config,
+            search_limit_override=search_limit_override,
+        )
+        assigned_ids = {
+            row["document_id"]
+            for row in connection.execute("SELECT document_id FROM selected")
+        }
+        fingerprints = {
+            row["fingerprint"]
+            for row in connection.execute("SELECT fingerprint FROM selected")
+        }
+        stage_stats = dict(completed)
+        for index, stage in enumerate(config["stages"], start=1):
+            if stage["name"] in completed:
+                logging.info("resuming after completed stage=%s", stage["name"])
+                continue
+            target_train_tokens = None
+            if index == len(config["stages"]):
+                target = int(config.get("output", {}).get("target_causal_tokens", 0))
+                if target:
+                    prior_tokens = sum(
+                        int(stats["unique_train_causal_tokens"])
+                        for stats in stage_stats.values()
+                    )
+                    target_train_tokens = max(target - prior_tokens, 0)
+            stage_stats[stage["name"]] = await _select_stage(
+                pool,
+                config,
+                stage,
+                index,
+                discovery,
+                connection,
+                counter,
+                build_dir,
+                assigned_ids,
+                fingerprints,
+                target_train_tokens=target_train_tokens,
+            )
+        manifest = _write_curriculum_and_manifest(
+            config,
+            output_dir,
+            build_dir,
+            discovery,
+            stage_stats,
+            counter,
+            config_hash,
+            enforce_minimum=search_limit_override is None,
+        )
+    finally:
+        connection.close()
+    if config.get("output", {}).get("cleanup_build_artifacts", True):
+        shutil.rmtree(build_dir)
+    return manifest

--- a/hermes-train/scripts/curriculum_streaming.py
+++ b/hermes-train/scripts/curriculum_streaming.py
@@ -274,6 +274,8 @@ def _state_connection(
         );
         CREATE INDEX IF NOT EXISTS matches_negative_lookup
             ON matches(stage, search, rank, document_id);
+        CREATE INDEX IF NOT EXISTS matches_document_cleanup
+            ON matches(document_id);
         CREATE TABLE IF NOT EXISTS stage_stats (
             stage TEXT PRIMARY KEY,
             stage_index INTEGER NOT NULL,

--- a/hermes-train/scripts/education_curriculum.py
+++ b/hermes-train/scripts/education_curriculum.py
@@ -8,9 +8,11 @@ live clients so selection, replay, and leakage controls are testable.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import io
 import json
+import logging
 import math
 import os
 import re
@@ -20,8 +22,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-MAX_SEARCH_WINDOW = 50_000
 MAX_SEARCH_API_PAGE = 500
+MIN_SEARCH_API_PAGE = 10
+MAX_SEARCH_WINDOW = MAX_SEARCH_API_PAGE
+CONTROL_CHARACTER_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+
+class SearchPageCapacityError(RuntimeError):
+    """A transient Search API failure that may improve with a smaller page."""
 
 
 @dataclass(frozen=True)
@@ -32,6 +40,7 @@ class SearchMatch:
     language: str | None
     rank: int
     score: float
+    partition: str = "all"
 
 
 @dataclass
@@ -119,6 +128,40 @@ def _nonnegative_number(value: Any, label: str) -> float:
     return float(value)
 
 
+def _validate_time_partitions(value: Any, label: str) -> None:
+    _require(
+        isinstance(value, list) and value,
+        f"{label} must be a non-empty array",
+    )
+    names: set[str] = set()
+    for partition in value:
+        _require(isinstance(partition, dict), f"{label} entries must be objects")
+        name = partition.get("name")
+        _require(
+            isinstance(name, str) and name.strip(),
+            f"{label} entries need a name",
+        )
+        _require(name not in names, f"duplicate {label} entry {name!r}")
+        issued_after = partition.get("issued_after")
+        issued_before = partition.get("issued_before")
+        for boundary, boundary_name in (
+            (issued_after, "issued_after"),
+            (issued_before, "issued_before"),
+        ):
+            if boundary is not None:
+                _require(
+                    isinstance(boundary, int) and not isinstance(boundary, bool),
+                    f"{label} entry {name!r} {boundary_name} must be Unix seconds",
+                )
+        _require(
+            issued_after is None
+            or issued_before is None
+            or issued_after < issued_before,
+            f"{label} entry {name!r} must have issued_after < issued_before",
+        )
+        names.add(name)
+
+
 def validate_config(config: dict[str, Any]) -> None:
     """Validate the versioned build configuration before any network I/O."""
     _require(
@@ -139,6 +182,30 @@ def validate_config(config: dict[str, Any]) -> None:
         page_size <= MAX_SEARCH_API_PAGE,
         "search_api.page_size exceeds the Search API page limit",
     )
+    _positive_int(
+        search_api.get("concurrency", 1),
+        "search_api.concurrency must be positive",
+    )
+    _positive_int(
+        search_api.get("fallback_concurrency", 1),
+        "search_api.fallback_concurrency must be positive",
+    )
+    _nonnegative_int(
+        search_api.get("minimum_page_retries", 12),
+        "search_api.minimum_page_retries must be non-negative",
+    )
+    minimum_page_retry = _nonnegative_number(
+        search_api.get("minimum_page_retry_seconds", 30),
+        "search_api.minimum_page_retry_seconds must be non-negative",
+    )
+    maximum_page_retry = _nonnegative_number(
+        search_api.get("minimum_page_retry_max_seconds", 180),
+        "search_api.minimum_page_retry_max_seconds must be non-negative",
+    )
+    _require(
+        maximum_page_retry >= minimum_page_retry,
+        "search_api.minimum_page_retry_max_seconds must be at least minimum_page_retry_seconds",
+    )
     _nonnegative_int(
         search_api.get("max_retries", 6),
         "search_api.max_retries must be non-negative",
@@ -155,6 +222,44 @@ def validate_config(config: dict[str, Any]) -> None:
         maximum_retry >= initial_retry,
         "search_api.retry_max_seconds must be at least retry_initial_seconds",
     )
+    for key in ("filter_language", "filter_document_types", "cross_rerank"):
+        if key in search_api:
+            _require(
+                isinstance(search_api[key], bool),
+                f"search_api.{key} must be boolean",
+            )
+    _require(
+        search_api.get("cross_rerank", False) is False,
+        "search_api.cross_rerank must be false for curriculum discovery",
+    )
+    _require(
+        "rerank_factor" not in search_api,
+        "search_api.rerank_factor is not supported for curriculum discovery",
+    )
+    if "heap_factor" in search_api:
+        heap_factor = search_api["heap_factor"]
+        _require(
+            isinstance(heap_factor, (int, float)) and 0 < heap_factor <= 1,
+            "search_api.heap_factor must be in (0, 1]",
+        )
+    _validate_time_partitions(
+        search_api.get("time_partitions", [{"name": "all"}]),
+        "search_api.time_partitions",
+    )
+    partition_profiles = search_api.get("time_partition_profiles", {})
+    _require(
+        isinstance(partition_profiles, dict),
+        "search_api.time_partition_profiles must be an object",
+    )
+    for profile_name, profile in partition_profiles.items():
+        _require(
+            isinstance(profile_name, str) and profile_name.strip(),
+            "search_api.time_partition_profiles keys must be non-empty",
+        )
+        _validate_time_partitions(
+            profile,
+            f"search_api.time_partition_profiles[{profile_name!r}]",
+        )
 
     stages = config.get("stages")
     _require(isinstance(stages, list) and stages, "at least one stage is required")
@@ -164,6 +269,21 @@ def validate_config(config: dict[str, Any]) -> None:
         name = stage.get("name")
         _require(isinstance(name, str) and name.strip(), f"stage {index} needs a name")
         _require(name not in names, f"duplicate stage name {name!r}")
+        _require(
+            not ("time_partitions" in stage and "time_partition_profile" in stage),
+            f"stage {name!r} cannot set both time_partitions and time_partition_profile",
+        )
+        if "time_partitions" in stage:
+            _validate_time_partitions(
+                stage["time_partitions"],
+                f"stage {name!r} time_partitions",
+            )
+        if "time_partition_profile" in stage:
+            profile_name = stage["time_partition_profile"]
+            _require(
+                isinstance(profile_name, str) and profile_name in partition_profiles,
+                f"stage {name!r} references unknown time partition profile {profile_name!r}",
+            )
         searches = stage.get("searches")
         _require(
             isinstance(searches, list) and searches, f"stage {name!r} needs searches"
@@ -193,7 +313,7 @@ def validate_config(config: dict[str, Any]) -> None:
             )
             _require(
                 limit <= MAX_SEARCH_WINDOW,
-                f"search {search_name!r} exceeds 50,000 hits",
+                f"search {search_name!r} exceeds the Search API 500-hit window",
             )
             search_names.add(search_name)
 
@@ -215,6 +335,21 @@ def validate_config(config: dict[str, Any]) -> None:
         _validate_training(name, stage.get("training"))
         names.add(name)
 
+    alloydb = config.get("alloydb", {})
+    _require(isinstance(alloydb, dict), "alloydb must be an object")
+    _positive_int(
+        alloydb.get("batch_size", 500),
+        "alloydb.batch_size must be positive",
+    )
+    connections = _positive_int(
+        alloydb.get("connections", 1),
+        "alloydb.connections must be positive",
+    )
+    _positive_int(
+        alloydb.get("prefetch_batches", connections),
+        "alloydb.prefetch_batches must be positive",
+    )
+
     output = config.get("output", {})
     _require(isinstance(output, dict), "output must be an object")
     _require(
@@ -226,6 +361,42 @@ def validate_config(config: dict[str, Any]) -> None:
         and 0 <= validation_fraction < 0.5,
         "output.validation_fraction must be in [0, 0.5)",
     )
+    for key in ("minimum_causal_tokens", "target_causal_tokens"):
+        if key in output:
+            _positive_int(output[key], f"output.{key} must be positive")
+    if "minimum_causal_tokens" in output and "target_causal_tokens" in output:
+        _require(
+            output["target_causal_tokens"] >= output["minimum_causal_tokens"],
+            "output.target_causal_tokens must be at least minimum_causal_tokens",
+        )
+    if output.get("streaming", False):
+        _require(
+            output.get("compression", "zstd") in {"none", "zstd"},
+            "streaming output has an invalid compression",
+        )
+        _positive_int(
+            output.get("token_batch_characters", 16_000_000),
+            "output.token_batch_characters must be positive",
+        )
+    for key in ("streaming", "cleanup_build_artifacts"):
+        if key in output:
+            _require(isinstance(output[key], bool), f"output.{key} must be boolean")
+    quality = config.get("quality", {})
+    _require(isinstance(quality, dict), "quality must be an object")
+    for key in (
+        "max_control_character_fraction",
+        "max_replacement_character_fraction",
+    ):
+        if key not in quality:
+            continue
+        value = quality[key]
+        _require(
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+            and 0 <= value < 1,
+            f"quality.{key} must be in [0, 1)",
+        )
 
 
 def _validate_training(stage_name: str, training: Any) -> None:
@@ -294,76 +465,187 @@ async def discover_with_search_api(
         "segments": info.get("num_segments"),
     }
     page_size = search_api.get("page_size", 250)
+    default_partitions = search_api.get("time_partitions", [{"name": "all"}])
+    partition_profiles = search_api.get("time_partition_profiles", {})
+    semaphore = asyncio.Semaphore(int(search_api.get("concurrency", 1)))
+    fallback_semaphore = asyncio.Semaphore(
+        int(search_api.get("fallback_concurrency", 1))
+    )
     candidates: dict[str, dict[str, Candidate]] = {
         stage["name"]: {} for stage in config["stages"]
     }
     search_stats: list[dict[str, Any]] = []
 
-    for stage in config["stages"]:
-        stage_candidates = candidates[stage["name"]]
-        for search in stage["searches"]:
-            configured_limit = search.get(
-                "limit", search_api.get("limit_per_search", 1_000)
-            )
-            limit = (
-                min(configured_limit, search_limit_override)
-                if search_limit_override is not None
-                else configured_limit
-            )
-            offset = 0
-            unique_ids: set[str] = set()
-            total_hits: int | None = None
-            while offset < limit:
-                request_limit = min(page_size, limit - offset)
-                response = await client.search(
+    async def run_search(
+        stage: dict[str, Any],
+        search: dict[str, Any],
+        partition: dict[str, Any],
+    ) -> tuple[
+        dict[str, Any],
+        dict[str, Any],
+        dict[str, Any],
+        list[tuple[int, dict[str, Any]]],
+        int | None,
+        int,
+    ]:
+        configured_limit = search.get(
+            "limit", search_api.get("limit_per_search", MAX_SEARCH_WINDOW)
+        )
+        limit = (
+            min(configured_limit, search_limit_override)
+            if search_limit_override is not None
+            else configured_limit
+        )
+        offset = 0
+        dynamic_page_size = page_size
+        minimum_page_failures = 0
+        unique_ids: set[str] = set()
+        ranked_hits: list[tuple[int, dict[str, Any]]] = []
+        total_hits: int | None = None
+
+        async def request_page(
+            request_limit: int, request_offset: int
+        ) -> dict[str, Any]:
+            async with semaphore:
+                return await client.search(
                     index_name,
                     query=search["query"],
                     limit=request_limit,
-                    offset=offset,
+                    offset=request_offset,
                     language=search.get("language"),
+                    document_types=tuple(stage.get("document_types", [])),
+                    issued_after=partition.get("issued_after"),
+                    issued_before=partition.get("issued_before"),
                 )
-                total_hits = response["total_hits"]
-                if not response["hits"]:
-                    break
-                for page_rank, hit in enumerate(response["hits"]):
-                    document_id = _as_scalar(hit.get("id"))
-                    if not document_id or document_id in unique_ids:
-                        continue
-                    unique_ids.add(document_id)
-                    candidate = stage_candidates.setdefault(
-                        document_id,
-                        Candidate(
-                            document_id=document_id,
-                            stage=stage["name"],
-                            uris=_as_strings(hit.get("uris")),
-                        ),
+
+        while offset < limit:
+            request_limit = min(dynamic_page_size, limit - offset)
+            try:
+                if dynamic_page_size < page_size:
+                    async with fallback_semaphore:
+                        response = await request_page(request_limit, offset)
+                else:
+                    response = await request_page(request_limit, offset)
+            except SearchPageCapacityError:
+                if request_limit <= MIN_SEARCH_API_PAGE:
+                    minimum_page_failures += 1
+                    maximum_failures = int(search_api.get("minimum_page_retries", 12))
+                    if minimum_page_failures > maximum_failures:
+                        raise
+                    delay = min(
+                        float(search_api.get("minimum_page_retry_seconds", 30))
+                        * (2 ** (minimum_page_failures - 1)),
+                        float(search_api.get("minimum_page_retry_max_seconds", 180)),
                     )
-                    score = float(hit.get("score", 0.0))
-                    candidate.matches.append(
-                        SearchMatch(
-                            stage=stage["name"],
-                            search=search["name"],
-                            retrieval_query=search["query"],
-                            language=search.get("language"),
-                            rank=offset + page_rank,
-                            score=score if math.isfinite(score) else 0.0,
-                        )
+                    logging.warning(
+                        "minimum Search API page failed stage=%s search=%s partition=%s offset=%d; retrying in %.1fs (%d/%d)",
+                        stage["name"],
+                        search["name"],
+                        partition["name"],
+                        offset,
+                        delay,
+                        minimum_page_failures,
+                        maximum_failures,
                     )
-                offset += len(response["hits"])
-                if (
-                    len(response["hits"]) < request_limit
-                    or offset >= response["total_hits"]
-                ):
-                    break
-            search_stats.append(
-                {
-                    "stage": stage["name"],
-                    "search": search["name"],
-                    "total_hits": total_hits,
-                    "fetched_unique_ids": len(unique_ids),
-                    "limit": limit,
-                }
+                    await asyncio.sleep(delay)
+                    continue
+                if request_limit > 250:
+                    dynamic_page_size = 250
+                elif request_limit > 50:
+                    dynamic_page_size = 50
+                else:
+                    dynamic_page_size = max(MIN_SEARCH_API_PAGE, request_limit // 2)
+                logging.warning(
+                    "splitting Search API page stage=%s search=%s partition=%s offset=%d from=%d to=%d",
+                    stage["name"],
+                    search["name"],
+                    partition["name"],
+                    offset,
+                    request_limit,
+                    dynamic_page_size,
+                )
+                continue
+            minimum_page_failures = 0
+            total_hits = response["total_hits"]
+            logging.info(
+                "discovered stage=%s search=%s partition=%s offset=%d hits=%d total_hits=%d",
+                stage["name"],
+                search["name"],
+                partition["name"],
+                offset,
+                len(response["hits"]),
+                total_hits,
             )
+            if not response["hits"]:
+                break
+            for page_rank, hit in enumerate(response["hits"]):
+                document_id = _as_scalar(hit.get("id"))
+                if not document_id or document_id in unique_ids:
+                    continue
+                unique_ids.add(document_id)
+                ranked_hits.append((offset + page_rank, hit))
+            offset += len(response["hits"])
+            if (
+                len(response["hits"]) < request_limit
+                or offset >= response["total_hits"]
+            ):
+                break
+        return stage, search, partition, ranked_hits, total_hits, limit
+
+    def stage_partitions(stage: dict[str, Any]) -> list[dict[str, Any]]:
+        if "time_partitions" in stage:
+            return stage["time_partitions"]
+        profile_name = stage.get("time_partition_profile")
+        if profile_name is not None:
+            return partition_profiles[profile_name]
+        return default_partitions
+
+    tasks = [
+        asyncio.create_task(run_search(stage, search, partition))
+        for stage in config["stages"]
+        for search in stage["searches"]
+        for partition in stage_partitions(stage)
+    ]
+    for task in asyncio.as_completed(tasks):
+        stage, search, partition, ranked_hits, total_hits, limit = await task
+        stage_candidates = candidates[stage["name"]]
+        for rank, hit in ranked_hits:
+            document_id = _as_scalar(hit.get("id"))
+            candidate = stage_candidates.setdefault(
+                document_id,
+                Candidate(
+                    document_id=document_id,
+                    stage=stage["name"],
+                    uris=_as_strings(hit.get("uris")),
+                ),
+            )
+            score = float(hit.get("score", 0.0))
+            candidate.matches.append(
+                SearchMatch(
+                    stage=stage["name"],
+                    search=search["name"],
+                    retrieval_query=search["query"],
+                    language=search.get("language"),
+                    rank=rank,
+                    score=score if math.isfinite(score) else 0.0,
+                    partition=partition["name"],
+                )
+            )
+        search_stats.append(
+            {
+                "stage": stage["name"],
+                "search": search["name"],
+                "partition": partition["name"],
+                "issued_after": partition.get("issued_after"),
+                "issued_before": partition.get("issued_before"),
+                "total_hits": total_hits,
+                "fetched_unique_ids": len(ranked_hits),
+                "limit": limit,
+            }
+        )
+    search_stats.sort(
+        key=lambda item: (item["stage"], item["search"], item["partition"])
+    )
     return Discovery(candidates=candidates, searches=search_stats, index=index)
 
 
@@ -443,13 +725,27 @@ def _eligible(
     stage: dict[str, Any],
     candidate: Candidate,
     document: FullDocument,
+    quality: dict[str, Any] | None = None,
 ) -> str | None:
     title = document.title
     content = document.content
+    quality = quality or {}
     if len(content) < stage.get("min_content_chars", 500):
         return "content_too_short"
     if len(content) > stage.get("max_content_chars", 5_000_000):
         return "content_too_long"
+    content_length = max(len(content), 1)
+    replacement_fraction = content.count("\ufffd") / content_length
+    if replacement_fraction > quality.get(
+        "max_replacement_character_fraction",
+        1.0,
+    ):
+        return "replacement_characters"
+    control_fraction = (
+        sum(1 for _ in CONTROL_CHARACTER_RE.finditer(content)) / content_length
+    )
+    if control_fraction > quality.get("max_control_character_fraction", 1.0):
+        return "control_characters"
     allowed_types = stage.get("document_types", [])
     if allowed_types and document.document_type not in allowed_types:
         return "document_type"
@@ -529,7 +825,12 @@ def select_documents(
             if document is None:
                 rejected["missing_in_alloydb"] += 1
                 continue
-            reason = _eligible(stage, candidate, document)
+            reason = _eligible(
+                stage,
+                candidate,
+                document,
+                config.get("quality", {}),
+            )
             if reason is not None:
                 rejected[reason] += 1
                 continue
@@ -558,6 +859,13 @@ def select_documents(
                 )
             )
         minimum = stage.get("min_documents", 2)
+        logging.info(
+            "selected stage=%s accepted=%d candidates=%d rejected=%s",
+            name,
+            len(accepted),
+            len(candidates),
+            json.dumps(dict(sorted(rejected.items())), sort_keys=True),
+        )
         _require(
             len(accepted) >= minimum,
             f"stage {name!r} selected {len(accepted)} documents, below min_documents {minimum}",
@@ -581,6 +889,13 @@ def _split_long_paragraph(paragraph: str, limit: int) -> list[str]:
     return pieces
 
 
+def _sanitize_training_text(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = text.replace("\x0c", "\n\n").replace("\ufffd", " ")
+    text = CONTROL_CHARACTER_RE.sub(" ", text)
+    return re.sub(r" {3,}", "  ", text).strip()
+
+
 def chunk_document(
     selected: SelectedDocument,
     *,
@@ -590,9 +905,9 @@ def chunk_document(
 ) -> list[str]:
     """Split a canonical document on paragraph boundaries without overlap."""
     document = selected.document
-    title = document.title
-    abstract = document.abstract
-    content = document.content.replace("\x00", "").replace("\r\n", "\n")
+    title = _sanitize_training_text(document.title)
+    abstract = _sanitize_training_text(document.abstract)
+    content = _sanitize_training_text(document.content)
     prefix_parts = []
     if title:
         prefix_parts.append(f"# {title}")
@@ -711,7 +1026,7 @@ def _retrieval_records(
         own_chunks = chunks.get(item.document.document_id, [])
         if not own_chunks:
             continue
-        title = item.document.title
+        title = _sanitize_training_text(item.document.title)
         fallback_query = min(
             item.candidate.matches, key=lambda match: match.rank
         ).retrieval_query
@@ -831,10 +1146,36 @@ def _write_jsonl(
     compression: str,
 ) -> dict[str, Any]:
     temporary = path.with_name(f".{path.name}.tmp")
+    uncompressed_bytes = 0
+    payload_characters = 0
     with _open_jsonl(temporary, compression) as stream:
         for record in records:
-            stream.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
-            stream.write("\n")
+            serialized = json.dumps(
+                record,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            line = f"{serialized}\n"
+            stream.write(line)
+            uncompressed_bytes += len(line.encode("utf-8"))
+            for key in (
+                "text",
+                "document",
+                "summary",
+                "request",
+                "plan",
+                "context",
+                "query",
+                "positive",
+            ):
+                value = record.get(key)
+                if isinstance(value, str):
+                    payload_characters += len(value)
+            negatives = record.get("negatives")
+            if isinstance(negatives, list):
+                payload_characters += sum(
+                    len(value) for value in negatives if isinstance(value, str)
+                )
     os.replace(temporary, path)
     digest = hashlib.sha256()
     with path.open("rb") as stream:
@@ -844,6 +1185,8 @@ def _write_jsonl(
         "path": path.name,
         "records": len(records),
         "bytes": path.stat().st_size,
+        "uncompressed_bytes": uncompressed_bytes,
+        "payload_characters": payload_characters,
         "sha256": digest.hexdigest(),
     }
 
@@ -963,10 +1306,24 @@ def write_outputs(
     stage_stats = {}
     for stage in config["stages"]:
         name = stage["name"]
+        stage_documents = selected[name]
         stage_stats[name] = {
-            "selected_documents": len(selected[name]),
-            "training_documents": sum(not item.validation for item in selected[name]),
-            "validation_documents": sum(item.validation for item in selected[name]),
+            "selected_documents": len(stage_documents),
+            "training_documents": sum(not item.validation for item in stage_documents),
+            "validation_documents": sum(item.validation for item in stage_documents),
+            "languages": dict(
+                sorted(Counter(item.language for item in stage_documents).items())
+            ),
+            "document_types": dict(
+                sorted(
+                    Counter(
+                        item.document.document_type for item in stage_documents
+                    ).items()
+                )
+            ),
+            "canonical_content_characters": sum(
+                len(item.document.content) for item in stage_documents
+            ),
             "rejections": rejection_stats[name],
         }
     manifest = {

--- a/hermes-train/scripts/education_curriculum.py
+++ b/hermes-train/scripts/education_curriculum.py
@@ -284,6 +284,26 @@ def validate_config(config: dict[str, Any]) -> None:
                 isinstance(profile_name, str) and profile_name in partition_profiles,
                 f"stage {name!r} references unknown time partition profile {profile_name!r}",
             )
+        split_document_types = stage.get("search_document_types_separately", False)
+        _require(
+            isinstance(split_document_types, bool),
+            f"stage {name!r} search_document_types_separately must be boolean",
+        )
+        if split_document_types:
+            document_types = stage.get("document_types")
+            _require(
+                isinstance(document_types, list)
+                and document_types
+                and all(
+                    isinstance(document_type, str) and document_type.strip()
+                    for document_type in document_types
+                ),
+                f"stage {name!r} needs document_types to split searches",
+            )
+            _require(
+                search_api.get("filter_document_types", False) is True,
+                f"stage {name!r} cannot split types when search document-type filtering is disabled",
+            )
         searches = stage.get("searches")
         _require(
             isinstance(searches, list) and searches, f"stage {name!r} needs searches"
@@ -480,10 +500,12 @@ async def discover_with_search_api(
         stage: dict[str, Any],
         search: dict[str, Any],
         partition: dict[str, Any],
+        document_types: tuple[str, ...],
     ) -> tuple[
         dict[str, Any],
         dict[str, Any],
         dict[str, Any],
+        tuple[str, ...],
         list[tuple[int, dict[str, Any]]],
         int | None,
         int,
@@ -513,7 +535,7 @@ async def discover_with_search_api(
                     limit=request_limit,
                     offset=request_offset,
                     language=search.get("language"),
-                    document_types=tuple(stage.get("document_types", [])),
+                    document_types=document_types,
                     issued_after=partition.get("issued_after"),
                     issued_before=partition.get("issued_before"),
                 )
@@ -538,10 +560,11 @@ async def discover_with_search_api(
                         float(search_api.get("minimum_page_retry_max_seconds", 180)),
                     )
                     logging.warning(
-                        "minimum Search API page failed stage=%s search=%s partition=%s offset=%d; retrying in %.1fs (%d/%d)",
+                        "minimum Search API page failed stage=%s search=%s partition=%s types=%s offset=%d; retrying in %.1fs (%d/%d)",
                         stage["name"],
                         search["name"],
                         partition["name"],
+                        ",".join(document_types) or "all",
                         offset,
                         delay,
                         minimum_page_failures,
@@ -556,10 +579,11 @@ async def discover_with_search_api(
                 else:
                     dynamic_page_size = max(MIN_SEARCH_API_PAGE, request_limit // 2)
                 logging.warning(
-                    "splitting Search API page stage=%s search=%s partition=%s offset=%d from=%d to=%d",
+                    "splitting Search API page stage=%s search=%s partition=%s types=%s offset=%d from=%d to=%d",
                     stage["name"],
                     search["name"],
                     partition["name"],
+                    ",".join(document_types) or "all",
                     offset,
                     request_limit,
                     dynamic_page_size,
@@ -568,10 +592,11 @@ async def discover_with_search_api(
             minimum_page_failures = 0
             total_hits = response["total_hits"]
             logging.info(
-                "discovered stage=%s search=%s partition=%s offset=%d hits=%d total_hits=%d",
+                "discovered stage=%s search=%s partition=%s types=%s offset=%d hits=%d total_hits=%d",
                 stage["name"],
                 search["name"],
                 partition["name"],
+                ",".join(document_types) or "all",
                 offset,
                 len(response["hits"]),
                 total_hits,
@@ -590,7 +615,15 @@ async def discover_with_search_api(
                 or offset >= response["total_hits"]
             ):
                 break
-        return stage, search, partition, ranked_hits, total_hits, limit
+        return (
+            stage,
+            search,
+            partition,
+            document_types,
+            ranked_hits,
+            total_hits,
+            limit,
+        )
 
     def stage_partitions(stage: dict[str, Any]) -> list[dict[str, Any]]:
         if "time_partitions" in stage:
@@ -600,14 +633,29 @@ async def discover_with_search_api(
             return partition_profiles[profile_name]
         return default_partitions
 
+    def stage_document_type_groups(stage: dict[str, Any]) -> list[tuple[str, ...]]:
+        document_types = tuple(stage.get("document_types", []))
+        if stage.get("search_document_types_separately", False):
+            return [(document_type,) for document_type in document_types]
+        return [document_types]
+
     tasks = [
-        asyncio.create_task(run_search(stage, search, partition))
+        asyncio.create_task(run_search(stage, search, partition, document_types))
         for stage in config["stages"]
         for search in stage["searches"]
         for partition in stage_partitions(stage)
+        for document_types in stage_document_type_groups(stage)
     ]
     for task in asyncio.as_completed(tasks):
-        stage, search, partition, ranked_hits, total_hits, limit = await task
+        (
+            stage,
+            search,
+            partition,
+            document_types,
+            ranked_hits,
+            total_hits,
+            limit,
+        ) = await task
         stage_candidates = candidates[stage["name"]]
         for rank, hit in ranked_hits:
             document_id = _as_scalar(hit.get("id"))
@@ -636,6 +684,7 @@ async def discover_with_search_api(
                 "stage": stage["name"],
                 "search": search["name"],
                 "partition": partition["name"],
+                "document_types": list(document_types),
                 "issued_after": partition.get("issued_after"),
                 "issued_before": partition.get("issued_before"),
                 "total_hits": total_hits,
@@ -644,7 +693,12 @@ async def discover_with_search_api(
             }
         )
     search_stats.sort(
-        key=lambda item: (item["stage"], item["search"], item["partition"])
+        key=lambda item: (
+            item["stage"],
+            item["search"],
+            item["partition"],
+            item["document_types"],
+        )
     )
     return Discovery(candidates=candidates, searches=search_stats, index=index)
 

--- a/hermes-train/scripts/test_education_curriculum.py
+++ b/hermes-train/scripts/test_education_curriculum.py
@@ -9,7 +9,11 @@ from urllib.error import HTTPError
 
 from audit_education_curriculum import audit
 from build_education_curriculum import SearchApiClient
-from curriculum_streaming import _sampled_records, build_live_streaming
+from curriculum_streaming import (
+    _sampled_records,
+    _state_connection,
+    build_live_streaming,
+)
 from education_curriculum import (
     Candidate,
     FullDocument,
@@ -635,6 +639,21 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(first, second)
         self.assertEqual(len(first), 23)
         self.assertEqual(len({record["document_id"] for record in first}), 23)
+
+    def test_streaming_state_indexes_cascade_cleanup_key(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            connection = _state_connection(
+                Path(temporary) / "state.sqlite3",
+                "config-hash",
+                "tokenizer-hash",
+            )
+            try:
+                indexes = {
+                    row[1] for row in connection.execute("PRAGMA index_list('matches')")
+                }
+            finally:
+                connection.close()
+        self.assertIn("matches_document_cleanup", indexes)
 
     def test_non_text_query_is_rejected(self):
         config = minimal_config()

--- a/hermes-train/scripts/test_education_curriculum.py
+++ b/hermes-train/scripts/test_education_curriculum.py
@@ -648,6 +648,25 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(ValueError, "rerank_factor is not supported"):
             validate_config(config)
 
+    def test_query_gated_stage_can_use_only_negative_title_patterns(self):
+        stage = minimal_config()["stages"][0]
+        stage.pop("title_allow_patterns")
+        stage["title_deny_patterns"] = ["course catalog"]
+        candidate = Candidate(document_id="selected", stage="foundations")
+        document = FullDocument(
+            document_id="selected",
+            document_type="book",
+            uris=(),
+            blob={
+                "title": "Collected exercises",
+                "languages": ["en"],
+                "content": "letters form words and sentences " * 20,
+            },
+        )
+        self.assertIsNone(_eligible(stage, candidate, document))
+        document.blob["title"] = "Course catalog"
+        self.assertEqual(_eligible(stage, candidate, document), "title_denied")
+
     def test_concentrated_extraction_corruption_is_rejected(self):
         stage = minimal_config()["stages"][0]
         candidate = Candidate(document_id="corrupt", stage="foundations")

--- a/hermes-train/scripts/test_education_curriculum.py
+++ b/hermes-train/scripts/test_education_curriculum.py
@@ -217,6 +217,25 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
             await discover_with_search_api(search_api, config)
         self.assertEqual(search_api.calls, 1)
 
+    async def test_discovery_can_split_each_search_by_document_type(self):
+        config = minimal_config()
+        stage = config["stages"][0]
+        stage["document_types"] = ["book", "report"]
+        stage["search_document_types_separately"] = True
+        search_api = FakeSearchApi()
+
+        discovery = await discover_with_search_api(search_api, config)
+
+        self.assertEqual(
+            {call[1]["document_types"] for call in search_api.calls},
+            {("book",), ("report",)},
+        )
+        self.assertEqual(len(discovery.candidates["foundations"]), 2)
+        self.assertEqual(
+            {tuple(item["document_types"]) for item in discovery.searches},
+            {("book",), ("report",)},
+        )
+
     async def test_search_api_does_not_retry_hydration_budget_errors(self):
         class OversizedClient(SearchApiClient):
             def __init__(self):
@@ -635,6 +654,19 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
         config = minimal_config()
         config["stages"][0]["time_partition_profile"] = "missing"
         with self.assertRaisesRegex(ValueError, "unknown time partition profile"):
+            validate_config(config)
+
+    def test_document_type_split_requires_document_types(self):
+        config = minimal_config()
+        stage = config["stages"][0]
+        stage["search_document_types_separately"] = True
+        stage["document_types"] = []
+        with self.assertRaisesRegex(ValueError, "needs document_types"):
+            validate_config(config)
+
+        config = minimal_config()
+        config["stages"][0]["search_document_types_separately"] = True
+        with self.assertRaisesRegex(ValueError, "filtering is disabled"):
             validate_config(config)
 
     def test_curriculum_discovery_cannot_enable_reranking(self):

--- a/hermes-train/scripts/test_education_curriculum.py
+++ b/hermes-train/scripts/test_education_curriculum.py
@@ -1,11 +1,20 @@
+import asyncio
 import json
 import tempfile
 import unittest
+from argparse import Namespace
+from io import BytesIO
 from pathlib import Path
 from urllib.error import HTTPError
 
+from audit_education_curriculum import audit
 from build_education_curriculum import SearchApiClient
+from curriculum_streaming import _sampled_records, build_live_streaming
 from education_curriculum import (
+    Candidate,
+    FullDocument,
+    SearchPageCapacityError,
+    _eligible,
     build_record_pools,
     discover_with_search_api,
     mix_replay,
@@ -119,6 +128,7 @@ class FakeConnection:
                     "content": (
                         f"CANONICAL FULL COPY {document_id}. "
                         "Letters form words and words form clear sentences."
+                        "\x1f\ufffd More words."
                     ),
                     "languages": ["en"],
                 },
@@ -146,9 +156,69 @@ class FakePool:
         return Acquire(self.connection)
 
 
+class FakeTokenCounter:
+    @property
+    def metadata(self):
+        return {
+            "engine": "test",
+            "version": "1",
+            "tokenizer_sha256": "fake-tokenizer",
+            "vocab_size": 100,
+        }
+
+    def count_batch(self, texts):
+        return [len(text.split()) for text in texts]
+
+
 class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
-    async def test_search_api_retries_capacity_errors_and_discards_text(self):
-        class FlakyClient(SearchApiClient):
+    async def test_discovery_splits_capacity_limited_pages_without_losing_depth(self):
+        class PageLimitedSearch(FakeSearchApi):
+            def __init__(self):
+                super().__init__()
+                self.hits = [
+                    {"id": f"doc-{index}", "score": 100 - index, "uris": []}
+                    for index in range(100)
+                ]
+
+            async def search(self, index_name, **kwargs):
+                self.calls.append((index_name, kwargs))
+                if kwargs["limit"] > 50:
+                    raise SearchPageCapacityError("capacity")
+                offset = kwargs["offset"]
+                limit = kwargs["limit"]
+                return {
+                    "hits": self.hits[offset : offset + limit],
+                    "total_hits": len(self.hits),
+                }
+
+        config = minimal_config()
+        config["search_api"]["page_size"] = 100
+        config["search_api"]["limit_per_search"] = 100
+        search_api = PageLimitedSearch()
+        discovery = await discover_with_search_api(search_api, config)
+        self.assertEqual([call[1]["limit"] for call in search_api.calls], [100, 50, 50])
+        self.assertEqual(len(discovery.candidates["foundations"]), 100)
+
+    async def test_search_contract_errors_do_not_trigger_page_splitting(self):
+        class InvalidSearch:
+            def __init__(self):
+                self.calls = 0
+
+            async def get_index_info(self, index_name):
+                return {"num_documents": 1, "num_segments": 1}
+
+            async def search(self, index_name, **kwargs):
+                self.calls += 1
+                raise RuntimeError("hybrid response omitted embed_ms")
+
+        search_api = InvalidSearch()
+        config = minimal_config()
+        with self.assertRaisesRegex(RuntimeError, "embed_ms"):
+            await discover_with_search_api(search_api, config)
+        self.assertEqual(search_api.calls, 1)
+
+    async def test_search_api_does_not_retry_hydration_budget_errors(self):
+        class OversizedClient(SearchApiClient):
             def __init__(self):
                 super().__init__(
                     {
@@ -157,6 +227,45 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
                         "retry_initial_seconds": 0,
                         "retry_max_seconds": 0,
                     }
+                )
+                self.attempts = 0
+
+            def _request_once(self, url, payload=None):
+                self.attempts += 1
+                raise HTTPError(
+                    url,
+                    500,
+                    "resource exhausted",
+                    {},
+                    BytesIO(b"Search response exceeds the hydration budget"),
+                )
+
+        client = OversizedClient()
+        with self.assertRaisesRegex(RuntimeError, "page_size"):
+            await client.search(
+                "documents",
+                query="primer",
+                limit=250,
+                offset=0,
+                language="en",
+            )
+        self.assertEqual(client.attempts, 1)
+
+    async def test_search_api_retries_capacity_errors_and_discards_text(self):
+        class FlakyClient(SearchApiClient):
+            def __init__(self, cache_dir):
+                super().__init__(
+                    {
+                        "url": "http://search-api/internal/v2/search/",
+                        "max_retries": 2,
+                        "retry_initial_seconds": 0,
+                        "retry_max_seconds": 0,
+                        "filter_language": False,
+                        "filter_document_types": True,
+                        "heap_factor": 0.2,
+                        "cross_rerank": False,
+                    },
+                    cache_dir=cache_dir,
                 )
                 self.attempts = 0
                 self.payload = None
@@ -181,18 +290,38 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
                     ],
                 }
 
-        client = FlakyClient()
-        response = await client.search(
-            "documents",
-            query="primer",
-            limit=1,
-            offset=0,
-            language="en",
-        )
+        with tempfile.TemporaryDirectory() as temporary:
+            cache_dir = Path(temporary)
+            client = FlakyClient(cache_dir)
+            response = await client.search(
+                "documents",
+                query="primer",
+                limit=1,
+                offset=0,
+                language="en",
+                document_types=("book",),
+            )
+            cached_response = await client.search(
+                "documents",
+                query="primer",
+                limit=1,
+                offset=0,
+                language="en",
+                document_types=("book",),
+            )
+            cache_text = next(cache_dir.glob("search-*.json")).read_text()
 
         self.assertEqual(client.attempts, 3)
         self.assertEqual(client.payload["mode"], "hybrid")
         self.assertEqual(client.payload["index_names"], ["documents"])
+        self.assertFalse(client.payload["rerank"])
+        self.assertFalse(client.payload["cross_rerank"])
+        self.assertFalse(client.payload["return_documents"])
+        self.assertNotIn("possible_languages", client.payload)
+        self.assertEqual(client.payload["filter_types"], ["book"])
+        self.assertNotIn("rerank_factor", client.payload)
+        self.assertNotIn("reranker_limit", client.payload)
+        self.assertEqual(client.payload["heap_factor"], 0.2)
         self.assertNotIn("vector", client.payload)
         self.assertNotIn("embedding", client.payload)
         self.assertEqual(
@@ -202,6 +331,52 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
                 "total_hits": 1,
             },
         )
+        self.assertEqual(cached_response, response)
+        self.assertNotIn("must be discarded", cache_text)
+
+    async def test_id_only_search_reuses_legacy_sanitized_cache(self):
+        class OfflineClient(SearchApiClient):
+            def _request_once(self, url, payload=None):
+                raise AssertionError("legacy cache should avoid a network request")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            client = OfflineClient(
+                {
+                    "url": "http://search-api/internal/v2/search/",
+                    "filter_language": False,
+                    "filter_document_types": True,
+                    "heap_factor": 0.2,
+                    "deduplicate": True,
+                },
+                cache_dir=Path(temporary),
+            )
+            legacy_payload = {
+                "query": "primer",
+                "index_names": ["documents"],
+                "mode": "hybrid",
+                "limit": 1,
+                "offset": 0,
+                "rerank": False,
+                "cross_rerank": False,
+                "deduplicate": True,
+                "filter_types": ["book"],
+                "heap_factor": 0.2,
+            }
+            expected = {
+                "hits": [{"id": "doc-a", "score": 2.0, "uris": []}],
+                "total_hits": 1,
+            }
+            client._store_cached(legacy_payload, expected)
+            response = await client.search(
+                "documents",
+                query="primer",
+                limit=1,
+                offset=0,
+                language="en",
+                document_types=("book",),
+            )
+
+        self.assertEqual(response, expected)
 
     async def test_search_api_discovers_and_alloydb_supplies_full_copy(self):
         config = minimal_config()
@@ -212,6 +387,7 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(search_api.calls), 1)
         self.assertEqual(search_api.calls[0][1]["query"], "beginner primer")
         self.assertEqual(search_api.calls[0][1]["language"], "en")
+        self.assertEqual(search_api.calls[0][1]["document_types"], ("book",))
 
         pool = FakePool()
         documents = await resolve_from_alloydb(pool, ["doc-a", "doc-b"], batch_size=2)
@@ -242,15 +418,159 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
                 .splitlines()[0]
             )
             self.assertIn("CANONICAL FULL COPY", record["text"])
+            self.assertNotIn("\x1f", record["text"])
+            self.assertNotIn("\ufffd", record["text"])
             self.assertEqual(
                 manifest["contract"],
                 "Search API discovery IDs -> AlloyDB documents_assembled full copies",
             )
+            stage_stats = manifest["stages"]["foundations"]
+            self.assertEqual(stage_stats["languages"], {"en": 2})
+            self.assertEqual(stage_stats["document_types"], {"book": 2})
+            self.assertGreater(stage_stats["canonical_content_characters"], 0)
+            causal_file = next(
+                item
+                for item in manifest["files"]
+                if item["path"] == "01-foundations-causal.jsonl"
+            )
+            self.assertEqual(causal_file["uncompressed_bytes"], causal_file["bytes"])
+            self.assertGreater(causal_file["payload_characters"], 0)
             curriculum = json.loads((output / "curriculum.json").read_text())
             self.assertEqual(
                 [stage["objective"]["type"] for stage in curriculum["stages"]],
                 ["causal_lm", "contrastive_retrieval"],
             )
+
+    async def test_partitioned_streaming_build_is_exact_and_bounded(self):
+        config = minimal_config()
+        config["search_api"]["concurrency"] = 2
+        config["search_api"]["time_partition_profiles"] = {
+            "test-yearly": [
+                {"name": "old", "issued_before": 0},
+                {"name": "new", "issued_after": 0},
+            ]
+        }
+        config["stages"][0]["time_partition_profile"] = "test-yearly"
+        config["output"].update(
+            {
+                "streaming": True,
+                "minimum_causal_tokens": 1,
+                "target_causal_tokens": 100,
+                "cleanup_build_artifacts": True,
+            }
+        )
+        validate_config(config)
+        search_api = FakeSearchApi()
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary)
+            manifest = await build_live_streaming(
+                search_api,
+                FakePool(),
+                config,
+                output,
+                FakeTokenCounter(),
+            )
+            records = [
+                json.loads(line)
+                for line in (output / "01-foundations-causal.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            audit_result = audit(
+                Namespace(
+                    output=output,
+                    tokenizer=None,
+                    token_batch_characters=1_000_000,
+                )
+            )
+            manifest_path = output / "manifest.json"
+            tampered = json.loads(manifest_path.read_text(encoding="utf-8"))
+            tampered["config"]["output"]["seed"] += 1
+            manifest_path.write_text(json.dumps(tampered), encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeError, "config_sha256"):
+                audit(
+                    Namespace(
+                        output=output,
+                        tokenizer=None,
+                        token_batch_characters=1_000_000,
+                    )
+                )
+            self.assertFalse((output / ".build").exists())
+
+        self.assertEqual(len(search_api.calls), 2)
+        calls = [call[1] for call in search_api.calls]
+        self.assertEqual(
+            {(call["issued_after"], call["issued_before"]) for call in calls},
+            {(None, 0), (0, None)},
+        )
+        self.assertEqual(manifest["tokens"]["minimum_required"], 1)
+        self.assertTrue(manifest["tokens"]["minimum_enforced"])
+        self.assertEqual(manifest["config"], config)
+        self.assertGreater(manifest["tokens"]["unique_train_causal"], 1)
+        self.assertEqual(
+            manifest["tokens"]["unique_train_causal"],
+            sum(record["token_count"] for record in records),
+        )
+        self.assertEqual(audit_result["train_eval_overlap"], 0)
+        self.assertTrue(audit_result["config_verified"])
+        self.assertEqual(
+            audit_result["unique_train_causal_tokens"],
+            manifest["tokens"]["unique_train_causal"],
+        )
+
+    async def test_final_streaming_stage_stops_at_exact_token_target(self):
+        concurrency = {"active": 0, "maximum": 0}
+
+        class SlowConnection(FakeConnection):
+            async def fetch(self, query, ids):
+                concurrency["active"] += 1
+                concurrency["maximum"] = max(
+                    concurrency["maximum"], concurrency["active"]
+                )
+                try:
+                    await asyncio.sleep(0.001)
+                    return await super().fetch(query, ids)
+                finally:
+                    concurrency["active"] -= 1
+
+        class ConcurrentPool:
+            def acquire(self):
+                return Acquire(SlowConnection())
+
+        search_api = FakeSearchApi()
+        search_api.hits = [
+            {"id": f"doc-{letter}", "score": 10 - index, "uris": []}
+            for index, letter in enumerate("abcdef")
+        ]
+        config = minimal_config()
+        config["search_api"]["page_size"] = 2
+        config["search_api"]["limit_per_search"] = 6
+        config["alloydb"]["connections"] = 2
+        config["alloydb"]["prefetch_batches"] = 2
+        config["output"].update(
+            {
+                "streaming": True,
+                "token_batch_characters": 1,
+                "minimum_causal_tokens": 1,
+                "target_causal_tokens": 1,
+                "cleanup_build_artifacts": True,
+            }
+        )
+        validate_config(config)
+        with tempfile.TemporaryDirectory() as temporary:
+            manifest = await build_live_streaming(
+                search_api,
+                ConcurrentPool(),
+                config,
+                Path(temporary),
+                FakeTokenCounter(),
+            )
+
+        stage = manifest["stages"]["foundations"]
+        self.assertEqual(stage["selected_documents"], 2)
+        self.assertEqual(stage["rejections"]["token_target"], 4)
+        self.assertEqual(concurrency["maximum"], 2)
+        self.assertGreaterEqual(manifest["tokens"]["unique_train_causal"], 1)
 
     def test_replay_is_deterministic_and_does_not_duplicate(self):
         current = [{"document_id": f"new-{index}", "chunk": 0} for index in range(8)]
@@ -273,6 +593,30 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(first), 10)
         self.assertEqual(len({record["document_id"] for record in first}), 10)
 
+    def test_streaming_replay_selects_exactly_in_constant_memory(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "records.jsonl"
+            path.write_text(
+                "".join(
+                    json.dumps({"document_id": f"doc-{index}"}) + "\n"
+                    for index in range(100)
+                ),
+                encoding="utf-8",
+            )
+            first = list(
+                _sampled_records(
+                    path, 100, 23, seed=7, namespace="advanced:foundations"
+                )
+            )
+            second = list(
+                _sampled_records(
+                    path, 100, 23, seed=7, namespace="advanced:foundations"
+                )
+            )
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 23)
+        self.assertEqual(len({record["document_id"] for record in first}), 23)
+
     def test_non_text_query_is_rejected(self):
         config = minimal_config()
         config["stages"][0]["searches"][0]["query"] = {
@@ -286,6 +630,60 @@ class EducationCurriculumTests(unittest.IsolatedAsyncioTestCase):
         config["search_api"]["mode"] = "sparse"
         with self.assertRaisesRegex(ValueError, r"sparse\+dense fusion"):
             validate_config(config)
+
+    def test_unknown_time_partition_profile_is_rejected(self):
+        config = minimal_config()
+        config["stages"][0]["time_partition_profile"] = "missing"
+        with self.assertRaisesRegex(ValueError, "unknown time partition profile"):
+            validate_config(config)
+
+    def test_curriculum_discovery_cannot_enable_reranking(self):
+        config = minimal_config()
+        config["search_api"]["cross_rerank"] = True
+        with self.assertRaisesRegex(ValueError, "cross_rerank must be false"):
+            validate_config(config)
+
+        config = minimal_config()
+        config["search_api"]["rerank_factor"] = 2
+        with self.assertRaisesRegex(ValueError, "rerank_factor is not supported"):
+            validate_config(config)
+
+    def test_concentrated_extraction_corruption_is_rejected(self):
+        stage = minimal_config()["stages"][0]
+        candidate = Candidate(document_id="corrupt", stage="foundations")
+        base = {
+            "title": "Primer",
+            "languages": ["en"],
+        }
+        replacement = FullDocument(
+            document_id="corrupt",
+            document_type="book",
+            uris=(),
+            blob={**base, "content": "letters and words " * 20 + "\ufffd" * 20},
+        )
+        control = FullDocument(
+            document_id="corrupt",
+            document_type="book",
+            uris=(),
+            blob={
+                **base,
+                "content": "letters and words " * 10
+                + "\x1f" * 20
+                + "more letters and words " * 10,
+            },
+        )
+        quality = {
+            "max_control_character_fraction": 0.01,
+            "max_replacement_character_fraction": 0.001,
+        }
+        self.assertEqual(
+            _eligible(stage, candidate, replacement, quality),
+            "replacement_characters",
+        )
+        self.assertEqual(
+            _eligible(stage, candidate, control, quality),
+            "control_characters",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- discover a four-stage English/Russian curriculum through Search API sparse+dense fusion with both rerankers disabled, then resolve canonical full copies from AlloyDB
- stream, checkpoint, replay, and size multi-billion-token shards with exact GigaToken counts, bounded ordered prefetch, and a hard 10B/target 15B contract
- embed the reproducible build config and independently audit checksums, splits, text hygiene, tokenizer identity, and every stored causal token count

## Tests

- `uvx --from ruff ruff format --check hermes-train/scripts/{build_education_curriculum.py,education_curriculum.py,curriculum_streaming.py,audit_education_curriculum.py,test_education_curriculum.py}`
- `uvx --from ruff ruff check hermes-train/scripts/{build_education_curriculum.py,education_curriculum.py,curriculum_streaming.py,audit_education_curriculum.py,test_education_curriculum.py}`
- `python3 -m unittest discover -s hermes-train/scripts -p 'test_education_curriculum.py'`
