### PR TITLE
fix(server): use INVALID_ARGUMENT for response-budget rejections

### DIFF
--- a/hermes-server/src/search_service.rs
+++ b/hermes-server/src/search_service.rs
@@ -348,10 +348,13 @@ impl SearchResponseBudget {
 
     fn reserve(counter: &mut usize, bytes: usize, maximum: usize) -> Result<(), Status> {
         let next = counter.checked_add(bytes).ok_or_else(|| {
-            Status::resource_exhausted("Search response size accounting overflowed")
+            Status::invalid_argument("Search response size accounting overflowed")
         })?;
         if next > maximum {
-            return Err(Status::resource_exhausted(format!(
+            // Deterministic for a given request shape: retrying cannot succeed,
+            // so this must not be RESOURCE_EXHAUSTED (which clients treat as
+            // retryable capacity pressure, e.g. "Search capacity is full").
+            return Err(Status::invalid_argument(format!(
                 "Search response exceeds the {maximum}-byte hydration budget; \
                  request fewer hits or fields"
             )));
@@ -369,7 +372,7 @@ impl SearchResponseBudget {
         let framed = payload
             .checked_add(protobuf_varint_len(payload))
             .and_then(|bytes| bytes.checked_add(1))
-            .ok_or_else(|| Status::resource_exhausted("Search response encoded size overflowed"))?;
+            .ok_or_else(|| Status::invalid_argument("Search response encoded size overflowed"))?;
         Self::reserve(&mut self.encoded_bytes, framed, self.maximum)
     }
 }
@@ -411,11 +414,11 @@ fn retained_field_value_bytes(value: &CoreFieldValue) -> Result<usize, Status> {
         CoreFieldValue::SparseVector(entries) => entries
             .len()
             .checked_mul(std::mem::size_of::<u32>() + std::mem::size_of::<f32>())
-            .ok_or_else(|| Status::resource_exhausted("Sparse field size overflowed"))?,
+            .ok_or_else(|| Status::invalid_argument("Sparse field size overflowed"))?,
         CoreFieldValue::DenseVector(values) => values
             .len()
             .checked_mul(std::mem::size_of::<f32>())
-            .ok_or_else(|| Status::resource_exhausted("Dense field size overflowed"))?,
+            .ok_or_else(|| Status::invalid_argument("Dense field size overflowed"))?,
         CoreFieldValue::Json(json) => {
             let mut writer = CountingWriter::default();
             serde_json::to_writer(&mut writer, json).map_err(|error| {
@@ -427,7 +430,7 @@ fn retained_field_value_bytes(value: &CoreFieldValue) -> Result<usize, Status> {
     std::mem::size_of::<FieldValue>()
         .saturating_mul(2)
         .checked_add(payload)
-        .ok_or_else(|| Status::resource_exhausted("Response field size overflowed"))
+        .ok_or_else(|| Status::invalid_argument("Response field size overflowed"))
 }
 
 fn retained_hit_base_bytes(ordinal_count: usize) -> Result<usize, Status> {
@@ -435,7 +438,7 @@ fn retained_hit_base_bytes(ordinal_count: usize) -> Result<usize, Status> {
         .checked_mul(std::mem::size_of::<OrdinalScore>())
         .and_then(|bytes| bytes.checked_add(std::mem::size_of::<SearchHit>()))
         .and_then(|bytes| bytes.checked_add(32)) // segment-id String backing bytes
-        .ok_or_else(|| Status::resource_exhausted("Search hit size overflowed"))
+        .ok_or_else(|| Status::invalid_argument("Search hit size overflowed"))
 }
 
 fn retained_field_entry_bytes(name: &str) -> usize {
@@ -1465,7 +1468,10 @@ mod tests {
         let mut retained = SearchResponseBudget::with_maximum(100);
         retained.reserve_retained(80).unwrap();
         let err = retained.reserve_retained(21).unwrap_err();
-        assert_eq!(err.code(), Code::ResourceExhausted);
+        // Budget violations are deterministic caller errors, not transient
+        // capacity pressure: clients retry ResourceExhausted with backoff,
+        // which can never succeed for an oversized hydration request.
+        assert_eq!(err.code(), Code::InvalidArgument);
 
         let hit = SearchHit {
             address: Some(DocAddress {
@@ -1485,7 +1491,7 @@ mod tests {
         };
         let mut encoded = SearchResponseBudget::with_maximum(64);
         let err = encoded.reserve_hit(&hit).unwrap_err();
-        assert_eq!(err.code(), Code::ResourceExhausted);
+        assert_eq!(err.code(), Code::InvalidArgument);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The search response hydration budget (48 MiB) and its size-accounting guards returned `RESOURCE_EXHAUSTED` — the same status as genuine capacity pressure (`Search capacity is full; retry with backoff`, `QueueFull`, `CommitInProgress`).

Clients reasonably treat `RESOURCE_EXHAUSTED` as retryable backpressure. The azeroth `hermes-client` retries it up to 3 times with backoff — but a budget violation is deterministic for a given request shape, so every retry re-hydrates the same oversized response and fails again. In production this surfaced as ~5.6 s stalls in search-api (4 full hydration passes + 1.2 s of backoff) before the caller got an opaque 500.

## Change

Budget violations and size-accounting overflows now return `INVALID_ARGUMENT`, matching the existing query-shape and result-window validation errors in the same file. Admission control and QueueFull/CommitInProgress backpressure keep `RESOURCE_EXHAUSTED`.

## Testing

- `response_budget_bounds_retained_and_encoded_bytes` re-pinned to `InvalidArgument` with a comment explaining why retryable semantics are wrong here
- `search_admission_rejects_overload_without_queueing` unchanged — still pins `ResourceExhausted` for capacity
- `cargo test -p hermes-server`: 35 passed; `cargo clippy -p hermes-server --all-targets -- -D warnings`: clean