### PR TITLE
feat(mal): add 300m moe retriever

### DIFF
--- a/hermes-mal/src/lib.rs
+++ b/hermes-mal/src/lib.rs
@@ -1467,6 +1467,23 @@ mod tests {
     }
 
     #[test]
+    fn retriever_300m_moe_has_the_intended_sparse_budget() {
+        let model = get_builtin_model("retriever-300m-moe").unwrap();
+        assert_eq!(model.estimated_params(), 299_929_088);
+        assert_eq!(model.num_layers, 24);
+        assert_eq!(model.pattern.as_ref().unwrap().len(), 6);
+
+        let moe_layers: Vec<_> = (0..model.num_layers)
+            .filter_map(|layer| model.block_for_layer(layer).ffn.moe.as_ref())
+            .collect();
+        assert_eq!(moe_layers.len(), 12);
+        assert!(moe_layers.iter().all(|moe| moe.experts == 15));
+        assert!(moe_layers.iter().all(|moe| moe.top_k == 2));
+        assert!(moe_layers.iter().all(|moe| moe.shared_experts == 0));
+        assert_eq!(model.block_for_layer(23).name, "attn_moe_block");
+    }
+
+    #[test]
     fn test_norm_none_and_rmsnorm() {
         let base = |norm: &str| {
             format!(

--- a/hermes-mal/well-known/retriever_300m_moe.mal
+++ b/hermes-mal/well-known/retriever_300m_moe.mal
@@ -1,0 +1,90 @@
+# ~300M-total / ~116M-active hybrid MoE retriever.
+#
+# This scales the routed capacity of retriever-200m-moe without changing its
+# active compute or proven hybrid backbone geometry:
+# - 24 x 512, with the same 2:1 Mamba:global-attention ratio
+# - 12 dense SwiGLU FFNs of width 1536
+# - 12 dropless token-choice MoE FFNs with 15 experts, top-2 routing, and
+#   width 768 per expert; two active experts equal one dense width-1536 FFN
+# - no shared expert, following OLMoE's controlled ablation
+#
+# Exact MAL estimate: 299,929,088 stored parameters. The parameters touched by
+# one token are approximately 115,904,000, including every router.
+
+attention retr_attn {
+    num_heads: 8
+    num_kv_heads: 4
+    bias: false
+    qk_norm: true
+    position_encoding: rope { theta: 100000.0 }
+}
+
+ssm retr_ssm {
+    state_dim: 16
+    conv_kernel: 4
+    expand: 2
+}
+
+ffn retr_dense_ffn {
+    hidden_dim: 1536
+    activation: swiglu
+    bias: false
+}
+
+ffn retr_moe_ffn {
+    hidden_dim: 768
+    activation: swiglu
+    bias: false
+    moe {
+        experts: 15
+        top_k: 2
+        shared_experts: 0
+        load_balance_loss_weight: 0.01
+        router_z_loss_weight: 0.001
+    }
+}
+
+block attn_dense_block {
+    attention: retr_attn
+    ffn: retr_dense_ffn
+    norm: rmsnorm { eps: 1e-5 }
+    norm_position: pre
+    residual: true
+}
+
+block attn_moe_block {
+    attention: retr_attn
+    ffn: retr_moe_ffn
+    norm: rmsnorm { eps: 1e-5 }
+    norm_position: pre
+    residual: true
+}
+
+block mamba_dense_block {
+    ssm: retr_ssm
+    ffn: retr_dense_ffn
+    norm: rmsnorm { eps: 1e-5 }
+    norm_position: pre
+    residual: true
+}
+
+block mamba_moe_block {
+    ssm: retr_ssm
+    ffn: retr_moe_ffn
+    norm: rmsnorm { eps: 1e-5 }
+    norm_position: pre
+    residual: true
+}
+
+model retriever-300m-moe {
+    description: "Hybrid Mamba+attention MoE retriever, ~300M total / ~116M active parameters"
+    vocab_size: 50277
+    max_seq_len: 8192
+    hidden_size: 512
+    num_layers: 24
+    block: attn_dense_block
+    pattern: [mamba_dense_block, mamba_moe_block, attn_dense_block, mamba_moe_block, mamba_dense_block, attn_moe_block]
+    embeddings {
+        tie_weights: true
+    }
+}

--- a/hermes-train/src/data.rs
+++ b/hermes-train/src/data.rs
@@ -6,7 +6,7 @@
 //! losses, while retrieval batches retain positive and hard-negative grouping.
 
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Read, Write};
+use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Read, Seek, Write};
 use std::path::Path;
 
 use anyhow::{Context, Result, ensure};
@@ -72,6 +72,7 @@ fn replay_token_cache(
         cache.write_all(TOKEN_CACHE_MAGIC)?;
         cache.flush()?;
     }
+    cache.rewind()?;
 
     let mut reader = BufReader::new(cache);
     let mut magic = [0_u8; 8];
@@ -595,6 +596,23 @@ mod tests {
                 .unwrap();
         assert_eq!(documents, 3);
         assert_eq!(replay_count, 2);
+    }
+
+    #[test]
+    fn new_token_cache_rewinds_after_writing_its_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        let mut packer = SamplePacker::new(3);
+        let mut count = 0;
+        let mut visit = |_| Ok(true);
+
+        let (documents, keep_going, writer) =
+            replay_token_cache(&path, 0, &mut packer, &mut count, &mut visit).unwrap();
+
+        assert_eq!(documents, 0);
+        assert!(keep_going);
+        assert!(writer.is_some());
+        assert_eq!(fs::read(path).unwrap(), TOKEN_CACHE_MAGIC);
     }
 
     #[test]


### PR DESCRIPTION
## Summary\n\n- add a well-known 299,929,088-parameter hybrid MoE retriever\n- preserve the 24x512 backbone and ~115.9M active-parameter budget\n- cover the exact expert count, sparse-layer placement, and parameter estimate\n\n## Tests\n\n- cargo test -p hermes-mal\n- pre-push checks