### PR TITLE
train: reduce periodic checkpoint stalls

### DIFF
--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -24,7 +24,7 @@ hermes-train train \
   --tokenizer tokenizer.json \
   --curriculum curriculum.json \
   --output checkpoint \
-  --checkpoint-every 100
+  --checkpoint-every 500
 ```
 
 ### Build the education curriculum
@@ -127,10 +127,13 @@ both parameter sets. It supports cosine or warmup-stable-decay scheduling and
 fine-tuning from safetensors. CUDA training uses BF16 Tensor Core operands while
 model parameters and optimizer state remain FP32; Muon's Newton-Schulz
 iterations also use BF16.
-It writes the latest checkpoint every 100 optimizer steps by default; pass
-`--checkpoint-every 0` to save only at completion. Files are staged behind an
-in-progress marker and the training-state file is published last, so resume and
-remote sync never consume a partially replaced checkpoint.
+It writes the latest checkpoint every 500 optimizer steps by default; pass
+`--checkpoint-every 0` to save only at completion. A full checkpoint includes
+the model and both optimizer states, so accelerator work pauses while those
+tensors are copied and published. Choose a shorter interval only when the
+additional recovery granularity is worth that throughput cost. Files are staged
+behind an in-progress marker and the training-state file is published last, so
+resume and remote sync never consume a partially replaced checkpoint.
 Each training checkpoint includes weights, AdamW and Muon state, and the exact
 curriculum position. Relaunch the same command with `--resume` to replay the
 deterministic bounded shuffle up to that position and continue the schedule.
@@ -140,6 +143,11 @@ state from this stream without re-running the tokenizer; an interrupted tail
 record is discarded and rebuilt from the corpus. The cache is derived, may be
 deleted safely between runs, and is intentionally not uploaded as part of the
 authoritative model/optimizer checkpoint.
+Corpus reading, Zstandard decompression, tokenization, packing, and bounded
+shuffling run on a dedicated reader thread. It stays up to two batches ahead of
+the optimizer, so increasing host-side buffering does not improve throughput
+when that queue is already full; in that case the remaining utilization gap is
+inside accelerator execution or deliberate checkpoint/diagnostic pauses.
 Resume verifies the entire curriculum and optimization signature. Use
 `--checkpoint` instead when warm-starting a new curriculum from existing
 safetensors.

--- a/hermes-train/scripts/relaunch.conf.example
+++ b/hermes-train/scripts/relaunch.conf.example
@@ -13,8 +13,7 @@ HERMES_TRAIN_COMMAND=(
   --config /opt/hermes-run/retriever-100m.json
   --tokenizer /opt/hermes-run/tokenizer.json
   --curriculum /opt/hermes-run/curriculum.json
-  --checkpoint-every 100
-  --layer-metrics-every 25
+  --checkpoint-every 500
 )
 
 # A failed trainer is resumed indefinitely by default. Set a positive value to

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -75,7 +75,7 @@ struct TrainArgs {
     #[arg(long, value_enum, default_value_t = Schedule::Wsd)]
     schedule: Schedule,
     /// Save a resumable checkpoint every N optimizer steps; 0 disables it.
-    #[arg(long, default_value_t = 100)]
+    #[arg(long, default_value_t = 500)]
     checkpoint_every: usize,
     /// Record pre-clip gradient L2 norm for every layer every N optimizer
     /// steps; 0 disables this opt-in visualization/debug metric.


### PR DESCRIPTION
## Summary
- change the default full-checkpoint interval from 100 to 500 optimizer steps
- remove high-frequency layer diagnostics from the production-style relaunch example
- document the existing two-batch reader/tokenizer prefetch pipeline and checkpoint throughput tradeoff

## Evidence
A100 profiling showed the input reader queue remains full and data wait is negligible. Active training reaches about 90% SM utilization, while synchronous full checkpoints create the long zero-utilization troughs. A device-batch prefetch experiment regressed active throughput by about 1%, and two async-checkpoint prototypes produced no end-to-end win, so neither is included.

## Validation
- cargo fmt --all -- --check
- cargo test -p hermes-train (15 passed)
- cargo check -p hermes-train --features cuda
- 130-step A100 comparison against the production checkpoint path