### PR TITLE
chore(llm): update Burn and Cube accelerator stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "burn-backend-extension"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "ahash",
  "burn-backend",
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "atomic_float",
  "burn-backend",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-core",
  "burn-derive",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "burn-pack"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-std",
  "byteorder",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "burn-remote"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-core",
  "burn-pack",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "cc",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
+source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
 ]
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -1971,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
+source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "burn-backend-extension"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "ahash",
  "burn-backend",
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -607,7 +607,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -618,7 +618,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -671,7 +671,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "atomic_float",
  "burn-backend",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-core",
  "burn-derive",
@@ -726,7 +726,7 @@ dependencies = [
 [[package]]
 name = "burn-pack"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-std",
  "byteorder",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "burn-remote"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -785,7 +785,7 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-core",
  "burn-pack",
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "cc",
@@ -842,7 +842,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=a115f62e0213dabebba66bb618be266a8008b1ae#a115f62e0213dabebba66bb618be266a8008b1ae"
+source = "git+https://github.com/ppodolsky/burn?rev=ef8f82ba164df50ef7b20605b0a87617f0ecc378#ef8f82ba164df50ef7b20605b0a87617f0ecc378"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
@@ -1505,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1576,7 +1576,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
@@ -1603,7 +1603,7 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1622,7 +1622,7 @@ dependencies = [
 [[package]]
 name = "cubecl-environment"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "async-channel",
  "backtrace",
@@ -1657,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "cubecl-common",
@@ -1687,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bumpalo",
  "cubecl-common",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1740,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1759,7 +1759,7 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
@@ -1804,7 +1804,7 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "bytemuck",
  "cfg-if 1.0.4",
@@ -1830,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+source = "git+https://github.com/ppodolsky/cubecl?rev=c0efe74d3d4b820fbf992dbbe443ed7125c5205c#c0efe74d3d4b820fbf992dbbe443ed7125c5205c"
 dependencies = [
  "derive-new",
  "serde",
@@ -1840,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -1858,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
 ]
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1922,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1932,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1958,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -1971,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=20949c37a43e3b4b0e8f4f06e3f8623a626d78f2#20949c37a43e3b4b0e8f4f06e3f8623a626d78f2"
+source = "git+https://github.com/ppodolsky/cubek?rev=7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90#7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90"
 dependencies = [
  "bytemuck",
  "cubecl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,8 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]
@@ -472,7 +474,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 [[package]]
 name = "burn-autodiff"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-std",
@@ -489,7 +491,7 @@ dependencies = [
 [[package]]
 name = "burn-backend"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-std",
  "bytemuck",
@@ -509,7 +511,7 @@ dependencies = [
 [[package]]
 name = "burn-backend-extension"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -519,7 +521,7 @@ dependencies = [
 [[package]]
 name = "burn-core"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "ahash",
  "burn-backend",
@@ -546,7 +548,7 @@ dependencies = [
 [[package]]
 name = "burn-cpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -557,7 +559,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-cubecl-fusion",
@@ -576,7 +578,7 @@ dependencies = [
 [[package]]
 name = "burn-cubecl-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -586,6 +588,7 @@ dependencies = [
  "cubek",
  "derive-new",
  "hashbrown 0.16.1",
+ "rmp-serde",
  "serde",
  "spin",
 ]
@@ -593,7 +596,7 @@ dependencies = [
 [[package]]
 name = "burn-cuda"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -604,7 +607,7 @@ dependencies = [
 [[package]]
 name = "burn-derive"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "derive-new",
  "proc-macro2",
@@ -615,7 +618,7 @@ dependencies = [
 [[package]]
 name = "burn-dispatch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-autodiff",
  "burn-backend",
@@ -633,7 +636,7 @@ dependencies = [
 [[package]]
 name = "burn-flex"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -651,7 +654,7 @@ dependencies = [
 [[package]]
 name = "burn-fusion"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-ir",
@@ -668,7 +671,7 @@ dependencies = [
 [[package]]
 name = "burn-ir"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "hashbrown 0.16.1",
@@ -678,10 +681,9 @@ dependencies = [
 [[package]]
 name = "burn-ndarray"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "atomic_float",
- "burn-autodiff",
  "burn-backend",
  "burn-ir",
  "burn-std",
@@ -700,7 +702,7 @@ dependencies = [
 [[package]]
 name = "burn-nn"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-core",
  "num-traits",
@@ -709,7 +711,7 @@ dependencies = [
 [[package]]
 name = "burn-optim"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-core",
  "burn-derive",
@@ -724,7 +726,7 @@ dependencies = [
 [[package]]
 name = "burn-pack"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-std",
  "byteorder",
@@ -735,7 +737,7 @@ dependencies = [
 [[package]]
 name = "burn-remote"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -757,7 +759,7 @@ dependencies = [
 [[package]]
 name = "burn-rocm"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -768,7 +770,7 @@ dependencies = [
 [[package]]
 name = "burn-router"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-fusion",
@@ -783,12 +785,13 @@ dependencies = [
 [[package]]
 name = "burn-std"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "ahash",
  "bytemuck",
  "bytes",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-zspace",
  "data-encoding",
  "derive-new",
@@ -809,7 +812,7 @@ dependencies = [
 [[package]]
 name = "burn-store"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-core",
  "burn-pack",
@@ -826,7 +829,7 @@ dependencies = [
 [[package]]
 name = "burn-tch"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "cc",
@@ -839,7 +842,7 @@ dependencies = [
 [[package]]
 name = "burn-tensor"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-dispatch",
@@ -853,7 +856,7 @@ dependencies = [
 [[package]]
 name = "burn-wgpu"
 version = "0.22.0-pre.1"
-source = "git+https://github.com/ppodolsky/burn?rev=e2fe66511a2d287974d127d50844c80ee18befc0#e2fe66511a2d287974d127d50844c80ee18befc0"
+source = "git+https://github.com/ppodolsky/burn?rev=10652a1c400c844d6e492558295a9247ee2cc792#10652a1c400c844d6e492558295a9247ee2cc792"
 dependencies = [
  "burn-backend",
  "burn-cubecl",
@@ -1164,6 +1167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1484,11 +1488,12 @@ dependencies = [
 [[package]]
 name = "cubecl"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "cubecl-core",
  "cubecl-cpu",
  "cubecl-cuda",
+ "cubecl-environment",
  "cubecl-hip",
  "cubecl-ir",
  "cubecl-runtime",
@@ -1500,52 +1505,36 @@ dependencies = [
 [[package]]
 name = "cubecl-common"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
- "backtrace",
  "bytemuck",
- "bytes",
- "cfg-if 1.0.4",
  "cfg_aliases",
- "ciborium",
+ "cubecl-environment",
  "derive-new",
  "derive_more",
- "embassy-futures",
- "embassy-time",
- "etcetera",
  "float4",
  "float8",
- "futures-lite",
  "half",
  "hashbrown 0.17.1",
  "log",
  "num-traits",
- "oneshot 0.2.1",
- "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
- "rand 0.10.2",
- "sanitize-filename",
  "serde",
- "serde_bytes",
- "serde_json",
  "spin",
- "toml",
- "tracing",
  "tynm",
- "wasm-bindgen-futures",
- "web-time",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "cubecl-core"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-ir",
  "cubecl-macros",
  "cubecl-runtime",
@@ -1570,11 +1559,12 @@ dependencies = [
 [[package]]
 name = "cubecl-cpp"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-opt",
  "cubecl-runtime",
  "derive-new",
@@ -1586,12 +1576,13 @@ dependencies = [
 [[package]]
 name = "cubecl-cpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bytemuck",
  "crossbeam-utils",
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-opt",
  "cubecl-runtime",
  "cubecl-std",
@@ -1612,12 +1603,13 @@ dependencies = [
 [[package]]
 name = "cubecl-cuda"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
  "cubecl-cpp",
+ "cubecl-environment",
  "cubecl-runtime",
  "cudarc",
  "derive-new",
@@ -1628,14 +1620,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "cubecl-environment"
+version = "0.11.0-pre.1"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
+dependencies = [
+ "async-channel",
+ "backtrace",
+ "bytemuck",
+ "bytes",
+ "cfg-if 1.0.4",
+ "cfg_aliases",
+ "ciborium",
+ "embassy-futures",
+ "embassy-time",
+ "etcetera",
+ "foldhash 0.2.0",
+ "futures-lite",
+ "hashbrown 0.17.1",
+ "log",
+ "oneshot 0.2.1",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rand 0.10.2",
+ "rusqlite",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "spin",
+ "toml",
+ "tracing",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "cubecl-hip"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bytemuck",
  "cubecl-common",
  "cubecl-core",
  "cubecl-cpp",
+ "cubecl-environment",
  "cubecl-hip-sys",
  "cubecl-runtime",
  "derive-new",
@@ -1659,10 +1687,11 @@ dependencies = [
 [[package]]
 name = "cubecl-ir"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "bumpalo",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-macros-internal",
  "derive-new",
  "derive_more",
@@ -1683,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "cubecl-common",
  "darling 0.23.0",
@@ -1700,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "cubecl-macros-internal"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1711,10 +1740,11 @@ dependencies = [
 [[package]]
 name = "cubecl-opt"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-ir",
  "float-ord",
  "hashbrown 0.17.1",
@@ -1729,20 +1759,19 @@ dependencies = [
 [[package]]
 name = "cubecl-runtime"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "ahash",
- "async-channel",
  "bytemuck",
  "cfg-if 1.0.4",
  "cfg_aliases",
  "cubecl-common",
+ "cubecl-environment",
  "cubecl-ir",
  "cubecl-zspace",
  "derive-new",
  "derive_more",
  "enumset",
- "etcetera",
  "futures-util",
  "hashbrown 0.17.1",
  "itertools 0.14.0",
@@ -1750,21 +1779,19 @@ dependencies = [
  "md5",
  "serde",
  "serde_json",
- "spin",
  "thiserror 2.0.19",
  "toml",
  "tracing",
- "wasm-bindgen-futures",
- "web-time",
 ]
 
 [[package]]
 name = "cubecl-std"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "cubecl-common",
  "cubecl-core",
+ "cubecl-environment",
  "cubecl-runtime",
  "half",
  "num-traits",
@@ -1777,15 +1804,15 @@ dependencies = [
 [[package]]
 name = "cubecl-wgpu"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
- "async-channel",
  "bytemuck",
  "cfg-if 1.0.4",
  "cfg_aliases",
  "cubecl-common",
  "cubecl-core",
  "cubecl-cpp",
+ "cubecl-environment",
  "cubecl-ir",
  "cubecl-runtime",
  "derive-new",
@@ -1803,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "cubecl-zspace"
 version = "0.11.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubecl?rev=dd61293f47c4202ca1db3e702cfedbb9c775b7de#dd61293f47c4202ca1db3e702cfedbb9c775b7de"
+source = "git+https://github.com/ppodolsky/cubecl?rev=45ed466abf28e404e1d3d1f3c25263941fb440e9#45ed466abf28e404e1d3d1f3c25263941fb440e9"
 dependencies = [
  "derive-new",
  "serde",
@@ -1813,7 +1840,7 @@ dependencies = [
 [[package]]
 name = "cubek"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubek-attention",
@@ -1831,7 +1858,7 @@ dependencies = [
 [[package]]
 name = "cubek-attention"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1845,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "cubek-convolution"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1861,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "cubek-fft"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
 ]
@@ -1869,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "cubek-interpolate"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1881,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "cubek-matmul"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -1895,7 +1922,7 @@ dependencies = [
 [[package]]
 name = "cubek-pool"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1905,7 +1932,7 @@ dependencies = [
 [[package]]
 name = "cubek-quant"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1917,10 +1944,11 @@ dependencies = [
 [[package]]
 name = "cubek-random"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
+ "cubecl-environment",
  "half",
  "num-traits",
  "rand 0.10.2",
@@ -1930,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "cubek-reduce"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubek-std",
@@ -1943,7 +1971,7 @@ dependencies = [
 [[package]]
 name = "cubek-std"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "cubecl",
  "cubecl-common",
@@ -1953,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "cubek-tile"
 version = "0.3.0-pre.1"
-source = "git+https://github.com/ppodolsky/cubek?rev=b4fe9788a774c0f5e5af26122776b5bf4c8ee94d#b4fe9788a774c0f5e5af26122776b5bf4c8ee94d"
+source = "git+https://github.com/ppodolsky/cubek?rev=17fcf4a084cb3344800bc928ad2a3bc7a89e0318#17fcf4a084cb3344800bc928ad2a3bc7a89e0318"
 dependencies = [
  "bytemuck",
  "cubecl",
@@ -2507,6 +2535,8 @@ checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
  "parking",
  "pin-project-lite",
+ "portable-atomic",
+ "portable-atomic-util",
 ]
 
 [[package]]
@@ -2518,6 +2548,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -3102,6 +3144,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4021,6 +4072,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5841,6 +5903,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6437,6 +6524,18 @@ dependencies = [
  "nom 7.1.3",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7128,8 +7227,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracel-llvm"
-version = "22.1.4-4"
-source = "git+https://github.com/tracel-ai/tracel-llvm?rev=82401e3c00a35a3fb7d5e2b415e79692e09e1079#82401e3c00a35a3fb7d5e2b415e79692e09e1079"
+version = "22.1.4-5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fdf8a19f43dfaa86f20c7e7f22376b1bb47f4846cd89f4e0bb9f1a4fa50a9e9"
 dependencies = [
  "tracel-mlir-rs",
  "tracel-mlir-sys",
@@ -7137,8 +7237,9 @@ dependencies = [
 
 [[package]]
 name = "tracel-llvm-bundler"
-version = "22.1.4-4"
-source = "git+https://github.com/tracel-ai/tracel-llvm?rev=82401e3c00a35a3fb7d5e2b415e79692e09e1079#82401e3c00a35a3fb7d5e2b415e79692e09e1079"
+version = "22.1.4-5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a3f7a4f173e6ccec871f31fba2d4cb71c5c41ab0089c0bf9559f4780dfaf07"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7156,8 +7257,9 @@ dependencies = [
 
 [[package]]
 name = "tracel-mlir-rs"
-version = "22.1.4-4"
-source = "git+https://github.com/tracel-ai/tracel-llvm?rev=82401e3c00a35a3fb7d5e2b415e79692e09e1079#82401e3c00a35a3fb7d5e2b415e79692e09e1079"
+version = "22.1.4-5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b1cf4683d1bf518040a8e13ebb2c1b18a8c2bb1db257f47603edbd99b094f8"
 dependencies = [
  "tracel-mlir-rs-macros",
  "tracel-mlir-sys",
@@ -7165,8 +7267,9 @@ dependencies = [
 
 [[package]]
 name = "tracel-mlir-rs-macros"
-version = "22.1.4-4"
-source = "git+https://github.com/tracel-ai/tracel-llvm?rev=82401e3c00a35a3fb7d5e2b415e79692e09e1079#82401e3c00a35a3fb7d5e2b415e79692e09e1079"
+version = "22.1.4-5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d4cea4e89fcaddbcc7fdeba0720b62d8bda63e23326ff28463d4b864ef9945"
 dependencies = [
  "comrak",
  "convert_case 0.8.0",
@@ -7181,16 +7284,18 @@ dependencies = [
 
 [[package]]
 name = "tracel-mlir-sys"
-version = "22.1.4-4"
-source = "git+https://github.com/tracel-ai/tracel-llvm?rev=82401e3c00a35a3fb7d5e2b415e79692e09e1079#82401e3c00a35a3fb7d5e2b415e79692e09e1079"
+version = "22.1.4-5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb813a9f259bb2112a5a1186fa366e6075e6dc1c041b5ae38a116535b9daca64"
 dependencies = [
  "tracel-llvm-bundler",
 ]
 
 [[package]]
 name = "tracel-tblgen-rs"
-version = "22.1.4-4"
-source = "git+https://github.com/tracel-ai/tracel-llvm?rev=82401e3c00a35a3fb7d5e2b415e79692e09e1079#82401e3c00a35a3fb7d5e2b415e79692e09e1079"
+version = "22.1.4-5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93699345d51e8bcb0d968165bf024ea28af87fee776a60d55875bdb1b898f2d"
 dependencies = [
  "paste",
  "thiserror 2.0.19",
@@ -7502,6 +7607,12 @@ dependencies = [
  "quote",
  "unsynn",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,16 +111,16 @@ uuid = { version = "1.19", features = ["v4"] }
 # Forward softmax-LSE emission used by Hermes attention training. Upstream:
 # https://github.com/tracel-ai/cubek/pull/428
 [patch."https://github.com/tracel-ai/cubek"]
-cubek = { git = "https://github.com/ppodolsky/cubek", rev = "20949c37a43e3b4b0e8f4f06e3f8623a626d78f2" }
+cubek = { git = "https://github.com/ppodolsky/cubek", rev = "7b26a4bdc68c092ecd77ee6ee8a2cd39d61d4a90" }
 
 # Allocation retry plus asynchronous cuBLASLt BF16 GEMM and grouped-GEMM dispatch.
 # Consolidated upstream:
 # https://github.com/tracel-ai/cubecl/pull/1440
 [patch."https://github.com/tracel-ai/cubecl"]
-cubecl = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
-cubecl-common = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
-cubecl-environment = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
-cubecl-zspace = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
+cubecl = { git = "https://github.com/ppodolsky/cubecl", rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c" }
+cubecl-common = { git = "https://github.com/ppodolsky/cubecl", rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c" }
+cubecl-environment = { git = "https://github.com/ppodolsky/cubecl", rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c" }
+cubecl-zspace = { git = "https://github.com/ppodolsky/cubecl", rev = "c0efe74d3d4b820fbf992dbbe443ed7125c5205c" }
 
 # Route every Burn crate to the pinned fork rebased on upstream `c1e987d6` plus the
 # BF16 native-GEMM matmul dispatch (autotune-arbitrated against fused CubeK)
@@ -129,15 +129,15 @@ cubecl-zspace = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf
 # Measured on A100: +15.6%/+14.8% training tokens/s at batch 16/20 with
 # identical losses (docs/cublas-gemm-dispatch.md).
 [patch."https://github.com/tracel-ai/burn"]
-burn-core = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-autodiff = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-nn = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-ndarray = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-wgpu = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-cuda = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-store = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-cubecl = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-fusion = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-ir = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-optim = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
-burn-pack = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-core = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-autodiff = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-nn = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-ndarray = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-wgpu = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-cuda = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-store = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-cubecl = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-fusion = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-ir = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-optim = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }
+burn-pack = { git = "https://github.com/ppodolsky/burn", rev = "ef8f82ba164df50ef7b20605b0a87617f0ecc378" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,32 +111,33 @@ uuid = { version = "1.19", features = ["v4"] }
 # Forward softmax-LSE emission used by Hermes attention training. Upstream:
 # https://github.com/tracel-ai/cubek/pull/428
 [patch."https://github.com/tracel-ai/cubek"]
-cubek = { git = "https://github.com/ppodolsky/cubek", rev = "b4fe9788a774c0f5e5af26122776b5bf4c8ee94d" }
+cubek = { git = "https://github.com/ppodolsky/cubek", rev = "17fcf4a084cb3344800bc928ad2a3bc7a89e0318" }
 
 # Allocation retry plus asynchronous cuBLASLt BF16 GEMM and grouped-GEMM dispatch.
 # Consolidated upstream:
 # https://github.com/tracel-ai/cubecl/pull/1440
 [patch."https://github.com/tracel-ai/cubecl"]
-cubecl = { git = "https://github.com/ppodolsky/cubecl", rev = "dd61293f47c4202ca1db3e702cfedbb9c775b7de" }
-cubecl-common = { git = "https://github.com/ppodolsky/cubecl", rev = "dd61293f47c4202ca1db3e702cfedbb9c775b7de" }
-cubecl-zspace = { git = "https://github.com/ppodolsky/cubecl", rev = "dd61293f47c4202ca1db3e702cfedbb9c775b7de" }
+cubecl = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
+cubecl-common = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
+cubecl-environment = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
+cubecl-zspace = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf28e404e1d3d1f3c25263941fb440e9" }
 
-# Route every Burn crate to the pinned fork: upstream `bd6e8fa2f` plus the
+# Route every Burn crate to the pinned fork rebased on upstream `c1e987d6` plus the
 # BF16 native-GEMM matmul dispatch (autotune-arbitrated against fused CubeK)
 # and the now-upstream foreign-stream drop-ordering fix. Native GEMM upstream:
 # https://github.com/tracel-ai/burn/pull/5190
 # Measured on A100: +15.6%/+14.8% training tokens/s at batch 16/20 with
 # identical losses (docs/cublas-gemm-dispatch.md).
 [patch."https://github.com/tracel-ai/burn"]
-burn-core = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-autodiff = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-nn = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-ndarray = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-wgpu = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-cuda = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-store = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-cubecl = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-fusion = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-ir = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-optim = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
-burn-pack = { git = "https://github.com/ppodolsky/burn", rev = "e2fe66511a2d287974d127d50844c80ee18befc0" }
+burn-core = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-autodiff = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-nn = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-ndarray = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-wgpu = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-cuda = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-store = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-cubecl = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-fusion = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-ir = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-optim = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-pack = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ uuid = { version = "1.19", features = ["v4"] }
 # Forward softmax-LSE emission used by Hermes attention training. Upstream:
 # https://github.com/tracel-ai/cubek/pull/428
 [patch."https://github.com/tracel-ai/cubek"]
-cubek = { git = "https://github.com/ppodolsky/cubek", rev = "17fcf4a084cb3344800bc928ad2a3bc7a89e0318" }
+cubek = { git = "https://github.com/ppodolsky/cubek", rev = "20949c37a43e3b4b0e8f4f06e3f8623a626d78f2" }
 
 # Allocation retry plus asynchronous cuBLASLt BF16 GEMM and grouped-GEMM dispatch.
 # Consolidated upstream:
@@ -129,15 +129,15 @@ cubecl-zspace = { git = "https://github.com/ppodolsky/cubecl", rev = "45ed466abf
 # Measured on A100: +15.6%/+14.8% training tokens/s at batch 16/20 with
 # identical losses (docs/cublas-gemm-dispatch.md).
 [patch."https://github.com/tracel-ai/burn"]
-burn-core = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-autodiff = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-nn = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-ndarray = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-wgpu = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-cuda = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-store = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-cubecl = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-fusion = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-ir = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-optim = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
-burn-pack = { git = "https://github.com/ppodolsky/burn", rev = "10652a1c400c844d6e492558295a9247ee2cc792" }
+burn-core = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-autodiff = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-nn = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-ndarray = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-wgpu = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-cuda = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-store = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-cubecl = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-fusion = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-ir = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-optim = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }
+burn-pack = { git = "https://github.com/ppodolsky/burn", rev = "a115f62e0213dabebba66bb618be266a8008b1ae" }

--- a/hermes-llm/Cargo.toml
+++ b/hermes-llm/Cargo.toml
@@ -14,20 +14,20 @@ publish = false
 [dependencies]
 # Burn is the sole inference runtime. CPU uses ndarray; GPU backends and the
 # custom selective-scan op use Burn's CubeCL tensor/runtime directly.
-burn = { package = "burn-core", git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std", "extension", "ndarray", "autodiff"] }
-burn-autodiff = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std"] }
-burn-nn = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std"] }
-burn-ndarray = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std"] }
-burn-wgpu = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", optional = true, default-features = false, features = ["std", "metal", "autotune"] }
-burn-store = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = [
+burn = { package = "burn-core", git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", default-features = false, features = ["std", "extension", "ndarray", "autodiff"] }
+burn-autodiff = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", default-features = false, features = ["std"] }
+burn-nn = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", default-features = false, features = ["std"] }
+burn-ndarray = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", default-features = false, features = ["std"] }
+burn-wgpu = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", optional = true, default-features = false, features = ["std", "metal", "autotune"] }
+burn-store = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", default-features = false, features = [
     "safetensors",
     "std",
 ] }
-burn-cubecl = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", optional = true, default-features = false, features = ["std"] }
-burn-fusion = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", optional = true, default-features = false, features = ["std"] }
-burn-ir = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", optional = true, default-features = false, features = ["std"] }
-cubecl = { git = "https://github.com/ppodolsky/cubecl.git", rev = "dd61293f47c4202ca1db3e702cfedbb9c775b7de", optional = true, default-features = false, features = ["std"] }
-cubek = { git = "https://github.com/ppodolsky/cubek", rev = "b4fe9788a774c0f5e5af26122776b5bf4c8ee94d", optional = true, default-features = false, features = ["attention", "stdlib"] }
+burn-cubecl = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", optional = true, default-features = false, features = ["std"] }
+burn-fusion = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", optional = true, default-features = false, features = ["std"] }
+burn-ir = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", optional = true, default-features = false, features = ["std"] }
+cubecl = { git = "https://github.com/tracel-ai/cubecl.git", rev = "c544dc74625faf3c818a4ab7f8f8bdb5f3338326", optional = true, default-features = false, features = ["std"] }
+cubek = { git = "https://github.com/tracel-ai/cubek", rev = "e6c291ad3bdccc77257417d7ac16f4866f49628c", optional = true, default-features = false, features = ["attention", "stdlib"] }
 half = { version = "2", optional = true, default-features = false }
 
 # Stable-Rust byte-level BPE shared by training and inference.

--- a/hermes-train/Cargo.toml
+++ b/hermes-train/Cargo.toml
@@ -11,10 +11,10 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-burn = { package = "burn-core", git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std", "extension", "ndarray", "autodiff"] }
-burn-nn = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std"] }
-burn-optim = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std"] }
-burn-pack = { git = "https://github.com/tracel-ai/burn.git", rev = "bd6e8fa2f23c2ecea1044af149bdc9e698a0848d", default-features = false, features = ["std"] }
+burn = { package = "burn-core", git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", default-features = false, features = ["std", "extension", "ndarray", "autodiff"] }
+burn-nn = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", default-features = false, features = ["std"] }
+burn-optim = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", default-features = false, features = ["std"] }
+burn-pack = { git = "https://github.com/tracel-ai/burn.git", rev = "c1e987d6a6eeda661a34f71b07c42a25dd2b4eba", default-features = false, features = ["std"] }
 clap.workspace = true
 hermes-llm.workspace = true
 rand.workspace = true


### PR DESCRIPTION
## Summary

- update the direct dependency bases to Burn `v0.22.0-pre.1`, CubeCL `v0.11.0-pre.1`, and CubeK `v0.3.0-pre.1`
- rebase the required accelerator changes on each current upstream `main`
- pin the three consolidated upstream PR heads until they merge:
  - tracel-ai/cubecl#1440
  - tracel-ai/cubek#428
  - tracel-ai/burn#5190
- include the CubeK matmul autotune-key fix that separates 16-byte-aligned and unaligned stride layouts within an anchored shape bucket

The legality split fixes a reproducible A100 failure where an async-copy matmul selected for an aligned tensor was cached and reused for an incompatible unaligned tensor. The later Burn fusion-ordering panic was a consequence of that first failed launch.

All Cargo files submitted to the upstream dependency PRs reference only `tracel-ai/*` repositories. This repository's root patch table temporarily resolves the fork PR heads and can be removed as each upstream PR merges.

## Validation

- `cargo check -p hermes-train --features cuda`
- CubeCL runtime and CUDA-example checks
- CubeK matmul-key regression tests plus attention checks
- Burn CUDA check plus accelerated-GEMM contract tests
- A100 exact-head smoke on the 299,929,088-parameter MoE model: five optimizer steps completed, loss 10.923190 → 10.607383, final throughput 41,997 tokens/s
- two order-reversed 130-step A/B pairs showed that explicitly flushing CubeCL's client dispatch queue regressed throughput by 0.254% (42,104.8 → 41,998.0 tokens/s), so that candidate and its API were removed

No model architecture, training data, curriculum, or checkpoint format changes are included.
