### PR TITLE
fix(train): harden exact resume and wake performance

### DIFF
--- a/hermes-llm/Cargo.toml
+++ b/hermes-llm/Cargo.toml
@@ -86,5 +86,9 @@ harness = false
 name = "moe_primitives"
 harness = false
 
+[[bench]]
+name = "memory_reserve"
+harness = false
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/hermes-llm/benches/memory_reserve.rs
+++ b/hermes-llm/benches/memory_reserve.rs
@@ -1,0 +1,190 @@
+//! Memory-reserve routing benchmark across dormant, one-active and two-active
+//! states.
+//!
+//! The compact default model runs on every backend. To measure the production
+//! sleep model on CUDA:
+//!
+//! ```text
+//! cargo bench -p hermes-llm --bench memory_reserve --features training-fusion -- \
+//!   --model hermes-mal/well-known/retriever_300m_moe_sleep.mal --tokens 8192
+//! ```
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use anyhow::{Context, Result, bail};
+use burn::prelude::*;
+use hermes_llm::{Transformer, default_device, parse_mal, parse_mal_file};
+use serde::Serialize;
+
+const COMPACT_MEMORY_MODEL: &str = r#"
+ffn base { hidden_dim: 16 activation: swiglu bias: false }
+memory reserve {
+    tier fast {
+        ffn: base
+        reserve_experts { capacity: 4 rank: 32 top_k: 1 }
+    }
+}
+model memory-reserve-bench {
+    vocab_size: 128 max_seq_len: 1 hidden_size: 128 num_layers: 1
+    block: { attention: { num_heads: 4 } memory: reserve }
+    embeddings { tie_weights: true }
+}
+"#;
+
+#[derive(Debug)]
+struct Args {
+    model: Option<PathBuf>,
+    tokens: usize,
+    warmup: usize,
+    iterations: usize,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            model: None,
+            tokens: 4_096,
+            warmup: 5,
+            iterations: 20,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Measurement {
+    active_slots_per_layer: usize,
+    median_ms: f64,
+    min_ms: f64,
+    tokens_per_second: f64,
+}
+
+#[derive(Serialize)]
+struct Report {
+    implementation: &'static str,
+    model: String,
+    device: String,
+    tokens: usize,
+    warmup: usize,
+    iterations: usize,
+    measurements: Vec<Measurement>,
+}
+
+fn main() -> Result<()> {
+    let args = parse_args()?;
+    let config = match &args.model {
+        Some(path) => {
+            parse_mal_file(path).with_context(|| format!("failed to parse {}", path.display()))?
+        }
+        None => parse_mal(COMPACT_MEMORY_MODEL).context("compact benchmark MAL is invalid")?,
+    };
+    let device = default_device();
+    device.seed(17);
+    let mut model = Transformer::new(&config, &device)?;
+    let input = Tensor::<2, Int>::zeros([args.tokens, 1], &device);
+    // Inputs are independent one-token rows; row-major end positions are
+    // therefore 0..batch, which exercises the router with `tokens` routes
+    // without adding a quadratic attention sequence to this microbenchmark.
+    let end_positions = Tensor::<1, Int>::arange(0..args.tokens as i64, &device);
+
+    let mut measurements = Vec::with_capacity(3);
+    measurements.push(measure(
+        &model,
+        input.clone(),
+        end_positions.clone(),
+        &device,
+        &args,
+        0,
+    )?);
+    model.activate_memory_slot_all_layers(0, 0)?;
+    measurements.push(measure(
+        &model,
+        input.clone(),
+        end_positions.clone(),
+        &device,
+        &args,
+        1,
+    )?);
+    model.activate_memory_slot_all_layers(0, 1)?;
+    measurements.push(measure(&model, input, end_positions, &device, &args, 2)?);
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&Report {
+            implementation: "fixed_width_cached_reserve_router",
+            model: config.name,
+            device: format!("{device:?}"),
+            tokens: args.tokens,
+            warmup: args.warmup,
+            iterations: args.iterations,
+            measurements,
+        })?
+    );
+    Ok(())
+}
+
+fn measure(
+    model: &Transformer,
+    input: Tensor<2, Int>,
+    end_positions: Tensor<1, Int>,
+    device: &Device,
+    args: &Args,
+    active_slots_per_layer: usize,
+) -> Result<Measurement> {
+    let operation = || {
+        let output = model.forward_embeddings(input.clone(), end_positions.clone(), None);
+        std::hint::black_box(output);
+    };
+    for _ in 0..args.warmup {
+        operation();
+        device.sync()?;
+    }
+    let mut elapsed = Vec::with_capacity(args.iterations);
+    for _ in 0..args.iterations {
+        device.sync()?;
+        let started = Instant::now();
+        operation();
+        device.sync()?;
+        elapsed.push(started.elapsed().as_secs_f64() * 1_000.0);
+    }
+    elapsed.sort_by(f64::total_cmp);
+    let median_ms = if args.iterations.is_multiple_of(2) {
+        (elapsed[args.iterations / 2 - 1] + elapsed[args.iterations / 2]) / 2.0
+    } else {
+        elapsed[args.iterations / 2]
+    };
+    Ok(Measurement {
+        active_slots_per_layer,
+        median_ms,
+        min_ms: elapsed[0],
+        tokens_per_second: args.tokens as f64 / (median_ms / 1_000.0),
+    })
+}
+
+fn parse_args() -> Result<Args> {
+    let mut parsed = Args::default();
+    let mut args = std::env::args().skip(1);
+    while let Some(flag) = args.next() {
+        let mut value = || args.next().with_context(|| format!("{flag} needs a value"));
+        match flag.as_str() {
+            "--model" => parsed.model = Some(PathBuf::from(value()?)),
+            "--tokens" => parsed.tokens = value()?.parse().context("invalid --tokens")?,
+            "--warmup" => parsed.warmup = value()?.parse().context("invalid --warmup")?,
+            "--iterations" => {
+                parsed.iterations = value()?.parse().context("invalid --iterations")?
+            }
+            "--bench" => {}
+            "--help" | "-h" => {
+                println!(
+                    "Usage: memory_reserve [--model PATH] [--tokens N] [--warmup N] [--iterations N]"
+                );
+                std::process::exit(0);
+            }
+            _ => bail!("unknown argument {flag:?}"),
+        }
+    }
+    if parsed.tokens == 0 || parsed.iterations == 0 {
+        bail!("--tokens and --iterations must be positive");
+    }
+    Ok(parsed)
+}

--- a/hermes-llm/src/lib.rs
+++ b/hermes-llm/src/lib.rs
@@ -70,8 +70,8 @@ pub mod trace;
 // Core types
 pub use model::{
     Device, InferenceState, MambaBackend, MemoryRouting, MemorySlotStatus, SelectedLogitProjector,
-    Transformer, WakeParameterAccounting, default_device, load_safetensors, save_safetensors,
-    upgrade_safetensors_to_memory,
+    Transformer, WakeParameterAccounting, default_device, load_safetensors, load_safetensors_bytes,
+    save_safetensors, upgrade_safetensors_to_memory,
 };
 
 // Generation

--- a/hermes-llm/src/model/block.rs
+++ b/hermes-llm/src/model/block.rs
@@ -366,6 +366,13 @@ impl TransformerBlock {
         }
     }
 
+    pub(crate) fn validate_memory_checkpoint_state(&self) -> anyhow::Result<()> {
+        if let Some(memory) = &self.memory {
+            memory.validate_checkpoint_state()?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn prepare_memory_upgrade_state(&mut self) {
         if let Some(memory) = &mut self.memory {
             memory.prepare_upgrade_state();

--- a/hermes-llm/src/model/memory.rs
+++ b/hermes-llm/src/model/memory.rs
@@ -173,13 +173,17 @@ impl LowRankExpertSlot {
         matmul_2(matmul_2(input.cast(DType::F32), self.a.val()), self.b.val()).cast(dtype)
     }
 
-    fn generation(&self) -> u64 {
+    fn generation_value(&self) -> i64 {
         self.generation
             .val()
             .into_data()
             .convert::<i64>()
             .to_vec::<i64>()
-            .expect("memory generation must be readable")[0] as u64
+            .expect("memory generation must be readable")[0]
+    }
+
+    fn generation(&self) -> u64 {
+        u64::try_from(self.generation_value()).expect("memory generation must be non-negative")
     }
 
     fn checkpoint_active(&self) -> bool {
@@ -190,6 +194,14 @@ impl LowRankExpertSlot {
             .expect("memory activation mask must be readable")[0]
     }
 
+    fn validate_checkpoint_state(&self) -> Result<()> {
+        anyhow::ensure!(
+            self.generation_value() >= 0,
+            "memory generation must be non-negative"
+        );
+        Ok(())
+    }
+
     fn set_active(&mut self, active: bool) {
         self.active = self.active.clone().map(|value| {
             let device = value.device();
@@ -198,24 +210,34 @@ impl LowRankExpertSlot {
         self.runtime_active = active;
     }
 
-    fn advance_generation(&mut self) {
-        let generation = self.generation().saturating_add(1) as i64;
+    fn next_generation(&self) -> Result<i64> {
+        let generation = self.generation_value();
+        anyhow::ensure!(generation >= 0, "memory generation must be non-negative");
+        generation
+            .checked_add(1)
+            .ok_or_else(|| anyhow::anyhow!("memory generation exceeds i64"))
+    }
+
+    fn set_generation(&mut self, generation: i64) {
         self.generation = self.generation.clone().map(|value| {
             let device = value.device();
             Tensor::<1, Int>::from_data([generation], &device)
         });
     }
 
-    fn activate(&mut self) {
-        self.advance_generation();
+    fn activate(&mut self) -> Result<()> {
+        let generation = self.next_generation()?;
+        self.set_generation(generation);
         self.set_active(true);
+        Ok(())
     }
 
     fn sync_state(&mut self) {
         self.runtime_active = self.checkpoint_active();
     }
 
-    fn reset(&mut self, seed: u64) {
+    fn reset(&mut self, seed: u64) -> Result<()> {
+        let generation = self.next_generation()?;
         let [hidden, rank] = self.a.shape().dims();
         let a_values = deterministic_values(hidden * rank, seed);
         self.a = self.a.clone().map(|value| {
@@ -228,8 +250,9 @@ impl LowRankExpertSlot {
             .weight
             .clone()
             .map(|value| Tensor::zeros_like(&value));
-        self.advance_generation();
+        self.set_generation(generation);
         self.set_active(false);
+        Ok(())
     }
 
     fn parameter_ids(&self) -> Vec<ParamId> {
@@ -265,6 +288,17 @@ struct LowRankExpertReserve {
     // projection width fixed. An active slot replaces its corresponding row;
     // a dormant slot's actual router parameter stays entirely off the graph.
     fallback_router: Tensor<2>,
+    // Activation changes only at consolidation boundaries, not on wake
+    // forwards. Keep its device-side routing metadata beside the checkpointed
+    // mask instead of rebuilding and uploading it for every token batch.
+    // These are derived exclusively from `slots[*].active`, which remains the
+    // checkpoint authority. Plain tensors are absent from parameter records,
+    // but must remain module fields so AutodiffModule::valid and device moves
+    // map them to the same backend as the learned slot parameters.
+    routing_mask: Tensor<2>,
+    global_to_local: Tensor<1, Int>,
+    #[module(skip)]
+    active_slots: Vec<usize>,
     #[module(skip)]
     top_k: usize,
 }
@@ -284,8 +318,61 @@ impl LowRankExpertReserve {
             ),
             fallback_b: Tensor::zeros([rank, hidden], device),
             fallback_router: Tensor::zeros([hidden, capacity], device),
+            routing_mask: Tensor::full([1, capacity], -1.0e30, device),
+            global_to_local: Tensor::zeros([capacity], device),
+            active_slots: Vec::new(),
             top_k,
         }
+    }
+
+    fn refresh_routing_cache(&mut self) {
+        self.active_slots = self
+            .slots
+            .iter()
+            .enumerate()
+            .filter_map(|(slot, expert)| expert.runtime_active.then_some(slot))
+            .collect();
+
+        let capacity = self.slots.len();
+        let mut mask = vec![-1.0e30_f32; capacity];
+        let mut global_to_local = vec![0_i64; capacity];
+        for (local, global) in self.active_slots.iter().copied().enumerate() {
+            mask[global] = 0.0;
+            global_to_local[global] = local as i64;
+        }
+        let device = self
+            .slots
+            .first()
+            .expect("memory reserve has positive validated capacity")
+            .a
+            .val()
+            .device();
+        self.routing_mask = Tensor::from_data(TensorData::new(mask, [1, capacity]), &device);
+        self.global_to_local =
+            Tensor::from_data(TensorData::new(global_to_local, [capacity]), &device);
+    }
+
+    /// Recreate parameter-free derived tensors after loading checkpointed slot
+    /// state or applying a custom module-device move. Slot parameters provide
+    /// the authoritative backend and device; none of these tensors belong in
+    /// optimizer or checkpoint records.
+    fn refresh_runtime_tensors(&mut self) {
+        let first = self
+            .slots
+            .first()
+            .expect("memory reserve has positive validated capacity");
+        let [hidden, rank] = first.a.shape().dims();
+        let device = first.a.val().device();
+        self.fallback_a = Tensor::from_data(
+            TensorData::new(
+                deterministic_values(hidden * rank, mix_seed(0, 0x4641_4c4c_4241_434b)),
+                [hidden, rank],
+            ),
+            &device,
+        );
+        self.fallback_b = Tensor::zeros([rank, hidden], &device);
+        self.fallback_router = Tensor::zeros([hidden, self.slots.len()], &device);
+        self.refresh_routing_cache();
     }
 
     fn fallback_forward<const D: usize>(&self, input: Tensor<D>, gate: Tensor<2>) -> Tensor<D> {
@@ -303,13 +390,7 @@ impl LowRankExpertReserve {
         .reshape(shape)
     }
 
-    fn forward<const D: usize>(&self, input: Tensor<D>) -> Option<Tensor<D>> {
-        let active = self
-            .slots
-            .iter()
-            .enumerate()
-            .filter(|(_, slot)| slot.runtime_active)
-            .collect::<Vec<_>>();
+    fn forward<const D: usize>(&self, input: Tensor<D>) -> Tensor<D> {
         debug_assert_eq!(self.top_k, 1);
         let shape = input.dims();
         let hidden = shape[D - 1];
@@ -319,29 +400,50 @@ impl LowRankExpertReserve {
         // corresponding parameter-free fallback. The matmul and top-k shapes
         // therefore never grow as stored slots activate, while dormant slot
         // parameters remain absent from both the forward and backward graph.
-        let router_weight = Tensor::cat(
-            self.slots
+        // Start with the cached parameter-free bank and overlay only active
+        // learned columns. This makes construction proportional to active
+        // compute instead of stored capacity, while slice assignment keeps
+        // every active router parameter on the autodiff graph.
+        let router_weight =
+            self.active_slots
                 .iter()
-                .enumerate()
-                .map(|(slot, expert)| {
-                    if expert.runtime_active {
-                        expert.router.weight.val()
-                    } else {
-                        self.fallback_router
-                            .clone()
-                            .slice([0..hidden, slot..slot + 1])
-                    }
-                })
-                .collect(),
-            1,
-        );
+                .copied()
+                .fold(self.fallback_router.clone(), |weight, slot| {
+                    weight.slice_assign(
+                        [0..hidden, slot..slot + 1],
+                        self.slots[slot].router.weight.val(),
+                    )
+                });
         let router_logits = matmul_2(flat.clone().cast(DType::F32), router_weight);
-        let mut mask = vec![-1.0e30_f32; self.slots.len()];
-        for (global, _) in &active {
-            mask[*global] = 0.0;
+        if self.active_slots.is_empty() {
+            // Preserve the fixed rank-shaped no-op route, while avoiding a
+            // top-k, sort and route-count round trip whose answer is known.
+            // Deriving the zero gate from the fixed router result keeps that
+            // projection in lazy-fusion graphs as part of constant wake work.
+            let gate = router_logits.slice([0..tokens, 0..1]).mul_scalar(0.0);
+            return self.fallback_forward(flat.reshape(shape), gate);
         }
-        let masked = router_logits.clone()
-            + Tensor::<2>::from_data(TensorData::new(mask, [1, self.slots.len()]), &flat.device());
+
+        if let [global] = self.active_slots.as_slice() {
+            // A sole active slot is necessarily top-1. Its gate still competes
+            // with the parameter-free zero fallback, so router gradients and
+            // the exact wake semantics are retained without dispatching or
+            // reading route counts back to the host.
+            let selected = router_logits.slice([0..tokens, *global..*global + 1]);
+            let gate = softmax(
+                Tensor::cat(
+                    vec![selected, Tensor::zeros([tokens, 1], &flat.device())],
+                    1,
+                ),
+                1,
+            )
+            .slice([0..tokens, 0..1]);
+            let dtype = flat.dtype();
+            let output = self.slots[*global].forward(flat) * gate.cast(dtype);
+            return output.reshape(shape);
+        }
+
+        let masked = router_logits + self.routing_mask.clone();
         let (_, global_indices) = masked.clone().topk_with_indices(1, 1);
         // Normalize against every active fixed-width row plus a parameter-free
         // zero fallback. Non-selected active rows therefore still receive the
@@ -353,41 +455,36 @@ impl LowRankExpertReserve {
         )
         .slice([0..tokens, 0..self.slots.len()])
         .gather(1, global_indices.clone());
-        if active.is_empty() {
-            // Actual reserve slots remain entirely off the graph.  The
-            // separate fixed fallback executes one rank-shaped no-op route,
-            // matching the top-1 expert cost paid after a slot activates.
-            return Some(self.fallback_forward(flat.reshape(shape), gate));
-        }
-
         let device = flat.device();
         // Inactive content buckets are masked before top-1. Convert the
         // resulting global slot number to the compact active-bank index used
         // by grouped dispatch. This selection is content-dependent without
         // scoring a growing bank of learned router rows.
-        let mut global_to_local = vec![0_i64; self.slots.len()];
-        for (local, (global, _)) in active.iter().enumerate() {
-            global_to_local[*global] = local as i64;
-        }
-        let top_indices = Tensor::<1, Int>::from_data(
-            TensorData::new(global_to_local, [self.slots.len()]),
-            &device,
-        )
-        .select(0, global_indices.reshape([tokens]))
-        .reshape([tokens, 1]);
+        let top_indices = if self.active_slots.len() == self.slots.len() {
+            global_indices
+        } else {
+            self.global_to_local
+                .clone()
+                .select(0, global_indices.reshape([tokens]))
+                .reshape([tokens, 1])
+        };
         let routes = tokens;
         #[cfg(feature = "cuda")]
         let (route_order, inverse_order, mut counts, device_counts) = if is_cuda_device(&device) {
-            let (order, inverse, counts) = route_plan(top_indices.clone(), active.len());
+            let (order, inverse, counts) = route_plan(top_indices.clone(), self.active_slots.len());
             (order, inverse, Vec::new(), Some(counts))
         } else {
-            let (order, inverse, counts) =
-                host_route_plan(top_indices.clone(), active.len(), routes, &device);
+            let (order, inverse, counts) = host_route_plan(
+                top_indices.clone(),
+                self.active_slots.len(),
+                routes,
+                &device,
+            );
             (order, inverse, counts, None)
         };
         #[cfg(not(feature = "cuda"))]
         let (route_order, inverse_order, counts) =
-            host_route_plan(top_indices, active.len(), routes, &device);
+            host_route_plan(top_indices, self.active_slots.len(), routes, &device);
 
         #[cfg(feature = "cuda")]
         let routed_input = if is_cuda_device(&device) {
@@ -426,23 +523,39 @@ impl LowRankExpertReserve {
 
         #[cfg(feature = "cuda")]
         let routed_output = if is_cuda_device(&device) {
-            let a = Tensor::stack::<3>(active.iter().map(|(_, slot)| slot.a.val()).collect(), 0);
-            let b = Tensor::stack::<3>(active.iter().map(|(_, slot)| slot.b.val()).collect(), 0);
+            // These trainable views must be rebuilt after every optimizer
+            // update; caching them would sever gradients or serve stale
+            // parameters. Activation-dependent masks and mappings above are
+            // safe to cache because they only change at sleep boundaries.
+            let a = Tensor::stack::<3>(
+                self.active_slots
+                    .iter()
+                    .map(|slot| self.slots[*slot].a.val())
+                    .collect(),
+                0,
+            );
+            let b = Tensor::stack::<3>(
+                self.active_slots
+                    .iter()
+                    .map(|slot| self.slots[*slot].b.val())
+                    .collect(),
+                0,
+            );
             let projected = grouped_linear(routed_input, matmul_input(a), &counts);
             grouped_linear(projected, matmul_input(b), &counts).cast(flat.dtype())
         } else {
-            Self::forward_compact(&active, routed_input, &counts, hidden)
+            self.forward_compact(routed_input, &counts, hidden)
         };
         #[cfg(not(feature = "cuda"))]
-        let routed_output = Self::forward_compact(&active, routed_input, &counts, hidden);
+        let routed_output = self.forward_compact(routed_input, &counts, hidden);
 
         let output =
             row_permute(routed_output, inverse_order, route_order) * gate.cast(flat.dtype());
-        Some(output.reshape(shape))
+        output.reshape(shape)
     }
 
     fn forward_compact(
-        active: &[(usize, &LowRankExpertSlot)],
+        &self,
         routed_input: Tensor<2>,
         counts: &[usize],
         hidden: usize,
@@ -456,7 +569,7 @@ impl LowRankExpertReserve {
             let input = routed_input
                 .clone()
                 .slice([offset..offset + count, 0..hidden]);
-            outputs.push(active[local].1.forward(input));
+            outputs.push(self.slots[self.active_slots[local]].forward(input));
             offset += count;
         }
         debug_assert_eq!(offset, routed_input.dims()[0]);
@@ -467,6 +580,14 @@ impl LowRankExpertReserve {
         for slot in &mut self.slots {
             slot.sync_state();
         }
+        self.refresh_runtime_tensors();
+    }
+
+    fn validate_checkpoint_state(&self) -> Result<()> {
+        for slot in &self.slots {
+            slot.validate_checkpoint_state()?;
+        }
+        Ok(())
     }
 
     /// Stored reserve parameters and the fixed route paid by every ordinary
@@ -527,13 +648,7 @@ impl MemoryTier {
             collect_auxiliary,
             routing,
         );
-        (
-            match reserve {
-                Some(reserve) => base + reserve,
-                None => base,
-            },
-            auxiliary,
-        )
+        (base + reserve, auxiliary)
     }
 
     fn wake_parameter_counts(&self) -> Result<(usize, usize)> {
@@ -629,6 +744,13 @@ impl MemoryChain {
         }
     }
 
+    pub(crate) fn validate_checkpoint_state(&self) -> Result<()> {
+        for tier in &self.tiers {
+            tier.reserve.validate_checkpoint_state()?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn wake_parameter_counts(&self) -> Result<(usize, usize)> {
         self.tiers
             .iter()
@@ -653,6 +775,7 @@ impl MemoryChain {
             for slot in &mut tier.reserve.slots {
                 slot.set_active(false);
             }
+            tier.reserve.refresh_routing_cache();
         }
     }
 
@@ -671,7 +794,8 @@ impl MemoryChain {
         if slot.runtime_active {
             anyhow::bail!("memory slot {slot_index} in tier {tier_index} is already active");
         }
-        slot.activate();
+        slot.activate()?;
+        tier.reserve.refresh_routing_cache();
         Ok(())
     }
 
@@ -686,6 +810,7 @@ impl MemoryChain {
             .get_mut(slot)
             .ok_or_else(|| anyhow::anyhow!("memory slot {slot} does not exist"))?;
         slot.set_active(false);
+        tier.reserve.refresh_routing_cache();
         Ok(())
     }
 
@@ -699,7 +824,8 @@ impl MemoryChain {
             .slots
             .get_mut(slot)
             .ok_or_else(|| anyhow::anyhow!("memory slot {slot} does not exist"))?;
-        slot.reset(seed);
+        slot.reset(seed)?;
+        tier.reserve.refresh_routing_cache();
         Ok(())
     }
 
@@ -781,6 +907,7 @@ impl MemoryChain {
 
 #[cfg(test)]
 mod tests {
+    use burn::module::AutodiffModule;
     use burn::tensor::Distribution;
 
     use super::*;
@@ -802,6 +929,10 @@ mod tests {
             "#,
         )
         .unwrap()
+    }
+
+    fn values<const D: usize>(tensor: Tensor<D>) -> Vec<f32> {
+        tensor.into_data().convert::<f32>().to_vec::<f32>().unwrap()
     }
 
     #[test]
@@ -925,6 +1056,110 @@ mod tests {
     }
 
     #[test]
+    fn routing_cache_tracks_runtime_and_checkpoint_activation() {
+        let config = memory_config();
+        let device = Device::ndarray();
+        let block = config.block.clone();
+        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+
+        let reserve = &memory.tiers[0].reserve;
+        assert!(reserve.active_slots.is_empty());
+        assert_eq!(values(reserve.routing_mask.clone()), vec![-1.0e30; 2]);
+
+        memory.activate_slot(0, 1).unwrap();
+        let reserve = &memory.tiers[0].reserve;
+        assert_eq!(reserve.active_slots, vec![1]);
+        assert_eq!(values(reserve.routing_mask.clone()), vec![-1.0e30, 0.0]);
+
+        memory.activate_slot(0, 0).unwrap();
+        let reserve = &memory.tiers[0].reserve;
+        assert_eq!(reserve.active_slots, vec![0, 1]);
+        assert_eq!(values(reserve.routing_mask.clone()), vec![0.0, 0.0]);
+        assert_eq!(
+            reserve
+                .global_to_local
+                .clone()
+                .into_data()
+                .convert::<i64>()
+                .to_vec::<i64>()
+                .unwrap(),
+            vec![0, 1]
+        );
+
+        memory.deactivate_slot(0, 0).unwrap();
+        assert_eq!(memory.tiers[0].reserve.active_slots, vec![1]);
+
+        // A checkpoint loader updates the serialized mask first, then calls
+        // sync_state. The cached device metadata must follow that source of
+        // truth rather than a stale runtime mirror.
+        let reserve = &mut memory.tiers[0].reserve;
+        reserve.slots[0].active = reserve.slots[0]
+            .active
+            .clone()
+            .map(|value| Tensor::<1, Bool>::from_data([true], &value.device()));
+        reserve.sync_state();
+        assert_eq!(reserve.active_slots, vec![0, 1]);
+        assert_eq!(values(reserve.routing_mask.clone()), vec![0.0, 0.0]);
+    }
+
+    #[test]
+    fn routing_cache_survives_autodiff_validation() {
+        let config = memory_config();
+        let device = Device::ndarray().autodiff();
+        let block = config.block.clone();
+        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        memory.activate_slot(0, 1).unwrap();
+
+        let inference = memory.valid();
+        let reserve = &inference.tiers[0].reserve;
+        assert_eq!(reserve.active_slots, vec![1]);
+        assert_eq!(values(reserve.routing_mask.clone()), vec![-1.0e30, 0.0]);
+        assert_eq!(
+            reserve
+                .global_to_local
+                .clone()
+                .into_data()
+                .convert::<i64>()
+                .to_vec::<i64>()
+                .unwrap(),
+            vec![0, 0]
+        );
+    }
+
+    #[test]
+    fn one_active_slot_matches_fallback_competition_equation() {
+        let config = memory_config();
+        let device = Device::ndarray();
+        let block = config.block.clone();
+        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        memory.activate_slot(0, 1).unwrap();
+        let reserve = &mut memory.tiers[0].reserve;
+        reserve.slots[1].b = reserve.slots[1]
+            .b
+            .clone()
+            .map(|value| Tensor::full(value.shape(), 0.1, &value.device()));
+
+        let input = Tensor::<2>::random([5, 8], Distribution::Default, &device);
+        let actual = reserve.forward(input.clone());
+        let logits = matmul_2(
+            input.clone().cast(DType::F32),
+            reserve.slots[1].router.weight.val(),
+        );
+        let gate = softmax(
+            Tensor::cat(vec![logits, Tensor::zeros([5, 1], &device)], 1),
+            1,
+        )
+        .slice([0..5, 0..1]);
+        let expected = reserve.slots[1].forward(input) * gate;
+        let max_diff = values(actual)
+            .into_iter()
+            .zip(values(expected))
+            .map(|(actual, expected)| (actual - expected).abs())
+            .fold(0.0_f32, f32::max);
+        assert!(max_diff <= 1e-7, "one-slot fast path drifted by {max_diff}");
+    }
+
+    #[test]
     fn dormant_reserve_executes_an_exact_untrainable_fallback_route() {
         let config = memory_config();
         let device = Device::ndarray().autodiff();
@@ -933,9 +1168,7 @@ mod tests {
         let reserve = &memory.tiers[0].reserve;
         let input = Tensor::<2>::random([5, 8], Distribution::Default, &device);
 
-        let output = reserve
-            .forward(input)
-            .expect("the fixed fallback always occupies the top-1 route lane");
+        let output = reserve.forward(input);
         let magnitude: f32 = output.abs().sum().into_scalar();
         assert_eq!(magnitude, 0.0, "fallback must be logit-exact no-op");
 
@@ -998,5 +1231,32 @@ mod tests {
             .sum()
             .into_scalar();
         assert_eq!(b, 0.0);
+    }
+
+    #[test]
+    fn generation_exhaustion_does_not_activate_or_reset_a_slot() {
+        let config = memory_config();
+        let device = Device::ndarray();
+        let block = config.block.clone();
+        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        let slot = &mut memory.tiers[0].reserve.slots[0];
+        slot.generation = slot
+            .generation
+            .clone()
+            .map(|value| Tensor::<1, Int>::from_data([i64::MAX], &value.device()));
+
+        let error = memory.activate_slot(0, 0).unwrap_err().to_string();
+        assert!(error.contains("generation exceeds i64"), "{error}");
+        let status = &memory.statuses(0)[0];
+        assert!(!status.active);
+        assert_eq!(status.generation, i64::MAX as u64);
+
+        let slot = &mut memory.tiers[0].reserve.slots[1];
+        slot.generation = slot
+            .generation
+            .clone()
+            .map(|value| Tensor::<1, Int>::from_data([-1_i64], &value.device()));
+        let error = memory.validate_checkpoint_state().unwrap_err().to_string();
+        assert!(error.contains("generation must be non-negative"), "{error}");
     }
 }

--- a/hermes-llm/src/model/mod.rs
+++ b/hermes-llm/src/model/mod.rs
@@ -59,7 +59,9 @@ pub use memory::{MemoryChain, MemoryRouting, MemorySlotStatus};
 pub use norm::Norm;
 pub use scan::MambaBackend;
 pub use transformer::{SelectedLogitProjector, Transformer, WakeParameterAccounting};
-pub use weights::{load_safetensors, save_safetensors, upgrade_safetensors_to_memory};
+pub use weights::{
+    load_safetensors, load_safetensors_bytes, save_safetensors, upgrade_safetensors_to_memory,
+};
 
 #[cfg(all(test, any(feature = "metal", feature = "cuda")))]
 mod test_support {

--- a/hermes-llm/src/model/transformer.rs
+++ b/hermes-llm/src/model/transformer.rs
@@ -1089,13 +1089,21 @@ impl Transformer {
         self.final_norm.forward(x)
     }
 
-    /// Refresh runtime mirrors from checkpointed memory masks. Strict Hermes
-    /// loaders call this automatically; call it after applying snapshots with
-    /// Burn APIs directly.
+    /// Refresh runtime mirrors and device-local routing caches from
+    /// checkpointed memory masks. Strict Hermes loaders call this
+    /// automatically; call it after applying snapshots or moving a model with
+    /// Burn module APIs directly.
     pub fn sync_memory_state(&mut self) {
         for layer in &mut self.layers {
             layer.sync_memory_state();
         }
+    }
+
+    pub(crate) fn validate_memory_checkpoint_state(&self) -> Result<()> {
+        for layer in &self.layers {
+            layer.validate_memory_checkpoint_state()?;
+        }
+        Ok(())
     }
 
     pub(crate) fn prepare_memory_upgrade_state(&mut self) {

--- a/hermes-llm/src/model/weights.rs
+++ b/hermes-llm/src/model/weights.rs
@@ -17,7 +17,33 @@ static ATOMIC_SAVE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 /// Load strictly: missing, unexpected, and shape-mismatched tensors are errors.
 pub fn load_safetensors(model: &mut Transformer, path: impl AsRef<Path>) -> Result<ApplyResult> {
     let path = path.as_ref();
-    let mut store = SafetensorsStore::from_file(path).skip_enum_variants(true);
+    load_safetensors_store(
+        model,
+        SafetensorsStore::from_file(path),
+        &format!("checkpoint {}", path.display()),
+    )
+}
+
+/// Load a strictly validated SafeTensors checkpoint from authenticated bytes.
+///
+/// This is used by crash-safe resume code after it has read and hashed an
+/// immutable checkpoint artifact through an already-authenticated directory
+/// handle. Keeping the byte buffer as the store's source prevents a later
+/// pathname replacement from changing what Burn applies to the model.
+pub fn load_safetensors_bytes(
+    model: &mut Transformer,
+    bytes: Vec<u8>,
+    label: &str,
+) -> Result<ApplyResult> {
+    load_safetensors_store(model, SafetensorsStore::from_bytes(Some(bytes)), label)
+}
+
+fn load_safetensors_store(
+    model: &mut Transformer,
+    store: SafetensorsStore,
+    label: &str,
+) -> Result<ApplyResult> {
+    let mut store = store.skip_enum_variants(true);
     // `ModuleSnapshot::load_from` may successfully apply the tensors it can
     // match and report the rest through `ApplyResult`.  Load into a private
     // clone so either the complete checkpoint is accepted or the caller's
@@ -25,12 +51,12 @@ pub fn load_safetensors(model: &mut Transformer, path: impl AsRef<Path>) -> Resu
     let mut loaded = model.clone();
     let result = loaded
         .load_from(&mut store)
-        .with_context(|| format!("failed to load weights from {}", path.display()))?;
+        .with_context(|| format!("failed to load weights from {label}"))?;
     ensure!(
         result.errors.is_empty() && result.missing.is_empty() && result.unused.is_empty(),
-        "checkpoint {} does not match the model topology:\n{result}",
-        path.display()
+        "{label} does not match the model topology:\n{result}"
     );
+    loaded.validate_memory_checkpoint_state()?;
     loaded.sync_memory_state();
     *model = loaded;
     Ok(result)
@@ -155,6 +181,7 @@ pub fn upgrade_safetensors_to_memory(
             unexpected_missing.join(", ")
         );
     }
+    upgraded.validate_memory_checkpoint_state()?;
     upgraded.sync_memory_state();
     if upgraded
         .memory_slot_statuses()
@@ -659,13 +686,38 @@ mod tests {
                 .all(|slot| !slot.active)
         );
 
+        let dormant_parameters = target.num_params();
         target.activate_memory_slot(0, 1, 0).unwrap();
+        let active_parameters = target.num_params();
+        assert_eq!(active_parameters, dormant_parameters);
+        let active_input = Tensor::<2, Int>::from_data([[2, 4, 6, 8]], &device);
+        let active_logits = target.forward(active_input.clone(), 0).into_data();
         save_safetensors(&target, &active_target_path).unwrap();
         let mut reloaded = Transformer::new(&target_config, &device).unwrap();
         load_safetensors(&mut reloaded, &active_target_path).unwrap();
+        assert_eq!(reloaded.num_params(), active_parameters);
+        assert!(
+            tensor_state(&reloaded).iter().all(|(path, _)| {
+                !path.contains("routing_mask") && !path.contains("global_to_local")
+            }),
+            "derived routing caches must not enter checkpoint state"
+        );
         let statuses = reloaded.memory_slot_statuses();
         assert!(statuses.iter().any(|slot| slot.tier == 1 && slot.active));
         assert!(statuses.iter().all(|slot| slot.tier == 1 || !slot.active));
+        let reloaded_logits = reloaded.forward(active_input, 0).into_data();
+        let maximum = active_logits
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .unwrap()
+            .into_iter()
+            .zip(reloaded_logits.convert::<f32>().to_vec::<f32>().unwrap())
+            .map(|(active, reloaded)| (active - reloaded).abs())
+            .fold(0.0_f32, f32::max);
+        assert!(
+            maximum < 1e-6,
+            "active memory logits changed by {maximum} after roundtrip"
+        );
     }
 
     #[test]

--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -705,6 +705,15 @@ including `generation-manifest.json`, then atomically replaces `current.json`.
 Every manifest file is size- and SHA-256-verified before resume. Unsupported
 checkpoint schema versions fail explicitly.
 
+`hermes-train verify-checkpoint --root CHECKPOINT --metrics
+CHECKPOINT/metrics.jsonl` exposes the same strict generation, training-state,
+accounting, optimizer-reference, and committed-metric-prefix checks for
+automation. The relaunch supervisor invokes this command for every local,
+downloaded, and pre-publication generation; its Python helper is limited to
+transport envelopes and immutable artifact copying. The built-in trainer also
+holds `.trainer.lock` for its full process lifetime, so a second direct trainer
+cannot mutate the same output root behind the supervisor.
+
 `metrics.jsonl` is a strict append-only schema-v2 stream. Typed events include
 optimization losses, throughput, phase timing, tier updates, active capacity,
 post-training update receipts, distillation divergence, imitation rewards,

--- a/hermes-train/scripts/relaunch.conf.example
+++ b/hermes-train/scripts/relaunch.conf.example
@@ -21,6 +21,10 @@ HERMES_TRAIN_COMMAND=(
   # --sleep-runtime /opt/hermes-run/sleep-runtime.json
   # --sleep-runtime-sha256 sha256:replace-with-the-runtime-file-digest
 )
+# The supervisor runs `<binary> verify-checkpoint` before trusting any local or
+# downloaded generation. This defaults to HERMES_TRAIN_COMMAND[0]; set it only
+# when the training command starts through a wrapper such as `env` or `cargo`.
+# HERMES_TRAIN_CHECKPOINT_VERIFIER_BIN=/opt/hermes-run/bin/hermes-train
 
 # A failed trainer is resumed indefinitely by default. Set a positive value to
 # stop after that many retries so a boot-time service can apply its own policy.

--- a/hermes-train/scripts/relaunch.sh
+++ b/hermes-train/scripts/relaunch.sh
@@ -21,6 +21,7 @@ readonly -a OBSOLETE_FLAT_CHECKPOINT_FILES=(
   adamw-state.bpk
   muon-state.bpk
   training-state.json
+  training-accounting.json
 )
 
 log() {
@@ -82,6 +83,7 @@ readonly WANDB_PYTHON=${HERMES_TRAIN_WANDB_PYTHON:-python3}
 readonly WANDB_SCRIPT=${HERMES_TRAIN_WANDB_SCRIPT:-"$RELAUNCH_SCRIPT_DIR/wandb_tail.py"}
 readonly WANDB_RESTART_DELAY=${HERMES_TRAIN_WANDB_RESTART_DELAY:-15}
 readonly WANDB_FLUSH_DELAY=${HERMES_TRAIN_WANDB_FLUSH_DELAY:-6}
+readonly CHECKPOINT_VERIFIER_BIN=${HERMES_TRAIN_CHECKPOINT_VERIFIER_BIN:-${HERMES_TRAIN_COMMAND[0]}}
 
 is_nonnegative_integer() {
   [[ $1 =~ ^[0-9]+$ ]]
@@ -117,6 +119,8 @@ fi
 command -v "$PYTHON_BIN" >/dev/null 2>&1 || die "Python is required: $PYTHON_BIN"
 command -v "${HERMES_TRAIN_COMMAND[0]}" >/dev/null 2>&1 \
   || die "trainer is unavailable: ${HERMES_TRAIN_COMMAND[0]}"
+command -v "$CHECKPOINT_VERIFIER_BIN" >/dev/null 2>&1 \
+  || die "checkpoint verifier is unavailable: $CHECKPOINT_VERIFIER_BIN"
 if [[ -n "$REMOTE" && $REMOTE != file://* ]]; then
   [[ $REMOTE == gs://* ]] || die "remote URL must use gs:// or file://"
   command -v "$GCLOUD_BIN" >/dev/null 2>&1 || die "gcloud is required for $REMOTE"
@@ -139,11 +143,15 @@ elif ! shlock -f "$LOCK_FILE" -p "$$"; then
 fi
 printf '%s\n' "$$" >"$STATE_DIR/supervisor.pid"
 
-# Keep checkpoint parsing and hashing in one implementation. Commands print only
-# path-safe, whitespace-free descriptors for Bash to consume.
+# This helper owns transport envelopes, safe paths, immutable copying, and
+# hashing. The trainer's `verify-checkpoint` command remains the authority for
+# exact-resume checkpoint contents. Commands print only path-safe,
+# whitespace-free descriptors for Bash to consume.
 checkpoint_tool() {
   "$PYTHON_BIN" - "$@" <<'PY'
 import hashlib
+import errno
+import fcntl
 import json
 import os
 import secrets
@@ -163,21 +171,7 @@ REMOTE_POINTER_KEYS = {
     "artifact_manifest_bytes",
     "artifact_manifest_sha256",
 }
-MANIFEST_KEYS = {
-    "version",
-    "training_state_version",
-    "global_step",
-    "phase",
-    "phase_id",
-    "files",
-}
 FILE_KEYS = {"path", "bytes", "sha256"}
-REQUIRED_FILES = {
-    "weights.safetensors",
-    "adamw-state.bpk",
-    "muon-state.bpk",
-    "training-state.json",
-}
 ARTIFACT_ROOT_SPEC_KEYS = {
     "version",
     "sleep_runtime_sha256",
@@ -278,25 +272,11 @@ def real_directory(path, label):
 
 
 def load_json_file(path, label):
-    regular_file(path, label)
-    try:
-        with open(path, "rb") as handle:
-            raw = handle.read()
-        def unique_object(pairs):
-            value = {}
-            for key, item in pairs:
-                if key in value:
-                    fail(f"{label} repeats JSON field {key!r}")
-                value[key] = item
-            return value
-
-        return json.loads(raw, object_pairs_hook=unique_object), raw
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
-        fail(f"{label} is invalid JSON: {error}")
+    _, _, raw = read_stable_regular_file(path, label, capture=True)
+    return load_unique_json_bytes(raw, label), raw
 
 
-def read_pointer(path, remote=False):
-    pointer, _ = load_json_file(path, "checkpoint current pointer")
+def parse_pointer(pointer, remote=False):
     expected_keys = REMOTE_POINTER_KEYS if remote else LOCAL_POINTER_KEYS
     if not isinstance(pointer, dict) or set(pointer) != expected_keys:
         fail("checkpoint current pointer has an invalid schema")
@@ -343,65 +323,50 @@ def read_pointer(path, remote=False):
     )
 
 
-def read_manifest(path, generation, expected_digest):
+def read_pointer(path, remote=False):
+    pointer, _ = load_json_file(path, "checkpoint current pointer")
+    return parse_pointer(pointer, remote=remote)
+
+
+def read_manifest_transport(path, generation, expected_digest):
+    """Extract only safe download paths from a content-addressed manifest.
+
+    The Rust verifier owns the checkpoint schema and authenticates every
+    materialized file. This parser deliberately knows only the transport
+    envelope needed to fetch those files without path traversal.
+    """
     manifest, raw = load_json_file(path, "checkpoint generation manifest")
     actual_digest = hashlib.sha256(raw).hexdigest()
     if actual_digest != expected_digest:
         fail("checkpoint generation manifest digest mismatch")
     if generation != "sha256-" + actual_digest:
         fail("checkpoint generation name and manifest digest differ")
-    if not isinstance(manifest, dict) or set(manifest) != MANIFEST_KEYS:
-        fail("checkpoint generation manifest has an invalid schema")
-    version(manifest["version"], 1, "checkpoint generation manifest")
-    version(
-        manifest["training_state_version"],
-        2,
-        "checkpoint generation training state",
-    )
-    integer(manifest["global_step"], "checkpoint manifest global_step")
-    integer(manifest["phase"], "checkpoint manifest phase")
-    if not isinstance(manifest["phase_id"], str) or not manifest["phase_id"].strip():
-        fail("checkpoint manifest phase_id is empty")
-    entries = manifest["files"]
+    if not isinstance(manifest, dict):
+        fail("checkpoint generation manifest is not an object")
+    entries = manifest.get("files")
     if not isinstance(entries, list):
         fail("checkpoint manifest files is not an array")
     paths = []
     for entry in entries:
-        if not isinstance(entry, dict) or set(entry) != FILE_KEYS:
-            fail("checkpoint manifest file has an invalid schema")
-        path_value = safe_path(entry["path"])
+        if not isinstance(entry, dict):
+            fail("checkpoint manifest file is not an object")
+        path_value = safe_path(entry.get("path"))
         if path_value == "generation-manifest.json":
             fail("checkpoint manifest cannot list itself")
-        integer(entry["bytes"], f"checkpoint file {path_value!r} size")
-        digest(entry["sha256"], f"checkpoint file {path_value!r} digest")
         paths.append(path_value)
     if paths != sorted(paths) or len(paths) != len(set(paths)):
         fail("checkpoint manifest file paths are not unique and sorted")
-    missing = sorted(REQUIRED_FILES.difference(paths))
-    if missing:
-        fail(f"checkpoint generation is missing required file {missing[0]!r}")
-    return manifest
+    return paths
 
 
-def hash_file(path):
-    hasher = hashlib.sha256()
-    length = 0
-    with open(path, "rb") as handle:
-        while True:
-            block = handle.read(1024 * 1024)
-            if not block:
-                break
-            length += len(block)
-            hasher.update(block)
-    return length, hasher.hexdigest()
-
-
-def stable_file_descriptor(path, label):
-    """Hash a regular file while rejecting replacement or in-place mutation."""
+def read_stable_regular_file(path, label, capture=False):
+    """Read/hash one opened regular file while rejecting path or byte races."""
     metadata = regular_file(path, label)
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
     try:
         descriptor = os.open(path, flags)
     except OSError as error:
@@ -410,33 +375,41 @@ def stable_file_descriptor(path, label):
         opened = os.fstat(descriptor)
         if not stat.S_ISREG(opened.st_mode):
             fail(f"{label} is not a regular file")
-        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+        identity = lambda value: (
+            value.st_dev,
+            value.st_ino,
+            value.st_mode,
+            value.st_size,
+            value.st_mtime_ns,
+            value.st_ctime_ns,
+        )
+        if identity(opened) != identity(metadata):
             fail(f"{label} changed while it was opened")
         hasher = hashlib.sha256()
         length = 0
+        chunks = [] if capture else None
         while True:
             block = os.read(descriptor, 1024 * 1024)
             if not block:
                 break
             length += len(block)
             hasher.update(block)
+            if chunks is not None:
+                chunks.append(block)
         after = os.fstat(descriptor)
         current = regular_file(path, label)
-        identity = (opened.st_dev, opened.st_ino)
-        if identity != (after.st_dev, after.st_ino) or identity != (
-            current.st_dev,
-            current.st_ino,
-        ):
-            fail(f"{label} was replaced while it was hashed")
-        if (
-            opened.st_size != after.st_size
-            or opened.st_mtime_ns != after.st_mtime_ns
-            or length != after.st_size
-        ):
+        if identity(opened) != identity(after) or identity(opened) != identity(current):
             fail(f"{label} changed while it was hashed")
-        return length, hasher.hexdigest()
+        if length != after.st_size:
+            fail(f"{label} changed while it was hashed")
+        return length, hasher.hexdigest(), None if chunks is None else b"".join(chunks)
     finally:
         os.close(descriptor)
+
+
+def stable_file_descriptor(path, label):
+    length, sha256, _ = read_stable_regular_file(path, label)
+    return length, sha256
 
 
 def load_unique_json_bytes(raw, label):
@@ -452,6 +425,656 @@ def load_unique_json_bytes(raw, label):
         return json.loads(raw, object_pairs_hook=unique_object)
     except (UnicodeDecodeError, json.JSONDecodeError) as error:
         fail(f"{label} is invalid JSON: {error}")
+
+
+def file_identity(metadata):
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def retained_directory_fd(value, label="file remote root"):
+    try:
+        inherited = int(value)
+    except (TypeError, ValueError):
+        fail(f"{label} descriptor is invalid")
+    try:
+        descriptor = os.dup(inherited)
+        metadata = os.fstat(descriptor)
+    except OSError as error:
+        fail(f"{label} descriptor is unavailable: {error}")
+    if not stat.S_ISDIR(metadata.st_mode):
+        os.close(descriptor)
+        fail(f"{label} descriptor is not a directory")
+    return descriptor
+
+
+def directory_open_flags():
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    return flags
+
+
+def regular_open_flags():
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    return flags
+
+
+def open_child_directory(parent, name, label):
+    try:
+        descriptor = os.open(name, directory_open_flags(), dir_fd=parent)
+    except OSError as error:
+        fail(f"{label} is unavailable or unsafe: {error}")
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        os.close(descriptor)
+        fail(f"{label} is not a real directory")
+    return descriptor
+
+
+def open_anchored_parent(root, relative, create=False):
+    relative = safe_path(relative)
+    parts = relative.split("/")
+    current = os.dup(root)
+    try:
+        for index, component in enumerate(parts[:-1]):
+            label = "/".join(parts[: index + 1])
+            try:
+                child = os.open(
+                    component,
+                    directory_open_flags(),
+                    dir_fd=current,
+                )
+            except FileNotFoundError:
+                if not create:
+                    raise
+                try:
+                    os.mkdir(component, 0o700, dir_fd=current)
+                    os.fsync(current)
+                except FileExistsError:
+                    pass
+                child = open_child_directory(current, component, label)
+            except OSError as error:
+                fail(f"file remote directory {label!r} is unsafe: {error}")
+            metadata = os.fstat(child)
+            if not stat.S_ISDIR(metadata.st_mode):
+                os.close(child)
+                fail(f"file remote directory {label!r} is not a real directory")
+            os.close(current)
+            current = child
+        return current, parts[-1]
+    except BaseException:
+        os.close(current)
+        raise
+
+
+def ensure_anchored_directory(root, relative):
+    parent, leaf = open_anchored_parent(root, relative, create=True)
+    try:
+        try:
+            descriptor = os.open(leaf, directory_open_flags(), dir_fd=parent)
+        except FileNotFoundError:
+            try:
+                os.mkdir(leaf, 0o700, dir_fd=parent)
+                os.fsync(parent)
+            except FileExistsError:
+                pass
+            descriptor = open_child_directory(parent, leaf, relative)
+        except OSError as error:
+            fail(f"file remote directory {relative!r} is unsafe: {error}")
+        if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            os.close(descriptor)
+            fail(f"file remote directory {relative!r} is not a real directory")
+        return descriptor
+    finally:
+        os.close(parent)
+
+
+def anchored_entry_metadata(root, relative):
+    parent, leaf = open_anchored_parent(root, relative)
+    try:
+        try:
+            return os.stat(leaf, dir_fd=parent, follow_symlinks=False)
+        except FileNotFoundError:
+            return None
+    finally:
+        os.close(parent)
+
+
+def anchored_entry_kind(root, relative):
+    metadata = anchored_entry_metadata(root, relative)
+    if metadata is None:
+        return "missing"
+    if stat.S_ISLNK(metadata.st_mode):
+        return "symlink"
+    if stat.S_ISREG(metadata.st_mode):
+        return "file"
+    if stat.S_ISDIR(metadata.st_mode):
+        return "directory"
+    return "other"
+
+
+def open_anchored_regular(root, relative, label):
+    parent, leaf = open_anchored_parent(root, relative)
+    try:
+        before = os.stat(leaf, dir_fd=parent, follow_symlinks=False)
+    except FileNotFoundError:
+        os.close(parent)
+        fail(f"{label} is unavailable")
+    if not stat.S_ISREG(before.st_mode):
+        os.close(parent)
+        fail(f"{label} is not a regular file")
+    try:
+        descriptor = os.open(leaf, regular_open_flags(), dir_fd=parent)
+    except OSError as error:
+        os.close(parent)
+        fail(f"{label} cannot be opened safely: {error}")
+    opened = os.fstat(descriptor)
+    if not stat.S_ISREG(opened.st_mode) or file_identity(opened) != file_identity(before):
+        os.close(descriptor)
+        os.close(parent)
+        fail(f"{label} changed while it was opened")
+    return parent, leaf, descriptor, opened
+
+
+def read_anchored_regular(root, relative, label):
+    parent, leaf, descriptor, opened = open_anchored_regular(root, relative, label)
+    try:
+        chunks = []
+        hasher = hashlib.sha256()
+        length = 0
+        while True:
+            block = os.read(descriptor, 1024 * 1024)
+            if not block:
+                break
+            chunks.append(block)
+            hasher.update(block)
+            length += len(block)
+        after = os.fstat(descriptor)
+        current = os.stat(leaf, dir_fd=parent, follow_symlinks=False)
+        if file_identity(after) != file_identity(opened) or file_identity(current) != file_identity(opened):
+            fail(f"{label} changed while it was read")
+        if length != after.st_size:
+            fail(f"{label} changed while it was read")
+        return b"".join(chunks), length, hasher.hexdigest()
+    finally:
+        os.close(descriptor)
+        os.close(parent)
+
+
+def write_all(descriptor, block):
+    offset = 0
+    while offset < len(block):
+        offset += os.write(descriptor, block[offset:])
+
+
+def copy_open_regular(source, destination, label):
+    hasher = hashlib.sha256()
+    length = 0
+    while True:
+        block = os.read(source, 1024 * 1024)
+        if not block:
+            break
+        write_all(destination, block)
+        hasher.update(block)
+        length += len(block)
+    return length, hasher.hexdigest()
+
+
+def local_atomic_destination(destination, writer):
+    parent_path = os.path.dirname(destination)
+    real_directory(parent_path, "local copy destination directory")
+    temporary = os.path.join(
+        parent_path,
+        f".hermes-fd-copy-{os.getpid()}-{secrets.token_hex(8)}.tmp",
+    )
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(temporary, flags, 0o600)
+    try:
+        writer(descriptor)
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        os.replace(temporary, destination)
+        parent = os.open(parent_path, directory_open_flags())
+        try:
+            os.fsync(parent)
+        finally:
+            os.close(parent)
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def copy_anchored_out(root, relative, destination):
+    label = f"file remote object {relative!r}"
+    parent, leaf, source, opened = open_anchored_regular(root, relative, label)
+    try:
+        observed = None
+
+        def writer(output):
+            nonlocal observed
+            observed = copy_open_regular(source, output, label)
+            after = os.fstat(source)
+            current = os.stat(leaf, dir_fd=parent, follow_symlinks=False)
+            if file_identity(after) != file_identity(opened) or file_identity(current) != file_identity(opened):
+                fail(f"{label} changed while it was copied")
+            if observed[0] != after.st_size:
+                fail(f"{label} changed while it was copied")
+
+        local_atomic_destination(destination, writer)
+        if observed is None:
+            fail(f"{label} was not copied")
+    finally:
+        os.close(source)
+        os.close(parent)
+
+
+def open_stable_source(path, label):
+    before = regular_file(path, label)
+    try:
+        descriptor = os.open(path, regular_open_flags())
+    except OSError as error:
+        fail(f"{label} cannot be opened safely: {error}")
+    opened = os.fstat(descriptor)
+    if not stat.S_ISREG(opened.st_mode) or file_identity(opened) != file_identity(before):
+        os.close(descriptor)
+        fail(f"{label} changed while it was opened")
+    return descriptor, opened
+
+
+def create_anchored_temporary(parent, prefix):
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    for _attempt in range(128):
+        name = f".{prefix}-{os.getpid()}-{secrets.token_hex(8)}.tmp"
+        try:
+            return name, os.open(name, flags, 0o600, dir_fd=parent)
+        except FileExistsError:
+            continue
+    fail("cannot allocate an anchored temporary file")
+
+
+def hash_anchored_leaf(parent, leaf, label):
+    before = os.stat(leaf, dir_fd=parent, follow_symlinks=False)
+    if not stat.S_ISREG(before.st_mode):
+        fail(f"{label} is not a regular file")
+    descriptor = os.open(leaf, regular_open_flags(), dir_fd=parent)
+    try:
+        opened = os.fstat(descriptor)
+        if file_identity(opened) != file_identity(before):
+            fail(f"{label} changed while it was opened")
+        hasher = hashlib.sha256()
+        length = 0
+        while True:
+            block = os.read(descriptor, 1024 * 1024)
+            if not block:
+                break
+            length += len(block)
+            hasher.update(block)
+        after = os.fstat(descriptor)
+        current = os.stat(leaf, dir_fd=parent, follow_symlinks=False)
+        if file_identity(after) != file_identity(opened) or file_identity(current) != file_identity(opened):
+            fail(f"{label} changed while it was hashed")
+        return length, hasher.hexdigest()
+    finally:
+        os.close(descriptor)
+
+
+def copy_into_anchored(
+    root,
+    source_path,
+    relative,
+    immutable=False,
+    expected_bytes=None,
+    expected_sha256=None,
+):
+    label = f"file remote upload source {source_path!r}"
+    source, opened = open_stable_source(source_path, label)
+    parent, leaf = open_anchored_parent(root, relative, create=True)
+    temporary = None
+    temporary_descriptor = None
+    try:
+        temporary, temporary_descriptor = create_anchored_temporary(parent, "upload")
+        observed_bytes, observed_sha256 = copy_open_regular(source, temporary_descriptor, label)
+        after = os.fstat(source)
+        current = regular_file(source_path, label)
+        if file_identity(after) != file_identity(opened) or file_identity(current) != file_identity(opened):
+            fail(f"{label} changed while it was copied")
+        if observed_bytes != after.st_size:
+            fail(f"{label} changed while it was copied")
+        if expected_bytes is not None and (
+            observed_bytes != expected_bytes or observed_sha256 != expected_sha256
+        ):
+            fail("file remote upload source differs from its expected size or digest")
+        os.fsync(temporary_descriptor)
+        os.close(temporary_descriptor)
+        temporary_descriptor = None
+
+        if immutable:
+            try:
+                existing = os.stat(leaf, dir_fd=parent, follow_symlinks=False)
+            except FileNotFoundError:
+                existing = None
+            if existing is not None:
+                if not stat.S_ISREG(existing.st_mode):
+                    fail(f"immutable file remote object {relative!r} is not a regular file")
+                length, digest_value = hash_anchored_leaf(
+                    parent, leaf, f"immutable file remote object {relative!r}"
+                )
+                if length != expected_bytes or digest_value != expected_sha256:
+                    fail(f"immutable file remote object {relative!r} contains different bytes")
+                return
+            try:
+                os.link(
+                    temporary,
+                    leaf,
+                    src_dir_fd=parent,
+                    dst_dir_fd=parent,
+                    follow_symlinks=False,
+                )
+            except FileExistsError:
+                length, digest_value = hash_anchored_leaf(
+                    parent, leaf, f"immutable file remote object {relative!r}"
+                )
+                if length != expected_bytes or digest_value != expected_sha256:
+                    fail(f"immutable file remote object {relative!r} raced with different bytes")
+        else:
+            os.replace(temporary, leaf, src_dir_fd=parent, dst_dir_fd=parent)
+            temporary = None
+        os.fsync(parent)
+    finally:
+        os.close(source)
+        if temporary_descriptor is not None:
+            os.close(temporary_descriptor)
+        if temporary is not None:
+            try:
+                os.unlink(temporary, dir_fd=parent)
+            except OSError:
+                pass
+        os.close(parent)
+
+
+def remove_anchored_entry_at(parent, name):
+    try:
+        metadata = os.stat(name, dir_fd=parent, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+        directory = open_child_directory(parent, name, f"removal directory {name!r}")
+        try:
+            for child in os.listdir(directory):
+                remove_anchored_entry_at(directory, child)
+        finally:
+            os.close(directory)
+        os.rmdir(name, dir_fd=parent)
+    else:
+        os.unlink(name, dir_fd=parent)
+
+
+def remove_anchored_entry(root, relative):
+    parent, leaf = open_anchored_parent(root, relative)
+    try:
+        remove_anchored_entry_at(parent, leaf)
+        os.fsync(parent)
+    finally:
+        os.close(parent)
+
+
+def copy_regular_between_directories(source_parent, destination_parent, name, label):
+    before = os.stat(name, dir_fd=source_parent, follow_symlinks=False)
+    if not stat.S_ISREG(before.st_mode):
+        fail(f"{label} is not a regular file")
+    source = os.open(name, regular_open_flags(), dir_fd=source_parent)
+    destination = None
+    try:
+        opened = os.fstat(source)
+        if file_identity(opened) != file_identity(before):
+            fail(f"{label} changed while it was opened")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        destination = os.open(name, flags, 0o600, dir_fd=destination_parent)
+        observed_bytes, _ = copy_open_regular(source, destination, label)
+        os.fsync(destination)
+        after = os.fstat(source)
+        current = os.stat(name, dir_fd=source_parent, follow_symlinks=False)
+        if file_identity(after) != file_identity(opened) or file_identity(current) != file_identity(opened):
+            fail(f"{label} changed while it was copied")
+        if observed_bytes != after.st_size:
+            fail(f"{label} changed while it was copied")
+    finally:
+        os.close(source)
+        if destination is not None:
+            os.close(destination)
+
+
+def copy_directory_tree(source, destination, label):
+    opened = os.fstat(source)
+    if not stat.S_ISDIR(opened.st_mode):
+        fail(f"{label} is not a directory")
+    names = sorted(os.listdir(source))
+    if not names:
+        fail(f"{label} contains an empty directory")
+    for name in names:
+        safe_path(name)
+        metadata = os.stat(name, dir_fd=source, follow_symlinks=False)
+        child_label = f"{label}/{name}"
+        if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+            os.mkdir(name, 0o700, dir_fd=destination)
+            source_child = open_child_directory(source, name, child_label)
+            destination_child = open_child_directory(destination, name, child_label)
+            try:
+                copy_directory_tree(source_child, destination_child, child_label)
+                os.fsync(destination_child)
+            finally:
+                os.close(source_child)
+                os.close(destination_child)
+        elif stat.S_ISREG(metadata.st_mode):
+            copy_regular_between_directories(source, destination, name, child_label)
+        else:
+            fail(f"{child_label} is not a regular file or real directory")
+    after = os.fstat(source)
+    if file_identity(after) != file_identity(opened):
+        fail(f"{label} changed while it was copied")
+
+
+def stage_anchored_tree(root, source_path, parent_relative):
+    source_metadata = os.stat(source_path, follow_symlinks=False)
+    if not stat.S_ISDIR(source_metadata.st_mode):
+        fail("file remote tree source is not a real directory")
+    source = os.open(source_path, directory_open_flags())
+    opened_source = os.fstat(source)
+    if file_identity(opened_source) != file_identity(source_metadata):
+        os.close(source)
+        fail("file remote tree source changed while it was opened")
+    parent = ensure_anchored_directory(root, parent_relative)
+    staging = None
+    staging_descriptor = None
+    try:
+        for _attempt in range(128):
+            candidate = f".upload-{os.getpid()}-{secrets.token_hex(8)}"
+            try:
+                os.mkdir(candidate, 0o700, dir_fd=parent)
+                staging = candidate
+                break
+            except FileExistsError:
+                continue
+        if staging is None:
+            fail("cannot allocate file remote generation staging directory")
+        staging_descriptor = open_child_directory(parent, staging, "generation staging")
+        copy_directory_tree(source, staging_descriptor, "checkpoint generation source")
+        os.fsync(staging_descriptor)
+        current_source = os.stat(source_path, follow_symlinks=False)
+        if file_identity(current_source) != file_identity(opened_source):
+            fail("file remote tree source changed while it was copied")
+        os.fsync(parent)
+        return f"{safe_path(parent_relative)}/{staging}"
+    except BaseException:
+        if staging is not None:
+            remove_anchored_entry_at(parent, staging)
+            os.fsync(parent)
+        raise
+    finally:
+        os.close(source)
+        if staging_descriptor is not None:
+            os.close(staging_descriptor)
+        os.close(parent)
+
+
+def rename_anchored_tree(root, source_relative, destination_relative, replace=False):
+    source_parent, source_leaf = open_anchored_parent(root, source_relative)
+    destination_parent, destination_leaf = open_anchored_parent(
+        root, destination_relative, create=True
+    )
+    quarantine = None
+    try:
+        source_metadata = os.stat(
+            source_leaf, dir_fd=source_parent, follow_symlinks=False
+        )
+        if not stat.S_ISDIR(source_metadata.st_mode):
+            fail("file remote staged generation is not a real directory")
+        destination_metadata = None
+        try:
+            destination_metadata = os.stat(
+                destination_leaf,
+                dir_fd=destination_parent,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            pass
+        if destination_metadata is not None:
+            if not replace:
+                fail("file remote generation destination already exists")
+            quarantine = f".corrupt-{os.getpid()}-{secrets.token_hex(8)}"
+            os.rename(
+                destination_leaf,
+                quarantine,
+                src_dir_fd=destination_parent,
+                dst_dir_fd=destination_parent,
+            )
+        try:
+            os.rename(
+                source_leaf,
+                destination_leaf,
+                src_dir_fd=source_parent,
+                dst_dir_fd=destination_parent,
+            )
+        except BaseException:
+            if quarantine is not None:
+                os.rename(
+                    quarantine,
+                    destination_leaf,
+                    src_dir_fd=destination_parent,
+                    dst_dir_fd=destination_parent,
+                )
+                quarantine = None
+            raise
+        os.fsync(source_parent)
+        if destination_parent != source_parent:
+            os.fsync(destination_parent)
+        if quarantine is not None:
+            remove_anchored_entry_at(destination_parent, quarantine)
+            quarantine = None
+            os.fsync(destination_parent)
+    finally:
+        if quarantine is not None:
+            try:
+                remove_anchored_entry_at(destination_parent, quarantine)
+            except BaseException:
+                pass
+        os.close(source_parent)
+        os.close(destination_parent)
+
+
+def verify_retained_storage_root(root, path):
+    opened = os.fstat(root)
+    current = os.stat(path, follow_symlinks=False)
+    if not stat.S_ISDIR(current.st_mode) or file_identity(opened) != file_identity(current):
+        fail("file remote root changed while its retained descriptor was opened")
+
+
+def read_anchored_json(root, relative, label):
+    raw, _, _ = read_anchored_regular(root, relative, label)
+    return load_unique_json_bytes(raw, label), raw
+
+
+def compare_remote_pointer_values(candidate, existing):
+    parse_pointer(candidate, remote=True)
+    parse_pointer(existing, remote=True)
+    candidate_step = integer(candidate["global_step"], "candidate remote step")
+    existing_step = integer(existing["global_step"], "existing remote step")
+    if existing_step > candidate_step:
+        return "newer"
+    if existing_step == candidate_step:
+        if existing["generation"] != candidate["generation"]:
+            fail(
+                "equal-step remote checkpoint fork: "
+                f"{existing['generation']} versus {candidate['generation']}"
+            )
+        if existing != candidate:
+            fail("same-generation remote release envelope differs from candidate")
+        return "same"
+    return "advance"
+
+
+def publish_anchored_remote_pointer(root, candidate_path):
+    candidate, _ = load_json_file(candidate_path, "candidate remote pointer")
+    parse_pointer(candidate, remote=True)
+    lock_flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        lock_flags |= os.O_NOFOLLOW
+    lock = os.open(".hermes-current.lock", lock_flags, 0o600, dir_fd=root)
+    try:
+        if not stat.S_ISREG(os.fstat(lock).st_mode):
+            fail("file remote pointer lock is not a regular file")
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        kind = anchored_entry_kind(root, "current.json")
+        if kind != "missing":
+            if kind != "file":
+                fail("file remote current pointer is not a regular file")
+            existing, _ = read_anchored_json(
+                root, "current.json", "existing file remote pointer"
+            )
+            state = compare_remote_pointer_values(candidate, existing)
+            if state in ("newer", "same"):
+                return state
+        copy_into_anchored(root, candidate_path, "current.json")
+        published, _ = read_anchored_json(
+            root, "current.json", "published file remote pointer"
+        )
+        if published != candidate:
+            fail("published file remote pointer differs from its candidate")
+        return "published"
+    finally:
+        os.close(lock)
 
 
 def sha256_reference(value, label):
@@ -1512,95 +2135,26 @@ def restore_artifact_snapshot(spec, manifest, snapshot_root):
             install_immutable(source, destination, entry["bytes"], entry["sha256"])
 
 
-def actual_generation_paths(root):
-    paths = []
-    for directory, names, files in os.walk(root, topdown=True, followlinks=False):
-        for name in names:
-            child = os.path.join(directory, name)
-            real_directory(child, f"checkpoint directory {child!r}")
-        for name in files:
-            child = os.path.join(directory, name)
-            regular_file(child, f"checkpoint file {child!r}")
-            relative = os.path.relpath(child, root).replace(os.sep, "/")
-            safe_path(relative)
-            if relative != "generation-manifest.json":
-                paths.append(relative)
-    return sorted(paths)
-
-
-def verify_generation(path, generation, expected_digest):
-    real_directory(path, f"checkpoint generation {generation!r}")
-    manifest = read_manifest(
-        os.path.join(path, "generation-manifest.json"), generation, expected_digest
-    )
-    declared = [entry["path"] for entry in manifest["files"]]
-    if actual_generation_paths(path) != declared:
-        fail("checkpoint generation contents do not match its manifest")
-    for entry in manifest["files"]:
-        file_path = os.path.join(path, *entry["path"].split("/"))
-        metadata = regular_file(file_path, f"checkpoint file {entry['path']!r}")
-        if metadata.st_size != entry["bytes"]:
-            fail(f"checkpoint file {entry['path']!r} has the wrong size")
-        length, actual_digest = hash_file(file_path)
-        if length != entry["bytes"] or actual_digest != entry["sha256"]:
-            fail(f"checkpoint file {entry['path']!r} has the wrong SHA-256")
-
-    state, _ = load_json_file(
-        os.path.join(path, "training-state.json"), "checkpoint training state"
-    )
-    if not isinstance(state, dict):
-        fail("checkpoint training state is not an object")
-    version(state.get("version"), 2, "training-state.json")
-    step = integer(state.get("global_step"), "training-state.json global_step")
-    records = integer(state.get("metric_records"), "training-state.json metric_records")
-    if step != manifest["global_step"]:
-        fail("checkpoint training state global_step differs from its manifest")
-    if "phase" in state and state["phase"] != manifest["phase"]:
-        fail("checkpoint training state phase differs from its manifest")
-    if "phase_id" in state and state["phase_id"] != manifest["phase_id"]:
-        fail("checkpoint training state phase_id differs from its manifest")
-
-    authenticated = set(declared)
-    optimizer_states = state.get("optimizer_states")
-    if optimizer_states is not None:
-        if not isinstance(optimizer_states, list):
-            fail("training-state.json optimizer_states is not an array")
-        referenced = []
-        scopes = []
-        for optimizer in optimizer_states:
-            if not isinstance(optimizer, dict):
-                fail("training-state.json has an invalid optimizer state")
-            scope = optimizer.get("scope")
-            if not isinstance(scope, str) or not scope.strip():
-                fail("training-state.json has an empty optimizer scope")
-            scopes.append(scope)
-            for key in ("adamw", "muon"):
-                reference = safe_path(optimizer.get(key))
-                if reference not in authenticated:
-                    fail(f"optimizer state {reference!r} is absent from the manifest")
-                referenced.append(reference)
-            reference = optimizer.get("gradient_accumulator")
-            if reference is not None:
-                reference = safe_path(reference)
-                if reference not in authenticated:
-                    fail(f"optimizer state {reference!r} is absent from the manifest")
-                referenced.append(reference)
-        if len(scopes) != len(set(scopes)) or len(referenced) != len(set(referenced)):
-            fail("training-state.json repeats an optimizer scope or state path")
-    return step, records
-
-
-def validate_metrics(path, committed_records):
-    regular_file(path, "checkpoint metric journal")
-    with open(path, "rb") as handle:
-        complete_records = sum(block.count(b"\n") for block in iter(lambda: handle.read(1024 * 1024), b""))
-    if complete_records < committed_records:
-        fail("metric journal has fewer records than the training checkpoint")
-
-
 def snapshot_metrics(source, committed_records, destination):
     committed_records = integer(committed_records, "committed metric records")
-    regular_file(source, "checkpoint metric journal")
+    source_metadata = regular_file(source, "checkpoint metric journal")
+    source_flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        source_flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        source_flags |= os.O_NONBLOCK
+    try:
+        source_descriptor = os.open(source, source_flags)
+    except OSError as error:
+        fail(f"checkpoint metric journal cannot be opened safely: {error}")
+    opened_source = os.fstat(source_descriptor)
+    if (
+        not stat.S_ISREG(opened_source.st_mode)
+        or (opened_source.st_dev, opened_source.st_ino)
+        != (source_metadata.st_dev, source_metadata.st_ino)
+    ):
+        os.close(source_descriptor)
+        fail("checkpoint metric journal changed while it was opened")
     parent = os.path.dirname(destination)
     real_directory(parent, "metric snapshot destination directory")
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
@@ -1608,27 +2162,57 @@ def snapshot_metrics(source, committed_records, destination):
         flags |= os.O_NOFOLLOW
     descriptor = os.open(destination, flags, 0o600)
     copied = 0
+    copied_bytes = 0
+    copied_hasher = hashlib.sha256()
     try:
-        with open(source, "rb") as input_file, os.fdopen(descriptor, "wb") as output:
+        with os.fdopen(source_descriptor, "rb") as input_file, os.fdopen(
+            descriptor, "wb"
+        ) as output:
+            source_descriptor = None
             descriptor = None
             while copied < committed_records:
                 record = input_file.readline()
                 if not record or not record.endswith(b"\n"):
                     fail("metric journal has a missing or torn committed record")
                 output.write(record)
+                copied_bytes += len(record)
+                copied_hasher.update(record)
                 copied += 1
+            # Make the first copy observable/durable before validating it
+            # against a second read of the same opened source descriptor.
             output.flush()
             os.fsync(output.fileno())
+
+            input_file.seek(0)
+            verified_bytes = 0
+            verified_hasher = hashlib.sha256()
+            while verified_bytes < copied_bytes:
+                block = input_file.read(min(1024 * 1024, copied_bytes - verified_bytes))
+                if not block:
+                    fail("checkpoint metric journal was truncated while it was copied")
+                verified_bytes += len(block)
+                verified_hasher.update(block)
+            if (
+                verified_bytes != copied_bytes
+                or verified_hasher.digest() != copied_hasher.digest()
+            ):
+                fail("checkpoint committed metric prefix changed while it was copied")
+
+            after_source = os.fstat(input_file.fileno())
+            current_source = regular_file(source, "checkpoint metric journal")
+            opened_identity = (opened_source.st_dev, opened_source.st_ino)
+            if opened_identity != (after_source.st_dev, after_source.st_ino) or opened_identity != (
+                current_source.st_dev,
+                current_source.st_ino,
+            ):
+                fail("checkpoint metric journal was replaced while it was copied")
+            if after_source.st_size < opened_source.st_size:
+                fail("checkpoint metric journal was truncated while it was copied")
     finally:
+        if source_descriptor is not None:
+            os.close(source_descriptor)
         if descriptor is not None:
             os.close(descriptor)
-
-
-def pointer_is_remote(path):
-    pointer, _ = load_json_file(path, "checkpoint current pointer")
-    if not isinstance(pointer, dict):
-        fail("checkpoint current pointer is not an object")
-    return pointer.get("version") == 2
 
 
 command = sys.argv[1]
@@ -1700,6 +2284,77 @@ elif command == "restore-artifact-snapshot":
 elif command == "file-descriptor":
     length, observed = stable_file_descriptor(sys.argv[2], "artifact file")
     print(length, observed, sep="\t")
+elif command == "verify-storage-fd":
+    root = retained_directory_fd(sys.argv[2])
+    try:
+        verify_retained_storage_root(root, sys.argv[3])
+    finally:
+        os.close(root)
+elif command == "fd-entry-kind":
+    root = retained_directory_fd(sys.argv[2])
+    try:
+        print(anchored_entry_kind(root, sys.argv[3]))
+    finally:
+        os.close(root)
+elif command == "fd-copy-out":
+    root = retained_directory_fd(sys.argv[2])
+    try:
+        copy_anchored_out(root, sys.argv[3], sys.argv[4])
+    finally:
+        os.close(root)
+elif command == "fd-copy-in":
+    root = retained_directory_fd(sys.argv[2])
+    try:
+        copy_into_anchored(root, sys.argv[3], sys.argv[4])
+    finally:
+        os.close(root)
+elif command == "fd-install-immutable":
+    root = retained_directory_fd(sys.argv[2])
+    expected_bytes = integer(int(sys.argv[5]), "immutable file remote size")
+    expected_sha256 = digest(sys.argv[6], "immutable file remote digest")
+    try:
+        copy_into_anchored(
+            root,
+            sys.argv[3],
+            sys.argv[4],
+            immutable=True,
+            expected_bytes=expected_bytes,
+            expected_sha256=expected_sha256,
+        )
+    finally:
+        os.close(root)
+elif command == "fd-stage-tree":
+    root = retained_directory_fd(sys.argv[2])
+    try:
+        print(stage_anchored_tree(root, sys.argv[3], sys.argv[4]))
+    finally:
+        os.close(root)
+elif command == "fd-remove-tree":
+    root = retained_directory_fd(sys.argv[2])
+    try:
+        remove_anchored_entry(root, sys.argv[3])
+    finally:
+        os.close(root)
+elif command == "fd-rename-tree":
+    root = retained_directory_fd(sys.argv[2])
+    mode = sys.argv[5]
+    if mode not in ("replace", "no-replace"):
+        fail(f"file remote rename mode {mode!r} is invalid")
+    try:
+        rename_anchored_tree(
+            root,
+            sys.argv[3],
+            sys.argv[4],
+            replace=(mode == "replace"),
+        )
+    finally:
+        os.close(root)
+elif command == "fd-publish-pointer":
+    root = retained_directory_fd(sys.argv[2])
+    try:
+        print(publish_anchored_remote_pointer(root, sys.argv[3]))
+    finally:
+        os.close(root)
 elif command == "verify-file":
     expected_bytes = integer(int(sys.argv[3]), "artifact file size")
     expected_digest = digest(sys.argv[4], "artifact file digest")
@@ -1755,74 +2410,10 @@ elif command == "make-local-pointer":
 elif command == "compare-remote-pointers":
     candidate, _ = load_json_file(sys.argv[2], "candidate remote pointer")
     existing, _ = load_json_file(sys.argv[3], "existing remote pointer")
-    read_pointer(sys.argv[2], remote=True)
-    read_pointer(sys.argv[3], remote=True)
-    candidate_step = integer(candidate["global_step"], "candidate remote step")
-    existing_step = integer(existing["global_step"], "existing remote step")
-    if existing_step > candidate_step:
-        print("newer")
-    elif existing_step == candidate_step:
-        if existing["generation"] != candidate["generation"]:
-            fail(
-                "equal-step remote checkpoint fork: "
-                f"{existing['generation']} versus {candidate['generation']}"
-            )
-        if existing != candidate:
-            fail("same-generation remote release envelope differs from candidate")
-        print("same")
-    else:
-        print("advance")
+    print(compare_remote_pointer_values(candidate, existing))
 elif command == "manifest-files":
-    manifest = read_manifest(sys.argv[2], sys.argv[3], sys.argv[4])
-    for entry in manifest["files"]:
-        print(entry["path"])
-elif command == "verify-generation":
-    step, records = verify_generation(sys.argv[2], sys.argv[3], sys.argv[4])
-    print(step, records, sep="\t")
-elif command == "verify-root":
-    root = sys.argv[2]
-    real_directory(root, "checkpoint root")
-    pointer_path = os.path.join(root, "current.json")
-    remote = pointer_is_remote(pointer_path)
-    pointer = read_pointer(pointer_path, remote=remote)
-    generation, manifest_digest = pointer[:2]
-    generations = os.path.join(root, "generations")
-    real_directory(generations, "checkpoint generations root")
-    step, records = verify_generation(
-        os.path.join(generations, generation), generation, manifest_digest
-    )
-    if remote:
-        (
-            _,
-            _,
-            pointer_step,
-            pointer_records,
-            metrics_path,
-            metrics_bytes,
-            metrics_sha256,
-            _,
-            _,
-        ) = pointer
-        if pointer_step != step or pointer_records != records:
-            fail("remote pointer step/metric count differs from its checkpoint generation")
-        metrics_file = os.path.join(root, *metrics_path.split("/"))
-        observed_bytes, observed_sha256 = stable_file_descriptor(
-            metrics_file, "remote checkpoint metric snapshot"
-        )
-        if observed_bytes != metrics_bytes or observed_sha256 != metrics_sha256:
-            fail("remote checkpoint metric snapshot differs from its pointer")
-        validate_metrics(metrics_file, records)
-        with open(metrics_file, "rb") as handle:
-            if sum(
-                block.count(b"\n")
-                for block in iter(lambda: handle.read(1024 * 1024), b"")
-            ) != records:
-                fail("remote checkpoint metric snapshot contains an uncommitted tail")
-    else:
-        validate_metrics(os.path.join(root, "metrics.jsonl"), records)
-    print(step, generation, manifest_digest, records, sep="\t")
-elif command == "metrics":
-    validate_metrics(sys.argv[2], integer(int(sys.argv[3]), "committed metric records"))
+    for path in read_manifest_transport(sys.argv[2], sys.argv[3], sys.argv[4]):
+        print(path)
 elif command == "snapshot-metrics":
     snapshot_metrics(sys.argv[2], int(sys.argv[3]), sys.argv[4])
 elif command == "atomic-copy":
@@ -1902,6 +2493,7 @@ rm -f -- "$artifact_root_spec_temporary"
 readonly ARTIFACT_ROOT_SPEC
 
 LOCAL_REMOTE_ROOT=
+LOCAL_REMOTE_FD=
 if [[ $REMOTE == file://* ]]; then
   raw_local_remote_root=${REMOTE#file://}
   [[ -n "$raw_local_remote_root" ]] || die "file remote root is empty"
@@ -1914,11 +2506,62 @@ if [[ $REMOTE == file://* ]]; then
   fi
   LOCAL_REMOTE_ROOT=$(checkpoint_tool canonical-storage-root "$raw_local_remote_root") \
     || die "cannot validate file remote root: $raw_local_remote_root"
+  exec 6<"$LOCAL_REMOTE_ROOT" \
+    || die "cannot retain file remote root: $LOCAL_REMOTE_ROOT"
+  LOCAL_REMOTE_FD=6
+  checkpoint_tool verify-storage-fd "$LOCAL_REMOTE_FD" "$LOCAL_REMOTE_ROOT" \
+    || die "file remote root changed while it was opened: $LOCAL_REMOTE_ROOT"
 fi
 readonly LOCAL_REMOTE_ROOT
+readonly LOCAL_REMOTE_FD
+
+trainer_generation_descriptor() {
+  local -a command=(
+    "$CHECKPOINT_VERIFIER_BIN" verify-checkpoint
+    --generation "$1"
+    --generation-name "$2"
+    --manifest-sha256 "$3"
+    --format tsv
+  )
+  [[ -z ${4:-} ]] || command+=(--metrics "$4")
+  [[ ${5:-false} != true ]] || command+=(--exact-metrics)
+  "${command[@]}"
+}
+
+verify_checkpoint_generation() {
+  local trainer step generation manifest_sha256 metric_records extra
+  trainer=$(trainer_generation_descriptor "$1" "$2" "$3") || return 1
+  [[ $trainer != *$'\n'* ]] || return 1
+  IFS=$'\t' read -r step generation manifest_sha256 metric_records extra <<<"$trainer"
+  is_nonnegative_integer "$step" \
+    && is_nonnegative_integer "$metric_records" \
+    && [[ $generation == "$2" && $manifest_sha256 == "$3" && -z $extra ]] \
+    || return 1
+  printf '%s\t%s\n' "$step" "$metric_records"
+}
 
 checkpoint_descriptor() {
-  checkpoint_tool verify-root "$1"
+  local root=$1 trainer
+  if trainer=$("$CHECKPOINT_VERIFIER_BIN" verify-checkpoint \
+    --root "$root" --metrics "$root/metrics.jsonl" --format tsv 2>/dev/null); then
+    printf '%s\n' "$trainer"
+    return 0
+  fi
+
+  local remote_pointer generation manifest_sha256 pointer_step pointer_records
+  local metrics_path metrics_bytes metrics_sha256 _artifact_bytes _artifact_sha256
+  remote_pointer=$(checkpoint_tool pointer-remote "$root/$CURRENT_POINTER") || return 1
+  IFS=$'\t' read -r generation manifest_sha256 pointer_step pointer_records \
+    metrics_path metrics_bytes metrics_sha256 _artifact_bytes _artifact_sha256 \
+    <<<"$remote_pointer"
+  checkpoint_tool verify-file "$root/$metrics_path" \
+    "$metrics_bytes" "$metrics_sha256" || return 1
+  trainer=$(trainer_generation_descriptor \
+    "$root/$GENERATIONS_DIRECTORY/$generation" \
+    "$generation" "$manifest_sha256" "$root/$metrics_path" true) || return 1
+  [[ $trainer == "$pointer_step"$'\t'"$generation"$'\t'"$manifest_sha256"$'\t'"$pointer_records" ]] \
+    || return 1
+  printf '%s\n' "$trainer"
 }
 
 checkpoint_artifacts_exist() {
@@ -1936,18 +2579,11 @@ remote_path() {
   printf '%s/%s' "${REMOTE%/}" "${1#/}"
 }
 
-local_remote_root() {
-  printf '%s' "$LOCAL_REMOTE_ROOT"
-}
-
 remote_download() {
   local relative=$1
   local destination=$2
   if [[ $REMOTE == file://* ]]; then
-    local source
-    source="$(local_remote_root)/$relative"
-    [[ -f "$source" && ! -L "$source" ]] || return 1
-    cp -- "$source" "$destination"
+    checkpoint_tool fd-copy-out "$LOCAL_REMOTE_FD" "$relative" "$destination"
   else
     "$GCLOUD_BIN" storage cp "$(remote_path "$relative")" "$destination"
   fi
@@ -1957,8 +2593,7 @@ remote_upload_file() {
   local source=$1
   local relative=$2
   if [[ $REMOTE == file://* ]]; then
-    mkdir -p -- "$(dirname -- "$(local_remote_root)/$relative")" || return 1
-    cp -- "$source" "$(local_remote_root)/$relative"
+    checkpoint_tool fd-copy-in "$LOCAL_REMOTE_FD" "$source" "$relative"
   else
     "$GCLOUD_BIN" storage cp "$source" "$(remote_path "$relative")"
   fi
@@ -1974,8 +2609,8 @@ remote_upload_immutable_file() {
   checkpoint_tool verify-file "$source" "$expected_bytes" "$expected_sha256" \
     || return 1
   if [[ $REMOTE == file://* ]]; then
-    checkpoint_tool install-immutable "$source" \
-      "$(local_remote_root)/$relative" "$expected_bytes" "$expected_sha256"
+    checkpoint_tool fd-install-immutable "$LOCAL_REMOTE_FD" "$source" \
+      "$relative" "$expected_bytes" "$expected_sha256"
     return
   fi
 
@@ -2011,44 +2646,7 @@ compare_remote_pointer_files() {
 
 publish_file_remote_pointer() (
   local candidate=$1
-  local destination
-  local existing state owner lock_owned=false
-  destination="$(local_remote_root)/$CURRENT_POINTER"
-  existing=$(mktemp "$STATE_DIR/existing-current.XXXXXX") || return 1
-  trap 'rm -f -- "$existing"; [[ $LOCK_TOOL != shlock || $lock_owned != true ]] || rm -f -- "$(local_remote_root)/.hermes-current.lock"' EXIT
-
-  if [[ $LOCK_TOOL == flock ]]; then
-    exec 7>"$(local_remote_root)/.hermes-current.lock"
-    flock 7 || return 1
-  else
-    owner=$(sh -c 'printf "%s" "$PPID"')
-    for _attempt in {1..100}; do
-      if shlock -f "$(local_remote_root)/.hermes-current.lock" -p "$owner"; then
-        lock_owned=true
-        break
-      fi
-      sleep 0.1
-    done
-    [[ $lock_owned == true ]] || return 1
-  fi
-
-  if [[ -e "$destination" || -L "$destination" ]]; then
-    [[ -f "$destination" && ! -L "$destination" ]] || return 1
-    cp -- "$destination" "$existing" || return 1
-    state=$(compare_remote_pointer_files "$candidate" "$existing") || return 1
-    case "$state" in
-      newer | same)
-        printf '%s\n' "$state"
-        return 0
-        ;;
-      advance) ;;
-      *) return 1 ;;
-    esac
-  fi
-  checkpoint_tool atomic-copy "$candidate" "$destination" || return 1
-  cp -- "$destination" "$existing" || return 1
-  [[ $(compare_remote_pointer_files "$candidate" "$existing") == same ]] || return 1
-  printf 'published\n'
+  checkpoint_tool fd-publish-pointer "$LOCAL_REMOTE_FD" "$candidate"
 )
 
 gcs_pointer_generation() {
@@ -2273,58 +2871,30 @@ remote_upload_generation() {
   local generation=$1
   local manifest_sha256=$2
   local source="$OUTPUT/$GENERATIONS_DIRECTORY/$generation"
-  local destination generation_root quarantine staging file plan upload_failed=false
+  local destination destination_kind staging file plan upload_failed=false
 
   if [[ $REMOTE == file://* ]]; then
-    generation_root="$(local_remote_root)/$GENERATIONS_DIRECTORY"
-    if [[ -e "$generation_root" || -L "$generation_root" ]]; then
-      [[ -d "$generation_root" && ! -L "$generation_root" ]] || return 1
-    else
-      mkdir -p -- "$generation_root" || return 1
-    fi
-    staging=$(mktemp -d "$generation_root/.upload.XXXXXX") || return 1
-    cp -R -- "$source/." "$staging/" || {
-      rm -rf -- "$staging"
+    staging=$(checkpoint_tool fd-stage-tree "$LOCAL_REMOTE_FD" \
+      "$source" "$GENERATIONS_DIRECTORY") || return 1
+    destination="$GENERATIONS_DIRECTORY/$generation"
+    destination_kind=$(checkpoint_tool fd-entry-kind \
+      "$LOCAL_REMOTE_FD" "$destination") || {
+      checkpoint_tool fd-remove-tree "$LOCAL_REMOTE_FD" "$staging" || true
       return 1
     }
-    checkpoint_tool verify-generation "$staging" \
-      "$generation" "$manifest_sha256" >/dev/null || {
-      rm -rf -- "$staging"
-      return 1
-    }
-    checkpoint_tool sync-tree "$staging" || {
-      rm -rf -- "$staging"
-      return 1
-    }
-    destination="$generation_root/$generation"
-    if [[ -e "$destination" || -L "$destination" ]]; then
-      if checkpoint_tool verify-generation "$destination" \
-        "$generation" "$manifest_sha256" >/dev/null 2>&1; then
-        rm -rf -- "$staging"
-        return 0
-      fi
-      quarantine=$(mktemp -d "$generation_root/.corrupt.XXXXXX") || {
-        rm -rf -- "$staging"
+    if [[ $destination_kind != missing ]]; then
+      checkpoint_tool fd-rename-tree "$LOCAL_REMOTE_FD" \
+        "$staging" "$destination" replace || {
+        checkpoint_tool fd-remove-tree "$LOCAL_REMOTE_FD" "$staging" || true
         return 1
       }
-      rmdir -- "$quarantine" || {
-        rm -rf -- "$staging" "$quarantine"
-        return 1
-      }
-      if ! mv -- "$destination" "$quarantine" \
-        || ! mv -- "$staging" "$destination"; then
-        [[ -e "$destination" || ! -e "$quarantine" ]] \
-          || mv -- "$quarantine" "$destination" 2>/dev/null || true
-        rm -rf -- "$staging"
-        return 1
-      fi
     else
-      mv -- "$staging" "$destination" || {
-        rm -rf -- "$staging"
+      checkpoint_tool fd-rename-tree "$LOCAL_REMOTE_FD" \
+        "$staging" "$destination" no-replace || {
+        checkpoint_tool fd-remove-tree "$LOCAL_REMOTE_FD" "$staging" || true
         return 1
       }
     fi
-    checkpoint_tool sync-directory "$generation_root"
     return
   fi
 
@@ -2354,11 +2924,6 @@ download_remote_generation() {
   local download_failed=false file plan
 
   mkdir -p -- "$destination" || return 1
-  if [[ $REMOTE == file://* ]]; then
-    checkpoint_tool verify-generation \
-      "$(local_remote_root)/$GENERATIONS_DIRECTORY/$generation" \
-      "$generation" "$manifest_sha256" >/dev/null || return 1
-  fi
   remote_download \
     "$GENERATIONS_DIRECTORY/$generation/$GENERATION_MANIFEST" \
     "$destination/$GENERATION_MANIFEST" >/dev/null || return 1
@@ -2379,7 +2944,7 @@ download_remote_generation() {
   done <"$plan"
   rm -f -- "$plan"
   [[ $download_failed == false ]] || return 1
-  checkpoint_tool verify-generation "$destination" \
+  verify_checkpoint_generation "$destination" \
     "$generation" "$manifest_sha256" >/dev/null
 }
 
@@ -2404,7 +2969,6 @@ download_remote_checkpoint() {
   local pointer descriptor generation manifest_sha256 step metric_records
   local pointer_step pointer_records metrics_path metrics_bytes metrics_sha256
   local closure_bytes closure_sha256
-  local direct_generation direct_manifest_sha256
 
   mkdir -p -- "$destination/$GENERATIONS_DIRECTORY" || return 1
   pointer="$destination/$CURRENT_POINTER"
@@ -2414,12 +2978,6 @@ download_remote_checkpoint() {
   IFS=$'\t' read -r generation manifest_sha256 pointer_step pointer_records \
     metrics_path metrics_bytes metrics_sha256 closure_bytes closure_sha256 <<<"$descriptor"
   [[ -n "$generation" && -n "$manifest_sha256" ]] || return 1
-  if [[ $REMOTE == file://* ]]; then
-    descriptor=$(checkpoint_descriptor "$(local_remote_root)") || return 1
-    IFS=$'\t' read -r _ direct_generation direct_manifest_sha256 _ <<<"$descriptor"
-    [[ $direct_generation == "$generation" \
-      && $direct_manifest_sha256 == "$manifest_sha256" ]] || return 1
-  fi
   download_remote_generation \
     "$destination/$GENERATIONS_DIRECTORY/$generation" \
     "$generation" "$manifest_sha256" || return 1
@@ -2427,7 +2985,7 @@ download_remote_checkpoint() {
     "$destination/$ARTIFACTS_DIRECTORY/$generation" \
     "$generation" "$manifest_sha256" \
     "$closure_bytes" "$closure_sha256" || return 1
-  descriptor=$(checkpoint_tool verify-generation \
+  descriptor=$(verify_checkpoint_generation \
     "$destination/$GENERATIONS_DIRECTORY/$generation" \
     "$generation" "$manifest_sha256") || return 1
   IFS=$'\t' read -r step metric_records <<<"$descriptor"
@@ -2455,10 +3013,11 @@ refresh_remote_checkpoint() {
   REMOTE_ARTIFACTS=false
   [[ -n "$REMOTE" ]] || return 1
   snapshot=$(mktemp -d "$STATE_DIR/remote-checkpoint.XXXXXX") || return 1
-  if [[ $REMOTE == file://* \
-    && ( -e "$(local_remote_root)/$CURRENT_POINTER" \
-      || -L "$(local_remote_root)/$CURRENT_POINTER" ) ]]; then
-    REMOTE_ARTIFACTS=true
+  if [[ $REMOTE == file://* ]]; then
+    local pointer_kind
+    pointer_kind=$(checkpoint_tool fd-entry-kind \
+      "$LOCAL_REMOTE_FD" "$CURRENT_POINTER") || return 1
+    [[ $pointer_kind == missing ]] || REMOTE_ARTIFACTS=true
   fi
   descriptor_file=$(mktemp "$STATE_DIR/remote-descriptor.XXXXXX") || {
     rm -rf -- "$snapshot"
@@ -2508,7 +3067,7 @@ restore_remote_checkpoint() {
     rm -rf -- "$staging"
     return 1
   }
-  checkpoint_tool verify-generation "$staging" \
+  verify_checkpoint_generation "$staging" \
     "$generation" "$manifest_sha256" >/dev/null || {
       rm -rf -- "$staging"
       return 1
@@ -2519,7 +3078,7 @@ restore_remote_checkpoint() {
   }
 
   if [[ -e "$destination" || -L "$destination" ]]; then
-    if checkpoint_tool verify-generation "$destination" \
+    if verify_checkpoint_generation "$destination" \
       "$generation" "$manifest_sha256" >/dev/null 2>&1; then
       rm -rf -- "$staging"
     else
@@ -2638,12 +3197,6 @@ verify_remote_generation() {
   local generation=$1
   local manifest_sha256=$2
   local verification
-  if [[ $REMOTE == file://* ]]; then
-    checkpoint_tool verify-generation \
-      "$(local_remote_root)/$GENERATIONS_DIRECTORY/$generation" \
-      "$generation" "$manifest_sha256" >/dev/null
-    return
-  fi
   verification=$(mktemp -d "$STATE_DIR/verify-upload.XXXXXX") || return 1
   if download_remote_generation "$verification" \
     "$generation" "$manifest_sha256"; then
@@ -2703,6 +3256,7 @@ sync_checkpoint_once() (
   fi
   clear_remote_snapshot
   if (( remote_step > step )); then
+    log "remote checkpoint advanced to step $remote_step; leaving local step $step unchanged"
     return 0
   fi
   if (( remote_step == step )); then
@@ -2728,6 +3282,11 @@ sync_checkpoint_once() (
   rm -f -- "$metrics_snapshot"
   checkpoint_tool snapshot-metrics "$OUTPUT/metrics.jsonl" \
     "$metric_records" "$metrics_snapshot" || return 1
+  descriptor=$(trainer_generation_descriptor \
+    "$OUTPUT/$GENERATIONS_DIRECTORY/$generation" \
+    "$generation" "$manifest_sha256" "$metrics_snapshot" true) || return 1
+  [[ $descriptor == "$step"$'\t'"$generation"$'\t'"$manifest_sha256"$'\t'"$metric_records" ]] \
+    || return 1
   descriptor=$(checkpoint_tool file-descriptor "$metrics_snapshot") || return 1
   IFS=$'\t' read -r metrics_bytes metrics_sha256 <<<"$descriptor"
   [[ -n "$metrics_bytes" && -n "$metrics_sha256" ]] || return 1
@@ -2783,6 +3342,7 @@ validate_wandb() {
 
 wandb_supervisor() {
   exec 9>&-
+  [[ -z "$LOCAL_REMOTE_FD" ]] || exec 6<&-
   local reporter_pid='' reporter_status
   trap '[[ -z $reporter_pid ]] || kill "$reporter_pid" 2>/dev/null; wait "$reporter_pid" 2>/dev/null || true; exit 0' TERM INT
   set -a
@@ -2898,6 +3458,7 @@ while true; do
 
   (
     exec 9>&-
+    [[ -z "$LOCAL_REMOTE_FD" ]] || exec 6<&-
     exec "${trainer[@]}"
   ) >>"$TRAIN_LOG" 2>&1 &
   TRAIN_PID=$!

--- a/hermes-train/scripts/relaunch_test.sh
+++ b/hermes-train/scripts/relaunch_test.sh
@@ -16,8 +16,17 @@ fail() {
 fake_trainer=$TEST_ROOT/fake-trainer
 fake_wandb_python=$TEST_ROOT/fake-wandb-python
 fake_checkpoint_writer=$TEST_ROOT/write-checkpoint
+fake_checkpoint_verifier=$TEST_ROOT/verify-checkpoint
 fake_gcloud=$TEST_ROOT/fake-gcloud
 fake_artifact_writer=$TEST_ROOT/write-artifacts
+checkpoint_helper=$TEST_ROOT/checkpoint-helper.py
+
+awk '
+  /<<'\''PY'\''$/ { inside=1; next }
+  inside && /^PY$/ { exit }
+  inside { print }
+' "$TEST_SCRIPT_DIR/relaunch.sh" >"$checkpoint_helper"
+python3 -m py_compile "$checkpoint_helper"
 
 cat >"$fake_checkpoint_writer" <<'PY'
 #!/usr/bin/env python3
@@ -34,6 +43,16 @@ step = int(sys.argv[2])
 version = int(sys.argv[3]) if len(sys.argv) > 3 else 2
 tag = sys.argv[4] if len(sys.argv) > 4 else str(step)
 state_step = int(sys.argv[5]) if len(sys.argv) > 5 else step
+workflow_signature = "sha256:" + "0" * 64
+
+
+def stable_cache_id(value):
+    digest = 0xCBF29CE484222325
+    for byte in value.encode():
+        digest = ((digest ^ byte) * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return f"{digest:016x}"
+
+
 root.mkdir(parents=True, exist_ok=True)
 generations = root / "generations"
 generations.mkdir(exist_ok=True)
@@ -41,20 +60,52 @@ staging = pathlib.Path(tempfile.mkdtemp(prefix=".fixture-", dir=generations))
 (staging / "weights.safetensors").write_text(f"weights-{tag}\n")
 (staging / "adamw-state.bpk").write_text(f"adamw-{tag}\n")
 (staging / "muon-state.bpk").write_text(f"muon-{tag}\n")
+weights = (staging / "weights.safetensors").read_bytes()
+(staging / "training-accounting.json").write_text(
+    json.dumps(
+        {
+            "version": 1,
+            "training_gpu_hours": 1.0,
+            "parameters": 2,
+            "routed_active_parameters": 2,
+            "weights_bytes": len(weights),
+            "weights_sha256": hashlib.sha256(weights).hexdigest(),
+        },
+        separators=(",", ":"),
+    )
+)
 state = {
     "version": version,
     "global_step": state_step,
     "phase": 0,
     "phase_id": "test",
+    "phase_kind": "pretrain",
+    "epoch": 0,
+    "records_in_phase": step,
+    "steps_in_phase": step,
+    "tokens_seen": max(step, 1),
     "metric_records": 1,
+    "workflow_signature": workflow_signature,
+    "data_manifest_hash": "sha256:" + "1" * 64,
+    "parameter_ids": [1, 2],
     "optimizer_states": [
         {
             "scope": "wake",
             "adamw": "adamw-state.bpk",
             "muon": "muon-state.bpk",
             "gradient_accumulator": None,
+            "update_clock": state_step,
         }
     ],
+    "sleep": None,
+    "artifacts": [],
+    "evaluator_hashes": [],
+    "rng_streams": [
+        {"name": "data", "seed": 0, "counter": step},
+        {"name": "model_dropout", "seed": 0, "counter": step},
+    ],
+    "wake_context_buffer": [],
+    "quantization": None,
 }
 if os.environ.get("TEST_CHECKPOINT_STATE_OVERLAY"):
     state.update(json.loads(pathlib.Path(os.environ["TEST_CHECKPOINT_STATE_OVERLAY"]).read_text()))
@@ -114,7 +165,7 @@ os.replace(pointer_temporary, root / "current.json")
             "schema_version": 2,
             "sequence": 0,
             "emitted_at_unix_ms": 1,
-            "run_id": "test",
+            "run_id": stable_cache_id(state["workflow_signature"]),
             "global_step": step,
             "phase": {"index": 0, "name": "test", "kind": "pretrain"},
             "event": {
@@ -139,6 +190,191 @@ os.replace(pointer_temporary, root / "current.json")
 )
 PY
 
+cat >"$fake_checkpoint_verifier" <<'PY'
+#!/usr/bin/env python3
+"""Test double for `hermes-train verify-checkpoint`'s stable CLI contract.
+
+Rust unit tests own the verifier semantics. The shell harness uses this small
+double so relaunch tests do not compile the CUDA-capable trainer binary.
+"""
+import hashlib
+import json
+import os
+import pathlib
+import stat
+import sys
+
+
+def stable_cache_id(value):
+    digest = 0xCBF29CE484222325
+    for byte in value.encode():
+        digest = ((digest ^ byte) * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return f"{digest:016x}"
+
+
+arguments = iter(sys.argv[1:])
+values = {}
+for argument in arguments:
+    if argument == "verify-checkpoint":
+        continue
+    if argument == "--exact-metrics":
+        values[argument] = True
+        continue
+    if argument.startswith("--"):
+        values[argument] = next(arguments)
+    else:
+        raise SystemExit(f"unexpected verifier argument {argument!r}")
+
+if "--root" in values:
+    root = pathlib.Path(values["--root"])
+    pointer = json.loads((root / "current.json").read_text())
+    if set(pointer) != {"version", "generation", "manifest_sha256"} or pointer["version"] != 1:
+        raise SystemExit("checkpoint current pointer has an invalid schema")
+    generation_name = pointer["generation"]
+    manifest_sha256 = pointer["manifest_sha256"]
+    generation = root / "generations" / generation_name
+elif "--generation" in values:
+    generation = pathlib.Path(values["--generation"])
+    generation_name = values["--generation-name"]
+    manifest_sha256 = values["--manifest-sha256"]
+else:
+    raise SystemExit("missing checkpoint target")
+
+if generation_name != "sha256-" + manifest_sha256:
+    raise SystemExit("checkpoint generation name and manifest digest differ")
+manifest_bytes = (generation / "generation-manifest.json").read_bytes()
+if hashlib.sha256(manifest_bytes).hexdigest() != manifest_sha256:
+    raise SystemExit("checkpoint generation manifest digest mismatch")
+manifest = json.loads(manifest_bytes)
+manifest_keys = {
+    "version", "training_state_version", "global_step", "phase", "phase_id", "files",
+}
+if set(manifest) != manifest_keys or manifest["version"] != 1:
+    raise SystemExit("checkpoint generation manifest has an invalid strict schema")
+required = {
+    "weights.safetensors", "adamw-state.bpk", "muon-state.bpk",
+    "training-state.json", "training-accounting.json",
+}
+declared = []
+for entry in manifest["files"]:
+    if set(entry) != {"path", "bytes", "sha256"}:
+        raise SystemExit("checkpoint generation manifest file has an invalid schema")
+    relative = entry["path"]
+    parts = relative.split("/") if isinstance(relative, str) else []
+    if (
+        not parts or any(part in {"", ".", ".."} for part in parts)
+        or "\\" in relative or relative.startswith("/")
+    ):
+        raise SystemExit("checkpoint generation manifest contains an unsafe path")
+    if not isinstance(entry["bytes"], int) or isinstance(entry["bytes"], bool):
+        raise SystemExit("checkpoint generation manifest contains an invalid size")
+    if (
+        not isinstance(entry["sha256"], str) or len(entry["sha256"]) != 64
+        or any(character not in "0123456789abcdef" for character in entry["sha256"])
+    ):
+        raise SystemExit("checkpoint generation manifest contains an invalid digest")
+    declared.append(relative)
+if declared != sorted(declared) or len(declared) != len(set(declared)):
+    raise SystemExit("checkpoint generation manifest paths are not unique and sorted")
+if not required.issubset(declared):
+    raise SystemExit("checkpoint generation is missing a required file")
+
+actual = []
+for directory, names, files in os.walk(generation, topdown=True, followlinks=False):
+    for name in names:
+        metadata = os.lstat(os.path.join(directory, name))
+        if not stat.S_ISDIR(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+            raise SystemExit("checkpoint generation contains an unsafe directory")
+    for name in files:
+        path = pathlib.Path(directory, name)
+        metadata = os.lstat(path)
+        if not stat.S_ISREG(metadata.st_mode) or stat.S_ISLNK(metadata.st_mode):
+            raise SystemExit("checkpoint generation contains an unsafe file")
+        relative = path.relative_to(generation).as_posix()
+        if relative != "generation-manifest.json":
+            actual.append(relative)
+if sorted(actual) != declared:
+    raise SystemExit("checkpoint generation contents differ from its manifest")
+for entry in manifest["files"]:
+    payload = (generation / entry["path"]).read_bytes()
+    if len(payload) != entry["bytes"] or hashlib.sha256(payload).hexdigest() != entry["sha256"]:
+        raise SystemExit("checkpoint generation file differs from its manifest")
+
+state = json.loads((generation / "training-state.json").read_text())
+state_keys = {
+    "version", "global_step", "phase", "phase_id", "phase_kind", "epoch",
+    "records_in_phase", "steps_in_phase", "tokens_seen", "metric_records",
+    "workflow_signature", "data_manifest_hash", "parameter_ids",
+    "optimizer_states", "sleep", "artifacts", "evaluator_hashes",
+    "rng_streams", "wake_context_buffer", "quantization",
+}
+if set(state) != state_keys or state["version"] != 2:
+    raise SystemExit("checkpoint training state has an invalid strict schema")
+if (
+    manifest["training_state_version"] != state["version"]
+    or state["global_step"] != manifest["global_step"]
+    or state["phase"] != manifest["phase"]
+    or state["phase_id"] != manifest["phase_id"]
+):
+    raise SystemExit("checkpoint training state does not match its generation manifest")
+authenticated = set(declared)
+references = []
+scopes = []
+for optimizer in state["optimizer_states"]:
+    scopes.append(optimizer["scope"])
+    references.extend([optimizer["adamw"], optimizer["muon"]])
+    if optimizer["gradient_accumulator"] is not None:
+        references.append(optimizer["gradient_accumulator"])
+if (
+    len(scopes) != len(set(scopes)) or len(references) != len(set(references))
+    or any(reference not in authenticated for reference in references)
+):
+    raise SystemExit("checkpoint optimizer state references are invalid")
+accounting = json.loads((generation / "training-accounting.json").read_text())
+if set(accounting) != {
+    "version", "training_gpu_hours", "parameters", "routed_active_parameters",
+    "weights_bytes", "weights_sha256",
+} or accounting["version"] != 1:
+    raise SystemExit("checkpoint training accounting has an invalid schema")
+weights = (generation / "weights.safetensors").read_bytes()
+if (
+    accounting["weights_bytes"] != len(weights)
+    or accounting["weights_sha256"] != hashlib.sha256(weights).hexdigest()
+):
+    raise SystemExit("checkpoint training accounting does not match its model weights")
+if "--metrics" in values:
+    lines = pathlib.Path(values["--metrics"]).read_bytes().splitlines(keepends=True)
+    committed = state["metric_records"]
+    if len(lines) < committed or any(not line.endswith(b"\n") for line in lines[:committed]):
+        raise SystemExit("metric journal has fewer complete committed records")
+    if "--exact-metrics" in values and len(lines) != committed:
+        raise SystemExit("immutable metric snapshot contains an uncommitted tail")
+    previous_step = None
+    run_id = stable_cache_id(state["workflow_signature"])
+    for sequence, line in enumerate(lines[:committed]):
+        try:
+            record = json.loads(line)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise SystemExit(f"invalid committed metric record: {error}") from error
+        if record.get("sequence") != sequence:
+            raise SystemExit("committed metric sequence is not contiguous")
+        if record.get("run_id") != run_id:
+            raise SystemExit("metric run does not match checkpoint workflow signature")
+        record_step = record.get("global_step")
+        if previous_step is not None and record_step < previous_step:
+            raise SystemExit("metric global step rewound")
+        previous_step = record_step
+    expected_step = state["global_step"] if committed else None
+    if previous_step != expected_step:
+        raise SystemExit("committed metric prefix ends at the wrong global step")
+if values.get("--format") != "tsv":
+    raise SystemExit("test verifier supports only --format tsv")
+print(
+    state["global_step"], generation_name, manifest_sha256,
+    state["metric_records"], sep="\t"
+)
+PY
+
 write_checkpoint() {
   "$fake_checkpoint_writer" "$@"
 }
@@ -158,6 +394,9 @@ checkpoint_file() {
 cat >"$fake_trainer" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ ${1:-} == verify-checkpoint ]]; then
+  exec "$TEST_CHECKPOINT_VERIFIER" "$@"
+fi
 output=
 resume=false
 while (( $# > 0 )); do
@@ -594,8 +833,10 @@ if history_count:
 (runtime / f"expected-{tag}.json").write_bytes(canonical(expected))
 print(overlay_path)
 PY
-chmod +x "$fake_trainer" "$fake_wandb_python" "$fake_checkpoint_writer" "$fake_gcloud" "$fake_artifact_writer"
+chmod +x "$fake_trainer" "$fake_wandb_python" "$fake_checkpoint_writer" \
+  "$fake_checkpoint_verifier" "$fake_gcloud" "$fake_artifact_writer"
 export TEST_CHECKPOINT_WRITER=$fake_checkpoint_writer
+export TEST_CHECKPOINT_VERIFIER=$fake_checkpoint_verifier
 
 write_sleep_runtime() {
   local case_root=$1
@@ -863,6 +1104,122 @@ EOF
     || fail "remote root metric journal was not restored"
 }
 
+run_file_remote_root_fd_anchor_test() {
+  local case_root=$TEST_ROOT/file-remote-root-anchor
+  local config=$case_root/relaunch.conf
+  local configured_remote=$case_root/remote
+  local retained_remote=$case_root/retained-remote
+  local supervisor_pid published=false
+  mkdir -p -- "$configured_remote"
+  cat >"$config" <<EOF
+HERMES_TRAIN_OUTPUT=$case_root/output
+HERMES_TRAIN_STATE_DIR=$case_root/state
+HERMES_TRAIN_REMOTE_URL=file://$configured_remote
+HERMES_TRAIN_COMMAND=($fake_trainer train)
+HERMES_TRAIN_SYNC_INTERVAL=1
+HERMES_TRAIN_MAX_RESTARTS=0
+EOF
+  export TEST_CALLS=$case_root/calls
+  export TEST_READY=$case_root/ready
+  export TEST_RELEASE=$case_root/release
+  export TEST_BLOCK=true
+  export TEST_FAIL_ONCE=false
+  unset TEST_EXPECT_STEP TEST_WANDB_CALLS TEST_FAILURE_MARKER
+  "$TEST_SCRIPT_DIR/relaunch.sh" "$config" >"$case_root/log" 2>&1 &
+  supervisor_pid=$!
+  for _attempt in {1..400}; do
+    [[ -e $TEST_READY ]] && break
+    sleep 0.05
+  done
+  [[ -e $TEST_READY ]] || {
+    : >"$TEST_RELEASE"
+    wait "$supervisor_pid" || true
+    fail "file remote root-anchor trainer did not start"
+  }
+
+  mv -- "$configured_remote" "$retained_remote"
+  mkdir -p -- "$configured_remote"
+  write_checkpoint "$case_root/output" 70
+  for _attempt in {1..400}; do
+    if [[ -s $retained_remote/current.json ]]; then
+      published=true
+      break
+    fi
+    sleep 0.05
+  done
+  : >"$TEST_RELEASE"
+  wait "$supervisor_pid"
+  unset TEST_BLOCK TEST_READY TEST_RELEASE
+  [[ $published == true ]] || {
+    sed -n '1,160p' "$case_root/state/sync.log" >&2 || true
+    fail "retained file remote descriptor did not survive root entry replacement"
+  }
+  [[ $(current_generation "$retained_remote") == \
+    $(current_generation "$case_root/output") ]] \
+    || fail "root entry replacement redirected the retained file remote"
+  [[ ! -e $configured_remote/current.json \
+    && ! -e $configured_remote/generations \
+    && ! -e $configured_remote/checkpoint-artifacts ]] \
+    || fail "file remote operation escaped through the replacement root path"
+}
+
+run_file_remote_entry_swap_rejected_test() {
+  local case_root=$TEST_ROOT/file-remote-entry-swap
+  local config=$case_root/relaunch.conf
+  local remote=$case_root/remote
+  local attacker=$case_root/attacker
+  local supervisor_pid rejected=false
+  mkdir -p -- "$remote/generations" "$attacker"
+  cat >"$config" <<EOF
+HERMES_TRAIN_OUTPUT=$case_root/output
+HERMES_TRAIN_STATE_DIR=$case_root/state
+HERMES_TRAIN_REMOTE_URL=file://$remote
+HERMES_TRAIN_COMMAND=($fake_trainer train)
+HERMES_TRAIN_SYNC_INTERVAL=1
+HERMES_TRAIN_MAX_RESTARTS=0
+EOF
+  export TEST_CALLS=$case_root/calls
+  export TEST_READY=$case_root/ready
+  export TEST_RELEASE=$case_root/release
+  export TEST_BLOCK=true
+  export TEST_FAIL_ONCE=false
+  unset TEST_EXPECT_STEP TEST_WANDB_CALLS TEST_FAILURE_MARKER
+  "$TEST_SCRIPT_DIR/relaunch.sh" "$config" >"$case_root/log" 2>&1 &
+  supervisor_pid=$!
+  for _attempt in {1..400}; do
+    [[ -e $TEST_READY ]] && break
+    sleep 0.05
+  done
+  [[ -e $TEST_READY ]] || {
+    : >"$TEST_RELEASE"
+    wait "$supervisor_pid" || true
+    fail "file remote entry-swap trainer did not start"
+  }
+
+  mv -- "$remote/generations" "$remote/original-generations"
+  ln -s -- "$attacker" "$remote/generations"
+  write_checkpoint "$case_root/output" 71
+  for _attempt in {1..400}; do
+    if grep -Eq 'unsafe|not a real directory' \
+      "$case_root/state/sync.log" 2>/dev/null; then
+      rejected=true
+      break
+    fi
+    sleep 0.05
+  done
+  : >"$TEST_RELEASE"
+  wait "$supervisor_pid"
+  unset TEST_BLOCK TEST_READY TEST_RELEASE
+  [[ $rejected == true ]] || {
+    sed -n '1,160p' "$case_root/state/sync.log" >&2 || true
+    fail "file remote child entry replacement was not rejected"
+  }
+  [[ -z $(find "$attacker" -mindepth 1 -print -quit) ]] \
+    || fail "file remote traversal followed a swapped child entry"
+  [[ ! -e $remote/current.json ]] \
+    || fail "file remote pointer was published after child entry replacement"
+}
+
 run_newer_local_wins_test() {
   local case_root=$TEST_ROOT/local-wins
   local config=$case_root/relaunch.conf
@@ -967,6 +1324,156 @@ EOF
   [[ ! -e $TEST_CALLS ]] || fail "trainer launched with a modified generation"
   grep -q 'local checkpoint is incomplete' "$case_root/log" \
     || fail "modified generation failure was not explained"
+}
+
+run_strict_training_state_rejected_test() {
+  local case_root=$TEST_ROOT/strict-training-state
+  local config=$case_root/relaunch.conf
+  mkdir -p -- "$case_root"
+  printf '{"unexpected":true}\n' >"$case_root/overlay.json"
+  export TEST_CHECKPOINT_STATE_OVERLAY=$case_root/overlay.json
+  write_checkpoint "$case_root/output" 14
+  unset TEST_CHECKPOINT_STATE_OVERLAY
+  cat >"$config" <<EOF
+HERMES_TRAIN_OUTPUT=$case_root/output
+HERMES_TRAIN_STATE_DIR=$case_root/state
+HERMES_TRAIN_COMMAND=($fake_trainer train)
+HERMES_TRAIN_MAX_RESTARTS=0
+EOF
+  export TEST_CALLS=$case_root/calls
+  export TEST_FAIL_ONCE=false
+  unset TEST_EXPECT_STEP TEST_WANDB_CALLS TEST_FAILURE_MARKER TEST_BLOCK
+
+  if "$TEST_SCRIPT_DIR/relaunch.sh" "$config" >"$case_root/log" 2>&1; then
+    fail "non-strict training-state schema was accepted"
+  fi
+  [[ ! -e $TEST_CALLS ]] || fail "trainer launched with an invalid training-state schema"
+}
+
+run_corrupt_metric_prefix_rejected_test() {
+  local case_root=$TEST_ROOT/corrupt-metric-prefix
+  local config=$case_root/relaunch.conf
+  write_checkpoint "$case_root/output" 16
+  python3 - "$case_root/output/metrics.jsonl" <<'PY'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_bytes(b'\0{"sequence":0,"global_step":16}\n')
+PY
+  cat >"$config" <<EOF
+HERMES_TRAIN_OUTPUT=$case_root/output
+HERMES_TRAIN_STATE_DIR=$case_root/state
+HERMES_TRAIN_COMMAND=($fake_trainer train)
+HERMES_TRAIN_MAX_RESTARTS=0
+EOF
+  export TEST_CALLS=$case_root/calls
+  export TEST_FAIL_ONCE=false
+  unset TEST_EXPECT_STEP TEST_WANDB_CALLS TEST_FAILURE_MARKER TEST_BLOCK
+
+  if "$TEST_SCRIPT_DIR/relaunch.sh" "$config" >"$case_root/log" 2>&1; then
+    fail "corrupt committed metric prefix was accepted"
+  fi
+  [[ ! -e $TEST_CALLS ]] || fail "trainer launched with a corrupt metric prefix"
+}
+
+run_metric_snapshot_stability_test() {
+  local case_root=$TEST_ROOT/metric-snapshot-stability
+  local source=$case_root/metrics.jsonl
+  local snapshot=$case_root/snapshot.jsonl
+  local helper_log=$case_root/helper.log
+  local helper_pid payload_bytes=$((32 * 1024 * 1024))
+  mkdir -p -- "$case_root"
+
+  python3 - "$source" "$payload_bytes" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+length = int(sys.argv[2])
+path.write_bytes(b"A" * (length - 1) + b"\n")
+PY
+  python3 "$checkpoint_helper" snapshot-metrics \
+    "$source" 1 "$snapshot" >"$helper_log" 2>&1 &
+  helper_pid=$!
+  python3 - "$source" "$snapshot" "$payload_bytes" "$helper_pid" <<'PY'
+import os
+import pathlib
+import sys
+import time
+
+source = pathlib.Path(sys.argv[1])
+snapshot = pathlib.Path(sys.argv[2])
+expected = int(sys.argv[3])
+pid = int(sys.argv[4])
+for _ in range(20_000):
+    try:
+        if snapshot.stat().st_size == expected:
+            with source.open("r+b", buffering=0) as handle:
+                handle.seek(expected - 4096)
+                handle.write(b"B")
+                os.fsync(handle.fileno())
+            break
+    except FileNotFoundError:
+        pass
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        raise SystemExit("snapshot helper exited before the mutation barrier")
+    time.sleep(0.0005)
+else:
+    raise SystemExit("snapshot mutation barrier timed out")
+PY
+  if wait "$helper_pid"; then
+    fail "committed metric prefix mutation was accepted"
+  fi
+  grep -q 'committed metric prefix changed' "$helper_log" \
+    || fail "committed metric prefix mutation failure was not explicit"
+
+  rm -f -- "$source" "$snapshot" "$helper_log"
+  python3 - "$source" "$payload_bytes" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+length = int(sys.argv[2])
+path.write_bytes(b"A" * (length - 1) + b"\n")
+PY
+  python3 "$checkpoint_helper" snapshot-metrics \
+    "$source" 1 "$snapshot" >"$helper_log" 2>&1 &
+  helper_pid=$!
+  python3 - "$source" "$snapshot" "$payload_bytes" "$helper_pid" <<'PY'
+import os
+import pathlib
+import sys
+import time
+
+source = pathlib.Path(sys.argv[1])
+snapshot = pathlib.Path(sys.argv[2])
+expected = int(sys.argv[3])
+pid = int(sys.argv[4])
+for _ in range(20_000):
+    try:
+        if snapshot.stat().st_size == expected:
+            with source.open("ab", buffering=0) as handle:
+                handle.write(b"append-only-tail\n")
+                os.fsync(handle.fileno())
+            break
+    except FileNotFoundError:
+        pass
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        raise SystemExit("snapshot helper exited before the append barrier")
+    time.sleep(0.0005)
+else:
+    raise SystemExit("snapshot append barrier timed out")
+PY
+  wait "$helper_pid" || {
+    sed -n '1,80p' "$helper_log" >&2
+    fail "append-only metric tail growth was rejected"
+  }
+  [[ $(wc -c <"$snapshot") -eq $payload_bytes ]] \
+    || fail "metric snapshot copied an uncommitted append-only tail"
 }
 
 run_global_step_mismatch_rejected_test() {
@@ -1516,14 +2023,17 @@ run_concurrent_pointer_race_test() {
   local second_config=$case_root/second.conf
   local first_step second_step first_generation second_generation
   local first_pid second_pid delayed=false published=false observed_generation
+  local sync_result=false expected_sync_pattern
   case "$mode" in
     stale)
       first_step=61
       second_step=62
+      expected_sync_pattern='remote checkpoint advanced|leaving it unchanged'
       ;;
     fork)
       first_step=63
       second_step=63
+      expected_sync_pattern='equal-step remote checkpoint fork'
       ;;
     *) fail "unknown pointer race mode: $mode" ;;
   esac
@@ -1594,6 +2104,16 @@ EOF
     sleep 0.05
   done
   : >"$TEST_GCS_DELAY_RELEASE"
+  # Let the deliberately delayed sync observe the winning pointer before the
+  # trainers exit; supervisor cleanup otherwise has permission to stop it.
+  for _attempt in {1..400}; do
+    if grep -Eq "$expected_sync_pattern" \
+      "$case_root/first-state/sync.log" 2>/dev/null; then
+      sync_result=true
+      break
+    fi
+    sleep 0.05
+  done
   : >"$case_root/release-first"
   : >"$case_root/release-second"
   wait "$first_pid"
@@ -1604,18 +2124,10 @@ EOF
   [[ $published == true ]] || fail "$mode winning checkpoint was not published"
   [[ $(current_generation "$case_root/gcs/test-bucket/$mode") == "$second_generation" ]] \
     || fail "$mode delayed publisher rewound or replaced the winning checkpoint"
-  case "$mode" in
-    stale)
-      grep -Eq 'remote checkpoint advanced|leaving it unchanged' \
-        "$case_root/first-state/sync.log" \
-        || fail "stale concurrent publisher did not report the newer checkpoint"
-      ;;
-    fork)
-      grep -q 'equal-step remote checkpoint fork' \
-        "$case_root/first-state/sync.log" \
-        || fail "equal-step concurrent fork was not rejected explicitly"
-      ;;
-  esac
+  [[ $sync_result == true ]] || {
+    sed "s/^/$mode publisher: /" "$case_root/first-state/sync.log" >&2
+    fail "$mode delayed publisher did not observe the winning checkpoint"
+  }
 }
 
 run_cross_generation_cas_dedup_test() {
@@ -1660,10 +2172,15 @@ PY
 
 run_restart_and_reporting_test
 run_remote_restore_test
+run_file_remote_root_fd_anchor_test
+run_file_remote_entry_swap_rejected_test
 run_newer_local_wins_test
 run_idempotent_lock_test
 run_version_one_checkpoint_rejected_test
 run_modified_generation_rejected_test
+run_strict_training_state_rejected_test
+run_corrupt_metric_prefix_rejected_test
+run_metric_snapshot_stability_test
 run_global_step_mismatch_rejected_test
 run_unsafe_pointer_rejected_test
 run_unsafe_manifest_path_rejected_test

--- a/hermes-train/src/builtin_sleep_runtime.rs
+++ b/hermes-train/src/builtin_sleep_runtime.rs
@@ -820,8 +820,9 @@ impl NativeSleepPhaseContext for BuiltinStandaloneSleepContext {
                 let mut updates =
                     ProspectiveTierUpdate::new(bank.clone(), &self.runtime.prospective_directory)?;
                 let trigger_clock = cursor.sleep.due_clocks[0];
+                let transaction_id = cursor.sleep.next_transaction_id()?;
                 let plan = updates.prepare_consolidation(
-                    cursor.sleep.cycle + 1,
+                    transaction_id,
                     sender,
                     trigger_clock,
                     &teacher,
@@ -1286,8 +1287,9 @@ impl PeriodicSleepBoundaryDriver for BuiltinPeriodicSleepBoundaryDriver {
                 .context("periodic sleep has no due sender")?;
             let mut updates =
                 ProspectiveTierUpdate::new(self.bank.clone(), &self.runtime.prospective_directory)?;
+            let transaction_id = checkpoint.sleep.next_transaction_id()?;
             let plan = updates.prepare_consolidation(
-                checkpoint.sleep.cycle + 1,
+                transaction_id,
                 sender,
                 checkpoint.sleep.due_clocks[0],
                 &self.live,

--- a/hermes-train/src/checkpoint.rs
+++ b/hermes-train/src/checkpoint.rs
@@ -6,19 +6,30 @@
 //! visible only when the small `current.json` pointer is atomically replaced,
 //! so an interrupted save cannot hide the preceding complete checkpoint.
 
+#[cfg(not(unix))]
+use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::fmt::Write as FmtWrite;
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(unix)]
+use std::ffi::{CStr, CString, OsStr, OsString};
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
 use anyhow::{Context, Result, ensure};
 use burn::module::{AutodiffModule, Module, ModuleMapper, Param, ParamId};
-use burn::tensor::{Bool, Device, Int, Tensor};
+use burn::tensor::{Bool, Bytes, Device, Int, Tensor};
 use burn_optim::ModuleOptimizer;
-use hermes_llm::{Transformer, load_safetensors, save_safetensors};
+use hermes_llm::{Transformer, load_safetensors_bytes, save_safetensors};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -29,7 +40,9 @@ use hermes_train::benchmark::{
 use hermes_train::builtin_sleep_adapters::WakeContextRecord;
 use hermes_train::metrics::MetricWriter;
 use hermes_train::native_sleep::NativeSleepCheckpoint;
-use hermes_train::optimizer_artifact::save_canonical_module_optimizer;
+use hermes_train::optimizer_artifact::{
+    canonical_module_optimizer_bytes, save_canonical_module_optimizer,
+};
 use hermes_train::quantization::QuantizationTransactionState;
 
 pub(crate) type AdamWOptimizer = ModuleOptimizer;
@@ -74,6 +87,44 @@ struct GenerationFile {
     path: String,
     bytes: u64,
     sha256: String,
+}
+
+#[derive(Debug)]
+struct GenerationSnapshot {
+    files: Vec<GenerationFile>,
+    manifest: Option<Vec<u8>>,
+    training_state: Option<Vec<u8>>,
+    training_accounting: Option<Vec<u8>>,
+    access: Option<GenerationAccess>,
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct GenerationAccess {
+    directory: SecureDirectory,
+}
+
+#[cfg(not(unix))]
+#[derive(Debug)]
+struct GenerationAccess {
+    files: BTreeMap<String, File>,
+}
+
+/// Stable, machine-readable result returned by the checkpoint verifier.
+///
+/// The relaunch supervisor uses this API instead of duplicating the trainer's
+/// exact-resume schema in Bash/Python. The workflow signature is retained only
+/// for binding metric validation to the checkpoint's run identity; it is not
+/// part of the stable JSON/TSV descriptor.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct VerifiedCheckpoint {
+    pub(crate) version: u32,
+    pub(crate) generation: String,
+    pub(crate) manifest_sha256: String,
+    pub(crate) global_step: usize,
+    pub(crate) metric_records: u64,
+    #[serde(skip_serializing)]
+    pub(crate) workflow_signature: String,
 }
 
 #[derive(Debug)]
@@ -584,7 +635,7 @@ fn publish_training_evidence(
                 "training evidence {} is not a regular file",
                 path.display()
             );
-            let existing = fs::read(&path)?;
+            let existing = read_file_stable(&path, "published training evidence")?;
             ensure!(
                 sha256_bytes(&existing) == sha256 && existing == bytes,
                 "content-addressed training-evidence collision or tampering at {}",
@@ -607,7 +658,8 @@ fn publish_training_evidence(
                             "training evidence {} is not a regular file",
                             path.display()
                         );
-                        let existing = fs::read(&path)?;
+                        let existing =
+                            read_file_stable(&path, "concurrently published training evidence")?;
                         ensure!(
                             sha256_bytes(&existing) == sha256 && existing == bytes,
                             "content-addressed training-evidence collision at {}",
@@ -639,7 +691,11 @@ fn publish_training_evidence(
 fn validate_checkpoint_relative_path(path: &str) -> Result<()> {
     ensure!(!path.trim().is_empty(), "checkpoint path is empty");
     ensure!(
-        !path.contains('\\') && !path.contains(':'),
+        !path.chars().any(|character| {
+            matches!(character, '\\' | ':' | '*' | '?' | '[' | ']')
+                || character.is_control()
+                || character == '\u{7f}'
+        }),
         "checkpoint path `{path}` is not portable"
     );
     let path = Path::new(path);
@@ -746,37 +802,520 @@ fn sha256_bytes(bytes: &[u8]) -> String {
     encoded
 }
 
-fn hash_file(path: &Path) -> Result<(u64, String)> {
-    let metadata = fs::symlink_metadata(path)?;
-    ensure!(
-        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-        "checkpoint path {} is not a regular file",
-        path.display()
-    );
-    let mut file = File::open(path)?;
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct StableFileIdentity {
+    device: u64,
+    inode: u64,
+    mode: u32,
+    length: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+    changed_seconds: i64,
+    changed_nanoseconds: i64,
+}
+
+#[cfg(unix)]
+impl StableFileIdentity {
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            mode: metadata.mode(),
+            length: metadata.len(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+            changed_seconds: metadata.ctime(),
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "freebsd"
+    )
+))]
+fn errno_slot() -> Option<*mut libc::c_int> {
+    Some(unsafe { libc::__error() })
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "emscripten",
+        target_os = "hurd",
+        target_os = "redox"
+    )
+))]
+fn errno_slot() -> Option<*mut libc::c_int> {
+    Some(unsafe { libc::__errno_location() })
+}
+
+#[cfg(all(
+    unix,
+    any(target_os = "android", target_os = "netbsd", target_os = "openbsd")
+))]
+fn errno_slot() -> Option<*mut libc::c_int> {
+    Some(unsafe { libc::__errno() })
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "emscripten",
+        target_os = "hurd",
+        target_os = "redox",
+        target_os = "android",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))
+))]
+fn errno_slot() -> Option<*mut libc::c_int> {
+    None
+}
+
+fn hash_open_file(
+    file: &mut File,
+    capture_bytes: bool,
+    label: &str,
+) -> Result<(u64, String, Option<Vec<u8>>)> {
+    let before = file
+        .metadata()
+        .with_context(|| format!("failed to inspect opened {label}"))?;
+    ensure!(before.is_file(), "{label} is not a regular file");
+    #[cfg(unix)]
+    let before_identity = StableFileIdentity::from_metadata(&before);
+    #[cfg(not(unix))]
+    let before_modified = before.modified().ok();
+
     let mut hasher = Sha256::new();
+    let mut captured = if capture_bytes {
+        let capacity = usize::try_from(before.len())
+            .context("checkpoint file length does not fit address space")?;
+        let mut captured = Vec::new();
+        captured
+            .try_reserve_exact(capacity)
+            .context("failed to reserve authenticated checkpoint buffer")?;
+        Some(captured)
+    } else {
+        None
+    };
     let mut buffer = [0_u8; 1024 * 1024];
     let mut bytes = 0_u64;
     loop {
-        let read = file.read(&mut buffer)?;
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("failed to read {label}"))?;
         if read == 0 {
             break;
         }
-        hasher.update(&buffer[..read]);
-        bytes = bytes
+        let next_bytes = bytes
             .checked_add(read as u64)
             .context("checkpoint file length overflow")?;
+        ensure!(
+            next_bytes <= before.len(),
+            "{label} grew while it was hashed"
+        );
+        hasher.update(&buffer[..read]);
+        if let Some(captured) = &mut captured {
+            captured.extend_from_slice(&buffer[..read]);
+        }
+        bytes = next_bytes;
     }
+    let after = file
+        .metadata()
+        .with_context(|| format!("failed to reinspect opened {label}"))?;
+    #[cfg(unix)]
+    ensure!(
+        StableFileIdentity::from_metadata(&after) == before_identity,
+        "{label} changed while it was hashed"
+    );
+    #[cfg(not(unix))]
+    ensure!(
+        after.is_file() && after.len() == before.len() && after.modified().ok() == before_modified,
+        "{label} changed while it was hashed"
+    );
+    ensure!(bytes == after.len(), "{label} changed while it was hashed");
     let digest = hasher.finalize();
     let mut encoded = String::with_capacity(64);
     for byte in digest {
         let _ = write!(encoded, "{byte:02x}");
     }
-    Ok((bytes, encoded))
+    Ok((bytes, encoded, captured))
 }
 
-fn collect_generation_files(root: &Path) -> Result<Vec<GenerationFile>> {
-    fn visit(root: &Path, directory: &Path, files: &mut Vec<GenerationFile>) -> Result<()> {
+fn read_hashed_path(
+    path: &Path,
+    capture_bytes: bool,
+    label: &str,
+) -> Result<(u64, String, Option<Vec<u8>>)> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect checkpoint path {}", path.display()))?;
+    ensure!(
+        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+        "{label} is not a regular file"
+    );
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("failed to open {label}"))?;
+    #[cfg(unix)]
+    ensure!(
+        StableFileIdentity::from_metadata(&file.metadata()?)
+            == StableFileIdentity::from_metadata(&metadata),
+        "{label} changed while it was opened"
+    );
+    let (bytes, sha256, captured) = hash_open_file(&mut file, capture_bytes, label)?;
+    let current = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to reinspect checkpoint path {}", path.display()))?;
+    #[cfg(unix)]
+    ensure!(
+        StableFileIdentity::from_metadata(&current) == StableFileIdentity::from_metadata(&metadata),
+        "{label} changed while it was hashed"
+    );
+    #[cfg(not(unix))]
+    ensure!(
+        current.file_type().is_file()
+            && !current.file_type().is_symlink()
+            && current.len() == metadata.len()
+            && current.modified().ok() == metadata.modified().ok(),
+        "{label} changed while it was hashed"
+    );
+    Ok((bytes, sha256, captured))
+}
+
+fn hash_file(path: &Path) -> Result<(u64, String)> {
+    let (bytes, sha256, _) =
+        read_hashed_path(path, false, &format!("checkpoint file {}", path.display()))?;
+    Ok((bytes, sha256))
+}
+
+fn read_file_stable(path: &Path, label: &str) -> Result<Vec<u8>> {
+    read_hashed_path(path, true, label)?
+        .2
+        .context("stable checkpoint read did not capture bytes")
+}
+
+impl GenerationSnapshot {
+    fn new() -> Self {
+        Self {
+            files: Vec::new(),
+            manifest: None,
+            training_state: None,
+            training_accounting: None,
+            access: None,
+        }
+    }
+
+    fn record_file(
+        &mut self,
+        relative: String,
+        bytes: u64,
+        sha256: String,
+        captured: Option<Vec<u8>>,
+    ) -> Result<()> {
+        match relative.as_str() {
+            GENERATION_MANIFEST => {
+                ensure!(
+                    self.manifest.is_none(),
+                    "checkpoint repeats its generation manifest"
+                );
+                self.manifest = captured;
+                return Ok(());
+            }
+            TRAINING_STATE_FILE => self.training_state = captured,
+            TRAINING_ACCOUNTING_FILE => self.training_accounting = captured,
+            _ => {}
+        }
+        validate_checkpoint_relative_path(&relative)?;
+        self.files.push(GenerationFile {
+            path: relative,
+            bytes,
+            sha256,
+        });
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<Self> {
+        self.files.sort_by(|left, right| left.path.cmp(&right.path));
+        ensure!(
+            self.files
+                .windows(2)
+                .all(|pair| pair[0].path != pair[1].path),
+            "checkpoint generation repeats a file path"
+        );
+        Ok(self)
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct SecureDirectory {
+    file: File,
+}
+
+#[cfg(unix)]
+impl SecureDirectory {
+    fn open_root(path: &Path) -> Result<Self> {
+        let path_metadata = fs::symlink_metadata(path).with_context(|| {
+            format!("failed to inspect checkpoint directory {}", path.display())
+        })?;
+        ensure!(
+            path_metadata.is_dir() && !path_metadata.file_type().is_symlink(),
+            "checkpoint generation {} is not a real directory",
+            path.display()
+        );
+        let file = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+            .open(path)
+            .with_context(|| format!("failed to open checkpoint directory {}", path.display()))?;
+        ensure!(
+            StableFileIdentity::from_metadata(&file.metadata()?)
+                == StableFileIdentity::from_metadata(&path_metadata),
+            "checkpoint directory {} changed while it was opened",
+            path.display()
+        );
+        Ok(Self { file })
+    }
+
+    fn open_child(&self, name: &OsStr) -> Result<File> {
+        let name = CString::new(name.as_bytes()).context("checkpoint name contains a NUL byte")?;
+        // O_NONBLOCK prevents an attacker-controlled FIFO from hanging the
+        // verifier before its file type can be rejected.
+        let descriptor = unsafe {
+            libc::openat(
+                self.file.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+                0,
+            )
+        };
+        if descriptor < 0 {
+            return Err(std::io::Error::last_os_error()).context("failed to open checkpoint entry");
+        }
+        // SAFETY: openat returned a new owned descriptor on success.
+        Ok(unsafe { File::from_raw_fd(descriptor) })
+    }
+
+    fn open_relative_file(&self, relative: &str) -> Result<File> {
+        validate_checkpoint_relative_path(relative)?;
+        let mut directory = Self {
+            file: self
+                .file
+                .try_clone()
+                .context("failed to duplicate authenticated checkpoint directory")?,
+        };
+        let mut components = Path::new(relative).components().peekable();
+        while let Some(component) = components.next() {
+            let Component::Normal(name) = component else {
+                anyhow::bail!("checkpoint path `{relative}` is not a safe relative path");
+            };
+            let child = directory
+                .open_child(name)
+                .with_context(|| format!("failed to open authenticated artifact `{relative}`"))?;
+            let metadata = child.metadata().with_context(|| {
+                format!("failed to inspect authenticated artifact `{relative}`")
+            })?;
+            if components.peek().is_none() {
+                ensure!(
+                    metadata.is_file(),
+                    "authenticated checkpoint artifact `{relative}` is not a regular file"
+                );
+                return Ok(child);
+            }
+            ensure!(
+                metadata.is_dir(),
+                "checkpoint artifact parent for `{relative}` is not a directory"
+            );
+            directory = Self { file: child };
+        }
+        anyhow::bail!("checkpoint path `{relative}` has no file name")
+    }
+
+    fn entries(&self) -> Result<Vec<OsString>> {
+        let duplicate = unsafe { libc::dup(self.file.as_raw_fd()) };
+        if duplicate < 0 {
+            return Err(std::io::Error::last_os_error())
+                .context("failed to duplicate checkpoint directory descriptor");
+        }
+        let stream = unsafe { libc::fdopendir(duplicate) };
+        if stream.is_null() {
+            let error = std::io::Error::last_os_error();
+            unsafe { libc::close(duplicate) };
+            return Err(error).context("failed to enumerate checkpoint directory");
+        }
+
+        struct DirectoryStream(*mut libc::DIR);
+        impl Drop for DirectoryStream {
+            fn drop(&mut self) {
+                unsafe { libc::closedir(self.0) };
+            }
+        }
+        let stream = DirectoryStream(stream);
+        let mut names = Vec::new();
+        loop {
+            let errno = errno_slot();
+            if let Some(slot) = errno {
+                // SAFETY: errno_slot returns this thread's errno storage.
+                unsafe { *slot = 0 };
+            }
+            // SAFETY: `stream` owns a private DIR used only by this loop. The
+            // returned entry is copied before the next call to readdir.
+            let entry = unsafe { libc::readdir(stream.0) };
+            if entry.is_null() {
+                let code = errno.map_or(0, |slot| unsafe { *slot });
+                if code != 0 {
+                    return Err(std::io::Error::from_raw_os_error(code))
+                        .context("failed while enumerating checkpoint directory");
+                }
+                break;
+            }
+            let bytes = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }.to_bytes();
+            if bytes == b"." || bytes == b".." {
+                continue;
+            }
+            names.push(OsString::from_vec(bytes.to_vec()));
+        }
+        names.sort();
+        Ok(names)
+    }
+}
+
+impl GenerationAccess {
+    fn read_authenticated(&mut self, relative: &str, expected: &GenerationFile) -> Result<Vec<u8>> {
+        ensure!(
+            expected.path == relative,
+            "checkpoint artifact identity does not match `{relative}`"
+        );
+        #[cfg(unix)]
+        let file = self.directory.open_relative_file(relative)?;
+        #[cfg(not(unix))]
+        let file = self
+            .files
+            .remove(relative)
+            .with_context(|| format!("checkpoint snapshot did not retain `{relative}`"))?;
+        read_authenticated_file(file, expected)
+    }
+}
+
+fn read_authenticated_file(mut file: File, expected: &GenerationFile) -> Result<Vec<u8>> {
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("failed to rewind checkpoint artifact `{}`", expected.path))?;
+    let (bytes, sha256, captured) = hash_open_file(
+        &mut file,
+        true,
+        &format!("authenticated checkpoint artifact `{}`", expected.path),
+    )?;
+    ensure!(
+        bytes == expected.bytes && sha256 == expected.sha256,
+        "checkpoint artifact `{}` no longer matches the authenticated generation manifest",
+        expected.path
+    );
+    captured.context("authenticated checkpoint read did not capture bytes")
+}
+
+#[cfg(unix)]
+fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<GenerationSnapshot> {
+    fn visit(
+        directory: &SecureDirectory,
+        relative_root: &Path,
+        snapshot: &mut GenerationSnapshot,
+    ) -> Result<()> {
+        let before = StableFileIdentity::from_metadata(&directory.file.metadata()?);
+        for name in directory.entries()? {
+            let relative_path = relative_root.join(&name);
+            let relative = relative_path
+                .to_str()
+                .context("checkpoint file name is not valid UTF-8")?
+                .replace(std::path::MAIN_SEPARATOR, "/");
+            validate_checkpoint_relative_path(&relative)?;
+            let mut child = directory.open_child(&name).with_context(|| {
+                format!("failed to open checkpoint generation entry `{relative}`")
+            })?;
+            let metadata = child.metadata()?;
+            if metadata.is_dir() {
+                let files_before = snapshot.files.len();
+                visit(&SecureDirectory { file: child }, &relative_path, snapshot)?;
+                ensure!(
+                    snapshot.files.len() > files_before,
+                    "checkpoint generation contains empty directory `{relative}`"
+                );
+                continue;
+            }
+            ensure!(
+                metadata.is_file(),
+                "checkpoint generation contains non-file `{relative}`"
+            );
+            let capture = matches!(
+                relative.as_str(),
+                GENERATION_MANIFEST | TRAINING_STATE_FILE | TRAINING_ACCOUNTING_FILE
+            );
+            let (bytes, sha256, captured) = hash_open_file(
+                &mut child,
+                capture,
+                &format!("checkpoint file `{relative}`"),
+            )?;
+            snapshot.record_file(relative, bytes, sha256, captured)?;
+        }
+        ensure!(
+            StableFileIdentity::from_metadata(&directory.file.metadata()?) == before,
+            "checkpoint directory changed while it was verified"
+        );
+        Ok(())
+    }
+
+    let directory = SecureDirectory::open_root(root)?;
+    let root_identity = StableFileIdentity::from_metadata(&directory.file.metadata()?);
+    let mut snapshot = GenerationSnapshot::new();
+    visit(&directory, Path::new(""), &mut snapshot)?;
+    let current = fs::symlink_metadata(root).with_context(|| {
+        format!(
+            "failed to reinspect checkpoint generation {}",
+            root.display()
+        )
+    })?;
+    ensure!(
+        current.is_dir()
+            && !current.file_type().is_symlink()
+            && StableFileIdentity::from_metadata(&current) == root_identity,
+        "checkpoint generation changed while it was verified"
+    );
+    if retain_access {
+        snapshot.access = Some(GenerationAccess { directory });
+    }
+    snapshot.finish()
+}
+
+#[cfg(not(unix))]
+fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<GenerationSnapshot> {
+    fn visit(
+        root: &Path,
+        directory: &Path,
+        snapshot: &mut GenerationSnapshot,
+        retained: &mut Option<BTreeMap<String, File>>,
+    ) -> Result<()> {
+        let before = fs::metadata(directory)?;
         let mut entries = fs::read_dir(directory)?.collect::<std::io::Result<Vec<_>>>()?;
         entries.sort_by_key(std::fs::DirEntry::file_name);
         for entry in entries {
@@ -788,7 +1327,13 @@ fn collect_generation_files(root: &Path) -> Result<Vec<GenerationFile>> {
                 path.display()
             );
             if metadata.is_dir() {
-                visit(root, &path, files)?;
+                let files_before = snapshot.files.len();
+                visit(root, &path, snapshot, retained)?;
+                ensure!(
+                    snapshot.files.len() > files_before,
+                    "checkpoint generation contains empty directory {}",
+                    path.display()
+                );
                 continue;
             }
             ensure!(
@@ -796,44 +1341,50 @@ fn collect_generation_files(root: &Path) -> Result<Vec<GenerationFile>> {
                 "checkpoint generation contains non-file {}",
                 path.display()
             );
-            let relative = path.strip_prefix(root)?;
-            let relative = relative
+            let relative = path
+                .strip_prefix(root)?
                 .to_str()
                 .context("checkpoint file name is not valid UTF-8")?
                 .replace(std::path::MAIN_SEPARATOR, "/");
-            if relative == GENERATION_MANIFEST {
-                continue;
-            }
             validate_checkpoint_relative_path(&relative)?;
-            let (bytes, sha256) = hash_file(&path)?;
-            files.push(GenerationFile {
-                path: relative,
-                bytes,
-                sha256,
-            });
+            let capture = matches!(
+                relative.as_str(),
+                GENERATION_MANIFEST | TRAINING_STATE_FILE | TRAINING_ACCOUNTING_FILE
+            );
+            let mut file = File::open(&path)?;
+            let (bytes, sha256, captured) =
+                hash_open_file(&mut file, capture, &format!("checkpoint file `{relative}`"))?;
+            if let Some(retained) = retained {
+                ensure!(
+                    retained.insert(relative.clone(), file).is_none(),
+                    "checkpoint repeats file `{relative}`"
+                );
+            }
+            snapshot.record_file(relative, bytes, sha256, captured)?;
         }
+        let after = fs::metadata(directory)?;
+        ensure!(
+            before.len() == after.len() && before.modified().ok() == after.modified().ok(),
+            "checkpoint directory changed while it was verified"
+        );
         Ok(())
     }
 
-    let mut files = Vec::new();
-    visit(root, root, &mut files)?;
-    files.sort_by(|left, right| left.path.cmp(&right.path));
+    let metadata = fs::symlink_metadata(root)?;
     ensure!(
-        files.windows(2).all(|pair| pair[0].path != pair[1].path),
-        "checkpoint generation repeats a file path"
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "checkpoint generation {} is not a real directory",
+        root.display()
     );
-    Ok(files)
+    let mut snapshot = GenerationSnapshot::new();
+    let mut retained = retain_access.then(BTreeMap::new);
+    visit(root, root, &mut snapshot, &mut retained)?;
+    snapshot.access = retained.map(|files| GenerationAccess { files });
+    snapshot.finish()
 }
 
-fn read_training_state(generation: &Path) -> Result<TrainingState> {
-    let path = generation.join(TRAINING_STATE_FILE);
-    let metadata = fs::symlink_metadata(&path)
-        .with_context(|| format!("checkpoint generation is missing {TRAINING_STATE_FILE}"))?;
-    ensure!(
-        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-        "checkpoint training state is not a regular file"
-    );
-    let state: TrainingState = serde_json::from_slice(&fs::read(&path)?)?;
+fn parse_training_state(bytes: &[u8]) -> Result<TrainingState> {
+    let state: TrainingState = serde_json::from_slice(bytes)?;
     state.validate()?;
     Ok(state)
 }
@@ -846,11 +1397,7 @@ fn optimizer_file_paths(state: &TrainingState) -> impl Iterator<Item = &str> {
     })
 }
 
-fn validate_optimizer_files(
-    state: &TrainingState,
-    generation: &Path,
-    files: &[GenerationFile],
-) -> Result<()> {
+fn validate_optimizer_files(state: &TrainingState, files: &[GenerationFile]) -> Result<()> {
     let authenticated = files
         .iter()
         .map(|file| file.path.as_str())
@@ -860,13 +1407,6 @@ fn validate_optimizer_files(
         ensure!(
             authenticated.contains(relative),
             "optimizer or gradient state `{relative}` is missing from the content-addressed generation"
-        );
-        let path = generation.join(relative);
-        let metadata = fs::symlink_metadata(&path)
-            .with_context(|| format!("optimizer or gradient state `{relative}` does not exist"))?;
-        ensure!(
-            metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-            "optimizer or gradient state `{relative}` is not a regular file"
         );
     }
     Ok(())
@@ -889,6 +1429,22 @@ fn ensure_required_files(files: &[GenerationFile]) -> Result<()> {
             "checkpoint generation is missing required file `{required}`"
         );
     }
+    Ok(())
+}
+
+fn validate_training_accounting(bytes: &[u8], files: &[GenerationFile]) -> Result<()> {
+    let accounting: TrainingAccounting =
+        serde_json::from_slice(bytes).context("checkpoint training accounting is invalid")?;
+    accounting.validate()?;
+
+    let weights = files
+        .iter()
+        .find(|file| file.path == WEIGHTS_FILE)
+        .context("checkpoint manifest has no model weights")?;
+    ensure!(
+        accounting.weights_bytes == weights.bytes && accounting.weights_sha256 == weights.sha256,
+        "checkpoint training accounting does not match its model weights"
+    );
     Ok(())
 }
 
@@ -919,10 +1475,30 @@ fn validate_generation_name(name: &str) -> Result<&str> {
 }
 
 fn seal_generation(output: &Path, staging: &Path) -> Result<SealedGeneration> {
-    let state = read_training_state(staging)?;
-    let files = collect_generation_files(staging)?;
+    let GenerationSnapshot {
+        files,
+        manifest,
+        training_state,
+        training_accounting,
+        access: _,
+    } = collect_generation_snapshot(staging, false)?;
+    ensure!(
+        manifest.is_none(),
+        "checkpoint staging directory already contains a generation manifest"
+    );
+    let state = parse_training_state(
+        training_state
+            .as_deref()
+            .context("checkpoint generation is missing training-state.json")?,
+    )?;
     ensure_required_files(&files)?;
-    validate_optimizer_files(&state, staging, &files)?;
+    validate_training_accounting(
+        training_accounting
+            .as_deref()
+            .context("checkpoint has no training accounting")?,
+        &files,
+    )?;
+    validate_optimizer_files(&state, &files)?;
     let manifest = GenerationManifest {
         version: CHECKPOINT_MANIFEST_VERSION,
         training_state_version: state.version,
@@ -1030,26 +1606,32 @@ fn verify_generation(
     generation_name: &str,
     expected_manifest_sha256: &str,
 ) -> Result<(GenerationManifest, TrainingState)> {
+    let (manifest, state, _) =
+        verify_generation_inner(generation, generation_name, expected_manifest_sha256, false)?;
+    Ok((manifest, state))
+}
+
+fn verify_generation_inner(
+    generation: &Path,
+    generation_name: &str,
+    expected_manifest_sha256: &str,
+    retain_access: bool,
+) -> Result<(GenerationManifest, TrainingState, Option<GenerationAccess>)> {
     let generation_digest = validate_generation_name(generation_name)?;
     validate_sha256(expected_manifest_sha256, "checkpoint manifest digest")?;
     ensure!(
         generation_digest == expected_manifest_sha256,
         "checkpoint generation name and manifest digest differ"
     );
-    let metadata = fs::symlink_metadata(generation)
-        .with_context(|| format!("checkpoint generation `{generation_name}` does not exist"))?;
-    ensure!(
-        metadata.is_dir() && !metadata.file_type().is_symlink(),
-        "checkpoint generation `{generation_name}` is not a directory"
-    );
-    let manifest_path = generation.join(GENERATION_MANIFEST);
-    let manifest_metadata =
-        fs::symlink_metadata(&manifest_path).context("checkpoint generation has no manifest")?;
-    ensure!(
-        manifest_metadata.file_type().is_file() && !manifest_metadata.file_type().is_symlink(),
-        "checkpoint generation manifest is not a regular file"
-    );
-    let manifest_bytes = fs::read(&manifest_path)?;
+    let GenerationSnapshot {
+        files,
+        manifest,
+        training_state,
+        training_accounting,
+        access,
+    } = collect_generation_snapshot(generation, retain_access)
+        .with_context(|| format!("failed to verify checkpoint generation `{generation_name}`"))?;
+    let manifest_bytes = manifest.context("checkpoint generation has no manifest")?;
     ensure!(
         sha256_bytes(&manifest_bytes) == expected_manifest_sha256,
         "checkpoint generation manifest digest mismatch"
@@ -1065,13 +1647,22 @@ fn verify_generation(
         "checkpoint generation contains training-state version {}",
         manifest.training_state_version
     );
-    let actual_files = collect_generation_files(generation)?;
     ensure!(
-        actual_files == manifest.files,
+        files == manifest.files,
         "checkpoint generation contents do not match its manifest"
     );
     ensure_required_files(&manifest.files)?;
-    let state = read_training_state(generation)?;
+    validate_training_accounting(
+        training_accounting
+            .as_deref()
+            .context("checkpoint has no training accounting")?,
+        &manifest.files,
+    )?;
+    let state = parse_training_state(
+        training_state
+            .as_deref()
+            .context("checkpoint generation is missing training-state.json")?,
+    )?;
     ensure!(
         state.version == manifest.training_state_version
             && state.global_step == manifest.global_step
@@ -1079,22 +1670,60 @@ fn verify_generation(
             && state.phase_id == manifest.phase_id,
         "checkpoint training state does not match its generation manifest"
     );
-    validate_optimizer_files(&state, generation, &manifest.files)?;
-    Ok((manifest, state))
+    validate_optimizer_files(&state, &manifest.files)?;
+    ensure!(
+        access.is_some() == retain_access,
+        "checkpoint verifier did not retain the requested generation access"
+    );
+    Ok((manifest, state, access))
 }
 
-fn resolve_current_generation(output: &Path) -> Result<(PathBuf, TrainingState)> {
+pub(crate) fn verify_checkpoint_generation(
+    generation: &Path,
+    generation_name: &str,
+    expected_manifest_sha256: &str,
+) -> Result<VerifiedCheckpoint> {
+    let (_, state) = verify_generation(generation, generation_name, expected_manifest_sha256)?;
+    Ok(VerifiedCheckpoint {
+        version: 1,
+        generation: generation_name.to_owned(),
+        manifest_sha256: expected_manifest_sha256.to_owned(),
+        global_step: state.global_step,
+        metric_records: state.metric_records,
+        workflow_signature: state.workflow_signature,
+    })
+}
+
+pub(crate) fn verify_checkpoint_root(output: &Path) -> Result<VerifiedCheckpoint> {
+    let (verified, _, _) = verify_checkpoint_root_with_state(output)?;
+    Ok(verified)
+}
+
+fn verify_checkpoint_root_with_state(
+    output: &Path,
+) -> Result<(VerifiedCheckpoint, PathBuf, TrainingState)> {
+    let (verified, generation, _, state, _) = verify_checkpoint_root_inner(output, false)?;
+    Ok((verified, generation, state))
+}
+
+fn verify_checkpoint_root_inner(
+    output: &Path,
+    retain_access: bool,
+) -> Result<(
+    VerifiedCheckpoint,
+    PathBuf,
+    GenerationManifest,
+    TrainingState,
+    Option<GenerationAccess>,
+)> {
+    validate_generation_root(output).context("checkpoint root is not a real directory")?;
     let pointer_path = output.join(CURRENT_POINTER);
-    let metadata = fs::symlink_metadata(&pointer_path).with_context(|| {
+    let pointer_bytes = read_file_stable(&pointer_path, "checkpoint current pointer").with_context(|| {
         format!(
             "checkpoint has no atomic `{CURRENT_POINTER}` pointer; a version-2 generation checkpoint is required"
         )
     })?;
-    ensure!(
-        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-        "checkpoint current pointer is not a regular file"
-    );
-    let pointer: CurrentCheckpoint = serde_json::from_slice(&fs::read(&pointer_path)?)?;
+    let pointer: CurrentCheckpoint = serde_json::from_slice(&pointer_bytes)?;
     ensure!(
         pointer.version == CHECKPOINT_POINTER_VERSION,
         "unsupported checkpoint pointer version {}",
@@ -1105,8 +1734,40 @@ fn resolve_current_generation(output: &Path) -> Result<(PathBuf, TrainingState)>
     let generations = output.join(GENERATIONS_DIRECTORY);
     validate_generation_root(&generations)?;
     let generation = generations.join(&pointer.generation);
-    let (_, state) = verify_generation(&generation, &pointer.generation, &pointer.manifest_sha256)?;
+    let (manifest, state, access) = verify_generation_inner(
+        &generation,
+        &pointer.generation,
+        &pointer.manifest_sha256,
+        retain_access,
+    )?;
+    let verified = VerifiedCheckpoint {
+        version: 1,
+        generation: pointer.generation,
+        manifest_sha256: pointer.manifest_sha256,
+        global_step: state.global_step,
+        metric_records: state.metric_records,
+        workflow_signature: state.workflow_signature.clone(),
+    };
+    Ok((verified, generation, manifest, state, access))
+}
+
+#[cfg(test)]
+fn resolve_current_generation(output: &Path) -> Result<(PathBuf, TrainingState)> {
+    let (_, generation, state) = verify_checkpoint_root_with_state(output)?;
     Ok((generation, state))
+}
+
+fn read_manifest_artifact(
+    access: &mut GenerationAccess,
+    manifest: &GenerationManifest,
+    relative: &str,
+) -> Result<Vec<u8>> {
+    let expected = manifest
+        .files
+        .iter()
+        .find(|file| file.path == relative)
+        .with_context(|| format!("checkpoint manifest has no artifact `{relative}`"))?;
+    access.read_authenticated(relative, expected)
 }
 
 pub(crate) fn load_training_state(
@@ -1116,20 +1777,111 @@ pub(crate) fn load_training_state(
     output: &Path,
     device: &Device,
 ) -> Result<(AdamWOptimizer, TrainingState)> {
-    let (generation, state) = resolve_current_generation(output)?;
-    restore_parameter_ids(model, &state.parameter_ids)?;
-    load_safetensors(model, generation.join(WEIGHTS_FILE))?;
+    load_training_state_inner(model, adamw, muon, output, device, |_, _| Ok(()))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResumeLoadStage {
+    AfterInitialVerify,
+    AfterStagedLoad,
+}
+
+fn load_training_state_inner(
+    model: &mut Transformer,
+    adamw: AdamWOptimizer,
+    muon: &mut BatchedMuon,
+    output: &Path,
+    device: &Device,
+    mut stage_hook: impl FnMut(ResumeLoadStage, &Path) -> Result<()>,
+) -> Result<(AdamWOptimizer, TrainingState)> {
+    let (verified_before, generation, manifest, state, access) =
+        verify_checkpoint_root_inner(output, true)?;
+    let mut access = access.context("checkpoint verifier did not retain generation access")?;
+    stage_hook(ResumeLoadStage::AfterInitialVerify, &generation)?;
+
+    let mut loaded_model = model.clone();
+    let mut loaded_muon = muon.clone();
+    restore_parameter_ids(&mut loaded_model, &state.parameter_ids)?;
+    let weights = read_manifest_artifact(&mut access, &manifest, WEIGHTS_FILE)?;
+    load_safetensors_bytes(
+        &mut loaded_model,
+        weights,
+        "authenticated training checkpoint weights",
+    )?;
     let wake = state
         .optimizer_states
         .iter()
         .find(|optimizer| optimizer.scope == "wake")
         .context("checkpoint has no `wake` optimizer state")?;
-    muon.set_parameter_ids(model.muon_parameter_ids());
-    muon.load(generation.join(&wake.muon), &device.clone().inner())?;
-    let adamw = adamw
-        .load(generation.join(&wake.adamw))
+    loaded_muon.set_parameter_ids(loaded_model.muon_parameter_ids());
+    let muon_bytes = read_manifest_artifact(&mut access, &manifest, &wake.muon)?;
+    loaded_muon.load_bytes(muon_bytes, &device.clone().inner())?;
+    ensure!(
+        state.global_step == 0 || !loaded_muon.is_empty(),
+        "Muon checkpoint has no velocities after optimizer progress"
+    );
+    let adamw_bytes = read_manifest_artifact(&mut access, &manifest, &wake.adamw)?;
+    let loaded_adamw = adamw
+        .from_bytes(Bytes::from_bytes_vec(adamw_bytes))
         .context("failed to load AdamW state")?;
-    Ok((adamw, state))
+    let expected_adamw = manifest
+        .files
+        .iter()
+        .find(|file| file.path == wake.adamw)
+        .context("checkpoint manifest has no authenticated AdamW state")?;
+    let canonical_adamw = canonical_module_optimizer_bytes(&loaded_adamw)
+        .context("failed to validate loaded AdamW state")?;
+    ensure!(
+        canonical_adamw.len() as u64 == expected_adamw.bytes
+            && sha256_bytes(&canonical_adamw) == expected_adamw.sha256,
+        "loaded AdamW state is not a lossless reconstruction of its authenticated artifact"
+    );
+    stage_hook(ResumeLoadStage::AfterStagedLoad, &generation)?;
+
+    let (verified_after, _, _) = verify_checkpoint_root_with_state(output)?;
+    ensure!(
+        verified_after == verified_before,
+        "checkpoint generation changed while its state was being loaded"
+    );
+
+    *model = loaded_model;
+    *muon = loaded_muon;
+    Ok((loaded_adamw, state))
+}
+
+#[cfg(test)]
+pub(crate) fn load_training_state_with_hook(
+    model: &mut Transformer,
+    adamw: AdamWOptimizer,
+    muon: &mut BatchedMuon,
+    output: &Path,
+    device: &Device,
+    stage_hook: impl FnMut(ResumeLoadStage, &Path) -> Result<()>,
+) -> Result<(AdamWOptimizer, TrainingState)> {
+    load_training_state_inner(model, adamw, muon, output, device, stage_hook)
+}
+
+#[cfg(test)]
+pub(crate) fn rewrite_current_generation_for_test(
+    output: &Path,
+    rewrite: impl FnOnce(&Path) -> Result<()>,
+) -> Result<PathBuf> {
+    let (_, source, manifest, _, _) = verify_checkpoint_root_inner(output, false)?;
+    let staging = create_staging_directory(output)?;
+    let mut guard = StagingGuard::new(staging.clone());
+    for artifact in &manifest.files {
+        let destination = staging.join(&artifact.path);
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(source.join(&artifact.path), &destination)
+            .with_context(|| format!("failed to copy test artifact `{}`", artifact.path))?;
+    }
+    rewrite(&staging)?;
+    let sealed = seal_generation(output, &staging)?;
+    guard.disarm();
+    publish_current(output, &sealed)?;
+    Ok(sealed.path)
 }
 
 #[cfg(test)]
@@ -1243,6 +1995,14 @@ mod tests {
         let mut shared = state_at(7);
         shared.optimizer_states[0].muon = ADAMW_FILE.into();
         assert!(shared.validate().is_err());
+
+        let mut control = state_at(7);
+        control.optimizer_states[0].muon = "muon\nstate.bpk".into();
+        assert!(control.validate().is_err());
+
+        let mut glob = state_at(7);
+        glob.optimizer_states[0].muon = "muon[0].bpk".into();
+        assert!(glob.validate().is_err());
     }
 
     #[test]
@@ -1312,6 +2072,39 @@ mod tests {
     }
 
     #[test]
+    fn public_verifier_reports_the_exact_resume_identity() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = state_at(7);
+        let staging = stage_test_generation(directory.path(), &state, "verify");
+        let generation = seal_generation(directory.path(), &staging).unwrap();
+        publish_current(directory.path(), &generation).unwrap();
+
+        let by_root = verify_checkpoint_root(directory.path()).unwrap();
+        let by_generation = verify_checkpoint_generation(
+            &generation.path,
+            &generation.name,
+            &generation.manifest_sha256,
+        )
+        .unwrap();
+        assert_eq!(by_root, by_generation);
+        assert_eq!(by_root.global_step, 7);
+        assert_eq!(by_root.metric_records, 14);
+    }
+
+    #[test]
+    fn generation_verification_rejects_invalid_training_accounting() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = state_at(7);
+        let staging = stage_test_generation(directory.path(), &state, "bad-accounting");
+        fs::write(staging.join(TRAINING_ACCOUNTING_FILE), br#"{"version":1}"#).unwrap();
+
+        let error = seal_generation(directory.path(), &staging)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("training accounting"), "{error}");
+    }
+
+    #[test]
     fn every_declared_optimizer_file_must_be_in_generation() {
         let directory = tempfile::tempdir().unwrap();
         let mut state = state_at(7);
@@ -1336,6 +2129,97 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("contents do not match"), "{error}");
+    }
+
+    #[test]
+    fn generation_verifier_rejects_unmanifested_empty_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = state_at(7);
+        let staging = stage_test_generation(directory.path(), &state, "empty-directory");
+        let generation = seal_generation(directory.path(), &staging).unwrap();
+        fs::create_dir(generation.path.join("unmanifested")).unwrap();
+
+        let error = verify_checkpoint_generation(
+            &generation.path,
+            &generation.name,
+            &generation.manifest_sha256,
+        )
+        .unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("empty directory"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generation_verifier_handles_long_portable_file_names() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = state_at(7);
+        let staging = stage_test_generation(directory.path(), &state, "long-name");
+        let long_name = format!("{}.bpk", "a".repeat(240));
+        write_synced_new(&staging.join(long_name), b"long-name-state").unwrap();
+        let generation = seal_generation(directory.path(), &staging).unwrap();
+
+        verify_checkpoint_generation(
+            &generation.path,
+            &generation.name,
+            &generation.manifest_sha256,
+        )
+        .unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generation_verifier_rejects_symlinked_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = state_at(7);
+        let staging = stage_test_generation(directory.path(), &state, "symlink-file");
+        let generation = seal_generation(directory.path(), &staging).unwrap();
+
+        let weights = generation.path.join(WEIGHTS_FILE);
+        let external = directory.path().join("external-weights.safetensors");
+        fs::rename(&weights, &external).unwrap();
+        std::os::unix::fs::symlink(&external, &weights).unwrap();
+
+        let error = verify_checkpoint_generation(
+            &generation.path,
+            &generation.name,
+            &generation.manifest_sha256,
+        )
+        .unwrap_err();
+        let error = format!("{error:#}");
+        assert!(
+            error.contains("failed to open checkpoint generation entry"),
+            "{error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generation_verifier_rejects_symlinked_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut state = state_at(7);
+        state.optimizer_states[0].gradient_accumulator = Some("nested/gradients.bpk".into());
+        let staging = stage_test_generation(directory.path(), &state, "symlink-directory");
+        fs::create_dir(staging.join("nested")).unwrap();
+        write_synced_new(&staging.join("nested/gradients.bpk"), b"gradients").unwrap();
+        let generation = seal_generation(directory.path(), &staging).unwrap();
+
+        let nested = generation.path.join("nested");
+        let external = directory.path().join("external-nested");
+        fs::rename(&nested, &external).unwrap();
+        std::os::unix::fs::symlink(&external, &nested).unwrap();
+
+        let error = verify_checkpoint_generation(
+            &generation.path,
+            &generation.name,
+            &generation.manifest_sha256,
+        )
+        .unwrap_err();
+        let error = format!("{error:#}");
+        assert!(
+            error.contains("failed to open checkpoint generation entry"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -1440,5 +2324,18 @@ mod tests {
         )
         .unwrap();
         assert!(resolve_current_generation(directory.path()).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn current_pointer_cannot_be_a_symlink() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("pointer-target.json");
+        write_synced_new(&target, b"{}").unwrap();
+        std::os::unix::fs::symlink(&target, directory.path().join(CURRENT_POINTER)).unwrap();
+
+        let error = resolve_current_generation(directory.path()).unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("not a regular file"), "{error}");
     }
 }

--- a/hermes-train/src/data.rs
+++ b/hermes-train/src/data.rs
@@ -5,9 +5,17 @@
 //! positions prevent EOS padding or prompts from contributing to supervised
 //! losses, while retrieval batches retain positive and hard-negative grouping.
 
+use std::ffi::{CString, OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Read, Seek, Write};
-use std::path::Path;
+use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 
 use anyhow::{Context, Result, ensure};
 use hermes_llm::Tokenizer;
@@ -15,6 +23,7 @@ use hermes_train::corpus::CorpusManifest;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
+use sha2::{Digest, Sha256};
 
 use crate::wake::ObjectiveConfig;
 
@@ -29,25 +38,588 @@ use structured::visit_structured_samples;
 
 const TOKENIZE_BATCH: usize = 1_000;
 const TOKEN_CACHE_MAGIC: &[u8; 8] = b"HERTOK01";
+// Fixed-size sidecar, rather than an in-band footer, keeps the append/repair
+// record format unchanged. Its final 32 bytes authenticate all preceding
+// metadata; the cache digest is also retained for full-scan identity checks.
+const TOKEN_CACHE_INDEX_MAGIC: &[u8; 8] = b"HERTIX01";
+const TOKEN_CACHE_INDEX_BYTES: usize = 144;
 const MAX_CACHED_DOCUMENT_TOKENS: usize = 100_000_000;
 
 struct TokenCacheWriter {
     writer: BufWriter<File>,
+    location: TokenCacheLocation,
+    digest: Sha256,
+    documents: u64,
+    stream_tokens: u64,
+    index_invalidated: bool,
 }
 
 impl TokenCacheWriter {
     fn append(&mut self, tokens: &[u32]) -> Result<()> {
-        let len = u32::try_from(tokens.len()).context("document is too large for token cache")?;
-        self.writer.write_all(&len.to_le_bytes())?;
-        for token in tokens {
-            self.writer.write_all(&token.to_le_bytes())?;
+        if !self.index_invalidated {
+            invalidate_token_cache_index(&self.location)?;
+            self.index_invalidated = true;
         }
+        let len = u32::try_from(tokens.len()).context("document is too large for token cache")?;
+        let len_bytes = len.to_le_bytes();
+        self.writer.write_all(&len_bytes)?;
+        self.digest.update(len_bytes);
+        for token in tokens {
+            let token_bytes = token.to_le_bytes();
+            self.writer.write_all(&token_bytes)?;
+            self.digest.update(token_bytes);
+        }
+        self.documents = self
+            .documents
+            .checked_add(1)
+            .context("token-cache document count overflows u64")?;
+        self.stream_tokens = self
+            .stream_tokens
+            .checked_add(u64::from(len) + 1)
+            .context("token-cache stream length overflows u64")?;
         Ok(())
     }
 
     fn flush(&mut self) -> Result<()> {
         self.writer.flush().context("failed to flush token cache")
     }
+
+    /// Durably mark this cache as a complete scan of its authoritative corpus.
+    /// Partial caches deliberately have no valid index and are replayed on the
+    /// next startup before an index can be published.
+    fn publish_index(&mut self) -> Result<()> {
+        self.flush()?;
+        self.writer
+            .get_ref()
+            .sync_all()
+            .context("failed to sync token cache")?;
+        let metadata = self.writer.get_ref().metadata()?;
+        let index = TokenCacheIndex {
+            identity: TokenCacheFileIdentity::from_metadata(&metadata),
+            documents: self.documents,
+            stream_tokens: self.stream_tokens,
+            cache_digest: self.digest.clone().finalize().into(),
+        };
+        index.validate_structure()?;
+
+        // A valid index for this exact cache incarnation is immutable. Avoid
+        // replacing it on every startup after the authoritative rescan.
+        if read_token_cache_index(&self.location, self.writer.get_ref())?.as_ref() == Some(&index) {
+            self.index_invalidated = false;
+            return Ok(());
+        }
+        write_token_cache_index_atomic(&self.location, &index.encode())?;
+        self.index_invalidated = false;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TokenCacheFileIdentity {
+    len: u64,
+    device: u64,
+    inode: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+    changed_seconds: i64,
+    changed_nanoseconds: i64,
+}
+
+impl TokenCacheFileIdentity {
+    #[cfg(unix)]
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        use std::os::unix::fs::MetadataExt;
+
+        Self {
+            len: metadata.len(),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+            changed_seconds: metadata.ctime(),
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        use std::time::UNIX_EPOCH;
+
+        let modified = metadata.modified().ok().and_then(|time| {
+            time.duration_since(UNIX_EPOCH).ok().and_then(|duration| {
+                i64::try_from(duration.as_secs())
+                    .ok()
+                    .map(|s| (s, duration))
+            })
+        });
+        Self {
+            len: metadata.len(),
+            device: 0,
+            inode: 0,
+            modified_seconds: modified.as_ref().map_or(0, |(seconds, _)| *seconds),
+            modified_nanoseconds: modified
+                .map_or(0, |(_, duration)| i64::from(duration.subsec_nanos())),
+            changed_seconds: 0,
+            changed_nanoseconds: 0,
+        }
+    }
+
+    /// Compare an index identity with an already-open cache handle when the
+    /// platform exposes a stable file incarnation. Portable `Metadata` only
+    /// guarantees length and timestamps; accepting those as an identity would
+    /// let a same-length replacement with a preserved timestamp reuse stale
+    /// counts. `None` therefore means the sidecar is only derived metadata and
+    /// the cache must be structurally replayed against its authoritative input.
+    fn matches_metadata(&self, metadata: &fs::Metadata) -> Option<bool> {
+        #[cfg(unix)]
+        {
+            Some(self == &Self::from_metadata(metadata))
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (self, metadata);
+            None
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TokenCacheIndex {
+    identity: TokenCacheFileIdentity,
+    documents: u64,
+    stream_tokens: u64,
+    cache_digest: [u8; 32],
+}
+
+impl TokenCacheIndex {
+    fn validate_structure(&self) -> Result<()> {
+        ensure!(
+            self.identity.len >= TOKEN_CACHE_MAGIC.len() as u64,
+            "indexed token cache is shorter than its header"
+        );
+        let record_bytes = self.identity.len - TOKEN_CACHE_MAGIC.len() as u64;
+        ensure!(
+            record_bytes.is_multiple_of(std::mem::size_of::<u32>() as u64),
+            "indexed token cache is not u32-aligned"
+        );
+        let stream_tokens = record_bytes / std::mem::size_of::<u32>() as u64;
+        ensure!(
+            self.stream_tokens == stream_tokens,
+            "token-cache index stream length does not match cache length"
+        );
+        ensure!(
+            self.documents <= self.stream_tokens,
+            "token-cache index has more documents than stream tokens"
+        );
+        Ok(())
+    }
+
+    fn encode(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(TOKEN_CACHE_INDEX_BYTES);
+        bytes.extend_from_slice(TOKEN_CACHE_INDEX_MAGIC);
+        bytes.extend_from_slice(&self.identity.len.to_le_bytes());
+        bytes.extend_from_slice(&self.identity.device.to_le_bytes());
+        bytes.extend_from_slice(&self.identity.inode.to_le_bytes());
+        bytes.extend_from_slice(&self.identity.modified_seconds.to_le_bytes());
+        bytes.extend_from_slice(&self.identity.modified_nanoseconds.to_le_bytes());
+        bytes.extend_from_slice(&self.identity.changed_seconds.to_le_bytes());
+        bytes.extend_from_slice(&self.identity.changed_nanoseconds.to_le_bytes());
+        bytes.extend_from_slice(&self.documents.to_le_bytes());
+        bytes.extend_from_slice(&self.stream_tokens.to_le_bytes());
+        bytes.extend_from_slice(&self.cache_digest);
+        let metadata_digest = Sha256::digest(&bytes);
+        bytes.extend_from_slice(&metadata_digest);
+        debug_assert_eq!(bytes.len(), TOKEN_CACHE_INDEX_BYTES);
+        bytes
+    }
+
+    fn decode(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() != TOKEN_CACHE_INDEX_BYTES
+            || &bytes[..TOKEN_CACHE_INDEX_MAGIC.len()] != TOKEN_CACHE_INDEX_MAGIC
+        {
+            return None;
+        }
+        let payload_end = TOKEN_CACHE_INDEX_BYTES - 32;
+        if Sha256::digest(&bytes[..payload_end]).as_slice() != &bytes[payload_end..] {
+            return None;
+        }
+        let mut offset = TOKEN_CACHE_INDEX_MAGIC.len();
+        let mut read_u64 = || {
+            let end = offset.checked_add(8)?;
+            let value = u64::from_le_bytes(bytes.get(offset..end)?.try_into().ok()?);
+            offset = end;
+            Some(value)
+        };
+        let len = read_u64()?;
+        let device = read_u64()?;
+        let inode = read_u64()?;
+        let modified_seconds = i64::from_le_bytes(read_u64()?.to_le_bytes());
+        let modified_nanoseconds = i64::from_le_bytes(read_u64()?.to_le_bytes());
+        let changed_seconds = i64::from_le_bytes(read_u64()?.to_le_bytes());
+        let changed_nanoseconds = i64::from_le_bytes(read_u64()?.to_le_bytes());
+        let documents = read_u64()?;
+        let stream_tokens = read_u64()?;
+        let digest_end = offset.checked_add(32)?;
+        let cache_digest = bytes.get(offset..digest_end)?.try_into().ok()?;
+        if digest_end != payload_end {
+            return None;
+        }
+        Some(Self {
+            identity: TokenCacheFileIdentity {
+                len,
+                device,
+                inode,
+                modified_seconds,
+                modified_nanoseconds,
+                changed_seconds,
+                changed_nanoseconds,
+            },
+            documents,
+            stream_tokens,
+            cache_digest,
+        })
+    }
+}
+
+#[cfg(test)]
+fn token_cache_index_path(cache_path: &Path) -> PathBuf {
+    let mut index_path = cache_path.as_os_str().to_os_string();
+    index_path.push(".index");
+    PathBuf::from(index_path)
+}
+
+/// An opened cache directory anchors all cache/index operations to one real
+/// directory object. On Unix, child operations use `openat`/`renameat`/
+/// `unlinkat`, so replacing `.token-cache` or a child with a symlink cannot
+/// redirect an already-running trainer outside its output directory.
+struct TokenCacheLocation {
+    #[cfg(unix)]
+    directory: File,
+    directory_path: PathBuf,
+    cache_name: OsString,
+    index_name: OsString,
+}
+
+impl TokenCacheLocation {
+    fn open(cache_path: &Path, create_directory: bool) -> Result<Option<Self>> {
+        let directory_path = cache_path.parent().unwrap_or_else(|| Path::new("."));
+        if create_directory {
+            fs::create_dir_all(directory_path).with_context(|| {
+                format!(
+                    "failed to create token-cache directory {}",
+                    directory_path.display()
+                )
+            })?;
+        }
+        let metadata = match fs::symlink_metadata(directory_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == ErrorKind::NotFound && !create_directory => {
+                return Ok(None);
+            }
+            Err(error) => return Err(error).context("failed to inspect token-cache directory"),
+        };
+        ensure!(
+            metadata.is_dir() && !metadata.file_type().is_symlink(),
+            "token-cache parent {} must be a real directory",
+            directory_path.display()
+        );
+
+        #[cfg(unix)]
+        let directory = {
+            use std::os::unix::fs::MetadataExt;
+
+            let file = OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW)
+                .open(directory_path)
+                .with_context(|| {
+                    format!(
+                        "failed to securely open token-cache directory {}",
+                        directory_path.display()
+                    )
+                })?;
+            let opened = file.metadata()?;
+            ensure!(
+                opened.dev() == metadata.dev() && opened.ino() == metadata.ino(),
+                "token-cache directory {} changed while it was opened",
+                directory_path.display()
+            );
+            file
+        };
+
+        let cache_name = cache_path
+            .file_name()
+            .context("token-cache path has no file name")?
+            .to_os_string();
+        let mut index_name = cache_name.clone();
+        index_name.push(".index");
+        Ok(Some(Self {
+            #[cfg(unix)]
+            directory,
+            directory_path: directory_path.to_owned(),
+            cache_name,
+            index_name,
+        }))
+    }
+
+    fn index_path(&self) -> PathBuf {
+        self.directory_path.join(&self.index_name)
+    }
+
+    #[cfg(unix)]
+    fn open_child(&self, name: &OsStr, flags: libc::c_int) -> Result<Option<File>> {
+        let name = CString::new(name.as_bytes()).context("token-cache name contains a NUL byte")?;
+        let descriptor = unsafe {
+            libc::openat(
+                self.directory.as_raw_fd(),
+                name.as_ptr(),
+                flags | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+                0o600,
+            )
+        };
+        if descriptor < 0 {
+            let error = std::io::Error::last_os_error();
+            if matches!(error.kind(), ErrorKind::NotFound | ErrorKind::AlreadyExists) {
+                return Ok(None);
+            }
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to securely open an entry in token-cache directory {}",
+                    self.directory_path.display()
+                )
+            });
+        }
+        let file = unsafe { File::from_raw_fd(descriptor) };
+        ensure!(
+            file.metadata()?.file_type().is_file(),
+            "token-cache entry is not a regular file"
+        );
+        Ok(Some(file))
+    }
+
+    fn open_cache(&self, create: bool) -> Result<Option<File>> {
+        #[cfg(unix)]
+        {
+            let mut flags = if create { libc::O_RDWR } else { libc::O_RDONLY };
+            if create {
+                flags |= libc::O_CREAT;
+            }
+            self.open_child(&self.cache_name, flags)
+        }
+        #[cfg(not(unix))]
+        {
+            self.open_child_portable(&self.cache_name, create, create)
+        }
+    }
+
+    fn open_index(&self) -> Result<Option<File>> {
+        #[cfg(unix)]
+        {
+            self.open_child(&self.index_name, libc::O_RDONLY)
+        }
+        #[cfg(not(unix))]
+        {
+            self.open_child_portable(&self.index_name, false, false)
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn open_child_portable(&self, name: &OsStr, create: bool, write: bool) -> Result<Option<File>> {
+        let path = self.directory_path.join(name);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) => ensure!(
+                metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+                "token-cache entry {} is not a regular file",
+                path.display()
+            ),
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+        let mut options = OpenOptions::new();
+        options.read(true).write(write).create(create);
+        match options.open(&path) {
+            Ok(file) => {
+                ensure!(file.metadata()?.file_type().is_file());
+                Ok(Some(file))
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound && !create => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn create_temporary(&self, name: &OsStr) -> Result<Option<File>> {
+        #[cfg(unix)]
+        {
+            self.open_child(name, libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL)
+        }
+        #[cfg(not(unix))]
+        {
+            let path = self.directory_path.join(name);
+            match OpenOptions::new().create_new(true).write(true).open(path) {
+                Ok(file) => Ok(Some(file)),
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => Ok(None),
+                Err(error) => Err(error.into()),
+            }
+        }
+    }
+
+    fn remove_child(&self, name: &OsStr) -> Result<bool> {
+        #[cfg(unix)]
+        {
+            let name =
+                CString::new(name.as_bytes()).context("token-cache name contains a NUL byte")?;
+            if unsafe { libc::unlinkat(self.directory.as_raw_fd(), name.as_ptr(), 0) } == 0 {
+                return Ok(true);
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() == ErrorKind::NotFound {
+                return Ok(false);
+            }
+            Err(error.into())
+        }
+        #[cfg(not(unix))]
+        {
+            match fs::remove_file(self.directory_path.join(name)) {
+                Ok(()) => Ok(true),
+                Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+                Err(error) => Err(error.into()),
+            }
+        }
+    }
+
+    fn rename_child(&self, from: &OsStr, to: &OsStr) -> Result<()> {
+        #[cfg(unix)]
+        {
+            let from =
+                CString::new(from.as_bytes()).context("token-cache name contains a NUL byte")?;
+            let to = CString::new(to.as_bytes()).context("token-cache name contains a NUL byte")?;
+            if unsafe {
+                libc::renameat(
+                    self.directory.as_raw_fd(),
+                    from.as_ptr(),
+                    self.directory.as_raw_fd(),
+                    to.as_ptr(),
+                )
+            } == 0
+            {
+                return Ok(());
+            }
+            Err(std::io::Error::last_os_error().into())
+        }
+        #[cfg(not(unix))]
+        {
+            fs::rename(self.directory_path.join(from), self.directory_path.join(to))?;
+            Ok(())
+        }
+    }
+
+    fn sync_directory(&self) -> Result<()> {
+        #[cfg(unix)]
+        self.directory.sync_all()?;
+        #[cfg(not(unix))]
+        File::open(&self.directory_path)?.sync_all()?;
+        Ok(())
+    }
+}
+
+enum TokenCacheIndexFile {
+    Missing,
+    Invalid,
+    Decoded(TokenCacheIndex),
+}
+
+fn decode_token_cache_index_file(location: &TokenCacheLocation) -> Result<TokenCacheIndexFile> {
+    let Some(file) = location.open_index()? else {
+        return Ok(TokenCacheIndexFile::Missing);
+    };
+    let mut bytes = Vec::with_capacity(TOKEN_CACHE_INDEX_BYTES + 1);
+    file.take((TOKEN_CACHE_INDEX_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    Ok(TokenCacheIndex::decode(&bytes)
+        .filter(|index| index.validate_structure().is_ok())
+        .map_or(TokenCacheIndexFile::Invalid, TokenCacheIndexFile::Decoded))
+}
+
+fn read_token_cache_index(
+    location: &TokenCacheLocation,
+    cache: &File,
+) -> Result<Option<TokenCacheIndex>> {
+    let TokenCacheIndexFile::Decoded(index) = decode_token_cache_index_file(location)? else {
+        return Ok(None);
+    };
+    let metadata = cache.metadata()?;
+    if !metadata.file_type().is_file() || index.identity.matches_metadata(&metadata) != Some(true) {
+        return Ok(None);
+    }
+    Ok(Some(index))
+}
+
+fn write_token_cache_index_atomic(location: &TokenCacheLocation, bytes: &[u8]) -> Result<()> {
+    let mut temporary = None;
+    for attempt in 0..1_024_u32 {
+        let mut name = location.index_name.clone();
+        name.push(format!(".tmp-{}-{attempt}", std::process::id()));
+        match location.create_temporary(&name)? {
+            Some(mut file) => {
+                if let Err(error) = (|| {
+                    file.write_all(bytes)?;
+                    file.sync_all()
+                })() {
+                    let _ = location.remove_child(&name);
+                    return Err(error).with_context(|| {
+                        format!(
+                            "failed to write token-cache index {}",
+                            location.index_path().display()
+                        )
+                    });
+                }
+                temporary = Some(name);
+                break;
+            }
+            None => continue,
+        }
+    }
+    let temporary = temporary.context("could not allocate a token-cache index temporary file")?;
+    if let Err(error) = location.rename_child(&temporary, &location.index_name) {
+        let _ = location.remove_child(&temporary);
+        return Err(error)
+            .with_context(|| format!("failed to publish {}", location.index_path().display()));
+    }
+    location.sync_directory()?;
+    Ok(())
+}
+
+fn invalidate_token_cache_index(location: &TokenCacheLocation) -> Result<()> {
+    if location.remove_child(&location.index_name)? {
+        location.sync_directory()?;
+    }
+    Ok(())
+}
+
+/// Return the causal sample count from a durably completed token cache without
+/// replaying its records. Missing, torn, stale, or corrupt metadata returns
+/// `None`, so callers can safely fall back to [`count_samples`].
+pub(crate) fn indexed_causal_sample_count(
+    token_cache: &Path,
+    seq_len: usize,
+) -> Result<Option<usize>> {
+    ensure!(seq_len > 0, "sequence_length must be positive");
+    let Some(location) = TokenCacheLocation::open(token_cache, false)? else {
+        return Ok(None);
+    };
+    let Some(cache) = location.open_cache(false)? else {
+        return Ok(None);
+    };
+    let Some(index) = read_token_cache_index(&location, &cache)? else {
+        return Ok(None);
+    };
+    let sequence_length = u64::try_from(seq_len).context("sequence_length exceeds u64")?;
+    let samples = if index.stream_tokens == 0 {
+        0
+    } else {
+        (index.stream_tokens - 1) / sequence_length
+    };
+    Ok(usize::try_from(samples).ok())
 }
 
 /// Replay complete cached documents and open an append-only writer at the
@@ -59,21 +631,48 @@ fn replay_token_cache(
     packer: &mut SamplePacker,
     count: &mut usize,
     visit: &mut impl FnMut(TrainingSample) -> Result<bool>,
-) -> Result<(usize, bool, Option<TokenCacheWriter>)> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let mut cache = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(path)
-        .with_context(|| format!("failed to open token cache {}", path.display()))?;
+) -> Result<(usize, bool, Option<TokenCacheWriter>, bool)> {
+    let location = TokenCacheLocation::open(path, true)?
+        .context("token-cache directory disappeared while it was opened")?;
+    let mut cache = location
+        .open_cache(true)?
+        .context("token-cache file was not created")?;
+    let mut expected_index = match decode_token_cache_index_file(&location)? {
+        TokenCacheIndexFile::Missing => None,
+        TokenCacheIndexFile::Invalid => {
+            // The sidecar is derived metadata and is atomically replaceable.
+            // Preserve a potentially multi-billion-token cache until its own
+            // record structure has been scanned; normal authoritative-corpus
+            // completion will then publish a fresh index.
+            invalidate_token_cache_index(&location)?;
+            None
+        }
+        TokenCacheIndexFile::Decoded(index) => {
+            match index.identity.matches_metadata(&cache.metadata()?) {
+                Some(true) => Some(index),
+                Some(false) => {
+                    // A completed cache changed without first invalidating its
+                    // sidecar. It is derived data, so discard it and rebuild from
+                    // the authoritative source rather than re-blessing payloads.
+                    invalidate_token_cache_index(&location)?;
+                    cache.set_len(0)?;
+                    None
+                }
+                None => {
+                    // This platform cannot prove that the path still names the
+                    // indexed file incarnation. Preserve the derived payload,
+                    // but require structural replay and an authoritative source
+                    // scan instead of treating the sidecar as completion proof.
+                    invalidate_token_cache_index(&location)?;
+                    None
+                }
+            }
+        }
+    };
     if cache.metadata()?.len() < TOKEN_CACHE_MAGIC.len() as u64 {
         cache.set_len(0)?;
         cache.write_all(TOKEN_CACHE_MAGIC)?;
-        cache.flush()?;
+        cache.sync_all()?;
     }
     cache.rewind()?;
 
@@ -87,6 +686,9 @@ fn replay_token_cache(
     );
     let mut valid_bytes = TOKEN_CACHE_MAGIC.len() as u64;
     let mut documents = 0usize;
+    let mut stream_tokens = 0_u64;
+    let mut digest = Sha256::new();
+    digest.update(TOKEN_CACHE_MAGIC);
     let mut torn_tail = false;
     loop {
         let mut len_bytes = [0_u8; 4];
@@ -126,28 +728,87 @@ fn replay_token_cache(
         documents = documents
             .checked_add(1)
             .context("cached document count overflows usize")?;
+        stream_tokens = stream_tokens
+            .checked_add(u64::from(len as u32) + 1)
+            .context("token-cache stream length overflows u64")?;
+        digest.update(len_bytes);
+        digest.update(&bytes);
         let tokens = bytes
             .chunks_exact(4)
             .map(|bytes| i64::from(u32::from_le_bytes(bytes.try_into().unwrap())))
             .chain(std::iter::once(i64::from(eos_token)));
         if !packer.push(tokens, count, visit)? {
-            return Ok((documents, false, None));
+            return Ok((documents, false, None, false));
         }
     }
-    drop(reader);
-    if torn_tail {
-        OpenOptions::new()
-            .write(true)
-            .open(path)?
-            .set_len(valid_bytes)?;
+    let mut cache = reader.into_inner();
+    let verified_complete = if let Some(expected) = expected_index.take() {
+        ensure!(
+            !torn_tail,
+            "completed token cache {} has a torn record",
+            path.display()
+        );
+        ensure!(
+            expected.documents == u64::try_from(documents)?,
+            "completed token cache {} document count changed",
+            path.display()
+        );
+        ensure!(
+            expected.stream_tokens == stream_tokens,
+            "completed token cache {} stream length changed",
+            path.display()
+        );
+        ensure!(
+            expected.cache_digest.as_slice() == digest.clone().finalize().as_slice(),
+            "completed token cache {} payload digest changed",
+            path.display()
+        );
+        ensure!(
+            expected.identity.matches_metadata(&cache.metadata()?) == Some(true),
+            "completed token cache {} changed while it was replayed",
+            path.display()
+        );
+        true
+    } else {
+        if torn_tail {
+            cache.set_len(valid_bytes)?;
+            cache.sync_all()?;
+        }
+        false
+    };
+    cache.seek(SeekFrom::End(0))?;
+    let writer = BufWriter::new(cache);
+    if verified_complete {
+        // No source scan or index rewrite is necessary for an immutable cache
+        // whose handle, record structure, counts, and digest all agree.
+        return Ok((
+            documents,
+            true,
+            Some(TokenCacheWriter {
+                writer,
+                location,
+                digest,
+                documents: u64::try_from(documents)
+                    .context("token-cache document count exceeds u64")?,
+                stream_tokens,
+                index_invalidated: false,
+            }),
+            true,
+        ));
     }
-    let writer = OpenOptions::new().append(true).open(path)?;
     Ok((
         documents,
         true,
         Some(TokenCacheWriter {
-            writer: BufWriter::new(writer),
+            writer,
+            location,
+            digest,
+            documents: u64::try_from(documents)
+                .context("token-cache document count exceeds u64")?,
+            stream_tokens,
+            index_invalidated: false,
         }),
+        false,
     ))
 }
 
@@ -358,7 +1019,7 @@ fn visit_causal_samples(
 ) -> Result<usize> {
     let mut count = 0;
     let mut packer = SamplePacker::new(seq_len);
-    let (cached_documents, keep_going, mut cache) = match token_cache {
+    let (cached_documents, keep_going, mut cache, cache_complete) = match token_cache {
         Some(path) => replay_token_cache(
             path,
             tokenizer.eos_token_id(),
@@ -366,7 +1027,7 @@ fn visit_causal_samples(
             &mut count,
             &mut visit,
         )?,
-        None => (0, true, None),
+        None => (0, true, None, false),
     };
     if cached_documents > 0
         && let Some(path) = token_cache
@@ -377,6 +1038,9 @@ fn visit_causal_samples(
         );
     }
     if !keep_going {
+        return Ok(count);
+    }
+    if cache_complete {
         return Ok(count);
     }
     let mut document_number = 0usize;
@@ -476,8 +1140,12 @@ fn visit_causal_samples(
     )? {
         return Ok(count);
     }
+    ensure!(
+        document_number >= cached_documents,
+        "authoritative corpus has {document_number} documents but token cache has {cached_documents}; remove the stale cache"
+    );
     if let Some(cache) = &mut cache {
-        cache.flush()?;
+        cache.publish_index()?;
     }
     Ok(count)
 }
@@ -679,7 +1347,7 @@ mod tests {
         let mut packer = SamplePacker::new(3);
         let mut samples = Vec::new();
         let mut count = 0;
-        let (documents, keep_going, mut writer) =
+        let (documents, keep_going, mut writer, _) =
             replay_token_cache(&path, 0, &mut packer, &mut count, &mut |sample| {
                 samples.push(sample);
                 Ok(true)
@@ -699,11 +1367,276 @@ mod tests {
         drop(writer);
         let mut replay = SamplePacker::new(3);
         let mut replay_count = 0;
-        let (documents, _, _) =
+        let (documents, _, _, _) =
             replay_token_cache(&path, 0, &mut replay, &mut replay_count, &mut |_| Ok(true))
                 .unwrap();
         assert_eq!(documents, 3);
         assert_eq!(replay_count, 2);
+    }
+
+    fn write_test_token_cache(path: &Path, documents: &[&[u32]], complete: bool) {
+        let mut packer = SamplePacker::new(4);
+        let mut count = 0;
+        let (_, keep_going, mut writer, _) =
+            replay_token_cache(path, 0, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
+        assert!(keep_going);
+        let writer = writer.as_mut().unwrap();
+        for document in documents {
+            writer.append(document).unwrap();
+        }
+        if complete {
+            writer.publish_index().unwrap();
+        } else {
+            writer.flush().unwrap();
+        }
+    }
+
+    #[test]
+    fn completed_token_cache_index_counts_packed_samples_in_constant_time() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        write_test_token_cache(&path, &[&[1, 2], &[], &[3, 4, 5]], true);
+
+        // Eight joined stream tokens: two/zero/three document tokens plus an
+        // EOS token for each document. Packing advances by `seq_len` while
+        // retaining one next-token label.
+        for (seq_len, expected) in [(1, 7), (2, 3), (3, 2), (4, 1), (7, 1), (8, 0), (64, 0)] {
+            assert_eq!(
+                indexed_causal_sample_count(&path, seq_len).unwrap(),
+                Some(expected),
+                "sequence length {seq_len}"
+            );
+        }
+
+        let mut packer = SamplePacker::new(4);
+        let mut replayed = 0;
+        let (_, _, _, complete) =
+            replay_token_cache(&path, 0, &mut packer, &mut replayed, &mut |_| Ok(true)).unwrap();
+        assert!(complete, "verified caches must not require a source rescan");
+        assert_eq!(replayed, 1);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn portable_metadata_never_fast_trusts_a_completed_cache_sidecar() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        write_test_token_cache(&path, &[&[1, 2], &[3, 4]], true);
+        let cache_bytes = fs::read(&path).unwrap();
+
+        // Portable std::fs::Metadata has no stable file-incarnation identity.
+        // The constant-time path must therefore fail closed even for a sidecar
+        // written by this process.
+        assert_eq!(indexed_causal_sample_count(&path, 3).unwrap(), None);
+
+        let mut packer = SamplePacker::new(3);
+        let mut count = 0;
+        let (documents, keep_going, _, complete) =
+            replay_token_cache(&path, 0, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
+        assert_eq!(documents, 2);
+        assert_eq!(count, 1);
+        assert!(keep_going);
+        assert!(!complete, "portable metadata is not completion proof");
+        assert_eq!(fs::read(&path).unwrap(), cache_bytes);
+        assert!(!token_cache_index_path(&path).exists());
+    }
+
+    #[test]
+    fn torn_or_corrupt_token_cache_index_falls_back_to_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        write_test_token_cache(&path, &[&[1, 2], &[3, 4]], true);
+        let index_path = token_cache_index_path(&path);
+        let valid_index = fs::read(&index_path).unwrap();
+
+        fs::write(&index_path, &valid_index[..valid_index.len() / 2]).unwrap();
+        assert_eq!(indexed_causal_sample_count(&path, 3).unwrap(), None);
+
+        let mut corrupt_index = valid_index.clone();
+        corrupt_index[80] ^= 0x80;
+        fs::write(&index_path, corrupt_index).unwrap();
+        assert_eq!(indexed_causal_sample_count(&path, 3).unwrap(), None);
+    }
+
+    #[test]
+    fn torn_index_reindexes_intact_cache_without_retokenizing_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        write_test_token_cache(&path, &[&[1, 2], &[3, 4]], true);
+        let cache_bytes = fs::read(&path).unwrap();
+        let index_path = token_cache_index_path(&path);
+        let index_bytes = fs::read(&index_path).unwrap();
+        fs::write(&index_path, &index_bytes[..17]).unwrap();
+
+        let mut packer = SamplePacker::new(3);
+        let mut count = 0;
+        let mut samples = Vec::new();
+        let (documents, keep_going, mut writer, complete) =
+            replay_token_cache(&path, 0, &mut packer, &mut count, &mut |sample| {
+                samples.push(sample);
+                Ok(true)
+            })
+            .unwrap();
+        assert_eq!(documents, 2);
+        assert_eq!(count, 1);
+        assert_eq!(samples.len(), 1);
+        assert!(keep_going);
+        assert!(!complete, "invalid metadata is not a completion proof");
+        assert_eq!(fs::read(&path).unwrap(), cache_bytes);
+        assert!(!index_path.exists());
+
+        // Production publishes here only after the authoritative source scan
+        // confirms document coverage. Exercise the same post-scan operation.
+        writer.as_mut().unwrap().publish_index().unwrap();
+        drop(writer);
+        assert_eq!(fs::read(&path).unwrap(), cache_bytes);
+        assert_eq!(indexed_causal_sample_count(&path, 3).unwrap(), Some(1));
+    }
+
+    #[test]
+    fn incomplete_or_changed_token_cache_never_uses_stale_index() {
+        let dir = tempfile::tempdir().unwrap();
+        let incomplete = dir.path().join("incomplete.bin");
+        write_test_token_cache(&incomplete, &[&[1, 2]], false);
+        assert!(!token_cache_index_path(&incomplete).exists());
+        assert_eq!(indexed_causal_sample_count(&incomplete, 2).unwrap(), None);
+
+        let changed = dir.path().join("changed.bin");
+        write_test_token_cache(&changed, &[&[1, 2]], true);
+        assert_eq!(indexed_causal_sample_count(&changed, 2).unwrap(), Some(1));
+        let mut packer = SamplePacker::new(2);
+        let mut count = 0;
+        let (_, _, mut writer, _) =
+            replay_token_cache(&changed, 0, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
+        writer.as_mut().unwrap().append(&[]).unwrap();
+        assert!(!token_cache_index_path(&changed).exists());
+        assert_eq!(indexed_causal_sample_count(&changed, 2).unwrap(), None);
+    }
+
+    #[test]
+    fn changed_completed_cache_is_discarded_instead_of_reblessed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        write_test_token_cache(&path, &[&[1, 2], &[3, 4]], true);
+
+        let mut cache = OpenOptions::new().write(true).open(&path).unwrap();
+        cache.seek(SeekFrom::Start(12)).unwrap();
+        cache.write_all(&99_u32.to_le_bytes()).unwrap();
+        cache.sync_all().unwrap();
+        assert_eq!(indexed_causal_sample_count(&path, 3).unwrap(), None);
+
+        let mut packer = SamplePacker::new(3);
+        let mut count = 0;
+        let (documents, _, _, complete) =
+            replay_token_cache(&path, 0, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
+        assert_eq!(documents, 0);
+        assert_eq!(count, 0);
+        assert!(!complete);
+        assert_eq!(
+            fs::metadata(&path).unwrap().len(),
+            TOKEN_CACHE_MAGIC.len() as u64
+        );
+        assert!(!token_cache_index_path(&path).exists());
+    }
+
+    #[test]
+    fn completed_cache_digest_is_checked_during_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        write_test_token_cache(&path, &[&[1, 2], &[3, 4]], true);
+
+        let mut cache = OpenOptions::new().write(true).open(&path).unwrap();
+        cache.seek(SeekFrom::Start(12)).unwrap();
+        cache.write_all(&99_u32.to_le_bytes()).unwrap();
+        cache.sync_all().unwrap();
+        let location = TokenCacheLocation::open(&path, false).unwrap().unwrap();
+        let opened_cache = location.open_cache(false).unwrap().unwrap();
+        let TokenCacheIndexFile::Decoded(mut index) =
+            decode_token_cache_index_file(&location).unwrap()
+        else {
+            panic!("expected decoded index")
+        };
+        // Simulate structurally valid metadata for the new file identity while
+        // retaining the original payload digest.
+        index.identity = TokenCacheFileIdentity::from_metadata(&opened_cache.metadata().unwrap());
+        write_token_cache_index_atomic(&location, &index.encode()).unwrap();
+        drop(opened_cache);
+        drop(location);
+
+        let mut packer = SamplePacker::new(3);
+        let mut count = 0;
+        let error = replay_token_cache(&path, 0, &mut packer, &mut count, &mut |_| Ok(true))
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(error.contains("payload digest changed"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn token_cache_rejects_symlink_entries_without_touching_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_root = dir.path().join("cache");
+        fs::create_dir(&cache_root).unwrap();
+        let victim = dir.path().join("victim");
+        fs::write(&victim, b"do not touch").unwrap();
+        let cache_path = cache_root.join("tokens.bin");
+        std::os::unix::fs::symlink(&victim, &cache_path).unwrap();
+
+        let mut packer = SamplePacker::new(3);
+        let mut count = 0;
+        assert!(
+            replay_token_cache(&cache_path, 0, &mut packer, &mut count, &mut |_| Ok(true)).is_err()
+        );
+        assert_eq!(fs::read(&victim).unwrap(), b"do not touch");
+
+        fs::remove_file(&cache_path).unwrap();
+        write_test_token_cache(&cache_path, &[&[1, 2]], false);
+        let index_victim = dir.path().join("index-victim");
+        fs::write(&index_victim, b"also do not touch").unwrap();
+        std::os::unix::fs::symlink(&index_victim, token_cache_index_path(&cache_path)).unwrap();
+        assert!(indexed_causal_sample_count(&cache_path, 3).is_err());
+        assert_eq!(fs::read(&index_victim).unwrap(), b"also do not touch");
+
+        let linked_root = dir.path().join("linked-cache-root");
+        std::os::unix::fs::symlink(&cache_root, &linked_root).unwrap();
+        let mut linked_packer = SamplePacker::new(3);
+        let mut linked_count = 0;
+        assert!(
+            replay_token_cache(
+                &linked_root.join("other.tokens"),
+                0,
+                &mut linked_packer,
+                &mut linked_count,
+                &mut |_| Ok(true),
+            )
+            .is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_token_cache_directory_cannot_be_redirected_by_symlink_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = dir.path().join("cache");
+        let moved = dir.path().join("moved-cache");
+        let outside = dir.path().join("outside");
+        fs::create_dir(&original).unwrap();
+        fs::create_dir(&outside).unwrap();
+        let path = original.join("tokens.bin");
+        let location = TokenCacheLocation::open(&path, false).unwrap().unwrap();
+
+        fs::rename(&original, &moved).unwrap();
+        std::os::unix::fs::symlink(&outside, &original).unwrap();
+        let mut cache = location.open_cache(true).unwrap().unwrap();
+        cache.write_all(TOKEN_CACHE_MAGIC).unwrap();
+        cache.sync_all().unwrap();
+
+        assert_eq!(
+            fs::read(moved.join("tokens.bin")).unwrap(),
+            TOKEN_CACHE_MAGIC
+        );
+        assert!(!outside.join("tokens.bin").exists());
     }
 
     #[test]
@@ -714,7 +1647,7 @@ mod tests {
         let mut count = 0;
         let mut visit = |_| Ok(true);
 
-        let (documents, keep_going, writer) =
+        let (documents, keep_going, writer, _) =
             replay_token_cache(&path, 0, &mut packer, &mut count, &mut visit).unwrap();
 
         assert_eq!(documents, 0);

--- a/hermes-train/src/device_sampler.rs
+++ b/hermes-train/src/device_sampler.rs
@@ -643,7 +643,11 @@ mod tests {
         let started = Instant::now();
         let mut sampler =
             NvidiaSmiSampler::start_with_program(config, program.as_os_str()).unwrap();
-        let deadline = Instant::now() + Duration::from_secs(2);
+        // Full workspace runs exercise several CPU-heavy index tests in
+        // parallel. Allow scheduler contention without weakening the hang
+        // check: the deliberately stuck helper sleeps for 30 seconds.
+        let timeout = Duration::from_secs(5);
+        let deadline = Instant::now() + timeout;
         loop {
             let drain = sampler.drain();
             if drain.diagnostics.iter().any(|diagnostic| {
@@ -658,7 +662,7 @@ mod tests {
             thread::sleep(Duration::from_millis(10));
         }
         drop(sampler);
-        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(started.elapsed() < timeout);
     }
 
     #[cfg(unix)]

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -35,7 +35,8 @@ use hermes_train::device_sampler::{
 use hermes_train::metrics::{
     MetricContext, MetricEvent, MetricPhase, MetricPhaseKind, MetricWriter, OptimizationMetrics,
     PhaseBoundary, PhaseTimingMetrics, QuantizationFormat as MetricQuantizationFormat,
-    QuantizationMetrics, QuantizationStage, ThroughputMetrics,
+    QuantizationMetrics, QuantizationStage, ThroughputMetrics, validate_metric_prefix_for_run,
+    validate_metric_snapshot_for_run,
 };
 use hermes_train::native_sleep::{
     NativeSleepCheckpoint, NativeSleepContextRegistry, NativeSleepPhaseExecutor,
@@ -72,11 +73,13 @@ use checkpoint::{
     AdamWOptimizer, ArtifactRef, CheckpointPublication, OptimizerStateRef,
     QuantizationTrainingState, RngStreamState, TRAINING_STATE_VERSION, TrainingState,
     load_training_state, parameter_ids, save_training_checkpoint_with_evidence,
+    verify_checkpoint_generation, verify_checkpoint_root,
 };
 #[cfg(test)]
 use data::TrainingSample;
 use data::{
-    BatchStats, SampleStreamConfig, TrainingBatch, count_samples, make_batch, visit_samples,
+    BatchStats, SampleStreamConfig, TrainingBatch, count_samples, indexed_causal_sample_count,
+    make_batch, visit_samples,
 };
 use muon::BatchedMuon;
 use wake::{ObjectiveConfig, ResolvedWakePlan, load_wake_plan};
@@ -101,6 +104,8 @@ enum Command {
     Train(TrainArgs),
     /// Validate and resolve a strict WorkflowV2 file.
     ValidateWorkflow(ValidateWorkflowArgs),
+    /// Verify an exact-resume checkpoint with the trainer's strict schema.
+    VerifyCheckpoint(VerifyCheckpointArgs),
     /// Build an immutable corpus using configured search and record adapters.
     PrepareCorpus(PrepareCorpusArgs),
     /// Compose classified corpus rows into fixed, stratified curriculum stages.
@@ -205,6 +210,38 @@ struct ValidateWorkflowArgs {
     /// runtime, without creating or advancing runtime state.
     #[arg(long)]
     signature_only: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum CheckpointVerificationFormat {
+    Json,
+    Tsv,
+}
+
+#[derive(clap::Args)]
+struct VerifyCheckpointArgs {
+    /// Checkpoint output root containing current.json and generations/.
+    #[arg(long, conflicts_with = "generation")]
+    root: Option<PathBuf>,
+    /// A materialized immutable generation directory.
+    #[arg(long, conflicts_with = "root")]
+    generation: Option<PathBuf>,
+    /// Content-addressed sha256-... generation name.
+    #[arg(long, requires = "generation")]
+    generation_name: Option<String>,
+    /// Lowercase SHA-256 of generation-manifest.json.
+    #[arg(long, requires = "generation")]
+    manifest_sha256: Option<String>,
+    /// Metric journal whose committed checkpoint prefix must be valid.
+    #[arg(long)]
+    metrics: Option<PathBuf>,
+    /// Require the metric file to end exactly at the committed prefix.
+    #[arg(long, requires = "metrics")]
+    exact_metrics: bool,
+    /// Stable output for automation. TSV fields are step, generation,
+    /// manifest digest, and committed metric records.
+    #[arg(long, value_enum, default_value_t = CheckpointVerificationFormat::Json)]
+    format: CheckpointVerificationFormat,
 }
 
 #[derive(clap::Args)]
@@ -688,23 +725,52 @@ struct PhasePlan {
     steps: usize,
 }
 
+fn planned_sample_count(
+    data: &Path,
+    objective: &ObjectiveConfig,
+    tokenizer: &Tokenizer,
+    sequence_length: usize,
+    token_cache: &Path,
+) -> Result<usize> {
+    if matches!(objective, ObjectiveConfig::CausalLm)
+        && let Some(samples) = indexed_causal_sample_count(token_cache, sequence_length)?
+    {
+        println!(
+            "token_cache={} indexed_samples={samples}",
+            token_cache.display()
+        );
+        return Ok(samples);
+    }
+    count_samples(
+        data,
+        objective,
+        tokenizer,
+        sequence_length,
+        Some(token_cache),
+    )
+}
+
 fn plan_training(
     workflow: &ResolvedWakePlan,
     tokenizer: &Tokenizer,
-    token_cache_root: &Path,
+    token_cache_paths: &[PathBuf],
 ) -> Result<(Vec<PhasePlan>, usize)> {
+    ensure!(
+        token_cache_paths.len() == workflow.phases.len(),
+        "every workflow phase must have one resolved token-cache path"
+    );
     let mut total_steps = 0usize;
     let mut plan = Vec::with_capacity(workflow.phases.len());
     for (phase_index, phase) in workflow.phases.iter().enumerate() {
         let (samples, steps) = match phase.steps {
             Some(steps) => (None, steps),
             None => {
-                let samples = count_samples(
+                let samples = planned_sample_count(
                     &phase.data,
                     &phase.objective,
                     tokenizer,
                     phase.sequence_length,
-                    Some(&token_cache_root.join(format!("phase-{phase_index:03}.tokens"))),
+                    &token_cache_paths[phase_index],
                 )?;
                 let steps_per_epoch =
                     (samples / phase.batch_size).div_euclid(phase.gradient_accumulation);
@@ -763,6 +829,26 @@ fn file_sha256(path: &Path) -> Result<String> {
 
 fn stable_cache_id(value: &str) -> String {
     format!("{:016x}", fnv1a64(value.as_bytes()))
+}
+
+#[derive(Serialize)]
+struct TokenCacheIdentity<'a> {
+    /// Bump whenever the document-token cache encoding or replay semantics
+    /// change. This prevents a new trainer from interpreting an old cache.
+    version: u32,
+    data: &'a str,
+    source: &'a Path,
+    tokenizer: &'a str,
+}
+
+fn token_cache_path(root: &Path, data: &str, source: &Path, tokenizer: &str) -> Result<PathBuf> {
+    let identity = serde_json::to_vec(&TokenCacheIdentity {
+        version: 1,
+        data,
+        source,
+        tokenizer,
+    })?;
+    Ok(root.join(format!("{:x}.tokens", Sha256::digest(identity))))
 }
 
 fn shuffle_seed(seed: u64, phase: usize, epoch: usize) -> u64 {
@@ -1282,6 +1368,66 @@ fn validate_workflow_command(args: ValidateWorkflowArgs) -> Result<()> {
     Ok(())
 }
 
+fn verify_checkpoint_command(args: VerifyCheckpointArgs) -> Result<()> {
+    let verified = match (
+        args.root,
+        args.generation,
+        args.generation_name,
+        args.manifest_sha256,
+    ) {
+        (Some(root), None, None, None) => verify_checkpoint_root(&root)?,
+        (None, Some(generation), Some(name), Some(manifest_sha256)) => {
+            verify_checkpoint_generation(&generation, &name, &manifest_sha256)?
+        }
+        (None, Some(_), _, _) => {
+            bail!("--generation requires both --generation-name and --manifest-sha256")
+        }
+        _ => bail!(
+            "provide either --root, or --generation with --generation-name and --manifest-sha256"
+        ),
+    };
+    if let Some(metrics) = args.metrics {
+        validate_checkpoint_metrics(&verified, metrics, args.exact_metrics)?;
+    }
+    match args.format {
+        CheckpointVerificationFormat::Json => {
+            println!("{}", serde_json::to_string(&verified)?);
+        }
+        CheckpointVerificationFormat::Tsv => println!(
+            "{}\t{}\t{}\t{}",
+            verified.global_step,
+            verified.generation,
+            verified.manifest_sha256,
+            verified.metric_records
+        ),
+    }
+    Ok(())
+}
+
+fn validate_checkpoint_metrics(
+    verified: &checkpoint::VerifiedCheckpoint,
+    metrics: impl AsRef<Path>,
+    exact: bool,
+) -> Result<()> {
+    let expected_run_id = stable_cache_id(&verified.workflow_signature);
+    if exact {
+        validate_metric_snapshot_for_run(
+            metrics,
+            &expected_run_id,
+            verified.metric_records,
+            verified.global_step as u64,
+        )?;
+    } else {
+        validate_metric_prefix_for_run(
+            metrics,
+            &expected_run_id,
+            verified.metric_records,
+            verified.global_step as u64,
+        )?;
+    }
+    Ok(())
+}
+
 fn prepare_corpus_command(args: PrepareCorpusArgs) -> Result<()> {
     let recipe = SearchApiPostgresCorpusRecipe::load(&args.recipe)?;
     let tokenizer = Tokenizer::from_file(&args.tokenizer)?;
@@ -1652,6 +1798,7 @@ fn main() -> Result<()> {
     match Cli::parse().command {
         Command::Train(args) => trainer::train(args),
         Command::ValidateWorkflow(args) => validate_workflow_command(args),
+        Command::VerifyCheckpoint(args) => verify_checkpoint_command(args),
         Command::PrepareCorpus(args) => prepare_corpus_command(args),
         Command::ComposeCurriculum(args) => compose_curriculum_command(args),
         Command::Quantize(args) => quantize_command(args),
@@ -1670,6 +1817,55 @@ mod tests {
     use hermes_llm::get_builtin_model;
 
     use super::*;
+
+    #[cfg(unix)]
+    struct GenerationSwapGuard {
+        original: PathBuf,
+        replacement: PathBuf,
+        parked_original: PathBuf,
+        active: bool,
+    }
+
+    #[cfg(unix)]
+    impl GenerationSwapGuard {
+        fn new(original: PathBuf, replacement: PathBuf) -> Self {
+            let parked_original =
+                original.with_extension(format!("resume-aba-{}", std::process::id()));
+            Self {
+                original,
+                replacement,
+                parked_original,
+                active: false,
+            }
+        }
+
+        fn swap(&mut self) -> Result<()> {
+            fs::rename(&self.original, &self.parked_original)?;
+            if let Err(error) = fs::rename(&self.replacement, &self.original) {
+                let _ = fs::rename(&self.parked_original, &self.original);
+                return Err(error.into());
+            }
+            self.active = true;
+            Ok(())
+        }
+
+        fn restore(&mut self) -> Result<()> {
+            if !self.active {
+                return Ok(());
+            }
+            fs::rename(&self.original, &self.replacement)?;
+            fs::rename(&self.parked_original, &self.original)?;
+            self.active = false;
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for GenerationSwapGuard {
+        fn drop(&mut self) {
+            let _ = self.restore();
+        }
+    }
 
     #[test]
     fn quantization_teacher_disables_every_dropout_without_mutating_student() {
@@ -2481,6 +2677,88 @@ mod tests {
             file_sha256(&path).unwrap(),
             "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         );
+
+        let cache_root = dir.path().join("cache");
+        let source = Path::new("corpus.jsonl.zst");
+        let first =
+            token_cache_path(&cache_root, "sha256:data", source, "sha256:tokenizer").unwrap();
+        assert_eq!(
+            first,
+            token_cache_path(&cache_root, "sha256:data", source, "sha256:tokenizer").unwrap()
+        );
+        assert_ne!(
+            first,
+            token_cache_path(&cache_root, "sha256:other-data", source, "sha256:tokenizer").unwrap()
+        );
+        assert_ne!(
+            first,
+            token_cache_path(&cache_root, "sha256:data", source, "sha256:other-tokenizer").unwrap()
+        );
+        assert_ne!(
+            first,
+            token_cache_path(
+                &cache_root,
+                "sha256:data",
+                Path::new("corpus.txt.zst"),
+                "sha256:tokenizer"
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            first.extension().and_then(|value| value.to_str()),
+            Some("tokens")
+        );
+    }
+
+    #[test]
+    fn checkpoint_metric_verification_rejects_a_swapped_run() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        let mut writer = MetricWriter::create(&path, "different-run").unwrap();
+        writer
+            .append_at(
+                MetricContext {
+                    global_step: 7,
+                    phase: MetricPhase {
+                        index: 0,
+                        name: "pretrain".into(),
+                        kind: MetricPhaseKind::Pretrain,
+                    },
+                    checkpoint_hash: None,
+                },
+                MetricEvent::Throughput(ThroughputMetrics {
+                    optimizer_steps: 1,
+                    compute_tokens: 8,
+                    supervised_tokens: 8,
+                    examples: 1,
+                    elapsed_seconds: 1.0,
+                    tokens_per_second: 8.0,
+                    examples_per_second: 1.0,
+                    input_wait_seconds: 0.0,
+                    host_to_device_seconds: 0.0,
+                    gpu_busy_seconds: 1.0,
+                }),
+                1,
+            )
+            .unwrap();
+        writer.sync_all().unwrap();
+        drop(writer);
+
+        let workflow_signature = format!("sha256:{}", "0".repeat(64));
+        let verified = checkpoint::VerifiedCheckpoint {
+            version: 1,
+            generation: format!("sha256-{}", "1".repeat(64)),
+            manifest_sha256: "1".repeat(64),
+            global_step: 7,
+            metric_records: 1,
+            workflow_signature,
+        };
+        let error = validate_checkpoint_metrics(&verified, &path, false).unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("run_id"), "{error}");
+        let error = validate_checkpoint_metrics(&verified, &path, true).unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("run_id"), "{error}");
     }
 
     #[test]
@@ -2786,5 +3064,243 @@ mod tests {
             .map(|(a, b)| (a - b).abs())
             .fold(0.0, f32::max);
         assert!(max_diff < 1e-6, "checkpoint max diff: {max_diff}");
+
+        #[cfg(unix)]
+        {
+            let current_pointer = dir.path().join("current.json");
+            let pointer_a = fs::read(&current_pointer).unwrap();
+            let generation_a = publication
+                .checkpoint_manifest
+                .parent()
+                .unwrap()
+                .to_path_buf();
+            let weights_a = fs::read(generation_a.join("weights.safetensors")).unwrap();
+            let muon_a = fs::read(generation_a.join("muon-state.bpk")).unwrap();
+            let adamw_a = fs::read(generation_a.join("adamw-state.bpk")).unwrap();
+
+            metrics
+                .append_at(
+                    MetricContext {
+                        global_step: 21,
+                        phase: MetricPhase {
+                            index: 1,
+                            name: "sft".into(),
+                            kind: MetricPhaseKind::Sft,
+                        },
+                        checkpoint_hash: None,
+                    },
+                    MetricEvent::Throughput(ThroughputMetrics {
+                        optimizer_steps: 1,
+                        compute_tokens: 640,
+                        supervised_tokens: 640,
+                        examples: 32,
+                        elapsed_seconds: 0.1,
+                        tokens_per_second: 6_400.0,
+                        examples_per_second: 320.0,
+                        input_wait_seconds: 0.005,
+                        host_to_device_seconds: 0.002,
+                        gpu_busy_seconds: 0.09,
+                    }),
+                    2,
+                )
+                .unwrap();
+            let mut state_b = state.clone();
+            state_b.global_step = 21;
+            state_b.records_in_phase = 672;
+            state_b.steps_in_phase = 11;
+            state_b.tokens_seen = 13_440;
+            state_b.metric_records = 2;
+            state_b.optimizer_states[0].update_clock = 21;
+            for stream in &mut state_b.rng_streams {
+                match stream.name.as_str() {
+                    DATA_RNG_STREAM => stream.counter = 672,
+                    MODEL_RNG_STREAM => stream.counter = 21,
+                    _ => {}
+                }
+            }
+            let publication_b = save_training_checkpoint_with_evidence(
+                &model,
+                &adamw_optimizer,
+                &muon_optimizer,
+                &state_b,
+                &mut metrics,
+                dir.path(),
+            )
+            .unwrap();
+            let generation_b = publication_b
+                .checkpoint_manifest
+                .parent()
+                .unwrap()
+                .to_path_buf();
+            let weights_b = fs::read(generation_b.join("weights.safetensors")).unwrap();
+            let muon_b = fs::read(generation_b.join("muon-state.bpk")).unwrap();
+            let adamw_b = fs::read(generation_b.join("adamw-state.bpk")).unwrap();
+            assert_ne!(
+                weights_a, weights_b,
+                "ABA generations need distinct weights"
+            );
+            assert_ne!(muon_a, muon_b, "ABA generations need distinct Muon state");
+            assert_ne!(
+                adamw_a, adamw_b,
+                "ABA generations need distinct AdamW state"
+            );
+
+            // Point at A, authenticate it, replace its pathname with the valid
+            // same-topology generation B, then restore A before the final
+            // pointer check. Path-based loaders accept this ABA sequence; the
+            // retained generation handle must still load only A's bytes.
+            fs::write(&current_pointer, &pointer_a).unwrap();
+            let mut aba_model = Transformer::new(&config, &device).unwrap();
+            let mut aba_muon = BatchedMuon::new(aba_model.muon_parameter_ids());
+            let aba_adamw = AdamWConfig::new()
+                .with_beta_2(0.95)
+                .with_epsilon(1e-8)
+                .with_weight_decay(0.0)
+                .init();
+            let mut swap = GenerationSwapGuard::new(generation_a.clone(), generation_b);
+            let (aba_adamw, aba_state) = checkpoint::load_training_state_with_hook(
+                &mut aba_model,
+                aba_adamw,
+                &mut aba_muon,
+                dir.path(),
+                &device,
+                |stage, _| match stage {
+                    checkpoint::ResumeLoadStage::AfterInitialVerify => swap.swap(),
+                    checkpoint::ResumeLoadStage::AfterStagedLoad => swap.restore(),
+                },
+            )
+            .unwrap();
+            assert_eq!(aba_state.global_step, state.global_step);
+
+            let aba_artifacts = tempfile::tempdir().unwrap();
+            let loaded_weights = aba_artifacts.path().join("weights.safetensors");
+            let loaded_muon = aba_artifacts.path().join("muon-state.bpk");
+            save_safetensors(&aba_model, &loaded_weights).unwrap();
+            aba_muon.save(&loaded_muon).unwrap();
+            let loaded_adamw =
+                hermes_train::optimizer_artifact::canonical_module_optimizer_bytes(&aba_adamw)
+                    .unwrap();
+            assert_eq!(fs::read(loaded_weights).unwrap(), weights_a);
+            assert_eq!(fs::read(loaded_muon).unwrap(), muon_a);
+            assert_eq!(&*loaded_adamw, adamw_a.as_slice());
+
+            let malformed_generation =
+                checkpoint::rewrite_current_generation_for_test(dir.path(), |staging| {
+                    let path = staging.join("adamw-state.bpk");
+                    let reader = burn_pack::Reader::from_file(&path)?;
+                    let metadata = reader.metadata().clone();
+                    let scalars = reader.scalars().clone();
+                    let mut tensors = reader.into_tensors()?;
+                    ensure!(
+                        tensors.len() > 1,
+                        "one-step AdamW fixture has too little state"
+                    );
+                    tensors.remove(0);
+                    let mut writer = burn_pack::Writer::new(tensors);
+                    for (key, value) in scalars {
+                        writer = writer.with_scalar(&key, value);
+                    }
+                    for (key, value) in metadata {
+                        writer = writer.with_metadata(&key, &value);
+                    }
+                    let replacement = staging.join("adamw-state-malformed.tmp");
+                    writer.write_to_file(&replacement)?;
+                    fs::rename(replacement, path)?;
+                    Ok(())
+                })
+                .unwrap();
+            assert_ne!(malformed_generation, generation_a);
+            verify_checkpoint_root(dir.path()).unwrap();
+
+            let mut rejected_model = aba_model.clone();
+            let mut rejected_muon = aba_muon.clone();
+            let rejected_artifacts = tempfile::tempdir().unwrap();
+            let rejected_model_before = rejected_artifacts.path().join("model-before.safetensors");
+            let rejected_model_after = rejected_artifacts.path().join("model-after.safetensors");
+            let rejected_muon_before = rejected_artifacts.path().join("muon-before.bpk");
+            let rejected_muon_after = rejected_artifacts.path().join("muon-after.bpk");
+            save_safetensors(&rejected_model, &rejected_model_before).unwrap();
+            rejected_muon.save(&rejected_muon_before).unwrap();
+            let rejected_adamw = AdamWConfig::new()
+                .with_beta_2(0.95)
+                .with_epsilon(1e-8)
+                .with_weight_decay(0.0)
+                .init();
+            let error = load_training_state(
+                &mut rejected_model,
+                rejected_adamw,
+                &mut rejected_muon,
+                dir.path(),
+                &device,
+            )
+            .err()
+            .expect("AdamW state with a missing moment tensor must be rejected");
+            assert!(
+                format!("{error:#}").contains("lossless reconstruction"),
+                "{error:#}"
+            );
+            save_safetensors(&rejected_model, &rejected_model_after).unwrap();
+            rejected_muon.save(&rejected_muon_after).unwrap();
+            assert_eq!(
+                fs::read(rejected_model_before).unwrap(),
+                fs::read(rejected_model_after).unwrap()
+            );
+            assert_eq!(
+                fs::read(rejected_muon_before).unwrap(),
+                fs::read(rejected_muon_after).unwrap()
+            );
+            fs::write(&current_pointer, &pointer_a).unwrap();
+        }
+
+        let snapshots = tempfile::tempdir().unwrap();
+        let mut raced_model = resumed.clone();
+        let raced_model_ids = parameter_ids(&raced_model);
+        let mut raced_muon = resumed_muon.clone();
+        let model_before = snapshots.path().join("model-before.safetensors");
+        let model_after = snapshots.path().join("model-after.safetensors");
+        let muon_before = snapshots.path().join("muon-before.bpk");
+        let muon_after = snapshots.path().join("muon-after.bpk");
+        save_safetensors(&raced_model, &model_before).unwrap();
+        raced_muon.save(&muon_before).unwrap();
+
+        let raced_adamw = AdamWConfig::new()
+            .with_beta_2(0.95)
+            .with_epsilon(1e-8)
+            .with_weight_decay(0.0)
+            .init();
+        let error = checkpoint::load_training_state_with_hook(
+            &mut raced_model,
+            raced_adamw,
+            &mut raced_muon,
+            dir.path(),
+            &device,
+            |stage, generation| {
+                if stage == checkpoint::ResumeLoadStage::AfterStagedLoad {
+                    fs::write(
+                        generation.join("weights.safetensors"),
+                        b"changed after load",
+                    )?;
+                }
+                Ok(())
+            },
+        )
+        .err()
+        .expect("checkpoint mutation should fail staged resume loading");
+        assert!(
+            format!("{error:#}").contains("contents do not match"),
+            "{error:#}"
+        );
+
+        save_safetensors(&raced_model, &model_after).unwrap();
+        raced_muon.save(&muon_after).unwrap();
+        assert_eq!(parameter_ids(&raced_model), raced_model_ids);
+        assert_eq!(
+            fs::read(model_after).unwrap(),
+            fs::read(model_before).unwrap()
+        );
+        assert_eq!(
+            fs::read(muon_after).unwrap(),
+            fs::read(muon_before).unwrap()
+        );
     }
 }

--- a/hermes-train/src/metrics.rs
+++ b/hermes-train/src/metrics.rs
@@ -9,7 +9,7 @@
 //! step cannot silently produce a misleading history.
 
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufWriter, Read, Write};
+use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -459,6 +459,103 @@ pub struct MetricLogDigests {
     pub last_global_step: Option<u64>,
 }
 
+/// Identity and mutation generation captured from an opened metric file.
+///
+/// Unix exposes a stable device/inode identity plus nanosecond mtime/ctime.
+/// Other platforms retain the same fail-closed call structure using the
+/// strongest portable metadata available from `std`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MetricFileStamp {
+    len: u64,
+    #[cfg(unix)]
+    dev: u64,
+    #[cfg(unix)]
+    ino: u64,
+    #[cfg(unix)]
+    mtime: i64,
+    #[cfg(unix)]
+    mtime_nsec: i64,
+    #[cfg(unix)]
+    ctime: i64,
+    #[cfg(unix)]
+    ctime_nsec: i64,
+    #[cfg(not(unix))]
+    modified: Option<SystemTime>,
+    #[cfg(not(unix))]
+    created: Option<SystemTime>,
+}
+
+impl MetricFileStamp {
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Self {
+                len: metadata.len(),
+                dev: metadata.dev(),
+                ino: metadata.ino(),
+                mtime: metadata.mtime(),
+                mtime_nsec: metadata.mtime_nsec(),
+                ctime: metadata.ctime(),
+                ctime_nsec: metadata.ctime_nsec(),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            Self {
+                len: metadata.len(),
+                modified: metadata.modified().ok(),
+                created: metadata.created().ok(),
+            }
+        }
+    }
+
+    fn same_file(&self, other: &Self) -> bool {
+        #[cfg(unix)]
+        {
+            self.dev == other.dev && self.ino == other.ino
+        }
+        #[cfg(not(unix))]
+        {
+            match (self.created, other.created) {
+                (Some(left), Some(right)) => left == right,
+                _ => self.same_version(other),
+            }
+        }
+    }
+
+    fn same_version(&self, other: &Self) -> bool {
+        if !self.same_file_without_version_fallback(other) || self.len != other.len {
+            return false;
+        }
+        #[cfg(unix)]
+        {
+            self.mtime == other.mtime
+                && self.mtime_nsec == other.mtime_nsec
+                && self.ctime == other.ctime
+                && self.ctime_nsec == other.ctime_nsec
+        }
+        #[cfg(not(unix))]
+        {
+            self.modified == other.modified
+        }
+    }
+
+    fn same_file_without_version_fallback(&self, other: &Self) -> bool {
+        #[cfg(unix)]
+        {
+            self.dev == other.dev && self.ino == other.ino
+        }
+        #[cfg(not(unix))]
+        {
+            match (self.created, other.created) {
+                (Some(left), Some(right)) => left == right,
+                _ => true,
+            }
+        }
+    }
+}
+
 /// Append-only writer that owns sequencing and validates every event.
 pub struct MetricWriter {
     path: PathBuf,
@@ -480,13 +577,7 @@ impl MetricWriter {
             fs::create_dir_all(parent)
                 .with_context(|| format!("create metric directory {}", parent.display()))?;
         }
-        reject_symlink_if_present(path, "metric log")?;
-        let file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(path)
-            .with_context(|| format!("create metric log {}", path.display()))?;
+        let file = create_empty_metric_file(path, "metric log")?;
         Ok(Self {
             path: path.to_owned(),
             run_id,
@@ -500,14 +591,11 @@ impl MetricWriter {
         let path = path.as_ref();
         let run_id = run_id.into();
         validate_identifier("run_id", &run_id)?;
-        ensure_regular_non_symlink(path, "metric log")?;
-        let mut file = OpenOptions::new()
-            .read(true)
-            .append(true)
-            .open(path)
-            .with_context(|| format!("open metric log {} for resume", path.display()))?;
-        let state = validate_open_log(&mut file, Some(&run_id))
+        let mut file = open_existing_metric_file(path, "metric log", true)?;
+        let (bytes, stamp) = read_open_metric_file_stable(&mut file, path, "metric log")?;
+        let state = validate_log_bytes(&bytes, Some(&run_id))
             .with_context(|| format!("validate metric log {}", path.display()))?;
+        ensure_open_metric_file_unchanged(&file, path, &stamp, "metric log")?;
         Ok(Self {
             path: path.to_owned(),
             run_id,
@@ -529,40 +617,16 @@ impl MetricWriter {
         let path = path.as_ref();
         let run_id = run_id.into();
         validate_identifier("run_id", &run_id)?;
-        let bytes = fs::read(path)
-            .with_context(|| format!("read metric log {} for checkpoint resume", path.display()))?;
         let committed_records = usize::try_from(committed_records)
             .context("committed metric record count exceeds usize")?;
-        let end = if committed_records == 0 {
-            0
-        } else {
-            bytes
-                .iter()
-                .enumerate()
-                .filter_map(|(index, byte)| (*byte == b'\n').then_some(index + 1))
-                .nth(committed_records - 1)
-                .context("metric log has fewer records than the training checkpoint")?
-        };
-        let state = validate_log_bytes(&bytes[..end], Some(&run_id))
-            .with_context(|| format!("validate committed metric prefix in {}", path.display()))?;
-        ensure!(
-            state.records == committed_records as u64,
-            "committed metric prefix record count is inconsistent"
-        );
         let expected_last_step = (committed_records > 0).then_some(committed_global_step);
-        ensure!(
-            state.last_global_step == expected_last_step,
-            "committed metric prefix does not end at checkpoint global step"
-        );
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)
-            .with_context(|| format!("open metric log {} for truncation", path.display()))?;
-        file.set_len(end as u64)?;
-        file.sync_all()?;
-        drop(file);
-        Self::resume(path, run_id)
+        Self::resume_validated_prefix(
+            path,
+            run_id,
+            committed_records,
+            expected_last_step,
+            "checkpoint resume",
+        )
     }
 
     /// Resume an external runtime at an exact committed metric prefix. Unlike
@@ -578,30 +642,58 @@ impl MetricWriter {
         let path = path.as_ref();
         let run_id = run_id.into();
         validate_identifier("run_id", &run_id)?;
-        let bytes = fs::read(path)
-            .with_context(|| format!("read metric log {} for exact resume", path.display()))?;
         let committed_records = usize::try_from(committed_records)
             .context("committed metric record count exceeds usize")?;
-        let end = committed_prefix_end(&bytes, committed_records)?;
-        let state = validate_log_bytes(&bytes[..end], Some(&run_id))
-            .with_context(|| format!("validate committed metric prefix in {}", path.display()))?;
+        Self::resume_validated_prefix(
+            path,
+            run_id,
+            committed_records,
+            committed_last_global_step,
+            "exact resume",
+        )
+    }
+
+    fn resume_validated_prefix(
+        path: &Path,
+        run_id: String,
+        committed_records: usize,
+        committed_last_global_step: Option<u64>,
+        operation: &str,
+    ) -> Result<Self> {
+        let mut file = open_existing_metric_file(path, "metric log", true)
+            .with_context(|| format!("open metric log {} for {operation}", path.display()))?;
+        let (bytes, stamp) = read_open_metric_file_stable(&mut file, path, "metric log")
+            .with_context(|| format!("read metric log {} for {operation}", path.display()))?;
+        let (end, state) = validate_committed_prefix_bytes(
+            &bytes,
+            path,
+            committed_records,
+            committed_last_global_step,
+            Some(&run_id),
+        )?;
+
+        // JSON validation can be substantial for a long journal. Reinspect
+        // both the descriptor and its pathname after validation so an
+        // in-place writer or path replacement cannot make us truncate bytes
+        // other than the exact generation that was parsed above.
+        ensure_open_metric_file_unchanged(&file, path, &stamp, "metric log")?;
+        file.set_len(end as u64)
+            .with_context(|| format!("truncate metric log {} for {operation}", path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync metric log {} after {operation}", path.display()))?;
+        let truncated = opened_metric_file_stamp(&file, "metric log")?;
         ensure!(
-            state.records == committed_records as u64,
-            "committed metric prefix record count is inconsistent"
+            truncated.same_file(&stamp) && truncated.len == end as u64,
+            "metric log changed while its committed prefix was truncated"
         );
-        ensure!(
-            state.last_global_step == committed_last_global_step,
-            "committed metric prefix global step is inconsistent"
-        );
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)
-            .with_context(|| format!("open metric log {} for truncation", path.display()))?;
-        file.set_len(end as u64)?;
-        file.sync_all()?;
-        drop(file);
-        Self::resume(path, run_id)
+        ensure_metric_path_matches_stamp(path, &truncated, "metric log", true)?;
+
+        Ok(Self {
+            path: path.to_owned(),
+            run_id,
+            output: BufWriter::new(file),
+            state,
+        })
     }
 
     pub fn path(&self) -> &Path {
@@ -729,6 +821,45 @@ fn committed_prefix_end(bytes: &[u8], committed_records: usize) -> Result<usize>
         .context("metric log has fewer records than the runtime checkpoint")
 }
 
+fn validate_committed_prefix_bytes(
+    bytes: &[u8],
+    path: &Path,
+    committed_records: usize,
+    committed_last_global_step: Option<u64>,
+    expected_run_id: Option<&str>,
+) -> Result<(usize, MetricLogState)> {
+    validate_committed_prefix_bytes_with(
+        bytes,
+        path,
+        committed_records,
+        committed_last_global_step,
+        expected_run_id,
+        |_| Ok(()),
+    )
+}
+
+fn validate_committed_prefix_bytes_with(
+    bytes: &[u8],
+    path: &Path,
+    committed_records: usize,
+    committed_last_global_step: Option<u64>,
+    expected_run_id: Option<&str>,
+    visitor: impl FnMut(&MetricRecord) -> Result<()>,
+) -> Result<(usize, MetricLogState)> {
+    let end = committed_prefix_end(bytes, committed_records)?;
+    let state = visit_validated_records(&bytes[..end], expected_run_id, visitor)
+        .with_context(|| format!("validate committed metric prefix in {}", path.display()))?;
+    ensure!(
+        state.records == committed_records as u64,
+        "committed metric prefix record count is inconsistent"
+    );
+    ensure!(
+        state.last_global_step == committed_last_global_step,
+        "committed metric prefix global step is inconsistent"
+    );
+    Ok((end, state))
+}
+
 /// Validate a metric log without opening it for append.
 pub fn validate_metric_log(
     path: impl AsRef<Path>,
@@ -738,11 +869,118 @@ pub fn validate_metric_log(
         validate_identifier("expected run_id", run_id)?;
     }
     let path = path.as_ref();
-    ensure_regular_non_symlink(path, "metric log")?;
-    let mut file = File::open(path)
-        .with_context(|| format!("open metric log {} for validation", path.display()))?;
-    validate_open_log(&mut file, expected_run_id)
-        .with_context(|| format!("validate metric log {}", path.display()))
+    let mut file = open_existing_metric_file(path, "metric log", false)?;
+    let (bytes, stamp) = read_open_metric_file_stable(&mut file, path, "metric log")?;
+    let state = validate_log_bytes(&bytes, expected_run_id)
+        .with_context(|| format!("validate metric log {}", path.display()))?;
+    ensure_open_metric_file_unchanged(&file, path, &stamp, "metric log")?;
+    Ok(state)
+}
+
+/// Validate the exact journal prefix committed by a training checkpoint
+/// without truncating or otherwise mutating the live journal.
+pub fn validate_metric_prefix(
+    path: impl AsRef<Path>,
+    committed_records: u64,
+    committed_global_step: u64,
+) -> Result<MetricLogState> {
+    validate_metric_prefix_impl(
+        path.as_ref(),
+        committed_records,
+        committed_global_step,
+        None,
+    )
+}
+
+/// Validate a committed journal prefix and bind every record to one run.
+pub fn validate_metric_prefix_for_run(
+    path: impl AsRef<Path>,
+    expected_run_id: &str,
+    committed_records: u64,
+    committed_global_step: u64,
+) -> Result<MetricLogState> {
+    validate_identifier("expected run_id", expected_run_id)?;
+    validate_metric_prefix_impl(
+        path.as_ref(),
+        committed_records,
+        committed_global_step,
+        Some(expected_run_id),
+    )
+}
+
+fn validate_metric_prefix_impl(
+    path: &Path,
+    committed_records: u64,
+    committed_global_step: u64,
+    expected_run_id: Option<&str>,
+) -> Result<MetricLogState> {
+    let bytes = read_regular_file_stable(path, "metric log")?;
+    let committed_records = usize::try_from(committed_records)
+        .context("committed metric record count exceeds usize")?;
+    let expected_last_step = (committed_records > 0).then_some(committed_global_step);
+    let (_, state) = validate_committed_prefix_bytes(
+        &bytes,
+        path,
+        committed_records,
+        expected_last_step,
+        expected_run_id,
+    )?;
+    Ok(state)
+}
+
+/// Validate an immutable metric snapshot that contains exactly the records
+/// committed by its checkpoint, with no live-journal tail.
+pub fn validate_metric_snapshot(
+    path: impl AsRef<Path>,
+    committed_records: u64,
+    committed_global_step: u64,
+) -> Result<MetricLogState> {
+    validate_metric_snapshot_impl(
+        path.as_ref(),
+        committed_records,
+        committed_global_step,
+        None,
+    )
+}
+
+/// Validate an immutable metric snapshot and bind every record to one run.
+pub fn validate_metric_snapshot_for_run(
+    path: impl AsRef<Path>,
+    expected_run_id: &str,
+    committed_records: u64,
+    committed_global_step: u64,
+) -> Result<MetricLogState> {
+    validate_identifier("expected run_id", expected_run_id)?;
+    validate_metric_snapshot_impl(
+        path.as_ref(),
+        committed_records,
+        committed_global_step,
+        Some(expected_run_id),
+    )
+}
+
+fn validate_metric_snapshot_impl(
+    path: &Path,
+    committed_records: u64,
+    committed_global_step: u64,
+    expected_run_id: Option<&str>,
+) -> Result<MetricLogState> {
+    let bytes = read_regular_file_stable(path, "metric snapshot")?;
+    let committed_records = usize::try_from(committed_records)
+        .context("committed metric record count exceeds usize")?;
+    let expected_last_step = (committed_records > 0).then_some(committed_global_step);
+    let (end, state) = validate_committed_prefix_bytes(
+        &bytes,
+        path,
+        committed_records,
+        expected_last_step,
+        expected_run_id,
+    )?;
+    ensure!(
+        end == bytes.len(),
+        "immutable metric snapshot contains an uncommitted tail"
+    );
+    Ok(state)
 }
 
 /// Measure committed single-accelerator work from a validated metric prefix.
@@ -758,54 +996,44 @@ pub fn summarize_committed_training_time(
 ) -> Result<CommittedTrainingTime> {
     validate_identifier("expected run_id", expected_run_id)?;
     let path = path.as_ref();
-    ensure_regular_non_symlink(path, "metric log")?;
     let bytes = read_regular_file_stable(path, "metric log for training evidence")?;
     let committed_records_usize = usize::try_from(committed_records)
         .context("committed metric record count exceeds usize")?;
-    let end = committed_prefix_end(&bytes, committed_records_usize)?;
-    let prefix = &bytes[..end];
-    let state = validate_log_bytes(prefix, Some(expected_run_id)).with_context(|| {
-        format!(
-            "validate committed metric prefix for training evidence in {}",
-            path.display()
-        )
-    })?;
-    ensure!(
-        state.records == committed_records,
-        "committed metric prefix record count is inconsistent"
-    );
-    ensure!(
-        state.last_global_step == Some(committed_global_step),
-        "committed metric prefix does not end at checkpoint global step"
-    );
-
     let mut optimizer_steps = 0_u64;
     let mut elapsed_nanoseconds = 0_u64;
-    for record in decode_validated_records(prefix)? {
-        let elapsed = match record.event {
-            MetricEvent::Throughput(metric) => {
-                optimizer_steps = optimizer_steps
-                    .checked_add(metric.optimizer_steps)
-                    .context("measured optimizer-step count overflows u64")?;
-                Some(metric.elapsed_seconds)
+    let (_, _) = validate_committed_prefix_bytes_with(
+        &bytes,
+        path,
+        committed_records_usize,
+        Some(committed_global_step),
+        Some(expected_run_id),
+        |record| {
+            let elapsed = match &record.event {
+                MetricEvent::Throughput(metric) => {
+                    optimizer_steps = optimizer_steps
+                        .checked_add(metric.optimizer_steps)
+                        .context("measured optimizer-step count overflows u64")?;
+                    Some(metric.elapsed_seconds)
+                }
+                MetricEvent::PhaseTiming(metric)
+                    if matches!(
+                        record.phase.kind,
+                        MetricPhaseKind::Sleep | MetricPhaseKind::Quantization
+                    ) && metric.boundary == PhaseBoundary::Completed =>
+                {
+                    Some(metric.elapsed_seconds)
+                }
+                _ => None,
+            };
+            if let Some(elapsed) = elapsed.filter(|elapsed| *elapsed > 0.0) {
+                let nanoseconds = seconds_to_nanoseconds(elapsed)?;
+                elapsed_nanoseconds = elapsed_nanoseconds
+                    .checked_add(nanoseconds)
+                    .context("measured training duration overflows u64 nanoseconds")?;
             }
-            MetricEvent::PhaseTiming(metric)
-                if matches!(
-                    record.phase.kind,
-                    MetricPhaseKind::Sleep | MetricPhaseKind::Quantization
-                ) && metric.boundary == PhaseBoundary::Completed =>
-            {
-                Some(metric.elapsed_seconds)
-            }
-            _ => None,
-        };
-        if let Some(elapsed) = elapsed.filter(|elapsed| *elapsed > 0.0) {
-            let nanoseconds = seconds_to_nanoseconds(elapsed)?;
-            elapsed_nanoseconds = elapsed_nanoseconds
-                .checked_add(nanoseconds)
-                .context("measured training duration overflows u64 nanoseconds")?;
-        }
-    }
+            Ok(())
+        },
+    )?;
     ensure!(
         optimizer_steps == committed_global_step,
         "throughput metrics account for {optimizer_steps} optimizer steps, checkpoint records {committed_global_step}"
@@ -835,7 +1063,6 @@ pub fn metric_log_digests(
         validate_identifier("expected run_id", run_id)?;
     }
     let path = path.as_ref();
-    ensure_regular_non_symlink(path, "metric log")?;
     let bytes = read_regular_file_stable(path, "metric log for digest")?;
     metric_log_digests_from_bytes(&bytes, expected_run_id)
         .with_context(|| format!("validate metric log {} for digest", path.display()))
@@ -851,16 +1078,14 @@ pub(crate) fn metric_log_digests_from_bytes(
     if let Some(run_id) = expected_run_id {
         validate_identifier("expected run_id", run_id)?;
     }
-    let state = validate_log_bytes(bytes, expected_run_id)?;
-
     let mut semantic = Sha256::new();
-    for record in decode_validated_records(bytes)? {
-        let Some(value) = semantic_record(&record)? else {
-            continue;
-        };
-        semantic.update(serde_json::to_vec(&canonicalize_json(value))?);
-        semantic.update(b"\n");
-    }
+    let state = visit_validated_records(bytes, expected_run_id, |record| {
+        if let Some(value) = semantic_record(record)? {
+            semantic.update(serde_json::to_vec(&canonicalize_json(value))?);
+            semantic.update(b"\n");
+        }
+        Ok(())
+    })?;
     Ok(MetricLogDigests {
         raw_sha256: hex_sha256(bytes),
         semantic_progress_sha256: format!("{:x}", semantic.finalize()),
@@ -870,63 +1095,205 @@ pub(crate) fn metric_log_digests_from_bytes(
 }
 
 fn read_regular_file_stable(path: &Path, label: &str) -> Result<Vec<u8>> {
-    let before = fs::symlink_metadata(path)
-        .with_context(|| format!("inspect {label} {}", path.display()))?;
-    ensure!(
-        before.is_file() && !before.file_type().is_symlink(),
-        "{label} {} must be a regular non-symlink file",
-        path.display()
-    );
-    let mut file = File::open(path).with_context(|| format!("open {label} {}", path.display()))?;
-    let opened = file.metadata()?;
-    ensure!(opened.is_file(), "{label} must open as a regular file");
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        ensure!(
-            before.dev() == opened.dev() && before.ino() == opened.ino(),
-            "{label} changed while it was opened"
-        );
-    }
-    let after = fs::symlink_metadata(path)?;
-    ensure!(
-        after.is_file() && !after.file_type().is_symlink(),
-        "{label} became a symlink or non-file while it was opened"
-    );
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        ensure!(
-            after.dev() == opened.dev() && after.ino() == opened.ino(),
-            "{label} changed while it was opened"
-        );
-    }
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes)?;
-    let final_metadata = file.metadata()?;
-    ensure!(
-        final_metadata.len() == bytes.len() as u64,
-        "{label} changed length while it was read"
-    );
+    let mut file = open_existing_metric_file(path, label, false)?;
+    let (bytes, stamp) = read_open_metric_file_stable(&mut file, path, label)?;
+    ensure_open_metric_file_unchanged(&file, path, &stamp, label)?;
     Ok(bytes)
 }
 
-fn decode_validated_records(bytes: &[u8]) -> Result<Vec<MetricRecord>> {
-    if bytes.is_empty() {
-        return Ok(Vec::new());
+fn create_empty_metric_file(path: &Path, label: &str) -> Result<File> {
+    let existing = match fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            ensure_regular_metric_metadata(&metadata, path, label)?;
+            Some(MetricFileStamp::from_metadata(&metadata))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspect {label} {}", path.display()));
+        }
+    };
+
+    let mut options = OpenOptions::new();
+    options.read(true).write(true);
+    if existing.is_none() {
+        options.create_new(true);
     }
+    harden_metric_open_options(&mut options, true);
+    let file = options
+        .open(path)
+        .with_context(|| format!("open {label} {} for initialization", path.display()))?;
+    let opened = opened_metric_file_stamp(&file, label)?;
+    if let Some(existing) = existing {
+        ensure!(
+            opened.same_version(&existing),
+            "{label} {} changed while it was opened for initialization",
+            path.display()
+        );
+    }
+    ensure_metric_path_matches_stamp(path, &opened, label, true)?;
+
+    // Truncate only after the opened descriptor is proven to be the exact
+    // regular file inspected above. A path swap can therefore make creation
+    // fail, but can never redirect truncation into the replacement.
+    ensure_open_metric_file_unchanged(&file, path, &opened, label)?;
+    file.set_len(0)
+        .with_context(|| format!("truncate {label} {}", path.display()))?;
+    let empty = opened_metric_file_stamp(&file, label)?;
     ensure!(
-        bytes.last() == Some(&b'\n'),
-        "metric log ends with a partial record"
+        empty.same_file(&opened) && empty.len == 0,
+        "{label} changed while it was initialized"
     );
-    bytes[..bytes.len() - 1]
-        .split(|byte| *byte == b'\n')
-        .enumerate()
-        .map(|(index, line)| {
-            serde_json::from_slice(line)
-                .with_context(|| format!("decode metric record at line {}", index + 1))
-        })
-        .collect()
+    ensure_metric_path_matches_stamp(path, &empty, label, true)?;
+    into_append_metric_file(file, path, label)
+}
+
+fn open_existing_metric_file(path: &Path, label: &str, append: bool) -> Result<File> {
+    let before = metric_path_stamp(path, label)?;
+    let mut options = OpenOptions::new();
+    options.read(true);
+    if append {
+        options.append(true);
+    }
+    harden_metric_open_options(&mut options, false);
+    let file = options
+        .open(path)
+        .with_context(|| format!("open {label} {}", path.display()))?;
+    let opened = opened_metric_file_stamp(&file, label)?;
+    ensure!(
+        opened.same_version(&before),
+        "{label} {} changed while it was opened",
+        path.display()
+    );
+    ensure_metric_path_matches_stamp(path, &opened, label, true)?;
+    Ok(file)
+}
+
+fn read_open_metric_file_stable(
+    file: &mut File,
+    path: &Path,
+    label: &str,
+) -> Result<(Vec<u8>, MetricFileStamp)> {
+    let before = opened_metric_file_stamp(file, label)?;
+    ensure_metric_path_matches_stamp(path, &before, label, true)?;
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("rewind opened {label} {}", path.display()))?;
+    let capacity = usize::try_from(before.len).context("metric file length exceeds usize")?;
+    let mut bytes = Vec::with_capacity(capacity);
+    file.read_to_end(&mut bytes)
+        .with_context(|| format!("read opened {label} {}", path.display()))?;
+    ensure!(
+        bytes.len() as u64 == before.len,
+        "{label} changed length while it was read"
+    );
+    ensure_open_metric_file_unchanged(file, path, &before, label)?;
+    Ok((bytes, before))
+}
+
+fn ensure_open_metric_file_unchanged(
+    file: &File,
+    path: &Path,
+    expected: &MetricFileStamp,
+    label: &str,
+) -> Result<()> {
+    ensure_metric_path_matches_stamp(path, expected, label, false)?;
+    let current = opened_metric_file_stamp(file, label)?;
+    ensure!(
+        current.same_version(expected),
+        "{label} changed in place while it was being verified"
+    );
+    ensure_metric_path_matches_stamp(path, &current, label, true)
+}
+
+fn metric_path_stamp(path: &Path, label: &str) -> Result<MetricFileStamp> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect {label} {}", path.display()))?;
+    ensure_regular_metric_metadata(&metadata, path, label)?;
+    Ok(MetricFileStamp::from_metadata(&metadata))
+}
+
+fn opened_metric_file_stamp(file: &File, label: &str) -> Result<MetricFileStamp> {
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("inspect opened {label}"))?;
+    ensure!(metadata.is_file(), "opened {label} must be a regular file");
+    Ok(MetricFileStamp::from_metadata(&metadata))
+}
+
+fn ensure_regular_metric_metadata(metadata: &fs::Metadata, path: &Path, label: &str) -> Result<()> {
+    ensure!(
+        metadata.is_file() && !metadata.file_type().is_symlink(),
+        "{label} {} must be a regular non-symlink file",
+        path.display()
+    );
+    Ok(())
+}
+
+fn ensure_metric_path_matches_stamp(
+    path: &Path,
+    expected: &MetricFileStamp,
+    label: &str,
+    require_same_version: bool,
+) -> Result<()> {
+    let current = metric_path_stamp(path, label)?;
+    ensure!(
+        current.same_file(expected),
+        "{label} {} was replaced while it was open",
+        path.display()
+    );
+    if require_same_version {
+        ensure!(
+            current.same_version(expected),
+            "{label} {} changed in place while it was open",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn harden_metric_open_options(options: &mut OpenOptions, creating: bool) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        if creating {
+            options.mode(0o600);
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = creating;
+}
+
+#[cfg(unix)]
+fn into_append_metric_file(file: File, path: &Path, label: &str) -> Result<File> {
+    use std::os::fd::AsRawFd;
+
+    let initialized = opened_metric_file_stamp(&file, label)?;
+    ensure_metric_path_matches_stamp(path, &initialized, label, true)?;
+    // SAFETY: `file` owns this descriptor throughout both fcntl calls. F_GETFL
+    // and F_SETFL do not consume it; O_APPEND is a supported status flag.
+    let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+    if flags == -1 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("read opened {label} descriptor flags"));
+    }
+    if unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFL, flags | libc::O_APPEND) } == -1 {
+        return Err(std::io::Error::last_os_error())
+            .with_context(|| format!("set opened {label} descriptor append-only"));
+    }
+    ensure_open_metric_file_unchanged(&file, path, &initialized, label)?;
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+fn into_append_metric_file(file: File, path: &Path, label: &str) -> Result<File> {
+    let initialized = opened_metric_file_stamp(&file, label)?;
+    let appended = open_existing_metric_file(path, label, true)?;
+    let reopened = opened_metric_file_stamp(&appended, label)?;
+    ensure!(
+        reopened.same_version(&initialized),
+        "{label} changed while it was reopened for append"
+    );
+    Ok(appended)
 }
 
 fn seconds_to_nanoseconds(seconds: f64) -> Result<u64> {
@@ -1016,13 +1383,15 @@ fn hex_sha256(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }
 
-fn validate_open_log(file: &mut File, expected_run_id: Option<&str>) -> Result<MetricLogState> {
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes).context("read metric log")?;
-    validate_log_bytes(&bytes, expected_run_id)
+fn validate_log_bytes(bytes: &[u8], expected_run_id: Option<&str>) -> Result<MetricLogState> {
+    visit_validated_records(bytes, expected_run_id, |_| Ok(()))
 }
 
-fn validate_log_bytes(bytes: &[u8], expected_run_id: Option<&str>) -> Result<MetricLogState> {
+fn visit_validated_records(
+    bytes: &[u8],
+    expected_run_id: Option<&str>,
+    mut visitor: impl FnMut(&MetricRecord) -> Result<()>,
+) -> Result<MetricLogState> {
     if bytes.is_empty() {
         return Ok(MetricLogState::default());
     }
@@ -1054,6 +1423,8 @@ fn validate_log_bytes(bytes: &[u8], expected_run_id: Option<&str>) -> Result<Met
                 record.run_id
             );
         }
+        visitor(&record)
+            .with_context(|| format!("process metric record at line {}", line_index + 1))?;
         advance_state(&mut state, &record)?;
     }
     Ok(state)
@@ -1561,32 +1932,6 @@ fn validate_sha256(name: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
-fn reject_symlink_if_present(path: &Path, label: &str) -> Result<()> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) => {
-            ensure!(
-                !metadata.file_type().is_symlink(),
-                "{label} {} must not be a symlink",
-                path.display()
-            );
-            Ok(())
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error).with_context(|| format!("inspect {label} {}", path.display())),
-    }
-}
-
-fn ensure_regular_non_symlink(path: &Path, label: &str) -> Result<()> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("inspect {label} {}", path.display()))?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "{label} {} must be a regular non-symlink file",
-        path.display()
-    );
-    Ok(())
-}
-
 fn finite(name: &str, value: f64) -> Result<()> {
     ensure!(value.is_finite(), "{name} must be finite");
     Ok(())
@@ -1771,8 +2116,64 @@ mod tests {
 
         assert!(MetricWriter::create(&link, "run-a").is_err());
         assert!(MetricWriter::resume(&link, "run-a").is_err());
+        assert!(MetricWriter::resume_from_checkpoint(&link, "run-a", 0, 0).is_err());
+        assert!(MetricWriter::resume_exact_prefix(&link, "run-a", 0, None).is_err());
         assert!(validate_metric_log(&link, None).is_err());
+        assert!(validate_metric_prefix(&link, 0, 0).is_err());
+        assert!(validate_metric_snapshot(&link, 0, 0).is_err());
         assert!(fs::read(&target).unwrap().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_metric_handle_detects_path_replacement_before_mutation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        {
+            let mut writer = MetricWriter::create(&path, "run-a").unwrap();
+            writer.append_at(context(1), throughput(), 100).unwrap();
+            writer.sync_all().unwrap();
+        }
+
+        let mut opened = open_existing_metric_file(&path, "metric log", true).unwrap();
+        let (verified, stamp) =
+            read_open_metric_file_stable(&mut opened, &path, "metric log").unwrap();
+        let displaced = directory.path().join("displaced.jsonl");
+        fs::rename(&path, &displaced).unwrap();
+        fs::write(&path, &verified).unwrap();
+        let replacement_before = fs::read(&path).unwrap();
+
+        let error = ensure_open_metric_file_unchanged(&opened, &path, &stamp, "metric log")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("replaced"), "{error}");
+        assert_eq!(fs::read(&path).unwrap(), replacement_before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_metric_handle_detects_same_length_in_place_mutation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        {
+            let mut writer = MetricWriter::create(&path, "run-a").unwrap();
+            writer.append_at(context(1), throughput(), 100).unwrap();
+            writer.sync_all().unwrap();
+        }
+
+        let mut opened = open_existing_metric_file(&path, "metric log", true).unwrap();
+        let (verified, stamp) =
+            read_open_metric_file_stable(&mut opened, &path, "metric log").unwrap();
+        let mut mutator = OpenOptions::new().write(true).open(&path).unwrap();
+        mutator.seek(SeekFrom::Start(0)).unwrap();
+        mutator.write_all(b"[").unwrap();
+        mutator.sync_all().unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().len(), verified.len() as u64);
+
+        let error = ensure_open_metric_file_unchanged(&opened, &path, &stamp, "metric log")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("changed in place"), "{error}");
     }
 
     #[test]
@@ -1799,6 +2200,97 @@ mod tests {
             validate_metric_log(&path, Some("run-a")).unwrap().records,
             2
         );
+    }
+
+    #[test]
+    fn read_only_checkpoint_prefix_validation_rejects_nul_corruption() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        {
+            let mut writer = MetricWriter::create(&path, "run-a").unwrap();
+            writer.append_at(context(1), throughput(), 100).unwrap();
+            writer.sync_all().unwrap();
+        }
+        let mut bytes = fs::read(&path).unwrap();
+        bytes[0] = 0;
+        fs::write(&path, bytes).unwrap();
+
+        assert!(validate_metric_prefix(&path, 1, 1).is_err());
+    }
+
+    #[test]
+    fn immutable_metric_snapshot_rejects_uncommitted_tail() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        {
+            let mut writer = MetricWriter::create(&path, "run-a").unwrap();
+            writer.append_at(context(1), throughput(), 100).unwrap();
+            writer.append_at(context(2), throughput(), 101).unwrap();
+            writer.sync_all().unwrap();
+        }
+
+        validate_metric_prefix(&path, 1, 1).unwrap();
+        let error = validate_metric_snapshot(&path, 1, 1)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("uncommitted tail"), "{error}");
+        validate_metric_snapshot(&path, 2, 2).unwrap();
+    }
+
+    #[test]
+    fn committed_prefix_and_snapshot_can_be_bound_to_the_expected_run() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        {
+            let mut writer = MetricWriter::create(&path, "run-a").unwrap();
+            writer.append_at(context(1), throughput(), 100).unwrap();
+            writer.sync_all().unwrap();
+        }
+
+        validate_metric_prefix_for_run(&path, "run-a", 1, 1).unwrap();
+        validate_metric_snapshot_for_run(&path, "run-a", 1, 1).unwrap();
+        let prefix_error = format!(
+            "{:#}",
+            validate_metric_prefix_for_run(&path, "run-b", 1, 1).unwrap_err()
+        );
+        assert!(
+            prefix_error.contains("does not match requested"),
+            "{prefix_error}"
+        );
+        let snapshot_error = format!(
+            "{:#}",
+            validate_metric_snapshot_for_run(&path, "run-b", 1, 1).unwrap_err()
+        );
+        assert!(
+            snapshot_error.contains("does not match requested"),
+            "{snapshot_error}"
+        );
+    }
+
+    #[test]
+    fn stale_initial_writer_cannot_create_a_sparse_hole_after_truncation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        let mut stale = MetricWriter::create(&path, "run-a").unwrap();
+        stale.append_at(context(1), throughput(), 100).unwrap();
+        stale.sync_all().unwrap();
+
+        fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&path)
+            .unwrap()
+            .sync_all()
+            .unwrap();
+        stale.append_at(context(2), throughput(), 101).unwrap();
+        stale.sync_all().unwrap();
+
+        let bytes = fs::read(&path).unwrap();
+        assert!(
+            !bytes.contains(&0),
+            "stale descriptor created a sparse hole"
+        );
+        assert_eq!(bytes.first(), Some(&b'{'));
     }
 
     #[test]

--- a/hermes-train/src/muon.rs
+++ b/hermes-train/src/muon.rs
@@ -1,13 +1,13 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use anyhow::{Context, Result, ensure};
-use burn::module::{Module, ModuleMapper, Param, ParamId};
+use burn::module::{Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 #[cfg(feature = "cuda")]
 use burn::tensor::FloatDType;
 use burn::tensor::{Device, Tensor, TensorData};
 use burn_optim::GradientsParams;
-use burn_pack::{Reader, Tensor as PackedTensor, Writer};
+use burn_pack::{Bytes, DType, Reader, Tensor as PackedTensor, Writer};
 
 const MOMENTUM: f64 = 0.95;
 const NS_COEFFICIENTS: (f64, f64, f64) = (3.4445, -4.775, 2.0315);
@@ -21,6 +21,7 @@ const EPSILON: f64 = 1e-7;
 /// avoids thousands of tiny GPU launches without changing optimizer state or
 /// hyperparameters. CUDA runs Newton-Schulz in BF16, its intended stable
 /// compute dtype, while parameters and momentum remain FP32.
+#[derive(Clone)]
 pub struct BatchedMuon {
     parameter_ids: Vec<ParamId>,
     velocities: BTreeMap<[usize; 2], Tensor<3>>,
@@ -59,27 +60,120 @@ impl BatchedMuon {
         Ok(())
     }
 
-    pub fn load(&mut self, path: impl AsRef<Path>, device: &Device) -> Result<()> {
-        self.velocities.clear();
-        for tensor in Reader::from_file(path)
-            .context("failed to open Muon state")?
-            .into_tensors()
-            .context("failed to read Muon state")?
-        {
+    /// Load Muon state from a byte buffer already authenticated by the
+    /// checkpoint layer.
+    pub fn load_bytes(&mut self, bytes: Vec<u8>, device: &Device) -> Result<()> {
+        let reader = Reader::from_bytes(Bytes::from_bytes_vec(bytes))
+            .context("failed to open authenticated Muon state")?;
+        self.load_reader(reader, device)
+    }
+
+    fn load_reader(&mut self, reader: Reader, device: &Device) -> Result<()> {
+        ensure!(
+            reader.metadata().is_empty() && reader.scalars().is_empty(),
+            "Muon checkpoint contains unsupported metadata or scalar state"
+        );
+        let mut velocities = BTreeMap::new();
+        for tensor in reader.into_tensors().context("failed to read Muon state")? {
             ensure!(
                 tensor.shape.rank() == 3,
                 "Muon velocity {} has rank {}, expected 3",
                 tensor.name,
                 tensor.shape.rank()
             );
+            let [batch, rows, columns] = tensor.shape.dims::<3>();
+            ensure!(
+                batch > 0 && rows > 0 && columns > 0,
+                "Muon velocity {} has a zero dimension",
+                tensor.name
+            );
+            ensure!(
+                tensor.dtype == DType::F32,
+                "Muon velocity {} has dtype {:?}, expected F32",
+                tensor.name,
+                tensor.dtype
+            );
+            ensure!(
+                tensor.param_id.is_none(),
+                "Muon velocity {} must not carry a parameter ID",
+                tensor.name
+            );
+            ensure!(
+                tensor.name == format!("{rows}x{columns}"),
+                "Muon velocity {} does not match its canonical {rows}x{columns} shape name",
+                tensor.name
+            );
             let velocity = Tensor::<3>::from_data(
                 TensorData::from_bytes(tensor.bytes, tensor.shape, tensor.dtype),
                 device,
             );
-            let [_, rows, columns] = velocity.dims();
             ensure!(
-                self.velocities.insert([rows, columns], velocity).is_none(),
+                velocities.insert([rows, columns], velocity).is_none(),
                 "Muon checkpoint contains duplicate {rows}x{columns} velocity groups"
+            );
+        }
+        self.velocities = velocities;
+        Ok(())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.velocities.is_empty()
+    }
+
+    /// Validate that every serialized velocity batch corresponds exactly to
+    /// the selected matrix parameters in the restored model.
+    pub fn validate_for_model<M: Module>(&self, model: &M, allow_empty: bool) -> Result<()> {
+        let remaining = self
+            .parameter_ids
+            .iter()
+            .map(|id| id.val())
+            .collect::<BTreeSet<_>>();
+        ensure!(
+            remaining.len() == self.parameter_ids.len(),
+            "Muon parameter selection repeats an ID"
+        );
+        let mut visitor = MuonShapeVisitor {
+            remaining,
+            groups: BTreeMap::new(),
+            non_matrix: Vec::new(),
+        };
+        model.visit(&mut visitor);
+        ensure!(
+            visitor.remaining.is_empty(),
+            "Muon selects {} parameters absent from the restored model",
+            visitor.remaining.len()
+        );
+        ensure!(
+            visitor.non_matrix.is_empty(),
+            "Muon selects non-matrix parameters {:?}",
+            visitor.non_matrix
+        );
+        if self.velocities.is_empty() {
+            ensure!(
+                allow_empty,
+                "Muon checkpoint has no velocities after optimizer progress"
+            );
+            return Ok(());
+        }
+        ensure!(
+            self.velocities.len() == visitor.groups.len(),
+            "Muon checkpoint has {} velocity groups, restored model requires {}",
+            self.velocities.len(),
+            visitor.groups.len()
+        );
+        for (shape, expected_batch) in visitor.groups {
+            let velocity = self.velocities.get(&shape).with_context(|| {
+                format!(
+                    "Muon checkpoint is missing the {}x{} velocity group",
+                    shape[0], shape[1]
+                )
+            })?;
+            let [actual_batch, rows, columns] = velocity.dims();
+            ensure!(
+                [rows, columns] == shape && actual_batch == expected_batch,
+                "Muon {}x{} velocity batch has {actual_batch} matrices, restored model requires {expected_batch}",
+                shape[0],
+                shape[1]
             );
         }
         Ok(())
@@ -137,6 +231,26 @@ impl BatchedMuon {
             updates.len()
         );
         Ok(model)
+    }
+}
+
+struct MuonShapeVisitor {
+    remaining: BTreeSet<u64>,
+    groups: BTreeMap<[usize; 2], usize>,
+    non_matrix: Vec<u64>,
+}
+
+impl ModuleVisitor for MuonShapeVisitor {
+    fn visit_float<const D: usize>(&mut self, parameter: &Param<Tensor<D>>) {
+        if !self.remaining.remove(&parameter.id.val()) {
+            return;
+        }
+        if D != 2 {
+            self.non_matrix.push(parameter.id.val());
+            return;
+        }
+        let shape = parameter.shape().dims::<D>();
+        *self.groups.entry([shape[0], shape[1]]).or_default() += 1;
     }
 }
 
@@ -217,6 +331,23 @@ mod tests {
 
     use super::*;
 
+    fn packed_velocity(
+        name: &str,
+        shape: [usize; 3],
+        dtype: DType,
+        param_id: Option<u64>,
+    ) -> Vec<u8> {
+        let elements = shape.into_iter().product::<usize>();
+        let tensor = PackedTensor::new(
+            name.into(),
+            dtype,
+            shape.to_vec(),
+            param_id,
+            Bytes::from_bytes_vec(vec![0; elements * dtype.size()]),
+        );
+        Writer::new(vec![tensor]).into_bytes().unwrap().to_vec()
+    }
+
     #[derive(Module, Debug)]
     struct MatrixPair {
         first: Param<Tensor<2>>,
@@ -286,5 +417,87 @@ mod tests {
             .map(|(actual, expected)| (actual - expected).abs())
             .fold(0.0, f32::max);
         assert!(max_diff < 2e-5, "Muon parameter max diff: {max_diff}");
+    }
+
+    #[test]
+    fn muon_archive_validation_is_strict_and_failure_atomic() {
+        let device = hermes_llm::default_device();
+        let mut muon = BatchedMuon::new(Vec::new());
+        muon.velocities.insert(
+            [2, 2],
+            Tensor::<3>::ones([1, 2, 2], &device.clone().inner()),
+        );
+        let before = muon.velocities[&[2, 2]].clone().into_data();
+
+        let error = muon
+            .load_bytes(
+                packed_velocity("not-a-shape", [1, 2, 2], DType::F32, None),
+                &device.clone().inner(),
+            )
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("canonical 2x2 shape name"));
+        assert_eq!(
+            muon.velocities[&[2, 2]].clone().into_data(),
+            before,
+            "a rejected archive changed existing Muon state"
+        );
+
+        for (bytes, message) in [
+            (
+                packed_velocity("2x2", [0, 2, 2], DType::F32, None),
+                "zero dimension",
+            ),
+            (
+                packed_velocity("2x2", [1, 2, 2], DType::F16, None),
+                "expected F32",
+            ),
+            (
+                packed_velocity("2x2", [1, 2, 2], DType::F32, Some(7)),
+                "must not carry a parameter ID",
+            ),
+        ] {
+            let error = BatchedMuon::new(Vec::new())
+                .load_bytes(bytes, &device.clone().inner())
+                .unwrap_err();
+            assert!(format!("{error:#}").contains(message), "{error:#}");
+        }
+    }
+
+    #[test]
+    fn muon_velocity_batches_match_selected_model_shapes() {
+        let device = hermes_llm::default_device();
+        let matrix = || {
+            Param::from_tensor(Tensor::<2>::zeros(
+                [4, 6],
+                &device.clone().autodiff().inner(),
+            ))
+        };
+        let model = MatrixPair {
+            first: matrix(),
+            second: matrix(),
+        };
+        let duplicate = BatchedMuon::new(vec![model.first.id, model.first.id]);
+        let error = duplicate.validate_for_model(&model, true).unwrap_err();
+        assert!(format!("{error:#}").contains("repeats an ID"), "{error:#}");
+
+        let ids = vec![model.first.id, model.second.id];
+        let mut muon = BatchedMuon::new(ids);
+
+        assert!(muon.validate_for_model(&model, true).is_ok());
+        assert!(
+            format!("{:#}", muon.validate_for_model(&model, false).unwrap_err())
+                .contains("no velocities")
+        );
+        muon.velocities.insert(
+            [4, 6],
+            Tensor::<3>::zeros([1, 4, 6], &device.clone().inner()),
+        );
+        let error = muon.validate_for_model(&model, false).unwrap_err();
+        assert!(format!("{error:#}").contains("requires 2"), "{error:#}");
+        muon.velocities.insert(
+            [4, 6],
+            Tensor::<3>::zeros([2, 4, 6], &device.clone().inner()),
+        );
+        muon.validate_for_model(&model, false).unwrap();
     }
 }

--- a/hermes-train/src/native_sleep.rs
+++ b/hermes-train/src/native_sleep.rs
@@ -2721,14 +2721,15 @@ mod tests {
     }
 
     #[test]
-    fn periodic_controller_drains_every_crossed_boundary_in_clock_and_tier_order() {
+    fn periodic_controller_rejects_coarse_clock_and_drains_split_boundaries_in_order() {
         let model = model();
         let (directory, mut checkpoint) = checkpoint(&model);
         let config = sleep_config(directory.path(), checkpoint.retention_suite.sha256.clone());
         let mut driver = RollbackBoundaryDriver::default();
         let mut sink = CountingSink::default();
 
-        drain_periodic_sleep_before_wake_step(
+        let before = checkpoint.clone();
+        let error = drain_periodic_sleep_before_wake_step(
             &mut checkpoint,
             &model,
             &config,
@@ -2736,7 +2737,23 @@ mod tests {
             &mut driver,
             &mut sink,
         )
-        .unwrap();
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("one tier gradient accumulator"), "{error}");
+        assert_eq!(checkpoint, before);
+        assert!(driver.0.is_empty());
+
+        for clock in [100, 200, 300, 400] {
+            drain_periodic_sleep_before_wake_step(
+                &mut checkpoint,
+                &model,
+                &config,
+                clock,
+                &mut driver,
+                &mut sink,
+            )
+            .unwrap();
+        }
 
         assert_eq!(
             driver.0,

--- a/hermes-train/src/posttrain.rs
+++ b/hermes-train/src/posttrain.rs
@@ -672,17 +672,20 @@ pub fn grpo_loss(
     let rewards: Vec<f64> = rollouts.iter().map(|rollout| rollout.reward).collect();
     ensure_finite(&rewards, "GRPO rewards")?;
     let mean_reward = rewards.iter().sum::<f64>() / rewards.len() as f64;
+    ensure!(mean_reward.is_finite(), "GRPO reward mean overflowed");
     let variance = rewards
         .iter()
         .map(|reward| (reward - mean_reward).powi(2))
         .sum::<f64>()
         / rewards.len() as f64;
+    ensure!(variance.is_finite(), "GRPO reward normalization overflowed");
     let reward_stddev = variance.sqrt();
     let denominator = reward_stddev.max(advantage_epsilon);
     let advantages: Vec<f64> = rewards
         .iter()
         .map(|reward| (reward - mean_reward) / denominator)
         .collect();
+    ensure_finite(&advantages, "GRPO normalized advantages")?;
 
     let group_scale = 1.0 / rollouts.len() as f64;
     let lower = 1.0 - clip_epsilon;
@@ -732,7 +735,7 @@ pub fn grpo_loss(
             let behavior = rollout.behavior_token_log_probs[token_index];
             let log_ratio = current - behavior;
             ensure!(
-                log_ratio <= 80.0,
+                log_ratio.is_finite() && log_ratio <= 80.0,
                 "GRPO rollout {rollout_index} token {token_index} has an unsafe importance ratio"
             );
             let ratio = log_ratio.exp();
@@ -748,7 +751,7 @@ pub fn grpo_loss(
                 Some(reference) => {
                     let log_ref_minus_policy = reference[token_index] - current;
                     ensure!(
-                        log_ref_minus_policy <= 80.0,
+                        log_ref_minus_policy.is_finite() && log_ref_minus_policy <= 80.0,
                         "GRPO rollout {rollout_index} token {token_index} has an unsafe KL ratio"
                     );
                     let ref_over_policy = log_ref_minus_policy.exp();
@@ -772,6 +775,14 @@ pub fn grpo_loss(
             row_gradients.push(token_scale * (-d_surrogate + kl_coefficient * d_kl));
         }
         gradients.push(row_gradients);
+    }
+
+    ensure!(
+        objective.is_finite() && total_kl.is_finite(),
+        "GRPO objective overflowed"
+    );
+    for row in &gradients {
+        ensure_finite(row, "GRPO current log-probability gradients")?;
     }
 
     Ok(GrpoLoss {
@@ -854,28 +865,96 @@ pub fn grpo_loss_tensor(
     );
 
     let rewards = rewards.detach();
+    let behavior_token_log_probs = behavior_token_log_probs.detach();
+    let reference_token_log_probs = reference_token_log_probs.map(Tensor::detach);
+    let log_importance_ratio =
+        current_token_log_probs.clone().detach() - behavior_token_log_probs.clone();
     let reward_mean = rewards.clone().mean();
-    let reward_stddev = (rewards.clone() - reward_mean.clone())
-        .powi_scalar(2)
-        .mean()
-        .sqrt()
-        .clamp_min(advantage_epsilon);
-    let advantages = ((rewards - reward_mean) / reward_stddev).reshape([group, 1]);
-    let ratio = (current_token_log_probs.clone() - behavior_token_log_probs.detach()).exp();
+    let centered_rewards = rewards.clone() - reward_mean.clone();
+    let reward_variance = centered_rewards.clone().powi_scalar(2).mean();
+    let reward_stddev = reward_variance.clone().sqrt().clamp_min(advantage_epsilon);
+
+    // Build the differentiable objective before materializing validation
+    // flags. This lets the same single device read that validates the inputs
+    // also reject overflow introduced by exp/KL scaling before callers can
+    // backpropagate a non-finite loss.
+    let advantages =
+        ((rewards.clone() - reward_mean.clone()) / reward_stddev.clone()).reshape([group, 1]);
+    let ratio = (current_token_log_probs.clone() - behavior_token_log_probs.clone()).exp();
     let clipped_ratio = ratio.clone().clamp(1.0 - clip_epsilon, 1.0 + clip_epsilon);
     let surrogate = (ratio * advantages.clone()).min_pair(clipped_ratio * advantages);
-    let mask = active_mask.detach();
+    let mask = active_mask.clone().detach();
     let active_per_rollout = mask.clone().sum_dim(1);
-    let token_objective = match reference_token_log_probs {
+    let token_objective = match &reference_token_log_probs {
         Some(reference) => {
-            let log_ref_minus_policy = reference.detach() - current_token_log_probs;
+            let log_ref_minus_policy = reference.clone() - current_token_log_probs.clone();
             let kl = log_ref_minus_policy.clone().exp() - log_ref_minus_policy - 1;
             surrogate - kl.mul_scalar(kl_coefficient)
         }
         None => surrogate,
     };
     let sequence_objective = (token_objective * mask).sum_dim(1) / active_per_rollout;
-    Ok(sequence_objective.mean().neg())
+    let loss = sequence_objective.mean().neg();
+
+    // Collapse every device-side precondition into one tiny transfer instead
+    // of synchronizing the accelerator once per check. The ordered labels
+    // preserve precise diagnostics while keeping validation overhead bounded.
+    let mut validation_names = vec![
+        "GRPO rewards contain a non-finite value",
+        "GRPO current log probabilities contain a non-finite value",
+        "GRPO behavior log probabilities contain a non-finite value",
+        "GRPO active_mask must contain only binary zero/one values",
+        "GRPO active_mask must contain at least one active token in every rollout",
+        "GRPO importance log-ratio is non-finite",
+        "GRPO importance log-ratio exceeds the safe exponential domain",
+        "GRPO reward normalization overflowed",
+        "GRPO tensor objective overflowed",
+    ];
+    let mut validation_tensors = vec![
+        rewards.clone().is_finite().all(),
+        current_token_log_probs.clone().is_finite().all(),
+        behavior_token_log_probs.clone().is_finite().all(),
+        active_mask
+            .clone()
+            .equal_elem(0.0)
+            .bool_or(active_mask.clone().equal_elem(1.0))
+            .all(),
+        active_mask.clone().sum_dim(1).greater_elem(0.0).all(),
+        log_importance_ratio.clone().is_finite().all(),
+        log_importance_ratio.clone().lower_equal_elem(80.0).all(),
+        centered_rewards
+            .clone()
+            .is_finite()
+            .all()
+            .bool_and(reward_variance.clone().is_finite().all()),
+        loss.clone().detach().is_finite().all(),
+    ];
+    if let Some(reference) = &reference_token_log_probs {
+        let log_reference_ratio = reference.clone() - current_token_log_probs.clone().detach();
+        validation_names.extend([
+            "GRPO reference log probabilities contain a non-finite value",
+            "GRPO reference log-ratio is non-finite",
+            "GRPO reference log-ratio exceeds the safe exponential domain",
+        ]);
+        validation_tensors.extend([
+            reference.clone().is_finite().all(),
+            log_reference_ratio.clone().is_finite().all(),
+            log_reference_ratio.lower_equal_elem(80.0).all(),
+        ]);
+    }
+    let validation_values = Tensor::cat(validation_tensors, 0)
+        .into_data()
+        .to_vec::<bool>()
+        .context("reading GRPO tensor validation flags")?;
+    ensure!(
+        validation_values.len() == validation_names.len(),
+        "GRPO backend returned an incomplete validation result"
+    );
+    for (valid, message) in validation_values.into_iter().zip(validation_names) {
+        ensure!(valid, message);
+    }
+
+    Ok(loss)
 }
 
 /// Request sent to an executor-owned rollout generator.
@@ -1039,627 +1118,6 @@ pub struct PostTrainingPhaseReport {
     pub metrics: BTreeMap<String, f64>,
 }
 
-#[derive(Default)]
-struct ReportAccumulator {
-    examples: usize,
-    optimizer_steps: usize,
-    loss_sum: f64,
-    metrics: BTreeMap<String, f64>,
-}
-
-impl ReportAccumulator {
-    fn add_metric(&mut self, name: &str, value: f64) {
-        *self.metrics.entry(name.to_owned()).or_default() += value;
-    }
-
-    fn finish(
-        mut self,
-        phase: &PhaseV2,
-        algorithm: &str,
-        trainable_model_identity: String,
-        frozen_model_identity: Option<String>,
-    ) -> Result<PostTrainingPhaseReport> {
-        ensure!(
-            self.examples > 0 && self.optimizer_steps > 0,
-            "post-training phase `{}` produced no optimizer steps",
-            phase.name
-        );
-        for value in self.metrics.values_mut() {
-            *value /= self.examples as f64;
-        }
-        Ok(PostTrainingPhaseReport {
-            phase: phase.name.clone(),
-            algorithm: algorithm.to_owned(),
-            examples: self.examples,
-            optimizer_steps: self.optimizer_steps,
-            trainable_model_identity,
-            frozen_model_identity,
-            mean_loss: self.loss_sum / self.examples as f64,
-            metrics: self.metrics,
-        })
-    }
-}
-
-/// Execute a complete preference, distillation, or verifiable-RL phase with
-/// injected model adapters. Epochs, optimizer geometry, step caps, loss
-/// weight, and learning-rate scale are honored. Unsupported hooks and raw
-/// parameters are rejected rather than ignored.
-pub fn execute_post_training_phase(
-    phase: &PhaseV2,
-    adapters: PostTrainingPhaseAdapters<'_>,
-) -> Result<PostTrainingPhaseReport> {
-    let task = phase
-        .task
-        .as_ref()
-        .with_context(|| format!("post-training phase `{}` has no task", phase.name))?;
-    let data = phase
-        .data
-        .as_deref()
-        .with_context(|| format!("post-training phase `{}` has no data", phase.name))?;
-    let sequence_length = phase.sequence_length.with_context(|| {
-        format!(
-            "post-training phase `{}` has no sequence_length",
-            phase.name
-        )
-    })?;
-    let update_examples = phase
-        .batch_size
-        .with_context(|| format!("post-training phase `{}` has no batch_size", phase.name))?
-        .checked_mul(phase.gradient_accumulation.with_context(|| {
-            format!(
-                "post-training phase `{}` has no gradient_accumulation",
-                phase.name
-            )
-        })?)
-        .context("post-training optimizer example count overflows usize")?;
-    ensure!(
-        update_examples > 0,
-        "post-training optimizer batch is empty"
-    );
-    ensure!(
-        phase.shuffle_buffer.is_none(),
-        "post-training phase `{}` requests shuffle_buffer, but this deterministic executor requires an injected ordering adapter",
-        phase.name
-    );
-    ensure!(
-        phase.periodic_sleep.is_none(),
-        "post-training phase `{}` has periodic_sleep; WorkflowV2 orchestration must own the sleep boundary",
-        phase.name
-    );
-    ensure!(
-        phase.parameters.is_empty(),
-        "post-training phase `{}` has unconsumed raw parameters; move algorithm settings into `post_training`",
-        phase.name
-    );
-    task.validate()?;
-    let config = phase.post_training.as_ref().with_context(|| {
-        format!(
-            "post-training phase `{}` has no typed post_training settings",
-            phase.name
-        )
-    })?;
-    config.validate()?;
-    if let PostTrainingConfig::Grpo { sampling, .. } = config {
-        ensure!(
-            sampling.max_new_tokens <= sequence_length,
-            "post-training phase `{}` GRPO max_new_tokens exceeds sequence_length",
-            phase.name
-        );
-    }
-
-    match (phase.kind, config, adapters) {
-        (
-            PhaseKind::Preference,
-            PostTrainingConfig::Dpo {
-                reference: reference_spec,
-                beta,
-                label_smoothing,
-                sequence_reduction,
-            },
-            PostTrainingPhaseAdapters::Dpo { policy, reference },
-        ) => execute_dpo_phase(
-            phase,
-            task,
-            data,
-            sequence_length,
-            update_examples,
-            reference_spec,
-            *beta,
-            *label_smoothing,
-            *sequence_reduction,
-            policy,
-            reference,
-        ),
-        (
-            PhaseKind::Distillation,
-            PostTrainingConfig::ForwardKl {
-                teacher: teacher_spec,
-                temperature,
-                scale_by_temperature_squared,
-            },
-            PostTrainingPhaseAdapters::ForwardKl { policy, teacher },
-        ) => execute_distillation_phase(
-            phase,
-            task,
-            data,
-            sequence_length,
-            update_examples,
-            teacher_spec,
-            *temperature,
-            *scale_by_temperature_squared,
-            policy,
-            teacher,
-        ),
-        (
-            PhaseKind::Rl,
-            PostTrainingConfig::Grpo {
-                group_size,
-                clip_epsilon,
-                advantage_epsilon,
-                kl_coefficient,
-                reference: reference_spec,
-                sampling,
-            },
-            PostTrainingPhaseAdapters::Grpo {
-                policy,
-                reference,
-                verifier,
-            },
-        ) => execute_grpo_phase(
-            phase,
-            task,
-            data,
-            sequence_length,
-            update_examples,
-            *group_size,
-            *clip_epsilon,
-            *advantage_epsilon,
-            *kl_coefficient,
-            reference_spec.as_ref(),
-            sampling,
-            policy,
-            reference,
-            verifier,
-        ),
-        (kind, config, _) => bail!(
-            "post-training phase `{}` type `{}` / algorithm `{}` / adapter set do not match",
-            phase.name,
-            kind.name(),
-            post_training_algorithm_name(config)
-        ),
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn execute_dpo_phase(
-    phase: &PhaseV2,
-    task: &TaskConfig,
-    data: &Path,
-    sequence_length: usize,
-    update_examples: usize,
-    reference_spec: &FrozenModelSpec,
-    beta: f64,
-    label_smoothing: f64,
-    reduction: SequenceReduction,
-    policy: &mut dyn PreferencePolicy,
-    reference: &mut dyn SequenceLogProbabilityProvider,
-) -> Result<PostTrainingPhaseReport> {
-    validate_frozen_provider(
-        reference_spec,
-        reference.identity(),
-        reference.tokenizer_identity(),
-        policy.tokenizer_identity(),
-    )?;
-    let policy_identity = policy.identity().to_owned();
-    let frozen_identity = reference.identity().to_owned();
-    let mut report = ReportAccumulator::default();
-    let mut pending = Vec::with_capacity(update_examples);
-    let max_steps = phase.steps.unwrap_or(usize::MAX);
-    for _ in 0..phase.epochs_or_default() {
-        if report.optimizer_steps >= max_steps {
-            break;
-        }
-        visit_task_examples_while(data, task, |example| {
-            pending.push(example);
-            if pending.len() == update_examples {
-                process_dpo_update(
-                    &mut pending,
-                    sequence_length,
-                    beta,
-                    label_smoothing,
-                    reduction,
-                    phase.loss_weight_or_default(),
-                    phase.learning_rate_scale_or_default(),
-                    policy,
-                    reference,
-                    &mut report,
-                )?;
-            }
-            Ok(report.optimizer_steps < max_steps)
-        })?;
-    }
-    if !pending.is_empty() && report.optimizer_steps < max_steps {
-        process_dpo_update(
-            &mut pending,
-            sequence_length,
-            beta,
-            label_smoothing,
-            reduction,
-            phase.loss_weight_or_default(),
-            phase.learning_rate_scale_or_default(),
-            policy,
-            reference,
-            &mut report,
-        )?;
-    }
-    report.finish(phase, "dpo", policy_identity, Some(frozen_identity))
-}
-
-#[allow(clippy::too_many_arguments)]
-fn process_dpo_update(
-    pending: &mut Vec<TaskExample>,
-    sequence_length: usize,
-    beta: f64,
-    label_smoothing: f64,
-    reduction: SequenceReduction,
-    loss_weight: f64,
-    learning_rate_scale: f64,
-    policy: &mut dyn PreferencePolicy,
-    reference: &mut dyn SequenceLogProbabilityProvider,
-    report: &mut ReportAccumulator,
-) -> Result<()> {
-    let batch_scale = loss_weight / pending.len() as f64;
-    for example in pending.iter() {
-        let TaskExample::PairwisePreference {
-            prompt,
-            chosen,
-            rejected,
-        } = example
-        else {
-            bail!("DPO executor received a non-pairwise task example");
-        };
-        let policy_chosen = policy.continuation_log_probs(prompt, chosen, sequence_length)?;
-        let policy_rejected = policy.continuation_log_probs(prompt, rejected, sequence_length)?;
-        let reference_chosen = reference.continuation_log_probs(prompt, chosen, sequence_length)?;
-        let reference_rejected =
-            reference.continuation_log_probs(prompt, rejected, sequence_length)?;
-        let objective = dpo_loss(
-            PairwiseLogProbabilities {
-                policy_chosen: reduce_sequence_log_probs(&policy_chosen, reduction)?,
-                policy_rejected: reduce_sequence_log_probs(&policy_rejected, reduction)?,
-                reference_chosen: reduce_sequence_log_probs(&reference_chosen, reduction)?,
-                reference_rejected: reduce_sequence_log_probs(&reference_rejected, reduction)?,
-            },
-            beta,
-            label_smoothing,
-        )?;
-        let chosen_gradient = distribute_sequence_gradient(
-            objective.d_policy_chosen * batch_scale,
-            policy_chosen.len(),
-            reduction,
-        );
-        let rejected_gradient = distribute_sequence_gradient(
-            objective.d_policy_rejected * batch_scale,
-            policy_rejected.len(),
-            reduction,
-        );
-        policy.backward_pairwise_log_probs(example, &chosen_gradient, &rejected_gradient)?;
-        report.loss_sum += objective.loss;
-        report.add_metric(
-            "preference_accuracy",
-            f64::from(objective.preference_correct),
-        );
-        report.add_metric("implicit_reward_margin", objective.implicit_reward_margin);
-        report.examples += 1;
-    }
-    policy.optimizer_step(learning_rate_scale)?;
-    report.optimizer_steps += 1;
-    pending.clear();
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-fn execute_distillation_phase(
-    phase: &PhaseV2,
-    task: &TaskConfig,
-    data: &Path,
-    sequence_length: usize,
-    update_examples: usize,
-    teacher_spec: &FrozenModelSpec,
-    temperature: f64,
-    scale_by_temperature_squared: bool,
-    policy: &mut dyn DistillationPolicy,
-    teacher: &mut dyn TeacherDistributionProvider,
-) -> Result<PostTrainingPhaseReport> {
-    validate_frozen_provider(
-        teacher_spec,
-        teacher.identity(),
-        teacher.tokenizer_identity(),
-        policy.tokenizer_identity(),
-    )?;
-    let policy_identity = policy.identity().to_owned();
-    let frozen_identity = teacher.identity().to_owned();
-    let mut report = ReportAccumulator::default();
-    let mut pending = Vec::with_capacity(update_examples);
-    let max_steps = phase.steps.unwrap_or(usize::MAX);
-    for _ in 0..phase.epochs_or_default() {
-        if report.optimizer_steps >= max_steps {
-            break;
-        }
-        visit_task_examples_while(data, task, |example| {
-            pending.push(example);
-            if pending.len() == update_examples {
-                process_distillation_update(
-                    &mut pending,
-                    sequence_length,
-                    temperature,
-                    scale_by_temperature_squared,
-                    phase.loss_weight_or_default(),
-                    phase.learning_rate_scale_or_default(),
-                    policy,
-                    teacher,
-                    &mut report,
-                )?;
-            }
-            Ok(report.optimizer_steps < max_steps)
-        })?;
-    }
-    if !pending.is_empty() && report.optimizer_steps < max_steps {
-        process_distillation_update(
-            &mut pending,
-            sequence_length,
-            temperature,
-            scale_by_temperature_squared,
-            phase.loss_weight_or_default(),
-            phase.learning_rate_scale_or_default(),
-            policy,
-            teacher,
-            &mut report,
-        )?;
-    }
-    report.finish(phase, "forward_kl", policy_identity, Some(frozen_identity))
-}
-
-#[allow(clippy::too_many_arguments)]
-fn process_distillation_update(
-    pending: &mut Vec<TaskExample>,
-    sequence_length: usize,
-    temperature: f64,
-    scale_by_temperature_squared: bool,
-    loss_weight: f64,
-    learning_rate_scale: f64,
-    policy: &mut dyn DistillationPolicy,
-    teacher: &mut dyn TeacherDistributionProvider,
-    report: &mut ReportAccumulator,
-) -> Result<()> {
-    let batch_scale = loss_weight / pending.len() as f64;
-    for example in pending.iter() {
-        let teacher_logits = teacher.token_logits(example, sequence_length)?;
-        let student_logits = policy.student_token_logits(example, sequence_length)?;
-        ensure!(
-            teacher_logits.len() == student_logits.len(),
-            "teacher/student target-token row counts differ"
-        );
-        let tokens: Vec<_> = teacher_logits
-            .iter()
-            .zip(&student_logits)
-            .map(|(teacher_logits, student_logits)| DistillationToken {
-                teacher_logits,
-                student_logits,
-                weight: 1.0,
-            })
-            .collect();
-        let objective =
-            forward_kl_distillation(&tokens, temperature, scale_by_temperature_squared)?;
-        let mut gradients = objective.student_gradients;
-        for row in &mut gradients {
-            for value in row {
-                *value *= batch_scale;
-            }
-        }
-        policy.backward_student_logits(example, &gradients)?;
-        report.loss_sum += objective.loss;
-        report.add_metric("forward_kl", objective.mean_forward_kl);
-        report.add_metric("teacher_entropy", objective.teacher_entropy);
-        report.add_metric("top1_agreement", objective.top1_agreement);
-        report.examples += 1;
-    }
-    policy.optimizer_step(learning_rate_scale)?;
-    report.optimizer_steps += 1;
-    pending.clear();
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-fn execute_grpo_phase(
-    phase: &PhaseV2,
-    task: &TaskConfig,
-    data: &Path,
-    sequence_length: usize,
-    update_examples: usize,
-    group_size: usize,
-    clip_epsilon: f64,
-    advantage_epsilon: f64,
-    kl_coefficient: f64,
-    reference_spec: Option<&FrozenModelSpec>,
-    sampling: &RolloutSampling,
-    policy: &mut dyn GrpoPolicy,
-    mut reference: Option<&mut dyn AlignedReferencePolicy>,
-    verifier: &dyn RewardVerifier,
-) -> Result<PostTrainingPhaseReport> {
-    match (reference_spec, reference.as_deref()) {
-        (Some(spec), Some(provider)) => validate_frozen_provider(
-            spec,
-            provider.identity(),
-            provider.tokenizer_identity(),
-            policy.tokenizer_identity(),
-        )?,
-        (Some(_), None) => bail!("GRPO phase requires its configured frozen reference adapter"),
-        (None, Some(_)) => bail!("GRPO adapter set supplied an unconfigured frozen reference"),
-        (None, None) => ensure!(
-            kl_coefficient == 0.0,
-            "GRPO without a frozen reference requires zero kl_coefficient"
-        ),
-    }
-    let policy_identity = policy.identity().to_owned();
-    let frozen_identity = reference
-        .as_deref()
-        .map(|provider| provider.identity().to_owned());
-    let mut report = ReportAccumulator::default();
-    let mut pending = Vec::with_capacity(update_examples);
-    let max_steps = phase.steps.unwrap_or(usize::MAX);
-    for _ in 0..phase.epochs_or_default() {
-        if report.optimizer_steps >= max_steps {
-            break;
-        }
-        visit_task_examples_while(data, task, |example| {
-            pending.push(example);
-            if pending.len() == update_examples {
-                process_grpo_update(
-                    &mut pending,
-                    task,
-                    sequence_length,
-                    group_size,
-                    clip_epsilon,
-                    advantage_epsilon,
-                    kl_coefficient,
-                    sampling,
-                    phase.loss_weight_or_default(),
-                    phase.learning_rate_scale_or_default(),
-                    policy,
-                    &mut reference,
-                    verifier,
-                    &mut report,
-                )?;
-            }
-            Ok(report.optimizer_steps < max_steps)
-        })?;
-    }
-    if !pending.is_empty() && report.optimizer_steps < max_steps {
-        process_grpo_update(
-            &mut pending,
-            task,
-            sequence_length,
-            group_size,
-            clip_epsilon,
-            advantage_epsilon,
-            kl_coefficient,
-            sampling,
-            phase.loss_weight_or_default(),
-            phase.learning_rate_scale_or_default(),
-            policy,
-            &mut reference,
-            verifier,
-            &mut report,
-        )?;
-    }
-    report.finish(phase, "grpo", policy_identity, frozen_identity)
-}
-
-#[allow(clippy::too_many_arguments)]
-fn process_grpo_update(
-    pending: &mut Vec<TaskExample>,
-    task: &TaskConfig,
-    sequence_length: usize,
-    group_size: usize,
-    clip_epsilon: f64,
-    advantage_epsilon: f64,
-    kl_coefficient: f64,
-    sampling: &RolloutSampling,
-    loss_weight: f64,
-    learning_rate_scale: f64,
-    policy: &mut dyn GrpoPolicy,
-    reference: &mut Option<&mut dyn AlignedReferencePolicy>,
-    verifier: &dyn RewardVerifier,
-    report: &mut ReportAccumulator,
-) -> Result<()> {
-    let batch_scale = loss_weight / pending.len() as f64;
-    for example in pending.iter() {
-        let TaskExample::VerifiableRollout { prompt, .. } = example else {
-            bail!("GRPO executor received a non-verifiable task example");
-        };
-        let generated = policy.generate(RolloutRequest {
-            prompt,
-            count: group_size,
-            max_sequence_tokens: sequence_length,
-            sampling,
-            rng_seed: 0,
-            rng_counter: u64::try_from(report.examples)
-                .context("GRPO example count exceeds u64")?
-                .checked_mul(u64::try_from(group_size).context("GRPO group size exceeds u64")?)
-                .context("GRPO compatibility RNG counter overflows u64")?,
-        })?;
-        ensure!(
-            generated.len() == group_size,
-            "rollout generator returned {} candidates, expected {group_size}",
-            generated.len()
-        );
-        let mut rewards = Vec::with_capacity(group_size);
-        let mut current_scores = Vec::with_capacity(group_size);
-        let mut reference_scores = Vec::with_capacity(group_size);
-        for (index, rollout) in generated.iter().enumerate() {
-            ensure!(
-                !rollout.text.trim().is_empty(),
-                "rollout {index} completion is empty"
-            );
-            ensure!(
-                !rollout.token_ids.is_empty()
-                    && rollout.token_ids.len() == rollout.behavior_token_log_probs.len(),
-                "rollout {index} token ids and behavior log-probs are not aligned"
-            );
-            ensure_finite(
-                &rollout.behavior_token_log_probs,
-                "rollout behavior log probabilities",
-            )?;
-            rewards.push(verify_rollout(task, example, verifier, &rollout.text)?.reward);
-            current_scores.push(policy.current_token_log_probs(
-                prompt,
-                rollout,
-                sequence_length,
-            )?);
-            reference_scores.push(match reference.as_deref_mut() {
-                Some(reference) => {
-                    Some(reference.rollout_token_log_probs(prompt, rollout, sequence_length)?)
-                }
-                None => None,
-            });
-        }
-        let scalar_rollouts: Vec<_> = generated
-            .iter()
-            .enumerate()
-            .map(|(index, rollout)| GrpoRollout {
-                reward: rewards[index],
-                current_token_log_probs: &current_scores[index],
-                behavior_token_log_probs: &rollout.behavior_token_log_probs,
-                reference_token_log_probs: reference_scores[index].as_deref(),
-            })
-            .collect();
-        let objective = grpo_loss(
-            &scalar_rollouts,
-            clip_epsilon,
-            advantage_epsilon,
-            kl_coefficient,
-        )?;
-        for (index, rollout) in generated.iter().enumerate() {
-            let gradients: Vec<f64> = objective.current_log_prob_gradients[index]
-                .iter()
-                .map(|gradient| gradient * batch_scale)
-                .collect();
-            policy.backward_rollout_log_probs(prompt, rollout, &gradients)?;
-        }
-        report.loss_sum += objective.loss;
-        report.add_metric("mean_reward", objective.mean_reward);
-        report.add_metric("reward_stddev", objective.reward_stddev);
-        report.add_metric("mean_kl", objective.mean_kl);
-        report.add_metric("clipped_fraction", objective.clipped_fraction);
-        report.examples += 1;
-    }
-    policy.optimizer_step(learning_rate_scale)?;
-    report.optimizer_steps += 1;
-    pending.clear();
-    Ok(())
-}
-
 fn validate_frozen_provider(
     spec: &FrozenModelSpec,
     provider_identity: &str,
@@ -1769,6 +1227,26 @@ impl PostTrainingClockReceipt {
             UpdateClock::ModelTokens => self.model_tokens,
         }
     }
+}
+
+fn validate_periodic_sleep_clock_window(
+    config: &InModelSleepConfig,
+    before: &PostTrainingClockReceipt,
+    after: PostTrainingClockValues,
+) -> Result<()> {
+    config.schedule.validate()?;
+    let start = before.selected(config.schedule.clock);
+    let end = after.selected(config.schedule.clock);
+    ensure!(end >= start, "periodic sleep clock cannot move backwards");
+    for tier in &config.schedule.tiers {
+        let crossed = end / tier.update_period - start / tier.update_period;
+        ensure!(
+            crossed <= 1,
+            "periodic sleep clock advance from {start} to {end} crosses {crossed} `{}` boundaries; one tier gradient accumulator cannot supply multiple updates, so reduce the per-update token budget or increase its update_period",
+            tier.id,
+        );
+    }
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -1997,6 +1475,15 @@ pub struct PreparedPostTrainingUpdate {
 pub struct PostTrainingClockValues {
     pub optimizer_steps: u64,
     pub model_tokens: u64,
+}
+
+impl PostTrainingClockValues {
+    fn selected(self, clock: UpdateClock) -> u64 {
+        match clock {
+            UpdateClock::OptimizerSteps => self.optimizer_steps,
+            UpdateClock::ModelTokens => self.model_tokens,
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -2481,6 +1968,11 @@ impl<R: NativePostTrainingSleepRuntime> PostTrainingBoundaryHook
                 && request.clock_after.model_tokens > request.clock_before.model_tokens,
             "post-training sleep target clock does not advance exactly one optimizer update"
         );
+        validate_periodic_sleep_clock_window(
+            request.config,
+            request.clock_before,
+            request.clock_after,
+        )?;
 
         let resumed = resume.is_some();
         let mut checkpoint = match resume {
@@ -2507,21 +1999,14 @@ impl<R: NativePostTrainingSleepRuntime> PostTrainingBoundaryHook
             );
         }
         ensure!(
-            checkpoint.sleep.clock
-                <= match request.config.schedule.clock {
-                    UpdateClock::OptimizerSteps => request.clock_after.optimizer_steps,
-                    UpdateClock::ModelTokens => request.clock_after.model_tokens,
-                },
+            checkpoint.sleep.clock <= request.clock_after.selected(request.config.schedule.clock),
             "resumed post-training sleep cursor is ahead of its target clock"
         );
 
         let state = self
             .runtime
             .advance_and_drain(request, &mut checkpoint, progress)?;
-        let target = match request.config.schedule.clock {
-            UpdateClock::OptimizerSteps => request.clock_after.optimizer_steps,
-            UpdateClock::ModelTokens => request.clock_after.model_tokens,
-        };
+        let target = request.clock_after.selected(request.config.schedule.clock);
         ensure!(
             checkpoint.sleep.clock == target
                 && checkpoint.sleep.phase == SleepPhase::Wake
@@ -2987,11 +2472,7 @@ impl PostTrainingBoundaryInFlight {
             native.sleep.validate_resume()?;
             ensure!(
                 native.sleep.clock >= before.selected(config.schedule.clock)
-                    && native.sleep.clock
-                        <= match config.schedule.clock {
-                            UpdateClock::OptimizerSteps => after.optimizer_steps,
-                            UpdateClock::ModelTokens => after.model_tokens,
-                        },
+                    && native.sleep.clock <= after.selected(config.schedule.clock),
                 "in-flight native sleep cursor is outside its clock interval"
             );
         }
@@ -3347,6 +2828,18 @@ pub fn drive_resumable_post_training_phase(
             cursor.clock.clone(),
             prepared_computation.summary,
         )?;
+        if let Some(config) = phase.periodic_sleep.as_ref() {
+            validate_periodic_sleep_clock_window(
+                config,
+                expected
+                    .clock_before
+                    .as_ref()
+                    .context("periodic update has no starting clock")?,
+                expected
+                    .clock_after
+                    .context("periodic update has no target clock")?,
+            )?;
+        }
         match &cursor.pending {
             Some(saved) => ensure!(
                 saved == &expected,
@@ -4880,6 +4373,158 @@ mod tests {
     }
 
     #[test]
+    fn grpo_tensor_rejects_fractional_and_empty_masks() {
+        let device = Device::ndarray();
+        for (mask, expected) in [
+            ([[1.0, 0.5], [1.0, 0.0]], "binary zero/one"),
+            ([[1.0, 0.0], [0.0, 0.0]], "at least one active token"),
+        ] {
+            let error = grpo_loss_tensor(
+                Tensor::<1>::from_floats([1.0, 0.0], &device),
+                Tensor::<2>::from_floats([[0.0, 0.0], [0.0, 0.0]], &device),
+                Tensor::<2>::from_floats([[0.0, 0.0], [0.0, 0.0]], &device),
+                None,
+                Tensor::<2>::from_floats(mask, &device),
+                0.2,
+                1e-6,
+                0.0,
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(error.contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn grpo_tensor_rejects_non_finite_and_unsafe_exponent_inputs() {
+        let device = Device::ndarray();
+        let error = grpo_loss_tensor(
+            Tensor::<1>::from_floats([1.0, 0.0], &device),
+            Tensor::<2>::from_floats([[f32::NAN], [0.0]], &device),
+            Tensor::<2>::from_floats([[0.0], [0.0]], &device),
+            None,
+            Tensor::<2>::from_floats([[1.0], [1.0]], &device),
+            0.2,
+            1e-6,
+            0.0,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("current log probabilities"), "{error}");
+
+        let error = grpo_loss_tensor(
+            Tensor::<1>::from_floats([1.0, 0.0], &device),
+            Tensor::<2>::from_floats([[81.0], [0.0]], &device),
+            Tensor::<2>::from_floats([[0.0], [0.0]], &device),
+            None,
+            Tensor::<2>::from_floats([[1.0], [1.0]], &device),
+            0.2,
+            1e-6,
+            0.0,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("importance log-ratio"), "{error}");
+
+        let error = grpo_loss_tensor(
+            Tensor::<1>::from_floats([1.0, 0.0], &device),
+            Tensor::<2>::from_floats([[0.0], [0.0]], &device),
+            Tensor::<2>::from_floats([[0.0], [0.0]], &device),
+            Some(Tensor::<2>::from_floats([[81.0], [0.0]], &device)),
+            Tensor::<2>::from_floats([[1.0], [1.0]], &device),
+            0.2,
+            1e-6,
+            0.1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("reference log-ratio"), "{error}");
+    }
+
+    #[test]
+    fn grpo_tensor_rejects_finite_inputs_that_overflow_the_objective() {
+        let device = Device::ndarray();
+        let error = grpo_loss_tensor(
+            Tensor::<1>::from_floats([1.0, 0.0], &device),
+            Tensor::<2>::from_floats([[-80.0], [-80.0]], &device),
+            Tensor::<2>::from_floats([[-80.0], [-80.0]], &device),
+            Some(Tensor::<2>::from_floats([[0.0], [0.0]], &device)),
+            Tensor::<2>::from_floats([[1.0], [1.0]], &device),
+            0.2,
+            1e-6,
+            1.0e10,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("tensor objective overflowed"), "{error}");
+    }
+
+    #[test]
+    fn grpo_scalar_rejects_finite_inputs_that_overflow_derived_values() {
+        let zero = [0.0];
+        let reward_overflow = [
+            GrpoRollout {
+                reward: f64::MAX,
+                current_token_log_probs: &zero,
+                behavior_token_log_probs: &zero,
+                reference_token_log_probs: None,
+            },
+            GrpoRollout {
+                reward: -f64::MAX,
+                current_token_log_probs: &zero,
+                behavior_token_log_probs: &zero,
+                reference_token_log_probs: None,
+            },
+        ];
+        let error = grpo_loss(&reward_overflow, 0.2, 1e-6, 0.0)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("reward normalization overflowed"), "{error}");
+
+        let current = [-f64::MAX];
+        let behavior = [f64::MAX];
+        let unsafe_ratio = [
+            GrpoRollout {
+                reward: 1.0,
+                current_token_log_probs: &current,
+                behavior_token_log_probs: &behavior,
+                reference_token_log_probs: None,
+            },
+            GrpoRollout {
+                reward: 0.0,
+                current_token_log_probs: &zero,
+                behavior_token_log_probs: &zero,
+                reference_token_log_probs: None,
+            },
+        ];
+        let error = grpo_loss(&unsafe_ratio, 0.2, 1e-6, 0.0)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("unsafe importance ratio"), "{error}");
+
+        let low = [-80.0];
+        let reference = [0.0];
+        let objective_overflow = [
+            GrpoRollout {
+                reward: 1.0,
+                current_token_log_probs: &low,
+                behavior_token_log_probs: &low,
+                reference_token_log_probs: Some(&reference),
+            },
+            GrpoRollout {
+                reward: 0.0,
+                current_token_log_probs: &low,
+                behavior_token_log_probs: &low,
+                reference_token_log_probs: Some(&reference),
+            },
+        ];
+        let error = grpo_loss(&objective_overflow, 0.2, 1e-6, f64::MAX)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("GRPO objective overflowed"), "{error}");
+    }
+
+    #[test]
     fn grpo_rejects_missing_reference_instead_of_dropping_kl() {
         let values = [0.0];
         let error = grpo_loss(
@@ -5077,63 +4722,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn typed_dpo_phase_executor_runs_records_and_optimizer_geometry() {
-        let dir = tempfile::tempdir().unwrap();
-        let artifact = dir.path().join("reference.safetensors");
-        std::fs::write(&artifact, b"abc").unwrap();
-        let data = dir.path().join("preference.jsonl");
-        std::fs::write(
-            &data,
-            concat!(
-                "{\"prompt\":\"p1\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n",
-                "{\"prompt\":\"p2\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n"
-            ),
-        )
-        .unwrap();
-        let phase: PhaseV2 = serde_json::from_value(json!({
-            "name": "preference",
-            "type": "preference",
-            "task": {"type": "pairwise_preference"},
-            "data": data,
-            "sequence_length": 128,
-            "batch_size": 1,
-            "gradient_accumulation": 2,
-            "steps": 1,
-            "learning_rate_scale": 0.5,
-            "post_training": {
-                "algorithm": "dpo",
-                "reference": {
-                    "adapter": "test",
-                    "artifact": artifact,
-                    "sha256": ABC_SHA256
-                }
-            }
-        }))
-        .unwrap();
-        let mut policy = TestSequencePolicy {
-            identity: "candidate:one".to_owned(),
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut reference = TestReference;
-        let report = execute_post_training_phase(
-            &phase,
-            PostTrainingPhaseAdapters::Dpo {
-                policy: &mut policy,
-                reference: &mut reference,
-            },
-        )
-        .unwrap();
-        assert_eq!(report.algorithm, "dpo");
-        assert_eq!(report.examples, 2);
-        assert_eq!(report.optimizer_steps, 1);
-        assert_eq!(policy.backward_calls, 2);
-        assert_eq!(policy.optimizer_steps, 1);
-        close(report.metrics["preference_accuracy"], 1.0);
-    }
-
     struct TestStudent {
         gradients: Vec<Vec<Vec<f64>>>,
         optimizer_steps: usize,
@@ -5196,53 +4784,6 @@ mod tests {
         ) -> Result<Vec<Vec<f64>>> {
             Ok(vec![vec![3.0_f64.ln(), 0.0]])
         }
-    }
-
-    #[test]
-    fn typed_distillation_phase_executor_applies_teacher_kl_gradients() {
-        let dir = tempfile::tempdir().unwrap();
-        let artifact = dir.path().join("teacher.safetensors");
-        std::fs::write(&artifact, b"abc").unwrap();
-        let data = dir.path().join("distill.txt");
-        std::fs::write(&data, "student input\n").unwrap();
-        let phase: PhaseV2 = serde_json::from_value(json!({
-            "name": "distill",
-            "type": "distillation",
-            "task": {"type": "causal_lm"},
-            "data": data,
-            "sequence_length": 128,
-            "batch_size": 1,
-            "gradient_accumulation": 1,
-            "steps": 1,
-            "post_training": {
-                "algorithm": "forward_kl",
-                "teacher": {
-                    "adapter": "test",
-                    "artifact": artifact,
-                    "sha256": ABC_SHA256
-                }
-            }
-        }))
-        .unwrap();
-        let mut policy = TestStudent {
-            gradients: Vec::new(),
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut teacher = TestTeacher;
-        let report = execute_post_training_phase(
-            &phase,
-            PostTrainingPhaseAdapters::ForwardKl {
-                policy: &mut policy,
-                teacher: &mut teacher,
-            },
-        )
-        .unwrap();
-        assert_eq!(report.examples, 1);
-        assert_eq!(policy.optimizer_steps, 1);
-        close(policy.gradients[0][0][0], -0.25);
-        close(policy.gradients[0][0][1], 0.25);
-        assert!(report.metrics["forward_kl"] > 0.0);
     }
 
     struct TestGrpoPolicy {
@@ -5313,57 +4854,6 @@ mod tests {
             self.optimizer_steps += 1;
             Ok(())
         }
-    }
-
-    #[test]
-    fn typed_grpo_phase_executor_generates_verifies_and_backpropagates() {
-        let dir = tempfile::tempdir().unwrap();
-        let data = dir.path().join("rl.jsonl");
-        std::fs::write(
-            &data,
-            "{\"prompt\":\"answer\",\"verifier_payload\":{},\"reference_answer\":\"ok\"}\n",
-        )
-        .unwrap();
-        let phase: PhaseV2 = serde_json::from_value(json!({
-            "name": "rl",
-            "type": "rl",
-            "task": {
-                "type": "verifiable_rl",
-                "verifier": {"adapter": "exact_answer"}
-            },
-            "data": data,
-            "sequence_length": 128,
-            "batch_size": 1,
-            "gradient_accumulation": 1,
-            "steps": 1,
-            "post_training": {
-                "algorithm": "grpo",
-                "group_size": 2,
-                "kl_coefficient": 0.0,
-                "sampling": {"max_new_tokens": 32}
-            }
-        }))
-        .unwrap();
-        let mut policy = TestGrpoPolicy {
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let report = execute_post_training_phase(
-            &phase,
-            PostTrainingPhaseAdapters::Grpo {
-                policy: &mut policy,
-                reference: None,
-                verifier: &ExactAnswerVerifier,
-            },
-        )
-        .unwrap();
-        assert_eq!(report.examples, 1);
-        assert_eq!(report.optimizer_steps, 1);
-        assert_eq!(policy.backward_calls, 2);
-        assert_eq!(policy.optimizer_steps, 1);
-        close(report.metrics["mean_reward"], 0.5);
-        close(report.mean_loss, 0.0);
     }
 
     #[test]
@@ -5652,10 +5142,7 @@ mod tests {
                 Some(cursor) => cursor,
                 None => test_native_sleep_cursor(request)?,
             };
-            let target = match request.config.schedule.clock {
-                UpdateClock::OptimizerSteps => request.clock_after.optimizer_steps,
-                UpdateClock::ModelTokens => request.clock_after.model_tokens,
-            };
+            let target = request.clock_after.selected(request.config.schedule.clock);
             if cursor.sleep.clock < target {
                 cursor
                     .sleep
@@ -5731,10 +5218,7 @@ mod tests {
             checkpoint: &mut NativeSleepCheckpoint,
             progress: &mut dyn NativeSleepProgressSink,
         ) -> Result<PostTrainingCommittedState> {
-            let target = match request.config.schedule.clock {
-                UpdateClock::OptimizerSteps => request.clock_after.optimizer_steps,
-                UpdateClock::ModelTokens => request.clock_after.model_tokens,
-            };
+            let target = request.clock_after.selected(request.config.schedule.clock);
             if checkpoint.sleep.clock < target {
                 checkpoint
                     .sleep
@@ -6358,7 +5842,7 @@ mod tests {
     }
 
     #[test]
-    fn model_token_jump_drains_every_crossed_boundary_fastest_to_slowest() {
+    fn model_token_jump_rejects_before_publishing_one_update_for_multiple_boundaries() {
         let (_dir, mut request) = test_request(TestPostTrainingAlgorithm::Grpo);
         request.phase.steps = Some(1);
         install_periodic_sleep(&mut request);
@@ -6399,7 +5883,7 @@ mod tests {
             verifier: &ExactAnswerVerifier,
         };
         let mut hook: Option<&mut dyn PostTrainingBoundaryHook> = Some(&mut controller);
-        let outcome = drive_resumable_post_training_phase(
+        let error = drive_resumable_post_training_phase(
             &test_sha("coarse-model-token-workflow"),
             &request,
             &mut adapters,
@@ -6410,15 +5894,11 @@ mod tests {
             usize::MAX,
             &mut TestPhaseProgress::default(),
         )
-        .unwrap();
-        let ResumablePostTrainingOutcome::Complete { cursor, .. } = outcome else {
-            panic!("coarse model-token phase did not complete");
-        };
-        assert_eq!(cursor.clock.as_ref().unwrap().model_tokens, 4);
-        assert_eq!(
-            &*due.borrow(),
-            &[(1, 0), (2, 0), (2, 1), (3, 0), (4, 0), (4, 1), (4, 2),]
-        );
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("crosses 4 `fast` boundaries"), "{error}");
+        assert_eq!(policy.optimizer_steps, 0);
+        assert!(due.borrow().is_empty());
     }
 
     #[test]

--- a/hermes-train/src/quantization.rs
+++ b/hermes-train/src/quantization.rs
@@ -2633,7 +2633,7 @@ mod tests {
     }
 
     #[test]
-    fn transformer_qat_clone_keeps_parameter_ids_and_backpropagates() {
+    fn transformer_qat_clone_keeps_parameter_ids_and_supports_an_accumulation_window() {
         let device = Device::default().autodiff();
         let mut config = hermes_llm::get_builtin_model("hybrid-tiny").unwrap();
         config.vocab_size = 32;
@@ -2659,20 +2659,27 @@ mod tests {
         assert!(tensors > 0);
         assert_eq!(burn::module::list_param_ids(&staged), before);
 
-        let input = Tensor::<2, Int>::from_data([[1, 2, 3, 4]], &device);
-        let target = Tensor::<2, Int>::from_data([[2, 3, 4, 5]], &device);
-        let mut gradients = staged.forward_loss(input, target).backward();
-        let gradients = burn_optim::GradientsParams::from_module(&mut gradients, &staged);
-        assert!(!gradients.is_empty());
-        let missing_muon = master
-            .muon_parameter_ids()
-            .into_iter()
-            .filter(|id| gradients.get::<2>(*id).is_none())
-            .collect::<Vec<_>>();
-        assert!(
-            missing_muon.is_empty(),
-            "fake-quantized forward omitted Muon gradients: {missing_muon:?}"
-        );
+        // A staged leaf model is reused for every microbatch until the master
+        // update. Repeated backwards must keep producing gradients for the
+        // original parameter IDs; otherwise window-level staging would drop
+        // all but the first microbatch.
+        for offset in 0..2 {
+            let input =
+                Tensor::<2, Int>::from_data([[1 + offset, 2 + offset, 3 + offset, 4]], &device);
+            let target = Tensor::<2, Int>::from_data([[2 + offset, 3 + offset, 4, 5]], &device);
+            let mut gradients = staged.forward_loss(input, target).backward();
+            let gradients = burn_optim::GradientsParams::from_module(&mut gradients, &staged);
+            assert!(!gradients.is_empty());
+            let missing_muon = master
+                .muon_parameter_ids()
+                .into_iter()
+                .filter(|id| gradients.get::<2>(*id).is_none())
+                .collect::<Vec<_>>();
+            assert!(
+                missing_muon.is_empty(),
+                "fake-quantized forward omitted Muon gradients: {missing_muon:?}"
+            );
+        }
     }
 
     #[test]

--- a/hermes-train/src/sleep.rs
+++ b/hermes-train/src/sleep.rs
@@ -249,6 +249,9 @@ pub struct ConsolidationTxn {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SleepState {
+    /// Highest consolidation attempt ID allocated so far. Successful and
+    /// rolled-back attempts both consume an ID so immutable receipts from a
+    /// rejected attempt can never alias a later transaction.
     pub cycle: u64,
     pub clock: u64,
     pub phase: SleepPhase,
@@ -724,8 +727,26 @@ impl SleepState {
                 tier.id
             );
         }
+        let due = self
+            .due_clocks
+            .iter()
+            .copied()
+            .zip(self.due_senders.iter().copied())
+            .collect::<Vec<_>>();
+        // A rejected terminal consolidation is retried before ordinary
+        // senders so no further transfer can fill its already-full reserve.
+        // That exceptional first entry may therefore precede an older due
+        // clock; the remainder always retains normal chronological ordering.
+        let terminal_retry_prefix = due.first().is_some_and(|(_, sender)| {
+            self.tiers.get(*sender).is_some_and(|tier| {
+                *sender + 1 == self.tiers.len() && tier.last_update_clock < tier.last_boundary_clock
+            })
+        });
+        let ordered_start = usize::from(terminal_retry_prefix);
+        let unique_due_senders = self.due_senders.iter().copied().collect::<BTreeSet<_>>();
         ensure!(
             self.due_senders.len() == self.due_clocks.len()
+                && unique_due_senders.len() == self.due_senders.len()
                 && self
                     .due_senders
                     .iter()
@@ -734,11 +755,7 @@ impl SleepState {
                     .due_clocks
                     .iter()
                     .all(|clock| *clock > 0 && *clock <= self.clock)
-                && self
-                    .due_clocks
-                    .iter()
-                    .zip(&self.due_senders)
-                    .collect::<Vec<_>>()
+                && due[ordered_start..]
                     .windows(2)
                     .all(|pair| pair[0] < pair[1]),
             "sleep checkpoint has an invalid due-boundary queue"
@@ -750,9 +767,12 @@ impl SleepState {
             validate_content_hash(manifest, "sleep artifact manifest")?;
         }
         validate_content_hash(&self.completed_chain_hash, "sleep completed-history hash")?;
+        let expected_completed_tail =
+            usize::try_from(self.completed_count.min(COMPLETED_TRANSACTION_TAIL as u64))
+                .context("sleep completed-transaction tail length exceeds usize")?;
         ensure!(
-            self.completed_transactions.len() <= COMPLETED_TRANSACTION_TAIL
-                && self.completed_count >= self.completed_transactions.len() as u64,
+            self.completed_count <= self.cycle
+                && self.completed_transactions.len() == expected_completed_tail,
             "sleep completed-transaction audit tail is inconsistent"
         );
         ensure!(
@@ -762,7 +782,9 @@ impl SleepState {
                 && self
                     .completed_transactions
                     .iter()
-                    .all(|txn| txn.committed && txn.candidate_hash.is_some()),
+                    .all(|txn| txn.id <= self.cycle
+                        && txn.committed
+                        && txn.candidate_hash.is_some()),
             "sleep completed-transaction audit tail is invalid"
         );
         match (self.phase, self.pending.as_ref()) {
@@ -805,6 +827,12 @@ impl SleepState {
                 ensure!(
                     txn.id == expected_id,
                     "sleep transaction id disagrees with cycle/commit state"
+                );
+                ensure!(
+                    self.completed_transactions
+                        .last()
+                        .is_none_or(|completed| completed.id < txn.id),
+                    "pending sleep transaction reuses a completed transaction id"
                 );
                 ensure!(
                     txn.terminal || txn.receiver_slot < self.tiers[txn.receiver].slots.len(),
@@ -1090,7 +1118,6 @@ impl SleepState {
             "sleep schedule topology differs from checkpoint state"
         );
         ensure!(clock >= self.clock, "sleep clock cannot move backwards");
-        self.clock = clock;
         let mut due = Vec::new();
         for (sender, tier) in schedule.tiers.iter().enumerate() {
             let last = self.tiers[sender].last_boundary_clock;
@@ -1099,22 +1126,93 @@ impl SleepState {
                 .and_then(|multiple| multiple.checked_add(1))
                 .and_then(|multiple| multiple.checked_mul(tier.update_period))
                 .context("sleep boundary clock overflow")?;
-            let mut boundary = first;
-            while boundary <= clock {
-                due.push((boundary, sender));
-                boundary = boundary
+            if first <= clock {
+                let second = first
                     .checked_add(tier.update_period)
                     .context("sleep boundary clock overflow")?;
+                ensure!(
+                    second > clock,
+                    "sleep clock advance from {} to {clock} crosses multiple `{}` boundaries ({first} and {second}); one tier gradient accumulator cannot supply multiple updates, so the host must split the advance at a boundary",
+                    self.clock,
+                    tier.id,
+                );
+                due.push((first, sender));
             }
         }
         due.sort_unstable();
+
+        // A failed terminal transfer leaves its active slots intact by
+        // design. Backpressure ordinary transfers until the next configured
+        // terminal boundary, then retry terminal first so capacity is either
+        // reclaimed before a new transfer or remains safely unchanged.
+        let terminal = self.tiers.len() - 1;
+        let terminal_retry_pending =
+            self.tiers[terminal].last_update_clock < self.tiers[terminal].last_boundary_clock;
+        if terminal_retry_pending {
+            if let Some(index) = due.iter().position(|(_, sender)| *sender == terminal) {
+                let retry = due.remove(index);
+                due.insert(0, retry);
+            } else {
+                // No terminal attempt is scheduled yet. Consume only the
+                // logical boundaries, not their accumulated gradients, so
+                // wake learning can continue without filling more reserves.
+                for (trigger_clock, sender) in &due {
+                    self.tiers[*sender].last_boundary_clock = *trigger_clock;
+                }
+                due.clear();
+            }
+        }
+
+        self.clock = clock;
         self.due_clocks = due.iter().map(|(clock, _)| *clock).collect();
         self.due_senders = due.into_iter().map(|(_, sender)| sender).collect();
         Ok(())
     }
 
+    pub fn next_due_boundary(&self) -> Option<(usize, u64)> {
+        self.due_senders
+            .first()
+            .copied()
+            .zip(self.due_clocks.first().copied())
+    }
+
     pub fn next_due_sender(&self) -> Option<usize> {
-        self.due_senders.first().copied()
+        self.next_due_boundary().map(|(sender, _)| sender)
+    }
+
+    fn ensure_next_due_boundary(
+        &self,
+        expected_sender: usize,
+        expected_clock: u64,
+        operation: &str,
+    ) -> Result<()> {
+        ensure!(
+            self.next_due_boundary() == Some((expected_sender, expected_clock)),
+            "{operation} boundary ({expected_clock}, {expected_sender}) is not first in the due queue"
+        );
+        Ok(())
+    }
+
+    fn consume_next_due_boundary(
+        &mut self,
+        expected_sender: usize,
+        expected_clock: u64,
+        operation: &str,
+    ) -> Result<()> {
+        self.ensure_next_due_boundary(expected_sender, expected_clock, operation)?;
+        self.due_senders.remove(0);
+        self.due_clocks.remove(0);
+        Ok(())
+    }
+
+    /// Allocate the identifier that the next consolidation attempt must use.
+    /// Successful and rolled-back attempts both advance `cycle`, so callers
+    /// preparing immutable transaction-keyed artifacts must use this checked
+    /// helper rather than arithmetic on the checkpoint field.
+    pub fn next_transaction_id(&self) -> Result<u64> {
+        self.cycle
+            .checked_add(1)
+            .context("sleep consolidation transaction ID overflows u64")
     }
 
     pub fn begin(
@@ -1134,8 +1232,14 @@ impl SleepState {
             sender < self.tiers.len(),
             "sender tier {sender} is out of range"
         );
+        let (next_sender, trigger_clock) = self.next_due_boundary().with_context(|| {
+            format!(
+                "sender tier {sender} has no paired due boundary at sleep clock {}",
+                self.clock
+            )
+        })?;
         ensure!(
-            self.next_due_sender() == Some(sender),
+            next_sender == sender,
             "sender tier {sender} is not next at sleep clock {}",
             self.clock
         );
@@ -1168,12 +1272,10 @@ impl SleepState {
             .enumerate()
             .filter_map(|(index, slot)| slot.active.then_some(index))
             .collect();
+        let transaction_id = self.next_transaction_id()?;
         let txn = ConsolidationTxn {
-            id: self.cycle + 1,
-            trigger_clock: *self
-                .due_clocks
-                .first()
-                .context("sender has no paired due clock")?,
+            id: transaction_id,
+            trigger_clock,
             sender,
             receiver,
             receiver_slot,
@@ -1380,8 +1482,9 @@ impl SleepState {
         );
         let txn = self
             .pending
-            .as_mut()
-            .ok_or_else(|| anyhow::anyhow!("no consolidation transaction"))?;
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no consolidation transaction"))?
+            .clone();
         if txn.committed {
             return Ok(());
         }
@@ -1397,31 +1500,61 @@ impl SleepState {
                 .context("consolidation has no published candidate hash")?,
             "published candidate hash",
         )?;
+        // Validate the whole metadata transaction before changing any slot.
+        // Corrupt resume state and generation exhaustion must fail without a
+        // partially activated receiver or partially reclaimed sender.
+        self.ensure_next_due_boundary(txn.sender, txn.trigger_clock, "committed")?;
+        let sender_tier = self
+            .tiers
+            .get(txn.sender)
+            .context("committed sender tier is out of range")?;
+        if !txn.terminal {
+            let receiver_slot = self
+                .tiers
+                .get(txn.receiver)
+                .context("committed receiver tier is out of range")?
+                .slots
+                .get(txn.receiver_slot)
+                .context("committed receiver slot is out of range")?;
+            ensure!(!receiver_slot.active, "receiver slot is already active");
+            ensure!(
+                receiver_slot.generation < u64::MAX,
+                "receiver reserve generation overflows u64"
+            );
+        }
+        for &slot in &txn.sender_slots_to_reset {
+            let sender_slot = sender_tier
+                .slots
+                .get(slot)
+                .context("sender reset plan contains an out-of-range slot")?;
+            ensure!(
+                sender_slot.active,
+                "sender reset plan contains dormant slot"
+            );
+            ensure!(
+                sender_slot.generation < u64::MAX,
+                "sender reserve generation overflows u64"
+            );
+        }
+        self.consume_next_due_boundary(txn.sender, txn.trigger_clock, "committed")?;
+
         if !txn.terminal {
             let receiver_slot = &mut self.tiers[txn.receiver].slots[txn.receiver_slot];
-            ensure!(!receiver_slot.active, "receiver slot is already active");
             receiver_slot.active = true;
             receiver_slot.generation += 1;
         }
         for &slot in &txn.sender_slots_to_reset {
             let sender_slot = &mut self.tiers[txn.sender].slots[slot];
-            ensure!(
-                sender_slot.active,
-                "sender reset plan contains dormant slot"
-            );
             sender_slot.active = false;
             sender_slot.generation += 1;
         }
         self.tiers[txn.sender].last_update_clock = txn.trigger_clock;
         self.tiers[txn.sender].last_boundary_clock = txn.trigger_clock;
-        ensure!(
-            self.due_senders.first() == Some(&txn.sender),
-            "committed sender is not first in the due queue"
-        );
-        self.due_senders.remove(0);
-        self.due_clocks.remove(0);
         self.cycle = txn.id;
-        txn.committed = true;
+        self.pending
+            .as_mut()
+            .expect("transaction was validated above")
+            .committed = true;
         Ok(())
     }
 
@@ -1524,17 +1657,54 @@ impl SleepState {
     /// Roll back metadata.  The backend must restore the immutable teacher
     /// checkpoint before this method is persisted.
     pub fn rollback(&mut self) -> Result<ConsolidationTxn> {
+        let (sender, trigger_clock) = self
+            .pending
+            .as_ref()
+            .map(|txn| (txn.sender, txn.trigger_clock))
+            .ok_or_else(|| anyhow::anyhow!("no consolidation transaction"))?;
+        ensure!(
+            sender < self.tiers.len(),
+            "rolled-back sender tier is out of range"
+        );
+        let terminal = self
+            .pending
+            .as_ref()
+            .expect("pending transaction was checked above")
+            .terminal;
+        if terminal {
+            ensure!(
+                self.due_senders.len() == self.due_clocks.len()
+                    && self
+                        .due_senders
+                        .iter()
+                        .all(|queued_sender| *queued_sender < self.tiers.len()),
+                "rolled-back terminal boundary has an invalid trailing due queue"
+            );
+        }
+        self.consume_next_due_boundary(sender, trigger_clock, "rolled-back")?;
         let txn = self
             .pending
             .take()
-            .ok_or_else(|| anyhow::anyhow!("no consolidation transaction"))?;
-        ensure!(
-            self.due_senders.first() == Some(&txn.sender),
-            "rolled-back sender is not first in the due queue"
-        );
-        self.tiers[txn.sender].last_boundary_clock = txn.trigger_clock;
-        self.due_senders.remove(0);
-        self.due_clocks.remove(0);
+            .expect("transaction was validated before consuming its due boundary");
+        self.tiers[sender].last_boundary_clock = trigger_clock;
+        if terminal {
+            // A terminal retry has priority because its reserve may already
+            // be full. If it is rejected, do not attempt any transfers that
+            // were queued behind it in the same coarse host advance. Their
+            // gradient accumulators remain intact and will be consumed at a
+            // later boundary after terminal retention succeeds.
+            for (sender, trigger_clock) in self
+                .due_senders
+                .iter()
+                .copied()
+                .zip(self.due_clocks.iter().copied())
+            {
+                self.tiers[sender].last_boundary_clock = trigger_clock;
+            }
+            self.due_senders.clear();
+            self.due_clocks.clear();
+        }
+        self.cycle = txn.id;
         self.phase = SleepPhase::Wake;
         Ok(txn)
     }
@@ -1614,20 +1784,34 @@ pub fn validate_model_memory_state(
     );
     let mut expected = Vec::new();
     for (sender, tier) in schedule.tiers.iter().enumerate() {
-        let mut boundary = state.tiers[sender]
+        let boundary = state.tiers[sender]
             .last_boundary_clock
             .checked_div(tier.update_period)
             .and_then(|multiple| multiple.checked_add(1))
             .and_then(|multiple| multiple.checked_mul(tier.update_period))
             .context("sleep resume boundary clock overflow")?;
-        while boundary <= state.clock {
-            expected.push((boundary, sender));
-            boundary = boundary
+        if boundary <= state.clock {
+            let second = boundary
                 .checked_add(tier.update_period)
                 .context("sleep resume boundary clock overflow")?;
+            ensure!(
+                second > state.clock,
+                "sleep checkpoint crosses multiple `{}` boundaries ({boundary} and {second}) without consuming the tier accumulator",
+                tier.id,
+            );
+            expected.push((boundary, sender));
         }
     }
     expected.sort_unstable();
+    let terminal = schedule.tiers.len() - 1;
+    let terminal_retry_pending =
+        state.tiers[terminal].last_update_clock < state.tiers[terminal].last_boundary_clock;
+    if terminal_retry_pending
+        && let Some(index) = expected.iter().position(|(_, sender)| *sender == terminal)
+    {
+        let retry = expected.remove(index);
+        expected.insert(0, retry);
+    }
     let expected_clocks = expected.iter().map(|(clock, _)| *clock).collect::<Vec<_>>();
     let expected_due = expected
         .into_iter()
@@ -2432,6 +2616,17 @@ mod tests {
     }
 
     #[test]
+    fn resume_rejects_multiple_unconsumed_boundaries_for_one_sender() {
+        let mut state = SleepState::new(&schedule(), 1).unwrap();
+        state.clock = 4;
+        state.due_senders = vec![0, 0];
+        state.due_clocks = vec![2, 4];
+
+        let error = state.validate_resume().unwrap_err().to_string();
+        assert!(error.contains("due-boundary queue"), "{error}");
+    }
+
+    #[test]
     fn immutable_identities_require_canonical_sha256() {
         let mut state = SleepState::new(&schedule(), 1).unwrap();
         state.advance_clock(&schedule(), 2).unwrap();
@@ -2637,6 +2832,67 @@ mod tests {
         assert_eq!(state.tiers[1].slots[0].generation, 1);
     }
 
+    #[test]
+    fn transaction_and_generation_exhaustion_fail_without_partial_mutation() {
+        let schedule = schedule();
+
+        let mut exhausted_id = SleepState::new(&schedule, 1).unwrap();
+        exhausted_id.cycle = u64::MAX;
+        exhausted_id.advance_clock(&schedule, 2).unwrap();
+        let before = exhausted_id.clone();
+        let error = exhausted_id
+            .begin(
+                0,
+                "teacher/id-overflow".into(),
+                test_hash('a'),
+                "student/id-overflow".into(),
+                test_hash('b'),
+                test_hash('c'),
+            )
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("transaction ID overflows"), "{error}");
+        assert_eq!(exhausted_id, before);
+
+        let mut exhausted_generation = SleepState::new(&schedule, 1).unwrap();
+        exhausted_generation.tiers[0].slots[0].active = true;
+        exhausted_generation.tiers[0].slots[0].generation = u64::MAX;
+        exhausted_generation.advance_clock(&schedule, 2).unwrap();
+        exhausted_generation
+            .begin(
+                0,
+                "teacher/generation-overflow".into(),
+                test_hash('a'),
+                "student/generation-overflow".into(),
+                test_hash('b'),
+                test_hash('c'),
+            )
+            .unwrap();
+        exhausted_generation
+            .transition(SleepPhase::KnowledgeSeeding)
+            .unwrap();
+        exhausted_generation
+            .transition(SleepPhase::Imitation)
+            .unwrap();
+        exhausted_generation
+            .transition(SleepPhase::RetentionValidation)
+            .unwrap();
+        exhausted_generation.transition(SleepPhase::Commit).unwrap();
+        exhausted_generation
+            .record_committed_candidate("candidate/generation-overflow".into(), test_hash('d'))
+            .unwrap();
+        let before = exhausted_generation.clone();
+        let error = exhausted_generation
+            .commit_consolidation()
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("sender reserve generation overflows"),
+            "{error}"
+        );
+        assert_eq!(exhausted_generation, before);
+    }
+
     #[derive(Default)]
     struct MockBackend {
         calls: Vec<&'static str>,
@@ -2719,6 +2975,141 @@ mod tests {
     }
 
     #[test]
+    fn rollback_consumes_attempt_id_before_any_later_receipt_can_be_published() {
+        let schedule = schedule();
+        let mut state = SleepState::new(&schedule, 1).unwrap();
+        state.advance_clock(&schedule, 2).unwrap();
+        let first = state
+            .begin(
+                0,
+                "teacher/first".into(),
+                test_hash('a'),
+                "student/first".into(),
+                test_hash('b'),
+                test_hash('c'),
+            )
+            .unwrap();
+        state.rollback().unwrap();
+        assert_eq!(state.cycle, first.id);
+
+        state.advance_clock(&schedule, 4).unwrap();
+        let second = state
+            .begin(
+                0,
+                "teacher/second".into(),
+                test_hash('a'),
+                "student/second".into(),
+                test_hash('b'),
+                test_hash('c'),
+            )
+            .unwrap();
+        assert_eq!(second.id, first.id + 1);
+    }
+
+    #[test]
+    fn rollback_rejects_a_missing_due_clock_without_mutation_or_panic() {
+        let mut state = begun_state();
+        state.due_clocks.clear();
+        let before = state.clone();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| state.rollback()));
+        let error = result
+            .expect("rollback panicked on a missing paired due clock")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("rolled-back boundary"), "{error}");
+        assert_eq!(state, before);
+    }
+
+    #[test]
+    fn rollback_rejects_a_mismatched_due_clock_without_mutation_or_panic() {
+        let mut state = begun_state();
+        state.due_clocks[0] += 1;
+        let before = state.clone();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| state.rollback()));
+        let error = result
+            .expect("rollback panicked on a mismatched paired due clock")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("rolled-back boundary"), "{error}");
+        assert_eq!(state, before);
+    }
+
+    #[test]
+    fn terminal_rollback_rejects_an_invalid_trailing_queue_without_mutation() {
+        let mut state = begun_state();
+        state.pending.as_mut().unwrap().terminal = true;
+        state.due_senders.push(usize::MAX);
+        state.due_clocks.push(4);
+        let before = state.clone();
+
+        let error = state.rollback().unwrap_err().to_string();
+
+        assert!(error.contains("invalid trailing due queue"), "{error}");
+        assert_eq!(state, before);
+    }
+
+    #[test]
+    fn commit_rejects_an_invalid_receiver_slot_without_mutation_or_panic() {
+        let mut state = begun_state();
+        state.transition(SleepPhase::KnowledgeSeeding).unwrap();
+        state.transition(SleepPhase::Imitation).unwrap();
+        state.transition(SleepPhase::RetentionValidation).unwrap();
+        state.transition(SleepPhase::Commit).unwrap();
+        state
+            .record_committed_candidate("candidate/invalid-slot".into(), test_hash('d'))
+            .unwrap();
+        state.pending.as_mut().unwrap().receiver_slot = usize::MAX;
+        let before = state.clone();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            state.commit_consolidation()
+        }));
+        let error = result
+            .expect("commit panicked on an invalid receiver slot")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("receiver slot is out of range"), "{error}");
+        assert_eq!(state, before);
+    }
+
+    #[test]
+    fn resume_rejects_completed_receipts_that_can_alias_attempt_ids() {
+        let mut finished = committed_state();
+        finished.transition(SleepPhase::Candidate).unwrap();
+        let completed = finished.finish_candidate().unwrap();
+        finished.validate_resume().unwrap();
+        assert_eq!(finished.cycle, completed.id);
+        assert_eq!(finished.completed_count, 1);
+
+        let mut future_receipt = finished.clone();
+        future_receipt.completed_transactions[0].id = future_receipt.cycle + 1;
+        let error = future_receipt.validate_resume().unwrap_err().to_string();
+        assert!(error.contains("audit tail is invalid"), "{error}");
+
+        let mut dropped_receipt = finished.clone();
+        dropped_receipt.completed_transactions.clear();
+        let error = dropped_receipt.validate_resume().unwrap_err().to_string();
+        assert!(error.contains("audit tail is inconsistent"), "{error}");
+
+        // A committed-but-not-finished transaction owns `cycle` already. Its
+        // immutable receipt key must not collide with a completed tail entry.
+        let mut duplicate_pending = committed_state();
+        duplicate_pending.completed_count = finished.completed_count;
+        duplicate_pending.completed_chain_hash = finished.completed_chain_hash.clone();
+        duplicate_pending.completed_transactions = finished.completed_transactions.clone();
+        let error = duplicate_pending.validate_resume().unwrap_err().to_string();
+        assert!(
+            error.contains("reuses a completed transaction id"),
+            "{error}"
+        );
+    }
+
+    #[test]
     fn failed_consolidation_restores_teacher() {
         let mut state = begun_state();
         let mut backend = MockBackend {
@@ -2762,38 +3153,138 @@ mod tests {
     }
 
     #[test]
-    fn coincident_boundary_queue_never_replays_a_completed_sender() {
+    fn coarse_clock_advance_fails_before_mutating_the_scheduler() {
         let schedule = schedule();
         let mut state = SleepState::new(&schedule, 1).unwrap();
+        let before = state.clone();
+        let error = state.advance_clock(&schedule, 4).unwrap_err().to_string();
+        assert!(
+            error.contains("crosses multiple `fast` boundaries"),
+            "{error}"
+        );
+        assert_eq!(state, before);
+    }
+
+    #[test]
+    fn terminal_rejection_retries_before_the_next_transfer() {
+        let schedule = SleepSchedule {
+            clock: UpdateClock::OptimizerSteps,
+            terminal_consolidation: TerminalConsolidation::DistillIntoBaseV1,
+            tiers: vec![
+                MemoryTierSchedule {
+                    id: "fast".into(),
+                    update_period: 1,
+                    reserve_slots: 1,
+                },
+                MemoryTierSchedule {
+                    id: "slow".into(),
+                    update_period: 2,
+                    reserve_slots: 2,
+                },
+            ],
+        };
+        let mut state = SleepState::new(&schedule, 1).unwrap();
+
+        let finish = |state: &mut SleepState, sender: usize, suffix: &str| {
+            let txn = state
+                .begin(
+                    sender,
+                    format!("teacher/{suffix}"),
+                    test_hash('a'),
+                    format!("student/{suffix}"),
+                    test_hash('b'),
+                    test_hash('c'),
+                )
+                .unwrap();
+            state.transition(SleepPhase::KnowledgeSeeding).unwrap();
+            state.transition(SleepPhase::Imitation).unwrap();
+            state.transition(SleepPhase::RetentionValidation).unwrap();
+            state.transition(SleepPhase::Commit).unwrap();
+            state
+                .record_committed_candidate(format!("candidate/{suffix}"), test_hash('d'))
+                .unwrap();
+            state.commit_consolidation().unwrap();
+            state.transition(SleepPhase::Candidate).unwrap();
+            state.finish_candidate().unwrap();
+            txn
+        };
+
+        state.advance_clock(&schedule, 1).unwrap();
+        finish(&mut state, 0, "fast-1");
+        state.advance_clock(&schedule, 2).unwrap();
+        finish(&mut state, 0, "fast-2");
+        assert!(state.tiers[1].slots.iter().all(|slot| slot.active));
+
+        state
+            .begin(
+                1,
+                "teacher/terminal-2".into(),
+                test_hash('a'),
+                "student/terminal-2".into(),
+                test_hash('b'),
+                test_hash('c'),
+            )
+            .unwrap();
+        let rejected_id = state.pending.as_ref().unwrap().id;
+        state.rollback().unwrap();
+        assert_eq!(state.cycle, rejected_id);
+
+        state.advance_clock(&schedule, 3).unwrap();
+        assert!(state.due_senders.is_empty());
+        assert_eq!(state.tiers[0].last_boundary_clock, 3);
+        let statuses = state
+            .tiers
+            .iter()
+            .enumerate()
+            .flat_map(|(tier, tier_state)| {
+                tier_state
+                    .slots
+                    .iter()
+                    .enumerate()
+                    .map(move |(slot, slot_state)| MemorySlotStatus {
+                        layer: 0,
+                        tier,
+                        tier_name: tier_state.id.clone(),
+                        slot,
+                        active: slot_state.active,
+                        generation: slot_state.generation,
+                        parameter_ids: vec![ParamId::new()],
+                    })
+            })
+            .collect::<Vec<_>>();
+        validate_model_memory_state(&schedule, &state, &statuses).unwrap();
+
         state.advance_clock(&schedule, 4).unwrap();
-        assert_eq!(state.due_senders, vec![0, 0, 1]);
-        assert_eq!(state.due_clocks, vec![2, 4, 4]);
-        state
+        assert_eq!(state.due_senders, vec![1, 0]);
+        validate_model_memory_state(&schedule, &state, &statuses).unwrap();
+        let retry = state
             .begin(
-                0,
-                "teacher/fast".into(),
+                1,
+                "teacher/terminal-retry-4".into(),
                 test_hash('a'),
-                "student/fast".into(),
+                "student/terminal-retry-4".into(),
                 test_hash('b'),
                 test_hash('c'),
             )
             .unwrap();
-        let mut rejected = MockBackend::default();
-        assert!(!run_consolidation(&mut state, &mut rejected).unwrap());
-        assert_eq!(state.next_due_sender(), Some(0));
-        state
-            .begin(
-                0,
-                "teacher/fast-4".into(),
-                test_hash('a'),
-                "student/fast-4".into(),
-                test_hash('b'),
-                test_hash('c'),
-            )
-            .unwrap();
-        assert!(!run_consolidation(&mut state, &mut rejected).unwrap());
-        assert_eq!(state.next_due_sender(), Some(1));
-        assert!(state.advance_clock(&schedule, 4).is_err());
+        assert!(retry.id > rejected_id);
+        state.rollback().unwrap();
+        assert!(state.due_senders.is_empty());
+
+        // A repeated rejection backpressures the coincident fast boundary.
+        state.advance_clock(&schedule, 5).unwrap();
+        assert!(state.due_senders.is_empty());
+        state.advance_clock(&schedule, 6).unwrap();
+        assert_eq!(state.due_senders, vec![1, 0]);
+        let accepted_retry = finish(&mut state, 1, "terminal-retry-6");
+        assert!(accepted_retry.id > retry.id);
+        assert!(state.tiers[1].slots.iter().all(|slot| !slot.active));
+
+        // The coincident fast transfer now has reclaimed receiver capacity.
+        let transfer = finish(&mut state, 0, "fast-6");
+        assert!(!transfer.terminal);
+        assert_eq!(transfer.receiver_slot, 0);
+        assert!(state.tiers[1].slots[0].active);
     }
 
     #[test]

--- a/hermes-train/src/trainer.rs
+++ b/hermes-train/src/trainer.rs
@@ -1,6 +1,89 @@
 //! Objective-aware streaming optimization loop.
 
 use super::*;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+
+const TRAINER_LOCK_FILE: &str = ".trainer.lock";
+
+/// Process-lifetime ownership of one mutable training output root.
+///
+/// The relaunch supervisor has its own orchestration lock, but direct trainer
+/// invocations must obey the same single-writer invariant. Without this lock,
+/// two metric writers can truncate/append the same journal and produce
+/// duplicated sequences or sparse NUL-filled holes.
+struct TrainingOutputLock {
+    file: fs::File,
+}
+
+impl TrainingOutputLock {
+    fn acquire(output: &Path) -> Result<Self> {
+        fs::create_dir_all(output)
+            .with_context(|| format!("creating training output {}", output.display()))?;
+        let output_metadata = fs::symlink_metadata(output)
+            .with_context(|| format!("inspecting training output {}", output.display()))?;
+        ensure!(
+            output_metadata.is_dir() && !output_metadata.file_type().is_symlink(),
+            "training output {} must be a real directory",
+            output.display()
+        );
+        let path = output.join(TRAINER_LOCK_FILE);
+        let mut options = fs::OpenOptions::new();
+        options.create(true).read(true).write(true);
+        #[cfg(unix)]
+        options
+            .mode(0o600)
+            .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+        let mut file = options
+            .open(&path)
+            .with_context(|| format!("opening trainer output lock {}", path.display()))?;
+        ensure!(
+            file.metadata()?.is_file(),
+            "trainer output lock {} is not a regular file",
+            path.display()
+        );
+
+        #[cfg(unix)]
+        {
+            // SAFETY: `file` owns a valid descriptor for the lifetime of this
+            // guard. LOCK_NB makes contention fail instead of hanging a boot
+            // supervisor indefinitely.
+            if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+                let error = std::io::Error::last_os_error();
+                if error
+                    .raw_os_error()
+                    .is_some_and(|code| code == libc::EWOULDBLOCK || code == libc::EAGAIN)
+                {
+                    bail!(
+                        "another hermes-train process already owns output {}",
+                        output.display()
+                    );
+                }
+                return Err(error)
+                    .with_context(|| format!("locking trainer output root {}", output.display()));
+            }
+        }
+        #[cfg(not(unix))]
+        bail!("exclusive trainer output locks are not implemented on this platform");
+
+        file.set_len(0)?;
+        writeln!(file, "{}", std::process::id())?;
+        file.sync_data()?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for TrainingOutputLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        // SAFETY: the descriptor stays valid until after Drop returns.
+        unsafe {
+            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
 
 fn publish_sleep_model(
     model: &Transformer,
@@ -135,6 +218,34 @@ struct PeriodicTrainingRuntime {
     journal_store: PathBuf,
     config_path: PathBuf,
     config_sha256: String,
+}
+
+/// Fake-quantized parameter leaves shared by the microbatches that contribute
+/// to one master-weight update. A window must never cross an optimizer step.
+struct StagedQuantizationWindow {
+    format: UltraQuantFormat,
+    model: Transformer,
+    tensor_count: u64,
+}
+
+enum PrefetchedSample {
+    CursorReady,
+    Sample(data::TrainingSample),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ResumeCursorAction {
+    Skip,
+    CursorReady,
+    Emit,
+}
+
+fn resume_cursor_action(visited: usize, records_to_skip: usize) -> ResumeCursorAction {
+    match visited.cmp(&records_to_skip) {
+        std::cmp::Ordering::Less => ResumeCursorAction::Skip,
+        std::cmp::Ordering::Equal => ResumeCursorAction::CursorReady,
+        std::cmp::Ordering::Greater => ResumeCursorAction::Emit,
+    }
 }
 
 impl PeriodicTrainingRuntime {
@@ -754,6 +865,20 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
     let mut config = load_config(&args.config)?;
     config.vocab_size = tokenizer.vocab_size();
     validate_model_wake_plan(&config, &workflow)?;
+
+    // A signature-only invocation remains read-only and hardware-independent.
+    // Real training, however, claims its output and initializes the selected
+    // accelerator before hashing a potentially multi-billion-token corpus.
+    // This both avoids duplicate startup work and reports a missing CUDA
+    // driver immediately instead of after a long CPU-only verification pass.
+    let training_runtime = if args.print_run_signature {
+        None
+    } else {
+        let output_lock = TrainingOutputLock::acquire(&args.output)?;
+        let device = hermes_llm::default_device().autodiff();
+        device.seed(args.seed);
+        Some((output_lock, device))
+    };
     let data_manifests = workflow
         .phases
         .iter()
@@ -771,22 +896,24 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
         println!("{signature}");
         return Ok(());
     }
-    fs::create_dir_all(&args.output)?;
-    let token_cache_root = args
-        .output
-        .join(".token-cache")
-        .join(stable_cache_id(&signature));
+    let (_output_lock, device) = training_runtime
+        .expect("non-signature training initialized its output lock and accelerator");
+    let token_cache_root = args.output.join(".token-cache");
     fs::create_dir_all(&token_cache_root)?;
-    let (phase_plan, total_steps) = plan_training(&workflow, &tokenizer, &token_cache_root)?;
+    let token_cache_paths = data_manifests
+        .iter()
+        .zip(&workflow.phases)
+        .map(|(data, phase)| {
+            token_cache_path(&token_cache_root, data, &phase.data, &tokenizer_hash)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let (phase_plan, total_steps) = plan_training(&workflow, &tokenizer, &token_cache_paths)?;
     ensure!(
         total_steps > 0,
         "training has zero complete optimizer steps"
     );
     let run_id = stable_cache_id(&signature);
     let metrics_path = args.output.join("metrics.jsonl");
-
-    let device = hermes_llm::default_device().autodiff();
-    device.seed(args.seed);
     let mut initial_model = Transformer::new(&config, &device)?;
     if let Some(path) = &args.checkpoint {
         load_safetensors(&mut initial_model, path)?;
@@ -916,6 +1043,13 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                 .is_none_or(|state| state.sleep.is_none()),
             "ordinary-model checkpoint unexpectedly contains native sleep state"
         );
+    }
+    if let Some(state) = &resume_state {
+        // Periodic-memory workflows narrow the global Muon selection to the
+        // exact wake scope above. Validate archive geometry only after that
+        // scope is known; validating against every model matrix would reject
+        // correct checkpoints whose tier matrices use independent optimizers.
+        muon_optimizer.validate_for_model(&initial_model, state.global_step == 0)?;
     }
     let mut metrics = if let Some(state) = &resume_state {
         MetricWriter::resume_from_checkpoint(
@@ -1167,7 +1301,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                 .as_ref()
                 .filter(|state| state.phase == phase_index && state.epoch == epoch)
                 .map_or(0, |state| state.records_in_phase);
-            let mut records_in_phase = 0;
+            let mut records_in_phase = records_to_skip;
             let model_rng = rng_stream(&training_state, MODEL_RNG_STREAM)?.clone();
             let mut native_sleep = training_state.sleep.clone();
             if let Some(cursor) = &mut native_sleep {
@@ -1208,7 +1342,8 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                     RngStreamState {
                         name: DATA_RNG_STREAM.into(),
                         seed: shuffle_seed(args.seed, phase_index, epoch),
-                        counter: 0,
+                        counter: u64::try_from(records_to_skip)
+                            .context("resume sample cursor exceeds u64")?,
                     },
                     model_rng,
                 ],
@@ -1231,10 +1366,18 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                 }),
             };
             let mut batch = Vec::with_capacity(phase.batch_size);
+            // Master weights are immutable throughout one gradient-accumulation
+            // window. Keep one fake-quantized leaf model for that whole window
+            // instead of re-quantizing every matrix for every microbatch.
+            // Parameter IDs are retained by `fake_quantized_transformer`, so
+            // each backward pass still accumulates directly into the master
+            // optimizer slots. The staged leaves are discarded immediately
+            // after the master update.
+            let mut quantized_window: Option<StagedQuantizationWindow> = None;
             let shuffle_seed = shuffle_seed(args.seed, phase_index, epoch);
             let tokenizer_ref = &tokenizer;
             let objective = phase.objective.clone();
-            let token_cache_path = token_cache_root.join(format!("phase-{phase_index:03}.tokens"));
+            let token_cache_path = token_cache_paths[phase_index].clone();
             std::thread::scope(|threads| -> Result<()> {
                 let prefetch_capacity = phase
                     .batch_size
@@ -1242,7 +1385,15 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                     .and_then(|capacity| capacity.checked_mul(2))
                     .context("training prefetch capacity overflows usize")?;
                 let (sender, receiver) = std::sync::mpsc::sync_channel(prefetch_capacity);
-                let reader = threads.spawn(move || {
+                let reader = threads.spawn(move || -> Result<()> {
+                    let mut visited = 0usize;
+                    let mut cursor_ready = false;
+                    if records_to_skip == 0 {
+                        if sender.send(PrefetchedSample::CursorReady).is_err() {
+                            return Ok(());
+                        }
+                        cursor_ready = true;
+                    }
                     visit_samples(
                         &phase.data,
                         &objective,
@@ -1253,13 +1404,53 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                             seed: shuffle_seed,
                             token_cache: Some(&token_cache_path),
                         },
-                        |sample| Ok(sender.send(sample).is_ok()),
-                    )
+                        |sample| {
+                            visited = visited
+                                .checked_add(1)
+                                .context("sample-reader cursor overflows usize")?;
+                            match resume_cursor_action(visited, records_to_skip) {
+                                ResumeCursorAction::Skip => return Ok(true),
+                                ResumeCursorAction::CursorReady => {
+                                    cursor_ready = sender
+                                        .send(PrefetchedSample::CursorReady)
+                                        .is_ok();
+                                    return Ok(cursor_ready);
+                                }
+                                ResumeCursorAction::Emit => {}
+                            }
+                            debug_assert!(cursor_ready);
+                            Ok(sender.send(PrefetchedSample::Sample(sample)).is_ok())
+                        },
+                    )?;
+                    ensure!(
+                        visited >= records_to_skip,
+                        "workflow phase `{}` epoch {} has only {visited} samples, fewer than resume cursor {records_to_skip}",
+                        phase.name,
+                        epoch + 1
+                    );
+                    Ok(())
                 });
+                let mut cursor_ready = false;
                 loop {
                     let input_wait_started = Instant::now();
                     let sample = match receiver.recv() {
-                        Ok(sample) => sample,
+                        Ok(PrefetchedSample::CursorReady) => {
+                            ensure!(
+                                !cursor_ready,
+                                "sample reader emitted duplicate cursor readiness"
+                            );
+                            cursor_ready = true;
+                            optimizer_step_started = Instant::now();
+                            step_input_wait_seconds = 0.0;
+                            continue;
+                        }
+                        Ok(PrefetchedSample::Sample(sample)) => {
+                            ensure!(
+                                cursor_ready,
+                                "sample reader emitted data before resume catch-up"
+                            );
+                            sample
+                        }
                         Err(_) => break,
                     };
                     step_input_wait_seconds += input_wait_started.elapsed().as_secs_f64();
@@ -1269,11 +1460,6 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                     training_state.records_in_phase = records_in_phase;
                     rng_stream_mut(&mut training_state, DATA_RNG_STREAM)?.counter =
                         records_in_phase as u64;
-                    if records_in_phase <= records_to_skip {
-                        optimizer_step_started = Instant::now();
-                        step_input_wait_seconds = 0.0;
-                        continue;
-                    }
                     batch.push(sample);
                     if batch.len() < phase.batch_size {
                         continue;
@@ -1297,30 +1483,39 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         .checked_add(1)
                         .context("model RNG counter overflows u64")?;
                     let current = model.as_ref().unwrap();
-                    let quantized = phase
+                    let quantization_format = phase
                         .quantization
                         .as_ref()
-                        .and_then(|plan| plan.format_at(step as u64))
-                        .map(|format| {
-                            fake_quantized_transformer(
-                                current,
-                                format,
-                                phase
-                                    .quantization
-                                    .as_ref()
-                                    .expect("format came from plan")
-                                    .recipe
-                                    .quantize_embeddings,
-                                phase
-                                    .quantization
-                                    .as_ref()
-                                    .expect("format came from plan")
-                                    .recipe
-                                    .quantize_lm_head,
-                            )
-                        })
-                        .transpose()?;
-                    let forward_model = quantized.as_ref().map_or(current, |(staged, _)| staged);
+                        .and_then(|plan| plan.format_at(step as u64));
+                    if let Some(format) = quantization_format
+                        && quantized_window.is_none()
+                    {
+                        let recipe = &phase
+                            .quantization
+                            .as_ref()
+                            .expect("format came from plan")
+                            .recipe;
+                        let (staged, tensors) = fake_quantized_transformer(
+                            current,
+                            format,
+                            recipe.quantize_embeddings,
+                            recipe.quantize_lm_head,
+                        )?;
+                        quantized_window = Some(StagedQuantizationWindow {
+                            format,
+                            model: staged,
+                            tensor_count: tensors as u64,
+                        });
+                    }
+                    ensure!(
+                        quantized_window
+                            .as_ref()
+                            .is_none_or(|window| Some(window.format) == quantization_format),
+                        "quantization format changed inside a gradient-accumulation window"
+                    );
+                    let forward_model = quantized_window
+                        .as_ref()
+                        .map_or(current, |window| &window.model);
                     let accelerator_started = Instant::now();
                     let distillation_loss = quantization_teacher
                         .as_ref()
@@ -1494,6 +1689,12 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         let current = model.take().unwrap();
                         let current = muon_optimizer.step(muon_lr, current, muon_grads)?;
                         model = Some(adamw_optimizer.step(lr.into(), current, adamw_grads));
+                        let step_quantized_tensors = quantized_window
+                            .as_ref()
+                            .map_or(0, |window| window.tensor_count);
+                        // The authoritative model has changed. Never reuse a
+                        // staged QAT leaf across optimizer-step boundaries.
+                        quantized_window = None;
                         step_accelerator_seconds += accelerator_started.elapsed().as_secs_f64();
                         step += 1;
                         steps_in_phase = steps_in_phase
@@ -1583,8 +1784,6 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         )?;
                         if let Some(plan) = &phase.quantization {
                             let active_format = plan.format_at((step - 1) as u64);
-                            let quantized_tensors =
-                                quantized.as_ref().map_or(0, |(_, tensors)| *tensors as u64);
                             metrics.append(
                                 context.clone(),
                                 MetricEvent::Quantization(QuantizationMetrics {
@@ -1599,7 +1798,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                                     group_size: plan.recipe.group_size as u32,
                                     progress_fraction: steps_in_phase as f64
                                         / phase_plan[phase_index].steps as f64,
-                                    tensors_quantized: quantized_tensors,
+                                    tensors_quantized: step_quantized_tensors,
                                     // Exact element and codec-error accounting is
                                     // emitted by the archive export pass.
                                     weights_quantized: 0,
@@ -1846,6 +2045,58 @@ fn print_checkpoint_publication(label: &str, publication: &CheckpointPublication
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resume_cursor_filter_preserves_exact_shuffled_suffix() {
+        let shuffled = [7, 2, 9, 1, 5, 8, 0, 6, 3, 4];
+        let cursor = 4;
+        let actions = (1..=shuffled.len())
+            .map(|visited| resume_cursor_action(visited, cursor))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actions[..cursor],
+            [
+                ResumeCursorAction::Skip,
+                ResumeCursorAction::Skip,
+                ResumeCursorAction::Skip,
+                ResumeCursorAction::CursorReady,
+            ]
+        );
+        let resumed = shuffled
+            .into_iter()
+            .zip(actions)
+            .filter_map(|(sample, action)| (action == ResumeCursorAction::Emit).then_some(sample))
+            .collect::<Vec<_>>();
+        assert_eq!(resumed, shuffled[cursor..]);
+        assert!(
+            (1..=shuffled.len()).all(|visited| resume_cursor_action(visited, shuffled.len() + 1)
+                == ResumeCursorAction::Skip)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn training_output_lock_rejects_a_second_writer_and_releases_on_drop() {
+        let directory = tempfile::tempdir().unwrap();
+        let first = TrainingOutputLock::acquire(directory.path()).unwrap();
+        let error = TrainingOutputLock::acquire(directory.path())
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(error.contains("already owns output"), "{error}");
+
+        drop(first);
+        TrainingOutputLock::acquire(directory.path()).unwrap();
+
+        let parent = tempfile::tempdir().unwrap();
+        let link = parent.path().join("linked-output");
+        std::os::unix::fs::symlink(directory.path(), &link).unwrap();
+        let error = TrainingOutputLock::acquire(&link)
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(error.contains("real directory"), "{error}");
+    }
 
     #[test]
     fn periodic_runtime_artifact_is_write_once_and_exact_on_resume() {


### PR DESCRIPTION
## Summary

- make checkpoint v2 resume authenticate and load one exact generation, with failure-atomic model and optimizer restoration
- harden token-cache indexing, resume cursors, metrics, relaunch locking, and stable remote checkpoint transfer
- optimize and validate dormant memory-reserve routing, QAT accumulation, GRPO, and sleep transaction boundaries
- remove the obsolete post-training executor instead of retaining a compatibility path

## Validation

- `cargo test --workspace --lib --tests --no-fail-fast -q`
- `cargo clippy -p hermes-llm -p hermes-train --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `shellcheck hermes-train/scripts/relaunch.sh hermes-train/scripts/relaunch_test.sh`
- `bash hermes-train/scripts/relaunch_test.sh`
- Metal inference and memory-reserve benchmark smoke tests

The active A100 training run was observed only; this change does not restart or mutate it.