### PR TITLE
feat(train): land reviewed training framework and fix audit findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3395,6 +3395,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
+ "tracing",
  "tracing-subscriber",
  "ureq",
  "zstd 0.13.3",

--- a/hermes-llm/benches/memory_reserve.rs
+++ b/hermes-llm/benches/memory_reserve.rs
@@ -1,21 +1,66 @@
-//! Memory-reserve routing benchmark across dormant, one-active and two-active
-//! states.
+//! Paired acceptance benchmark for sleep-memory wake overhead.
 //!
-//! The compact default model runs on every backend. To measure the production
-//! sleep model on CUDA:
+//! This benchmark answers two different performance questions without
+//! conflating them:
+//!
+//! 1. `static_backbone_vs_dormant_memory` compares the unchanged static model
+//!    with its MAL-validated sleep-capable counterpart. This measures the
+//!    total wake cost of opting into the memory hierarchy.
+//! 2. `one_active_vs_n_active` compares two instances of the *same* memory
+//!    topology. Both have identical stored and routed-active parameter counts;
+//!    only their checkpointed active-slot masks differ. This is the direct
+//!    acceptance check that active compute does not grow across sleep cycles.
+//!
+//! Each result contains raw, interleaved A/B timings for at least three seeds,
+//! forward and forward/backward modes, per-seed summaries, and paired ratios.
+//! The default 5% gate is reported but only enforced with `--enforce`.
+//!
+//! The embedded compact pair is useful for local smoke tests. Official CUDA
+//! evidence must use the production pair and explicitly require CUDA:
 //!
 //! ```text
 //! cargo bench -p hermes-llm --bench memory_reserve --features training-fusion -- \
-//!   --model hermes-mal/well-known/retriever_300m_moe_sleep.mal --tokens 8192
+//!   --model hermes-mal/well-known/retriever_300m_moe_sleep.mal \
+//!   --baseline-model hermes-mal/well-known/retriever_300m_moe.mal \
+//!   --tokens 8192 --tier 0 --max-active 2 --require-cuda --enforce \
+//!   --output memory-reserve-cuda.json
 //! ```
+//!
+//! A non-CUDA run is deliberately labelled `local_non_cuda_smoke_only` and
+//! must not be presented as CUDA acceptance evidence.
 
-use std::path::PathBuf;
+#[path = "memory_reserve/cli.rs"]
+mod cli;
+#[path = "memory_reserve/fairness.rs"]
+mod fairness;
+#[path = "memory_reserve/stats.rs"]
+mod stats;
+
+use std::path::Path;
 use std::time::Instant;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, bail, ensure};
+use burn::module::AutodiffModule;
 use burn::prelude::*;
-use hermes_llm::{Transformer, default_device, parse_mal, parse_mal_file};
+use burn::tensor::{DType, TensorData};
+use hermes_llm::{
+    ModelDef, Transformer, WakeParameterAccounting, default_device, parse_mal, parse_mal_file,
+};
 use serde::Serialize;
+
+use cli::{Args, backend_name, parse_args};
+use stats::{ExecutionOrder, PairedSample, PairedSummary, PairedTrial};
+
+const MODEL_INITIALIZATION_SEED: u64 = 0x4845_524d_4553;
+
+const COMPACT_STATIC_MODEL: &str = r#"
+ffn base { hidden_dim: 16 activation: swiglu bias: false }
+model static-memory-reserve-bench {
+    vocab_size: 128 max_seq_len: 1 hidden_size: 128 num_layers: 1
+    block: { attention: { num_heads: 4 } ffn: base }
+    embeddings { tie_weights: true }
+}
+"#;
 
 const COMPACT_MEMORY_MODEL: &str = r#"
 ffn base { hidden_dim: 16 activation: swiglu bias: false }
@@ -25,166 +70,613 @@ memory reserve {
         reserve_experts { capacity: 4 rank: 32 top_k: 1 }
     }
 }
-model memory-reserve-bench {
+model sleep-memory-reserve-bench {
     vocab_size: 128 max_seq_len: 1 hidden_size: 128 num_layers: 1
     block: { attention: { num_heads: 4 } memory: reserve }
     embeddings { tie_weights: true }
 }
 "#;
 
-#[derive(Debug)]
-struct Args {
-    model: Option<PathBuf>,
-    tokens: usize,
-    warmup: usize,
-    iterations: usize,
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+struct ParameterAccounting {
+    stored: u64,
+    routed_active: u64,
 }
 
-impl Default for Args {
-    fn default() -> Self {
+impl From<WakeParameterAccounting> for ParameterAccounting {
+    fn from(value: WakeParameterAccounting) -> Self {
         Self {
-            model: None,
-            tokens: 4_096,
-            warmup: 5,
-            iterations: 20,
+            stored: value.stored_parameters,
+            routed_active: value.routed_active_parameters,
         }
     }
 }
 
-#[derive(Serialize)]
-struct Measurement {
-    active_slots_per_layer: usize,
-    median_ms: f64,
-    min_ms: f64,
-    tokens_per_second: f64,
+#[derive(Debug, Serialize)]
+struct FairnessEvidence {
+    static_backbone_matched: bool,
+    layers_checked: usize,
+    selected_tier: usize,
+    selected_tier_capacity: usize,
+    memory_layers: usize,
+    later_memory_tiers_are_residual_noops: bool,
+    static_accounting: ParameterAccounting,
+    memory_accounting: ParameterAccounting,
+    added_stored_parameters: u64,
+    added_routed_active_parameters: u64,
 }
 
-#[derive(Serialize)]
-struct Report {
-    implementation: &'static str,
+#[derive(Clone, Debug, Serialize)]
+struct StateDescription {
     model: String,
+    kind: &'static str,
+    active_slots_per_memory_layer: usize,
+    accounting: ParameterAccounting,
+}
+
+#[derive(Debug, Serialize)]
+struct Acceptance {
+    statistic: &'static str,
+    max_overhead_percent: f64,
+    observed_overhead_percent: f64,
+    passed: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ModeReport {
+    mode: &'static str,
+    trials: Vec<PairedTrial>,
+    summary: PairedSummary,
+    reference_tokens_per_second: f64,
+    candidate_tokens_per_second: f64,
+    acceptance: Acceptance,
+}
+
+#[derive(Debug, Serialize)]
+struct ComparisonReport {
+    comparison: &'static str,
+    contract: &'static str,
+    model_initialization_seed: u64,
+    reference: StateDescription,
+    candidate: StateDescription,
+    routed_active_parameters_equal: bool,
+    modes: Vec<ModeReport>,
+}
+
+#[derive(Debug, Serialize)]
+struct Workload {
+    logical_tokens: usize,
+    batch_size: usize,
+    sequence_length: usize,
+    backward_objective: &'static str,
+    note: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct BuildDescription {
+    backend: &'static str,
     device: String,
-    tokens: usize,
-    warmup: usize,
-    iterations: usize,
-    measurements: Vec<Measurement>,
+    training_fusion: bool,
+    measurement_scope: &'static str,
+    cuda_acceptance_eligible: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    schema_version: u32,
+    implementation: &'static str,
+    static_model: String,
+    memory_model: String,
+    build: BuildDescription,
+    workload: Workload,
+    warmup_iterations_per_operation: usize,
+    measured_iterations_per_seed: usize,
+    paired_seeds: Vec<u64>,
+    fairness: FairnessEvidence,
+    comparisons: Vec<ComparisonReport>,
+    gate_enforced: bool,
+    all_gates_passed: bool,
+}
+
+#[derive(Clone, Copy)]
+enum ModelKind {
+    Static,
+    Memory { active: usize },
+}
+
+struct ComparisonSpec<'a> {
+    name: &'static str,
+    contract: &'static str,
+    reference_config: &'a ModelDef,
+    reference_kind: ModelKind,
+    candidate_config: &'a ModelDef,
+    candidate_kind: ModelKind,
 }
 
 fn main() -> Result<()> {
     let args = parse_args()?;
-    let config = match &args.model {
-        Some(path) => {
-            parse_mal_file(path).with_context(|| format!("failed to parse {}", path.display()))?
-        }
-        None => parse_mal(COMPACT_MEMORY_MODEL).context("compact benchmark MAL is invalid")?,
-    };
+    let (static_config, memory_config) = load_configs(&args)?;
+    fairness::validate_matched_backbone(&static_config, &memory_config)?;
+
+    let backend = backend_name();
+    let cuda_acceptance_eligible = backend == "cuda" && cfg!(feature = "training-fusion");
+    if args.require_cuda && !cuda_acceptance_eligible {
+        bail!(
+            "--require-cuda requested, but this binary uses backend={backend}, training_fusion={}; rebuild on Linux with --features training-fusion",
+            cfg!(feature = "training-fusion")
+        );
+    }
+
     let device = default_device();
-    device.seed(17);
-    let mut model = Transformer::new(&config, &device)?;
-    let input = Tensor::<2, Int>::zeros([args.tokens, 1], &device);
-    // Inputs are independent one-token rows; row-major end positions are
-    // therefore 0..batch, which exercises the router with `tokens` routes
-    // without adding a quadratic attention sequence to this microbenchmark.
-    let end_positions = Tensor::<1, Int>::arange(0..args.tokens as i64, &device);
-
-    let mut measurements = Vec::with_capacity(3);
-    measurements.push(measure(
-        &model,
-        input.clone(),
-        end_positions.clone(),
-        &device,
-        &args,
-        0,
-    )?);
-    model.activate_memory_slot_all_layers(0, 0)?;
-    measurements.push(measure(
-        &model,
-        input.clone(),
-        end_positions.clone(),
-        &device,
-        &args,
-        1,
-    )?);
-    model.activate_memory_slot_all_layers(0, 1)?;
-    measurements.push(measure(&model, input, end_positions, &device, &args, 2)?);
-
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&Report {
-            implementation: "fixed_width_cached_reserve_router",
-            model: config.name,
-            device: format!("{device:?}"),
-            tokens: args.tokens,
-            warmup: args.warmup,
-            iterations: args.iterations,
-            measurements,
-        })?
+    let training_device = device.clone().autodiff();
+    let (memory_layers, tier_capacity) = selected_tier_shape(&memory_config, args.tier)?;
+    ensure!(
+        args.max_active <= tier_capacity,
+        "--max-active {} exceeds tier {} capacity {}",
+        args.max_active,
+        args.tier,
+        tier_capacity
     );
+
+    let mut specs = vec![ComparisonSpec {
+        name: "static_backbone_vs_dormant_memory",
+        contract: "total wake overhead of the MAL-validated sleep-capable topology",
+        reference_config: &static_config,
+        reference_kind: ModelKind::Static,
+        candidate_config: &memory_config,
+        candidate_kind: ModelKind::Memory { active: 0 },
+    }];
+    if args.max_active > 1 {
+        specs.push(ComparisonSpec {
+            name: "one_active_vs_n_active",
+            contract: "wake compute must not grow as additional stored reserve slots activate",
+            reference_config: &memory_config,
+            reference_kind: ModelKind::Memory { active: 1 },
+            candidate_config: &memory_config,
+            candidate_kind: ModelKind::Memory {
+                active: args.max_active,
+            },
+        });
+    }
+
+    let mut comparisons = Vec::with_capacity(specs.len());
+    for spec in specs {
+        comparisons.push(run_comparison(spec, &args, &device, &training_device)?);
+    }
+    let static_accounting = comparisons[0].reference.accounting;
+    let memory_accounting = comparisons[0].candidate.accounting;
+    let fairness = FairnessEvidence {
+        static_backbone_matched: true,
+        layers_checked: memory_config.num_layers,
+        selected_tier: args.tier,
+        selected_tier_capacity: tier_capacity,
+        memory_layers,
+        later_memory_tiers_are_residual_noops: true,
+        static_accounting,
+        memory_accounting,
+        added_stored_parameters: memory_accounting
+            .stored
+            .checked_sub(static_accounting.stored)
+            .context("memory model stores fewer parameters than its matched static backbone")?,
+        added_routed_active_parameters: memory_accounting
+            .routed_active
+            .checked_sub(static_accounting.routed_active)
+            .context("memory model routes fewer parameters than its matched static backbone")?,
+    };
+    let all_gates_passed = comparisons
+        .iter()
+        .flat_map(|comparison| &comparison.modes)
+        .all(|mode| mode.acceptance.passed);
+
+    let report = Report {
+        schema_version: 2,
+        implementation: "fixed_width_cached_reserve_router_paired_acceptance",
+        static_model: static_config.name,
+        memory_model: memory_config.name,
+        build: BuildDescription {
+            backend,
+            device: format!("{device:?}"),
+            training_fusion: cfg!(feature = "training-fusion"),
+            measurement_scope: if cuda_acceptance_eligible {
+                "cuda_single_device_acceptance"
+            } else if backend == "cuda" {
+                "cuda_without_training_fusion_smoke_only"
+            } else {
+                "local_non_cuda_smoke_only"
+            },
+            cuda_acceptance_eligible,
+        },
+        workload: Workload {
+            logical_tokens: args.tokens,
+            batch_size: args.tokens,
+            sequence_length: 1,
+            backward_objective: "deterministically weighted embedding mean plus configured router losses",
+            note: "independent one-token rows isolate flattened FFN/reserve routing without quadratic attention",
+        },
+        warmup_iterations_per_operation: args.warmup,
+        measured_iterations_per_seed: args.iterations,
+        paired_seeds: args.seeds.clone(),
+        fairness,
+        comparisons,
+        gate_enforced: args.enforce,
+        all_gates_passed,
+    };
+
+    let json = serde_json::to_string_pretty(&report)?;
+    println!("{json}");
+    if let Some(path) = &args.output {
+        std::fs::write(path, format!("{json}\n"))
+            .with_context(|| format!("failed to write {}", path.display()))?;
+    }
+    if args.enforce && !all_gates_passed {
+        bail!(
+            "memory-reserve overhead exceeded {:.3}% (see JSON report)",
+            args.max_overhead_percent
+        );
+    }
     Ok(())
 }
 
-fn measure(
-    model: &Transformer,
-    input: Tensor<2, Int>,
-    end_positions: Tensor<1, Int>,
-    device: &Device,
+fn run_comparison(
+    spec: ComparisonSpec<'_>,
     args: &Args,
-    active_slots_per_layer: usize,
-) -> Result<Measurement> {
-    let operation = || {
-        let output = model.forward_embeddings(input.clone(), end_positions.clone(), None);
-        std::hint::black_box(output);
-    };
-    for _ in 0..args.warmup {
-        operation();
-        device.sync()?;
+    inference_device: &Device,
+    training_device: &Device,
+) -> Result<ComparisonReport> {
+    let mut forward_trials = Vec::with_capacity(args.seeds.len());
+    let mut backward_trials = Vec::with_capacity(args.seeds.len());
+    let reference = instantiate(
+        spec.reference_config,
+        spec.reference_kind,
+        args.tier,
+        training_device,
+        MODEL_INITIALIZATION_SEED,
+    )?;
+    let candidate = instantiate(
+        spec.candidate_config,
+        spec.candidate_kind,
+        args.tier,
+        training_device,
+        MODEL_INITIALIZATION_SEED,
+    )?;
+    let reference_description =
+        describe_state(spec.reference_config, spec.reference_kind, &reference)?;
+    let candidate_description =
+        describe_state(spec.candidate_config, spec.candidate_kind, &candidate)?;
+    let reference_valid = reference.clone().valid();
+    let candidate_valid = candidate.clone().valid();
+
+    for (trial_index, &seed) in args.seeds.iter().enumerate() {
+        let token_count = i64::try_from(args.tokens)
+            .context("--tokens exceeds the backend's signed index range")?;
+        let objective_elements = args
+            .tokens
+            .checked_mul(spec.memory_hidden_size())
+            .context("benchmark objective tensor size overflows usize")?;
+        let ids = deterministic_token_ids(args.tokens, spec.memory_vocab_size(), seed);
+        let inference_input = Tensor::<2, Int>::from_data(
+            TensorData::new(ids.clone(), [args.tokens, 1]),
+            inference_device,
+        );
+        let inference_ends = Tensor::<1, Int>::arange(0..token_count, inference_device);
+        let training_input =
+            Tensor::<2, Int>::from_data(TensorData::new(ids, [args.tokens, 1]), training_device);
+        let training_ends = Tensor::<1, Int>::arange(0..token_count, training_device);
+        let training_weights = Tensor::<2>::from_data(
+            TensorData::new(
+                deterministic_objective_weights(objective_elements, seed ^ 0x6a09_e667_f3bc_c909),
+                [args.tokens, spec.memory_hidden_size()],
+            ),
+            training_device,
+        );
+
+        let forward = measure_paired(
+            args,
+            inference_device,
+            trial_index,
+            || {
+                let output = reference_valid.forward_embeddings(
+                    inference_input.clone(),
+                    inference_ends.clone(),
+                    None,
+                );
+                std::hint::black_box(output);
+            },
+            || {
+                let output = candidate_valid.forward_embeddings(
+                    inference_input.clone(),
+                    inference_ends.clone(),
+                    None,
+                );
+                std::hint::black_box(output);
+            },
+        )?;
+        forward_trials.push(PairedTrial::new(seed, forward)?);
+
+        let backward = measure_paired(
+            args,
+            training_device,
+            trial_index,
+            || {
+                backward_embeddings(
+                    &reference,
+                    training_input.clone(),
+                    training_ends.clone(),
+                    training_weights.clone(),
+                )
+            },
+            || {
+                backward_embeddings(
+                    &candidate,
+                    training_input.clone(),
+                    training_ends.clone(),
+                    training_weights.clone(),
+                )
+            },
+        )?;
+        backward_trials.push(PairedTrial::new(seed, backward)?);
+        training_device.sync()?;
     }
-    let mut elapsed = Vec::with_capacity(args.iterations);
-    for _ in 0..args.iterations {
-        device.sync()?;
-        let started = Instant::now();
-        operation();
-        device.sync()?;
-        elapsed.push(started.elapsed().as_secs_f64() * 1_000.0);
+
+    let routed_active_parameters_equal = reference_description.accounting.routed_active
+        == candidate_description.accounting.routed_active;
+    if spec.name == "one_active_vs_n_active" {
+        ensure!(
+            reference_description.accounting == candidate_description.accounting,
+            "constant-active comparison changed parameter accounting: {:?} vs {:?}",
+            reference_description.accounting,
+            candidate_description.accounting
+        );
     }
-    elapsed.sort_by(f64::total_cmp);
-    let median_ms = if args.iterations.is_multiple_of(2) {
-        (elapsed[args.iterations / 2 - 1] + elapsed[args.iterations / 2]) / 2.0
-    } else {
-        elapsed[args.iterations / 2]
-    };
-    Ok(Measurement {
-        active_slots_per_layer,
-        median_ms,
-        min_ms: elapsed[0],
-        tokens_per_second: args.tokens as f64 / (median_ms / 1_000.0),
+
+    Ok(ComparisonReport {
+        comparison: spec.name,
+        contract: spec.contract,
+        model_initialization_seed: MODEL_INITIALIZATION_SEED,
+        reference: reference_description,
+        candidate: candidate_description,
+        routed_active_parameters_equal,
+        modes: vec![
+            mode_report(
+                "forward",
+                forward_trials,
+                args.tokens,
+                args.max_overhead_percent,
+            )?,
+            mode_report(
+                "forward_backward",
+                backward_trials,
+                args.tokens,
+                args.max_overhead_percent,
+            )?,
+        ],
     })
 }
 
-fn parse_args() -> Result<Args> {
-    let mut parsed = Args::default();
-    let mut args = std::env::args().skip(1);
-    while let Some(flag) = args.next() {
-        let mut value = || args.next().with_context(|| format!("{flag} needs a value"));
-        match flag.as_str() {
-            "--model" => parsed.model = Some(PathBuf::from(value()?)),
-            "--tokens" => parsed.tokens = value()?.parse().context("invalid --tokens")?,
-            "--warmup" => parsed.warmup = value()?.parse().context("invalid --warmup")?,
-            "--iterations" => {
-                parsed.iterations = value()?.parse().context("invalid --iterations")?
-            }
-            "--bench" => {}
-            "--help" | "-h" => {
-                println!(
-                    "Usage: memory_reserve [--model PATH] [--tokens N] [--warmup N] [--iterations N]"
-                );
-                std::process::exit(0);
-            }
-            _ => bail!("unknown argument {flag:?}"),
+impl ComparisonSpec<'_> {
+    fn memory_vocab_size(&self) -> usize {
+        match (self.reference_kind, self.candidate_kind) {
+            (ModelKind::Memory { .. }, _) => self.reference_config.vocab_size,
+            (_, ModelKind::Memory { .. }) => self.candidate_config.vocab_size,
+            _ => unreachable!("every comparison contains the memory model"),
         }
     }
-    if parsed.tokens == 0 || parsed.iterations == 0 {
-        bail!("--tokens and --iterations must be positive");
+
+    fn memory_hidden_size(&self) -> usize {
+        match (self.reference_kind, self.candidate_kind) {
+            (ModelKind::Memory { .. }, _) => self.reference_config.hidden_size,
+            (_, ModelKind::Memory { .. }) => self.candidate_config.hidden_size,
+            _ => unreachable!("every comparison contains the memory model"),
+        }
     }
-    Ok(parsed)
+}
+
+fn mode_report(
+    mode: &'static str,
+    trials: Vec<PairedTrial>,
+    tokens: usize,
+    max_overhead_percent: f64,
+) -> Result<ModeReport> {
+    let summary = stats::summarize(&trials)?;
+    let observed_overhead_percent = (summary.median_of_seed_median_ratios - 1.0) * 100.0;
+    let acceptance = Acceptance {
+        statistic: "median of per-seed median paired candidate/reference ratios",
+        max_overhead_percent,
+        observed_overhead_percent,
+        passed: observed_overhead_percent <= max_overhead_percent,
+    };
+    Ok(ModeReport {
+        mode,
+        trials,
+        reference_tokens_per_second: tokens as f64 / (summary.reference_median_ms / 1_000.0),
+        candidate_tokens_per_second: tokens as f64 / (summary.candidate_median_ms / 1_000.0),
+        summary,
+        acceptance,
+    })
+}
+
+fn backward_embeddings(
+    model: &Transformer,
+    input: Tensor<2, Int>,
+    ends: Tensor<1, Int>,
+    weights: Tensor<2>,
+) {
+    let (output, auxiliary) = model.forward_embeddings_with_router(input, ends, None);
+    let mut loss = (output.cast(DType::F32) * weights).mean();
+    if let Some(auxiliary) = auxiliary {
+        loss = loss + auxiliary;
+    }
+    let gradients = loss.backward();
+    std::hint::black_box(gradients);
+}
+
+fn measure_paired(
+    args: &Args,
+    device: &Device,
+    trial_index: usize,
+    mut reference: impl FnMut(),
+    mut candidate: impl FnMut(),
+) -> Result<Vec<PairedSample>> {
+    for warmup in 0..args.warmup {
+        if (trial_index + warmup).is_multiple_of(2) {
+            run_and_sync(device, &mut reference)?;
+            run_and_sync(device, &mut candidate)?;
+        } else {
+            run_and_sync(device, &mut candidate)?;
+            run_and_sync(device, &mut reference)?;
+        }
+    }
+
+    let mut samples = Vec::with_capacity(args.iterations);
+    for iteration in 0..args.iterations {
+        let reference_first = (trial_index + iteration).is_multiple_of(2);
+        let (reference_ms, candidate_ms, order) = if reference_first {
+            (
+                time_synchronized(device, &mut reference)?,
+                time_synchronized(device, &mut candidate)?,
+                ExecutionOrder::ReferenceThenCandidate,
+            )
+        } else {
+            let candidate_ms = time_synchronized(device, &mut candidate)?;
+            let reference_ms = time_synchronized(device, &mut reference)?;
+            (
+                reference_ms,
+                candidate_ms,
+                ExecutionOrder::CandidateThenReference,
+            )
+        };
+        samples.push(PairedSample::new(
+            iteration,
+            order,
+            reference_ms,
+            candidate_ms,
+        )?);
+    }
+    Ok(samples)
+}
+
+fn run_and_sync(device: &Device, operation: &mut impl FnMut()) -> Result<()> {
+    operation();
+    device.sync()?;
+    Ok(())
+}
+
+fn time_synchronized(device: &Device, operation: &mut impl FnMut()) -> Result<f64> {
+    device.sync()?;
+    let started = Instant::now();
+    operation();
+    device.sync()?;
+    Ok(started.elapsed().as_secs_f64() * 1_000.0)
+}
+
+fn instantiate(
+    config: &ModelDef,
+    kind: ModelKind,
+    tier: usize,
+    device: &Device,
+    seed: u64,
+) -> Result<Transformer> {
+    device.seed(seed);
+    let mut model = Transformer::new(config, device)
+        .with_context(|| format!("failed to instantiate model '{}'", config.name))?;
+    match kind {
+        ModelKind::Static => ensure!(
+            model.memory_slot_statuses().is_empty(),
+            "static benchmark model '{}' unexpectedly has memory slots",
+            config.name
+        ),
+        ModelKind::Memory { active } => {
+            for slot in 0..active {
+                model
+                    .activate_memory_slot_all_layers(tier, slot)
+                    .with_context(|| {
+                        format!(
+                            "activating tier {tier} slot {slot} in model '{}'",
+                            config.name
+                        )
+                    })?;
+            }
+        }
+    }
+    Ok(model)
+}
+
+fn describe_state(
+    config: &ModelDef,
+    kind: ModelKind,
+    model: &Transformer,
+) -> Result<StateDescription> {
+    let (kind, active) = match kind {
+        ModelKind::Static => ("static_backbone", 0),
+        ModelKind::Memory { active } => ("fixed_capacity_memory", active),
+    };
+    Ok(StateDescription {
+        model: config.name.clone(),
+        kind,
+        active_slots_per_memory_layer: active,
+        accounting: model.wake_parameter_accounting()?.into(),
+    })
+}
+
+fn selected_tier_shape(config: &ModelDef, tier: usize) -> Result<(usize, usize)> {
+    let capacities = (0..config.num_layers)
+        .filter_map(|layer| {
+            config
+                .block_for_layer(layer)
+                .memory
+                .as_ref()?
+                .tiers
+                .get(tier)
+                .map(|tier| tier.reserve_experts.capacity)
+        })
+        .collect::<Vec<_>>();
+    ensure!(!capacities.is_empty(), "memory tier {tier} does not exist");
+    let capacity = capacities[0];
+    ensure!(
+        capacities.iter().all(|candidate| *candidate == capacity),
+        "memory tier {tier} does not have identical reserve slots in every memory layer"
+    );
+    Ok((capacities.len(), capacity))
+}
+
+fn load_configs(args: &Args) -> Result<(ModelDef, ModelDef)> {
+    match (&args.baseline_model, &args.model) {
+        (Some(static_path), Some(memory_path)) => {
+            Ok((parse_file(static_path)?, parse_file(memory_path)?))
+        }
+        (None, None) => Ok((
+            parse_mal(COMPACT_STATIC_MODEL).context("compact static benchmark MAL is invalid")?,
+            parse_mal(COMPACT_MEMORY_MODEL).context("compact memory benchmark MAL is invalid")?,
+        )),
+        _ => bail!("--model and --baseline-model must be supplied together"),
+    }
+}
+
+fn parse_file(path: &Path) -> Result<ModelDef> {
+    parse_mal_file(path).with_context(|| format!("failed to parse {}", path.display()))
+}
+
+fn deterministic_token_ids(tokens: usize, vocab_size: usize, seed: u64) -> Vec<i64> {
+    let mut state = seed.max(1);
+    (0..tokens)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state % vocab_size as u64) as i64
+        })
+        .collect()
+}
+
+fn deterministic_objective_weights(len: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed.max(1);
+    (0..len)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let unit = (state >> 40) as f32 / (1_u32 << 24) as f32;
+            unit * 2.0 - 1.0
+        })
+        .collect()
 }

--- a/hermes-llm/benches/memory_reserve/cli.rs
+++ b/hermes-llm/benches/memory_reserve/cli.rs
@@ -1,0 +1,145 @@
+//! Command-line parsing and acceptance-run guardrails.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail, ensure};
+
+#[derive(Debug)]
+pub(super) struct Args {
+    pub(super) model: Option<PathBuf>,
+    pub(super) baseline_model: Option<PathBuf>,
+    pub(super) output: Option<PathBuf>,
+    pub(super) tokens: usize,
+    pub(super) tier: usize,
+    pub(super) max_active: usize,
+    pub(super) warmup: usize,
+    pub(super) iterations: usize,
+    pub(super) seeds: Vec<u64>,
+    pub(super) max_overhead_percent: f64,
+    pub(super) enforce: bool,
+    pub(super) require_cuda: bool,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            model: None,
+            baseline_model: None,
+            output: None,
+            tokens: 4_096,
+            tier: 0,
+            max_active: 2,
+            warmup: 3,
+            iterations: 10,
+            seeds: vec![17, 23, 29],
+            max_overhead_percent: 5.0,
+            enforce: false,
+            require_cuda: false,
+        }
+    }
+}
+
+pub(super) fn parse_args() -> Result<Args> {
+    parse_args_from(std::env::args().skip(1))
+}
+
+fn parse_args_from(mut values: impl Iterator<Item = String>) -> Result<Args> {
+    let mut parsed = Args::default();
+    while let Some(flag) = values.next() {
+        let mut value = || {
+            values
+                .next()
+                .with_context(|| format!("{flag} needs a value"))
+        };
+        match flag.as_str() {
+            "--model" => parsed.model = Some(PathBuf::from(value()?)),
+            "--baseline-model" => parsed.baseline_model = Some(PathBuf::from(value()?)),
+            "--output" => parsed.output = Some(PathBuf::from(value()?)),
+            "--tokens" => parsed.tokens = value()?.parse().context("invalid --tokens")?,
+            "--tier" => parsed.tier = value()?.parse().context("invalid --tier")?,
+            "--max-active" => {
+                parsed.max_active = value()?.parse().context("invalid --max-active")?
+            }
+            "--warmup" => parsed.warmup = value()?.parse().context("invalid --warmup")?,
+            "--iterations" => {
+                parsed.iterations = value()?.parse().context("invalid --iterations")?
+            }
+            "--seeds" => parsed.seeds = parse_seeds(&value()?)?,
+            "--max-overhead-percent" => {
+                parsed.max_overhead_percent =
+                    value()?.parse().context("invalid --max-overhead-percent")?
+            }
+            "--enforce" => parsed.enforce = true,
+            "--require-cuda" => parsed.require_cuda = true,
+            // Cargo appends this marker for harness-less bench targets.
+            "--bench" => {}
+            "--help" | "-h" => {
+                println!(
+                    "Usage: memory_reserve [--model PATH --baseline-model PATH] [--tokens N] [--tier N] [--max-active N] [--warmup N] [--iterations N] [--seeds A,B,C] [--max-overhead-percent P] [--enforce] [--require-cuda] [--output PATH]"
+                );
+                std::process::exit(0);
+            }
+            _ => bail!("unknown argument {flag:?}"),
+        }
+    }
+    validate(parsed)
+}
+
+fn validate(parsed: Args) -> Result<Args> {
+    ensure!(
+        parsed.model.is_some() == parsed.baseline_model.is_some(),
+        "--model and --baseline-model must be supplied together"
+    );
+    ensure!(
+        parsed.tokens > 0 && parsed.iterations > 0 && parsed.max_active > 0,
+        "--tokens, --iterations, and --max-active must be positive"
+    );
+    ensure!(
+        parsed.seeds.len() >= 3,
+        "at least three paired seeds are required"
+    );
+    ensure!(
+        parsed.seeds.iter().copied().collect::<BTreeSet<_>>().len() == parsed.seeds.len(),
+        "paired seeds must be unique"
+    );
+    ensure!(
+        parsed.max_overhead_percent.is_finite() && parsed.max_overhead_percent >= 0.0,
+        "--max-overhead-percent must be finite and non-negative"
+    );
+    if parsed.enforce {
+        ensure!(
+            parsed.warmup >= 3 && parsed.iterations >= 10,
+            "--enforce requires at least 3 warmups and 10 measured iterations per seed"
+        );
+        ensure!(
+            parsed.max_active >= 2,
+            "--enforce requires --max-active of at least 2 to test constant active compute"
+        );
+    }
+    Ok(parsed)
+}
+
+fn parse_seeds(value: &str) -> Result<Vec<u64>> {
+    value
+        .split(',')
+        .map(|seed| {
+            ensure!(!seed.is_empty(), "--seeds contains an empty value");
+            seed.parse().context("invalid seed in --seeds")
+        })
+        .collect()
+}
+
+pub(super) fn backend_name() -> &'static str {
+    if cfg!(all(
+        feature = "cuda",
+        target_os = "linux",
+        not(feature = "metal")
+    )) {
+        "cuda"
+    } else if cfg!(feature = "metal") {
+        "metal"
+    } else {
+        "ndarray"
+    }
+}

--- a/hermes-llm/benches/memory_reserve/fairness.rs
+++ b/hermes-llm/benches/memory_reserve/fairness.rs
@@ -1,0 +1,99 @@
+//! Structural fairness checks for static-versus-memory benchmark pairs.
+
+use anyhow::{Context, Result, ensure};
+use hermes_llm::{BlockDef, MemoryTierInit, ModelDef};
+use serde::Serialize;
+use serde_json::Value;
+
+/// Verify that the candidate is an additive sleep-memory variant of the
+/// reference rather than a differently sized or otherwise easier backbone.
+pub fn validate_matched_backbone(static_model: &ModelDef, memory_model: &ModelDef) -> Result<()> {
+    ensure!(
+        static_model.vocab_size == memory_model.vocab_size
+            && static_model.max_seq_len == memory_model.max_seq_len
+            && static_model.hidden_size == memory_model.hidden_size
+            && static_model.num_layers == memory_model.num_layers,
+        "static and memory models must have identical vocabulary, context, hidden size, and layer count"
+    );
+    ensure!(
+        canonical_value(&static_model.embeddings)? == canonical_value(&memory_model.embeddings)?,
+        "static and memory embedding configurations differ"
+    );
+    ensure!(
+        canonical_value(&static_model.output)? == canonical_value(&memory_model.output)?,
+        "static and memory output configurations differ"
+    );
+
+    for layer in 0..static_model.num_layers {
+        let static_block = static_model.block_for_layer(layer);
+        let memory_block = memory_model.block_for_layer(layer);
+        ensure!(
+            static_block.memory.is_none(),
+            "baseline layer {layer} is not static"
+        );
+        let memory = memory_block
+            .memory
+            .as_ref()
+            .with_context(|| format!("candidate layer {layer} has no memory hierarchy"))?;
+        let fast = memory
+            .tiers
+            .first()
+            .with_context(|| format!("candidate layer {layer} has no memory tiers"))?;
+        ensure!(
+            canonical_value(&static_block.ffn)? == canonical_value(&fast.ffn)?,
+            "layer {layer} static FFN does not match the candidate fast tier"
+        );
+        ensure!(
+            matches!(fast.residual_init, MemoryTierInit::Default),
+            "layer {layer} fast memory tier does not preserve the static FFN initialization"
+        );
+        ensure!(
+            memory
+                .tiers
+                .iter()
+                .skip(1)
+                .all(|tier| matches!(tier.residual_init, MemoryTierInit::ResidualZero)),
+            "layer {layer} has a later memory tier that is not initialized as a residual no-op"
+        );
+        ensure!(
+            canonical_mixer_block(static_block)? == canonical_mixer_block(memory_block)?,
+            "layer {layer} sequence mixer, normalization, residual, or dropout differs"
+        );
+    }
+    Ok(())
+}
+
+fn canonical_mixer_block(block: &BlockDef) -> Result<Value> {
+    let mut value = serde_json::to_value(block)?;
+    let object = value
+        .as_object_mut()
+        .context("serialized block is not an object")?;
+    object.remove("name");
+    object.remove("ffn");
+    object.remove("memory");
+    strip_symbolic_names(&mut value);
+    Ok(value)
+}
+
+fn canonical_value(value: &impl Serialize) -> Result<Value> {
+    let mut value = serde_json::to_value(value)?;
+    strip_symbolic_names(&mut value);
+    Ok(value)
+}
+
+fn strip_symbolic_names(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            object.remove("name");
+            for value in object.values_mut() {
+                strip_symbolic_names(value);
+            }
+        }
+        Value::Array(array) => {
+            for value in array {
+                strip_symbolic_names(value);
+            }
+        }
+        _ => {}
+    }
+}

--- a/hermes-llm/benches/memory_reserve/stats.rs
+++ b/hermes-llm/benches/memory_reserve/stats.rs
@@ -1,0 +1,152 @@
+//! Pure paired-statistics support for the memory reserve benchmark.
+
+use anyhow::{Result, ensure};
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionOrder {
+    ReferenceThenCandidate,
+    CandidateThenReference,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PairedSample {
+    pub iteration: usize,
+    pub order: ExecutionOrder,
+    pub reference_ms: f64,
+    pub candidate_ms: f64,
+    pub candidate_to_reference_ratio: f64,
+}
+
+impl PairedSample {
+    pub fn new(
+        iteration: usize,
+        order: ExecutionOrder,
+        reference_ms: f64,
+        candidate_ms: f64,
+    ) -> Result<Self> {
+        ensure!(
+            reference_ms.is_finite() && reference_ms > 0.0,
+            "reference duration must be finite and positive"
+        );
+        ensure!(
+            candidate_ms.is_finite() && candidate_ms > 0.0,
+            "candidate duration must be finite and positive"
+        );
+        let ratio = candidate_ms / reference_ms;
+        ensure!(
+            ratio.is_finite() && ratio > 0.0,
+            "candidate/reference timing ratio must be finite and positive"
+        );
+        Ok(Self {
+            iteration,
+            order,
+            reference_ms,
+            candidate_ms,
+            candidate_to_reference_ratio: ratio,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct PairedTrial {
+    pub seed: u64,
+    pub samples: Vec<PairedSample>,
+    pub reference_median_ms: f64,
+    pub candidate_median_ms: f64,
+    pub paired_ratio_median: f64,
+}
+
+impl PairedTrial {
+    pub fn new(seed: u64, samples: Vec<PairedSample>) -> Result<Self> {
+        ensure!(!samples.is_empty(), "paired trial must contain samples");
+        let reference_median_ms = median(samples.iter().map(|sample| sample.reference_ms))?;
+        let candidate_median_ms = median(samples.iter().map(|sample| sample.candidate_ms))?;
+        let paired_ratio_median = median(
+            samples
+                .iter()
+                .map(|sample| sample.candidate_to_reference_ratio),
+        )?;
+        Ok(Self {
+            seed,
+            samples,
+            reference_median_ms,
+            candidate_median_ms,
+            paired_ratio_median,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct PairedSummary {
+    pub seed_count: usize,
+    pub sample_count: usize,
+    pub reference_median_ms: f64,
+    pub candidate_median_ms: f64,
+    pub paired_ratio_median: f64,
+    pub paired_ratio_p95: f64,
+    pub median_of_seed_median_ratios: f64,
+    pub worst_seed_median_ratio: f64,
+}
+
+pub fn summarize(trials: &[PairedTrial]) -> Result<PairedSummary> {
+    ensure!(!trials.is_empty(), "summary requires paired trials");
+    ensure!(
+        trials.iter().all(|trial| !trial.samples.is_empty()),
+        "summary cannot include an empty paired trial"
+    );
+    let sample_count = trials.iter().map(|trial| trial.samples.len()).sum();
+    let paired_ratios = trials.iter().flat_map(|trial| {
+        trial
+            .samples
+            .iter()
+            .map(|sample| sample.candidate_to_reference_ratio)
+    });
+    let seed_ratios = trials.iter().map(|trial| trial.paired_ratio_median);
+    Ok(PairedSummary {
+        seed_count: trials.len(),
+        sample_count,
+        reference_median_ms: median(
+            trials
+                .iter()
+                .flat_map(|trial| trial.samples.iter().map(|sample| sample.reference_ms)),
+        )?,
+        candidate_median_ms: median(
+            trials
+                .iter()
+                .flat_map(|trial| trial.samples.iter().map(|sample| sample.candidate_ms)),
+        )?,
+        paired_ratio_median: median(paired_ratios.clone())?,
+        paired_ratio_p95: percentile(paired_ratios, 0.95)?,
+        median_of_seed_median_ratios: median(seed_ratios.clone())?,
+        worst_seed_median_ratio: seed_ratios.fold(f64::NEG_INFINITY, f64::max),
+    })
+}
+
+fn median(values: impl IntoIterator<Item = f64>) -> Result<f64> {
+    percentile(values, 0.5)
+}
+
+fn percentile(values: impl IntoIterator<Item = f64>, probability: f64) -> Result<f64> {
+    ensure!(
+        probability.is_finite() && (0.0..=1.0).contains(&probability),
+        "percentile probability must be in [0, 1]"
+    );
+    let mut values = values.into_iter().collect::<Vec<_>>();
+    ensure!(!values.is_empty(), "cannot summarize an empty sample");
+    ensure!(
+        values.iter().all(|value| value.is_finite()),
+        "cannot summarize non-finite samples"
+    );
+    values.sort_by(f64::total_cmp);
+    let rank = probability * (values.len() - 1) as f64;
+    let lower = rank.floor() as usize;
+    let upper = rank.ceil() as usize;
+    if lower == upper {
+        Ok(values[lower])
+    } else {
+        let fraction = rank - lower as f64;
+        Ok(values[lower] + (values[upper] - values[lower]) * fraction)
+    }
+}

--- a/hermes-llm/src/model/block.rs
+++ b/hermes-llm/src/model/block.rs
@@ -37,7 +37,7 @@ pub struct TransformerBlock {
 }
 
 impl TransformerBlock {
-    pub fn new(config: &ModelDef, block: &BlockDef, device: &Device) -> Self {
+    pub fn new(config: &ModelDef, block: &BlockDef, layer: usize, device: &Device) -> Self {
         let (attention, ssm) = match &block.ssm {
             Some(ssm) => (None, Some(MambaMixer::new(config, ssm, device))),
             None => (Some(MultiHeadAttention::new(config, block, device)), None),
@@ -60,7 +60,7 @@ impl TransformerBlock {
             memory: block
                 .memory
                 .as_ref()
-                .map(|memory| MemoryChain::new(config, block, memory, device)),
+                .map(|memory| MemoryChain::new(config, block, memory, layer, device)),
             attn_norm: make_norm(),
             ffn_norm: make_norm(),
             residual_dropout: DropoutConfig::new(block.dropout).init(),
@@ -420,6 +420,28 @@ impl TransformerBlock {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("layer has no memory chain"))?
             .tier_parameter_ids(tier)
+    }
+
+    pub(crate) fn has_memory_tier(&self, tier: usize) -> bool {
+        self.memory
+            .as_ref()
+            .is_some_and(|memory| memory.has_tier(tier))
+    }
+
+    pub(crate) fn memory_tier_active_parameter_ids(
+        &self,
+        tier: usize,
+    ) -> anyhow::Result<Vec<ParamId>> {
+        self.memory
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("layer has no memory chain"))?
+            .tier_active_parameter_ids(tier)
+    }
+
+    pub(crate) fn dormant_memory_parameter_ids(&self) -> Vec<ParamId> {
+        self.memory
+            .as_ref()
+            .map_or_else(Vec::new, MemoryChain::dormant_parameter_ids)
     }
 
     pub(crate) fn memory_tier_base_parameter_ids(

--- a/hermes-llm/src/model/memory.rs
+++ b/hermes-llm/src/model/memory.rs
@@ -131,6 +131,25 @@ pub struct MemorySlotStatus {
     pub parameter_ids: Vec<ParamId>,
 }
 
+/// Where a reserve slot sits in the model. Initialization is salted by all
+/// three coordinates so no two slots start from the same `A`, matching the
+/// per-layer salting that slot reclamation already applies.
+#[derive(Clone, Copy)]
+struct SlotPosition {
+    layer: usize,
+    tier: usize,
+    slot: usize,
+}
+
+impl SlotPosition {
+    fn seed(self) -> u64 {
+        let mixed = mix_seed(self.slot as u64, 0x41)
+            ^ (self.layer as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15)
+            ^ (self.tier as u64).wrapping_mul(0xc2b2_ae3d_27d4_eb4f);
+        mix_seed(mixed, 0x41)
+    }
+}
+
 #[derive(Module, Debug)]
 struct LowRankExpertSlot {
     router: Linear,
@@ -145,8 +164,8 @@ struct LowRankExpertSlot {
 }
 
 impl LowRankExpertSlot {
-    fn new(hidden: usize, rank: usize, slot: usize, device: &Device) -> Self {
-        let a_values = deterministic_values(hidden * rank, mix_seed(slot as u64, 0x41));
+    fn new(hidden: usize, rank: usize, position: SlotPosition, device: &Device) -> Self {
+        let a_values = deterministic_values(hidden * rank, position.seed());
         Self {
             router: LinearConfig::new(hidden, 1).with_bias(false).init(device),
             a: Param::from_tensor(Tensor::from_data(
@@ -304,10 +323,20 @@ struct LowRankExpertReserve {
 }
 
 impl LowRankExpertReserve {
-    fn new(hidden: usize, capacity: usize, rank: usize, top_k: usize, device: &Device) -> Self {
+    fn new(
+        hidden: usize,
+        capacity: usize,
+        rank: usize,
+        top_k: usize,
+        layer: usize,
+        tier: usize,
+        device: &Device,
+    ) -> Self {
         Self {
             slots: (0..capacity)
-                .map(|slot| LowRankExpertSlot::new(hidden, rank, slot, device))
+                .map(|slot| {
+                    LowRankExpertSlot::new(hidden, rank, SlotPosition { layer, tier, slot }, device)
+                })
                 .collect(),
             fallback_a: Tensor::from_data(
                 TensorData::new(
@@ -672,16 +701,22 @@ pub struct MemoryChain {
 }
 
 impl MemoryChain {
+    pub(crate) fn has_tier(&self, tier: usize) -> bool {
+        tier < self.tiers.len()
+    }
+
     pub(crate) fn new(
         config: &ModelDef,
         block: &BlockDef,
         definition: &MemoryDef,
+        layer: usize,
         device: &Device,
     ) -> Self {
         let tiers = definition
             .tiers
             .iter()
-            .map(|definition| {
+            .enumerate()
+            .map(|(tier, definition)| {
                 let mut tier_block = block.clone();
                 tier_block.memory = None;
                 tier_block.ffn = definition.ffn.clone();
@@ -696,6 +731,8 @@ impl MemoryChain {
                         definition.reserve_experts.capacity,
                         definition.reserve_experts.rank,
                         definition.reserve_experts.top_k,
+                        layer,
+                        tier,
                         device,
                     ),
                     name: definition.name.clone(),
@@ -868,6 +905,45 @@ impl MemoryChain {
         Ok(ids.0)
     }
 
+    /// Float parameters that are eligible for ordinary wake gradients in one
+    /// tier. Activation changes only at consolidation boundaries, so this uses
+    /// the runtime mirror instead of reading checkpoint mask/generation tensors
+    /// back from the device on every optimizer step.
+    pub(crate) fn tier_active_parameter_ids(&self, tier: usize) -> Result<Vec<ParamId>> {
+        let tier = self
+            .tiers
+            .get(tier)
+            .ok_or_else(|| anyhow::anyhow!("memory tier {tier} does not exist"))?;
+        #[derive(Default)]
+        struct FloatIds(Vec<ParamId>);
+        impl ModuleVisitor for FloatIds {
+            fn visit_float<const D: usize>(&mut self, parameter: &Param<Tensor<D>>) {
+                self.0.push(parameter.id);
+            }
+        }
+        let mut ids = FloatIds::default();
+        tier.feed_forward.visit(&mut ids);
+        ids.0.extend(
+            tier.reserve
+                .slots
+                .iter()
+                .filter(|slot| slot.runtime_active)
+                .flat_map(LowRankExpertSlot::parameter_ids),
+        );
+        Ok(ids.0)
+    }
+
+    /// Dormant reserve parameters across the complete chain, derived without
+    /// synchronizing the serialized activation tensors to the host.
+    pub(crate) fn dormant_parameter_ids(&self) -> Vec<ParamId> {
+        self.tiers
+            .iter()
+            .flat_map(|tier| &tier.reserve.slots)
+            .filter(|slot| !slot.runtime_active)
+            .flat_map(LowRankExpertSlot::parameter_ids)
+            .collect()
+    }
+
     /// Float parameters of the tier's persistent base FFN/MoE, excluding all
     /// preallocated reserve experts. Terminal consolidation targets exactly
     /// this scope before it can reclaim the bounded slow reserve.
@@ -983,7 +1059,8 @@ mod tests {
         let config = memory_config();
         let device = Device::ndarray().autodiff();
         let block = config.block.clone();
-        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        let mut memory =
+            MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), 0, &device);
         let run = |memory: &MemoryChain| {
             let input = Tensor::<2>::random([5, 8], Distribution::Default, &device);
             memory
@@ -1060,7 +1137,8 @@ mod tests {
         let config = memory_config();
         let device = Device::ndarray();
         let block = config.block.clone();
-        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        let mut memory =
+            MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), 0, &device);
 
         let reserve = &memory.tiers[0].reserve;
         assert!(reserve.active_slots.is_empty());
@@ -1103,11 +1181,109 @@ mod tests {
     }
 
     #[test]
+    fn lightweight_parameter_scopes_follow_the_runtime_activation_cache() {
+        let config = memory_config();
+        let device = Device::ndarray();
+        let block = config.block.clone();
+        let mut memory =
+            MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), 0, &device);
+
+        let all = memory
+            .tier_parameter_ids(0)
+            .unwrap()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        let base = memory
+            .tier_base_parameter_ids(0)
+            .unwrap()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        let active = memory
+            .tier_active_parameter_ids(0)
+            .unwrap()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        let dormant = memory
+            .dormant_parameter_ids()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(active, base);
+        assert_eq!(
+            active
+                .union(&dormant)
+                .copied()
+                .collect::<std::collections::BTreeSet<_>>(),
+            all
+        );
+
+        let activated = memory.tiers[0].reserve.slots[1]
+            .parameter_ids()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        memory.activate_slot(0, 1).unwrap();
+        let active_after = memory
+            .tier_active_parameter_ids(0)
+            .unwrap()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        let dormant_after = memory
+            .dormant_parameter_ids()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(active_after, base.union(&activated).copied().collect());
+        assert!(dormant_after.is_disjoint(&activated));
+        assert_eq!(
+            active_after
+                .union(&dormant_after)
+                .copied()
+                .collect::<std::collections::BTreeSet<_>>(),
+            all
+        );
+
+        // Scope selection must not consult checkpoint tensors on the ordinary
+        // wake path. A direct snapshot mutation is intentionally invisible
+        // until the explicit boundary/load synchronization runs.
+        let checkpoint_only = memory.tiers[0].reserve.slots[0]
+            .parameter_ids()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        memory.tiers[0].reserve.slots[0].active = memory.tiers[0].reserve.slots[0]
+            .active
+            .clone()
+            .map(|value| Tensor::<1, Bool>::from_data([true], &value.device()));
+        let before_sync = memory
+            .dormant_parameter_ids()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert!(checkpoint_only.is_subset(&before_sync));
+
+        memory.sync_state();
+        let after_sync = memory
+            .tier_active_parameter_ids(0)
+            .unwrap()
+            .into_iter()
+            .map(|id| id.val())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert!(checkpoint_only.is_subset(&after_sync));
+        assert_eq!(memory.tiers[0].reserve.active_slots, vec![0, 1]);
+    }
+
+    #[test]
     fn routing_cache_survives_autodiff_validation() {
         let config = memory_config();
         let device = Device::ndarray().autodiff();
         let block = config.block.clone();
-        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        let mut memory =
+            MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), 0, &device);
         memory.activate_slot(0, 1).unwrap();
 
         let inference = memory.valid();
@@ -1131,7 +1307,8 @@ mod tests {
         let config = memory_config();
         let device = Device::ndarray();
         let block = config.block.clone();
-        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        let mut memory =
+            MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), 0, &device);
         memory.activate_slot(0, 1).unwrap();
         let reserve = &mut memory.tiers[0].reserve;
         reserve.slots[1].b = reserve.slots[1]
@@ -1164,7 +1341,7 @@ mod tests {
         let config = memory_config();
         let device = Device::ndarray().autodiff();
         let block = config.block.clone();
-        let memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        let memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), 0, &device);
         let reserve = &memory.tiers[0].reserve;
         let input = Tensor::<2>::random([5, 8], Distribution::Default, &device);
 
@@ -1190,7 +1367,8 @@ mod tests {
         let config = memory_config();
         let device = Device::ndarray();
         let block = config.block.clone();
-        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        let mut memory =
+            MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), 0, &device);
         let reserve = &memory.tiers[0].reserve;
         let first = &reserve.slots[0];
         let expected = first.router.num_params() * reserve.slots.len()
@@ -1217,7 +1395,8 @@ mod tests {
         let config = memory_config();
         let device = Device::ndarray();
         let block = config.block.clone();
-        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        let mut memory =
+            MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), 0, &device);
         memory.activate_slot(0, 0).unwrap();
         assert!(memory.statuses(0)[0].active);
         memory.reset_slot(0, 0, 17).unwrap();
@@ -1238,7 +1417,8 @@ mod tests {
         let config = memory_config();
         let device = Device::ndarray();
         let block = config.block.clone();
-        let mut memory = MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), &device);
+        let mut memory =
+            MemoryChain::new(&config, &block, block.memory.as_ref().unwrap(), 0, &device);
         let slot = &mut memory.tiers[0].reserve.slots[0];
         slot.generation = slot
             .generation

--- a/hermes-llm/src/model/transformer.rs
+++ b/hermes-llm/src/model/transformer.rs
@@ -6,8 +6,10 @@ use anyhow::{Context, Result, bail, ensure};
 use burn::module::{Initializer, ModuleVisitor, Param, ParamId};
 use burn::prelude::*;
 use burn::tensor::{DType, Int};
+use burn_nn::loss::CrossEntropyLossConfig;
 use burn_nn::{Dropout, DropoutConfig, Embedding, EmbeddingConfig, Linear, LinearConfig};
 use burn_nn::{RotaryEncoding, RotaryEncodingConfig};
+use burn_store::ModuleSnapshot;
 
 use crate::mal::{BlockDef, ModelDef, NormConfig, PositionEncoding};
 
@@ -163,6 +165,36 @@ fn validate_config(config: &ModelDef) -> Result<()> {
                             tier.name
                         );
                     }
+                    let factor_parameters = config
+                        .hidden_size
+                        .checked_mul(reserve.rank)
+                        .and_then(|count| count.checked_mul(2))
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "layer {i} memory tier '{}' reserve low-rank shape overflows usize",
+                                tier.name
+                            )
+                        })?;
+                    factor_parameters
+                        .checked_mul(reserve.capacity)
+                        .and_then(|count| {
+                            config
+                                .hidden_size
+                                .checked_mul(reserve.capacity)
+                                .and_then(|router| count.checked_add(router))
+                        })
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "layer {i} memory tier '{}' reserve capacity overflows usize",
+                                tier.name
+                            )
+                        })?;
+                    i64::try_from(reserve.capacity).with_context(|| {
+                        format!(
+                            "layer {i} memory tier '{}' reserve capacity exceeds device index range",
+                            tier.name
+                        )
+                    })?;
                     if reserve.top_k != 1 {
                         bail!(
                             "layer {i} memory tier '{}' reserve top_k must be 1 so wake active compute stays constant as stored capacity activates",
@@ -424,7 +456,7 @@ impl Transformer {
         );
         let embedding_dropout = DropoutConfig::new(config.embeddings.dropout).init();
         let layers = (0..config.num_layers)
-            .map(|i| TransformerBlock::new(config, config.block_for_layer(i), device))
+            .map(|i| TransformerBlock::new(config, config.block_for_layer(i), i, device))
             .collect();
         let norm_block = config.block_for_layer(0);
         let norm_config = config.output.norm.as_ref().unwrap_or(&norm_block.norm);
@@ -584,21 +616,31 @@ impl Transformer {
         input_ids: Tensor<2, Int>,
         targets: Tensor<2, Int>,
     ) -> (Tensor<1>, Option<Tensor<1>>) {
-        let [batch, seq_len] = targets.dims();
-        let tokens = batch * seq_len;
-        let (hidden, router_loss) =
-            self.forward_hidden_through_with_aux(input_ids, 0, self.layers.len());
-        let hidden = hidden.reshape([tokens, self.config.hidden_size]);
-        let (weight, bias) = self.output_parameters();
-        let loss = linear_cross_entropy(
-            hidden,
-            weight,
-            bias,
-            targets.reshape([tokens]),
-            self.config.vocab_size,
-            tokens.div_ceil(LOSS_CHUNKS),
-        );
+        let (loss, router_loss, logits) =
+            self.forward_language_objective(input_ids, targets, None, false);
+        debug_assert!(logits.is_none());
         (loss, router_loss)
+    }
+
+    /// Next-token loss, MoE router regularization, and flattened vocabulary
+    /// logits from one shared backbone pass.
+    ///
+    /// Quantization distillation needs both the ordinary task loss and student
+    /// logits. Keeping this as one model operation prevents QAT from running
+    /// the complete Transformer twice for every microbatch while retaining the
+    /// same chunked cross-entropy implementation and gradients.
+    pub fn forward_loss_and_logits_with_router(
+        &self,
+        input_ids: Tensor<2, Int>,
+        targets: Tensor<2, Int>,
+    ) -> (Tensor<1>, Option<Tensor<1>>, Tensor<2>) {
+        let (loss, router_loss, logits) =
+            self.forward_language_objective(input_ids, targets, None, true);
+        (
+            loss,
+            router_loss,
+            logits.expect("requested language logits are present"),
+        )
     }
 
     /// Causal cross-entropy over selected flattened token positions.
@@ -623,27 +665,74 @@ impl Transformer {
         targets: Tensor<2, Int>,
         positions: Tensor<1, Int>,
     ) -> (Tensor<1>, Option<Tensor<1>>) {
+        let (loss, router_loss, logits) =
+            self.forward_language_objective(input_ids, targets, Some(positions), false);
+        debug_assert!(logits.is_none());
+        (loss, router_loss)
+    }
+
+    /// Selected-position language loss, MoE router regularization, and the
+    /// corresponding vocabulary logits from one shared backbone pass.
+    pub fn forward_masked_loss_and_logits_with_router(
+        &self,
+        input_ids: Tensor<2, Int>,
+        targets: Tensor<2, Int>,
+        positions: Tensor<1, Int>,
+    ) -> (Tensor<1>, Option<Tensor<1>>, Tensor<2>) {
+        let (loss, router_loss, logits) =
+            self.forward_language_objective(input_ids, targets, Some(positions), true);
+        (
+            loss,
+            router_loss,
+            logits.expect("requested masked-language logits are present"),
+        )
+    }
+
+    fn forward_language_objective(
+        &self,
+        input_ids: Tensor<2, Int>,
+        targets: Tensor<2, Int>,
+        positions: Option<Tensor<1, Int>>,
+        materialize_logits: bool,
+    ) -> (Tensor<1>, Option<Tensor<1>>, Option<Tensor<2>>) {
         let [batch, seq_len] = targets.dims();
         assert_eq!(input_ids.dims(), [batch, seq_len]);
-        let [selected_tokens] = positions.dims();
-        assert!(selected_tokens > 0, "masked loss requires target tokens");
         let tokens = batch * seq_len;
         let (hidden, router_loss) =
             self.forward_hidden_through_with_aux(input_ids, 0, self.layers.len());
-        let hidden = hidden
-            .reshape([tokens, self.config.hidden_size])
-            .select(0, positions.clone());
-        let targets = targets.reshape([tokens]).select(0, positions);
-        let (weight, bias) = self.output_parameters();
-        let loss = linear_cross_entropy(
-            hidden,
-            weight,
-            bias,
-            targets,
-            self.config.vocab_size,
-            selected_tokens.div_ceil(LOSS_CHUNKS),
-        );
-        (loss, router_loss)
+        let hidden = hidden.reshape([tokens, self.config.hidden_size]);
+        let targets = targets.reshape([tokens]);
+        let (hidden, targets, supervised_tokens) = match positions {
+            Some(positions) => {
+                let [selected_tokens] = positions.dims();
+                assert!(selected_tokens > 0, "masked loss requires target tokens");
+                (
+                    hidden.select(0, positions.clone()),
+                    targets.select(0, positions),
+                    selected_tokens,
+                )
+            }
+            None => (hidden, targets, tokens),
+        };
+        let logits =
+            materialize_logits.then(|| self.project_flat_hidden(hidden.clone(), supervised_tokens));
+        let loss = match &logits {
+            Some(logits) => CrossEntropyLossConfig::new()
+                .init(&logits.device())
+                .forward(logits.clone(), targets),
+            None => {
+                let (weight, bias) = self.output_parameters();
+                linear_cross_entropy(
+                    hidden,
+                    weight,
+                    bias,
+                    targets,
+                    self.config.vocab_size,
+                    supervised_tokens.div_ceil(LOSS_CHUNKS),
+                )
+            }
+        };
+        (loss, router_loss, logits)
     }
 
     /// Vocabulary logits only for selected row-major token positions.
@@ -923,6 +1012,43 @@ impl Transformer {
         Ok(visitor.ids)
     }
 
+    /// Canonical SafeTensors paths selected by the ultra-low-bit QAT policy.
+    ///
+    /// This resolves paths through the same Burn snapshot traversal and enum-
+    /// variant policy used by [`crate::save_safetensors`]. It is primarily an
+    /// integration invariant for proving that the training-time ParamId policy
+    /// and archive-time tensor policy select the same matrices exactly.
+    pub fn ultra_quant_parameter_names(
+        &self,
+        quantize_embeddings: bool,
+        quantize_lm_head: bool,
+    ) -> Result<Vec<String>> {
+        let selected = self.ultra_quant_parameter_ids(quantize_embeddings, quantize_lm_head)?;
+        let mut matched = Vec::with_capacity(selected.len());
+        let mut names = self
+            .collect(None, None, true)
+            .into_iter()
+            .filter_map(|snapshot| {
+                let id = snapshot.tensor_id?;
+                selected.contains(&id).then(|| {
+                    matched.push(id);
+                    snapshot.full_path()
+                })
+            })
+            .collect::<Vec<_>>();
+        names.sort();
+        names.dedup();
+        ensure!(
+            selected.iter().all(|id| matched.contains(id)),
+            "QAT parameter selection contains an ID absent from canonical SafeTensors traversal"
+        );
+        ensure!(
+            matched.len() == selected.len() && names.len() == selected.len(),
+            "QAT parameter selection is not one-to-one with canonical SafeTensors paths"
+        );
+        Ok(names)
+    }
+
     /// Visit one transformer block without exposing its module fields. This is
     /// used by opt-in trainer diagnostics such as per-layer gradient norms.
     pub fn visit_layer<V: ModuleVisitor>(&self, index: usize, visitor: &mut V) -> Result<()> {
@@ -1031,9 +1157,31 @@ impl Transformer {
         state: &mut InferenceState,
         routing: MemoryRouting,
     ) -> Tensor<2> {
-        self.project_last_logits(
-            self.forward_hidden_with_state_and_routing(input_ids, state, routing),
+        self.forward_next_features_and_logits_with_state_and_memory_routing(
+            input_ids, state, routing,
         )
+        .1
+    }
+
+    /// Run cached generation and return the final hidden feature together with
+    /// its vocabulary logits.
+    ///
+    /// Dreaming applies an isolated LM-head policy to this feature. Returning
+    /// both values from the same cached backbone pass avoids recomputing the
+    /// complete prefix for every generated token.
+    pub fn forward_next_features_and_logits_with_state_and_memory_routing(
+        &self,
+        input_ids: Tensor<2, Int>,
+        state: &mut InferenceState,
+        routing: MemoryRouting,
+    ) -> (Tensor<2>, Tensor<2>) {
+        let hidden = self.forward_hidden_with_state_and_routing(input_ids, state, routing);
+        let [batch, seq_len, width] = hidden.dims();
+        let feature = hidden
+            .slice([0..batch, seq_len - 1..seq_len, 0..width])
+            .reshape([batch, width]);
+        let logits = self.project_flat_hidden(feature.clone(), batch);
+        (feature, logits)
     }
 
     fn forward_hidden_with_state(
@@ -1245,38 +1393,71 @@ impl Transformer {
 
     /// Float parameters for one logical tier across all memory-bearing layers.
     pub fn memory_tier_parameter_ids_all_layers(&self, tier: usize) -> Result<Vec<ParamId>> {
-        let layers = self
-            .memory_slot_statuses()
-            .into_iter()
-            .filter(|status| status.tier == tier)
-            .map(|status| status.layer)
-            .collect::<std::collections::BTreeSet<_>>();
-        ensure!(!layers.is_empty(), "memory tier {tier} does not exist");
         let mut ids = Vec::new();
-        for layer in layers {
-            ids.extend(self.memory_tier_parameter_ids(layer, tier)?);
+        let mut matching_layers = 0_usize;
+        for (layer, block) in self.layers.iter().enumerate() {
+            if !block.has_memory_tier(tier) {
+                continue;
+            }
+            matching_layers += 1;
+            ids.extend(
+                block
+                    .memory_tier_parameter_ids(tier)
+                    .with_context(|| format!("reading layer {layer} memory tier {tier}"))?,
+            );
         }
+        ensure!(matching_layers > 0, "memory tier {tier} does not exist");
         Ok(ids)
+    }
+
+    /// Wake-eligible parameters for one logical memory tier across all layers.
+    /// This is a synchronization-free query over parameter IDs and the
+    /// boundary-refreshed runtime activation mirror.
+    pub fn memory_tier_active_parameter_ids_all_layers(&self, tier: usize) -> Result<Vec<ParamId>> {
+        let mut ids = Vec::new();
+        let mut matching_layers = 0_usize;
+        for (layer, block) in self.layers.iter().enumerate() {
+            if !block.has_memory_tier(tier) {
+                continue;
+            }
+            matching_layers += 1;
+            ids.extend(
+                block
+                    .memory_tier_active_parameter_ids(tier)
+                    .with_context(|| format!("reading active layer {layer} memory tier {tier}"))?,
+            );
+        }
+        ensure!(matching_layers > 0, "memory tier {tier} does not exist");
+        Ok(ids)
+    }
+
+    /// Parameters of every dormant reserve slot. Unlike
+    /// [`Self::memory_slot_statuses`], this does not read serialized masks or
+    /// generations from the device and is safe on the per-step wake path.
+    pub fn dormant_memory_parameter_ids(&self) -> Vec<ParamId> {
+        self.layers
+            .iter()
+            .flat_map(TransformerBlock::dormant_memory_parameter_ids)
+            .collect()
     }
 
     /// Persistent base FFN/MoE parameters for one memory tier across every
     /// memory-bearing layer. Reserve expert tensors are deliberately excluded.
     pub fn memory_tier_base_parameter_ids_all_layers(&self, tier: usize) -> Result<Vec<ParamId>> {
-        let layers = self
-            .memory_slot_statuses()
-            .into_iter()
-            .filter(|status| status.tier == tier)
-            .map(|status| status.layer)
-            .collect::<std::collections::BTreeSet<_>>();
-        ensure!(!layers.is_empty(), "memory tier {tier} does not exist");
         let mut ids = Vec::new();
-        for layer in layers {
+        let mut matching_layers = 0_usize;
+        for (layer, block) in self.layers.iter().enumerate() {
+            if !block.has_memory_tier(tier) {
+                continue;
+            }
+            matching_layers += 1;
             ids.extend(
-                self.layers[layer]
+                block
                     .memory_tier_base_parameter_ids(tier)
                     .with_context(|| format!("reading layer {layer} memory tier {tier} base"))?,
             );
         }
+        ensure!(matching_layers > 0, "memory tier {tier} does not exist");
         ensure!(
             !ids.is_empty(),
             "memory tier {tier} base has no float parameters"
@@ -1633,6 +1814,66 @@ mod tests {
     }
 
     #[test]
+    fn task_loss_and_distillation_logits_match_independent_model_apis() {
+        let mut config = get_builtin_model("tiny").unwrap();
+        config.vocab_size = 32;
+        config.hidden_size = 8;
+        config.num_layers = 1;
+        config.max_seq_len = 8;
+        config.embeddings.dropout = 0.0;
+        config.block.dropout = 0.0;
+        config.block.attention.dropout = 0.0;
+        config.block.attention.num_heads = Some(2);
+        config.block.attention.num_kv_heads = Some(1);
+        config.block.attention.head_dim = Some(4);
+        config.block.ffn.dropout = 0.0;
+        config.block.ffn.hidden_dim = Some(16);
+        let device = Device::ndarray().autodiff();
+        device.seed(43);
+        let model = Transformer::new(&config, &device).unwrap();
+        let inputs = vec![1_i64, 2, 3, 4, 5, 6, 7, 8];
+        let targets = vec![2_i64, 3, 4, 5, 6, 7, 8, 9];
+        let batch = || {
+            (
+                Tensor::<2, Int>::from_data(TensorData::new(inputs.clone(), [2, 4]), &device),
+                Tensor::<2, Int>::from_data(TensorData::new(targets.clone(), [2, 4]), &device),
+            )
+        };
+        let value = |loss: Tensor<1>| loss.into_data().convert::<f32>().to_vec::<f32>().unwrap()[0];
+
+        let (input, target) = batch();
+        let (combined_loss, router_loss, combined_logits) =
+            model.forward_loss_and_logits_with_router(input, target);
+        assert!(router_loss.is_none());
+        let (input, target) = batch();
+        let independent_loss = model.forward_loss(input, target);
+        let (input, _) = batch();
+        let independent_logits = model.forward(input, 0).reshape([8, config.vocab_size]);
+        assert!((value(combined_loss) - value(independent_loss)).abs() < 1e-6);
+        let maximum: f32 = (combined_logits - independent_logits)
+            .abs()
+            .max()
+            .into_scalar();
+        assert!(maximum < 1e-6, "causal QAT logits differ by {maximum}");
+
+        let positions = || Tensor::<1, Int>::from_data([1_i64, 6], &device);
+        let (input, target) = batch();
+        let (combined_loss, router_loss, combined_logits) =
+            model.forward_masked_loss_and_logits_with_router(input, target, positions());
+        assert!(router_loss.is_none());
+        let (input, target) = batch();
+        let independent_loss = model.forward_masked_loss(input, target, positions());
+        let (input, _) = batch();
+        let independent_logits = model.forward_selected_logits(input, positions());
+        assert!((value(combined_loss) - value(independent_loss)).abs() < 1e-6);
+        let maximum: f32 = (combined_logits - independent_logits)
+            .abs()
+            .max()
+            .into_scalar();
+        assert!(maximum < 1e-6, "masked QAT logits differ by {maximum}");
+    }
+
+    #[test]
     fn selected_logits_match_materialized_positions() {
         let mut config = get_builtin_model("tiny").unwrap();
         config.vocab_size = 32;
@@ -1862,6 +2103,53 @@ mod tests {
     }
 
     #[test]
+    fn sync_free_tier_scopes_skip_layers_without_the_requested_tier() {
+        let config = crate::mal::parse_mal(
+            r#"
+            ffn base { hidden_dim: 12 activation: swiglu }
+            memory fast_only {
+                tier fast {
+                    ffn: base
+                    reserve_experts { capacity: 1 rank: 3 top_k: 1 }
+                }
+            }
+            memory fast_slow {
+                tier fast {
+                    ffn: base
+                    reserve_experts { capacity: 1 rank: 3 top_k: 1 }
+                }
+                tier slow {
+                    ffn: base residual_init: zero
+                    reserve_experts { capacity: 1 rank: 3 top_k: 1 }
+                }
+            }
+            block short { attention: { num_heads: 1 } memory: fast_only }
+            block long { attention: { num_heads: 1 } memory: fast_slow }
+            model heterogeneous-sleeper {
+                vocab_size: 16 max_seq_len: 8 hidden_size: 8 num_layers: 2
+                block: short
+                pattern: [short, long]
+            }
+            "#,
+        )
+        .unwrap();
+        let model = Transformer::new(&config, &Device::ndarray()).unwrap();
+
+        let direct = model.memory_tier_parameter_ids(1, 1).unwrap();
+        assert_eq!(
+            model.memory_tier_parameter_ids_all_layers(1).unwrap(),
+            direct
+        );
+        assert_eq!(
+            model
+                .memory_tier_active_parameter_ids_all_layers(1)
+                .unwrap(),
+            model.memory_tier_base_parameter_ids_all_layers(1).unwrap()
+        );
+        assert!(model.memory_tier_parameter_ids_all_layers(2).is_err());
+    }
+
+    #[test]
     fn memory_reserve_rejects_growing_top_k_compute() {
         let config = crate::mal::parse_mal(
             r#"
@@ -1887,6 +2175,34 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("reserve top_k must be 1"), "{error}");
+    }
+
+    #[test]
+    fn memory_reserve_rejects_overflowing_low_rank_capacity_before_allocation() {
+        let mut config = crate::mal::parse_mal(
+            r#"
+            ffn base { hidden_dim: 12 activation: swiglu }
+            memory cms {
+                tier fast {
+                    ffn: base
+                    reserve_experts { capacity: 1 rank: 3 top_k: 1 }
+                }
+            }
+            model sleeper {
+                vocab_size: 16 max_seq_len: 8 hidden_size: 8 num_layers: 1
+                block: { attention: { num_heads: 1 } memory: cms }
+            }
+            "#,
+        )
+        .unwrap();
+        config.block.memory.as_mut().unwrap().tiers[0]
+            .reserve_experts
+            .rank = usize::MAX;
+
+        let error = Transformer::new(&config, &Device::ndarray())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("low-rank shape overflows"), "{error}");
     }
 
     #[test]
@@ -1951,6 +2267,26 @@ mod tests {
             difference > 0.0,
             "persistent MoE exploration should remain active with one receiver slot"
         );
+
+        let cached_input = Tensor::<2, Int>::from_data([[1_i64, 2, 3]], &device);
+        let mut feature_state = model.make_state_with_capacity(1, 3, &device);
+        let (features, cached_logits) = model
+            .forward_next_features_and_logits_with_state_and_memory_routing(
+                cached_input.clone(),
+                &mut feature_state,
+                MemoryRouting::Dream { seed: 0x5678 },
+            );
+        let mut logits_state = model.make_state_with_capacity(1, 3, &device);
+        let logits_only = model.forward_next_logits_with_state_and_memory_routing(
+            cached_input,
+            &mut logits_state,
+            MemoryRouting::Dream { seed: 0x5678 },
+        );
+        assert_eq!(features.dims(), [1, config.hidden_size]);
+        assert_eq!(feature_state.pos(), 3);
+        assert_eq!(logits_state.pos(), 3);
+        let cached_difference: f32 = (cached_logits - logits_only).abs().max().into_scalar();
+        assert!(cached_difference < 1e-6, "difference={cached_difference}");
     }
 
     #[test]

--- a/hermes-llm/tests/memory_reserve_benchmark_stats.rs
+++ b/hermes-llm/tests/memory_reserve_benchmark_stats.rs
@@ -1,0 +1,95 @@
+//! Executes the pure statistical checks shared with the harness-less memory
+//! reserve benchmark. Keeping the arithmetic outside device code makes ratio
+//! and acceptance reporting part of the ordinary test suite.
+
+#[path = "../benches/memory_reserve/fairness.rs"]
+mod fairness;
+#[path = "../benches/memory_reserve/stats.rs"]
+mod stats;
+
+use stats::{ExecutionOrder, PairedSample, PairedTrial};
+
+fn sample(reference: f64, candidate: f64) -> PairedSample {
+    PairedSample::new(
+        0,
+        ExecutionOrder::ReferenceThenCandidate,
+        reference,
+        candidate,
+    )
+    .unwrap()
+}
+
+fn production_pair() -> (hermes_llm::ModelDef, hermes_llm::ModelDef) {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../hermes-mal/well-known");
+    (
+        hermes_llm::parse_mal_file(root.join("retriever_300m_moe.mal")).unwrap(),
+        hermes_llm::parse_mal_file(root.join("retriever_300m_moe_sleep.mal")).unwrap(),
+    )
+}
+
+fn first_memory_tiers(model: &mut hermes_llm::ModelDef) -> &mut [hermes_llm::MemoryTierDef] {
+    &mut model.pattern.as_mut().unwrap()[0]
+        .memory
+        .as_mut()
+        .unwrap()
+        .tiers
+}
+
+#[test]
+fn paired_summary_uses_ratios_of_matched_samples() {
+    let trials = vec![
+        PairedTrial::new(1, vec![sample(10.0, 11.0), sample(20.0, 18.0)]).unwrap(),
+        PairedTrial::new(2, vec![sample(100.0, 105.0), sample(80.0, 88.0)]).unwrap(),
+        PairedTrial::new(3, vec![sample(50.0, 50.0), sample(40.0, 44.0)]).unwrap(),
+    ];
+    let summary = stats::summarize(&trials).unwrap();
+    assert_eq!(summary.seed_count, 3);
+    assert_eq!(summary.sample_count, 6);
+    assert!((summary.paired_ratio_median - 1.075).abs() < 1e-12);
+    assert!((summary.median_of_seed_median_ratios - 1.05).abs() < 1e-12);
+    assert!((summary.worst_seed_median_ratio - 1.075).abs() < 1e-12);
+}
+
+#[test]
+fn invalid_timing_is_rejected_before_json_output() {
+    assert!(PairedSample::new(0, ExecutionOrder::CandidateThenReference, 0.0, 1.0).is_err());
+    assert!(PairedSample::new(0, ExecutionOrder::CandidateThenReference, 1.0, f64::NAN).is_err());
+    assert!(
+        PairedSample::new(
+            0,
+            ExecutionOrder::CandidateThenReference,
+            f64::MIN_POSITIVE,
+            f64::MAX,
+        )
+        .is_err()
+    );
+    assert!(stats::summarize(&[]).is_err());
+}
+
+#[test]
+fn production_static_and_sleep_models_are_a_matched_pair() {
+    let (static_model, memory_model) = production_pair();
+    fairness::validate_matched_backbone(&static_model, &memory_model).unwrap();
+}
+
+#[test]
+fn fairness_check_rejects_an_easier_candidate() {
+    let (static_model, mut memory_model) = production_pair();
+    memory_model.hidden_size /= 2;
+    assert!(fairness::validate_matched_backbone(&static_model, &memory_model).is_err());
+}
+
+#[test]
+fn fairness_check_requires_later_tiers_to_start_as_noops() {
+    let (static_model, mut memory_model) = production_pair();
+    first_memory_tiers(&mut memory_model)[1].residual_init = hermes_llm::MemoryTierInit::Default;
+    assert!(fairness::validate_matched_backbone(&static_model, &memory_model).is_err());
+}
+
+#[test]
+fn fairness_check_requires_fast_tier_to_preserve_static_ffn() {
+    let (static_model, mut memory_model) = production_pair();
+    first_memory_tiers(&mut memory_model)[0].residual_init =
+        hermes_llm::MemoryTierInit::ResidualZero;
+    assert!(fairness::validate_matched_backbone(&static_model, &memory_model).is_err());
+}

--- a/hermes-train/Cargo.toml
+++ b/hermes-train/Cargo.toml
@@ -22,6 +22,7 @@ libc = "0.2"
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tracing.workspace = true
 tracing-subscriber.workspace = true
 ureq = { version = "2.12", features = ["json"] }
 postgres = { version = "0.19", features = ["with-serde_json-1"] }
@@ -43,3 +44,7 @@ cuda = ["hermes-llm/training-fusion"]
 [[bin]]
 name = "hermes-train"
 path = "src/main.rs"
+
+[[bench]]
+name = "wake_tier_step"
+harness = false

--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -67,6 +67,69 @@ hermes-train train \
   --output checkpoint
 ```
 
+For the schedule- and capacity-matched no-sleep ablation in the stock wake
+trainer, replace `periodic_sleep` on every wake phase with the same typed
+`memory_update_mode` object and omit the sleep-runtime flags:
+
+```json
+{
+  "memory_update_mode": {
+    "type": "wake_only",
+    "schedule": {
+      "clock": "optimizer_steps",
+      "terminal_consolidation": "distill_into_base_v1",
+      "tiers": [
+        { "id": "fast", "update_period": 100, "reserve_slots": 2 },
+        { "id": "medium", "update_period": 400, "reserve_slots": 4 },
+        { "id": "slow", "update_period": 3200, "reserve_slots": 8 }
+      ]
+    },
+    "tier_optimizer": {
+      "learning_rate": 0.0003,
+      "beta_1": 0.9,
+      "beta_2": 0.95,
+      "epsilon": 1e-8,
+      "weight_decay": 0.1
+    }
+  }
+}
+```
+
+`wake_only` retains each tier's independent clock and pending gradients and
+applies due base updates fastest-to-slowest. It performs no consolidation,
+transfer, reserve activation/reset, or Dreaming. Checkpoints bind the exact
+mode, schedule, optimizer settings, clocks, moments, and pending accumulators.
+The native DPO, forward-KL, and GRPO executor rejects `memory_update_mode`
+instead of silently applying its ordinary optimizer; for memory-model tier
+scheduling, those phases currently support `periodic_sleep` only.
+The stock trainer accepts either `[fast, slow]` or `[fast, medium, slow]` so its
+typed tier metrics remain unambiguous. Memory training currently requires the
+memory hierarchy in every model layer; mixed memory/ordinary-FFN layer
+topologies are rejected explicitly.
+
+Profile the complete tier wake step—not only model forward/backward—with the
+harness-less `wake_tier_step` benchmark. It emits interleaved raw non-boundary
+and boundary timings for at least three paired seeds, including gradient
+partitioning, tier accumulation/commit, and the wake-only update path:
+
+```bash
+cargo bench -p hermes-train --bench wake_tier_step --features cuda -- \
+  --model hermes-mal/well-known/retriever_300m_moe_sleep.mal \
+  --batch-size 4 --sequence-length 1024 --periods 100,400,3200 \
+  --non-due-clock 99 --due-clock 100 --require-cuda \
+  --output wake-tier-step-cuda.json
+```
+
+The report records that each paired case starts from a fresh tier bank. This
+keeps the compared model, gradients, and optimizer state byte-identical and
+profiles the cold first-boundary path; use the separate `memory_reserve`
+benchmark's matched static-model gate for the steady-state 5% wake-overhead
+acceptance decision.
+
+Runs without the CUDA plus `training-fusion` stack are labelled smoke-only in
+the JSON and are not CUDA acceptance evidence. The embedded compact model is
+intended only for quick local smoke runs.
+
 Create the runtime's `workflow_signature` without touching checkpoint or
 runtime state. Use every training-semantic option from the eventual invocation;
 the output path itself is not part of the signature:
@@ -172,6 +235,14 @@ worker hash, and metric run id. Optimization/mutation results must be new
 immutable checkpoint URIs and assessment cannot change weights. The native
 promotion gate releases only the exact accepted current candidate.
 
+All pinned phase, benchmark, and resource workers run with an empty inherited
+environment and `/` as their working directory. A script worker must therefore
+name its interpreter directly with an absolute shebang such as `#!/bin/sh` or
+`#!/opt/hermes/venv/bin/python`; `#!/usr/bin/env ...` and other `env`-interpreter
+shebangs are rejected. Worker subprocess paths must likewise be absolute or be
+resolved internally by a self-contained binary—the host never injects an
+ambient `PATH`.
+
 If a worker yields, invoke the same command with `--resume` and without either
 initial-checkpoint option. The runtime verifies the workflow, worker digest,
 metric run id, and committed metric prefix before continuing. The concrete
@@ -189,6 +260,16 @@ is accepted only when the trainer supplies an authenticated
 idempotent boundary hook. Trainable policy adapters report a monotonic exact
 model-token counter; the executor samples it around each deterministic update
 instead of estimating token usage from padded sequence geometry.
+
+Forward-KL accepts causal-LM and supervised-generation task examples, including
+instruction tuning, and applies the task's explicit prompt/target structure.
+Every local frozen teacher or reference uses the same canonical
+`sha256:<64 lowercase hex>` identity as runtime checkpoints; alternate digest
+spellings are rejected rather than normalized. Revision-pinned remote models
+derive that canonical runtime identity from the adapter, immutable revision,
+and adapter parameters, so equal revision labels from different providers or
+model repositories cannot alias one another. Context factories should use
+`FrozenModelSpec::immutable_identity()` as their exact expected value.
 
 The complete education recipe combines periodic sleep with phase kinds outside
 the wake trainer and therefore uses the public embedded host in `native_host`.
@@ -361,9 +442,11 @@ Sleep schedules, Knowledge Seeding, semantic/edit imitation with GRPO,
 retention transactions, dream selection by model-loss gradient alignment,
 isolated frozen-model LM-head LoRA trials (paper geometry rank 64 / alpha 128),
 and ReSTEM updates have an in-process tensor implementation. Each built-in
-trial derives final-normalized hidden features once, trains only `[rank,
-hidden]` and `[rank, vocabulary]` adapter tensors, and adds their delta to the
-frozen base projection. Its content-addressed receipt binds the adapter to the
+trial supervises only the generated continuation, derives its final-normalized
+hidden features once, caches the immutable evaluation features across trials,
+and trains only `[rank, hidden]` and `[rank, vocabulary]` adapter tensors with
+batched device GEMMs. It adds their delta to the frozen base projection. Its
+content-addressed receipt binds the adapter to the
 immutable base checkpoint and exact model-parameter digest, logical
 output-projection target, exact shapes, candidate, and evaluator. The stock
 runtime provides model-owned rollout generation, a frozen
@@ -385,8 +468,10 @@ gradient-accumulation window is discarded for every scope. One global norm and
 clip covers wake and tier gradients before a completed optimizer window is
 committed.
 
-Dream generation adds exactly one deterministic-random expert per token from
-outside each persistent FFN MoE's ordinary top-k. Reserve-memory routers remain
+Dream generation prefills each wake prefix once and then uses the ordinary KV
+or recurrent inference state for linear-time single-token decoding. It adds
+exactly one deterministic-random expert per token from outside each persistent
+FFN MoE's ordinary top-k. Reserve-memory routers remain
 ordinary top-1 from the initial zero fallback onward. Their capacity-width
 projection is fixed; dormant learned rows stay off graph behind parameter-free
 zero columns, and activation replaces columns without growing router work.
@@ -517,7 +602,11 @@ fixed by the runner rather than inferred from filenames.
 First produce each immutable run with the content-pinned evaluator. `PATH=HASH`
 arguments use raw 64-character SHA-256 digests; the evaluator identity includes
 the `sha256:` prefix and must exactly equal `evaluator_version` in the run
-config.
+config. `evaluator_arguments` in that same config is the exact UTF-8 argument
+vector: repeat `--evaluator-arg` with identical values when launching the run.
+The host clears the inherited environment and runs the evaluator from `/`, so
+the pinned evaluator must be self-contained and may not depend on ambient
+shell, working-directory, or secret state.
 
 ```bash
 hermes-train run-benchmark \

--- a/hermes-train/benches/wake_tier_step.rs
+++ b/hermes-train/benches/wake_tier_step.rs
@@ -1,0 +1,597 @@
+//! Paired profile of the complete memory-tier wake hot path.
+//!
+//! Unlike the model-only reserve benchmark, every timed operation here runs a
+//! real Transformer language-model forward/backward, partitions the resulting
+//! graph, commits tier gradients into their independently clocked accumulators,
+//! and calls `TierOptimizerBank::apply_wake_only_due_updates`. The paired cases
+//! differ only in whether the supplied clock is a tier boundary.
+//!
+//! The embedded model is intentionally compact for local correctness smoke
+//! runs. A local CPU or Metal result is always labelled smoke-only. CUDA
+//! profiling must opt in explicitly and build hermes-train's `cuda` feature,
+//! which enables Hermes LLM's CUDA plus `training-fusion` stack:
+//!
+//! ```text
+//! cargo bench -p hermes-train --bench wake_tier_step --features cuda -- \
+//!   --model hermes-mal/well-known/retriever_300m_moe_sleep.mal \
+//!   --batch-size 4 --sequence-length 1024 --periods 100,400,3200 \
+//!   --non-due-clock 99 --due-clock 100 --require-cuda \
+//!   --output wake-tier-step-cuda.json
+//! ```
+//!
+//! Model initialization and input construction are outside the timed region.
+
+#[path = "wake_tier_step/cli.rs"]
+mod cli;
+#[path = "wake_tier_step/stats.rs"]
+mod stats;
+
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{Context, Result, bail, ensure};
+use burn::prelude::*;
+use burn::tensor::TensorData;
+use hermes_llm::{Device, ModelDef, Transformer, default_device, parse_mal};
+use hermes_train::artifact_io::{read_regular_bounded, sha256_identity};
+use hermes_train::sleep::{MemoryTierSchedule, SleepSchedule, TerminalConsolidation, UpdateClock};
+use hermes_train::tier_optimizer::{TierOptimizerBank, TierOptimizerConfig};
+use hermes_train::workflow::validate_sleep_schedule_for_model;
+use serde::Serialize;
+
+use cli::{Args, backend_name, parse_args};
+use stats::{ExecutionOrder, PairedSample, PairedSummary, PairedTrial};
+
+const MODEL_INITIALIZATION_SEED: u64 = 0x5741_4b45_5449_4552;
+const MODEL_EXECUTION_SEED_DOMAIN: u64 = 0x5041_4952_4544_524e;
+const MAX_MODEL_MAL_BYTES: u64 = 4 * 1024 * 1024;
+
+const COMPACT_MEMORY_MODEL: &str = r#"
+ffn base { hidden_dim: 64 activation: swiglu dropout: 0.0 bias: false }
+memory wake_bench {
+    tier fast {
+        ffn: base
+        reserve_experts { capacity: 1 rank: 8 top_k: 1 }
+    }
+    tier slow {
+        ffn: base residual_init: zero
+        reserve_experts { capacity: 2 rank: 8 top_k: 1 }
+    }
+}
+model wake-tier-step-bench {
+    vocab_size: 128 max_seq_len: 32 hidden_size: 32 num_layers: 1
+    block: {
+        attention: { num_heads: 4 dropout: 0.0 position_encoding: none }
+        memory: wake_bench
+        dropout: 0.0
+    }
+    embeddings { tie_weights: true }
+}
+"#;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct StepObservation {
+    wake_gradient_tensors: usize,
+    tier_gradient_tensors: Vec<usize>,
+    due_tiers: Vec<usize>,
+    accumulated_steps_after: Vec<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct BuildDescription {
+    backend: &'static str,
+    device: String,
+    hermes_llm_training_fusion: bool,
+    measurement_scope: &'static str,
+    cuda_acceptance_eligible: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkloadDescription {
+    batch_size: usize,
+    sequence_length: usize,
+    logical_tokens_per_step: usize,
+    optimizer_start_state: &'static str,
+    paired_model_rng: &'static str,
+    timed_operations: [&'static str; 4],
+    excluded_from_timing: [&'static str; 3],
+}
+
+#[derive(Debug, Serialize)]
+struct ClockDescription {
+    tier_update_periods: Vec<u64>,
+    non_due_clock: u64,
+    due_clock: u64,
+    due_tiers: Vec<usize>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+struct AppliedUpdateIdentity {
+    tier: usize,
+    tier_id: String,
+    trigger_clock: u64,
+    accumulated_optimizer_steps: u64,
+    prospective_update_sha256: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PairedUpdateIdentity {
+    seed: u64,
+    iteration: usize,
+    input_seed: u64,
+    non_due_updates: Vec<AppliedUpdateIdentity>,
+    due_updates: Vec<AppliedUpdateIdentity>,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateDescription {
+    optimizer: TierOptimizerConfig,
+    prospective_update_identity: &'static str,
+    samples: Vec<PairedUpdateIdentity>,
+}
+
+#[derive(Debug, Serialize)]
+struct ThroughputDescription {
+    non_due_tokens_per_second: f64,
+    due_tokens_per_second: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    schema_version: u32,
+    implementation: &'static str,
+    model: String,
+    model_mal_sha256: String,
+    model_initialization_seed: u64,
+    build: BuildDescription,
+    workload: WorkloadDescription,
+    clocks: ClockDescription,
+    warmup_pairs: usize,
+    measured_iterations_per_seed: usize,
+    paired_seeds: Vec<u64>,
+    expected_non_due_observation: StepObservation,
+    expected_due_observation: StepObservation,
+    updates: UpdateDescription,
+    trials: Vec<PairedTrial>,
+    summary: PairedSummary,
+    throughput: ThroughputDescription,
+}
+
+struct PreparedStep {
+    model: Transformer,
+    bank: TierOptimizerBank,
+    input: Tensor<2, Int>,
+    targets: Tensor<2, Int>,
+    rng_seed: u64,
+    trigger_clock: u64,
+    expected_due_tiers: Vec<usize>,
+}
+
+fn main() -> Result<()> {
+    let args = parse_args()?;
+    let (config, model_mal_sha256) = load_config(args.model.as_deref())?;
+    ensure!(
+        args.sequence_length <= config.max_seq_len,
+        "--sequence-length {} exceeds model max_seq_len {}",
+        args.sequence_length,
+        config.max_seq_len
+    );
+    ensure!(
+        config.vocab_size > 1,
+        "benchmark model vocabulary is too small"
+    );
+    let schedule = schedule_for_model(&config, &args.update_periods)?;
+    let optimizer = TierOptimizerConfig::default();
+
+    let backend = backend_name();
+    // hermes-train's `cuda` feature maps directly to hermes-llm's
+    // `training-fusion`, which itself includes the CUDA backend.
+    let training_fusion = cfg!(feature = "cuda");
+    let cuda_acceptance_eligible = backend == "cuda" && training_fusion;
+    if args.require_cuda && !cuda_acceptance_eligible {
+        bail!(
+            "--require-cuda requested, but this benchmark uses backend={backend}, hermes_llm_training_fusion={training_fusion}; rebuild on Linux with --features cuda"
+        );
+    }
+
+    let device = default_device().autodiff();
+    device.seed(MODEL_INITIALIZATION_SEED);
+    let mut base_model = Transformer::new(&config, &device)
+        .with_context(|| format!("failed to instantiate model '{}'", config.name))?;
+    base_model
+        .activate_memory_slot_all_layers(0, 0)
+        .context("activating the fast-tier benchmark reserve")?;
+
+    let due_tiers = schedule.due_senders(args.due_clock);
+    ensure!(!due_tiers.is_empty(), "due benchmark clock has no sender");
+    ensure!(
+        schedule.due_senders(args.non_due_clock).is_empty(),
+        "non-due benchmark clock unexpectedly has a sender"
+    );
+
+    for warmup in 0..args.warmup {
+        let seed = args.seeds[warmup % args.seeds.len()]
+            ^ (warmup as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15);
+        let pair = prepare_pair(&base_model, &schedule, &optimizer, &args, &device, seed)?;
+        if warmup.is_multiple_of(2) {
+            run_and_sync(pair.0, &device)?;
+            run_and_sync(pair.1, &device)?;
+        } else {
+            run_and_sync(pair.1, &device)?;
+            run_and_sync(pair.0, &device)?;
+        }
+    }
+
+    let mut trials = Vec::with_capacity(args.seeds.len());
+    let mut expected_non_due = None;
+    let mut expected_due = None;
+    let mut update_identities = Vec::with_capacity(
+        args.seeds
+            .len()
+            .checked_mul(args.iterations)
+            .context("paired sample count overflowed after validation")?,
+    );
+    for (trial_index, &seed) in args.seeds.iter().enumerate() {
+        let mut samples = Vec::with_capacity(args.iterations);
+        for iteration in 0..args.iterations {
+            let sample_seed = seed
+                ^ (iteration as u64)
+                    .wrapping_add(1)
+                    .wrapping_mul(0xd1b5_4a32_d192_ed03);
+            let (non_due, due) = prepare_pair(
+                &base_model,
+                &schedule,
+                &optimizer,
+                &args,
+                &device,
+                sample_seed,
+            )?;
+            let non_due_first = (trial_index + iteration).is_multiple_of(2);
+            let (non_due_timing, due_timing, order) = if non_due_first {
+                (
+                    time_synchronized(non_due, &device)?,
+                    time_synchronized(due, &device)?,
+                    ExecutionOrder::NonDueThenDue,
+                )
+            } else {
+                let due = time_synchronized(due, &device)?;
+                let non_due = time_synchronized(non_due, &device)?;
+                (non_due, due, ExecutionOrder::DueThenNonDue)
+            };
+            record_expected(&mut expected_non_due, &non_due_timing.observation)?;
+            record_expected(&mut expected_due, &due_timing.observation)?;
+            update_identities.push(PairedUpdateIdentity {
+                seed,
+                iteration,
+                input_seed: sample_seed,
+                non_due_updates: non_due_timing.updates,
+                due_updates: due_timing.updates,
+            });
+            samples.push(PairedSample::new(
+                iteration,
+                order,
+                non_due_timing.elapsed_ms,
+                due_timing.elapsed_ms,
+            )?);
+        }
+        trials.push(PairedTrial::new(seed, samples)?);
+    }
+    let summary = stats::summarize(&trials)?;
+    let logical_tokens = args
+        .batch_size
+        .checked_mul(args.sequence_length)
+        .context("benchmark token count overflowed after validation")?;
+    let throughput = ThroughputDescription {
+        non_due_tokens_per_second: logical_tokens as f64 / (summary.non_due_median_ms / 1_000.0),
+        due_tokens_per_second: logical_tokens as f64 / (summary.due_median_ms / 1_000.0),
+    };
+    let report = Report {
+        schema_version: 1,
+        implementation: "paired_complete_memory_tier_wake_step",
+        model: config.name,
+        model_mal_sha256,
+        model_initialization_seed: MODEL_INITIALIZATION_SEED,
+        build: BuildDescription {
+            backend,
+            device: format!("{device:?}"),
+            hermes_llm_training_fusion: training_fusion,
+            measurement_scope: if cuda_acceptance_eligible {
+                "cuda_training_fusion_profile"
+            } else if backend == "cuda" {
+                "cuda_without_training_fusion_smoke_only"
+            } else if backend == "ndarray" {
+                "local_cpu_smoke_only"
+            } else {
+                "local_non_cuda_smoke_only"
+            },
+            cuda_acceptance_eligible,
+        },
+        workload: WorkloadDescription {
+            batch_size: args.batch_size,
+            sequence_length: args.sequence_length,
+            logical_tokens_per_step: logical_tokens,
+            optimizer_start_state: "fresh_bank_without_adam_moments_or_pending_tier_gradients",
+            paired_model_rng: "reseeded_identically_before_each_due/non_due_forward",
+            timed_operations: [
+                "transformer_forward_backward",
+                "gradient_partition",
+                "tier_gradient_accumulation_commit",
+                "wake_only_due_update_check_or_apply",
+            ],
+            excluded_from_timing: [
+                "model_and_optimizer_construction",
+                "input_construction",
+                "paired_rng_reseed",
+            ],
+        },
+        clocks: ClockDescription {
+            tier_update_periods: args.update_periods.clone(),
+            non_due_clock: args.non_due_clock,
+            due_clock: args.due_clock,
+            due_tiers,
+        },
+        warmup_pairs: args.warmup,
+        measured_iterations_per_seed: args.iterations,
+        paired_seeds: args.seeds.clone(),
+        expected_non_due_observation: expected_non_due
+            .context("benchmark produced no non-due observations")?,
+        expected_due_observation: expected_due.context("benchmark produced no due observations")?,
+        updates: UpdateDescription {
+            optimizer,
+            prospective_update_identity: "sha256 over canonical before/after tensors in the eligible sender scope (hermes-prospective-update-v2)",
+            samples: update_identities,
+        },
+        trials,
+        summary,
+        throughput,
+    };
+    let json = serde_json::to_string_pretty(&report)?;
+    println!("{json}");
+    if let Some(path) = &args.output {
+        std::fs::write(path, format!("{json}\n"))
+            .with_context(|| format!("failed to write {}", path.display()))?;
+    }
+    Ok(())
+}
+
+fn load_config(path: Option<&Path>) -> Result<(ModelDef, String)> {
+    let bytes = match path {
+        Some(path) => read_regular_bounded(path, MAX_MODEL_MAL_BYTES, "wake-tier benchmark MAL")
+            .with_context(|| format!("failed to load benchmark MAL {}", path.display()))?,
+        None => COMPACT_MEMORY_MODEL.as_bytes().to_vec(),
+    };
+    let source = std::str::from_utf8(&bytes).with_context(|| match path {
+        Some(path) => format!("benchmark MAL {} is not UTF-8", path.display()),
+        None => "embedded benchmark MAL is not UTF-8".to_owned(),
+    })?;
+    let config = parse_mal(source).with_context(|| match path {
+        Some(path) => format!("failed to parse benchmark MAL {}", path.display()),
+        None => "invalid embedded benchmark MAL".to_owned(),
+    })?;
+    Ok((config, sha256_identity(&bytes)))
+}
+
+fn schedule_for_model(config: &ModelDef, periods: &[u64]) -> Result<SleepSchedule> {
+    let memory = config
+        .block_for_layer(0)
+        .memory
+        .as_ref()
+        .context("wake-tier benchmark model has no memory hierarchy")?;
+    ensure!(
+        memory.tiers.len() == periods.len(),
+        "--periods contains {} values, but model defines {} memory tiers",
+        periods.len(),
+        memory.tiers.len()
+    );
+    let schedule = SleepSchedule {
+        clock: UpdateClock::OptimizerSteps,
+        terminal_consolidation: TerminalConsolidation::DistillIntoBaseV1,
+        tiers: memory
+            .tiers
+            .iter()
+            .zip(periods)
+            .map(|(tier, &update_period)| MemoryTierSchedule {
+                id: tier.name.clone(),
+                update_period,
+                reserve_slots: tier.reserve_experts.capacity,
+            })
+            .collect(),
+    };
+    schedule.validate()?;
+    validate_sleep_schedule_for_model(config, &schedule, "wake_tier_step benchmark")?;
+    Ok(schedule)
+}
+
+fn prepare_pair(
+    base_model: &Transformer,
+    schedule: &SleepSchedule,
+    optimizer: &TierOptimizerConfig,
+    args: &Args,
+    device: &Device,
+    seed: u64,
+) -> Result<(PreparedStep, PreparedStep)> {
+    Ok((
+        prepare_step(
+            base_model,
+            schedule,
+            optimizer,
+            args,
+            device,
+            seed,
+            args.non_due_clock,
+        )?,
+        prepare_step(
+            base_model,
+            schedule,
+            optimizer,
+            args,
+            device,
+            seed,
+            args.due_clock,
+        )?,
+    ))
+}
+
+fn prepare_step(
+    base_model: &Transformer,
+    schedule: &SleepSchedule,
+    optimizer: &TierOptimizerConfig,
+    args: &Args,
+    device: &Device,
+    seed: u64,
+    trigger_clock: u64,
+) -> Result<PreparedStep> {
+    let logical_tokens = args
+        .batch_size
+        .checked_mul(args.sequence_length)
+        .context("benchmark token count overflowed after validation")?;
+    let (input, targets) =
+        deterministic_tokens(logical_tokens, base_model.config().vocab_size, seed);
+    let model = base_model.clone();
+    let bank = TierOptimizerBank::new(&model, schedule, optimizer.clone())?;
+    Ok(PreparedStep {
+        model,
+        bank,
+        input: Tensor::<2, Int>::from_data(
+            TensorData::new(input, [args.batch_size, args.sequence_length]),
+            device,
+        ),
+        targets: Tensor::<2, Int>::from_data(
+            TensorData::new(targets, [args.batch_size, args.sequence_length]),
+            device,
+        ),
+        rng_seed: seed ^ MODEL_EXECUTION_SEED_DOMAIN,
+        trigger_clock,
+        expected_due_tiers: schedule.due_senders(trigger_clock),
+    })
+}
+
+fn deterministic_tokens(count: usize, vocab_size: usize, seed: u64) -> (Vec<i64>, Vec<i64>) {
+    let mut state = seed ^ 0xa076_1d64_78bd_642f;
+    let mut input = Vec::with_capacity(count);
+    let mut targets = Vec::with_capacity(count);
+    for _ in 0..count {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        let token = state.wrapping_mul(0x2545_f491_4f6c_dd1d) % vocab_size as u64;
+        input.push(token as i64);
+        targets.push(token.wrapping_add(1) as i64 % vocab_size as i64);
+    }
+    (input, targets)
+}
+
+struct StepResult {
+    observation: StepObservation,
+    updates: Vec<AppliedUpdateIdentity>,
+}
+
+fn execute_step(step: PreparedStep) -> Result<StepResult> {
+    let (task_loss, router_loss) = step
+        .model
+        .forward_loss_with_router(step.input, step.targets);
+    let loss = match router_loss {
+        Some(router_loss) => task_loss + router_loss,
+        None => task_loss,
+    };
+    let mut gradients = loss.backward();
+    let partitioned = step.bank.partition_gradients(&step.model, &mut gradients)?;
+    let wake_gradient_tensors = partitioned.report.wake_gradient_tensors;
+    let tier_gradient_tensors = partitioned.report.tier_gradient_tensors;
+    std::hint::black_box(partitioned.wake);
+    let committed = step
+        .bank
+        .commit_tier_gradients(&step.model, partitioned.tiers, 1)?;
+    ensure!(
+        committed
+            .accumulated_micro_steps
+            .iter()
+            .all(|steps| *steps == 1),
+        "fresh benchmark bank did not commit exactly one optimizer step"
+    );
+    let (updated_model, update) = step
+        .bank
+        .apply_wake_only_due_updates(&step.model, step.trigger_clock)?;
+    let due_tiers = update
+        .updates
+        .iter()
+        .map(|update| update.tier)
+        .collect::<Vec<_>>();
+    ensure!(
+        due_tiers == step.expected_due_tiers,
+        "wake-only update applied tiers {due_tiers:?}, expected {:?}",
+        step.expected_due_tiers
+    );
+    let clocks = step.bank.tier_clocks()?;
+    let accumulated_steps_after = clocks
+        .iter()
+        .map(|(_, _, accumulated)| *accumulated)
+        .collect::<Vec<_>>();
+    std::hint::black_box(updated_model);
+    let updates = update
+        .updates
+        .into_iter()
+        .map(|update| AppliedUpdateIdentity {
+            tier: update.tier,
+            tier_id: update.tier_id,
+            trigger_clock: update.trigger_clock,
+            accumulated_optimizer_steps: update.accumulated_optimizer_steps,
+            prospective_update_sha256: update.prospective_update_sha256,
+        })
+        .collect();
+    Ok(StepResult {
+        observation: StepObservation {
+            wake_gradient_tensors,
+            tier_gradient_tensors,
+            due_tiers,
+            accumulated_steps_after,
+        },
+        updates,
+    })
+}
+
+struct TimedStep {
+    elapsed_ms: f64,
+    observation: StepObservation,
+    updates: Vec<AppliedUpdateIdentity>,
+}
+
+fn run_and_sync(step: PreparedStep, device: &Device) -> Result<StepObservation> {
+    device.seed(step.rng_seed);
+    device.sync()?;
+    let result = execute_step(step)?;
+    device.sync()?;
+    Ok(result.observation)
+}
+
+fn time_synchronized(step: PreparedStep, device: &Device) -> Result<TimedStep> {
+    // Model initialization, inputs, and RNG setup are deliberately outside
+    // the timed region. Reseeding makes stochastic layers (for example
+    // dropout in a supplied MAL) consume identical randomness in each pair.
+    device.seed(step.rng_seed);
+    device.sync()?;
+    let started = Instant::now();
+    let result = execute_step(step)?;
+    device.sync()?;
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1_000.0;
+    ensure!(
+        elapsed_ms.is_finite() && elapsed_ms > 0.0,
+        "benchmark clock returned an invalid duration"
+    );
+    Ok(TimedStep {
+        elapsed_ms,
+        observation: result.observation,
+        updates: result.updates,
+    })
+}
+
+fn record_expected(slot: &mut Option<StepObservation>, observed: &StepObservation) -> Result<()> {
+    match slot {
+        Some(expected) => ensure!(
+            expected == observed,
+            "benchmark operation shape changed across paired samples"
+        ),
+        None => *slot = Some(observed.clone()),
+    }
+    Ok(())
+}

--- a/hermes-train/benches/wake_tier_step/cli.rs
+++ b/hermes-train/benches/wake_tier_step/cli.rs
@@ -1,0 +1,193 @@
+//! Command-line parsing and bounded workload validation.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail, ensure};
+
+const MAX_BATCH_SIZE: usize = 65_536;
+const MAX_SEQUENCE_LENGTH: usize = 8_192;
+const MAX_LOGICAL_TOKENS: usize = 16 * 1024 * 1024;
+const MAX_WARMUPS: usize = 100;
+const MAX_ITERATIONS: usize = 10_000;
+const MAX_SEEDS: usize = 64;
+const MAX_PAIRED_SAMPLES: usize = 100_000;
+const MAX_TIERS: usize = 32;
+
+#[derive(Debug)]
+pub(super) struct Args {
+    pub(super) model: Option<PathBuf>,
+    pub(super) output: Option<PathBuf>,
+    pub(super) batch_size: usize,
+    pub(super) sequence_length: usize,
+    pub(super) warmup: usize,
+    pub(super) iterations: usize,
+    pub(super) seeds: Vec<u64>,
+    pub(super) update_periods: Vec<u64>,
+    pub(super) non_due_clock: u64,
+    pub(super) due_clock: u64,
+    pub(super) require_cuda: bool,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            model: None,
+            output: None,
+            batch_size: 2,
+            sequence_length: 8,
+            warmup: 3,
+            iterations: 10,
+            seeds: vec![17, 23, 29],
+            update_periods: vec![2, 4],
+            non_due_clock: 1,
+            due_clock: 2,
+            require_cuda: false,
+        }
+    }
+}
+
+pub(super) fn parse_args() -> Result<Args> {
+    parse_args_from(std::env::args().skip(1))
+}
+
+pub(super) fn parse_args_from(mut values: impl Iterator<Item = String>) -> Result<Args> {
+    let mut parsed = Args::default();
+    while let Some(flag) = values.next() {
+        let mut value = || {
+            values
+                .next()
+                .with_context(|| format!("{flag} needs a value"))
+        };
+        match flag.as_str() {
+            "--model" => parsed.model = Some(PathBuf::from(value()?)),
+            "--output" => parsed.output = Some(PathBuf::from(value()?)),
+            "--batch-size" => {
+                parsed.batch_size = value()?.parse().context("invalid --batch-size")?
+            }
+            "--sequence-length" => {
+                parsed.sequence_length = value()?.parse().context("invalid --sequence-length")?
+            }
+            "--warmup" => parsed.warmup = value()?.parse().context("invalid --warmup")?,
+            "--iterations" => {
+                parsed.iterations = value()?.parse().context("invalid --iterations")?
+            }
+            "--seeds" => parsed.seeds = parse_csv(&value()?, "--seeds")?,
+            "--periods" => parsed.update_periods = parse_csv(&value()?, "--periods")?,
+            "--non-due-clock" => {
+                parsed.non_due_clock = value()?.parse().context("invalid --non-due-clock")?
+            }
+            "--due-clock" => parsed.due_clock = value()?.parse().context("invalid --due-clock")?,
+            "--require-cuda" => parsed.require_cuda = true,
+            // Cargo appends this marker for harness-less benchmark targets.
+            "--bench" => {}
+            "--help" | "-h" => {
+                println!(
+                    "Usage: wake_tier_step [--model PATH] [--batch-size N] [--sequence-length N] [--warmup N] [--iterations N] [--seeds A,B,C] [--periods FAST,SLOW,...] [--non-due-clock N] [--due-clock N] [--require-cuda] [--output PATH]"
+                );
+                std::process::exit(0);
+            }
+            _ => bail!("unknown argument {flag:?}"),
+        }
+    }
+    validate(parsed)
+}
+
+pub(super) fn validate(parsed: Args) -> Result<Args> {
+    ensure!(
+        (1..=MAX_BATCH_SIZE).contains(&parsed.batch_size),
+        "--batch-size must be in 1..={MAX_BATCH_SIZE}"
+    );
+    ensure!(
+        (2..=MAX_SEQUENCE_LENGTH).contains(&parsed.sequence_length),
+        "--sequence-length must be in 2..={MAX_SEQUENCE_LENGTH}"
+    );
+    let logical_tokens = parsed
+        .batch_size
+        .checked_mul(parsed.sequence_length)
+        .context("benchmark token count overflows usize")?;
+    ensure!(
+        logical_tokens <= MAX_LOGICAL_TOKENS,
+        "benchmark workload exceeds the {MAX_LOGICAL_TOKENS}-token safety bound"
+    );
+    ensure!(
+        parsed.warmup <= MAX_WARMUPS,
+        "--warmup must not exceed {MAX_WARMUPS}"
+    );
+    ensure!(
+        (1..=MAX_ITERATIONS).contains(&parsed.iterations),
+        "--iterations must be in 1..={MAX_ITERATIONS}"
+    );
+    ensure!(
+        (3..=MAX_SEEDS).contains(&parsed.seeds.len()),
+        "--seeds must contain between 3 and {MAX_SEEDS} values"
+    );
+    ensure!(
+        parsed.seeds.windows(2).all(|pair| pair[0] < pair[1]),
+        "paired seeds must be unique and strictly increasing"
+    );
+    let paired_samples = parsed
+        .seeds
+        .len()
+        .checked_mul(parsed.iterations)
+        .context("paired sample count overflows usize")?;
+    ensure!(
+        paired_samples <= MAX_PAIRED_SAMPLES,
+        "benchmark run exceeds the {MAX_PAIRED_SAMPLES}-sample safety bound"
+    );
+    ensure!(
+        (2..=MAX_TIERS).contains(&parsed.update_periods.len()),
+        "--periods must contain between 2 and {MAX_TIERS} tier periods"
+    );
+    ensure!(
+        parsed.update_periods.iter().all(|period| *period > 0),
+        "--periods values must be positive"
+    );
+    ensure!(
+        parsed.non_due_clock > 0 && parsed.due_clock > 0,
+        "benchmark clocks must be positive"
+    );
+    ensure!(
+        parsed
+            .update_periods
+            .iter()
+            .all(|period| !parsed.non_due_clock.is_multiple_of(*period)),
+        "--non-due-clock is a boundary for at least one configured tier"
+    );
+    ensure!(
+        parsed
+            .update_periods
+            .iter()
+            .any(|period| parsed.due_clock.is_multiple_of(*period)),
+        "--due-clock is not a boundary for any configured tier"
+    );
+    Ok(parsed)
+}
+
+fn parse_csv<T>(value: &str, flag: &str) -> Result<Vec<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    value
+        .split(',')
+        .map(|item| {
+            ensure!(!item.is_empty(), "{flag} contains an empty value");
+            item.parse()
+                .with_context(|| format!("invalid value in {flag}"))
+        })
+        .collect()
+}
+
+pub(super) fn backend_name() -> &'static str {
+    if cfg!(all(
+        feature = "cuda",
+        target_os = "linux",
+        not(feature = "metal")
+    )) {
+        "cuda"
+    } else if cfg!(feature = "metal") {
+        "metal"
+    } else {
+        "ndarray"
+    }
+}

--- a/hermes-train/benches/wake_tier_step/stats.rs
+++ b/hermes-train/benches/wake_tier_step/stats.rs
@@ -1,0 +1,145 @@
+//! Pure paired-timing summaries for the wake-tier benchmark.
+
+use anyhow::{Result, ensure};
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum ExecutionOrder {
+    NonDueThenDue,
+    DueThenNonDue,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct PairedSample {
+    pub(super) iteration: usize,
+    pub(super) order: ExecutionOrder,
+    pub(super) non_due_ms: f64,
+    pub(super) due_ms: f64,
+    pub(super) due_to_non_due_ratio: f64,
+}
+
+impl PairedSample {
+    pub(super) fn new(
+        iteration: usize,
+        order: ExecutionOrder,
+        non_due_ms: f64,
+        due_ms: f64,
+    ) -> Result<Self> {
+        ensure!(
+            non_due_ms.is_finite() && non_due_ms > 0.0,
+            "non-due duration must be finite and positive"
+        );
+        ensure!(
+            due_ms.is_finite() && due_ms > 0.0,
+            "due duration must be finite and positive"
+        );
+        let due_to_non_due_ratio = due_ms / non_due_ms;
+        ensure!(
+            due_to_non_due_ratio.is_finite() && due_to_non_due_ratio > 0.0,
+            "due/non-due ratio must be finite and positive"
+        );
+        Ok(Self {
+            iteration,
+            order,
+            non_due_ms,
+            due_ms,
+            due_to_non_due_ratio,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(super) struct PairedTrial {
+    pub(super) seed: u64,
+    pub(super) samples: Vec<PairedSample>,
+    pub(super) non_due_median_ms: f64,
+    pub(super) due_median_ms: f64,
+    pub(super) paired_ratio_median: f64,
+}
+
+impl PairedTrial {
+    pub(super) fn new(seed: u64, samples: Vec<PairedSample>) -> Result<Self> {
+        ensure!(!samples.is_empty(), "paired trial must contain samples");
+        Ok(Self {
+            seed,
+            non_due_median_ms: median(samples.iter().map(|sample| sample.non_due_ms))?,
+            due_median_ms: median(samples.iter().map(|sample| sample.due_ms))?,
+            paired_ratio_median: median(samples.iter().map(|sample| sample.due_to_non_due_ratio))?,
+            samples,
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct PairedSummary {
+    pub(super) seed_count: usize,
+    pub(super) sample_count: usize,
+    pub(super) non_due_median_ms: f64,
+    pub(super) due_median_ms: f64,
+    pub(super) paired_ratio_median: f64,
+    pub(super) paired_ratio_p95: f64,
+    pub(super) median_of_seed_median_ratios: f64,
+    pub(super) worst_seed_median_ratio: f64,
+}
+
+pub(super) fn summarize(trials: &[PairedTrial]) -> Result<PairedSummary> {
+    ensure!(!trials.is_empty(), "summary requires paired trials");
+    ensure!(
+        trials.iter().all(|trial| !trial.samples.is_empty()),
+        "summary cannot include an empty paired trial"
+    );
+    let sample_count = trials.iter().map(|trial| trial.samples.len()).sum();
+    let paired_ratios = trials.iter().flat_map(|trial| {
+        trial
+            .samples
+            .iter()
+            .map(|sample| sample.due_to_non_due_ratio)
+    });
+    let seed_ratios = trials.iter().map(|trial| trial.paired_ratio_median);
+    Ok(PairedSummary {
+        seed_count: trials.len(),
+        sample_count,
+        non_due_median_ms: median(
+            trials
+                .iter()
+                .flat_map(|trial| trial.samples.iter().map(|sample| sample.non_due_ms)),
+        )?,
+        due_median_ms: median(
+            trials
+                .iter()
+                .flat_map(|trial| trial.samples.iter().map(|sample| sample.due_ms)),
+        )?,
+        paired_ratio_median: median(paired_ratios.clone())?,
+        paired_ratio_p95: percentile(paired_ratios, 0.95)?,
+        median_of_seed_median_ratios: median(seed_ratios.clone())?,
+        worst_seed_median_ratio: seed_ratios.fold(f64::NEG_INFINITY, f64::max),
+    })
+}
+
+fn median(values: impl IntoIterator<Item = f64>) -> Result<f64> {
+    percentile(values, 0.5)
+}
+
+fn percentile(values: impl IntoIterator<Item = f64>, probability: f64) -> Result<f64> {
+    ensure!(
+        probability.is_finite() && (0.0..=1.0).contains(&probability),
+        "percentile probability must be in [0, 1]"
+    );
+    let mut values = values.into_iter().collect::<Vec<_>>();
+    ensure!(!values.is_empty(), "cannot summarize an empty sample");
+    ensure!(
+        values.iter().all(|value| value.is_finite()),
+        "cannot summarize non-finite samples"
+    );
+    values.sort_by(f64::total_cmp);
+    let rank = probability * (values.len() - 1) as f64;
+    let lower = rank.floor() as usize;
+    let upper = rank.ceil() as usize;
+    if lower == upper {
+        Ok(values[lower])
+    } else {
+        let fraction = rank - lower as f64;
+        Ok(values[lower] + (values[upper] - values[lower]) * fraction)
+    }
+}

--- a/hermes-train/corpus.production.example.json
+++ b/hermes-train/corpus.production.example.json
@@ -209,6 +209,7 @@
     "max_retries": 3,
     "retry_initial_ms": 1000,
     "retry_max_ms": 30000,
+    "max_response_bytes": 67108864,
     "auth": null
   },
   "postgres": {

--- a/hermes-train/src/acceptance.rs
+++ b/hermes-train/src/acceptance.rs
@@ -10,7 +10,8 @@ use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Result, ensure};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+
+use crate::artifact_io::{sha256_identity, validate_sha256_hex, validate_sha256_identity};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -159,6 +160,7 @@ pub struct ResourceComparison {
 pub const RESOURCE_COMPARISON_VERSION: u32 = 2;
 pub const ACCEPTANCE_POLICY_VERSION: u32 = 2;
 pub const RESOURCE_EXECUTION_PROTOCOL_VERSION: u32 = 2;
+const MAX_ACCEPTANCE_PAIRED_SEEDS: usize = 64;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -198,10 +200,9 @@ impl ResourceExecutionReceipt {
             ("baseline target", self.baseline_target_sha256.as_str()),
             ("candidate target", self.candidate_target_sha256.as_str()),
         ] {
-            validate_prefixed_sha256(value).map_err(|error| anyhow::anyhow!("{name}: {error}"))?;
+            validate_sha256_identity(value, name)?;
         }
-        validate_sha256(&self.policy_sha256)
-            .map_err(|error| anyhow::anyhow!("resource policy: {error}"))?;
+        validate_sha256_hex(&self.policy_sha256, "resource policy")?;
         ensure!(
             self.evaluator_arguments.len() <= 64
                 && self
@@ -351,8 +352,7 @@ pub struct KernelParityEvidence {
 
 impl KernelParityEvidence {
     fn validate(&self, name: &str) -> Result<()> {
-        validate_sha256(&self.fixture_sha256)
-            .map_err(|error| anyhow::anyhow!("{name} fixture: {error}"))?;
+        validate_sha256_hex(&self.fixture_sha256, &format!("{name} fixture"))?;
         ensure!(
             !self.samples.is_empty(),
             "{name} parity evaluated no values"
@@ -397,11 +397,8 @@ pub struct ExactResumeArtifact {
 
 impl ExactResumeArtifact {
     fn validate(&self, name: &str) -> Result<()> {
-        ensure!(
-            !self.path.as_os_str().is_empty(),
-            "{name} artifact path is empty"
-        );
-        validate_sha256(&self.sha256).map_err(|error| anyhow::anyhow!("{name}: {error}"))
+        validate_safe_relative_path(&self.path, &format!("{name} artifact path"))?;
+        validate_sha256_hex(&self.sha256, name)
     }
 }
 
@@ -436,6 +433,10 @@ impl ExactResumeEvidence {
             self.interruption_step > 0,
             "resume evidence must interrupt after at least one step"
         );
+        ensure!(
+            self.resumed_from_step == self.interruption_step,
+            "resumed step must equal the interrupted checkpoint step"
+        );
         Ok(())
     }
 }
@@ -460,14 +461,15 @@ impl ResourceComparison {
             !self.strongest_baseline_id.trim().is_empty(),
             "strongest_baseline_id is empty"
         );
-        validate_sha256(&self.benchmark_run_sha256)
-            .map_err(|error| anyhow::anyhow!("benchmark run: {error}"))?;
+        validate_sha256_hex(&self.benchmark_run_sha256, "benchmark run")?;
         ensure!(
             !self.measurement_evaluator_id.trim().is_empty(),
             "resource measurement evaluator id is empty"
         );
-        validate_prefixed_sha256(&self.measurement_evaluator_version)
-            .map_err(|error| anyhow::anyhow!("resource measurement evaluator: {error}"))?;
+        validate_sha256_identity(
+            &self.measurement_evaluator_version,
+            "resource measurement evaluator",
+        )?;
         ensure!(
             !self.wake_trials.is_empty(),
             "resource evidence has no wake trials"
@@ -544,7 +546,7 @@ impl ResourceComparison {
                 resumed_from_step: exact.resumed_from_step,
             },
         })?;
-        Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+        Ok(sha256_identity(&bytes))
     }
 
     pub(crate) fn derived_measurements(&self) -> Result<DerivedResourceMeasurements> {
@@ -623,13 +625,62 @@ impl ResourceComparison {
             .map(|observation| observation.stored_bytes)
             .min()
             .expect("resource validation requires capacity observations");
+        let baseline_wake_tokens_per_second = baseline_tokens as f64 / baseline_elapsed;
+        let candidate_wake_tokens_per_second = candidate_tokens as f64 / candidate_elapsed;
+        let baseline_wake_p95_ms = nearest_rank_p95(&mut baseline_latencies);
+        let candidate_wake_p95_ms = nearest_rank_p95(&mut candidate_latencies);
+        let throughput_log_ratios = self
+            .wake_trials
+            .iter()
+            // Paired trials are required to process the same token workload,
+            // so the throughput ratio is exactly baseline/candidate elapsed
+            // time. Avoiding an unnecessary u64-to-f64 token conversion also
+            // preserves precision for very large workloads.
+            .map(|trial| trial.baseline.elapsed_seconds.ln() - trial.candidate.elapsed_seconds.ln())
+            .collect::<Vec<_>>();
+        let latency_log_ratios = self
+            .wake_trials
+            .iter()
+            .map(|trial| {
+                let mut baseline = trial.baseline.request_latency_ms.clone();
+                let mut candidate = trial.candidate.request_latency_ms.clone();
+                nearest_rank_p95(&mut candidate).ln() - nearest_rank_p95(&mut baseline).ln()
+            })
+            .collect::<Vec<_>>();
+        // A single trial yields an unbounded interval, which would otherwise
+        // surface downstream as an opaque overflow rather than the actual
+        // problem. The policy floor is checked separately and is never lower.
+        ensure!(
+            self.wake_trials.len() >= 2,
+            "wake performance needs at least 2 paired trials to form a confidence interval, got {}",
+            self.wake_trials.len()
+        );
+        let (_, throughput_log_lower_95, _) = paired_interval_95(&throughput_log_ratios)?;
+        let (_, _, latency_log_upper_95) = paired_interval_95(&latency_log_ratios)?;
+        let wake_throughput_ratio_lower_95 = throughput_log_lower_95.exp();
+        let wake_latency_ratio_upper_95 = latency_log_upper_95.exp();
+        ensure!(
+            [
+                baseline_wake_tokens_per_second,
+                candidate_wake_tokens_per_second,
+                baseline_wake_p95_ms,
+                candidate_wake_p95_ms,
+                wake_throughput_ratio_lower_95,
+                wake_latency_ratio_upper_95,
+            ]
+            .iter()
+            .all(|measurement| measurement.is_finite() && *measurement > 0.0),
+            "derived wake measurements overflowed or underflowed"
+        );
         Ok(DerivedResourceMeasurements {
             wake_trials: self.wake_trials.len(),
             wake_latency_samples: baseline_latencies.len(),
-            baseline_wake_tokens_per_second: baseline_tokens as f64 / baseline_elapsed,
-            candidate_wake_tokens_per_second: candidate_tokens as f64 / candidate_elapsed,
-            baseline_wake_p95_ms: nearest_rank_p95(&mut baseline_latencies),
-            candidate_wake_p95_ms: nearest_rank_p95(&mut candidate_latencies),
+            baseline_wake_tokens_per_second,
+            candidate_wake_tokens_per_second,
+            baseline_wake_p95_ms,
+            candidate_wake_p95_ms,
+            wake_throughput_ratio_lower_95,
+            wake_latency_ratio_upper_95,
             initial_routed_active_parameters: initial.routed_active_parameters,
             initial_stored_parameters: initial.stored_parameters,
             initial_stored_bytes: initial.stored_bytes,
@@ -652,6 +703,13 @@ pub(crate) struct DerivedResourceMeasurements {
     pub candidate_wake_tokens_per_second: f64,
     pub baseline_wake_p95_ms: f64,
     pub candidate_wake_p95_ms: f64,
+    /// Lower endpoint of a paired, trial-level 95% interval over log
+    /// throughput ratios. Trial-level inference avoids treating requests from
+    /// one run as independent replicates.
+    pub wake_throughput_ratio_lower_95: f64,
+    /// Upper endpoint of the analogous paired interval over per-trial p95
+    /// latency ratios.
+    pub wake_latency_ratio_upper_95: f64,
     pub initial_routed_active_parameters: u64,
     pub initial_stored_parameters: u64,
     pub initial_stored_bytes: u64,
@@ -675,8 +733,7 @@ pub struct KernelParityPolicy {
 
 impl KernelParityPolicy {
     fn validate(&self, name: &str) -> Result<()> {
-        validate_sha256(&self.fixture_sha256)
-            .map_err(|error| anyhow::anyhow!("{name} fixture: {error}"))?;
+        validate_sha256_hex(&self.fixture_sha256, &format!("{name} fixture"))?;
         ensure!(
             self.minimum_samples > 0,
             "{name} policy requires no parity samples"
@@ -753,8 +810,8 @@ impl AcceptancePolicy {
             self.version
         );
         ensure!(
-            self.minimum_paired_seeds >= 3,
-            "promotion requires at least three paired seeds"
+            (3..=MAX_ACCEPTANCE_PAIRED_SEEDS).contains(&self.minimum_paired_seeds),
+            "promotion requires between 3 and {MAX_ACCEPTANCE_PAIRED_SEEDS} paired seeds"
         );
         ensure!(
             self.maximum_anchor_regression.is_finite() && self.maximum_anchor_regression >= 0.0,
@@ -772,11 +829,10 @@ impl AcceptancePolicy {
             !self.resource_evaluator_id.trim().is_empty(),
             "resource evaluator id is empty"
         );
-        validate_prefixed_sha256(&self.resource_evaluator_version)
-            .map_err(|error| anyhow::anyhow!("resource evaluator: {error}"))?;
+        validate_sha256_identity(&self.resource_evaluator_version, "resource evaluator")?;
         ensure!(
-            self.minimum_wake_trials > 0 && self.minimum_wake_latency_samples > 0,
-            "wake measurement minima must be positive"
+            self.minimum_wake_trials >= 3 && self.minimum_wake_latency_samples >= 3,
+            "wake performance gates require at least three trials and latency samples"
         );
         ensure!(
             self.minimum_wake_throughput_ratio.is_finite()
@@ -983,8 +1039,9 @@ pub(crate) fn evaluate_with_verified_context(
             .get(case.id.as_str())
             .ok_or_else(|| anyhow::anyhow!("missing acceptance result `{}`", case.id))?;
         ensure!(
-            result.pairs.len() >= policy.minimum_paired_seeds,
-            "acceptance case `{}` has {} paired seeds; need {}",
+            (policy.minimum_paired_seeds..=MAX_ACCEPTANCE_PAIRED_SEEDS)
+                .contains(&result.pairs.len()),
+            "acceptance case `{}` has {} paired seeds; need {}..={MAX_ACCEPTANCE_PAIRED_SEEDS}",
             case.id,
             result.pairs.len(),
             policy.minimum_paired_seeds
@@ -1031,20 +1088,29 @@ pub(crate) fn evaluate_with_verified_context(
             .iter()
             .map(|pair| pair.candidate - pair.baseline)
             .collect::<Vec<_>>();
-        let (mean_delta, lower_confidence_bound) = paired_lower_95(&deltas);
-        let allowed_anchor_regression = case.stable_anchor.then(|| {
-            policy
-                .maximum_anchor_regression
-                .max(sample_standard_deviation(
-                    &result
-                        .pairs
-                        .iter()
-                        .map(|pair| pair.baseline)
-                        .collect::<Vec<_>>(),
-                ))
-        });
+        ensure!(
+            deltas.iter().all(|delta| delta.is_finite()),
+            "acceptance case `{}` metric deltas overflowed",
+            case.id
+        );
+        ensure_representable_metrics(
+            &case.id,
+            &result
+                .pairs
+                .iter()
+                .flat_map(|pair| [pair.baseline, pair.candidate])
+                .collect::<Vec<_>>(),
+        )?;
+        let (mean_delta, lower_confidence_bound) = paired_lower_95(&deltas)?;
+        // The tolerance comes from the addressed policy alone. Widening it by a
+        // spread computed from the submitted pairs would let evidence choose its
+        // own tolerance; paired-sample noise is already handled conservatively by
+        // gating on the lower confidence bound rather than the mean.
+        let allowed_anchor_regression = case
+            .stable_anchor
+            .then_some(policy.maximum_anchor_regression);
         let passed = if case.stable_anchor {
-            mean_delta >= -allowed_anchor_regression.unwrap()
+            lower_confidence_bound >= -allowed_anchor_regression.unwrap()
         } else {
             lower_confidence_bound > 0.0
         };
@@ -1065,6 +1131,13 @@ pub(crate) fn evaluate_with_verified_context(
     let throughput_ratio = measurements.candidate_wake_tokens_per_second
         / measurements.baseline_wake_tokens_per_second;
     let latency_ratio = measurements.candidate_wake_p95_ms / measurements.baseline_wake_p95_ms;
+    ensure!(
+        throughput_ratio.is_finite()
+            && throughput_ratio > 0.0
+            && latency_ratio.is_finite()
+            && latency_ratio > 0.0,
+        "wake performance ratios overflowed or underflowed"
+    );
     let grouped_mm_errors = resources.grouped_mm_parity.maximum_errors();
     let pytorch_errors = resources.pytorch_parity.maximum_errors();
     let resource_gates = BTreeMap::from([
@@ -1126,11 +1199,14 @@ pub(crate) fn evaluate_with_verified_context(
         ),
         (
             "wake_throughput".into(),
-            throughput_ratio >= policy.minimum_wake_throughput_ratio,
+            throughput_ratio >= policy.minimum_wake_throughput_ratio
+                && measurements.wake_throughput_ratio_lower_95
+                    >= policy.minimum_wake_throughput_ratio,
         ),
         (
             "wake_latency".into(),
-            latency_ratio <= policy.maximum_wake_latency_ratio,
+            latency_ratio <= policy.maximum_wake_latency_ratio
+                && measurements.wake_latency_ratio_upper_95 <= policy.maximum_wake_latency_ratio,
         ),
     ]);
     let accepted = cases.iter().all(|case| case.passed)
@@ -1147,56 +1223,71 @@ pub(crate) fn evaluate_with_verified_context(
     })
 }
 
-fn validate_sha256(value: &str) -> Result<()> {
+fn nearest_rank_p95(values: &mut [f64]) -> f64 {
+    let rank = (95 * values.len()).div_ceil(100);
+    let index = rank.saturating_sub(1);
+    let (_, value, _) = values.select_nth_unstable_by(index, f64::total_cmp);
+    *value
+}
+
+/// Reject raw metrics whose magnitudes cannot be aggregated, so extreme but
+/// individually finite scores fail closed instead of gating on a delta that
+/// happens to cancel.
+fn ensure_representable_metrics(case_id: &str, values: &[f64]) -> Result<()> {
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
     ensure!(
-        value.len() == 64
-            && value
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "SHA-256 must contain exactly 64 lowercase hexadecimal characters"
+        mean.is_finite(),
+        "acceptance case `{case_id}` metric mean overflowed"
+    );
+    let dispersion = values
+        .iter()
+        .map(|value| (value - mean).powi(2))
+        .sum::<f64>();
+    ensure!(
+        dispersion.is_finite(),
+        "acceptance case `{case_id}` metric variance overflowed"
     );
     Ok(())
 }
 
-fn validate_prefixed_sha256(value: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .ok_or_else(|| anyhow::anyhow!("identity must use the `sha256:<hex>` form"))?;
-    validate_sha256(digest)
+fn paired_lower_95(deltas: &[f64]) -> Result<(f64, f64)> {
+    let (mean, lower, _) = paired_interval_95(deltas)?;
+    Ok((mean, lower))
 }
 
-fn nearest_rank_p95(values: &mut [f64]) -> f64 {
-    values.sort_by(f64::total_cmp);
-    let rank = (95 * values.len()).div_ceil(100);
-    values[rank.saturating_sub(1)]
-}
-
-fn sample_standard_deviation(values: &[f64]) -> f64 {
-    if values.len() < 2 {
-        return 0.0;
+fn paired_interval_95(values: &[f64]) -> Result<(f64, f64, f64)> {
+    ensure!(!values.is_empty(), "paired confidence interval is empty");
+    ensure!(
+        values.iter().all(|value| value.is_finite()),
+        "paired confidence interval contains a non-finite delta"
+    );
+    let count = values.len();
+    let mean = values.iter().sum::<f64>() / count as f64;
+    ensure!(
+        mean.is_finite(),
+        "paired confidence-interval mean overflowed"
+    );
+    if count == 1 {
+        return Ok((mean, f64::NEG_INFINITY, f64::INFINITY));
     }
-    let mean = values.iter().sum::<f64>() / values.len() as f64;
-    (values
+    let variance = values
         .iter()
         .map(|value| (value - mean).powi(2))
         .sum::<f64>()
-        / (values.len() - 1) as f64)
-        .sqrt()
-}
-
-fn paired_lower_95(deltas: &[f64]) -> (f64, f64) {
-    let count = deltas.len();
-    let mean = deltas.iter().sum::<f64>() / count as f64;
-    if count == 1 {
-        return (mean, f64::NEG_INFINITY);
-    }
-    let variance = deltas
-        .iter()
-        .map(|delta| (delta - mean).powi(2))
-        .sum::<f64>()
         / (count - 1) as f64;
+    ensure!(
+        variance.is_finite() && variance >= 0.0,
+        "paired confidence-interval variance overflowed"
+    );
     let standard_error = (variance / count as f64).sqrt();
-    (mean, mean - t_critical_95(count - 1) * standard_error)
+    let half_width = t_critical_95(count - 1) * standard_error;
+    let lower = mean - half_width;
+    let upper = mean + half_width;
+    ensure!(
+        standard_error.is_finite() && lower.is_finite() && upper.is_finite(),
+        "paired confidence interval overflowed"
+    );
+    Ok((mean, lower, upper))
 }
 
 /// Two-sided 95% Student-t critical values; the lower bound therefore uses
@@ -1207,12 +1298,27 @@ fn t_critical_95(df: usize) -> f64 {
         2.145, 2.131, 2.120, 2.110, 2.101, 2.093, 2.086, 2.080, 2.074, 2.069, 2.064, 2.060, 2.056,
         2.052, 2.048, 2.045, 2.042,
     ];
-    TABLE.get(df.saturating_sub(1)).copied().unwrap_or(1.96)
+    // The normal 1.96 limit is approached only asymptotically. Jumping from
+    // t(30)=2.042 straight to 1.96 at df=31 makes the interval spuriously
+    // narrower exactly when another paired seed is added. Keep the last
+    // tabulated value for larger samples: it is monotone and conservative,
+    // while avoiding a statistical dependency in the promotion boundary.
+    TABLE
+        .get(df.saturating_sub(1))
+        .copied()
+        .unwrap_or(*TABLE.last().expect("Student-t table is non-empty"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn paired_interval_does_not_narrow_discontinuously_after_t_table() {
+        assert_eq!(t_critical_95(30), 2.042);
+        assert_eq!(t_critical_95(31), 2.042);
+        assert_eq!(t_critical_95(10_000), 2.042);
+    }
 
     fn suite() -> AcceptanceSuite {
         AcceptanceSuite {
@@ -1419,6 +1525,198 @@ mod tests {
     }
 
     #[test]
+    fn stable_anchor_tolerance_ignores_the_spread_of_submitted_baselines() {
+        let results = vec![
+            CaseResult {
+                case_id: "quality".into(),
+                pairs: [1, 2, 3]
+                    .into_iter()
+                    .map(|seed| PairedRun {
+                        seed,
+                        baseline: 0.4,
+                        candidate: 0.5,
+                    })
+                    .collect(),
+            },
+            CaseResult {
+                case_id: "retention".into(),
+                // Widely spread baselines with a candidate that is consistently
+                // worse by 0.15 — far beyond the 0.01 policy tolerance.
+                pairs: [0.6, 0.8, 1.0]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, baseline)| PairedRun {
+                        seed: (index + 1) as u64,
+                        baseline,
+                        candidate: baseline - 0.15,
+                    })
+                    .collect(),
+            },
+        ];
+        let resources = resources();
+        let report = evaluate_with_verified_context(
+            &suite(),
+            &results,
+            &resources,
+            &policy(),
+            &verified_context(&resources),
+        )
+        .unwrap();
+
+        assert!(!report.sealed.passed);
+        assert!(!report.accepted);
+    }
+
+    #[test]
+    fn stable_anchor_uses_its_confidence_bound_not_only_the_mean() {
+        let results = vec![
+            CaseResult {
+                case_id: "quality".into(),
+                pairs: [1, 2, 3]
+                    .into_iter()
+                    .map(|seed| PairedRun {
+                        seed,
+                        baseline: 0.4,
+                        candidate: 0.5,
+                    })
+                    .collect(),
+            },
+            CaseResult {
+                case_id: "retention".into(),
+                pairs: [0.01, 0.01, -0.015]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, delta)| PairedRun {
+                        seed: (index + 1) as u64,
+                        baseline: 0.8,
+                        candidate: 0.8 + delta,
+                    })
+                    .collect(),
+            },
+        ];
+        let resources = resources();
+        let report = evaluate_with_verified_context(
+            &suite(),
+            &results,
+            &resources,
+            &policy(),
+            &verified_context(&resources),
+        )
+        .unwrap();
+
+        assert!(!report.sealed.passed);
+        assert!(!report.accepted);
+    }
+
+    #[test]
+    fn finite_samples_with_overflowing_statistics_fail_closed() {
+        let quality = CaseResult {
+            case_id: "quality".into(),
+            pairs: [1, 2, 3]
+                .into_iter()
+                .map(|seed| PairedRun {
+                    seed,
+                    baseline: 0.0,
+                    candidate: 1.0,
+                })
+                .collect(),
+        };
+        let retention = CaseResult {
+            case_id: "retention".into(),
+            pairs: [1, 2, 3]
+                .into_iter()
+                .map(|seed| PairedRun {
+                    seed,
+                    baseline: f64::MAX,
+                    candidate: f64::MAX,
+                })
+                .collect(),
+        };
+        let resources = resources();
+        let error = evaluate_with_verified_context(
+            &suite(),
+            &[quality, retention],
+            &resources,
+            &policy(),
+            &verified_context(&resources),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("mean overflowed"), "{error}");
+
+        let overflowed_delta = CaseResult {
+            case_id: "quality".into(),
+            pairs: [1, 2, 3]
+                .into_iter()
+                .map(|seed| PairedRun {
+                    seed,
+                    baseline: -f64::MAX,
+                    candidate: f64::MAX,
+                })
+                .collect(),
+        };
+        let stable = CaseResult {
+            case_id: "retention".into(),
+            pairs: [1, 2, 3]
+                .into_iter()
+                .map(|seed| PairedRun {
+                    seed,
+                    baseline: 1.0,
+                    candidate: 1.0,
+                })
+                .collect(),
+        };
+        let error = evaluate_with_verified_context(
+            &suite(),
+            &[overflowed_delta, stable],
+            &resources,
+            &policy(),
+            &verified_context(&resources),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("metric deltas overflowed"), "{error}");
+    }
+
+    #[test]
+    fn finite_wake_measurements_with_nonfinite_ratios_fail_closed() {
+        let results = suite()
+            .cases
+            .iter()
+            .map(|case| CaseResult {
+                case_id: case.id.clone(),
+                pairs: [1, 2, 3]
+                    .into_iter()
+                    .map(|seed| PairedRun {
+                        seed,
+                        baseline: 0.5,
+                        candidate: if case.stable_anchor { 0.5 } else { 0.6 },
+                    })
+                    .collect(),
+            })
+            .collect::<Vec<_>>();
+        let mut resources = resources();
+        for trial in &mut resources.wake_trials {
+            trial.baseline.tokens = 1;
+            trial.baseline.elapsed_seconds = 1e289;
+            trial.candidate.tokens = 1;
+            trial.candidate.elapsed_seconds = 1e-20;
+        }
+        reseal(&mut resources);
+
+        let error = evaluate_with_verified_context(
+            &suite(),
+            &results,
+            &resources,
+            &policy(),
+            &verified_context(&resources),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("overflowed or underflowed"), "{error}");
+    }
+
+    #[test]
     fn active_compute_growth_rejects_candidate() {
         let mut resources = resources();
         resources
@@ -1582,6 +1880,24 @@ mod tests {
     }
 
     #[test]
+    fn wake_confidence_policy_requires_three_independent_trials() {
+        let mut trial_policy = policy();
+        trial_policy.minimum_wake_trials = 2;
+        let error = trial_policy.validate().unwrap_err().to_string();
+        assert!(error.contains("at least three trials"), "{error}");
+
+        let mut latency_policy = policy();
+        latency_policy.minimum_wake_latency_samples = 2;
+        let error = latency_policy.validate().unwrap_err().to_string();
+        assert!(error.contains("latency samples"), "{error}");
+
+        let mut unbounded_seed_policy = policy();
+        unbounded_seed_policy.minimum_paired_seeds = MAX_ACCEPTANCE_PAIRED_SEEDS + 1;
+        let error = unbounded_seed_policy.validate().unwrap_err().to_string();
+        assert!(error.contains("paired seeds"), "{error}");
+    }
+
+    #[test]
     fn raw_json_inputs_can_never_promote() {
         let results = suite()
             .cases
@@ -1644,6 +1960,14 @@ mod tests {
         let mut exact = resources().exact_resume;
         exact.validate().unwrap();
         exact.resumed_metrics.path = PathBuf::new();
+        assert!(exact.validate().is_err());
+
+        let mut exact = resources().exact_resume;
+        exact.resumed_from_step += 1;
+        assert!(exact.validate().is_err());
+
+        let mut exact = resources().exact_resume;
+        exact.resumed_metrics.path = "../outside/metrics.jsonl".into();
         assert!(exact.validate().is_err());
     }
 
@@ -1736,6 +2060,69 @@ mod tests {
         .unwrap();
         assert!(!report.resource_gates["wake_throughput"]);
         assert!(!report.resource_gates["wake_latency"]);
+    }
+
+    #[test]
+    fn wake_performance_requires_paired_trial_confidence() {
+        let mut resources = resources();
+        for (trial, (elapsed, latency)) in
+            resources
+                .wake_trials
+                .iter_mut()
+                .zip([(9.0, 9.0), (9.0, 9.0), (13.0, 10.4)])
+        {
+            trial.candidate.elapsed_seconds = elapsed;
+            trial.candidate.request_latency_ms = vec![latency];
+        }
+        reseal(&mut resources);
+        let results = suite()
+            .cases
+            .iter()
+            .map(|case| CaseResult {
+                case_id: case.id.clone(),
+                pairs: [1, 2, 3]
+                    .into_iter()
+                    .map(|seed| PairedRun {
+                        seed,
+                        baseline: 0.0,
+                        candidate: 1.0,
+                    })
+                    .collect(),
+            })
+            .collect::<Vec<_>>();
+        let measurements = resources.derived_measurements().unwrap();
+        assert!(
+            measurements.candidate_wake_tokens_per_second
+                / measurements.baseline_wake_tokens_per_second
+                >= policy().minimum_wake_throughput_ratio
+        );
+        assert!(
+            measurements.candidate_wake_p95_ms / measurements.baseline_wake_p95_ms
+                <= policy().maximum_wake_latency_ratio
+        );
+
+        let report = evaluate_with_verified_context(
+            &suite(),
+            &results,
+            &resources,
+            &policy(),
+            &verified_context(&resources),
+        )
+        .unwrap();
+        assert!(!report.resource_gates["wake_throughput"]);
+        assert!(!report.resource_gates["wake_latency"]);
+        assert!(!report.accepted);
+    }
+
+    #[test]
+    fn derived_wake_measurements_reject_finite_arithmetic_overflow() {
+        let mut resources = resources();
+        for trial in &mut resources.wake_trials {
+            trial.baseline.elapsed_seconds = f64::MIN_POSITIVE;
+        }
+        reseal(&mut resources);
+        let error = resources.derived_measurements().unwrap_err().to_string();
+        assert!(error.contains("derived wake measurements"), "{error}");
     }
 
     #[test]

--- a/hermes-train/src/artifact_io.rs
+++ b/hermes-train/src/artifact_io.rs
@@ -1,0 +1,1272 @@
+//! Exact, fixed-schema reads from an immutable artifact directory.
+//!
+//! Resume code must not authenticate a pathname and later reopen that path:
+//! a directory or file can be replaced between those operations. The shared
+//! primitives in this module open directories and members once, retain those
+//! handles, and stream-verify or bounded-read them only when requested. The
+//! final identity check distinguishes a transient A->B->A directory swap (the
+//! opened generation remains authoritative) from a replacement which is still
+//! published when loading finishes.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
+
+#[cfg(unix)]
+use std::ffi::{CStr, CString, OsStr, OsString};
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+use anyhow::{Context, Result, ensure};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+static IMMUTABLE_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+const MAX_PINNED_DIRECTORY_ENTRIES: usize = 4_096;
+const SHA256_HEX_LENGTH: usize = 64;
+const SHA256_IDENTITY_PREFIX: &str = "sha256:";
+
+/// Return the SHA-256 digest as exactly 64 lowercase hexadecimal characters.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+/// Return the canonical content identity `sha256:<64 lowercase hex>`.
+pub fn sha256_identity(bytes: &[u8]) -> String {
+    format!("{SHA256_IDENTITY_PREFIX}{}", sha256_hex(bytes))
+}
+
+/// Prefix an already-computed canonical raw digest after validating it.
+pub fn sha256_identity_from_hex(digest: &str, label: &str) -> Result<String> {
+    validate_sha256_hex(digest, label)?;
+    Ok(format!("{SHA256_IDENTITY_PREFIX}{digest}"))
+}
+
+/// Serialize a fixed-schema value as compact JSON and hash those exact bytes.
+pub fn json_sha256_identity<T: Serialize + ?Sized>(value: &T) -> Result<String> {
+    Ok(sha256_identity(&serde_json::to_vec(value)?))
+}
+
+/// Validate an unprefixed SHA-256 digest in its canonical lowercase form.
+pub fn validate_sha256_hex(value: &str, label: &str) -> Result<()> {
+    ensure!(
+        value.len() == SHA256_HEX_LENGTH
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
+        "{label} must use exactly 64 lowercase hexadecimal characters"
+    );
+    Ok(())
+}
+
+/// Validate a canonical prefixed SHA-256 content identity.
+pub fn validate_sha256_identity(value: &str, label: &str) -> Result<()> {
+    let digest = value
+        .strip_prefix(SHA256_IDENTITY_PREFIX)
+        .with_context(|| format!("{label} must use the `sha256:<64 lowercase hex>` form"))?;
+    validate_sha256_hex(digest, label)
+        .with_context(|| format!("{label} must use the `sha256:<64 lowercase hex>` form"))
+}
+
+pub fn ensure_real_directory(path: &Path, label: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspecting {label} {}", path.display()))?;
+    ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "{label} {} is not a real directory",
+        path.display()
+    );
+    Ok(())
+}
+
+pub fn ensure_directory(path: &Path, label: &str) -> Result<()> {
+    fs::create_dir_all(path).with_context(|| format!("creating {label} {}", path.display()))?;
+    ensure_real_directory(path, label)
+}
+
+pub fn sync_directory(path: &Path) -> Result<()> {
+    ensure_real_directory(path, "synced directory")?;
+    File::open(path)?.sync_all()?;
+    Ok(())
+}
+
+pub(crate) fn open_regular(path: &Path, label: &str) -> Result<(File, StableIdentity)> {
+    let path_metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspecting {label} {}", path.display()))?;
+    ensure!(
+        path_metadata.is_file() && !path_metadata.file_type().is_symlink(),
+        "{label} {} is not a regular file or is a symlink",
+        path.display()
+    );
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    let file = options
+        .open(path)
+        .with_context(|| format!("opening {label} {}", path.display()))?;
+    let identity = StableIdentity::from_metadata(&file.metadata()?);
+    ensure!(
+        identity == StableIdentity::from_metadata(&path_metadata),
+        "{label} {} changed while it was opened",
+        path.display()
+    );
+    Ok((file, identity))
+}
+
+pub fn ensure_regular_file(path: &Path, label: &str) -> Result<()> {
+    let _ = open_regular(path, label)?;
+    Ok(())
+}
+
+/// Hash an already-open regular file generation. When `capture_limit` is
+/// present, return its bytes only after rejecting the size before allocation.
+/// The digest is returned as lowercase hexadecimal without a `sha256:` prefix.
+pub fn hash_open_file(
+    file: &mut File,
+    capture_limit: Option<u64>,
+    label: &str,
+) -> Result<(u64, String, Option<Vec<u8>>)> {
+    let before = file
+        .metadata()
+        .with_context(|| format!("inspecting opened {label}"))?;
+    ensure!(before.is_file(), "opened {label} is not a regular file");
+    let identity = StableIdentity::from_metadata(&before);
+    let mut captured = match capture_limit {
+        Some(limit) => {
+            ensure!(
+                before.len() <= limit,
+                "opened {label} exceeds its {limit}-byte limit"
+            );
+            let capacity = usize::try_from(before.len())
+                .with_context(|| format!("{label} is too large for this address space"))?;
+            let mut bytes = Vec::new();
+            bytes
+                .try_reserve_exact(capacity)
+                .with_context(|| format!("reserving authenticated buffer for {label}"))?;
+            Some(bytes)
+        }
+        None => None,
+    };
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("rewinding opened {label}"))?;
+    let mut hasher = Sha256::new();
+    let mut observed = 0_u64;
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("reading opened {label}"))?;
+        if read == 0 {
+            break;
+        }
+        observed = observed
+            .checked_add(u64::try_from(read).context("artifact read length exceeds u64")?)
+            .context("artifact length overflow")?;
+        ensure!(
+            observed <= before.len(),
+            "opened {label} grew while it was read"
+        );
+        hasher.update(&buffer[..read]);
+        if let Some(captured) = &mut captured {
+            captured.extend_from_slice(&buffer[..read]);
+        }
+    }
+    let after = file
+        .metadata()
+        .with_context(|| format!("reinspecting opened {label}"))?;
+    ensure!(
+        StableIdentity::from_metadata(&after) == identity && observed == after.len(),
+        "opened {label} changed while it was read"
+    );
+    Ok((observed, format!("{:x}", hasher.finalize()), captured))
+}
+
+/// Stream-hash an opened file while requiring the length pinned by an earlier
+/// caller snapshot. Authentication and consumption still use the same file
+/// descriptor, and changes before or during the read fail closed.
+pub fn hash_open_file_exact_length(
+    file: &mut File,
+    expected_bytes: u64,
+    label: &str,
+) -> Result<String> {
+    let observed_before = file
+        .metadata()
+        .with_context(|| format!("inspecting opened {label}"))?
+        .len();
+    ensure!(
+        observed_before >= expected_bytes,
+        "{label} was truncated before it was hashed"
+    );
+    ensure!(
+        observed_before <= expected_bytes,
+        "{label} grew before it was hashed"
+    );
+    let (observed, digest, _) = hash_open_file(file, None, label)?;
+    ensure!(
+        observed >= expected_bytes,
+        "{label} was truncated while it was hashed"
+    );
+    ensure!(
+        observed <= expected_bytes,
+        "{label} grew while it was hashed"
+    );
+    Ok(digest)
+}
+
+fn read_hashed_path(
+    path: &Path,
+    capture_limit: Option<u64>,
+    label: &str,
+) -> Result<(u64, String, Option<Vec<u8>>)> {
+    let (mut file, identity) = open_regular(path, label)?;
+    let result = hash_open_file(&mut file, capture_limit, label)?;
+    let current = fs::symlink_metadata(path)
+        .with_context(|| format!("reinspecting {label} {}", path.display()))?;
+    ensure!(
+        StableIdentity::from_metadata(&current) == identity,
+        "{label} {} changed while it was consumed",
+        path.display()
+    );
+    Ok(result)
+}
+
+#[cfg(test)]
+fn read_regular(path: &Path) -> Result<Vec<u8>> {
+    read_regular_bounded(path, u64::MAX, &format!("artifact {}", path.display()))
+}
+
+pub fn read_regular_bounded(path: &Path, max_bytes: u64, label: &str) -> Result<Vec<u8>> {
+    read_hashed_path(path, Some(max_bytes), label)?
+        .2
+        .context("authenticated read did not capture bytes")
+}
+
+/// Stream-hash a stable regular file and return an unprefixed lowercase digest.
+pub fn hash_regular_file_hex(path: &Path) -> Result<(u64, String)> {
+    let label = format!("artifact {}", path.display());
+    let (bytes, digest, _) = read_hashed_path(path, None, &label)?;
+    Ok((bytes, digest))
+}
+
+/// Stream-hash a stable regular file and return its canonical content identity.
+pub fn hash_regular_file(path: &Path) -> Result<(u64, String)> {
+    let (bytes, digest) = hash_regular_file_hex(path)?;
+    Ok((bytes, sha256_identity_from_hex(&digest, "artifact digest")?))
+}
+
+pub fn sync_regular_file(path: &Path, label: &str) -> Result<()> {
+    let (file, identity) = open_regular(path, label)?;
+    file.sync_all()
+        .with_context(|| format!("syncing {label} {}", path.display()))?;
+    let current = fs::symlink_metadata(path)
+        .with_context(|| format!("reinspecting {label} {}", path.display()))?;
+    ensure!(
+        StableIdentity::from_metadata(&current) == identity,
+        "{label} {} changed while it was synced",
+        path.display()
+    );
+    Ok(())
+}
+
+pub fn write_new_synced(path: &Path, bytes: &[u8]) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("creating immutable file {}", path.display()))?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+/// Idempotently publish immutable bytes without ever replacing an existing
+/// pathname. Concurrent same-content publishers converge on the same file.
+pub fn atomic_write_new(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path.parent().context("atomic artifact has no parent")?;
+    ensure_directory(parent, "atomic artifact parent")?;
+    let expected_bytes = u64::try_from(bytes.len()).context("immutable artifact exceeds u64")?;
+    if path.exists() {
+        ensure!(
+            read_regular_bounded(path, expected_bytes, "existing immutable artifact")? == bytes,
+            "immutable artifact already exists with different bytes"
+        );
+        return Ok(());
+    }
+    let name = path
+        .file_name()
+        .context("atomic artifact has no file name")?
+        .to_string_lossy();
+    let temporary = parent.join(format!(
+        ".{name}.staging-{}-{}",
+        std::process::id(),
+        IMMUTABLE_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    if let Err(error) = write_new_synced(&temporary, bytes) {
+        let _ = fs::remove_file(&temporary);
+        return Err(error);
+    }
+    let publication = (|| -> Result<()> {
+        match fs::hard_link(&temporary, path) {
+            Ok(()) => {
+                // `hard_link` resolves its source pathname after the staged
+                // handle has been closed. A process with write access to the
+                // parent could replace that name in the interval. Never
+                // report a successful immutable publication until the exact
+                // destination bytes have independently been authenticated.
+                ensure!(
+                    read_regular_bounded(path, expected_bytes, "published immutable artifact")?
+                        == bytes,
+                    "published immutable artifact differs from staged bytes"
+                );
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                ensure!(
+                    read_regular_bounded(path, expected_bytes, "concurrent immutable artifact")?
+                        == bytes,
+                    "concurrent immutable publication differs"
+                );
+                Ok(())
+            }
+            Err(error) => Err(error).context("atomically linking immutable artifact"),
+        }
+    })();
+    let cleanup = fs::remove_file(&temporary)
+        .with_context(|| format!("removing immutable staging file {}", temporary.display()));
+    match (publication, cleanup) {
+        (Err(primary), _) => Err(primary),
+        (Ok(()), Err(cleanup)) => Err(cleanup),
+        (Ok(()), Ok(())) => sync_directory(parent),
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StableIdentity {
+    length: u64,
+    modified: Option<SystemTime>,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    mode: u32,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+}
+
+impl StableIdentity {
+    pub fn from_metadata(metadata: &fs::Metadata) -> Self {
+        Self {
+            length: metadata.len(),
+            modified: metadata.modified().ok(),
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            mode: metadata.mode(),
+            #[cfg(unix)]
+            changed_seconds: metadata.ctime(),
+            #[cfg(unix)]
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+
+    #[cfg(unix)]
+    pub fn same_object(&self, other: &Self) -> bool {
+        self.device == other.device && self.inode == other.inode && self.mode == other.mode
+    }
+
+    #[cfg(not(unix))]
+    pub fn same_object(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+/// Pinned members and the identity of the directory handle they came from.
+pub struct AuthenticatedDirectorySnapshot {
+    path: PathBuf,
+    label: String,
+    identity: StableIdentity,
+    files: BTreeMap<String, CapturedFile>,
+    file_identities: BTreeMap<String, StableIdentity>,
+    #[cfg(unix)]
+    directory: PinnedDirectory,
+}
+
+struct CapturedFiles {
+    identity: StableIdentity,
+    files: BTreeMap<String, CapturedFile>,
+    file_identities: BTreeMap<String, StableIdentity>,
+}
+
+struct CapturedFile {
+    file: File,
+    identity: StableIdentity,
+    verified: Option<(u64, String)>,
+}
+
+#[cfg(unix)]
+struct UnixCapture {
+    captured: CapturedFiles,
+    directory: PinnedDirectory,
+}
+
+impl AuthenticatedDirectorySnapshot {
+    pub(crate) fn capture(path: &Path, expected: &[&str], label: &str) -> Result<Self> {
+        let expected = validate_expected_names(expected)?;
+        #[cfg(unix)]
+        let UnixCapture {
+            captured,
+            directory,
+        } = capture_unix(path, &expected, label)?;
+        #[cfg(not(unix))]
+        let captured = capture_portable(path, &expected, label)?;
+        Ok(Self {
+            path: path.to_owned(),
+            label: label.to_owned(),
+            identity: captured.identity,
+            files: captured.files,
+            file_identities: captured.file_identities,
+            #[cfg(unix)]
+            directory,
+        })
+    }
+
+    /// Read one pinned member, with a caller-owned bound. Directory capture is
+    /// deliberately handle-only: eager reads multiply peak memory by every
+    /// model/optimizer member in a generation.
+    pub(crate) fn read_bounded(&mut self, name: &str, max_bytes: u64) -> Result<Vec<u8>> {
+        let member = self
+            .files
+            .get_mut(name)
+            .with_context(|| format!("authenticated {} has no `{name}`", self.label))?;
+        member.read_bounded(max_bytes, &format!("{} file `{name}`", self.label))
+    }
+
+    /// Stream-authenticate a pinned member without materializing it.
+    pub(crate) fn verify(
+        &mut self,
+        name: &str,
+        expected_bytes: u64,
+        expected_sha256: &str,
+    ) -> Result<()> {
+        let member = self
+            .files
+            .get_mut(name)
+            .with_context(|| format!("authenticated {} has no `{name}`", self.label))?;
+        member.verify(
+            expected_bytes,
+            expected_sha256,
+            &format!("{} file `{name}`", self.label),
+        )
+    }
+
+    /// Read a member that was already stream-authenticated with [`Self::verify`].
+    pub(crate) fn take(&mut self, name: &str, max_bytes: u64) -> Result<Vec<u8>> {
+        let mut member = self
+            .files
+            .remove(name)
+            .with_context(|| format!("authenticated {} has no `{name}`", self.label))?;
+        let (expected_bytes, expected_sha256) = member
+            .verified
+            .clone()
+            .with_context(|| format!("authenticated {} `{name}` was not verified", self.label))?;
+        member.read_verified(
+            expected_bytes,
+            &expected_sha256,
+            max_bytes,
+            &format!("{} file `{name}`", self.label),
+        )
+    }
+
+    /// Require the exact directory opened at capture time to still occupy its
+    /// published pathname.  All returned data remains sourced from captured
+    /// handles; this check only prevents accepting a persistent replacement.
+    pub(crate) fn ensure_still_published(&self) -> Result<()> {
+        self.ensure_still_published_after_children(|| Ok(()))
+    }
+
+    fn ensure_still_published_after_children(
+        &self,
+        after_children: impl FnOnce() -> Result<()>,
+    ) -> Result<()> {
+        self.ensure_published_directory_identity()?;
+        #[cfg(unix)]
+        {
+            let expected = self
+                .file_identities
+                .keys()
+                .cloned()
+                .collect::<BTreeSet<_>>();
+            ensure!(
+                utf8_names(&self.directory, &self.label, expected.len())? == expected,
+                "published {} file set changed during authenticated load",
+                self.label
+            );
+            for (name, expected) in &self.file_identities {
+                let file = self.directory.open_child(OsStr::new(name), &self.label)?;
+                let observed = file.metadata().with_context(|| {
+                    format!("reinspecting published {} file `{name}`", self.label)
+                })?;
+                ensure!(
+                    observed.is_file() && StableIdentity::from_metadata(&observed) == *expected,
+                    "published {} file `{name}` changed during authenticated load",
+                    self.label
+                );
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let observed =
+                portable_utf8_names(&self.path, &self.label, self.file_identities.len())?;
+            ensure!(
+                observed
+                    == self
+                        .file_identities
+                        .keys()
+                        .cloned()
+                        .collect::<BTreeSet<_>>(),
+                "published {} file set changed during authenticated load",
+                self.label
+            );
+            for (name, expected) in &self.file_identities {
+                let metadata = fs::symlink_metadata(self.path.join(name))?;
+                ensure!(
+                    metadata.is_file()
+                        && !metadata.file_type().is_symlink()
+                        && StableIdentity::from_metadata(&metadata) == *expected,
+                    "published {} file `{name}` changed during authenticated load",
+                    self.label
+                );
+            }
+        }
+        // The pathname can be swapped after the first identity check while
+        // child handles are inspected. Close that avoidable race before the
+        // authenticated bytes are allowed to commit caller state.
+        after_children()?;
+        self.ensure_published_directory_identity()
+    }
+
+    fn ensure_published_directory_identity(&self) -> Result<()> {
+        let metadata = fs::symlink_metadata(&self.path).with_context(|| {
+            format!(
+                "reinspecting published {} {}",
+                self.label,
+                self.path.display()
+            )
+        })?;
+        ensure!(
+            metadata.is_dir()
+                && !metadata.file_type().is_symlink()
+                && StableIdentity::from_metadata(&metadata).same_object(&self.identity),
+            "published {} changed during authenticated load",
+            self.label
+        );
+        Ok(())
+    }
+}
+
+fn validate_expected_names(expected: &[&str]) -> Result<BTreeSet<String>> {
+    ensure!(
+        expected.len() <= MAX_PINNED_DIRECTORY_ENTRIES,
+        "authenticated artifact schema exceeds its {MAX_PINNED_DIRECTORY_ENTRIES}-entry limit"
+    );
+    let mut names = BTreeSet::new();
+    for name in expected {
+        let mut components = Path::new(name).components();
+        ensure!(
+            matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none(),
+            "authenticated artifact name `{name}` is not one safe path component"
+        );
+        ensure!(
+            names.insert((*name).to_owned()),
+            "authenticated artifact schema repeats `{name}`"
+        );
+    }
+    ensure!(!names.is_empty(), "authenticated artifact schema is empty");
+    Ok(names)
+}
+
+impl CapturedFile {
+    fn open(file: File, label: &str) -> Result<Self> {
+        let metadata = file
+            .metadata()
+            .with_context(|| format!("inspecting opened {label}"))?;
+        ensure!(metadata.is_file(), "opened {label} is not a regular file");
+        Ok(Self {
+            file,
+            identity: StableIdentity::from_metadata(&metadata),
+            verified: None,
+        })
+    }
+
+    fn ensure_unchanged(&self, observed_bytes: u64, label: &str) -> Result<()> {
+        let after = self
+            .file
+            .metadata()
+            .with_context(|| format!("reinspecting opened {label}"))?;
+        ensure!(
+            StableIdentity::from_metadata(&after) == self.identity && observed_bytes == after.len(),
+            "opened {label} changed while it was consumed"
+        );
+        Ok(())
+    }
+
+    fn read_bounded(&mut self, max_bytes: u64, label: &str) -> Result<Vec<u8>> {
+        ensure!(
+            self.identity.length <= max_bytes,
+            "opened {label} exceeds its {max_bytes}-byte limit"
+        );
+        let (observed, _, captured) = hash_open_file(&mut self.file, Some(max_bytes), label)?;
+        self.ensure_unchanged(observed, label)?;
+        captured.context("authenticated read did not capture bytes")
+    }
+
+    fn verify(&mut self, expected_bytes: u64, expected_sha256: &str, label: &str) -> Result<()> {
+        ensure!(
+            self.identity.length == expected_bytes,
+            "opened {label} length differs from its manifest"
+        );
+        let (observed, digest, _) = hash_open_file(&mut self.file, None, label)?;
+        self.ensure_unchanged(observed, label)?;
+        ensure!(
+            format!("sha256:{digest}") == expected_sha256,
+            "opened {label} hash differs from its manifest"
+        );
+        self.verified = Some((expected_bytes, expected_sha256.to_owned()));
+        Ok(())
+    }
+
+    fn read_verified(
+        &mut self,
+        expected_bytes: u64,
+        expected_sha256: &str,
+        max_bytes: u64,
+        label: &str,
+    ) -> Result<Vec<u8>> {
+        ensure!(
+            expected_bytes <= max_bytes,
+            "opened {label} exceeds its {max_bytes}-byte limit"
+        );
+        let bytes = self.read_bounded(max_bytes, label)?;
+        ensure!(
+            bytes.len() as u64 == expected_bytes && sha256_identity(&bytes) == expected_sha256,
+            "opened {label} differs from its authenticated manifest entry"
+        );
+        self.verified = Some((expected_bytes, expected_sha256.to_owned()));
+        Ok(bytes)
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+pub struct PinnedDirectory {
+    file: File,
+}
+
+#[cfg(unix)]
+impl PinnedDirectory {
+    pub fn open(path: &Path, label: &str) -> Result<(Self, StableIdentity)> {
+        let path_metadata = fs::symlink_metadata(path)
+            .with_context(|| format!("inspecting {label} {}", path.display()))?;
+        ensure!(
+            path_metadata.is_dir() && !path_metadata.file_type().is_symlink(),
+            "{label} {} is not a real directory",
+            path.display()
+        );
+        let file = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+            .open(path)
+            .with_context(|| format!("opening {label} {}", path.display()))?;
+        let identity = StableIdentity::from_metadata(&file.metadata()?);
+        ensure!(
+            identity == StableIdentity::from_metadata(&path_metadata),
+            "{label} changed while it was opened"
+        );
+        Ok((Self { file }, identity))
+    }
+
+    pub fn from_open_directory(file: File, label: &str) -> Result<Self> {
+        let metadata = file
+            .metadata()
+            .with_context(|| format!("inspecting opened {label}"))?;
+        ensure!(metadata.is_dir(), "opened {label} is not a directory");
+        Ok(Self { file })
+    }
+
+    pub fn identity(&self) -> Result<StableIdentity> {
+        Ok(StableIdentity::from_metadata(&self.file.metadata()?))
+    }
+
+    pub fn open_child(&self, name: &OsStr, label: &str) -> Result<File> {
+        let mut components = Path::new(name).components();
+        ensure!(
+            matches!(components.next(), Some(Component::Normal(component)) if component == name)
+                && components.next().is_none(),
+            "authenticated {label} child `{}` is not one safe path component",
+            name.to_string_lossy()
+        );
+        let name =
+            CString::new(name.as_bytes()).context("authenticated artifact name contains NUL")?;
+        // SAFETY: the directory descriptor remains owned by `self`; openat
+        // returns a new descriptor and O_NOFOLLOW rejects symlink leaves.
+        let descriptor = unsafe {
+            libc::openat(
+                self.file.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+                0,
+            )
+        };
+        if descriptor < 0 {
+            return Err(std::io::Error::last_os_error()).with_context(|| {
+                format!(
+                    "opening authenticated {label} file `{}`",
+                    name.to_string_lossy()
+                )
+            });
+        }
+        // SAFETY: openat returned a newly owned descriptor on success.
+        Ok(unsafe { File::from_raw_fd(descriptor) })
+    }
+
+    pub fn open_relative_file(&self, relative: &Path, label: &str) -> Result<File> {
+        ensure!(
+            !relative.is_absolute(),
+            "authenticated relative path must not be absolute"
+        );
+        let mut directory = Self {
+            file: self
+                .file
+                .try_clone()
+                .with_context(|| format!("duplicating authenticated {label} directory"))?,
+        };
+        let mut components = relative.components().peekable();
+        while let Some(component) = components.next() {
+            let Component::Normal(name) = component else {
+                anyhow::bail!(
+                    "authenticated path `{}` is not normalized",
+                    relative.display()
+                );
+            };
+            let child = directory.open_child(name, label)?;
+            let metadata = child
+                .metadata()
+                .with_context(|| format!("inspecting authenticated {label} child"))?;
+            if components.peek().is_none() {
+                ensure!(
+                    metadata.is_file(),
+                    "authenticated {label} `{}` is not a regular file",
+                    relative.display()
+                );
+                return Ok(child);
+            }
+            ensure!(
+                metadata.is_dir(),
+                "authenticated {label} parent for `{}` is not a directory",
+                relative.display()
+            );
+            directory = Self::from_open_directory(child, label)?;
+        }
+        anyhow::bail!("authenticated path has no file name")
+    }
+
+    /// Enumerate a pinned directory with a conservative default cardinality
+    /// bound. Fixed-schema callers should use [`Self::entries_bounded`] with
+    /// their exact expected member count.
+    pub fn entries(&self, label: &str) -> Result<Vec<OsString>> {
+        self.entries_bounded(label, MAX_PINNED_DIRECTORY_ENTRIES)
+    }
+
+    pub fn entries_bounded(&self, label: &str, maximum_entries: usize) -> Result<Vec<OsString>> {
+        let maximum_entries = maximum_entries.min(MAX_PINNED_DIRECTORY_ENTRIES);
+        let current = CString::new(".").expect("static path contains no NUL");
+        // `dup` would share one open-file-description directory cursor with
+        // every concurrent enumeration. Open `.` relative to the pinned
+        // descriptor instead so this DIR stream owns an independent cursor.
+        // SAFETY: the pinned directory descriptor and static C string are
+        // valid for the duration of this call; openat returns a new owned fd.
+        let descriptor = unsafe {
+            libc::openat(
+                self.file.as_raw_fd(),
+                current.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW,
+                0,
+            )
+        };
+        if descriptor < 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("opening an independent {label} directory cursor"));
+        }
+        // SAFETY: `descriptor` is valid and ownership transfers to fdopendir.
+        let stream = unsafe { libc::fdopendir(descriptor) };
+        if stream.is_null() {
+            let error = std::io::Error::last_os_error();
+            // SAFETY: fdopendir did not take ownership on failure.
+            unsafe { libc::close(descriptor) };
+            return Err(error).with_context(|| format!("enumerating {label}"));
+        }
+        struct DirectoryStream(*mut libc::DIR);
+        impl Drop for DirectoryStream {
+            fn drop(&mut self) {
+                // SAFETY: the wrapper uniquely owns the DIR pointer.
+                unsafe { libc::closedir(self.0) };
+            }
+        }
+        let stream = DirectoryStream(stream);
+        let mut names = Vec::new();
+        loop {
+            let errno = errno_slot();
+            if let Some(slot) = errno {
+                // SAFETY: errno_slot returns this thread's errno storage.
+                unsafe { *slot = 0 };
+            }
+            // SAFETY: stream owns a private DIR and each name is copied before
+            // the next call.
+            let entry = unsafe { libc::readdir(stream.0) };
+            if entry.is_null() {
+                let code = errno.map_or(0, |slot| unsafe { *slot });
+                if code != 0 {
+                    return Err(std::io::Error::from_raw_os_error(code))
+                        .with_context(|| format!("enumerating {label}"));
+                }
+                break;
+            }
+            let raw = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }.to_bytes();
+            if raw == b"." || raw == b".." {
+                continue;
+            }
+            ensure!(
+                names.len() < maximum_entries,
+                "{label} exceeds its {maximum_entries}-entry limit"
+            );
+            names.push(OsString::from_vec(raw.to_vec()));
+        }
+        names.sort();
+        Ok(names)
+    }
+}
+
+#[cfg(unix)]
+fn capture_unix(path: &Path, expected: &BTreeSet<String>, label: &str) -> Result<UnixCapture> {
+    let (directory, identity) = PinnedDirectory::open(path, label)?;
+    ensure!(
+        utf8_names(&directory, label, expected.len())? == *expected,
+        "{label} file set differs from its fixed schema"
+    );
+    let mut files = BTreeMap::new();
+    let mut file_identities = BTreeMap::new();
+    for name in expected {
+        let file = directory.open_child(OsStr::new(name), label)?;
+        let member = CapturedFile::open(file, &format!("{label} `{name}`"))?;
+        file_identities.insert(name.clone(), member.identity.clone());
+        files.insert(name.clone(), member);
+    }
+    ensure!(
+        StableIdentity::from_metadata(&directory.file.metadata()?) == identity,
+        "{label} changed while its files were captured"
+    );
+    Ok(UnixCapture {
+        captured: CapturedFiles {
+            identity,
+            files,
+            file_identities,
+        },
+        directory,
+    })
+}
+
+#[cfg(unix)]
+fn utf8_names(
+    directory: &PinnedDirectory,
+    label: &str,
+    maximum_entries: usize,
+) -> Result<BTreeSet<String>> {
+    directory
+        .entries_bounded(label, maximum_entries)?
+        .into_iter()
+        .map(|name| {
+            name.into_string()
+                .map_err(|_| anyhow::anyhow!("{label} contains a non-UTF-8 file name"))
+        })
+        .collect()
+}
+
+#[cfg(not(unix))]
+fn capture_portable(
+    path: &Path,
+    expected: &BTreeSet<String>,
+    label: &str,
+) -> Result<CapturedFiles> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspecting {label} {}", path.display()))?;
+    ensure!(
+        metadata.is_dir() && !metadata.file_type().is_symlink(),
+        "{label} {} is not a real directory",
+        path.display()
+    );
+    let identity = StableIdentity::from_metadata(&metadata);
+    let observed = portable_utf8_names(path, label, expected.len())?;
+    ensure!(
+        observed == *expected,
+        "{label} file set differs from its fixed schema"
+    );
+    let mut files = BTreeMap::new();
+    let mut file_identities = BTreeMap::new();
+    for name in expected {
+        let child = path.join(name);
+        let child_metadata = fs::symlink_metadata(&child)?;
+        ensure!(
+            child_metadata.is_file() && !child_metadata.file_type().is_symlink(),
+            "{label} `{name}` is not a regular non-symlink file"
+        );
+        let member = CapturedFile::open(File::open(&child)?, &format!("{label} `{name}`"))?;
+        file_identities.insert(name.clone(), member.identity.clone());
+        files.insert(name.clone(), member);
+    }
+    ensure!(
+        StableIdentity::from_metadata(&fs::symlink_metadata(path)?) == identity,
+        "{label} changed while its files were captured"
+    );
+    Ok(CapturedFiles {
+        identity,
+        files,
+        file_identities,
+    })
+}
+
+#[cfg(not(unix))]
+fn portable_utf8_names(
+    path: &Path,
+    label: &str,
+    maximum_entries: usize,
+) -> Result<BTreeSet<String>> {
+    let mut names = BTreeSet::new();
+    for entry in fs::read_dir(path)? {
+        ensure!(
+            names.len() < maximum_entries,
+            "{label} exceeds its {maximum_entries}-entry limit"
+        );
+        let name = entry?
+            .file_name()
+            .into_string()
+            .map_err(|_| anyhow::anyhow!("{label} contains a non-UTF-8 file name"))?;
+        names.insert(name);
+    }
+    Ok(names)
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "freebsd"
+    )
+))]
+fn errno_slot() -> Option<*mut libc::c_int> {
+    // SAFETY: libc returns this thread's errno storage.
+    Some(unsafe { libc::__error() })
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "emscripten",
+        target_os = "hurd",
+        target_os = "redox"
+    )
+))]
+fn errno_slot() -> Option<*mut libc::c_int> {
+    // SAFETY: libc returns this thread's errno storage.
+    Some(unsafe { libc::__errno_location() })
+}
+
+#[cfg(all(
+    unix,
+    any(target_os = "android", target_os = "netbsd", target_os = "openbsd")
+))]
+fn errno_slot() -> Option<*mut libc::c_int> {
+    // SAFETY: libc returns this thread's errno storage.
+    Some(unsafe { libc::__errno() })
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos",
+        target_os = "visionos",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "emscripten",
+        target_os = "hurd",
+        target_os = "redox",
+        target_os = "android",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))
+))]
+fn errno_slot() -> Option<*mut libc::c_int> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn immutable_file_publication_is_idempotent_and_leaves_no_staging_files() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("receipt.json");
+
+        atomic_write_new(&path, b"sealed").unwrap();
+        atomic_write_new(&path, b"sealed").unwrap();
+        let error = atomic_write_new(&path, b"different")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("different bytes"), "{error}");
+        assert_eq!(read_regular(&path).unwrap(), b"sealed");
+        assert!(fs::read_dir(directory.path()).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .contains(".staging-")
+        }));
+    }
+
+    #[test]
+    fn directory_capture_pins_large_members_without_eager_allocation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("weights.safetensors");
+        let file = File::create(&path).unwrap();
+        file.set_len(2 * 1024 * 1024 * 1024).unwrap();
+        drop(file);
+
+        let mut snapshot = AuthenticatedDirectorySnapshot::capture(
+            directory.path(),
+            &["weights.safetensors"],
+            "large fixture",
+        )
+        .unwrap();
+        let error = snapshot
+            .read_bounded("weights.safetensors", 1024)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("1024-byte limit"), "{error}");
+    }
+
+    #[test]
+    fn fixed_schema_capture_bounds_hostile_directory_cardinality() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(directory.path().join("state.json"), b"state").unwrap();
+        for index in 0..128 {
+            fs::write(directory.path().join(format!("unexpected-{index:03}")), b"").unwrap();
+        }
+
+        let error = AuthenticatedDirectorySnapshot::capture(
+            directory.path(),
+            &["state.json"],
+            "hostile fixture",
+        )
+        .err()
+        .expect("oversized directory must fail before collecting every name");
+        assert!(format!("{error:#}").contains("1-entry limit"), "{error:#}");
+    }
+
+    #[test]
+    fn bounded_path_read_rejects_size_before_allocation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("oversized.json");
+        let file = File::create(&path).unwrap();
+        file.set_len(1024 * 1024).unwrap();
+        drop(file);
+
+        let error = read_regular_bounded(&path, 1024, "bounded fixture")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("1024-byte limit"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_helpers_reject_symlinked_files_and_directories() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target.bin");
+        let file_link = directory.path().join("file-link.bin");
+        let directory_link = directory.path().join("directory-link");
+        fs::write(&target, b"target").unwrap();
+        symlink(&target, &file_link).unwrap();
+        symlink(directory.path(), &directory_link).unwrap();
+
+        assert!(read_regular_bounded(&file_link, 64, "symlink fixture").is_err());
+        assert!(hash_regular_file(&file_link).is_err());
+        assert!(ensure_real_directory(&directory_link, "symlink directory").is_err());
+    }
+
+    #[test]
+    fn verified_member_is_read_from_the_same_pinned_handle() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(directory.path().join("state.bin"), b"pinned-state").unwrap();
+        let mut snapshot = AuthenticatedDirectorySnapshot::capture(
+            directory.path(),
+            &["state.bin"],
+            "state fixture",
+        )
+        .unwrap();
+        snapshot
+            .verify("state.bin", 12, &sha256_identity(b"pinned-state"))
+            .unwrap();
+        assert_eq!(snapshot.take("state.bin", 64).unwrap(), b"pinned-state");
+    }
+
+    #[test]
+    fn sha256_syntax_is_canonical_and_distinguishes_raw_from_prefixed() {
+        const ABC_HEX: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        assert_eq!(sha256_hex(b"abc"), ABC_HEX);
+        assert_eq!(sha256_identity(b"abc"), format!("sha256:{ABC_HEX}"));
+        validate_sha256_hex(ABC_HEX, "raw digest").unwrap();
+        validate_sha256_identity(&format!("sha256:{ABC_HEX}"), "identity").unwrap();
+
+        for invalid in [
+            &ABC_HEX[..63],
+            "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD",
+            "ga7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            &format!("sha256:{ABC_HEX}"),
+        ] {
+            assert!(validate_sha256_hex(invalid, "raw digest").is_err());
+        }
+        assert!(validate_sha256_identity(ABC_HEX, "identity").is_err());
+        assert!(
+            validate_sha256_identity(
+                "sha256:BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD",
+                "identity"
+            )
+            .is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pinned_directory_enumerations_have_independent_cursors() {
+        use std::sync::{Arc, Barrier};
+
+        let directory = tempfile::tempdir().unwrap();
+        for name in ["alpha", "beta", "gamma"] {
+            fs::write(directory.path().join(name), name).unwrap();
+        }
+        let (pinned, _) = PinnedDirectory::open(directory.path(), "concurrent fixture").unwrap();
+        let pinned = Arc::new(pinned);
+        let barrier = Arc::new(Barrier::new(8));
+        let expected = ["alpha", "beta", "gamma"]
+            .into_iter()
+            .map(OsString::from)
+            .collect::<Vec<_>>();
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let pinned = Arc::clone(&pinned);
+                let barrier = Arc::clone(&barrier);
+                let expected = expected.clone();
+                scope.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..64 {
+                        assert_eq!(pinned.entries("concurrent fixture").unwrap(), expected);
+                    }
+                });
+            }
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pinned_directory_rejects_non_component_children_and_caps_enumeration() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(directory.path().join("safe"), b"safe").unwrap();
+        let (pinned, _) = PinnedDirectory::open(directory.path(), "hostile fixture").unwrap();
+
+        assert!(
+            pinned
+                .open_child(OsStr::new("safe"), "hostile fixture")
+                .is_ok()
+        );
+        for hostile in ["", ".", "..", "../safe", "subdir/safe", "/tmp/safe"] {
+            let error = pinned
+                .open_child(OsStr::new(hostile), "hostile fixture")
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("one safe path component"), "{error}");
+        }
+
+        assert_eq!(
+            pinned
+                .entries_bounded("hostile fixture", usize::MAX)
+                .unwrap(),
+            vec![OsString::from("safe")]
+        );
+    }
+
+    #[test]
+    fn fixed_schema_cardinality_has_a_global_cap() {
+        let names = (0..=MAX_PINNED_DIRECTORY_ENTRIES)
+            .map(|index| format!("member-{index}"))
+            .collect::<Vec<_>>();
+        let references = names.iter().map(String::as_str).collect::<Vec<_>>();
+        let error = validate_expected_names(&references)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("4096-entry limit"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn final_directory_identity_check_rejects_a_late_persistent_swap() {
+        let parent = tempfile::tempdir().unwrap();
+        let published = parent.path().join("published");
+        let replacement = parent.path().join("replacement");
+        let parked = parent.path().join("parked");
+        fs::create_dir(&published).unwrap();
+        fs::create_dir(&replacement).unwrap();
+        fs::write(published.join("state.json"), b"authenticated").unwrap();
+        fs::write(replacement.join("state.json"), b"authenticated").unwrap();
+        let snapshot =
+            AuthenticatedDirectorySnapshot::capture(&published, &["state.json"], "fixture")
+                .unwrap();
+
+        let error = snapshot
+            .ensure_still_published_after_children(|| {
+                fs::rename(&published, &parked)?;
+                fs::rename(&replacement, &published)?;
+                Ok(())
+            })
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("changed during authenticated load"),
+            "{error}"
+        );
+    }
+}

--- a/hermes-train/src/benchmark.rs
+++ b/hermes-train/src/benchmark.rs
@@ -11,8 +11,8 @@
 //! expose sealed results only as an aggregate gate.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File};
-use std::io::Read;
+use std::fs;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result, ensure};
@@ -24,11 +24,18 @@ use crate::acceptance::{
     CaseResult, ExactResumeArtifact, ExactResumeEvidence, PairedRun, PromotionReport,
     ResourceComparison, SuiteVisibility, VerifiedPromotionContext, evaluate_with_verified_context,
 };
-use crate::metrics::metric_log_digests_from_bytes;
-use crate::qat_candidate::open_qat_candidate;
+use crate::artifact_io::{
+    StableIdentity, hash_open_file, open_regular, sha256_hex, validate_sha256_hex,
+    validate_sha256_identity,
+};
+use crate::metrics::metric_log_digests;
+use crate::qat_candidate::open_qat_candidate_addressed;
 
 pub const BENCHMARK_MANIFEST_VERSION: u32 = 2;
 pub const MINIMUM_PAIRED_SEEDS: usize = 3;
+pub const MAXIMUM_PAIRED_SEEDS: usize = 64;
+const MAX_BENCHMARK_JSON_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_SAFETENSORS_HEADER_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Whether a catalog entry gates current promotion or belongs to a later
 /// language/long-context sweep from the sleep paper reproduction plan.
@@ -299,7 +306,7 @@ impl BenchmarkSuiteManifest {
                 "benchmark case `{}` has an empty artifact path",
                 case.id
             );
-            validate_sha256(&case.artifact.sha256)
+            validate_sha256_hex(&case.artifact.sha256, "benchmark artifact")
                 .with_context(|| format!("invalid artifact hash for `{}`", case.id))?;
         }
         Ok(())
@@ -319,14 +326,18 @@ pub struct VerifiedBenchmarkSuite {
     pub manifest: BenchmarkSuiteManifest,
     pub manifest_path: PathBuf,
     pub manifest_sha256: String,
+    manifest_bytes: Vec<u8>,
+    manifest_identity: StableIdentity,
     artifacts: BTreeMap<String, VerifiedArtifact>,
+    artifact_identities: BTreeMap<String, StableIdentity>,
 }
 
 impl VerifiedBenchmarkSuite {
     pub fn load(path: impl AsRef<Path>, expected_sha256: &str) -> Result<Self> {
-        validate_sha256(expected_sha256).context("invalid expected manifest hash")?;
-        let path = path.as_ref();
-        let bytes = read_regular_file(path, "benchmark manifest")?;
+        validate_sha256_hex(expected_sha256, "expected benchmark manifest")
+            .context("invalid expected manifest hash")?;
+        let path = checked_artifact_path(path.as_ref(), "benchmark manifest")?;
+        let (bytes, manifest_identity) = read_json_file_with_identity(&path, "benchmark manifest")?;
         let actual_sha256 = sha256_hex(&bytes);
         ensure!(
             actual_sha256.eq_ignore_ascii_case(expected_sha256),
@@ -341,17 +352,17 @@ impl VerifiedBenchmarkSuite {
 
         let base = path.parent().unwrap_or_else(|| Path::new("."));
         let mut artifacts = BTreeMap::new();
+        let mut artifact_identities = BTreeMap::new();
         for case in &manifest.cases {
             let artifact_path = if case.artifact.path.is_absolute() {
                 case.artifact.path.clone()
             } else {
                 base.join(&case.artifact.path)
             };
-            let artifact_bytes = read_regular_file(
+            let (artifact_bytes, actual, identity) = hash_file_with_identity(
                 &artifact_path,
                 &format!("artifact for benchmark `{}`", case.id),
             )?;
-            let actual = sha256_hex(&artifact_bytes);
             ensure!(
                 actual.eq_ignore_ascii_case(&case.artifact.sha256),
                 "artifact hash mismatch for benchmark `{}`: expected {}, got {}",
@@ -364,15 +375,19 @@ impl VerifiedBenchmarkSuite {
                 VerifiedArtifact {
                     path: artifact_path,
                     sha256: actual,
-                    bytes: artifact_bytes.len() as u64,
+                    bytes: artifact_bytes,
                 },
             );
+            artifact_identities.insert(case.id.clone(), identity);
         }
         Ok(Self {
             manifest,
             manifest_path: path.to_path_buf(),
             manifest_sha256: actual_sha256,
+            manifest_bytes: bytes,
+            manifest_identity,
             artifacts,
+            artifact_identities,
         })
     }
 
@@ -383,21 +398,38 @@ impl VerifiedBenchmarkSuite {
     /// Re-check files immediately before an expensive run, closing the gap
     /// between suite loading and evaluator access.
     pub fn verify_contents(&self) -> Result<()> {
-        let manifest_bytes = read_regular_file(&self.manifest_path, "benchmark manifest")?;
-        let actual_manifest = sha256_hex(&manifest_bytes);
+        ensure_path_identity(
+            &self.manifest_path,
+            &self.manifest_identity,
+            "benchmark manifest",
+        )?;
+        let actual_manifest = sha256_hex(&self.manifest_bytes);
         ensure!(
             actual_manifest == self.manifest_sha256,
-            "benchmark manifest changed after verification: {}",
-            self.manifest_path.display()
+            "in-memory benchmark manifest differs from its verified bytes"
+        );
+        let manifest: BenchmarkSuiteManifest = serde_json::from_slice(&self.manifest_bytes)
+            .context("verified benchmark manifest bytes became invalid")?;
+        ensure!(
+            manifest == self.manifest,
+            "in-memory benchmark manifest differs from its content-addressed artifact"
         );
         for (case_id, artifact) in &self.artifacts {
-            let bytes = read_regular_file(
+            let identity = self
+                .artifact_identities
+                .get(case_id)
+                .context("verified benchmark artifact has no pinned identity")?;
+            ensure_path_identity(
+                &artifact.path,
+                identity,
+                &format!("artifact for benchmark `{case_id}`"),
+            )?;
+            let (bytes, actual) = hash_file(
                 &artifact.path,
                 &format!("artifact for benchmark `{case_id}`"),
             )?;
-            let actual = sha256_hex(&bytes);
             ensure!(
-                actual == artifact.sha256 && bytes.len() as u64 == artifact.bytes,
+                actual == artifact.sha256 && bytes == artifact.bytes,
                 "artifact for benchmark `{case_id}` changed after verification"
             );
         }
@@ -417,16 +449,12 @@ pub fn validate_catalog_coverage(
         visibilities.insert(suite.manifest.visibility);
         for case in &suite.manifest.cases {
             let key = (case.catalog_id(), suite.manifest.visibility);
-            if let Some(previous) = cases.insert(key, case) {
-                ensure!(
-                    previous.family == case.family,
-                    "catalog id `{}` is assigned conflicting {:?} families {:?} and {:?}",
-                    case.catalog_id(),
-                    suite.manifest.visibility,
-                    previous.family,
-                    case.family
-                );
-            }
+            ensure!(
+                cases.insert(key, case).is_none(),
+                "benchmark catalog repeats {:?} entry `{}`",
+                suite.manifest.visibility,
+                case.catalog_id()
+            );
         }
     }
     ensure!(
@@ -500,7 +528,7 @@ impl TrainingAccounting {
             "training accounting routes more parameters than it stores"
         );
         ensure!(self.weights_bytes > 0, "training accounting has no weights");
-        validate_sha256(&self.weights_sha256)
+        validate_sha256_hex(&self.weights_sha256, "training-accounting model weights")
             .context("invalid model-weights hash in training accounting")?;
         Ok(())
     }
@@ -536,9 +564,12 @@ impl TrainingEvidence {
             "unsupported training-evidence version {}",
             self.version
         );
-        validate_sha256(&self.checkpoint_manifest_sha256)
-            .context("invalid checkpoint hash in training evidence")?;
-        validate_sha256(&self.accounting_sha256)
+        validate_sha256_hex(
+            &self.checkpoint_manifest_sha256,
+            "training-evidence checkpoint manifest",
+        )
+        .context("invalid checkpoint hash in training evidence")?;
+        validate_sha256_hex(&self.accounting_sha256, "training-evidence accounting")
             .context("invalid accounting hash in training evidence")?;
         ensure!(
             self.training_gpu_hours.is_finite() && self.training_gpu_hours > 0.0,
@@ -556,7 +587,7 @@ impl TrainingEvidence {
             self.stored_bytes > 0,
             "training evidence has no stored bytes"
         );
-        validate_sha256(&self.weights_sha256)
+        validate_sha256_hex(&self.weights_sha256, "training-evidence model weights")
             .context("invalid model-weights hash in training evidence")?;
         Ok(())
     }
@@ -695,10 +726,16 @@ impl BenchmarkTarget {
             "benchmark target `{}` routes more parameters than it stores",
             self.id
         );
-        validate_sha256(&self.checkpoint_manifest_sha256)
-            .with_context(|| format!("invalid checkpoint hash for `{}`", self.id))?;
-        validate_sha256(&self.training_evidence_sha256)
-            .with_context(|| format!("invalid training evidence hash for `{}`", self.id))?;
+        validate_sha256_hex(
+            &self.checkpoint_manifest_sha256,
+            "benchmark target checkpoint manifest",
+        )
+        .with_context(|| format!("invalid checkpoint hash for `{}`", self.id))?;
+        validate_sha256_hex(
+            &self.training_evidence_sha256,
+            "benchmark target training evidence",
+        )
+        .with_context(|| format!("invalid training evidence hash for `{}`", self.id))?;
         ensure!(
             self.training_gpu_hours.is_finite() && self.training_gpu_hours > 0.0,
             "benchmark target `{}` has invalid measured training GPU hours",
@@ -719,7 +756,7 @@ impl BenchmarkTarget {
                 "HQUANT benchmark target `{}` has no candidate manifest",
                 self.id
             );
-            validate_prefixed_sha256(candidate_manifest_sha256)
+            validate_sha256_identity(candidate_manifest_sha256, "HQUANT candidate manifest")
                 .with_context(|| format!("invalid HQUANT candidate hash for `{}`", self.id))?;
         }
         Ok(())
@@ -727,7 +764,7 @@ impl BenchmarkTarget {
 
     pub fn verify(&self) -> Result<VerifiedModelRepresentation> {
         self.validate_identity()?;
-        let manifest_bytes = read_regular_file(
+        let manifest_bytes = read_json_file(
             &self.checkpoint_manifest,
             &format!("checkpoint manifest for `{}`", self.id),
         )?;
@@ -761,7 +798,7 @@ impl BenchmarkTarget {
             .with_context(|| format!("invalid checkpoint manifest for `{}`", self.id))?;
         validate_checkpoint_manifest(&manifest, &self.id)?;
 
-        let evidence_bytes = read_regular_file(
+        let evidence_bytes = read_json_file(
             &self.training_evidence,
             &format!("training evidence for `{}`", self.id),
         )?;
@@ -799,7 +836,7 @@ impl BenchmarkTarget {
         );
 
         let accounting_entry = manifest_file(&manifest, TRAINING_ACCOUNTING_FILE, &self.id)?;
-        let accounting_bytes = read_manifest_file(
+        let accounting_bytes = read_manifest_json(
             generation,
             accounting_entry,
             &format!("training accounting for `{}`", self.id),
@@ -815,16 +852,13 @@ impl BenchmarkTarget {
         accounting.validate()?;
 
         let weights_entry = manifest_file(&manifest, CHECKPOINT_WEIGHTS_FILE, &self.id)?;
-        let weights = read_manifest_file(
+        let (weights_bytes, weights_sha256, actual_parameters) = verify_safetensor_manifest_file(
             generation,
             weights_entry,
             &format!("model weights for `{}`", self.id),
         )?;
-        let weights_sha256 = sha256_hex(&weights);
-        let actual_parameters = safetensor_parameter_count(&weights)
-            .with_context(|| format!("invalid model weights for `{}`", self.id))?;
         ensure!(
-            accounting.weights_bytes == weights.len() as u64
+            accounting.weights_bytes == weights_bytes
                 && accounting
                     .weights_sha256
                     .eq_ignore_ascii_case(&weights_sha256)
@@ -874,9 +908,11 @@ impl BenchmarkTarget {
                 let candidate_root = candidate_manifest
                     .parent()
                     .context("HQUANT candidate manifest has no candidate directory")?;
-                let publication = open_qat_candidate(candidate_root).with_context(|| {
-                    format!("invalid sealed HQUANT candidate for `{}`", self.id)
-                })?;
+                let publication =
+                    open_qat_candidate_addressed(candidate_root, candidate_manifest_sha256)
+                        .with_context(|| {
+                            format!("invalid sealed HQUANT candidate for `{}`", self.id)
+                        })?;
                 ensure!(
                     publication.candidate_manifest_path == *candidate_manifest
                         && publication.candidate_manifest_sha256 == *candidate_manifest_sha256,
@@ -932,7 +968,7 @@ fn validate_checkpoint_manifest(manifest: &CheckpointManifest, target: &str) -> 
     for file in &manifest.files {
         validate_manifest_relative_path(&file.path)?;
         ensure!(file.bytes > 0, "checkpoint file `{}` is empty", file.path);
-        validate_sha256(&file.sha256)
+        validate_sha256_hex(&file.sha256, "checkpoint manifest member")
             .with_context(|| format!("invalid hash for checkpoint file `{}`", file.path))?;
         ensure!(
             paths.insert(file.path.as_str()),
@@ -978,13 +1014,13 @@ fn manifest_file<'a>(
     Ok(matches[0])
 }
 
-fn read_manifest_file(
+fn read_manifest_json(
     generation: &Path,
     entry: &CheckpointManifestFile,
     label: &str,
 ) -> Result<Vec<u8>> {
     let path = generation.join(&entry.path);
-    let bytes = read_regular_file(&path, label)?;
+    let bytes = read_json_file(&path, label)?;
     ensure!(
         bytes.len() as u64 == entry.bytes && sha256_hex(&bytes).eq_ignore_ascii_case(&entry.sha256),
         "{label} does not match the checkpoint manifest"
@@ -992,31 +1028,77 @@ fn read_manifest_file(
     Ok(bytes)
 }
 
-fn safetensor_parameter_count(bytes: &[u8]) -> Result<u64> {
-    let tensors = safetensors::SafeTensors::deserialize(bytes)?;
-    let mut total = 0_u64;
-    for (_, tensor) in tensors.tensors() {
-        let elements = tensor
-            .shape()
-            .iter()
-            .try_fold(1_u64, |product, dimension| {
-                product
-                    .checked_mul(
-                        (*dimension)
-                            .try_into()
-                            .context("tensor dimension exceeds u64")?,
-                    )
-                    .context("tensor element count overflows u64")
-            })?;
-        total = total
+fn verify_safetensor_manifest_file(
+    generation: &Path,
+    entry: &CheckpointManifestFile,
+    label: &str,
+) -> Result<(u64, String, u64)> {
+    let path = generation.join(&entry.path);
+    let (mut file, identity) = open_regular(&path, label)?;
+    let file_bytes = file.metadata()?.len();
+    ensure!(
+        file_bytes == entry.bytes,
+        "{label} byte length does not match the checkpoint manifest"
+    );
+    let (_, digest, _) = hash_open_file(&mut file, None, label)?;
+    ensure!(
+        digest.eq_ignore_ascii_case(&entry.sha256),
+        "{label} hash does not match the checkpoint manifest"
+    );
+    file.seek(SeekFrom::Start(0))?;
+
+    let mut encoded_header_bytes = [0_u8; 8];
+    file.read_exact(&mut encoded_header_bytes)
+        .with_context(|| format!("{label} has a truncated safetensors header"))?;
+    let header_bytes = u64::from_le_bytes(encoded_header_bytes);
+    ensure!(
+        header_bytes <= MAX_SAFETENSORS_HEADER_BYTES,
+        "{label} safetensors header exceeds its {MAX_SAFETENSORS_HEADER_BYTES}-byte limit"
+    );
+    let header_len = usize::try_from(header_bytes)
+        .with_context(|| format!("{label} safetensors header exceeds this address space"))?;
+    let mut header = Vec::new();
+    header
+        .try_reserve_exact(header_len)
+        .with_context(|| format!("reserving {label} safetensors header"))?;
+    header.resize(header_len, 0);
+    file.read_exact(&mut header)
+        .with_context(|| format!("{label} has a truncated safetensors header"))?;
+    let metadata: safetensors::tensor::Metadata = serde_json::from_slice(&header)
+        .with_context(|| format!("invalid safetensors metadata in {label}"))?;
+    let expected_file_bytes = 8_u64
+        .checked_add(header_bytes)
+        .and_then(|bytes| {
+            u64::try_from(metadata.data_len())
+                .ok()
+                .and_then(|data| bytes.checked_add(data))
+        })
+        .context("safetensors file length overflows u64")?;
+    ensure!(
+        expected_file_bytes == file_bytes,
+        "{label} safetensors metadata does not cover the exact file"
+    );
+
+    let mut parameters = 0_u64;
+    for tensor in metadata.tensors().into_values() {
+        let elements = tensor.shape.iter().try_fold(1_u64, |product, dimension| {
+            product
+                .checked_mul(u64::try_from(*dimension).context("tensor dimension exceeds u64")?)
+                .context("tensor element count overflows u64")
+        })?;
+        parameters = parameters
             .checked_add(elements)
             .context("model parameter count overflows u64")?;
     }
-    ensure!(total > 0, "model weights contain no tensors");
-    Ok(total)
+    ensure!(parameters > 0, "model weights contain no tensors");
+    ensure!(
+        StableIdentity::from_metadata(&file.metadata()?) == identity,
+        "{label} changed while its safetensors header was read"
+    );
+    Ok((file_bytes, digest, parameters))
 }
 
-fn read_regular_file(path: &Path, label: &str) -> Result<Vec<u8>> {
+fn checked_artifact_path(path: &Path, label: &str) -> Result<PathBuf> {
     let absolute;
     let path = if path.is_absolute() {
         path
@@ -1035,56 +1117,71 @@ fn read_regular_file(path: &Path, label: &str) -> Result<Vec<u8>> {
             parent.display()
         );
     }
-    let before = fs::symlink_metadata(path)
+    let metadata = fs::symlink_metadata(path)
         .with_context(|| format!("failed to inspect {label} at {}", path.display()))?;
     ensure!(
-        before.is_file() && !before.file_type().is_symlink(),
+        metadata.is_file() && !metadata.file_type().is_symlink(),
         "{label} must be a regular non-symlink file"
     );
-    let mut file = File::open(path)
-        .with_context(|| format!("failed to open {label} at {}", path.display()))?;
-    let opened = file
-        .metadata()
-        .with_context(|| format!("failed to inspect opened {label} at {}", path.display()))?;
-    ensure!(opened.is_file(), "{label} must open as a regular file");
+    Ok(path.to_owned())
+}
 
-    // Compare the lstat identity before and after open with fstat on the
-    // actual handle. This rejects a regular-file -> symlink/other-file swap in
-    // the check/open gap while retaining a stable handle for the read itself.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        ensure!(
-            before.dev() == opened.dev() && before.ino() == opened.ino(),
-            "{label} changed while it was opened"
-        );
-    }
-    let after = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to re-inspect {label} at {}", path.display()))?;
-    ensure!(
-        after.is_file() && !after.file_type().is_symlink(),
-        "{label} became a symlink or non-file while it was opened"
-    );
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        ensure!(
-            after.dev() == opened.dev() && after.ino() == opened.ino(),
-            "{label} changed while it was opened"
-        );
-    }
+fn read_json_file(path: &Path, label: &str) -> Result<Vec<u8>> {
+    read_json_file_with_identity(path, label).map(|(bytes, _)| bytes)
+}
 
-    let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes)
-        .with_context(|| format!("failed to read {label} at {}", path.display()))?;
-    let final_metadata = file
-        .metadata()
-        .with_context(|| format!("failed to inspect read {label} at {}", path.display()))?;
+fn read_json_file_with_identity(path: &Path, label: &str) -> Result<(Vec<u8>, StableIdentity)> {
+    let path = checked_artifact_path(path, label)?;
+    let (mut file, identity) = open_regular(&path, label)?;
+    let (_, _, bytes) = hash_open_file(&mut file, Some(MAX_BENCHMARK_JSON_BYTES), label)?;
+    ensure_path_identity(&path, &identity, label)?;
+    Ok((
+        bytes.context("bounded benchmark JSON read did not capture bytes")?,
+        identity,
+    ))
+}
+
+fn hash_file(path: &Path, label: &str) -> Result<(u64, String)> {
+    hash_file_with_identity(path, label).map(|(bytes, sha256, _)| (bytes, sha256))
+}
+
+fn hash_file_with_identity(path: &Path, label: &str) -> Result<(u64, String, StableIdentity)> {
+    let path = checked_artifact_path(path, label)?;
+    let (mut file, identity) = open_regular(&path, label)?;
+    let (bytes, digest, _) = hash_open_file(&mut file, None, label)
+        .with_context(|| format!("failed to hash {label} at {}", path.display()))?;
+    ensure_path_identity(&path, &identity, label)?;
+    Ok((bytes, digest, identity))
+}
+
+fn ensure_path_identity(path: &Path, expected: &StableIdentity, label: &str) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to reinspect {label} at {}", path.display()))?;
     ensure!(
-        final_metadata.len() == bytes.len() as u64,
-        "{label} changed length while it was read"
+        metadata.is_file() && !metadata.file_type().is_symlink(),
+        "{label} must remain a regular non-symlink file: {}",
+        path.display()
     );
-    Ok(bytes)
+    ensure!(
+        StableIdentity::from_metadata(&metadata) == *expected,
+        "{label} changed after verification: {}",
+        path.display()
+    );
+    Ok(())
+}
+
+const MAX_BENCHMARK_EVALUATOR_ARGUMENTS: usize = 64;
+const MAX_BENCHMARK_EVALUATOR_ARGUMENT_BYTES: usize = 4_096;
+
+pub(crate) fn validate_benchmark_evaluator_arguments(arguments: &[String]) -> Result<()> {
+    ensure!(
+        arguments.len() <= MAX_BENCHMARK_EVALUATOR_ARGUMENTS
+            && arguments.iter().all(|argument| {
+                argument.len() <= MAX_BENCHMARK_EVALUATOR_ARGUMENT_BYTES && !argument.contains('\0')
+            }),
+        "benchmark evaluator arguments exceed protocol limits"
+    );
+    Ok(())
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -1092,6 +1189,10 @@ fn read_regular_file(path: &Path, label: &str) -> Result<Vec<u8>> {
 pub struct BenchmarkRunConfig {
     pub evaluator_id: String,
     pub evaluator_version: String,
+    /// Exact UTF-8 argument vector passed to the pinned evaluator. Keeping it
+    /// in the content-addressed run configuration prevents two materially
+    /// different harness invocations from sharing one evaluator identity.
+    pub evaluator_arguments: Vec<String>,
     /// Strictly increasing order; the order itself is part of run identity.
     pub paired_seeds: Vec<u64>,
     /// Controls example ordering inside every evaluator.  A case-specific seed
@@ -1109,9 +1210,12 @@ impl BenchmarkRunConfig {
             !self.evaluator_id.trim().is_empty() && !self.evaluator_version.trim().is_empty(),
             "benchmark evaluator id and version are required"
         );
+        validate_sha256_identity(&self.evaluator_version, "benchmark evaluator version")
+            .context("benchmark evaluator_version is not a pinned executable identity")?;
+        validate_benchmark_evaluator_arguments(&self.evaluator_arguments)?;
         ensure!(
-            self.paired_seeds.len() >= MINIMUM_PAIRED_SEEDS,
-            "benchmarks require at least {MINIMUM_PAIRED_SEEDS} paired seeds"
+            (MINIMUM_PAIRED_SEEDS..=MAXIMUM_PAIRED_SEEDS).contains(&self.paired_seeds.len()),
+            "benchmarks require between {MINIMUM_PAIRED_SEEDS} and {MAXIMUM_PAIRED_SEEDS} paired seeds"
         );
         ensure!(
             self.paired_seeds.windows(2).all(|pair| pair[0] < pair[1]),
@@ -1137,6 +1241,7 @@ pub enum TargetRole {
 /// `max_gpu_hours`. `target` supplies training lineage and resource identity;
 /// it is not permission to substitute the checkpoint's FP weights for an
 /// HQUANT `model`.
+#[derive(Clone, Copy)]
 pub struct EvaluationRequest<'a> {
     pub suite_id: &'a str,
     pub visibility: SuiteVisibility,
@@ -1227,6 +1332,7 @@ pub struct RawCaseResult {
 pub struct BenchmarkRunMetadata {
     pub evaluator_id: String,
     pub evaluator_version: String,
+    pub evaluator_arguments: Vec<String>,
     pub paired_seeds: Vec<u64>,
     pub order_seed: u64,
     pub fixed_case_order: Vec<String>,
@@ -1320,9 +1426,16 @@ impl BenchmarkRun {
                 && !self.metadata.evaluator_version.trim().is_empty(),
             "benchmark run has no evaluator identity"
         );
+        validate_sha256_identity(
+            &self.metadata.evaluator_version,
+            "benchmark run evaluator version",
+        )
+        .context("benchmark run evaluator_version is not a pinned executable identity")?;
+        validate_benchmark_evaluator_arguments(&self.metadata.evaluator_arguments)?;
         ensure!(
-            self.metadata.paired_seeds.len() >= MINIMUM_PAIRED_SEEDS,
-            "benchmark run requires at least {MINIMUM_PAIRED_SEEDS} paired seeds"
+            (MINIMUM_PAIRED_SEEDS..=MAXIMUM_PAIRED_SEEDS)
+                .contains(&self.metadata.paired_seeds.len()),
+            "benchmark run requires between {MINIMUM_PAIRED_SEEDS} and {MAXIMUM_PAIRED_SEEDS} paired seeds"
         );
         ensure!(
             self.metadata
@@ -1364,7 +1477,7 @@ impl BenchmarkRun {
                 !suite_id.trim().is_empty(),
                 "empty suite id in run metadata"
             );
-            validate_sha256(digest)
+            validate_sha256_hex(digest, "benchmark suite manifest")
                 .with_context(|| format!("invalid manifest hash for suite `{suite_id}`"))?;
         }
 
@@ -1451,6 +1564,8 @@ pub struct VerifiedBenchmarkRun {
     pub(crate) run: BenchmarkRun,
     pub(crate) path: PathBuf,
     pub(crate) sha256: String,
+    bytes: Vec<u8>,
+    identity: StableIdentity,
 }
 
 impl VerifiedBenchmarkRun {
@@ -1467,9 +1582,10 @@ impl VerifiedBenchmarkRun {
     }
 
     pub fn load(path: impl AsRef<Path>, expected_sha256: &str) -> Result<Self> {
-        validate_sha256(expected_sha256).context("invalid expected benchmark run hash")?;
-        let path = path.as_ref();
-        let bytes = read_regular_file(path, "benchmark run")?;
+        validate_sha256_hex(expected_sha256, "expected benchmark run")
+            .context("invalid expected benchmark run hash")?;
+        let path = checked_artifact_path(path.as_ref(), "benchmark run")?;
+        let (bytes, identity) = read_json_file_with_identity(&path, "benchmark run")?;
         let actual = sha256_hex(&bytes);
         ensure!(
             actual.eq_ignore_ascii_case(expected_sha256),
@@ -1485,23 +1601,29 @@ impl VerifiedBenchmarkRun {
             run,
             path: path.to_path_buf(),
             sha256: actual,
+            bytes,
+            identity,
         })
     }
 
-    pub fn verify_contents(&self) -> Result<()> {
-        let bytes = read_regular_file(&self.path, "benchmark run")?;
+    fn verify_run_contents(&self) -> Result<()> {
+        ensure_path_identity(&self.path, &self.identity, "benchmark run")?;
         ensure!(
-            sha256_hex(&bytes) == self.sha256,
-            "benchmark run changed after verification: {}",
-            self.path.display()
+            sha256_hex(&self.bytes) == self.sha256,
+            "in-memory benchmark run differs from its verified bytes"
         );
-        let disk_run: BenchmarkRun = serde_json::from_slice(&bytes)
+        let disk_run: BenchmarkRun = serde_json::from_slice(&self.bytes)
             .with_context(|| format!("invalid benchmark run {}", self.path.display()))?;
         disk_run.validate()?;
         ensure!(
             serde_json::to_vec(&disk_run)? == serde_json::to_vec(&self.run)?,
             "in-memory benchmark run differs from its content-addressed artifact"
         );
+        Ok(())
+    }
+
+    pub fn verify_contents(&self) -> Result<()> {
+        self.verify_run_contents()?;
         self.run.metadata.baseline.verify()?;
         self.run.metadata.candidate.verify()?;
         Ok(())
@@ -1514,6 +1636,8 @@ pub struct VerifiedResourceComparison {
     pub(crate) comparison: ResourceComparison,
     pub(crate) path: PathBuf,
     pub(crate) sha256: String,
+    bytes: Vec<u8>,
+    identity: StableIdentity,
     exact_resume_verified: bool,
 }
 
@@ -1531,9 +1655,10 @@ impl VerifiedResourceComparison {
     }
 
     pub fn load(path: impl AsRef<Path>, expected_sha256: &str) -> Result<Self> {
-        validate_sha256(expected_sha256).context("invalid expected resource evidence hash")?;
-        let path = path.as_ref();
-        let bytes = read_regular_file(path, "resource evidence")?;
+        validate_sha256_hex(expected_sha256, "expected resource evidence")
+            .context("invalid expected resource evidence hash")?;
+        let path = checked_artifact_path(path.as_ref(), "resource evidence")?;
+        let (bytes, identity) = read_json_file_with_identity(&path, "resource evidence")?;
         let actual = sha256_hex(&bytes);
         ensure!(
             actual.eq_ignore_ascii_case(expected_sha256),
@@ -1545,23 +1670,24 @@ impl VerifiedResourceComparison {
         let comparison: ResourceComparison = serde_json::from_slice(&bytes)
             .with_context(|| format!("invalid resource evidence {}", path.display()))?;
         comparison.validate()?;
-        verify_resource_comparison_artifacts(&comparison, path)?;
+        verify_resource_comparison_artifacts(&comparison, &path)?;
         Ok(Self {
             comparison,
             path: path.to_path_buf(),
             sha256: actual,
+            bytes,
+            identity,
             exact_resume_verified: true,
         })
     }
 
     pub fn verify_contents(&self) -> Result<()> {
-        let bytes = read_regular_file(&self.path, "resource evidence")?;
+        ensure_path_identity(&self.path, &self.identity, "resource evidence")?;
         ensure!(
-            sha256_hex(&bytes) == self.sha256,
-            "resource evidence changed after verification: {}",
-            self.path.display()
+            sha256_hex(&self.bytes) == self.sha256,
+            "in-memory resource evidence differs from its verified bytes"
         );
-        let disk_comparison: ResourceComparison = serde_json::from_slice(&bytes)
+        let disk_comparison: ResourceComparison = serde_json::from_slice(&self.bytes)
             .with_context(|| format!("invalid resource evidence {}", self.path.display()))?;
         disk_comparison.validate()?;
         ensure!(
@@ -1602,8 +1728,8 @@ fn resolve_exact_resume_paths(evidence: &mut ExactResumeEvidence, source: &Path)
     }
 }
 
-fn read_exact_artifact(artifact: &ExactResumeArtifact, label: &str) -> Result<Vec<u8>> {
-    let bytes = read_regular_file(&artifact.path, label)?;
+fn read_exact_json(artifact: &ExactResumeArtifact, label: &str) -> Result<Vec<u8>> {
+    let bytes = read_json_file(&artifact.path, label)?;
     let actual = sha256_hex(&bytes);
     ensure!(
         actual.eq_ignore_ascii_case(&artifact.sha256),
@@ -1622,7 +1748,7 @@ fn verify_checkpoint_artifact(
             == Some("generation-manifest.json"),
         "{label} must address generation-manifest.json"
     );
-    let bytes = read_exact_artifact(artifact, label)?;
+    let bytes = read_exact_json(artifact, label)?;
     let manifest: CheckpointManifest =
         serde_json::from_slice(&bytes).with_context(|| format!("invalid {label}"))?;
     validate_checkpoint_manifest(&manifest, label)?;
@@ -1636,7 +1762,13 @@ fn verify_checkpoint_artifact(
         "{label} generation directory does not match its manifest hash"
     );
     for file in &manifest.files {
-        read_manifest_file(generation, file, &format!("{label} file `{}`", file.path))?;
+        let path = generation.join(&file.path);
+        let (bytes, sha256) = hash_file(&path, &format!("{label} file `{}`", file.path))?;
+        ensure!(
+            bytes == file.bytes && sha256.eq_ignore_ascii_case(&file.sha256),
+            "{label} file `{}` does not match the checkpoint manifest",
+            file.path
+        );
     }
     Ok(manifest)
 }
@@ -1675,13 +1807,23 @@ fn verify_exact_resume_artifacts(evidence: &ExactResumeEvidence) -> Result<()> {
         "interrupted and uninterrupted runs did not reach byte-identical final state"
     );
 
-    let uninterrupted_metrics = read_exact_artifact(
-        &evidence.uninterrupted_metrics,
+    let uninterrupted_path = checked_artifact_path(
+        &evidence.uninterrupted_metrics.path,
         "uninterrupted metric journal",
     )?;
-    let resumed_metrics = read_exact_artifact(&evidence.resumed_metrics, "resumed metric journal")?;
-    let uninterrupted_digest = metric_log_digests_from_bytes(&uninterrupted_metrics, None)?;
-    let resumed_digest = metric_log_digests_from_bytes(&resumed_metrics, None)?;
+    let resumed_path =
+        checked_artifact_path(&evidence.resumed_metrics.path, "resumed metric journal")?;
+    let uninterrupted_digest = metric_log_digests(&uninterrupted_path, None)?;
+    let resumed_digest = metric_log_digests(&resumed_path, None)?;
+    ensure!(
+        uninterrupted_digest
+            .raw_sha256
+            .eq_ignore_ascii_case(&evidence.uninterrupted_metrics.sha256)
+            && resumed_digest
+                .raw_sha256
+                .eq_ignore_ascii_case(&evidence.resumed_metrics.sha256),
+        "exact-resume metric journal hash mismatch"
+    );
     ensure!(
         uninterrupted_digest.last_global_step == Some(uninterrupted.global_step as u64)
             && resumed_digest.last_global_step == Some(resumed.global_step as u64),
@@ -1749,6 +1891,7 @@ pub fn evaluate_verified_promotion(
         comparison_runs,
         policy,
         policy_sha256,
+        &strongest_baseline_id,
         comparison,
         resources.path(),
     )?;
@@ -1781,7 +1924,7 @@ pub(crate) fn verified_resource_benchmark_context(
     selected_run: &VerifiedBenchmarkRun,
     comparison_runs: &[VerifiedBenchmarkRun],
 ) -> Result<String> {
-    selected_run.verify_contents()?;
+    selected_run.verify_run_contents()?;
     selected_run.run.validate()?;
     validate_run_catalog_coverage(&selected_run.run, false)?;
     let selected_occurrences = comparison_runs
@@ -1792,7 +1935,18 @@ pub(crate) fn verified_resource_benchmark_context(
         selected_occurrences == 1,
         "the selected benchmark run must occur exactly once in the comparison set"
     );
-    validate_comparison_set(comparison_runs)?;
+    let mut verified_targets = Vec::new();
+    verify_target_once(
+        &selected_run.run.metadata.baseline,
+        &selected_run.path,
+        &mut verified_targets,
+    )?;
+    verify_target_once(
+        &selected_run.run.metadata.candidate,
+        &selected_run.path,
+        &mut verified_targets,
+    )?;
+    validate_comparison_set(comparison_runs, &mut verified_targets)?;
     derive_strongest_baseline(comparison_runs)
 }
 
@@ -1831,7 +1985,32 @@ fn validate_run_catalog_coverage(run: &BenchmarkRun, include_later_sweeps: bool)
     Ok(())
 }
 
-fn validate_comparison_set(runs: &[VerifiedBenchmarkRun]) -> Result<()> {
+fn verify_target_once(
+    target: &BenchmarkTarget,
+    source: &Path,
+    verified_targets: &mut Vec<BenchmarkTarget>,
+) -> Result<()> {
+    // Resolve on a clone so the run stays byte-identical to its
+    // content-addressed artifact while verification reads the artifacts the
+    // run actually declared, never paths relative to the process directory.
+    let mut target = target.clone();
+    target.resolve_paths(source);
+    // The fixed ablation matrix deliberately reuses one candidate in every
+    // run. Its weights may be many gigabytes, so authenticate identical target
+    // transports once per comparison instead of re-reading them for each
+    // ablation. Distinct paths or resource claims remain distinct targets.
+    if verified_targets.contains(&target) {
+        return Ok(());
+    }
+    target.verify()?;
+    verified_targets.push(target);
+    Ok(())
+}
+
+fn validate_comparison_set(
+    runs: &[VerifiedBenchmarkRun],
+    verified_targets: &mut Vec<BenchmarkTarget>,
+) -> Result<()> {
     ensure!(
         runs.len() == AblationId::ALL.len(),
         "promotion comparison set must contain all {} fixed ablations",
@@ -1840,8 +2019,11 @@ fn validate_comparison_set(runs: &[VerifiedBenchmarkRun]) -> Result<()> {
     let reference = runs.first().context("promotion comparison set is empty")?;
     let mut ablations = BTreeSet::new();
     let mut baseline_ids = BTreeSet::new();
+    let mut baseline_checkpoints = BTreeSet::new();
     for run in runs {
-        run.verify_contents()?;
+        run.verify_run_contents()?;
+        verify_target_once(&run.run.metadata.baseline, &run.path, verified_targets)?;
+        verify_target_once(&run.run.metadata.candidate, &run.path, verified_targets)?;
         run.run.validate()?;
         validate_run_catalog_coverage(&run.run, false)?;
         let ablation = run
@@ -1857,6 +2039,17 @@ fn validate_comparison_set(runs: &[VerifiedBenchmarkRun]) -> Result<()> {
         ensure!(
             baseline_ids.insert(run.run.metadata.baseline.id.as_str()),
             "comparison set repeats baseline `{}`",
+            run.run.metadata.baseline.id
+        );
+        ensure!(
+            baseline_checkpoints.insert(
+                run.run
+                    .metadata
+                    .baseline
+                    .checkpoint_manifest_sha256
+                    .to_ascii_lowercase()
+            ),
+            "comparison baselines `{}` and another ablation reuse the same checkpoint",
             run.run.metadata.baseline.id
         );
         ensure!(
@@ -1881,6 +2074,7 @@ fn validate_comparison_compatibility(reference: &BenchmarkRun, run: &BenchmarkRu
     ensure!(
         left.evaluator_id == right.evaluator_id
             && left.evaluator_version == right.evaluator_version
+            && left.evaluator_arguments == right.evaluator_arguments
             && left.paired_seeds == right.paired_seeds
             && left.order_seed == right.order_seed
             && left.fixed_case_order == right.fixed_case_order
@@ -1893,7 +2087,7 @@ fn validate_comparison_compatibility(reference: &BenchmarkRun, run: &BenchmarkRu
                 right.gpu_hour_budget_per_target
             )
             && left.suite_manifest_sha256 == right.suite_manifest_sha256,
-        "comparison baseline `{}` was not evaluated with the fixed evaluator, order, suites, seeds, and compute budget",
+        "comparison baseline `{}` was not evaluated with the fixed evaluator invocation, order, suites, seeds, and compute budget",
         right.baseline.id
     );
     ensure!(
@@ -1922,9 +2116,7 @@ fn validate_comparison_compatibility(reference: &BenchmarkRun, run: &BenchmarkRu
             ensure!(
                 expected_pair.seed == actual_pair.seed
                     && expected_pair.example_order_seed == actual_pair.example_order_seed
-                    && expected_pair.candidate.score.to_bits()
-                        == actual_pair.candidate.score.to_bits()
-                    && expected_pair.candidate.examples == actual_pair.candidate.examples,
+                    && same_measurement(&expected_pair.candidate, &actual_pair.candidate),
                 "candidate measurement is not deterministic for `{}` seed {}",
                 expected.case_id,
                 expected_pair.seed
@@ -1932,6 +2124,19 @@ fn validate_comparison_compatibility(reference: &BenchmarkRun, run: &BenchmarkRu
         }
     }
     Ok(())
+}
+
+fn same_measurement(left: &EvaluationMeasurement, right: &EvaluationMeasurement) -> bool {
+    left.score.to_bits() == right.score.to_bits()
+        && left.gpu_hours.to_bits() == right.gpu_hours.to_bits()
+        && left.examples == right.examples
+        && left.metrics.len() == right.metrics.len()
+        && left.metrics.iter().all(|(name, value)| {
+            right
+                .metrics
+                .get(name)
+                .is_some_and(|other| value.to_bits() == other.to_bits())
+        })
 }
 
 fn same_target_identity(left: &BenchmarkTarget, right: &BenchmarkTarget) -> bool {
@@ -2078,23 +2283,39 @@ impl BenchmarkRunner {
                     pair_ordinal,
                     max_gpu_hours: self.config.gpu_hours_per_evaluation,
                 };
-                let baseline_measurement =
-                    evaluator.evaluate(&baseline_request).with_context(|| {
-                        format!("baseline evaluation failed for `{}` seed {seed}", case.id)
-                    })?;
-                baseline_measurement.validate(&case.id, self.config.gpu_hours_per_evaluation)?;
-
                 let candidate_request = EvaluationRequest {
                     target: candidate,
                     model: &candidate_model,
                     role: TargetRole::Candidate,
                     ..baseline_request
                 };
-                let candidate_measurement =
-                    evaluator.evaluate(&candidate_request).with_context(|| {
+                // Alternate pair order to counterbalance persistent-worker
+                // warm-cache, thermal, and allocator effects. Both requests
+                // retain the same pair ordinal, model seed, example order,
+                // and hard budget; only which role executes first changes.
+                let (baseline_measurement, candidate_measurement) = if pair_ordinal
+                    .is_multiple_of(2)
+                {
+                    let baseline = evaluator.evaluate(&baseline_request).with_context(|| {
+                        format!("baseline evaluation failed for `{}` seed {seed}", case.id)
+                    })?;
+                    baseline.validate(&case.id, self.config.gpu_hours_per_evaluation)?;
+                    let candidate = evaluator.evaluate(&candidate_request).with_context(|| {
                         format!("candidate evaluation failed for `{}` seed {seed}", case.id)
                     })?;
-                candidate_measurement.validate(&case.id, self.config.gpu_hours_per_evaluation)?;
+                    candidate.validate(&case.id, self.config.gpu_hours_per_evaluation)?;
+                    (baseline, candidate)
+                } else {
+                    let candidate = evaluator.evaluate(&candidate_request).with_context(|| {
+                        format!("candidate evaluation failed for `{}` seed {seed}", case.id)
+                    })?;
+                    candidate.validate(&case.id, self.config.gpu_hours_per_evaluation)?;
+                    let baseline = evaluator.evaluate(&baseline_request).with_context(|| {
+                        format!("baseline evaluation failed for `{}` seed {seed}", case.id)
+                    })?;
+                    baseline.validate(&case.id, self.config.gpu_hours_per_evaluation)?;
+                    (baseline, candidate)
+                };
 
                 pairs.push(RawPairedResult {
                     seed,
@@ -2117,11 +2338,23 @@ impl BenchmarkRunner {
             });
         }
 
+        // Evaluators receive paths and may run for hours. Re-authenticate all
+        // externally readable inputs before accepting their measurements so a
+        // replacement or in-place mutation during the run cannot become
+        // durable benchmark evidence. Target verification is intentionally
+        // repeated because it also binds sealed accounting to actual weights.
+        for suite in suites {
+            suite.verify_contents()?;
+        }
+        baseline.verify()?;
+        candidate.verify()?;
+
         let evaluation_count = raw_cases.len() * self.config.paired_seeds.len();
         let run = BenchmarkRun {
             metadata: BenchmarkRunMetadata {
                 evaluator_id: self.config.evaluator_id.clone(),
                 evaluator_version: self.config.evaluator_version.clone(),
+                evaluator_arguments: self.config.evaluator_arguments.clone(),
                 paired_seeds: self.config.paired_seeds.clone(),
                 order_seed: self.config.order_seed,
                 fixed_case_order,
@@ -2156,41 +2389,13 @@ fn same_f64(left: f64, right: f64) -> bool {
     (left - right).abs() <= f64::EPSILON * left.abs().max(right.abs()).max(1.0) * 8.0
 }
 
-fn validate_sha256(value: &str) -> Result<()> {
-    ensure!(
-        value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()),
-        "SHA-256 must contain exactly 64 hexadecimal characters"
-    );
-    Ok(())
-}
-
-fn validate_prefixed_sha256(value: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .context("SHA-256 identity must use sha256:<64 lowercase hex>")?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "SHA-256 identity must use sha256:<64 lowercase hex>"
-    );
-    Ok(())
-}
-
-fn sha256_hex(bytes: &[u8]) -> String {
-    let digest = Sha256::digest(bytes);
-    let mut output = String::with_capacity(64);
-    for byte in digest {
-        use std::fmt::Write as _;
-        write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
-    }
-    output
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn evaluator_sha256() -> String {
+        format!("sha256:{}", "e".repeat(64))
+    }
 
     struct MockEvaluator {
         calls: Vec<(String, u64, u64, TargetRole)>,
@@ -2258,7 +2463,9 @@ mod tests {
         let output = root.join(id);
         let staging = output.join("generations").join("staging");
         fs::create_dir_all(&staging).unwrap();
-        let salt = id.bytes().fold(0_u64, |sum, byte| sum + u64::from(byte)) as f32;
+        let salt = id.bytes().enumerate().fold(0_u64, |sum, (index, byte)| {
+            sum.wrapping_add((index as u64 + 1).wrapping_mul(u64::from(byte)))
+        }) as f32;
         let raw_weights = (0..parameters)
             .map(|index| ((index as f32 + salt) * 0.03125).sin())
             .flat_map(f32::to_le_bytes)
@@ -2752,7 +2959,8 @@ mod tests {
         let runner = BenchmarkRunner {
             config: BenchmarkRunConfig {
                 evaluator_id: "mock".into(),
-                evaluator_version: "1".into(),
+                evaluator_version: evaluator_sha256(),
+                evaluator_arguments: vec!["--profile=fixed".into()],
                 paired_seeds: vec![11, 22, 33],
                 order_seed: 7,
                 gpu_hours_per_evaluation: 0.25,
@@ -2768,15 +2976,26 @@ mod tests {
             run.metadata.fixed_case_order,
             ["public-score", "sealed-loss"]
         );
+        assert_eq!(run.metadata.evaluator_arguments, ["--profile=fixed"]);
         assert!(run.capacity_matched());
         assert_eq!(run.metadata.gpu_hour_budget_per_target, 1.5);
+        let mut differently_invoked = run.clone();
+        differently_invoked
+            .metadata
+            .evaluator_arguments
+            .push("--different".into());
+        assert!(validate_comparison_compatibility(&run, &differently_invoked).is_err());
         assert_eq!(evaluator.calls.len(), 12);
-        for calls in evaluator.calls.chunks_exact(2) {
+        for (pair_ordinal, calls) in evaluator.calls.chunks_exact(2).enumerate() {
             assert_eq!(calls[0].0, calls[1].0);
             assert_eq!(calls[0].1, calls[1].1);
             assert_eq!(calls[0].2, calls[1].2);
-            assert_eq!(calls[0].3, TargetRole::Baseline);
-            assert_eq!(calls[1].3, TargetRole::Candidate);
+            let expected_roles = if pair_ordinal.is_multiple_of(2) {
+                [TargetRole::Baseline, TargetRole::Candidate]
+            } else {
+                [TargetRole::Candidate, TargetRole::Baseline]
+            };
+            assert_eq!([calls[0].3, calls[1].3], expected_roles);
         }
 
         let (suite, results) = run.acceptance_inputs();
@@ -2788,6 +3007,77 @@ mod tests {
                 assert!((pair.candidate - pair.baseline - 0.1).abs() < 1e-12);
             }
         }
+    }
+
+    #[test]
+    fn runner_rejects_input_mutation_during_evaluation() {
+        struct MutatingEvaluator {
+            path: PathBuf,
+            mutated: bool,
+        }
+
+        impl BenchmarkEvaluator for MutatingEvaluator {
+            fn evaluate(
+                &mut self,
+                request: &EvaluationRequest<'_>,
+            ) -> Result<EvaluationMeasurement> {
+                if !self.mutated {
+                    fs::write(&self.path, b"tampered during evaluation\n")?;
+                    self.mutated = true;
+                }
+                Ok(EvaluationMeasurement {
+                    score: 0.5,
+                    gpu_hours: request.max_gpu_hours / 2.0,
+                    examples: 1,
+                    metrics: BTreeMap::new(),
+                })
+            }
+        }
+
+        let temporary = tempfile::tempdir().unwrap();
+        let suite = write_suite(
+            temporary.path(),
+            "public",
+            SuiteVisibility::Public,
+            "quality",
+            MetricDirection::Maximize,
+        );
+        let artifact = suite.artifact("quality").unwrap().path.clone();
+        let baseline = target(temporary.path(), "baseline", 100);
+        let candidate = target(temporary.path(), "candidate", 100);
+        let mut evaluator = MutatingEvaluator {
+            path: artifact,
+            mutated: false,
+        };
+        let error = BenchmarkRunner {
+            config: BenchmarkRunConfig {
+                evaluator_id: "mock".into(),
+                evaluator_version: evaluator_sha256(),
+                evaluator_arguments: Vec::new(),
+                paired_seeds: vec![1, 2, 3],
+                order_seed: 7,
+                gpu_hours_per_evaluation: 0.25,
+                ablation: None,
+            },
+        }
+        .run(&[suite], &baseline, &candidate, &mut evaluator)
+        .unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("changed after verification"), "{error}");
+    }
+
+    #[test]
+    fn benchmark_json_is_bounded_before_deserialization() {
+        let temporary = tempfile::tempdir().unwrap();
+        let path = temporary.path().join("oversized-run.json");
+        let file = fs::File::create(&path).unwrap();
+        file.set_len(MAX_BENCHMARK_JSON_BYTES + 1).unwrap();
+        drop(file);
+
+        let error = VerifiedBenchmarkRun::load(&path, &"0".repeat(64))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("byte limit"), "{error}");
     }
 
     #[test]
@@ -2953,8 +3243,11 @@ mod tests {
             unreachable!()
         };
         *candidate_manifest_sha256 = format!("sha256:{}", "0".repeat(64));
-        let error = wrong_hash.verify().unwrap_err().to_string();
-        assert!(error.contains("manifest identity mismatch"), "{error}");
+        let error = wrong_hash.verify().unwrap_err();
+        assert!(
+            format!("{error:#}").contains("receipt identity mismatch"),
+            "{error:#}"
+        );
 
         let mut wrong_storage = attach_hquant_candidate(
             temporary.path(),
@@ -3043,7 +3336,8 @@ mod tests {
         let runner = BenchmarkRunner {
             config: BenchmarkRunConfig {
                 evaluator_id: "hquant-backend".into(),
-                evaluator_version: "1".into(),
+                evaluator_version: evaluator_sha256(),
+                evaluator_arguments: Vec::new(),
                 paired_seeds: vec![1, 2, 3],
                 order_seed: 9,
                 gpu_hours_per_evaluation: 0.25,
@@ -3116,7 +3410,8 @@ mod tests {
         let run = BenchmarkRunner {
             config: BenchmarkRunConfig {
                 evaluator_id: "fixed".into(),
-                evaluator_version: "sha256:evaluator".into(),
+                evaluator_version: evaluator_sha256(),
+                evaluator_arguments: Vec::new(),
                 paired_seeds: vec![1, 2, 3],
                 order_seed: 7,
                 gpu_hours_per_evaluation: 0.25,
@@ -3235,7 +3530,8 @@ mod tests {
     fn runner_rejects_fewer_than_three_or_reordered_seeds() {
         let config = BenchmarkRunConfig {
             evaluator_id: "mock".into(),
-            evaluator_version: "1".into(),
+            evaluator_version: evaluator_sha256(),
+            evaluator_arguments: Vec::new(),
             paired_seeds: vec![2, 1, 3],
             order_seed: 0,
             gpu_hours_per_evaluation: 1.0,
@@ -3247,6 +3543,32 @@ mod tests {
             paired_seeds: vec![1, 2],
             ..config
         };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn benchmark_configuration_bounds_and_binds_evaluator_arguments() {
+        let mut config = BenchmarkRunConfig {
+            evaluator_id: "mock".into(),
+            evaluator_version: evaluator_sha256(),
+            evaluator_arguments: vec!["--profile=h100".into()],
+            paired_seeds: vec![1, 2, 3],
+            order_seed: 0,
+            gpu_hours_per_evaluation: 1.0,
+            ablation: None,
+        };
+        config.validate().unwrap();
+
+        config.evaluator_arguments = vec!["x".repeat(4_097)];
+        assert!(config.validate().is_err());
+        config.evaluator_arguments = vec!["x\0y".into()];
+        assert!(config.validate().is_err());
+        config.evaluator_arguments.clear();
+        config.evaluator_version = "latest".into();
+        assert!(config.validate().is_err());
+
+        config.evaluator_version = evaluator_sha256();
+        config.paired_seeds = (0..=MAXIMUM_PAIRED_SEEDS as u64).collect();
         assert!(config.validate().is_err());
     }
 
@@ -3301,7 +3623,8 @@ mod tests {
             let runner = BenchmarkRunner {
                 config: BenchmarkRunConfig {
                     evaluator_id: "fixed-evaluator".into(),
-                    evaluator_version: "sha256:evaluator".into(),
+                    evaluator_version: evaluator_sha256(),
+                    evaluator_arguments: Vec::new(),
                     paired_seeds: vec![11, 22, 33],
                     order_seed: 7,
                     gpu_hours_per_evaluation: 0.25,
@@ -3362,6 +3685,19 @@ mod tests {
         assert!(!serialized.contains("sealed-arc_dreaming"));
         assert!(!serialized.contains("sealed-pretraining_causal"));
 
+        let mut duplicate_baseline_run = runs[1].run.clone();
+        let distinct_label = duplicate_baseline_run.metadata.baseline.id.clone();
+        duplicate_baseline_run.metadata.baseline = runs[0].run.metadata.baseline.clone();
+        duplicate_baseline_run.metadata.baseline.id = distinct_label;
+        duplicate_baseline_run.validate().unwrap();
+        let duplicate_baseline = write_run(temporary.path(), 99, &duplicate_baseline_run);
+        let mut duplicate_matrix = runs.clone();
+        duplicate_matrix[1] = duplicate_baseline;
+        let error = verified_resource_benchmark_context(selected, &duplicate_matrix)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("reuse the same checkpoint"), "{error}");
+
         let mut in_memory_resources = resources.clone();
         in_memory_resources.comparison.wake_trials[0]
             .candidate
@@ -3393,6 +3729,69 @@ mod tests {
     }
 
     #[test]
+    fn comparison_matrix_requires_the_same_candidate_acceptance_measurement() {
+        let temporary = tempfile::tempdir().unwrap();
+        let public =
+            write_catalog_suite(temporary.path(), "public-catalog", SuiteVisibility::Public);
+        let sealed =
+            write_catalog_suite(temporary.path(), "sealed-catalog", SuiteVisibility::Sealed);
+        let candidate = target(temporary.path(), "candidate", 100);
+        let make_run =
+            |baseline_id: &str, ablation: AblationId, evaluator: &mut RankingEvaluator| {
+                BenchmarkRunner {
+                    config: BenchmarkRunConfig {
+                        evaluator_id: "fixed-evaluator".into(),
+                        evaluator_version: evaluator_sha256(),
+                        evaluator_arguments: Vec::new(),
+                        paired_seeds: vec![11, 22, 33],
+                        order_seed: 7,
+                        gpu_hours_per_evaluation: 0.25,
+                        ablation: Some(ablation),
+                    },
+                }
+                .run(
+                    &[public.clone(), sealed.clone()],
+                    &target(temporary.path(), baseline_id, 100),
+                    &candidate,
+                    evaluator,
+                )
+                .unwrap()
+            };
+        let reference = make_run("baseline-01", AblationId::WakeOnly, &mut RankingEvaluator);
+        let unchanged = make_run(
+            "baseline-02",
+            AblationId::StaticReplay,
+            &mut RankingEvaluator,
+        );
+        let mut changed = unchanged.clone();
+        changed.cases[0].pairs[0].candidate.gpu_hours /= 2.0;
+        changed.validate().unwrap();
+        let error = validate_comparison_compatibility(&reference, &changed)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("candidate measurement"), "{error}");
+
+        changed = unchanged.clone();
+        changed.cases[0].pairs[0]
+            .candidate
+            .metrics
+            .insert("timing_jitter".into(), 1.0);
+        changed.validate().unwrap();
+        let error = validate_comparison_compatibility(&reference, &changed)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("candidate measurement"), "{error}");
+
+        changed = unchanged;
+        changed.cases[0].pairs[0].candidate.score += 0.01;
+        changed.validate().unwrap();
+        let error = validate_comparison_compatibility(&reference, &changed)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("candidate measurement"), "{error}");
+    }
+
+    #[test]
     fn coverage_requires_each_public_and_sealed_catalog_case() {
         let temporary = tempfile::tempdir().unwrap();
         let public =
@@ -3404,6 +3803,23 @@ mod tests {
         let mut incomplete = sealed;
         incomplete.manifest.cases.pop();
         assert!(validate_catalog_coverage(&[public, incomplete], false).is_err());
+    }
+
+    #[test]
+    fn coverage_rejects_duplicate_catalog_entries_before_evaluation() {
+        let temporary = tempfile::tempdir().unwrap();
+        let mut public =
+            write_catalog_suite(temporary.path(), "public-catalog", SuiteVisibility::Public);
+        let sealed =
+            write_catalog_suite(temporary.path(), "sealed-catalog", SuiteVisibility::Sealed);
+        let mut duplicate = public.manifest.cases[0].clone();
+        duplicate.id.push_str("-duplicate");
+        public.manifest.cases.push(duplicate);
+
+        let error = validate_catalog_coverage(&[public, sealed], false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("repeats"), "{error}");
     }
 
     #[test]

--- a/hermes-train/src/benchmark_worker.rs
+++ b/hermes-train/src/benchmark_worker.rs
@@ -3,27 +3,37 @@
 //! Benchmark orchestration verifies suites and model manifests in-process. A
 //! long-lived local worker performs model-specific evaluation without making
 //! the benchmark framework depend on a particular generation or retrieval
-//! implementation. The executable is hashed before it starts, requests are
-//! strictly versioned, and every response is validated by `BenchmarkRunner`.
+//! implementation. The executable is opened and hashed before it starts,
+//! requests are strictly versioned, and every response is validated by
+//! `BenchmarkRunner`.
 
 use std::ffi::OsString;
-use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::process::{Child, Stdio};
+use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, ensure};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+use anyhow::{Context, Result, bail, ensure};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use crate::acceptance::SuiteVisibility;
+use crate::artifact_io::validate_sha256_identity;
 use crate::benchmark::{
     BenchmarkEvaluator, BenchmarkSpec, BenchmarkTarget, EvaluationMeasurement, EvaluationRequest,
     TargetRole, VerifiedArtifact, VerifiedModelRepresentation,
+    validate_benchmark_evaluator_arguments,
 };
+use crate::pinned_executable::file_sha256 as pinned_file_sha256;
+#[cfg(unix)]
+use crate::pinned_executable::{PinnedExecutable, StagedExecutable};
+#[cfg(unix)]
+use crate::protocol_process::{ProtocolRead, SupervisedProcess};
 
 pub const BENCHMARK_WORKER_PROTOCOL_VERSION: u32 = 2;
-const MAX_RESPONSE_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_BENCHMARK_EVALUATOR_TIMEOUT: Duration = Duration::from_secs(3_600);
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -50,10 +60,132 @@ struct BenchmarkWorkerResponse {
     measurement: EvaluationMeasurement,
 }
 
+#[cfg(unix)]
 struct RunningWorker {
-    child: Child,
-    input: Option<BufWriter<ChildStdin>>,
-    output: BufReader<ChildStdout>,
+    process: SupervisedProcess,
+}
+
+#[cfg(unix)]
+impl RunningWorker {
+    fn from_child(child: Child, executable: StagedExecutable) -> Result<Self> {
+        Ok(Self {
+            process: SupervisedProcess::new(
+                child,
+                executable,
+                "benchmark evaluator",
+                MAX_MESSAGE_BYTES,
+            )?,
+        })
+    }
+
+    fn exchange(&mut self, request: &[u8], timeout: Duration) -> Result<Vec<u8>> {
+        match self.process.read_line()? {
+            ProtocolRead::Line(_) => {
+                bail!("benchmark evaluator emitted an unsolicited response")
+            }
+            ProtocolRead::Eof => {
+                bail!("benchmark evaluator closed stdout before receiving a request")
+            }
+            ProtocolRead::Pending => ensure!(
+                !self.process.has_buffered_output(),
+                "benchmark evaluator emitted an unsolicited response"
+            ),
+        }
+        if let Some(status) = self.process.try_wait()? {
+            bail!("benchmark evaluator exited with status {status} before receiving a request");
+        }
+
+        let deadline = checked_deadline(timeout)?;
+        let mut written = 0_usize;
+        loop {
+            self.process.write_available(request, &mut written)?;
+            match self.process.read_line()? {
+                ProtocolRead::Line(line) => {
+                    ensure!(
+                        written == request.len(),
+                        "benchmark evaluator responded before consuming the complete request"
+                    );
+                    // Drain bytes that were queued with the response. A second
+                    // frame or partial frame is never assigned to the next
+                    // request on this persistent connection.
+                    match self.process.read_line()? {
+                        ProtocolRead::Line(_) => {
+                            bail!("benchmark evaluator emitted data after its response")
+                        }
+                        ProtocolRead::Pending => ensure!(
+                            !self.process.has_buffered_output(),
+                            "benchmark evaluator emitted data after its response"
+                        ),
+                        ProtocolRead::Eof => {}
+                    }
+                    return Ok(line);
+                }
+                ProtocolRead::Eof => match self.process.try_wait()? {
+                    Some(status) => {
+                        bail!("benchmark evaluator exited with status {status} before responding")
+                    }
+                    None => bail!("benchmark evaluator closed stdout before responding"),
+                },
+                ProtocolRead::Pending => {}
+            }
+            if let Some(status) = self.process.try_wait()? {
+                bail!("benchmark evaluator exited with status {status} before responding");
+            }
+            ensure_before_deadline(deadline, timeout)?;
+            self.process
+                .wait_for_activity(written < request.len(), deadline)?;
+        }
+    }
+
+    fn finish_protocol(&mut self, timeout: Duration) -> Result<()> {
+        self.process.close_input();
+        let deadline = checked_deadline(timeout)?;
+        loop {
+            match self.process.read_line()? {
+                ProtocolRead::Line(_) => {
+                    bail!("benchmark evaluator emitted an unsolicited response")
+                }
+                ProtocolRead::Pending => ensure!(
+                    !self.process.has_buffered_output(),
+                    "benchmark evaluator emitted an unsolicited response"
+                ),
+                ProtocolRead::Eof => {}
+            }
+            if let Some(status) = self.process.try_wait()? {
+                // A successful leader may leave a descendant holding stdout.
+                // The protocol grants no background-process lifetime, so reap
+                // the complete group before accepting the exit.
+                self.process.terminate_process_group();
+                ensure!(
+                    status.success(),
+                    "benchmark evaluator exited with status {status}"
+                );
+                return Ok(());
+            }
+            ensure_before_deadline(deadline, timeout)?;
+            self.process.wait_for_activity(false, deadline)?;
+        }
+    }
+
+    fn terminate(&mut self) {
+        self.process.terminate();
+    }
+}
+
+#[cfg(not(unix))]
+struct RunningWorker;
+
+#[cfg(not(unix))]
+impl RunningWorker {
+    fn exchange(&mut self, _: &[u8], _: Duration) -> Result<Vec<u8>> {
+        bail!("external benchmark evaluators require a Unix process host")
+    }
+
+    fn finish_protocol(&mut self, _: Duration) -> Result<()> {
+        bail!("external benchmark evaluators require a Unix process host")
+    }
+
+    fn terminate(&mut self) {}
 }
 
 /// Persistent evaluator process used for a complete paired benchmark run.
@@ -61,8 +193,9 @@ struct RunningWorker {
 /// artifact paths and immutable target metadata.
 pub struct ExternalBenchmarkEvaluator {
     executable: PathBuf,
-    arguments: Vec<OsString>,
+    arguments: Vec<String>,
     expected_sha256: String,
+    timeout: Duration,
     running: Option<RunningWorker>,
 }
 
@@ -72,108 +205,155 @@ impl ExternalBenchmarkEvaluator {
         arguments: Vec<OsString>,
         expected_sha256: impl Into<String>,
     ) -> Result<Self> {
+        let arguments = arguments
+            .into_iter()
+            .map(|argument| {
+                argument
+                    .into_string()
+                    .map_err(|_| anyhow::anyhow!("benchmark evaluator argument is not valid UTF-8"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        validate_benchmark_evaluator_arguments(&arguments)?;
         let evaluator = Self {
             executable: executable.into(),
             arguments,
             expected_sha256: expected_sha256.into(),
+            timeout: DEFAULT_BENCHMARK_EVALUATOR_TIMEOUT,
             running: None,
         };
         evaluator.verify_identity()?;
         Ok(evaluator)
     }
 
+    /// Set the hard wall-clock bound for each request and for graceful worker
+    /// shutdown. A timeout always kills and reaps the entire worker process
+    /// group before returning.
+    pub fn with_timeout(mut self, timeout: Duration) -> Result<Self> {
+        ensure!(
+            !timeout.is_zero(),
+            "benchmark evaluator timeout must be positive"
+        );
+        checked_deadline(timeout)?;
+        self.timeout = timeout;
+        Ok(self)
+    }
+
     pub fn expected_sha256(&self) -> &str {
         &self.expected_sha256
     }
 
+    /// Canonical argument vector that is part of benchmark run identity.
+    pub fn arguments(&self) -> &[String] {
+        &self.arguments
+    }
+
+    #[cfg(unix)]
     pub fn verify_identity(&self) -> Result<()> {
-        validate_sha256(&self.expected_sha256)?;
-        let metadata = std::fs::symlink_metadata(&self.executable).with_context(|| {
-            format!(
-                "benchmark evaluator {} is unavailable",
-                self.executable.display()
-            )
-        })?;
-        ensure!(
-            metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-            "benchmark evaluator {} must be a regular non-symlink file",
-            self.executable.display()
-        );
-        ensure!(
-            file_sha256(&self.executable)? == self.expected_sha256,
-            "benchmark evaluator {} does not match its pinned SHA-256",
-            self.executable.display()
-        );
+        validate_sha256_identity(&self.expected_sha256, "benchmark evaluator identity")?;
+        PinnedExecutable::verify(
+            &self.executable,
+            &self.expected_sha256,
+            "benchmark evaluator",
+        )?;
         Ok(())
     }
 
+    #[cfg(not(unix))]
+    pub fn verify_identity(&self) -> Result<()> {
+        bail!("external benchmark evaluators require a Unix process host")
+    }
+
+    #[cfg(unix)]
     fn start(&mut self) -> Result<()> {
         if self.running.is_some() {
             return Ok(());
         }
-        self.verify_identity()?;
-        let mut child = Command::new(&self.executable)
+        // Hash the opened descriptor and execute a private materialization of
+        // those exact bytes. A pathname replacement after verification cannot
+        // change the bytes selected for exec.
+        let executable = PinnedExecutable::open(
+            &self.executable,
+            &self.expected_sha256,
+            "benchmark evaluator",
+            "benchmark-evaluator",
+        )?;
+        let mut command = executable.command();
+        command
             .args(&self.arguments)
+            .env_clear()
+            .current_dir("/")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
-            .spawn()
-            .with_context(|| {
-                format!(
-                    "failed to start benchmark evaluator {}",
-                    self.executable.display()
-                )
-            })?;
-        let input = child
-            .stdin
-            .take()
-            .context("benchmark evaluator stdin is unavailable")?;
-        let output = child
-            .stdout
-            .take()
-            .context("benchmark evaluator stdout is unavailable")?;
-        self.running = Some(RunningWorker {
-            child,
-            input: Some(BufWriter::new(input)),
-            output: BufReader::new(output),
-        });
+            .process_group(0);
+        let child = command.spawn().with_context(|| {
+            format!(
+                "failed to start benchmark evaluator {}",
+                self.executable.display()
+            )
+        })?;
+        // Keep the private executable path alive for the lifetime of the
+        // worker. Shebang interpreters may open it after `spawn` returns.
+        self.running = Some(RunningWorker::from_child(child, executable.into_staged())?);
         Ok(())
     }
 
-    /// Close the protocol cleanly and require a successful worker exit. This
-    /// must be called after `BenchmarkRunner::run`; `Drop` only provides
-    /// best-effort cleanup on an earlier error.
+    #[cfg(not(unix))]
+    fn start(&mut self) -> Result<()> {
+        bail!("external benchmark evaluators require a Unix process host")
+    }
+
+    /// Close the protocol cleanly and require a successful worker exit.
     pub fn finish(mut self) -> Result<()> {
         let Some(mut running) = self.running.take() else {
             return Ok(());
         };
-        if let Some(mut input) = running.input.take() {
-            input.flush()?;
-            drop(input);
+        running.finish_protocol(self.timeout)
+    }
+
+    fn evaluate_wire(
+        &mut self,
+        wire: &BenchmarkWorkerRequest<'_>,
+    ) -> Result<EvaluationMeasurement> {
+        let mut request = serde_json::to_vec(wire)?;
+        ensure!(
+            request.len() < MAX_MESSAGE_BYTES,
+            "benchmark evaluator request exceeds {MAX_MESSAGE_BYTES} bytes"
+        );
+        request.push(b'\n');
+        self.start()?;
+        let result = self
+            .running
+            .as_mut()
+            .expect("benchmark worker was started above")
+            .exchange(&request, self.timeout)
+            .and_then(|line| {
+                let response: BenchmarkWorkerResponse = serde_json::from_slice(&line)
+                    .context("benchmark evaluator emitted invalid protocol JSON")?;
+                ensure!(
+                    response.version == BENCHMARK_WORKER_PROTOCOL_VERSION,
+                    "unsupported benchmark evaluator response version {}",
+                    response.version
+                );
+                Ok(response.measurement)
+            });
+        if result.is_err() {
+            // A protocol failure poisons stream framing. Never reuse that
+            // process for another evaluation.
+            if let Some(mut running) = self.running.take() {
+                running.terminate();
+            }
         }
-        ensure!(
-            read_bounded_line(&mut running.output)?.is_none(),
-            "benchmark evaluator emitted an unsolicited response"
-        );
-        let status = running.child.wait()?;
-        ensure!(
-            status.success(),
-            "benchmark evaluator exited with status {status}"
-        );
-        Ok(())
+        result
     }
 }
 
 impl BenchmarkEvaluator for ExternalBenchmarkEvaluator {
     fn evaluate(&mut self, request: &EvaluationRequest<'_>) -> Result<EvaluationMeasurement> {
-        self.start()?;
-        let running = self
-            .running
-            .as_mut()
-            .expect("benchmark worker was started above");
+        let expected_sha256 = self.expected_sha256.clone();
         let wire = BenchmarkWorkerRequest {
             version: BENCHMARK_WORKER_PROTOCOL_VERSION,
-            evaluator_sha256: &self.expected_sha256,
+            evaluator_sha256: &expected_sha256,
             suite_id: request.suite_id,
             visibility: request.visibility,
             case: request.case,
@@ -186,90 +366,24 @@ impl BenchmarkEvaluator for ExternalBenchmarkEvaluator {
             pair_ordinal: request.pair_ordinal,
             max_gpu_hours: request.max_gpu_hours,
         };
-        let input = running
-            .input
-            .as_mut()
-            .context("benchmark evaluator input is closed")?;
-        serde_json::to_writer(&mut *input, &wire)?;
-        input.write_all(b"\n")?;
-        input.flush()?;
-
-        let line = read_bounded_line(&mut running.output)?
-            .context("benchmark evaluator exited before responding")?;
-        let response: BenchmarkWorkerResponse = serde_json::from_slice(&line)
-            .context("benchmark evaluator emitted invalid protocol JSON")?;
-        ensure!(
-            response.version == BENCHMARK_WORKER_PROTOCOL_VERSION,
-            "unsupported benchmark evaluator response version {}",
-            response.version
-        );
-        Ok(response.measurement)
-    }
-}
-
-impl Drop for ExternalBenchmarkEvaluator {
-    fn drop(&mut self) {
-        if let Some(running) = &mut self.running {
-            let _ = running.input.take();
-            let _ = running.child.kill();
-            let _ = running.child.wait();
-        }
+        self.evaluate_wire(&wire)
     }
 }
 
 pub fn file_sha256(path: &Path) -> Result<String> {
-    let mut input = BufReader::new(
-        File::open(path).with_context(|| format!("failed to hash {}", path.display()))?,
-    );
-    let mut hasher = Sha256::new();
-    let mut buffer = [0_u8; 1024 * 1024];
-    loop {
-        let read = input.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(format!("sha256:{:x}", hasher.finalize()))
+    pinned_file_sha256(path)
 }
 
-fn read_bounded_line(reader: &mut impl BufRead) -> Result<Option<Vec<u8>>> {
-    let mut line = Vec::new();
-    loop {
-        let available = reader.fill_buf()?;
-        if available.is_empty() {
-            ensure!(
-                line.is_empty(),
-                "benchmark evaluator response is unterminated"
-            );
-            return Ok(None);
-        }
-        let take = available
-            .iter()
-            .position(|byte| *byte == b'\n')
-            .map_or(available.len(), |position| position + 1);
-        ensure!(
-            line.len() as u64 + take as u64 <= MAX_RESPONSE_BYTES,
-            "benchmark evaluator response exceeds {MAX_RESPONSE_BYTES} bytes"
-        );
-        line.extend_from_slice(&available[..take]);
-        reader.consume(take);
-        if line.ends_with(b"\n") {
-            return Ok(Some(line));
-        }
-    }
+fn checked_deadline(timeout: Duration) -> Result<Instant> {
+    Instant::now()
+        .checked_add(timeout)
+        .context("benchmark evaluator timeout is too large for the monotonic clock")
 }
 
-fn validate_sha256(value: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .context("evaluator identity must use `sha256:<64 lowercase hex>`")?;
+fn ensure_before_deadline(deadline: Instant, timeout: Duration) -> Result<()> {
     ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "evaluator identity must use `sha256:<64 lowercase hex>`"
+        Instant::now() < deadline,
+        "benchmark evaluator exceeded its {timeout:?} execution timeout"
     );
     Ok(())
 }
@@ -277,37 +391,34 @@ fn validate_sha256(value: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::time::Instant;
 
     use super::*;
     use crate::acceptance::{BenchmarkFamily, SuiteVisibility};
     use crate::benchmark::{BenchmarkArtifact, BenchmarkSpec, MetricDirection, TargetRole};
 
     #[cfg(unix)]
-    #[test]
-    fn persistent_worker_receives_strict_requests_and_finishes() {
+    fn worker_script(directory: &Path, body: &str) -> PathBuf {
         use std::os::unix::fs::PermissionsExt;
 
-        let directory = tempfile::tempdir().unwrap();
-        let worker = directory.path().join("evaluator.sh");
-        std::fs::write(
-            &worker,
-            concat!(
-                "#!/bin/sh\n",
-                "while IFS= read -r request; do\n",
-                "  test -n \"$request\" || exit 7\n",
-                "  case \"$request\" in *'\"model\":{\"type\":\"full_precision\",'*) ;; *) exit 8 ;; esac\n",
-                "  printf '%s\\n' '{\"version\":2,\"measurement\":{\"score\":0.75,\"gpu_hours\":0.01,\"examples\":4}}'\n",
-                "done\n"
-            ),
-        )
-        .unwrap();
+        let worker = directory.join("evaluator.sh");
+        std::fs::write(&worker, format!("#!/bin/sh\n{body}")).unwrap();
         let mut permissions = std::fs::metadata(&worker).unwrap().permissions();
         permissions.set_mode(0o700);
         std::fs::set_permissions(&worker, permissions).unwrap();
-        let hash = file_sha256(&worker).unwrap();
-        let mut evaluator = ExternalBenchmarkEvaluator::new(&worker, Vec::new(), &hash).unwrap();
+        worker
+    }
+
+    fn fixture(
+        directory: &Path,
+    ) -> (
+        VerifiedArtifact,
+        BenchmarkSpec,
+        BenchmarkTarget,
+        VerifiedModelRepresentation,
+    ) {
         let artifact = VerifiedArtifact {
-            path: directory.path().join("fixture.jsonl"),
+            path: directory.join("fixture.jsonl"),
             sha256: "1".repeat(64),
             bytes: 1,
         };
@@ -326,9 +437,9 @@ mod tests {
         };
         let target = BenchmarkTarget {
             id: "candidate".into(),
-            checkpoint_manifest: directory.path().join("checkpoint.json"),
+            checkpoint_manifest: directory.join("checkpoint.json"),
             checkpoint_manifest_sha256: "2".repeat(64),
-            training_evidence: directory.path().join("training-evidence.json"),
+            training_evidence: directory.join("training-evidence.json"),
             training_evidence_sha256: "3".repeat(64),
             training_gpu_hours: 1.0,
             parameters: 10,
@@ -337,11 +448,19 @@ mod tests {
             representation: crate::benchmark::ModelRepresentationTarget::FullPrecision,
         };
         let model = VerifiedModelRepresentation::FullPrecision {
-            weights: directory.path().join("weights.safetensors"),
+            weights: directory.join("weights.safetensors"),
             weights_sha256: "4".repeat(64),
             stored_bytes: 100,
         };
-        let request = EvaluationRequest {
+        (artifact, case, target, model)
+    }
+
+    fn evaluate_once(
+        evaluator: &mut ExternalBenchmarkEvaluator,
+        directory: &Path,
+    ) -> Result<EvaluationMeasurement> {
+        let (artifact, case, target, model) = fixture(directory);
+        evaluator.evaluate(&EvaluationRequest {
             suite_id: "public",
             visibility: SuiteVisibility::Public,
             case: &case,
@@ -353,11 +472,198 @@ mod tests {
             example_order_seed: 9,
             pair_ordinal: 0,
             max_gpu_hours: 0.1,
-        };
-        let first = evaluator.evaluate(&request).unwrap();
-        let second = evaluator.evaluate(&request).unwrap();
+        })
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persistent_worker_receives_strict_requests_and_finishes() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker = worker_script(
+            directory.path(),
+            concat!(
+                "while IFS= read -r request; do\n",
+                "  test -n \"$request\" || exit 7\n",
+                "  case \"$request\" in *'\"model\":{\"type\":\"full_precision\",'*) ;; *) exit 8 ;; esac\n",
+                "  test \"$(pwd)\" = / || exit 9\n",
+                "  test -z \"${HOME+x}\" || exit 10\n",
+                "  test \"$1\" = '--profile=a b' || exit 11\n",
+                "  printf '%s\\n' '{\"version\":2,\"measurement\":{\"score\":0.75,\"gpu_hours\":0.01,\"examples\":4}}'\n",
+                "done\n"
+            ),
+        );
+        let hash = file_sha256(&worker).unwrap();
+        let mut evaluator =
+            ExternalBenchmarkEvaluator::new(&worker, vec![OsString::from("--profile=a b")], &hash)
+                .unwrap();
+        assert_eq!(evaluator.arguments(), ["--profile=a b"]);
+        let first = evaluate_once(&mut evaluator, directory.path()).unwrap();
+        let second = evaluate_once(&mut evaluator, directory.path()).unwrap();
         assert_eq!(first.score, 0.75);
         assert_eq!(second.examples, 4);
         evaluator.finish().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn response_timeout_terminates_the_worker() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker = worker_script(directory.path(), "read -r request\n/bin/sleep 30\n");
+        let hash = file_sha256(&worker).unwrap();
+        let mut evaluator = ExternalBenchmarkEvaluator::new(&worker, Vec::new(), &hash)
+            .unwrap()
+            .with_timeout(Duration::from_millis(100))
+            .unwrap();
+        let started = Instant::now();
+        let error = evaluate_once(&mut evaluator, directory.path())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("execution timeout"), "{error}");
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(evaluator.running.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn finish_kills_descendants_that_retain_protocol_pipes() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker = worker_script(
+            directory.path(),
+            concat!(
+                "while IFS= read -r request; do\n",
+                "  printf '%s\\n' '{\"version\":2,\"measurement\":{\"score\":0.5,\"gpu_hours\":0.01,\"examples\":1}}'\n",
+                "done\n",
+                "/bin/sleep 30 &\n",
+                "exit 0\n"
+            ),
+        );
+        let hash = file_sha256(&worker).unwrap();
+        let mut evaluator = ExternalBenchmarkEvaluator::new(&worker, Vec::new(), &hash)
+            .unwrap()
+            // Process startup can contend with the other lifecycle tests;
+            // this remains far below the descendant's 30-second lifetime.
+            .with_timeout(Duration::from_secs(2))
+            .unwrap();
+        evaluate_once(&mut evaluator, directory.path()).unwrap();
+        let started = Instant::now();
+        evaluator.finish().unwrap();
+        assert!(started.elapsed() < Duration::from_secs(4));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn finish_timeout_terminates_a_worker_that_does_not_exit() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker = worker_script(
+            directory.path(),
+            concat!(
+                "while IFS= read -r request; do\n",
+                "  printf '%s\\n' '{\"version\":2,\"measurement\":{\"score\":0.5,\"gpu_hours\":0.01,\"examples\":1}}'\n",
+                "done\n",
+                "/bin/sleep 30\n"
+            ),
+        );
+        let hash = file_sha256(&worker).unwrap();
+        let mut evaluator = ExternalBenchmarkEvaluator::new(&worker, Vec::new(), &hash)
+            .unwrap()
+            .with_timeout(Duration::from_secs(2))
+            .unwrap();
+        evaluate_once(&mut evaluator, directory.path()).unwrap();
+        let started = Instant::now();
+        let error = evaluator.finish().unwrap_err().to_string();
+        assert!(error.contains("execution timeout"), "{error}");
+        assert!(started.elapsed() < Duration::from_secs(4));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn malformed_response_poisoning_cleans_up_the_worker() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker = worker_script(
+            directory.path(),
+            "read -r request\nprintf '%s\\n' '{not-json}'\n/bin/sleep 30\n",
+        );
+        let hash = file_sha256(&worker).unwrap();
+        let mut evaluator = ExternalBenchmarkEvaluator::new(&worker, Vec::new(), &hash)
+            .unwrap()
+            .with_timeout(Duration::from_secs(3))
+            .unwrap();
+        let error = evaluate_once(&mut evaluator, directory.path())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("invalid protocol JSON"), "{error}");
+        assert!(evaluator.running.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extra_response_is_rejected_and_worker_is_cleaned_up() {
+        let directory = tempfile::tempdir().unwrap();
+        let response =
+            "{\"version\":2,\"measurement\":{\"score\":0.5,\"gpu_hours\":0.01,\"examples\":1}}";
+        let worker = worker_script(
+            directory.path(),
+            &format!(
+                "read -r request\nprintf '%s\\n%s\\n' '{response}' '{response}'\n/bin/sleep 30\n"
+            ),
+        );
+        let hash = file_sha256(&worker).unwrap();
+        let mut evaluator = ExternalBenchmarkEvaluator::new(&worker, Vec::new(), &hash)
+            .unwrap()
+            .with_timeout(Duration::from_secs(3))
+            .unwrap();
+        let error = evaluate_once(&mut evaluator, directory.path())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("data after its response"), "{error}");
+        assert!(evaluator.running.is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn evaluator_arguments_are_canonical_and_bounded() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let worker = worker_script(directory.path(), "exit 0\n");
+        let hash = file_sha256(&worker).unwrap();
+
+        let error =
+            ExternalBenchmarkEvaluator::new(&worker, vec![OsString::from_vec(vec![0xff])], &hash)
+                .err()
+                .unwrap()
+                .to_string();
+        assert!(error.contains("not valid UTF-8"), "{error}");
+
+        let error =
+            ExternalBenchmarkEvaluator::new(&worker, vec![OsString::from("argument"); 65], &hash)
+                .err()
+                .unwrap()
+                .to_string();
+        assert!(error.contains("exceed protocol limits"), "{error}");
+
+        let error =
+            ExternalBenchmarkEvaluator::new(&worker, vec![OsString::from("contains\0nul")], &hash)
+                .err()
+                .unwrap()
+                .to_string();
+        assert!(error.contains("exceed protocol limits"), "{error}");
+    }
+
+    #[test]
+    fn timeout_must_be_positive() {
+        let directory = tempfile::tempdir().unwrap();
+        #[cfg(unix)]
+        {
+            let worker = worker_script(directory.path(), "exit 0\n");
+            let hash = file_sha256(&worker).unwrap();
+            let error = ExternalBenchmarkEvaluator::new(&worker, Vec::new(), &hash)
+                .unwrap()
+                .with_timeout(Duration::ZERO)
+                .err()
+                .unwrap()
+                .to_string();
+            assert!(error.contains("timeout must be positive"));
+        }
     }
 }

--- a/hermes-train/src/builtin_dreaming.rs
+++ b/hermes-train/src/builtin_dreaming.rs
@@ -7,38 +7,53 @@
 //! No corpus, network handle, or caller-provided reward enters this module.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(test)]
+use std::fs;
 
 use anyhow::{Context, Result, bail, ensure};
 use burn::module::{AutodiffModule, Module, ModuleVisitor, Param};
 use burn::tensor::{Int, Tensor, TensorData};
+use burn_nn::loss::CrossEntropyLossConfig;
 use burn_optim::GradientsParams;
 use hermes_llm::{Device, MemoryRouting, Transformer};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::artifact_io::{
+    atomic_write_new, ensure_directory, read_regular_bounded, sha256_identity,
+    validate_sha256_identity,
+};
 use crate::builtin_sleep_adapters::{PinnedLocalArtifact, PinnedWakeContextJournal};
-use crate::sleep::{ConsolidationTxn, DreamTrial, GeneratedDream, RngReservation};
+use crate::sleep::{ConsolidationTxn, DreamTrial, DreamingConfig, GeneratedDream, RngReservation};
 use crate::tensor_sleep::{TokenRolloutBatch, TransformerDreamOps, model_parameter_hash};
 
 pub const DREAM_SEQUENCE_SET_VERSION: u32 = 1;
-const DREAM_CANDIDATE_VERSION: u32 = 2;
-const DREAM_MANIFEST_VERSION: u32 = 2;
-const DREAM_GENERATION_RECEIPT_VERSION: u32 = 2;
-const DREAM_ADAPTER_VERSION: u32 = 2;
-const RESTEM_POLICY_VERSION: u32 = 2;
-const GENERATION_POLICY_ADAPTER_VERSION: u32 = 1;
-const DREAM_ROUTING_NAME: &str = "memory_dream_random_extra_expert_v1";
+const DREAM_CANDIDATE_VERSION: u32 = 3;
+const DREAM_MANIFEST_VERSION: u32 = 3;
+const DREAM_GENERATION_RECEIPT_VERSION: u32 = 3;
+const DREAM_ADAPTER_VERSION: u32 = 3;
+pub(crate) const RESTEM_POLICY_VERSION: u32 = 3;
+const GENERATION_POLICY_ADAPTER_VERSION: u32 = 2;
+const DREAM_ROUTING_NAME: &str = "memory_dream_cached_random_extra_expert_v2";
 const DREAM_LORA_TARGET_MODULE: &str = "transformer.output_projection";
 const GENERATION_POLICY_TARGET_MODULE: &str = "transformer.output_projection.dream_policy";
 const GRADIENT_PROJECTION_DOMAIN: u64 = 0x6772_6164_2d70_726f;
 const GENERATION_DOMAIN: u64 = 0x6472_6561_6d2d_6765;
 const LORA_DOMAIN: u64 = 0x6c6f_7261_2d74_7269;
 
-static TEMPORARY_ORDINAL: AtomicU64 = AtomicU64::new(0);
+const MAX_DREAM_JSON_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_DREAM_ADAPTER_BYTES: u64 = 512 * 1024 * 1024;
+const MAX_DREAM_ADAPTER_PARAMETER_BYTES: u64 = MAX_DREAM_ADAPTER_BYTES - MAX_DREAM_JSON_BYTES;
+const MAX_DREAM_LM_HEAD_DATA_BYTES: usize = 512 * 1024 * 1024;
+const MAX_DREAM_SEQUENCES: usize = 4_096;
+const MAX_DREAM_SEQUENCE_TOKENS: usize = 65_536;
+const MAX_DREAM_SEQUENCE_TOTAL_TOKENS: usize = 4 * 1024 * 1024;
+const MAX_DREAM_SEQUENCE_ID_BYTES: usize = 1_024;
+const MAX_RESTEM_POLICY_GENERATIONS: usize = 4_096;
+const MAX_DREAM_CANDIDATE_TOKENS: usize =
+    MAX_DREAM_SEQUENCE_TOKENS + BuiltinDreamingRuntimeConfig::MAX_NEW_TOKENS;
 
 fn default_max_new_tokens() -> usize {
     32
@@ -109,6 +124,10 @@ pub struct BuiltinDreamingRuntimeConfig {
 }
 
 impl BuiltinDreamingRuntimeConfig {
+    pub const MAX_NEW_TOKENS: usize = 4_096;
+    pub const MAX_GRADIENT_DIMENSIONS: usize = 4_096;
+    pub const MAX_LORA_STEPS: usize = 1_024;
+
     pub fn resolve_paths(mut self, base: &Path) -> Result<Self> {
         ensure!(!base.as_os_str().is_empty(), "Dreaming path base is empty");
         if self.artifact_directory.is_relative() {
@@ -135,10 +154,25 @@ impl BuiltinDreamingRuntimeConfig {
         );
         ensure!(self.max_new_tokens > 0, "Dreaming must generate tokens");
         ensure!(
+            self.max_new_tokens <= Self::MAX_NEW_TOKENS,
+            "Dreaming max_new_tokens exceeds the {}-token operational limit",
+            Self::MAX_NEW_TOKENS
+        );
+        ensure!(
             self.gradient_dimensions > 0,
             "Dreaming gradient projection is empty"
         );
+        ensure!(
+            self.gradient_dimensions <= Self::MAX_GRADIENT_DIMENSIONS,
+            "Dreaming gradient dimensions exceed the {}-dimension operational limit",
+            Self::MAX_GRADIENT_DIMENSIONS
+        );
         ensure!(self.lora_steps > 0, "Dreaming LoRA steps must be positive");
+        ensure!(
+            self.lora_steps <= Self::MAX_LORA_STEPS,
+            "Dreaming LoRA steps exceed the {}-step operational limit",
+            Self::MAX_LORA_STEPS
+        );
         ensure!(
             self.generation_temperature.is_finite() && self.generation_temperature > 0.0,
             "Dreaming generation temperature must be finite and positive"
@@ -146,6 +180,16 @@ impl BuiltinDreamingRuntimeConfig {
         ensure!(
             self.generation_policy_rank > 0 && self.generation_policy_alpha > 0,
             "Dreaming generation-policy LoRA geometry must be positive"
+        );
+        ensure!(
+            self.generation_policy_rank <= DreamingConfig::MAX_LORA_RANK,
+            "Dreaming generation-policy LoRA rank exceeds the {}-rank operational limit",
+            DreamingConfig::MAX_LORA_RANK
+        );
+        ensure!(
+            self.generation_policy_alpha <= DreamingConfig::MAX_LORA_ALPHA,
+            "Dreaming generation-policy LoRA alpha exceeds the {} operational limit",
+            DreamingConfig::MAX_LORA_ALPHA
         );
         ensure!(
             self.lora_learning_rate.is_finite() && self.lora_learning_rate > 0.0,
@@ -156,15 +200,15 @@ impl BuiltinDreamingRuntimeConfig {
             "Dreaming ReSTEM learning rate must be finite and positive"
         );
         if let Some(journal) = &self.wake_context_journal {
-            validate_sha256(&journal.sha256, "wake-context journal")?;
+            validate_sha256_identity(&journal.sha256, "wake-context journal")?;
         }
-        validate_sha256(&self.reference_set.sha256, "Dreaming reference set")?;
-        validate_sha256(
+        validate_sha256_identity(&self.reference_set.sha256, "Dreaming reference set")?;
+        validate_sha256_identity(
             &self.independent_evaluation_set.sha256,
             "Dreaming independent evaluator",
         )?;
         if let Some(policy) = &self.initial_policy {
-            validate_sha256(&policy.sha256, "Dreaming initial policy")?;
+            validate_sha256_identity(&policy.sha256, "Dreaming initial policy")?;
         }
         Ok(())
     }
@@ -218,11 +262,16 @@ impl DreamSequenceSet {
             self.version
         );
         ensure!(!self.sequences.is_empty(), "Dreaming sequence set is empty");
+        ensure!(
+            self.sequences.len() <= MAX_DREAM_SEQUENCES,
+            "Dreaming sequence set exceeds the {MAX_DREAM_SEQUENCES}-sequence operational limit"
+        );
         let mut ids = BTreeSet::new();
+        let mut total_tokens = 0usize;
         for sequence in &self.sequences {
             ensure!(
-                !sequence.id.trim().is_empty(),
-                "Dreaming sequence id is empty"
+                !sequence.id.trim().is_empty() && sequence.id.len() <= MAX_DREAM_SEQUENCE_ID_BYTES,
+                "Dreaming sequence id must contain 1..={MAX_DREAM_SEQUENCE_ID_BYTES} bytes"
             );
             ensure!(
                 ids.insert(sequence.id.as_str()),
@@ -235,8 +284,23 @@ impl DreamSequenceSet {
                 sequence.id
             );
             ensure!(
-                sequence.token_ids.iter().all(|token| *token >= 0),
-                "Dreaming sequence `{}` contains a negative token",
+                sequence.token_ids.len() <= MAX_DREAM_SEQUENCE_TOKENS,
+                "Dreaming sequence `{}` exceeds the {MAX_DREAM_SEQUENCE_TOKENS}-token operational limit",
+                sequence.id
+            );
+            total_tokens = total_tokens
+                .checked_add(sequence.token_ids.len())
+                .context("Dreaming sequence-set token count overflow")?;
+            ensure!(
+                total_tokens <= MAX_DREAM_SEQUENCE_TOTAL_TOKENS,
+                "Dreaming sequence set exceeds the {MAX_DREAM_SEQUENCE_TOTAL_TOKENS}-token operational limit"
+            );
+            ensure!(
+                sequence
+                    .token_ids
+                    .iter()
+                    .all(|token| u32::try_from(*token).is_ok()),
+                "Dreaming sequence `{}` contains a token outside the u32 range",
                 sequence.id
             );
         }
@@ -327,19 +391,20 @@ impl AdapterReceipt {
             "unsupported dream-adapter version {}",
             self.version
         );
-        validate_sha256(&self.base_checkpoint_sha256, "dream LoRA base checkpoint")?;
-        validate_sha256(
+        validate_sha256_identity(&self.base_checkpoint_sha256, "dream LoRA base checkpoint")?;
+        validate_sha256_identity(
             &self.base_model_parameter_sha256,
             "dream LoRA base-model parameters",
         )?;
-        validate_sha256(
+        validate_sha256_identity(
             &self.candidate_artifact_hash,
             "dream LoRA candidate artifact",
         )?;
-        validate_sha256(&self.evaluator_hash, "dream LoRA evaluator")?;
+        validate_sha256_identity(&self.evaluator_hash, "dream LoRA evaluator")?;
         ensure!(
-            !self.candidate_id.trim().is_empty(),
-            "dream LoRA candidate ID is empty"
+            !self.candidate_id.trim().is_empty()
+                && self.candidate_id.len() <= MAX_DREAM_SEQUENCE_ID_BYTES,
+            "dream LoRA candidate ID is invalid"
         );
         ensure!(
             self.target_module == DREAM_LORA_TARGET_MODULE,
@@ -351,12 +416,18 @@ impl AdapterReceipt {
             "dream LoRA receipt has invalid geometry"
         );
         ensure!(
+            self.rank <= DreamingConfig::MAX_LORA_RANK
+                && self.alpha <= DreamingConfig::MAX_LORA_ALPHA,
+            "dream LoRA receipt geometry exceeds operational limits"
+        );
+        ensure!(
             self.a_shape == [self.rank, self.input_features]
                 && self.b_shape == [self.rank, self.output_features],
             "dream LoRA tensor shapes do not match its target geometry"
         );
         ensure!(
             self.steps > 0
+                && self.steps <= BuiltinDreamingRuntimeConfig::MAX_LORA_STEPS
                 && self.learning_rate.is_finite()
                 && self.learning_rate > 0.0
                 && [
@@ -417,22 +488,22 @@ impl RestemPolicyState {
             self.version
         );
         if let Some(parent) = &self.parent_policy_sha256 {
-            validate_sha256(parent, "ReSTEM parent policy")?;
+            validate_sha256_identity(parent, "ReSTEM parent policy")?;
         }
         if let Some(parent) = &self.parent_adapter_sha256 {
-            validate_sha256(parent, "ReSTEM parent adapter")?;
+            validate_sha256_identity(parent, "ReSTEM parent adapter")?;
         }
         ensure!(
             self.parent_policy_sha256.is_some() == self.parent_adapter_sha256.is_some(),
             "ReSTEM parent binding is incomplete"
         );
-        validate_sha256(&self.source_checkpoint_sha256, "ReSTEM source checkpoint")?;
-        validate_sha256(
+        validate_sha256_identity(&self.source_checkpoint_sha256, "ReSTEM source checkpoint")?;
+        validate_sha256_identity(
             &self.source_model_parameter_sha256,
             "ReSTEM source model parameters",
         )?;
-        validate_sha256(&self.topology_sha256, "ReSTEM model topology")?;
-        validate_sha256(&self.adapter_sha256, "ReSTEM generation adapter")?;
+        validate_sha256_identity(&self.topology_sha256, "ReSTEM model topology")?;
+        validate_sha256_identity(&self.adapter_sha256, "ReSTEM generation adapter")?;
         ensure!(
             self.target_module == GENERATION_POLICY_TARGET_MODULE,
             "ReSTEM policy targets unsupported module `{}`",
@@ -443,6 +514,15 @@ impl RestemPolicyState {
             "ReSTEM policy has invalid adapter geometry"
         );
         ensure!(
+            self.rank <= DreamingConfig::MAX_LORA_RANK
+                && self.alpha <= DreamingConfig::MAX_LORA_ALPHA,
+            "ReSTEM policy adapter geometry exceeds operational limits"
+        );
+        ensure!(
+            self.iterations <= DreamingConfig::MAX_RESTEM_ITERATIONS,
+            "ReSTEM policy iteration count exceeds the operational limit"
+        );
+        ensure!(
             self.learning_rate.is_finite() && self.learning_rate > 0.0,
             "ReSTEM policy has an invalid learning rate"
         );
@@ -451,19 +531,23 @@ impl RestemPolicyState {
             "ReSTEM policy accepted-candidate evidence is incomplete"
         );
         ensure!(
+            self.accepted_candidates.len() <= DreamingConfig::MAX_CANDIDATES,
+            "ReSTEM policy accepted-candidate evidence exceeds the operational limit"
+        );
+        ensure!(
             (self.iterations == 0) == self.accepted_candidates.is_empty(),
             "ReSTEM policy update count disagrees with accepted trials"
         );
         let mut candidates = BTreeSet::new();
         for hash in &self.accepted_candidates {
-            validate_sha256(hash, "ReSTEM accepted candidate")?;
+            validate_sha256_identity(hash, "ReSTEM accepted candidate")?;
             ensure!(
                 candidates.insert(hash),
                 "ReSTEM policy repeats an accepted candidate"
             );
         }
         for hash in &self.accepted_adapters {
-            validate_sha256(hash, "ReSTEM accepted adapter")?;
+            validate_sha256_identity(hash, "ReSTEM accepted adapter")?;
         }
         Ok(())
     }
@@ -500,20 +584,20 @@ impl GenerationPolicyAdapterReceipt {
             "unsupported generation-policy adapter version {}",
             self.version
         );
-        validate_sha256(
+        validate_sha256_identity(
             &self.source_checkpoint_sha256,
             "generation-policy source checkpoint",
         )?;
-        validate_sha256(
+        validate_sha256_identity(
             &self.source_model_parameter_sha256,
             "generation-policy source model parameters",
         )?;
-        validate_sha256(&self.topology_sha256, "generation-policy topology")?;
+        validate_sha256_identity(&self.topology_sha256, "generation-policy topology")?;
         if let Some(parent) = &self.parent_policy_sha256 {
-            validate_sha256(parent, "generation-policy parent policy")?;
+            validate_sha256_identity(parent, "generation-policy parent policy")?;
         }
         if let Some(parent) = &self.parent_adapter_sha256 {
-            validate_sha256(parent, "generation-policy parent adapter")?;
+            validate_sha256_identity(parent, "generation-policy parent adapter")?;
         }
         ensure!(
             self.parent_policy_sha256.is_some() == self.parent_adapter_sha256.is_some(),
@@ -529,6 +613,11 @@ impl GenerationPolicyAdapterReceipt {
             "generation-policy adapter has invalid geometry"
         );
         ensure!(
+            self.rank <= DreamingConfig::MAX_LORA_RANK
+                && self.alpha <= DreamingConfig::MAX_LORA_ALPHA,
+            "generation-policy adapter geometry exceeds operational limits"
+        );
+        ensure!(
             self.a_shape == [self.rank, self.input_features]
                 && self.b_shape == [self.rank, self.output_features],
             "generation-policy adapter shapes do not match its geometry"
@@ -536,6 +625,14 @@ impl GenerationPolicyAdapterReceipt {
         ensure!(
             self.learning_rate.is_finite() && self.learning_rate > 0.0,
             "generation-policy adapter has invalid learning rate"
+        );
+        ensure!(
+            self.iterations <= DreamingConfig::MAX_RESTEM_ITERATIONS,
+            "generation-policy adapter iteration count exceeds the operational limit"
+        );
+        ensure!(
+            self.accepted_candidates.len() <= DreamingConfig::MAX_CANDIDATES,
+            "generation-policy adapter accepted-trial evidence exceeds the operational limit"
         );
         ensure!(
             self.accepted_candidates.len() == self.accepted_trial_adapters.len()
@@ -555,7 +652,7 @@ impl GenerationPolicyAdapterReceipt {
             .iter()
             .chain(&self.accepted_trial_adapters)
         {
-            validate_sha256(hash, "generation-policy accepted artifact")?;
+            validate_sha256_identity(hash, "generation-policy accepted artifact")?;
         }
         let a_values = self
             .rank
@@ -577,6 +674,7 @@ pub struct BuiltinDreamOps {
     evaluation_set: DreamSequenceSet,
     initial_policy: Option<RestemPolicyState>,
     generation_policy: Option<HostLmHeadLora>,
+    evaluation_cache: Option<DeviceEvaluationCache>,
     bound_teacher_sha256: String,
     device: Device,
 }
@@ -622,6 +720,7 @@ impl BuiltinDreamOps {
             evaluation_set,
             initial_policy,
             generation_policy: None,
+            evaluation_cache: None,
             bound_teacher_sha256,
             device,
         };
@@ -660,8 +759,8 @@ impl BuiltinDreamOps {
         phase_input_sha256: &str,
         teacher_sha256: &str,
     ) -> Result<()> {
-        validate_sha256(phase_input_sha256, "Dreaming phase input")?;
-        validate_sha256(teacher_sha256, "Dreaming transaction teacher")?;
+        validate_sha256_identity(phase_input_sha256, "Dreaming phase input")?;
+        validate_sha256_identity(teacher_sha256, "Dreaming transaction teacher")?;
         ensure!(
             self.journal.source_checkpoint_sha256() == phase_input_sha256,
             "Dreaming wake journal belongs to {}, authenticated phase input is {}",
@@ -732,7 +831,7 @@ impl BuiltinDreamOps {
 
     fn generation_receipt_path(&self, txn: &ConsolidationTxn) -> PathBuf {
         let mut key = Sha256::new();
-        key.update(b"hermes-dream-generation-receipt-key-v1\0");
+        key.update(b"hermes-dream-generation-receipt-key-v2\0");
         key.update(txn.id.to_le_bytes());
         key.update(self.journal.sha256().as_bytes());
         key.update(
@@ -770,7 +869,7 @@ impl BuiltinDreamOps {
         if !path.exists() {
             return Ok(None);
         }
-        let bytes = read_regular_file(&path, "Dreaming generation receipt")?;
+        let bytes = read_regular_json(&path, "Dreaming generation receipt")?;
         let receipt: DreamGenerationReceipt = serde_json::from_slice(&bytes)?;
         let shared_candidate = txn.candidate_hash.as_deref().unwrap_or(&txn.student_hash);
         let (policy_sha256, adapter_sha256) = self.generation_policy_identity();
@@ -788,7 +887,7 @@ impl BuiltinDreamOps {
                     == self.config.generation_temperature.to_bits(),
             "completed Dreaming generation receipt disagrees with retry request"
         );
-        validate_sha256(&receipt.manifest_sha256, "Dreaming receipt manifest")?;
+        validate_sha256_identity(&receipt.manifest_sha256, "Dreaming receipt manifest")?;
         let dreams = self.load(txn, &receipt.manifest_sha256)?;
         ensure!(
             dreams.len() == candidate_count,
@@ -798,7 +897,7 @@ impl BuiltinDreamOps {
     }
 
     fn read_candidate(&self, hash: &str) -> Result<DreamCandidateArtifact> {
-        let bytes = read_addressed(&self.candidate_path(hash)?, hash, "dream candidate")?;
+        let bytes = read_addressed_json(&self.candidate_path(hash)?, hash, "dream candidate")?;
         let artifact: DreamCandidateArtifact = serde_json::from_slice(&bytes)?;
         ensure!(
             artifact.version == DREAM_CANDIDATE_VERSION,
@@ -806,8 +905,9 @@ impl BuiltinDreamOps {
             artifact.version
         );
         ensure!(
-            artifact.wake_journal_sha256 == self.journal.sha256(),
-            "dream candidate belongs to another wake journal"
+            artifact.wake_journal_sha256 == self.journal.sha256()
+                && artifact.source_checkpoint_sha256 == self.journal.source_checkpoint_sha256(),
+            "dream candidate belongs to another wake journal or source checkpoint"
         );
         ensure!(
             artifact.routing == DREAM_ROUTING_NAME,
@@ -826,8 +926,28 @@ impl BuiltinDreamOps {
             "dream candidate is too short"
         );
         ensure!(
+            artifact.token_ids.len() <= MAX_DREAM_CANDIDATE_TOKENS,
+            "dream candidate exceeds the {MAX_DREAM_CANDIDATE_TOKENS}-token operational limit"
+        );
+        ensure!(
+            artifact.wake_record_id.len() <= MAX_DREAM_SEQUENCE_ID_BYTES
+                && !artifact.wake_record_id.trim().is_empty(),
+            "dream candidate wake-record id is invalid"
+        );
+        ensure!(
+            artifact.ordinal < DreamingConfig::MAX_CANDIDATES,
+            "dream candidate ordinal exceeds the operational limit"
+        );
+        ensure!(
             artifact.wake_token_count > 0 && artifact.wake_token_count < artifact.token_ids.len(),
             "dream candidate has an invalid wake-prefix length"
+        );
+        ensure!(
+            artifact
+                .token_ids
+                .iter()
+                .all(|token| u32::try_from(*token).is_ok()),
+            "dream candidate contains a token outside the u32 range"
         );
         ensure!(
             artifact.generation_temperature.is_finite() && artifact.generation_temperature > 0.0,
@@ -839,10 +959,10 @@ impl BuiltinDreamOps {
             "dream candidate has an incomplete generation-policy binding"
         );
         if let Some(policy) = &artifact.generation_policy_sha256 {
-            validate_sha256(policy, "dream candidate generation policy")?;
+            validate_sha256_identity(policy, "dream candidate generation policy")?;
         }
         if let Some(adapter) = &artifact.generation_policy_adapter_sha256 {
-            validate_sha256(adapter, "dream candidate generation adapter")?;
+            validate_sha256_identity(adapter, "dream candidate generation adapter")?;
         }
         Ok(artifact)
     }
@@ -869,8 +989,82 @@ impl BuiltinDreamOps {
     }
 
     fn sequence_lm_head_rows(&self, model: &Transformer, tokens: &[i64]) -> Result<LmHeadRows> {
-        self.model_sequence(model, tokens, "LoRA sequence")?;
-        let rows = tokens.len() - 1;
+        self.wake_lm_head_rows(model, tokens, 1, "LoRA sequence")
+    }
+
+    fn candidate_lm_head_rows(
+        &self,
+        model: &Transformer,
+        artifact: &DreamCandidateArtifact,
+    ) -> Result<LmHeadRows> {
+        ensure!(
+            artifact.wake_token_count > 0 && artifact.wake_token_count < artifact.token_ids.len(),
+            "dream LoRA candidate has an invalid wake-prefix length"
+        );
+        self.wake_lm_head_rows(
+            model,
+            &artifact.token_ids,
+            artifact.wake_token_count,
+            "dream LoRA candidate",
+        )
+    }
+
+    fn evaluation_lm_head_rows(
+        &mut self,
+        model: &Transformer,
+        model_parameter_sha256: &str,
+    ) -> Result<Vec<DeviceLmHeadRows>> {
+        if let Some(cache) = self
+            .evaluation_cache
+            .as_ref()
+            .filter(|cache| cache.model_parameter_sha256 == model_parameter_sha256)
+        {
+            return Ok(cache.rows.clone());
+        }
+        let total_rows =
+            self.evaluation_set
+                .sequences
+                .iter()
+                .try_fold(0usize, |total, sequence| {
+                    total
+                        .checked_add(sequence.token_ids.len() - 1)
+                        .context("Dreaming evaluation row count overflow")
+                })?;
+        checked_lm_head_row_geometry(
+            total_rows,
+            model.config().hidden_size,
+            model.config().vocab_size,
+        )?;
+        let rows = self
+            .evaluation_set
+            .sequences
+            .iter()
+            .map(|sequence| self.sequence_lm_head_rows(model, &sequence.token_ids))
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .map(|rows| rows.into_device(&self.device))
+            .collect::<Result<Vec<_>>>()?;
+        self.evaluation_cache = Some(DeviceEvaluationCache {
+            model_parameter_sha256: model_parameter_sha256.to_owned(),
+            rows: rows.clone(),
+        });
+        Ok(rows)
+    }
+
+    fn wake_lm_head_rows(
+        &self,
+        model: &Transformer,
+        tokens: &[i64],
+        target_start: usize,
+        label: &str,
+    ) -> Result<LmHeadRows> {
+        self.model_sequence(model, tokens, label)?;
+        ensure!(
+            target_start > 0 && target_start < tokens.len(),
+            "{label} has an invalid supervised-token range"
+        );
+        let input_rows = tokens.len() - 1;
+        let rows = tokens.len() - target_start;
         let devices = model.devices();
         ensure!(
             devices.len() == 1,
@@ -879,11 +1073,14 @@ impl BuiltinDreamOps {
         );
         let device = devices[0].clone();
         let inputs = Tensor::<2, Int>::from_data(
-            TensorData::new(tokens[..rows].to_vec(), [1, rows]),
+            TensorData::new(tokens[..input_rows].to_vec(), [1, input_rows]),
             &device,
         );
         let positions = Tensor::<1, Int>::from_data(
-            TensorData::new((0..rows as i64).collect::<Vec<_>>(), [rows]),
+            TensorData::new(
+                ((target_start - 1) as i64..input_rows as i64).collect::<Vec<_>>(),
+                [rows],
+            ),
             &device,
         );
         let projector = model.prepare_selected_logits(inputs, positions);
@@ -901,8 +1098,9 @@ impl BuiltinDreamOps {
             .context("reading frozen LM-head base logits")?;
         let hidden = model.config().hidden_size;
         let vocab = model.config().vocab_size;
+        let (feature_values, logit_values) = checked_lm_head_row_geometry(rows, hidden, vocab)?;
         ensure!(
-            features.len() == rows * hidden && base_logits.len() == rows * vocab,
+            features.len() == feature_values && base_logits.len() == logit_values,
             "frozen LM-head feature/logit shape mismatch"
         );
         ensure!(
@@ -918,7 +1116,10 @@ impl BuiltinDreamOps {
             vocab: model.config().vocab_size,
             features,
             base_logits,
-            targets: tokens[1..].iter().map(|token| *token as usize).collect(),
+            targets: tokens[target_start..]
+                .iter()
+                .map(|token| *token as usize)
+                .collect(),
         })
     }
 
@@ -933,45 +1134,71 @@ impl BuiltinDreamOps {
             "ReSTEM dream sequence has an invalid wake-prefix length"
         );
         let rows = artifact.token_ids.len() - artifact.wake_token_count;
-        let mut features = Vec::with_capacity(rows * model.config().hidden_size);
-        let mut base_logits = Vec::with_capacity(rows * model.config().vocab_size);
-        let mut targets = Vec::with_capacity(rows);
+        let (feature_values, logit_values) = checked_lm_head_row_geometry(
+            rows,
+            model.config().hidden_size,
+            model.config().vocab_size,
+        )?;
+        let mut feature_rows = Vec::new();
+        feature_rows
+            .try_reserve_exact(rows)
+            .context("reserving ReSTEM hidden-state tensors")?;
+        let mut logit_rows = Vec::new();
+        logit_rows
+            .try_reserve_exact(rows)
+            .context("reserving ReSTEM logit tensors")?;
+        let mut targets = Vec::new();
+        targets
+            .try_reserve_exact(rows)
+            .context("reserving ReSTEM target rows")?;
+        let devices = model.devices();
+        ensure!(
+            devices.len() == 1,
+            "frozen ReSTEM model spans {} devices",
+            devices.len()
+        );
+        let device = &devices[0];
+        let mut state = model.make_state_with_capacity(1, artifact.token_ids.len() - 1, device);
         for generated in 0..rows {
             let prefix = artifact.wake_token_count + generated;
             let step_seed =
                 mix64(artifact.generation_seed ^ generated as u64 ^ artifact.routing_seed);
-            self.device.seed(step_seed);
+            device.seed(step_seed);
+            let input_tokens = if generated == 0 {
+                &artifact.token_ids[..prefix]
+            } else {
+                &artifact.token_ids[prefix - 1..prefix]
+            };
             let input = Tensor::<2, Int>::from_data(
-                TensorData::new(artifact.token_ids[..prefix].to_vec(), [1, prefix]),
-                &self.device,
+                TensorData::new(input_tokens.to_vec(), [1, input_tokens.len()]),
+                device,
             );
-            let position = Tensor::<1, Int>::from_data(
-                TensorData::new(vec![(prefix - 1) as i64], [1]),
-                &self.device,
-            );
-            let projector = model.prepare_selected_logits_with_memory_routing(
-                input,
-                position,
-                MemoryRouting::Dream { seed: step_seed },
-            );
-            features.extend(
-                projector
-                    .hidden(0..1)
-                    .into_data()
-                    .convert::<f32>()
-                    .to_vec::<f32>()
-                    .context("reading ReSTEM dream hidden state")?,
-            );
-            base_logits.extend(
-                projector
-                    .logits(0..1)
-                    .into_data()
-                    .convert::<f32>()
-                    .to_vec::<f32>()
-                    .context("reading ReSTEM dream base logits")?,
-            );
+            let (hidden, logits) = model
+                .forward_next_features_and_logits_with_state_and_memory_routing(
+                    input,
+                    &mut state,
+                    MemoryRouting::Dream { seed: step_seed },
+                );
+            feature_rows.push(hidden);
+            logit_rows.push(logits);
             targets.push(artifact.token_ids[prefix] as usize);
         }
+        let features = Tensor::cat(feature_rows, 0)
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .context("reading ReSTEM dream hidden states")?;
+        let base_logits = Tensor::cat(logit_rows, 0)
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .context("reading ReSTEM dream base logits")?;
+        ensure!(
+            features.len() == feature_values
+                && base_logits.len() == logit_values
+                && targets.len() == rows,
+            "ReSTEM LM-head feature/logit shape mismatch"
+        );
         ensure!(
             features
                 .iter()
@@ -1116,12 +1343,16 @@ impl BuiltinDreamOps {
         head_sha256: &str,
         head: &RestemPolicyState,
     ) -> Result<HostLmHeadLora> {
-        validate_sha256(head_sha256, "ReSTEM head policy")?;
+        validate_sha256_identity(head_sha256, "ReSTEM head policy")?;
         let mut current_hash = head_sha256.to_owned();
         let mut current = head.clone();
         let mut seen = BTreeSet::new();
         let mut head_adapter = None;
         loop {
+            ensure!(
+                seen.len() < MAX_RESTEM_POLICY_GENERATIONS,
+                "ReSTEM policy chain exceeds the {MAX_RESTEM_POLICY_GENERATIONS}-generation operational limit"
+            );
             ensure!(
                 seen.insert(current_hash.clone()),
                 "ReSTEM policy parent chain contains a cycle"
@@ -1139,7 +1370,7 @@ impl BuiltinDreamOps {
                 );
                 break;
             };
-            let bytes = read_addressed(
+            let bytes = read_addressed_json(
                 &self.policy_path(&parent_hash)?,
                 &parent_hash,
                 "ReSTEM parent policy",
@@ -1197,6 +1428,11 @@ impl TransformerDreamOps for BuiltinDreamOps {
     ) -> Result<(String, Vec<GeneratedDream>)> {
         self.validate_transaction(txn)?;
         ensure!(candidate_count > 0, "Dreaming candidate count is zero");
+        ensure!(
+            candidate_count <= DreamingConfig::MAX_CANDIDATES,
+            "Dreaming candidate count exceeds the {}-candidate operational limit",
+            DreamingConfig::MAX_CANDIDATES
+        );
         let reservation = txn
             .dream_generation_rng
             .context("Dreaming generation has no persisted RNG reservation")?;
@@ -1207,14 +1443,30 @@ impl TransformerDreamOps for BuiltinDreamOps {
         let MemoryRouting::Dream { seed: routing_seed } = routing else {
             bail!("Dreaming generation must use random-extra-expert routing");
         };
+        ensure!(
+            routing_seed == txn.id,
+            "Dreaming routing seed must equal the persisted transaction ID"
+        );
         if let Some(completed) =
             self.completed_generation(txn, candidate_count, reservation, routing_seed)?
         {
             return Ok(completed);
         }
         self.validate_generation_policy_for_model(model)?;
+        let generation_model = model.clone().valid();
+        let generation_devices = generation_model.devices();
         ensure!(
-            self.config.max_new_tokens < model.config().max_seq_len,
+            generation_devices.len() == 1,
+            "Dreaming generation model spans {} devices",
+            generation_devices.len()
+        );
+        let generation_device = &generation_devices[0];
+        let generation_policy = self
+            .generation_policy
+            .as_ref()
+            .map(|policy| DeviceLmHeadPolicy::from_host(policy, generation_device));
+        ensure!(
+            self.config.max_new_tokens < generation_model.config().max_seq_len,
             "Dreaming continuation must be shorter than model context"
         );
 
@@ -1222,48 +1474,51 @@ impl TransformerDreamOps for BuiltinDreamOps {
         for ordinal in 0..candidate_count {
             let generation_seed = derive_seed(txn, reservation, GENERATION_DOMAIN, ordinal as u64);
             let record = &self.journal.records()[self.select_context_index(generation_seed)];
-            let available = model.config().max_seq_len - self.config.max_new_tokens;
+            let available = generation_model.config().max_seq_len - self.config.max_new_tokens;
             let keep = record.token_ids.len().min(available).max(1);
             let mut tokens = record.token_ids[record.token_ids.len() - keep..].to_vec();
             ensure!(
-                tokens
-                    .iter()
-                    .all(|token| *token >= 0 && (*token as usize) < model.config().vocab_size),
+                tokens.iter().all(|token| {
+                    *token >= 0 && (*token as usize) < generation_model.config().vocab_size
+                }),
                 "wake context `{}` contains an out-of-vocabulary token",
                 record.id
             );
+            let state_capacity = keep
+                .checked_add(self.config.max_new_tokens - 1)
+                .context("Dreaming inference-state capacity overflow")?;
+            let mut state =
+                generation_model.make_state_with_capacity(1, state_capacity, generation_device);
             for step in 0..self.config.max_new_tokens {
                 let step_seed = mix64(generation_seed ^ step as u64 ^ routing_seed);
-                self.device.seed(step_seed);
-                let input = Tensor::<2, Int>::from_data(
-                    TensorData::new(tokens.clone(), [1, tokens.len()]),
-                    &self.device,
-                );
-                let position = Tensor::<1, Int>::from_data(
-                    TensorData::new(vec![(tokens.len() - 1) as i64], [1]),
-                    &self.device,
-                );
-                let projector = model.prepare_selected_logits_with_memory_routing(
-                    input,
-                    position,
-                    MemoryRouting::Dream { seed: step_seed },
-                );
-                let features = projector
-                    .hidden(0..1)
-                    .into_data()
-                    .convert::<f32>()
-                    .to_vec::<f32>()
-                    .context("reading Dreaming generation hidden state")?;
-                let base_logits = projector
-                    .logits(0..1)
-                    .into_data()
-                    .convert::<f32>()
-                    .to_vec::<f32>()
-                    .context("reading Dreaming logits")?;
-                let logits = match &self.generation_policy {
-                    Some(policy) => policy.adapted(&features, &base_logits)?.1,
-                    None => base_logits,
+                generation_device.seed(step_seed);
+                let input_tokens = if step == 0 {
+                    &tokens[..]
+                } else {
+                    &tokens[tokens.len() - 1..]
                 };
+                let input = Tensor::<2, Int>::from_data(
+                    TensorData::new(input_tokens.to_vec(), [1, input_tokens.len()]),
+                    generation_device,
+                );
+                let (features, base_logits) = generation_model
+                    .forward_next_features_and_logits_with_state_and_memory_routing(
+                        input,
+                        &mut state,
+                        MemoryRouting::Dream { seed: step_seed },
+                    );
+                let logits = match &generation_policy {
+                    Some(policy) => policy.adapted(features, base_logits)?,
+                    None => base_logits,
+                }
+                .into_data()
+                .convert::<f32>()
+                .to_vec::<f32>()
+                .context("reading Dreaming generation logits")?;
+                ensure!(
+                    logits.len() == generation_model.config().vocab_size,
+                    "Dreaming generation logit shape mismatch"
+                );
                 let next = sample_temperature(
                     &logits,
                     self.config.generation_temperature,
@@ -1271,7 +1526,7 @@ impl TransformerDreamOps for BuiltinDreamOps {
                 )?;
                 tokens.push(next as i64);
             }
-            self.model_sequence(model, &tokens, "generated dream")?;
+            self.model_sequence(&generation_model, &tokens, "generated dream")?;
             let (policy_sha256, adapter_sha256) = self.generation_policy_identity();
             let artifact = DreamCandidateArtifact {
                 version: DREAM_CANDIDATE_VERSION,
@@ -1290,7 +1545,7 @@ impl TransformerDreamOps for BuiltinDreamOps {
                 token_ids: tokens.clone(),
             };
             let bytes = canonical_json(&artifact)?;
-            let artifact_hash = sha256_bytes(&bytes);
+            let artifact_hash = sha256_identity(&bytes);
             publish_immutable(&self.candidate_path(&artifact_hash)?, &bytes)?;
             let gradient = gradient_fingerprint(
                 model,
@@ -1322,7 +1577,7 @@ impl TransformerDreamOps for BuiltinDreamOps {
             dreams: dreams.clone(),
         };
         let bytes = canonical_json(&manifest)?;
-        let hash = sha256_bytes(&bytes);
+        let hash = sha256_identity(&bytes);
         publish_immutable(&self.manifest_path(&hash)?, &bytes)?;
         let receipt = DreamGenerationReceipt {
             version: DREAM_GENERATION_RECEIPT_VERSION,
@@ -1350,7 +1605,8 @@ impl TransformerDreamOps for BuiltinDreamOps {
 
     fn load(&mut self, txn: &ConsolidationTxn, manifest: &str) -> Result<Vec<GeneratedDream>> {
         self.validate_transaction(txn)?;
-        let bytes = read_addressed(&self.manifest_path(manifest)?, manifest, "dream manifest")?;
+        let bytes =
+            read_addressed_json(&self.manifest_path(manifest)?, manifest, "dream manifest")?;
         let artifact: DreamManifest = serde_json::from_slice(&bytes)?;
         ensure!(
             artifact.version == DREAM_MANIFEST_VERSION,
@@ -1360,6 +1616,10 @@ impl TransformerDreamOps for BuiltinDreamOps {
         ensure!(
             artifact.transaction_id == txn.id,
             "dream manifest transaction mismatch"
+        );
+        ensure!(
+            Some(artifact.generation_reservation) == txn.dream_generation_rng,
+            "dream manifest RNG reservation differs from its transaction"
         );
         ensure!(
             artifact.wake_journal_sha256 == self.journal.sha256()
@@ -1379,12 +1639,22 @@ impl TransformerDreamOps for BuiltinDreamOps {
             "dream manifest generation-policy binding mismatch"
         );
         ensure!(!artifact.dreams.is_empty(), "dream manifest is empty");
+        ensure!(
+            artifact.dreams.len() <= DreamingConfig::MAX_CANDIDATES,
+            "dream manifest exceeds the {}-candidate operational limit",
+            DreamingConfig::MAX_CANDIDATES
+        );
         let mut ids = BTreeSet::new();
-        for dream in &artifact.dreams {
+        for (ordinal, dream) in artifact.dreams.iter().enumerate() {
+            ensure!(
+                !dream.id.trim().is_empty() && dream.id.len() <= MAX_DREAM_SEQUENCE_ID_BYTES,
+                "dream manifest contains an invalid id"
+            );
             ensure!(
                 ids.insert(dream.id.as_str()),
                 "dream manifest repeats an id"
             );
+            validate_sha256_identity(&dream.artifact_hash, "dream candidate")?;
             ensure!(
                 dream.gradient.len() == self.config.gradient_dimensions
                     && dream.gradient.iter().all(|value| value.is_finite()),
@@ -1395,6 +1665,45 @@ impl TransformerDreamOps for BuiltinDreamOps {
             ensure!(
                 candidate.transaction_id == txn.id,
                 "dream candidate transaction mismatch"
+            );
+            ensure!(
+                candidate.ordinal == ordinal
+                    && candidate.generation_seed
+                        == derive_seed(
+                            txn,
+                            artifact.generation_reservation,
+                            GENERATION_DOMAIN,
+                            ordinal as u64,
+                        )
+                    && candidate.routing_seed == txn.id,
+                "dream candidate ordinal or generation seed is inconsistent with its manifest"
+            );
+            ensure!(
+                candidate.token_ids.len() - candidate.wake_token_count
+                    == self.config.max_new_tokens,
+                "dream candidate continuation length differs from runtime configuration"
+            );
+            let record = self
+                .journal
+                .records()
+                .iter()
+                .find(|record| record.id == candidate.wake_record_id)
+                .context("dream candidate wake record is absent from its journal")?;
+            ensure!(
+                candidate.wake_token_count <= record.token_ids.len()
+                    && candidate.token_ids[..candidate.wake_token_count]
+                        == record.token_ids[record.token_ids.len() - candidate.wake_token_count..],
+                "dream candidate wake prefix differs from its journal record"
+            );
+            ensure!(
+                dream.id
+                    == format!(
+                        "dream-{}-{ordinal}-{}",
+                        txn.id,
+                        short_hash(&dream.artifact_hash)
+                    )
+                    && dream.diversity_key == mix64(candidate.generation_seed ^ ordinal as u64),
+                "dream manifest identity metadata is inconsistent with its candidate"
             );
         }
         Ok(artifact.dreams)
@@ -1447,6 +1756,10 @@ impl TransformerDreamOps for BuiltinDreamOps {
     ) -> Result<DreamTrial> {
         self.validate_transaction(txn)?;
         ensure!(rank > 0 && alpha > 0, "Dreaming LoRA geometry is empty");
+        ensure!(
+            rank <= DreamingConfig::MAX_LORA_RANK && alpha <= DreamingConfig::MAX_LORA_ALPHA,
+            "Dreaming LoRA geometry exceeds operational limits"
+        );
         let trial_rng = txn
             .dream_trial_rngs
             .iter()
@@ -1463,42 +1776,42 @@ impl TransformerDreamOps for BuiltinDreamOps {
             .candidate_hash
             .as_deref()
             .context("Dreaming LoRA transaction has no immutable candidate checkpoint hash")?;
-        validate_sha256(base_checkpoint_sha256, "Dreaming LoRA base checkpoint")?;
+        validate_sha256_identity(base_checkpoint_sha256, "Dreaming LoRA base checkpoint")?;
         let base_model_parameter_sha256 = txn
             .dream_shared_checkpoint_hash
             .as_deref()
             .context("Dreaming LoRA transaction has no shared model-parameter hash")?;
-        validate_sha256(
+        validate_sha256_identity(
             base_model_parameter_sha256,
             "Dreaming LoRA base-model parameters",
         )?;
 
         // `valid` detaches the forked model and disables training-only dropout.
-        // All optimization below happens in the two host adapter tensors; the
-        // frozen Transformer supplies only final hidden features and base
-        // output-projection logits.
+        // All optimization below happens in two isolated device-owned adapter
+        // tensors; the frozen Transformer supplies only final hidden features
+        // and base output-projection logits.
         let frozen_model = isolated_model.valid();
-        let training = self.sequence_lm_head_rows(&frozen_model, &artifact.token_ids)?;
-        let evaluation = self
-            .evaluation_set
-            .sequences
-            .iter()
-            .map(|sequence| self.sequence_lm_head_rows(&frozen_model, &sequence.token_ids))
-            .collect::<Result<Vec<_>>>()?;
+        let training = self
+            .candidate_lm_head_rows(&frozen_model, &artifact)?
+            .into_device(&self.device)?;
+        let evaluation =
+            self.evaluation_lm_head_rows(&frozen_model, base_model_parameter_sha256)?;
         let seed = derive_seed(txn, trial_rng, LORA_DOMAIN, 0);
-        let mut adapter = HostLmHeadLora::new(training.hidden, training.vocab, rank, alpha, seed)?;
-        let training_loss_before = adapter.loss(&training)?;
-        let evaluation_loss_before = mean_loss(&adapter, &evaluation)?;
+        let adapter = HostLmHeadLora::new(training.hidden, training.vocab, rank, alpha, seed)?;
+        let mut adapter = DeviceLmHeadLora::from_host(adapter, &self.device);
+        let training_loss_before = adapter.loss_value(&training)?;
+        let evaluation_loss_before = adapter.mean_loss_value(&evaluation)?;
         for _ in 0..self.config.lora_steps {
             adapter.train_step(&training, self.config.lora_learning_rate)?;
         }
-        let training_loss_after = adapter.loss(&training)?;
-        let evaluation_loss_after = mean_loss(&adapter, &evaluation)?;
+        let training_loss_after = adapter.loss_value(&training)?;
+        let evaluation_loss_after = adapter.mean_loss_value(&evaluation)?;
         let improvement = evaluation_loss_before - evaluation_loss_after;
         ensure!(
             improvement.is_finite(),
             "Dreaming trial produced a non-finite reward"
         );
+        let adapter = adapter.into_host()?;
 
         let receipt = AdapterReceipt {
             version: DREAM_ADAPTER_VERSION,
@@ -1525,14 +1838,17 @@ impl TransformerDreamOps for BuiltinDreamOps {
         };
         receipt.validate()?;
         let header = serde_json::to_vec(&receipt)?;
-        let mut bytes =
-            Vec::with_capacity(8 + header.len() + 4 * (adapter.a.len() + adapter.b.len()));
+        let capacity = adapter_payload_capacity(header.len(), adapter.a.len(), adapter.b.len())?;
+        let mut bytes = Vec::new();
+        bytes
+            .try_reserve_exact(capacity)
+            .context("reserving isolated dream LoRA artifact")?;
         bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
         bytes.extend_from_slice(&header);
         for value in adapter.a.iter().chain(&adapter.b) {
             bytes.extend_from_slice(&value.to_bits().to_le_bytes());
         }
-        let adapter_hash = sha256_bytes(&bytes);
+        let adapter_hash = sha256_identity(&bytes);
         publish_immutable(&self.adapter_path(&adapter_hash)?, &bytes)?;
         Ok(DreamTrial {
             candidate_id: candidate.id.clone(),
@@ -1551,17 +1867,33 @@ impl TransformerDreamOps for BuiltinDreamOps {
     ) -> Result<String> {
         self.validate_transaction(txn)?;
         ensure!(iterations > 0, "ReSTEM iterations must be positive");
+        ensure!(
+            iterations <= DreamingConfig::MAX_RESTEM_ITERATIONS,
+            "ReSTEM iteration count exceeds the operational limit"
+        );
+        ensure!(
+            accepted.len() <= DreamingConfig::MAX_CANDIDATES,
+            "ReSTEM accepted-trial count exceeds the operational limit"
+        );
+        let policy_work = accepted
+            .len()
+            .checked_mul(iterations)
+            .context("ReSTEM policy work overflows usize")?;
+        ensure!(
+            policy_work <= DreamingConfig::MAX_POLICY_WORK,
+            "ReSTEM policy work exceeds the operational limit"
+        );
         self.validate_generation_policy_for_model(model)?;
         let source_checkpoint_sha256 = txn
             .candidate_hash
             .as_deref()
             .context("ReSTEM transaction has no immutable candidate checkpoint hash")?;
-        validate_sha256(source_checkpoint_sha256, "ReSTEM source checkpoint")?;
+        validate_sha256_identity(source_checkpoint_sha256, "ReSTEM source checkpoint")?;
         let source_model_parameter_sha256 = txn
             .dream_shared_checkpoint_hash
             .as_deref()
             .context("ReSTEM transaction has no shared model-parameter hash")?;
-        validate_sha256(
+        validate_sha256_identity(
             source_model_parameter_sha256,
             "ReSTEM source model parameters",
         )?;
@@ -1640,11 +1972,17 @@ impl TransformerDreamOps for BuiltinDreamOps {
                 ),
             )?,
         };
+        let frozen_model = model.clone().valid();
         let training_sets = verified
             .iter()
-            .map(|(_, _, candidate, _)| self.dream_sequence_lm_head_rows(model, candidate))
+            .map(|(_, _, candidate, _)| self.dream_sequence_lm_head_rows(&frozen_model, candidate))
             .collect::<Result<Vec<_>>>()?;
         if !training_sets.is_empty() {
+            let training_sets = training_sets
+                .into_iter()
+                .map(|rows| rows.into_device(&self.device))
+                .collect::<Result<Vec<_>>>()?;
+            let mut device_adapter = DeviceLmHeadLora::from_host(adapter, &self.device);
             let reward_sum = verified
                 .iter()
                 .map(|(_, receipt, _, _)| receipt.independent_task_improvement)
@@ -1657,9 +1995,11 @@ impl TransformerDreamOps for BuiltinDreamOps {
                 for (data, (_, receipt, _, _)) in training_sets.iter().zip(&verified) {
                     let reward_weight =
                         receipt.independent_task_improvement * verified.len() as f32 / reward_sum;
-                    adapter.train_step(data, self.config.restem_learning_rate * reward_weight)?;
+                    device_adapter
+                        .train_step(data, self.config.restem_learning_rate * reward_weight)?;
                 }
             }
+            adapter = device_adapter.into_host()?;
         }
         let accepted_candidates = verified
             .iter()
@@ -1700,14 +2040,18 @@ impl TransformerDreamOps for BuiltinDreamOps {
             };
             receipt.validate()?;
             let header = serde_json::to_vec(&receipt)?;
-            let mut bytes =
-                Vec::with_capacity(8 + header.len() + 4 * (adapter.a.len() + adapter.b.len()));
+            let capacity =
+                adapter_payload_capacity(header.len(), adapter.a.len(), adapter.b.len())?;
+            let mut bytes = Vec::new();
+            bytes
+                .try_reserve_exact(capacity)
+                .context("reserving generation-policy LoRA artifact")?;
             bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
             bytes.extend_from_slice(&header);
             for value in adapter.a.iter().chain(&adapter.b) {
                 bytes.extend_from_slice(&value.to_bits().to_le_bytes());
             }
-            let hash = sha256_bytes(&bytes);
+            let hash = sha256_identity(&bytes);
             publish_immutable(&self.generation_policy_adapter_path(&hash)?, &bytes)?;
             hash
         };
@@ -1734,7 +2078,7 @@ impl TransformerDreamOps for BuiltinDreamOps {
         };
         state.validate()?;
         let bytes = canonical_json(&state)?;
-        let hash = sha256_bytes(&bytes);
+        let hash = sha256_identity(&bytes);
         publish_immutable(&self.policy_path(&hash)?, &bytes)?;
         Ok(hash)
     }
@@ -1748,6 +2092,264 @@ struct LmHeadRows {
     features: Vec<f32>,
     base_logits: Vec<f32>,
     targets: Vec<usize>,
+}
+
+fn checked_lm_head_row_geometry(
+    rows: usize,
+    hidden: usize,
+    vocab: usize,
+) -> Result<(usize, usize)> {
+    ensure!(rows > 0 && hidden > 0 && vocab > 1, "invalid LM-head rows");
+    let feature_values = rows
+        .checked_mul(hidden)
+        .context("LM-head feature geometry overflows usize")?;
+    let logit_values = rows
+        .checked_mul(vocab)
+        .context("LM-head logit geometry overflows usize")?;
+    let data_bytes = feature_values
+        .checked_add(logit_values)
+        .and_then(|values| values.checked_mul(std::mem::size_of::<f32>()))
+        .context("LM-head dataset geometry overflows usize")?;
+    ensure!(
+        data_bytes <= MAX_DREAM_LM_HEAD_DATA_BYTES,
+        "LM-head dataset exceeds the {MAX_DREAM_LM_HEAD_DATA_BYTES}-byte operational limit"
+    );
+    Ok((feature_values, logit_values))
+}
+
+impl LmHeadRows {
+    fn validate_for(&self, hidden: usize, vocab: usize) -> Result<()> {
+        let (feature_values, logit_values) =
+            checked_lm_head_row_geometry(self.rows, hidden, vocab)?;
+        ensure!(
+            self.hidden == hidden
+                && self.vocab == vocab
+                && self.rows == self.targets.len()
+                && self.features.len() == feature_values
+                && self.base_logits.len() == logit_values,
+            "LM-head LoRA dataset shape mismatch"
+        );
+        ensure!(
+            self.targets.iter().all(|target| *target < vocab),
+            "LM-head LoRA target is outside vocabulary"
+        );
+        Ok(())
+    }
+
+    fn into_device(self, device: &Device) -> Result<DeviceLmHeadRows> {
+        self.validate_for(self.hidden, self.vocab)?;
+        let rows = self.rows;
+        let hidden = self.hidden;
+        let vocab = self.vocab;
+        let targets = self
+            .targets
+            .into_iter()
+            .map(i64::try_from)
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("LM-head LoRA target exceeds i64")?;
+        Ok(DeviceLmHeadRows {
+            rows,
+            hidden,
+            vocab,
+            features: Tensor::<2>::from_data(
+                TensorData::new(self.features, [rows, hidden]),
+                device,
+            ),
+            base_logits: Tensor::<2>::from_data(
+                TensorData::new(self.base_logits, [rows, vocab]),
+                device,
+            ),
+            targets: Tensor::<1, Int>::from_data(TensorData::new(targets, [rows]), device),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct DeviceLmHeadRows {
+    rows: usize,
+    hidden: usize,
+    vocab: usize,
+    features: Tensor<2>,
+    base_logits: Tensor<2>,
+    targets: Tensor<1, Int>,
+}
+
+struct DeviceEvaluationCache {
+    model_parameter_sha256: String,
+    rows: Vec<DeviceLmHeadRows>,
+}
+
+struct DeviceLmHeadLora {
+    hidden: usize,
+    vocab: usize,
+    rank: usize,
+    alpha: usize,
+    scale: f32,
+    a: Tensor<2>,
+    b: Tensor<2>,
+}
+
+struct DeviceLmHeadPolicy {
+    hidden: usize,
+    vocab: usize,
+    scale: f32,
+    a: Tensor<2>,
+    b: Tensor<2>,
+}
+
+impl DeviceLmHeadPolicy {
+    fn from_host(adapter: &HostLmHeadLora, device: &Device) -> Self {
+        Self {
+            hidden: adapter.hidden,
+            vocab: adapter.vocab,
+            scale: adapter.scale,
+            a: Tensor::<2>::from_data(
+                TensorData::new(adapter.a.clone(), [adapter.rank, adapter.hidden]),
+                device,
+            ),
+            b: Tensor::<2>::from_data(
+                TensorData::new(adapter.b.clone(), [adapter.rank, adapter.vocab]),
+                device,
+            ),
+        }
+    }
+
+    fn adapted(&self, features: Tensor<2>, base_logits: Tensor<2>) -> Result<Tensor<2>> {
+        ensure!(
+            features.dims() == [1, self.hidden] && base_logits.dims() == [1, self.vocab],
+            "device generation-policy feature/logit shape mismatch"
+        );
+        Ok(base_logits
+            + features
+                .matmul(self.a.clone().transpose())
+                .matmul(self.b.clone())
+                .mul_scalar(self.scale))
+    }
+}
+
+impl DeviceLmHeadLora {
+    fn from_host(adapter: HostLmHeadLora, device: &Device) -> Self {
+        let a = Tensor::<2>::from_data(
+            TensorData::new(adapter.a, [adapter.rank, adapter.hidden]),
+            device,
+        )
+        .require_grad();
+        let b = Tensor::<2>::from_data(
+            TensorData::new(adapter.b, [adapter.rank, adapter.vocab]),
+            device,
+        )
+        .require_grad();
+        Self {
+            hidden: adapter.hidden,
+            vocab: adapter.vocab,
+            rank: adapter.rank,
+            alpha: adapter.alpha,
+            scale: adapter.scale,
+            a,
+            b,
+        }
+    }
+
+    fn loss(&self, data: &DeviceLmHeadRows) -> Result<Tensor<1>> {
+        ensure!(
+            data.rows > 0 && data.hidden == self.hidden && data.vocab == self.vocab,
+            "device LM-head LoRA dataset shape mismatch"
+        );
+        let logits = data.base_logits.clone()
+            + data
+                .features
+                .clone()
+                .matmul(self.a.clone().transpose())
+                .matmul(self.b.clone())
+                .mul_scalar(self.scale);
+        Ok(CrossEntropyLossConfig::new()
+            .init(&logits.device())
+            .forward(logits, data.targets.clone()))
+    }
+
+    fn loss_value(&self, data: &DeviceLmHeadRows) -> Result<f32> {
+        let value = self
+            .loss(data)?
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .context("reading device LM-head LoRA loss")?[0];
+        ensure!(value.is_finite(), "device LM-head LoRA loss is non-finite");
+        Ok(value)
+    }
+
+    fn mean_loss_value(&self, sets: &[DeviceLmHeadRows]) -> Result<f32> {
+        ensure!(!sets.is_empty(), "Dreaming evaluation set is empty");
+        let losses = sets
+            .iter()
+            .map(|set| self.loss(set))
+            .collect::<Result<Vec<_>>>()?;
+        let value = Tensor::cat(losses, 0)
+            .mean()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .context("reading mean device LM-head LoRA loss")?[0];
+        ensure!(
+            value.is_finite(),
+            "mean device LM-head LoRA loss is non-finite"
+        );
+        Ok(value)
+    }
+
+    fn train_step(&mut self, data: &DeviceLmHeadRows, learning_rate: f32) -> Result<()> {
+        ensure!(
+            learning_rate.is_finite() && learning_rate > 0.0,
+            "device LM-head LoRA learning rate is invalid"
+        );
+        let mut gradients = self.loss(data)?.backward();
+        let grad_a = self
+            .a
+            .grad_remove(&mut gradients)
+            .context("device LM-head LoRA produced no A gradient")?;
+        let grad_b = self
+            .b
+            .grad_remove(&mut gradients)
+            .context("device LM-head LoRA produced no B gradient")?;
+        let mean_gradient_norm = (grad_a.clone().square().sum() + grad_b.clone().square().sum())
+            .sqrt()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .context("reading device LM-head LoRA gradient norm")?[0];
+        ensure!(
+            mean_gradient_norm.is_finite(),
+            "device LM-head LoRA gradient norm is non-finite"
+        );
+        // The paper-inspired host recipe clipped the summed full-batch
+        // gradient. CrossEntropyLoss emits a mean gradient, so restore the sum
+        // norm before applying the same update rule.
+        let denominator = (mean_gradient_norm * data.rows as f32).max(1.0);
+        let rate = learning_rate / denominator;
+        self.a =
+            Tensor::from_inner(self.a.clone().inner() - grad_a.mul_scalar(rate)).require_grad();
+        self.b =
+            Tensor::from_inner(self.b.clone().inner() - grad_b.mul_scalar(rate)).require_grad();
+        Ok(())
+    }
+
+    fn into_host(self) -> Result<HostLmHeadLora> {
+        let a = self
+            .a
+            .detach()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .context("reading trained LM-head LoRA A")?;
+        let b = self
+            .b
+            .detach()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .context("reading trained LM-head LoRA B")?;
+        HostLmHeadLora::from_parts(self.hidden, self.vocab, self.rank, self.alpha, a, b)
+    }
 }
 
 /// Isolated LoRA on the frozen model's logical output projection.
@@ -1766,25 +2368,78 @@ struct HostLmHeadLora {
     b: Vec<f32>,
 }
 
+fn checked_lora_parameter_geometry(
+    hidden: usize,
+    vocab: usize,
+    rank: usize,
+    alpha: usize,
+) -> Result<(usize, usize)> {
+    ensure!(
+        hidden > 0 && vocab > 1 && rank > 0 && alpha > 0,
+        "invalid LM-head LoRA shape"
+    );
+    ensure!(
+        rank <= DreamingConfig::MAX_LORA_RANK && alpha <= DreamingConfig::MAX_LORA_ALPHA,
+        "LM-head LoRA geometry exceeds the configured operational limits"
+    );
+    let a_values = rank
+        .checked_mul(hidden)
+        .context("LM-head LoRA A shape overflow")?;
+    let b_values = rank
+        .checked_mul(vocab)
+        .context("LM-head LoRA B shape overflow")?;
+    let parameter_bytes = a_values
+        .checked_add(b_values)
+        .and_then(|values| values.checked_mul(std::mem::size_of::<f32>()))
+        .context("LM-head LoRA parameter size overflow")?;
+    ensure!(
+        u64::try_from(parameter_bytes).context("LM-head LoRA parameter size exceeds u64")?
+            <= MAX_DREAM_ADAPTER_PARAMETER_BYTES,
+        "LM-head LoRA parameters exceed the {MAX_DREAM_ADAPTER_PARAMETER_BYTES}-byte operational limit"
+    );
+    Ok((a_values, b_values))
+}
+
+fn adapter_payload_capacity(
+    header_bytes: usize,
+    a_values: usize,
+    b_values: usize,
+) -> Result<usize> {
+    let capacity = a_values
+        .checked_add(b_values)
+        .and_then(|values| values.checked_mul(std::mem::size_of::<f32>()))
+        .and_then(|parameter_bytes| parameter_bytes.checked_add(header_bytes))
+        .and_then(|payload| payload.checked_add(std::mem::size_of::<u64>()))
+        .context("dream LoRA adapter payload size overflow")?;
+    ensure!(
+        u64::try_from(capacity).context("dream LoRA adapter payload exceeds u64")?
+            <= MAX_DREAM_ADAPTER_BYTES,
+        "dream LoRA adapter payload exceeds the {MAX_DREAM_ADAPTER_BYTES}-byte limit"
+    );
+    Ok(capacity)
+}
+
+fn zeroed_f32(count: usize, label: &str) -> Result<Vec<f32>> {
+    let mut values = Vec::new();
+    values
+        .try_reserve_exact(count)
+        .with_context(|| format!("reserving {label}"))?;
+    values.resize(count, 0.0);
+    Ok(values)
+}
+
 impl HostLmHeadLora {
     fn new(hidden: usize, vocab: usize, rank: usize, alpha: usize, seed: u64) -> Result<Self> {
-        ensure!(
-            hidden > 0 && vocab > 1 && rank > 0 && alpha > 0,
-            "invalid LM-head LoRA shape"
-        );
-        let a_values = rank
-            .checked_mul(hidden)
-            .context("LM-head LoRA A shape overflow")?;
-        let b_values = rank
-            .checked_mul(vocab)
-            .context("LM-head LoRA B shape overflow")?;
+        let (a_values, b_values) = checked_lora_parameter_geometry(hidden, vocab, rank, alpha)?;
         let mut state = seed;
-        let a = (0..a_values)
-            .map(|_| {
-                state = mix64(state);
-                (((state >> 40) as i32 - (1 << 23)) as f32 / (1 << 23) as f32) * 0.01
-            })
-            .collect();
+        let mut a = Vec::new();
+        a.try_reserve_exact(a_values)
+            .context("reserving LM-head LoRA A parameters")?;
+        for _ in 0..a_values {
+            state = mix64(state);
+            a.push((((state >> 40) as i32 - (1 << 23)) as f32 / (1 << 23) as f32) * 0.01);
+        }
+        let b = zeroed_f32(b_values, "LM-head LoRA B parameters")?;
         Ok(Self {
             hidden,
             vocab,
@@ -1792,7 +2447,7 @@ impl HostLmHeadLora {
             alpha,
             scale: alpha as f32 / rank as f32,
             a,
-            b: vec![0.0; b_values],
+            b,
         })
     }
 
@@ -1804,19 +2459,9 @@ impl HostLmHeadLora {
         a: Vec<f32>,
         b: Vec<f32>,
     ) -> Result<Self> {
+        let (a_values, b_values) = checked_lora_parameter_geometry(hidden, vocab, rank, alpha)?;
         ensure!(
-            hidden > 0 && vocab > 1 && rank > 0 && alpha > 0,
-            "invalid LM-head LoRA shape"
-        );
-        ensure!(
-            a.len()
-                == rank
-                    .checked_mul(hidden)
-                    .context("LM-head LoRA A shape overflow")?
-                && b.len()
-                    == rank
-                        .checked_mul(vocab)
-                        .context("LM-head LoRA B shape overflow")?,
+            a.len() == a_values && b.len() == b_values,
             "LM-head LoRA parameter lengths do not match geometry"
         );
         ensure!(
@@ -1834,6 +2479,7 @@ impl HostLmHeadLora {
         })
     }
 
+    #[cfg(test)]
     fn adapted(&self, features: &[f32], base_logits: &[f32]) -> Result<(Vec<f32>, Vec<f32>)> {
         ensure!(
             features.len() == self.hidden,
@@ -1850,13 +2496,17 @@ impl HostLmHeadLora {
                 .all(|value| value.is_finite()),
             "LM-head LoRA input is non-finite"
         );
-        let mut low_rank = vec![0.0_f32; self.rank];
+        let mut low_rank = zeroed_f32(self.rank, "LM-head LoRA activation")?;
         for (rank, low_rank_value) in low_rank.iter_mut().enumerate() {
             for (feature, value) in features.iter().copied().enumerate() {
                 *low_rank_value += value * self.a[rank * self.hidden + feature];
             }
         }
-        let mut output = base_logits.to_vec();
+        let mut output = Vec::new();
+        output
+            .try_reserve_exact(base_logits.len())
+            .context("reserving adapted LM-head logits")?;
+        output.extend_from_slice(base_logits);
         for (token, output_value) in output.iter_mut().enumerate() {
             let mut residual = 0.0;
             for (rank, low_rank_value) in low_rank.iter().copied().enumerate() {
@@ -1867,15 +2517,9 @@ impl HostLmHeadLora {
         Ok((low_rank, output))
     }
 
+    #[cfg(test)]
     fn loss(&self, data: &LmHeadRows) -> Result<f32> {
-        ensure!(
-            data.hidden == self.hidden
-                && data.vocab == self.vocab
-                && data.rows == data.targets.len()
-                && data.features.len() == data.rows * data.hidden
-                && data.base_logits.len() == data.rows * data.vocab,
-            "LM-head LoRA dataset shape mismatch"
-        );
+        data.validate_for(self.hidden, self.vocab)?;
         let mut sum = 0.0;
         for row in 0..data.rows {
             let (_, logits) = self.adapted(
@@ -1887,25 +2531,18 @@ impl HostLmHeadLora {
         Ok(sum / data.rows as f32)
     }
 
+    #[cfg(test)]
     fn train_step(&mut self, data: &LmHeadRows, learning_rate: f32) -> Result<()> {
-        ensure!(
-            data.hidden == self.hidden
-                && data.vocab == self.vocab
-                && data.rows > 0
-                && data.rows == data.targets.len()
-                && data.features.len() == data.rows * data.hidden
-                && data.base_logits.len() == data.rows * data.vocab,
-            "LM-head LoRA training data shape mismatch"
-        );
-        let mut grad_a = vec![0.0_f32; self.a.len()];
-        let mut grad_b = vec![0.0_f32; self.b.len()];
+        data.validate_for(self.hidden, self.vocab)?;
+        let mut grad_a = zeroed_f32(self.a.len(), "LM-head LoRA A gradient")?;
+        let mut grad_b = zeroed_f32(self.b.len(), "LM-head LoRA B gradient")?;
         for row in 0..data.rows {
             let features = &data.features[row * self.hidden..(row + 1) * self.hidden];
             let base_logits = &data.base_logits[row * self.vocab..(row + 1) * self.vocab];
             let (low_rank, logits) = self.adapted(features, base_logits)?;
             let mut error = softmax_host(&logits)?;
             error[data.targets[row]] -= 1.0;
-            let mut grad_low_rank = vec![0.0_f32; self.rank];
+            let mut grad_low_rank = zeroed_f32(self.rank, "LM-head LoRA activation gradient")?;
             for (rank, grad_low_rank_value) in grad_low_rank.iter_mut().enumerate() {
                 for (token, error_value) in error.iter().copied().enumerate() {
                     grad_b[rank * self.vocab + token] += self.scale * low_rank[rank] * error_value;
@@ -1942,17 +2579,7 @@ impl HostLmHeadLora {
     }
 }
 
-fn mean_loss(adapter: &HostLmHeadLora, sets: &[LmHeadRows]) -> Result<f32> {
-    ensure!(!sets.is_empty(), "independent evaluation set is empty");
-    Ok(sets
-        .iter()
-        .map(|set| adapter.loss(set))
-        .collect::<Result<Vec<_>>>()?
-        .into_iter()
-        .sum::<f32>()
-        / sets.len() as f32)
-}
-
+#[cfg(test)]
 fn softmax_host(logits: &[f32]) -> Result<Vec<f32>> {
     ensure!(!logits.is_empty(), "softmax input is empty");
     let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
@@ -1969,6 +2596,7 @@ fn softmax_host(logits: &[f32]) -> Result<Vec<f32>> {
     Ok(values)
 }
 
+#[cfg(test)]
 fn cross_entropy(logits: &[f32], target: usize) -> Result<f32> {
     ensure!(
         target < logits.len(),
@@ -2140,7 +2768,7 @@ fn sample_temperature(logits: &[f32], temperature: f32, seed: u64) -> Result<usi
 }
 
 fn model_topology_sha256(model: &Transformer) -> Result<String> {
-    Ok(sha256_bytes(&canonical_json(model.config())?))
+    Ok(sha256_identity(&canonical_json(model.config())?))
 }
 
 fn canonical_json<T: Serialize>(value: &T) -> Result<Vec<u8>> {
@@ -2149,50 +2777,42 @@ fn canonical_json<T: Serialize>(value: &T) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("sha256:{:x}", Sha256::digest(bytes))
-}
-
-fn validate_sha256(value: &str, label: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .with_context(|| format!("{label} hash must start with `sha256:`"))?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{label} hash must contain 64 lowercase hexadecimal digits"
-    );
-    Ok(())
-}
-
 fn short_hash(hash: &str) -> &str {
     &hash[7..19]
 }
 
 fn addressed_path(root: &Path, kind: &str, hash: &str, extension: &str) -> Result<PathBuf> {
-    validate_sha256(hash, kind)?;
+    validate_sha256_identity(hash, kind)?;
     Ok(root
         .join(kind)
         .join(format!("{}.{}", &hash[7..], extension)))
 }
 
 fn read_regular_file(path: &Path, label: &str) -> Result<Vec<u8>> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to inspect {label} {}", path.display()))?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "{label} {} must be a regular non-symlink file",
-        path.display()
-    );
-    fs::read(path).with_context(|| format!("failed to read {label} {}", path.display()))
+    read_regular_bounded(path, MAX_DREAM_ADAPTER_BYTES, label)
+        .with_context(|| format!("failed to read {label} {}", path.display()))
+}
+
+fn read_regular_json(path: &Path, label: &str) -> Result<Vec<u8>> {
+    read_regular_bounded(path, MAX_DREAM_JSON_BYTES, label)
+        .with_context(|| format!("failed to read {label} {}", path.display()))
 }
 
 fn read_addressed(path: &Path, expected: &str, label: &str) -> Result<Vec<u8>> {
-    validate_sha256(expected, label)?;
+    validate_sha256_identity(expected, label)?;
     let bytes = read_regular_file(path, label)?;
-    let observed = sha256_bytes(&bytes);
+    let observed = sha256_identity(&bytes);
+    ensure!(
+        observed == expected,
+        "{label} content hash changed: expected {expected}, observed {observed}"
+    );
+    Ok(bytes)
+}
+
+fn read_addressed_json(path: &Path, expected: &str, label: &str) -> Result<Vec<u8>> {
+    validate_sha256_identity(expected, label)?;
+    let bytes = read_regular_json(path, label)?;
+    let observed = sha256_identity(&bytes);
     ensure!(
         observed == expected,
         "{label} content hash changed: expected {expected}, observed {observed}"
@@ -2201,68 +2821,11 @@ fn read_addressed(path: &Path, expected: &str, label: &str) -> Result<Vec<u8>> {
 }
 
 fn ensure_real_directory(path: &Path) -> Result<()> {
-    if !path.exists() {
-        fs::create_dir_all(path)
-            .with_context(|| format!("creating Dreaming directory {}", path.display()))?;
-    }
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("inspecting Dreaming directory {}", path.display()))?;
-    ensure!(
-        metadata.is_dir() && !metadata.file_type().is_symlink(),
-        "Dreaming directory {} must be a real directory",
-        path.display()
-    );
-    Ok(())
-}
-
-fn sync_directory(path: &Path) -> Result<()> {
-    File::open(path)?.sync_all()?;
-    Ok(())
+    ensure_directory(path, "Dreaming directory")
 }
 
 fn publish_immutable(path: &Path, bytes: &[u8]) -> Result<()> {
-    let parent = path.parent().context("immutable artifact has no parent")?;
-    ensure_real_directory(parent)?;
-    if path.exists() {
-        ensure!(
-            read_regular_file(path, "immutable Dreaming artifact")? == bytes,
-            "immutable Dreaming artifact {} already differs",
-            path.display()
-        );
-        return Ok(());
-    }
-    let name = path
-        .file_name()
-        .and_then(|value| value.to_str())
-        .context("artifact name is not UTF-8")?;
-    let temporary = parent.join(format!(
-        ".{name}.tmp.{}.{}",
-        std::process::id(),
-        TEMPORARY_ORDINAL.fetch_add(1, Ordering::Relaxed)
-    ));
-    let result = (|| {
-        let mut output = OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&temporary)?;
-        output.write_all(bytes)?;
-        output.sync_all()?;
-        drop(output);
-        match fs::hard_link(&temporary, path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => ensure!(
-                read_regular_file(path, "immutable Dreaming artifact")? == bytes,
-                "immutable Dreaming artifact publication raced with different bytes"
-            ),
-            Err(error) => return Err(error.into()),
-        }
-        fs::remove_file(&temporary)?;
-        sync_directory(parent)
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&temporary);
-    }
-    result
+    atomic_write_new(path, bytes)
 }
 
 #[cfg(test)]
@@ -2311,7 +2874,7 @@ mod tests {
         fs::write(&path, &bytes).unwrap();
         PinnedLocalArtifact {
             path,
-            sha256: sha256_bytes(&bytes),
+            sha256: sha256_identity(&bytes),
         }
     }
 
@@ -2370,7 +2933,7 @@ mod tests {
             .push(WakeContextRecord {
                 id: "wake-10-0".into(),
                 optimizer_step: 10,
-                token_ids: vec![1, 2, 3, 4],
+                token_ids: vec![2, 3, 4, 1],
             })
             .unwrap();
         let journal_path = directory.path().join("wake.json");
@@ -2402,7 +2965,7 @@ mod tests {
                 &evaluation_set,
             ),
             initial_policy: None,
-            max_new_tokens: 2,
+            max_new_tokens: 1,
             gradient_dimensions: 16,
             lora_steps,
             lora_learning_rate: 0.25,
@@ -2426,18 +2989,24 @@ mod tests {
     fn manual_candidate(
         operations: &BuiltinDreamOps,
         txn: &ConsolidationTxn,
-        id: &str,
         tokens: Vec<i64>,
     ) -> GeneratedDream {
+        let ordinal = 0;
+        let generation_seed = derive_seed(
+            txn,
+            txn.dream_generation_rng.unwrap(),
+            GENERATION_DOMAIN,
+            ordinal,
+        );
         let artifact = DreamCandidateArtifact {
             version: DREAM_CANDIDATE_VERSION,
             transaction_id: txn.id,
-            ordinal: 0,
+            ordinal: ordinal as usize,
             wake_journal_sha256: operations.journal.sha256().to_owned(),
             source_checkpoint_sha256: operations.journal.source_checkpoint_sha256().to_owned(),
             wake_record_id: operations.journal.records()[0].id.clone(),
             wake_token_count: 1,
-            generation_seed: 19,
+            generation_seed,
             routing_seed: txn.id,
             routing: DREAM_ROUTING_NAME.into(),
             generation_policy_sha256: operations
@@ -2453,13 +3022,13 @@ mod tests {
             token_ids: tokens,
         };
         let bytes = canonical_json(&artifact).unwrap();
-        let artifact_hash = sha256_bytes(&bytes);
+        let artifact_hash = sha256_identity(&bytes);
         publish_immutable(&operations.candidate_path(&artifact_hash).unwrap(), &bytes).unwrap();
         GeneratedDream {
-            id: id.into(),
+            id: format!("dream-{}-{ordinal}-{}", txn.id, short_hash(&artifact_hash)),
             artifact_hash,
             gradient: vec![0.25; operations.config.gradient_dimensions],
-            diversity_key: 19,
+            diversity_key: mix64(generation_seed ^ ordinal),
         }
     }
 
@@ -2488,9 +3057,52 @@ mod tests {
             dreams,
         };
         let bytes = canonical_json(&manifest).unwrap();
-        let hash = sha256_bytes(&bytes);
+        let hash = sha256_identity(&bytes);
         publish_immutable(&operations.manifest_path(&hash).unwrap(), &bytes).unwrap();
         hash
+    }
+
+    #[test]
+    fn dreaming_json_reads_reject_oversized_input_before_allocation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("oversized.json");
+        let file = fs::File::create(&path).unwrap();
+        file.set_len(MAX_DREAM_JSON_BYTES + 1).unwrap();
+        drop(file);
+
+        let error = read_regular_json(&path, "dreaming fixture").unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("byte limit"), "{error}");
+    }
+
+    #[test]
+    fn dream_sequence_sets_reject_semantically_unbounded_work() {
+        let sequence = |id: String, token_ids: Vec<i64>| DreamSequence { id, token_ids };
+        let too_many = DreamSequenceSet {
+            version: DREAM_SEQUENCE_SET_VERSION,
+            sequences: (0..=MAX_DREAM_SEQUENCES)
+                .map(|index| sequence(format!("sequence-{index}"), vec![1, 2]))
+                .collect(),
+        };
+        let error = too_many.validate().unwrap_err().to_string();
+        assert!(error.contains("sequence operational limit"), "{error}");
+
+        let too_long = DreamSequenceSet {
+            version: DREAM_SEQUENCE_SET_VERSION,
+            sequences: vec![sequence(
+                "too-long".into(),
+                vec![1; MAX_DREAM_SEQUENCE_TOKENS + 1],
+            )],
+        };
+        let error = too_long.validate().unwrap_err().to_string();
+        assert!(error.contains("token operational limit"), "{error}");
+
+        let invalid_token = DreamSequenceSet {
+            version: DREAM_SEQUENCE_SET_VERSION,
+            sequences: vec![sequence("invalid-token".into(), vec![1, i64::MAX])],
+        };
+        let error = invalid_token.validate().unwrap_err().to_string();
+        assert!(error.contains("outside the u32 range"), "{error}");
     }
 
     #[test]
@@ -2519,6 +3131,102 @@ mod tests {
         assert!(adapter.b.iter().any(|value| *value != 0.0));
         assert_eq!(data.base_logits, base_before);
         assert_eq!(data.features, features_before);
+    }
+
+    #[test]
+    fn device_lm_head_lora_uses_batched_tensor_updates() {
+        let rows = LmHeadRows {
+            rows: 2,
+            hidden: 2,
+            vocab: 3,
+            features: vec![0.5, -1.0, -0.25, 0.75],
+            base_logits: vec![0.1, -0.2, 0.3, -0.4, 0.2, 0.1],
+            targets: vec![1, 2],
+        };
+        let device = Device::ndarray().autodiff();
+        let rows = rows.into_device(&device).unwrap();
+        let adapter = HostLmHeadLora::new(2, 3, 2, 4, 17).unwrap();
+        let mut adapter = DeviceLmHeadLora::from_host(adapter, &device);
+        let before = adapter.loss_value(&rows).unwrap();
+        for _ in 0..4 {
+            adapter.train_step(&rows, 0.25).unwrap();
+        }
+        let after = adapter.loss_value(&rows).unwrap();
+        assert!(after < before, "before={before}, after={after}");
+        let adapter = adapter.into_host().unwrap();
+        assert!(adapter.b.iter().any(|value| *value != 0.0));
+
+        let features = vec![0.25, -0.75];
+        let base_logits = vec![0.1, -0.2, 0.3];
+        let expected = adapter.adapted(&features, &base_logits).unwrap().1;
+        let inference_device = Device::ndarray();
+        let policy = DeviceLmHeadPolicy::from_host(&adapter, &inference_device);
+        let actual = policy
+            .adapted(
+                Tensor::<2>::from_data(TensorData::new(features, [1, 2]), &inference_device),
+                Tensor::<2>::from_data(TensorData::new(base_logits, [1, 3]), &inference_device),
+            )
+            .unwrap()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .unwrap();
+        assert!(
+            actual
+                .iter()
+                .zip(expected)
+                .all(|(actual, expected)| (actual - expected).abs() < 1e-5)
+        );
+    }
+
+    #[test]
+    fn isolated_candidate_lora_supervises_only_the_dream_continuation() {
+        let seed = seed(vec![1, 2], 1);
+        let operations = BuiltinDreamOps::load(seed.config.clone(), seed.device.clone()).unwrap();
+        let mut artifact = operations
+            .read_candidate(
+                &manual_candidate(&operations, &seed.txn, vec![1, 2, 3, 4]).artifact_hash,
+            )
+            .unwrap();
+        artifact.wake_token_count = 3;
+
+        let rows = operations
+            .candidate_lm_head_rows(&seed.model, &artifact)
+            .unwrap();
+        assert_eq!(rows.rows, 1);
+        assert_eq!(rows.targets, vec![4]);
+        assert_eq!(rows.features.len(), tiny_config().hidden_size);
+        assert_eq!(rows.base_logits.len(), tiny_config().vocab_size);
+    }
+
+    #[test]
+    fn lora_geometry_overflow_fails_before_parameter_allocation() {
+        let oversized_rows = MAX_DREAM_LM_HEAD_DATA_BYTES / std::mem::size_of::<f32>() / 5 + 1;
+        let error = checked_lm_head_row_geometry(oversized_rows, 2, 3).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("dataset exceeds"),
+            "{error:#}"
+        );
+
+        let error = HostLmHeadLora::new(usize::MAX, 3, 2, 4, 17)
+            .err()
+            .expect("overflowing LoRA geometry must be rejected");
+        assert!(format!("{error:#}").contains("shape overflow"), "{error:#}");
+
+        let adapter = HostLmHeadLora::new(2, 3, 2, 4, 17).unwrap();
+        let malformed_rows = LmHeadRows {
+            rows: usize::MAX,
+            hidden: 2,
+            vocab: 3,
+            features: Vec::new(),
+            base_logits: Vec::new(),
+            targets: Vec::new(),
+        };
+        let error = adapter.loss(&malformed_rows).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("geometry overflows"),
+            "{error:#}"
+        );
     }
 
     #[test]
@@ -2577,13 +3285,45 @@ mod tests {
     }
 
     #[test]
+    fn dream_manifest_reauthenticates_candidate_provenance() {
+        let seed = seed(vec![1, 2], 1);
+        let mut operations =
+            BuiltinDreamOps::load(seed.config.clone(), seed.device.clone()).unwrap();
+        let mut dream = manual_candidate(&operations, &seed.txn, vec![1, 2]);
+        let mut artifact = operations.read_candidate(&dream.artifact_hash).unwrap();
+        artifact.generation_seed ^= 1;
+        let bytes = canonical_json(&artifact).unwrap();
+        dream.artifact_hash = sha256_identity(&bytes);
+        publish_immutable(
+            &operations.candidate_path(&dream.artifact_hash).unwrap(),
+            &bytes,
+        )
+        .unwrap();
+        dream.id = format!(
+            "dream-{}-0-{}",
+            seed.txn.id,
+            short_hash(&dream.artifact_hash)
+        );
+        dream.diversity_key = mix64(artifact.generation_seed);
+        let manifest = publish_manifest(&operations, &seed.txn, vec![dream]);
+
+        let error = operations.load(&seed.txn, &manifest).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("generation seed is inconsistent"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
     fn isolated_lm_head_lora_is_shape_bound_and_cannot_mutate_shared_model() {
         // Candidate and evaluator have the same input token but competing
         // targets. A real gradient step toward token 2 therefore worsens the
         // held-out token-3 objective and must be rejected by run_dreaming.
         let mut seed = seed(vec![1, 3], 8);
         let operations = BuiltinDreamOps::load(seed.config, seed.device.clone()).unwrap();
-        let candidate = manual_candidate(&operations, &seed.txn, "reject-me", vec![1, 2]);
+        let candidate = manual_candidate(&operations, &seed.txn, vec![1, 2]);
         seed.txn.dream_trial_rngs.push(DreamTrialRng {
             candidate_id: candidate.id.clone(),
             reservation: RngReservation {
@@ -2600,6 +3340,14 @@ mod tests {
         let trial = backend
             .isolated_lora_trial(&seed.txn, &candidate, 4, 8)
             .unwrap();
+        assert_eq!(
+            backend
+                .operations()
+                .evaluation_cache
+                .as_ref()
+                .map(|cache| cache.model_parameter_sha256.as_str()),
+            Some(before.as_str())
+        );
         assert!(
             trial.independent_task_improvement < 0.0,
             "competing-target trial unexpectedly improved by {}",
@@ -2625,7 +3373,7 @@ mod tests {
     fn accepted_lora_drives_a_content_addressed_idempotent_restem_receipt() {
         let mut seed = seed(vec![1, 2], 1);
         let operations = BuiltinDreamOps::load(seed.config.clone(), seed.device.clone()).unwrap();
-        let candidate = manual_candidate(&operations, &seed.txn, "accept-me", vec![1, 2]);
+        let candidate = manual_candidate(&operations, &seed.txn, vec![1, 2]);
         let candidate_artifact = operations.read_candidate(&candidate.artifact_hash).unwrap();
         let policy_training_rows = operations
             .dream_sequence_lm_head_rows(&seed.model, &candidate_artifact)
@@ -2757,7 +3505,7 @@ mod tests {
         let mut seed = seed(vec![1, 3], 1);
         let mut operations =
             BuiltinDreamOps::load(seed.config.clone(), seed.device.clone()).unwrap();
-        let candidate = manual_candidate(&operations, &seed.txn, "reject-me", vec![1, 2]);
+        let candidate = manual_candidate(&operations, &seed.txn, vec![1, 2]);
         seed.txn.generated_manifest =
             Some(publish_manifest(&operations, &seed.txn, vec![candidate]));
         seed.txn.dream_shared_checkpoint_hash = Some(model_parameter_hash(&seed.model).unwrap());
@@ -2804,8 +3552,7 @@ mod tests {
         next_txn.trigger_clock += 1;
         next_txn.dream_generation_rng.as_mut().unwrap().start += 100;
         next_txn.dream_shared_checkpoint_hash = Some(model_parameter_hash(&seed.model).unwrap());
-        let next_candidate =
-            manual_candidate(&next_operations, &next_txn, "reject-again", vec![1, 2]);
+        let next_candidate = manual_candidate(&next_operations, &next_txn, vec![1, 2]);
         next_txn.generated_manifest = Some(publish_manifest(
             &next_operations,
             &next_txn,
@@ -2868,10 +3615,50 @@ mod tests {
                 .to_string()
                 .contains("geometry")
         );
+        for (invalid, expected) in [
+            (
+                BuiltinDreamingRuntimeConfig {
+                    max_new_tokens: BuiltinDreamingRuntimeConfig::MAX_NEW_TOKENS + 1,
+                    ..seed.config.clone()
+                },
+                "max_new_tokens",
+            ),
+            (
+                BuiltinDreamingRuntimeConfig {
+                    gradient_dimensions: BuiltinDreamingRuntimeConfig::MAX_GRADIENT_DIMENSIONS + 1,
+                    ..seed.config.clone()
+                },
+                "gradient dimensions",
+            ),
+            (
+                BuiltinDreamingRuntimeConfig {
+                    lora_steps: BuiltinDreamingRuntimeConfig::MAX_LORA_STEPS + 1,
+                    ..seed.config.clone()
+                },
+                "LoRA steps",
+            ),
+            (
+                BuiltinDreamingRuntimeConfig {
+                    generation_policy_rank: DreamingConfig::MAX_LORA_RANK + 1,
+                    ..seed.config.clone()
+                },
+                "LoRA rank",
+            ),
+            (
+                BuiltinDreamingRuntimeConfig {
+                    generation_policy_alpha: DreamingConfig::MAX_LORA_ALPHA + 1,
+                    ..seed.config.clone()
+                },
+                "LoRA alpha",
+            ),
+        ] {
+            let error = invalid.validate().unwrap_err();
+            assert!(format!("{error:#}").contains(expected), "{error:#}");
+        }
 
         let mut operations =
             BuiltinDreamOps::load(seed.config.clone(), seed.device.clone()).unwrap();
-        let candidate = manual_candidate(&operations, &seed.txn, "reject-me", vec![1, 2]);
+        let candidate = manual_candidate(&operations, &seed.txn, vec![1, 2]);
         seed.txn.generated_manifest =
             Some(publish_manifest(&operations, &seed.txn, vec![candidate]));
         seed.txn.dream_shared_checkpoint_hash = Some(model_parameter_hash(&seed.model).unwrap());

--- a/hermes-train/src/builtin_sleep_adapters.rs
+++ b/hermes-train/src/builtin_sleep_adapters.rs
@@ -7,11 +7,11 @@
 //! handles, which keeps retries deterministic and prevents sleep from reading
 //! new training data.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(test)]
+use std::fs;
 
 use anyhow::{Context, Result, ensure};
 use burn::tensor::{Int, Tensor, TensorData};
@@ -21,10 +21,13 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::artifact_io::{
+    atomic_write_new, read_regular_bounded, sha256_identity, validate_sha256_identity,
+};
 use crate::sleep::{ConsolidationTxn, RngReservation};
 use crate::tensor_sleep::{
-    ConsolidationRollouts, ImitationGroup, RetentionEvaluator, RetentionScores, RolloutOwner,
-    SemanticJudge, TokenRolloutBatch,
+    ConsolidationRollouts, ImitationGroup, MAX_TENSOR_IMITATION_GROUPS, RetentionEvaluator,
+    RetentionScores, RolloutOwner, SemanticJudge, TokenRolloutBatch,
 };
 
 pub const WAKE_CONTEXT_JOURNAL_VERSION: u32 = 1;
@@ -38,35 +41,35 @@ const TEACHER_GENERATION_DOMAIN: u64 = 0x7465_6163_6865_722d;
 const STUDENT_GENERATION_DOMAIN: u64 = 0x7374_7564_656e_742d;
 const RETENTION_EVALUATION_DOMAIN: u64 = 0x7265_7465_6e74_696f;
 
-static TEMPORARY_ORDINAL: AtomicU64 = AtomicU64::new(0);
-
-fn validate_sha256(value: &str, label: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .with_context(|| format!("{label} must start with `sha256:`"))?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{label} must contain 64 lowercase hexadecimal digits"
-    );
-    Ok(())
-}
-
-fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("sha256:{:x}", Sha256::digest(bytes))
-}
+const MAX_SLEEP_INPUT_JSON_BYTES: u64 = 64 * 1024 * 1024;
+/// A sleep journal is deliberately a small model-owned context ring, not a
+/// second replay corpus. These limits bound both authenticated JSON parsing
+/// and the generation work induced by one valid runtime configuration.
+pub const MAX_WAKE_CONTEXT_RECORDS: usize = 4_096;
+pub const MAX_WAKE_CONTEXT_TOKENS: usize = 65_536;
+pub const MAX_WAKE_CONTEXT_TOTAL_TOKENS: usize = 4 * 1024 * 1024;
+pub const MAX_WAKE_CONTEXT_ID_BYTES: usize = 1_024;
+const MAX_ROLLOUT_CONTINUATION_TOKENS: usize = 16_384;
+const MAX_ROLLOUT_TOP_K: usize = 262_144;
+const MAX_RETENTION_SEQUENCES: usize = 4_096;
+const MAX_RETENTION_SEQUENCE_TOKENS: usize = 65_536;
+const MAX_RETENTION_TOTAL_TOKENS: usize = 4 * 1024 * 1024;
+const MAX_RETENTION_SEQUENCE_ID_BYTES: usize = 1_024;
+const MAX_SEMANTIC_EQUIVALENCE_CLASSES: usize = 65_536;
+const MAX_SEMANTIC_ALIAS_TOKENS: usize = 262_144;
 
 fn read_regular_file(path: &Path, label: &str) -> Result<Vec<u8>> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to inspect {label} {}", path.display()))?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "{label} {} must be a regular non-symlink file",
-        path.display()
-    );
-    fs::read(path).with_context(|| format!("failed to read {label} {}", path.display()))
+    // Model checkpoints also use `PinnedLocalArtifact` and are intentionally
+    // consumed from one authenticated handle by the model loader. Their size
+    // is topology-dependent, so only schema-bearing JSON uses the fixed bound
+    // below.
+    read_regular_bounded(path, u64::MAX, label)
+        .with_context(|| format!("failed to read {label} {}", path.display()))
+}
+
+fn read_regular_json(path: &Path, label: &str) -> Result<Vec<u8>> {
+    read_regular_bounded(path, MAX_SLEEP_INPUT_JSON_BYTES, label)
+        .with_context(|| format!("failed to read {label} {}", path.display()))
 }
 
 fn read_pinned_json<T: DeserializeOwned>(
@@ -74,9 +77,9 @@ fn read_pinned_json<T: DeserializeOwned>(
     expected_sha256: &str,
     label: &str,
 ) -> Result<T> {
-    validate_sha256(expected_sha256, &format!("{label} hash"))?;
-    let bytes = read_regular_file(path, label)?;
-    let observed = sha256_bytes(&bytes);
+    validate_sha256_identity(expected_sha256, &format!("{label} hash"))?;
+    let bytes = read_regular_json(path, label)?;
+    let observed = sha256_identity(&bytes);
     ensure!(
         observed == expected_sha256,
         "{label} {} changed: expected {expected_sha256}, observed {observed}",
@@ -102,7 +105,7 @@ impl PinnedLocalArtifact {
             !self.path.as_os_str().is_empty(),
             "pinned artifact path is empty"
         );
-        validate_sha256(&self.sha256, "pinned artifact hash")?;
+        validate_sha256_identity(&self.sha256, "pinned artifact hash")?;
         if self.path.is_relative() {
             self.path = base.join(&self.path);
         }
@@ -110,9 +113,9 @@ impl PinnedLocalArtifact {
     }
 
     pub fn verify_bytes(&self) -> Result<Vec<u8>> {
-        validate_sha256(&self.sha256, "pinned artifact hash")?;
+        validate_sha256_identity(&self.sha256, "pinned artifact hash")?;
         let bytes = read_regular_file(&self.path, "pinned artifact")?;
-        let observed = sha256_bytes(&bytes);
+        let observed = sha256_identity(&bytes);
         ensure!(
             observed == self.sha256,
             "pinned artifact {} changed: expected {}, observed {observed}",
@@ -123,78 +126,24 @@ impl PinnedLocalArtifact {
     }
 
     pub fn verify_json<T: DeserializeOwned>(&self) -> Result<T> {
-        serde_json::from_slice(&self.verify_bytes()?)
+        validate_sha256_identity(&self.sha256, "pinned artifact hash")?;
+        let bytes = read_regular_json(&self.path, "pinned JSON artifact")?;
+        let observed = sha256_identity(&bytes);
+        ensure!(
+            observed == self.sha256,
+            "pinned artifact {} changed: expected {}, observed {observed}",
+            self.path.display(),
+            self.sha256
+        );
+        serde_json::from_slice(&bytes)
             .with_context(|| format!("invalid pinned JSON artifact {}", self.path.display()))
     }
-}
-
-fn sync_directory(path: &Path) -> Result<()> {
-    File::open(path)
-        .with_context(|| format!("failed to open directory {} for sync", path.display()))?
-        .sync_all()
-        .with_context(|| format!("failed to sync directory {}", path.display()))
 }
 
 /// Publish bytes without replacing an existing artifact. An existing target is
 /// accepted only when it is a regular file containing the exact same bytes.
 fn publish_immutable(path: &Path, bytes: &[u8]) -> Result<()> {
-    let parent = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    let parent_metadata = fs::symlink_metadata(parent)
-        .with_context(|| format!("failed to inspect output directory {}", parent.display()))?;
-    ensure!(
-        parent_metadata.is_dir() && !parent_metadata.file_type().is_symlink(),
-        "output parent {} must be a real directory",
-        parent.display()
-    );
-    if path.exists() {
-        ensure!(
-            read_regular_file(path, "immutable artifact")? == bytes,
-            "immutable artifact {} already exists with different contents",
-            path.display()
-        );
-        return Ok(());
-    }
-
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .context("immutable artifact filename is not UTF-8")?;
-    let ordinal = TEMPORARY_ORDINAL.fetch_add(1, Ordering::Relaxed);
-    let temporary = parent.join(format!(
-        ".{file_name}.tmp.{}.{}",
-        std::process::id(),
-        ordinal
-    ));
-    let result = (|| {
-        let mut output = OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&temporary)
-            .with_context(|| format!("failed to create {}", temporary.display()))?;
-        output.write_all(bytes)?;
-        output.sync_all()?;
-        drop(output);
-        match fs::hard_link(&temporary, path) {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                ensure!(
-                    read_regular_file(path, "immutable artifact")? == bytes,
-                    "immutable artifact {} won a publication race with different contents",
-                    path.display()
-                );
-            }
-            Err(error) => return Err(error).context("publishing immutable artifact"),
-        }
-        fs::remove_file(&temporary)?;
-        sync_directory(parent)
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&temporary);
-    }
-    result
+    atomic_write_new(path, bytes)
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -208,15 +157,25 @@ pub struct WakeContextRecord {
 
 impl WakeContextRecord {
     fn validate(&self) -> Result<()> {
-        ensure!(!self.id.trim().is_empty(), "wake context id is empty");
+        ensure!(
+            !self.id.trim().is_empty() && self.id.len() <= MAX_WAKE_CONTEXT_ID_BYTES,
+            "wake context id must contain 1..={MAX_WAKE_CONTEXT_ID_BYTES} bytes"
+        );
         ensure!(
             !self.token_ids.is_empty(),
             "wake context `{}` has no tokens",
             self.id
         );
         ensure!(
-            self.token_ids.iter().all(|token| *token >= 0),
-            "wake context `{}` contains a negative token id",
+            self.token_ids.len() <= MAX_WAKE_CONTEXT_TOKENS,
+            "wake context `{}` exceeds the {MAX_WAKE_CONTEXT_TOKENS}-token limit",
+            self.id
+        );
+        ensure!(
+            self.token_ids
+                .iter()
+                .all(|token| u32::try_from(*token).is_ok()),
+            "wake context `{}` contains a token outside the u32 vocabulary range",
             self.id
         );
         Ok(())
@@ -241,7 +200,7 @@ impl WakeContextJournal {
             source_checkpoint_sha256: source_checkpoint_sha256.into(),
             records: Vec::new(),
         };
-        validate_sha256(
+        validate_sha256_identity(
             &journal.source_checkpoint_sha256,
             "wake-context source checkpoint hash",
         )?;
@@ -250,6 +209,10 @@ impl WakeContextJournal {
 
     pub fn push(&mut self, record: WakeContextRecord) -> Result<()> {
         record.validate()?;
+        ensure!(
+            self.records.len() < MAX_WAKE_CONTEXT_RECORDS,
+            "wake context journal exceeds the {MAX_WAKE_CONTEXT_RECORDS}-record limit"
+        );
         ensure!(
             !self.records.iter().any(|existing| existing.id == record.id),
             "wake context journal repeats id `{}`",
@@ -271,11 +234,24 @@ impl WakeContextJournal {
             "unsupported wake-context journal version {}",
             self.version
         );
-        validate_sha256(
+        validate_sha256_identity(
             &self.source_checkpoint_sha256,
             "wake-context source checkpoint hash",
         )?;
         ensure!(!self.records.is_empty(), "wake context journal is empty");
+        ensure!(
+            self.records.len() <= MAX_WAKE_CONTEXT_RECORDS,
+            "wake context journal exceeds the {MAX_WAKE_CONTEXT_RECORDS}-record limit"
+        );
+        let total_tokens = self.records.iter().try_fold(0usize, |total, record| {
+            total
+                .checked_add(record.token_ids.len())
+                .context("wake context journal token count overflow")
+        })?;
+        ensure!(
+            total_tokens <= MAX_WAKE_CONTEXT_TOTAL_TOKENS,
+            "wake context journal exceeds the {MAX_WAKE_CONTEXT_TOTAL_TOKENS}-token limit"
+        );
         let mut ids = BTreeSet::new();
         let mut previous_step = 0;
         for (index, record) in self.records.iter().enumerate() {
@@ -299,7 +275,7 @@ impl WakeContextJournal {
         self.validate()?;
         let mut bytes = serde_json::to_vec_pretty(self)?;
         bytes.push(b'\n');
-        let sha256 = sha256_bytes(&bytes);
+        let sha256 = sha256_identity(&bytes);
         publish_immutable(path, &bytes)?;
         PinnedWakeContextJournal::load(path, &sha256)
     }
@@ -381,17 +357,28 @@ impl JournalRolloutConfig {
             "journal rollout context and continuation lengths must be positive"
         );
         ensure!(
+            self.max_context_tokens <= MAX_WAKE_CONTEXT_TOKENS,
+            "journal rollout context exceeds the {MAX_WAKE_CONTEXT_TOKENS}-token limit"
+        );
+        ensure!(
+            self.continuation_tokens <= MAX_ROLLOUT_CONTINUATION_TOKENS,
+            "journal rollout continuation exceeds the {MAX_ROLLOUT_CONTINUATION_TOKENS}-token limit"
+        );
+        ensure!(
             self.temperature.is_finite() && self.temperature > 0.0,
             "journal rollout temperature must be finite and positive"
         );
-        ensure!(self.top_k > 0, "journal rollout top_k must be positive");
+        ensure!(
+            (1..=MAX_ROLLOUT_TOP_K).contains(&self.top_k),
+            "journal rollout top_k must be in 1..={MAX_ROLLOUT_TOP_K}"
+        );
         ensure!(
             self.repetition_penalty.is_finite() && self.repetition_penalty >= 1.0,
             "journal rollout repetition penalty must be finite and at least one"
         );
         ensure!(
-            self.imitation_groups > 0,
-            "journal rollout imitation_groups must be positive"
+            (1..=MAX_TENSOR_IMITATION_GROUPS).contains(&self.imitation_groups),
+            "journal rollout imitation_groups must be in 1..={MAX_TENSOR_IMITATION_GROUPS}"
         );
         Ok(())
     }
@@ -435,8 +422,8 @@ impl JournalRollouts {
         config: JournalRolloutConfig,
     ) -> Result<Self> {
         config.validate()?;
-        validate_sha256(phase_input_sha256, "sleep phase input checkpoint")?;
-        validate_sha256(teacher_sha256, "sleep transaction teacher")?;
+        validate_sha256_identity(phase_input_sha256, "sleep phase input checkpoint")?;
+        validate_sha256_identity(teacher_sha256, "sleep transaction teacher")?;
         ensure!(
             journal.source_checkpoint_sha256() == phase_input_sha256,
             "wake-context journal belongs to {}, phase input is {}",
@@ -661,11 +648,23 @@ impl TokenSemanticJudgeArtifact {
                 && self.unigram_weight + self.bigram_weight > 0.0,
             "semantic-judge n-gram weights must be finite, non-negative, and not both zero"
         );
+        ensure!(
+            self.equivalence_classes.len() <= MAX_SEMANTIC_EQUIVALENCE_CLASSES,
+            "semantic judge exceeds the {MAX_SEMANTIC_EQUIVALENCE_CLASSES}-class limit"
+        );
         let mut seen = BTreeSet::new();
+        let mut aliases = 0_usize;
         for class in &self.equivalence_classes {
             ensure!(
                 class.len() >= 2 && class.iter().all(|token| *token >= 0),
                 "semantic equivalence classes require at least two non-negative token ids"
+            );
+            aliases = aliases
+                .checked_add(class.len())
+                .context("semantic alias count overflow")?;
+            ensure!(
+                aliases <= MAX_SEMANTIC_ALIAS_TOKENS,
+                "semantic judge exceeds the {MAX_SEMANTIC_ALIAS_TOKENS}-alias limit"
             );
             for token in class {
                 ensure!(
@@ -684,7 +683,7 @@ impl TokenSemanticJudgeArtifact {
 pub struct PinnedTokenSemanticJudge {
     artifact_sha256: String,
     artifact: TokenSemanticJudgeArtifact,
-    aliases: BTreeMap<i64, i64>,
+    aliases: HashMap<i64, i64>,
 }
 
 impl PinnedTokenSemanticJudge {
@@ -707,11 +706,8 @@ impl PinnedTokenSemanticJudge {
         })
     }
 
-    fn canonical(&self, tokens: &[i64]) -> Vec<i64> {
-        tokens
-            .iter()
-            .map(|token| self.aliases.get(token).copied().unwrap_or(*token))
-            .collect()
+    fn canonical(&self, token: i64) -> i64 {
+        self.aliases.get(&token).copied().unwrap_or(token)
     }
 }
 
@@ -729,18 +725,24 @@ impl SemanticJudge for PinnedTokenSemanticJudge {
             teacher.iter().chain(candidate).all(|token| *token >= 0),
             "semantic judge received a negative token id"
         );
-        let teacher = self.canonical(teacher);
-        let candidate = self.canonical(candidate);
         let unigram = multiset_f1(
-            teacher.iter().copied().map(|token| (token, i64::MIN)),
-            candidate.iter().copied().map(|token| (token, i64::MIN)),
+            teacher
+                .iter()
+                .map(|token| (self.canonical(*token), i64::MIN)),
+            candidate
+                .iter()
+                .map(|token| (self.canonical(*token), i64::MIN)),
         );
         let bigram = if teacher.len() < 2 || candidate.len() < 2 {
             unigram
         } else {
             multiset_f1(
-                teacher.windows(2).map(|pair| (pair[0], pair[1])),
-                candidate.windows(2).map(|pair| (pair[0], pair[1])),
+                teacher
+                    .windows(2)
+                    .map(|pair| (self.canonical(pair[0]), self.canonical(pair[1]))),
+                candidate
+                    .windows(2)
+                    .map(|pair| (self.canonical(pair[0]), self.canonical(pair[1]))),
             )
         };
         let weight = self.artifact.unigram_weight + self.artifact.bigram_weight;
@@ -755,23 +757,25 @@ fn multiset_f1(
     left: impl Iterator<Item = (i64, i64)>,
     right: impl Iterator<Item = (i64, i64)>,
 ) -> f32 {
-    let mut left_counts = BTreeMap::<(i64, i64), usize>::new();
-    let mut right_counts = BTreeMap::<(i64, i64), usize>::new();
+    let mut left_counts = HashMap::<(i64, i64), usize>::new();
     for item in left {
         *left_counts.entry(item).or_default() += 1;
     }
-    for item in right {
-        *right_counts.entry(item).or_default() += 1;
-    }
     let left_total = left_counts.values().sum::<usize>();
-    let right_total = right_counts.values().sum::<usize>();
+    let mut right_total = 0_usize;
+    let mut overlap = 0_usize;
+    for item in right {
+        right_total += 1;
+        if let Some(remaining) = left_counts.get_mut(&item)
+            && *remaining > 0
+        {
+            *remaining -= 1;
+            overlap += 1;
+        }
+    }
     if left_total == 0 || right_total == 0 {
         return 0.0;
     }
-    let overlap = left_counts
-        .iter()
-        .map(|(item, count)| (*count).min(right_counts.get(item).copied().unwrap_or(0)))
-        .sum::<usize>();
     2.0 * overlap as f32 / (left_total + right_total) as f32
 }
 
@@ -810,8 +814,17 @@ impl RetentionSequence {
     fn validate(&self) -> Result<()> {
         ensure!(!self.id.trim().is_empty(), "retention sequence id is empty");
         ensure!(
+            self.id.len() <= MAX_RETENTION_SEQUENCE_ID_BYTES,
+            "retention sequence id exceeds the {MAX_RETENTION_SEQUENCE_ID_BYTES}-byte limit"
+        );
+        ensure!(
             self.token_ids.len() >= 2 && self.token_ids.iter().all(|token| *token >= 0),
             "retention sequence `{}` needs at least two non-negative token ids",
+            self.id
+        );
+        ensure!(
+            self.token_ids.len() <= MAX_RETENTION_SEQUENCE_TOKENS,
+            "retention sequence `{}` exceeds the {MAX_RETENTION_SEQUENCE_TOKENS}-token limit",
             self.id
         );
         Ok(())
@@ -837,9 +850,26 @@ impl RetentionSuiteArtifact {
             !self.stable_anchors.is_empty() && !self.incorporation.is_empty(),
             "retention suite requires stable-anchor and incorporation sequences"
         );
+        let sequence_count = self
+            .stable_anchors
+            .len()
+            .checked_add(self.incorporation.len())
+            .context("retention-suite sequence count overflow")?;
+        ensure!(
+            sequence_count <= MAX_RETENTION_SEQUENCES,
+            "retention suite exceeds the {MAX_RETENTION_SEQUENCES}-sequence limit"
+        );
         let mut ids = BTreeSet::new();
+        let mut total_tokens = 0_usize;
         for sequence in self.stable_anchors.iter().chain(&self.incorporation) {
             sequence.validate()?;
+            total_tokens = total_tokens
+                .checked_add(sequence.token_ids.len())
+                .context("retention-suite token count overflow")?;
+            ensure!(
+                total_tokens <= MAX_RETENTION_TOTAL_TOKENS,
+                "retention suite exceeds the {MAX_RETENTION_TOTAL_TOKENS}-token limit"
+            );
             ensure!(
                 ids.insert(sequence.id.as_str()),
                 "retention suite repeats sequence id `{}`",
@@ -896,7 +926,8 @@ impl PinnedLikelihoodRetentionEvaluator {
                 sequence
                     .token_ids
                     .iter()
-                    .all(|token| (*token as usize) < model.config().vocab_size),
+                    .all(|token| usize::try_from(*token)
+                        .is_ok_and(|token| token < model.config().vocab_size)),
                 "retention sequence `{}` contains an out-of-vocabulary token",
                 sequence.id
             );
@@ -977,7 +1008,7 @@ mod tests {
     fn write_json(path: &Path, value: &impl Serialize) -> String {
         let bytes = serde_json::to_vec_pretty(value).unwrap();
         fs::write(path, &bytes).unwrap();
-        sha256_bytes(&bytes)
+        sha256_identity(&bytes)
     }
 
     fn transaction(teacher_hash: String) -> ConsolidationTxn {
@@ -1017,6 +1048,90 @@ mod tests {
             dream_trials: Vec::new(),
             dream_policy_receipt: None,
             committed: false,
+        }
+    }
+
+    #[test]
+    fn pinned_sleep_json_rejects_oversized_input_before_allocation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("oversized.json");
+        let file = fs::File::create(&path).unwrap();
+        file.set_len(MAX_SLEEP_INPUT_JSON_BYTES + 1).unwrap();
+        drop(file);
+
+        let artifact = PinnedLocalArtifact {
+            path,
+            sha256: hash('a'),
+        };
+        let error = artifact.verify_json::<serde_json::Value>().unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("byte limit"), "{error}");
+    }
+
+    #[test]
+    fn wake_journal_and_rollout_work_are_semantically_bounded() {
+        let mut journal = WakeContextJournal::new(hash('1')).unwrap();
+        assert!(
+            journal
+                .push(WakeContextRecord {
+                    id: "oversized".into(),
+                    optimizer_step: 1,
+                    token_ids: vec![1; MAX_WAKE_CONTEXT_TOKENS + 1],
+                })
+                .is_err()
+        );
+        for record in [
+            WakeContextRecord {
+                id: "x".repeat(MAX_WAKE_CONTEXT_ID_BYTES + 1),
+                optimizer_step: 1,
+                token_ids: vec![1],
+            },
+            WakeContextRecord {
+                id: "invalid-token".into(),
+                optimizer_step: 1,
+                token_ids: vec![i64::from(u32::MAX) + 1],
+            },
+        ] {
+            assert!(journal.push(record).is_err());
+        }
+
+        journal.records = (0..=MAX_WAKE_CONTEXT_RECORDS)
+            .map(|index| WakeContextRecord {
+                id: format!("wake:{index}"),
+                optimizer_step: index as u64,
+                token_ids: vec![1],
+            })
+            .collect();
+        assert!(journal.validate().is_err());
+
+        let valid = JournalRolloutConfig {
+            max_context_tokens: 4,
+            continuation_tokens: 2,
+            temperature: 0.8,
+            top_k: 4,
+            repetition_penalty: 1.0,
+            eos_token: None,
+            imitation_groups: 2,
+        };
+        valid.validate().unwrap();
+        let mutations: [fn(&mut JournalRolloutConfig); 4] = [
+            |config: &mut JournalRolloutConfig| {
+                config.max_context_tokens = MAX_WAKE_CONTEXT_TOKENS + 1;
+            },
+            |config: &mut JournalRolloutConfig| {
+                config.continuation_tokens = MAX_ROLLOUT_CONTINUATION_TOKENS + 1;
+            },
+            |config: &mut JournalRolloutConfig| {
+                config.top_k = MAX_ROLLOUT_TOP_K + 1;
+            },
+            |config: &mut JournalRolloutConfig| {
+                config.imitation_groups = MAX_TENSOR_IMITATION_GROUPS + 1;
+            },
+        ];
+        for mutate in mutations {
+            let mut invalid = valid.clone();
+            mutate(&mut invalid);
+            assert!(invalid.validate().is_err());
         }
     }
 
@@ -1171,5 +1286,37 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn retention_suite_cardinality_and_record_sizes_are_bounded() {
+        let valid = || RetentionSequence {
+            id: "anchor".into(),
+            token_ids: vec![1, 2],
+        };
+
+        let mut oversized_id = valid();
+        oversized_id.id = "x".repeat(MAX_RETENTION_SEQUENCE_ID_BYTES + 1);
+        assert!(oversized_id.validate().is_err());
+
+        let mut oversized_tokens = valid();
+        oversized_tokens.token_ids = vec![1; MAX_RETENTION_SEQUENCE_TOKENS + 1];
+        assert!(oversized_tokens.validate().is_err());
+
+        let suite = RetentionSuiteArtifact {
+            version: RETENTION_SUITE_VERSION,
+            stable_anchors: (0..MAX_RETENTION_SEQUENCES)
+                .map(|index| RetentionSequence {
+                    id: format!("anchor-{index}"),
+                    token_ids: vec![1, 2],
+                })
+                .collect(),
+            incorporation: vec![RetentionSequence {
+                id: "incorporation".into(),
+                token_ids: vec![2, 1],
+            }],
+        };
+        let error = suite.validate().unwrap_err().to_string();
+        assert!(error.contains("sequence limit"), "{error}");
     }
 }

--- a/hermes-train/src/builtin_sleep_runtime.rs
+++ b/hermes-train/src/builtin_sleep_runtime.rs
@@ -8,21 +8,17 @@
 //! native factory and boundary-driver contracts without weakening these
 //! bindings.
 
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail, ensure};
-use burn::module::list_param_ids;
-use burn_optim::{AdamWConfig, ModuleOptimizer};
-use hermes_llm::{Device, ModelDef, Transformer, default_device, load_safetensors, parse_mal};
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-
+use crate::artifact_io::{
+    atomic_write_new, ensure_directory, sha256_identity, validate_sha256_identity,
+};
 use crate::builtin_dreaming::{BuiltinDreamOps, BuiltinDreamingRuntimeConfig};
 use crate::builtin_sleep_adapters::{
-    JournalRolloutConfig, JournalRollouts, PinnedLikelihoodRetentionEvaluator, PinnedLocalArtifact,
-    PinnedTokenSemanticJudge, PinnedWakeContextJournal,
+    JournalRolloutConfig, JournalRollouts, MAX_WAKE_CONTEXT_RECORDS, MAX_WAKE_CONTEXT_TOTAL_TOKENS,
+    PinnedLikelihoodRetentionEvaluator, PinnedLocalArtifact, PinnedTokenSemanticJudge,
+    PinnedWakeContextJournal,
 };
 use crate::native_sleep::{
     NativeCheckpointRef, NativeConsolidationOutcome, NativeSleepCheckpoint,
@@ -31,6 +27,7 @@ use crate::native_sleep::{
     execute_native_consolidation, execute_native_dreaming,
 };
 use crate::runtime::PhaseExecutionRequest;
+use crate::sleep::MAX_SLEEP_RNG_STREAMS;
 use crate::tensor_sleep::{
     ImmutableTransformerCheckpoint, TensorConsolidationBackend, TensorDreamBackend,
     TensorTransactionStore, restore_parameter_ids,
@@ -40,6 +37,13 @@ use crate::tier_optimizer::{
     TierOptimizerBank, TierOptimizerConfig,
 };
 use crate::workflow::InModelSleepConfig;
+use anyhow::{Context, Result, bail, ensure};
+use burn::module::list_param_ids;
+use burn_optim::{AdamWConfig, ModuleOptimizer};
+use hermes_llm::{
+    Device, ModelDef, Transformer, default_device, load_safetensors_bytes, parse_mal,
+};
+use serde::{Deserialize, Serialize};
 
 pub const BUILTIN_SLEEP_RUNTIME_CONFIG_VERSION: u32 = 1;
 pub const MODEL_PARAMETER_IDS_VERSION: u32 = 1;
@@ -164,13 +168,22 @@ impl BuiltinSleepRuntimeConfig {
             "unsupported built-in sleep runtime version {}",
             self.version
         );
-        validate_sha256(&self.workflow_signature, "workflow signature")?;
+        validate_sha256_identity(&self.workflow_signature, "workflow signature")?;
         self.rollouts.validate()?;
         self.tier_optimizer.validate()?;
-        ensure!(self.rng_streams > 0, "sleep runtime has no RNG streams");
         ensure!(
-            self.max_wake_context_records > 0,
-            "sleep runtime wake-context ring is empty"
+            (1..=MAX_SLEEP_RNG_STREAMS).contains(&self.rng_streams),
+            "sleep runtime must contain 1..={MAX_SLEEP_RNG_STREAMS} RNG streams"
+        );
+        ensure!(
+            (1..=MAX_WAKE_CONTEXT_RECORDS).contains(&self.max_wake_context_records),
+            "sleep runtime wake-context ring must contain 1..={MAX_WAKE_CONTEXT_RECORDS} records"
+        );
+        ensure!(
+            self.max_wake_context_records
+                .checked_mul(self.rollouts.max_context_tokens)
+                .is_some_and(|tokens| tokens <= MAX_WAKE_CONTEXT_TOTAL_TOKENS),
+            "sleep runtime wake-context ring exceeds the {MAX_WAKE_CONTEXT_TOTAL_TOKENS}-token limit"
         );
         let mut directories = vec![
             &self.tensor_transaction_directory,
@@ -292,7 +305,7 @@ impl ModelParameterIdsArtifact {
             "unsupported model parameter-id artifact version {}",
             self.version
         );
-        validate_sha256(&self.checkpoint_sha256, "parameter-id checkpoint")?;
+        validate_sha256_identity(&self.checkpoint_sha256, "parameter-id checkpoint")?;
         ensure!(
             !self.parameter_ids.is_empty(),
             "model parameter-id artifact is empty"
@@ -408,7 +421,7 @@ impl BuiltinSleepPhaseContextFactory {
             &config.candidate_directory,
             &config.rejection_report_directory,
         ] {
-            ensure_real_directory(directory)?;
+            ensure_directory(directory, "sleep runtime directory")?;
         }
         Ok(Self {
             identity: expected_sha256.to_owned(),
@@ -534,6 +547,31 @@ impl NativeSleepProgressSink for ProgressForward<'_> {
     }
 }
 
+fn load_pinned_checkpoint_model(
+    artifact: &PinnedLocalArtifact,
+    model_def: &ModelDef,
+    device: &Device,
+) -> Result<Transformer> {
+    load_pinned_checkpoint_model_inner(artifact, model_def, device, |_| Ok(()))
+}
+
+fn load_pinned_checkpoint_model_inner(
+    artifact: &PinnedLocalArtifact,
+    model_def: &ModelDef,
+    device: &Device,
+    stage_hook: impl FnOnce(&Path) -> Result<()>,
+) -> Result<Transformer> {
+    let bytes = artifact.verify_bytes()?;
+    stage_hook(&artifact.path)?;
+    let mut model = Transformer::new(model_def, device)?;
+    load_safetensors_bytes(
+        &mut model,
+        bytes,
+        "authenticated standalone sleep checkpoint",
+    )?;
+    Ok(model)
+}
+
 impl BuiltinStandaloneSleepContext {
     fn model_def(&self) -> Result<ModelDef> {
         let bytes = self.runtime.model_mal.verify_bytes()?;
@@ -550,9 +588,7 @@ impl BuiltinStandaloneSleepContext {
             path: PathBuf::from(&reference.uri),
             sha256: reference.sha256.clone(),
         };
-        artifact.verify_bytes()?;
-        let mut model = Transformer::new(model_def, &self.device)?;
-        load_safetensors(&mut model, &artifact.path)?;
+        let model = load_pinned_checkpoint_model(&artifact, model_def, &self.device)?;
         Ok(ImmutableTransformerCheckpoint {
             uri: reference.uri.clone(),
             sha256: reference.sha256.clone(),
@@ -781,11 +817,7 @@ impl NativeSleepPhaseContext for BuiltinStandaloneSleepContext {
 
         // Rehydrate every durable optimizer generation before either replaying
         // an in-flight transaction or preparing the next sender.
-        let scope_model_ref = if let Some(txn) = &cursor.sleep.pending {
-            NativeCheckpointRef::new(&txn.teacher_checkpoint, &txn.teacher_hash)?
-        } else {
-            cursor.live_checkpoint.clone()
-        };
+        let scope_model_ref = cursor.optimizer_scope_checkpoint()?;
         let scope_model = self.recover_model_for_ref(
             &cursor,
             &scope_model_ref,
@@ -866,6 +898,7 @@ impl NativeSleepPhaseContext for BuiltinStandaloneSleepContext {
                             probe,
                             ops,
                         )?;
+                        dreaming.bind_candidate_checkpoint(&committed.uri, &committed.sha256)?;
                         execute_native_dreaming(
                             &mut cursor,
                             &committed.model,
@@ -1383,6 +1416,7 @@ impl PeriodicSleepBoundaryDriver for BuiltinPeriodicSleepBoundaryDriver {
                     probe,
                     ops,
                 )?;
+                dreaming.bind_candidate_checkpoint(&self.live.uri, &self.live.sha256)?;
                 execute_native_dreaming(
                     checkpoint,
                     &self.live.model,
@@ -1415,6 +1449,10 @@ impl PeriodicSleepBoundaryDriver for BuiltinPeriodicSleepBoundaryDriver {
 struct NoDreamBackend;
 
 impl crate::sleep::DreamingBackend for NoDreamBackend {
+    fn verify_committed_candidate(&mut self, _: &crate::sleep::ConsolidationTxn) -> Result<()> {
+        unreachable!("Dreaming backend is absent")
+    }
+
     fn shared_checkpoint_hash(&mut self) -> Result<String> {
         unreachable!("Dreaming backend is absent")
     }
@@ -1481,27 +1519,14 @@ struct RejectionReport {
 }
 
 fn publish_json<T: Serialize>(root: &Path, stem: &str, value: &T) -> Result<(String, String)> {
-    ensure_real_directory(root)?;
+    ensure_directory(root, "sleep runtime directory")?;
     let bytes = serde_json::to_vec_pretty(value)?;
-    let sha256 = sha256_bytes(&bytes);
+    let sha256 = sha256_identity(&bytes);
     let digest = sha256
         .strip_prefix("sha256:")
         .expect("hash helper returns prefixed digest");
     let path = root.join(format!("{stem}-sha256-{digest}.json"));
-    if path.exists() {
-        ensure!(
-            read_regular(&path)? == bytes,
-            "immutable report hash collision"
-        );
-    } else {
-        let mut file = OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&path)?;
-        file.write_all(&bytes)?;
-        file.sync_all()?;
-        File::open(root)?.sync_all()?;
-    }
+    atomic_write_new(&path, &bytes).context("publishing immutable sleep report")?;
     Ok((
         path.to_str()
             .context("report path is not UTF-8")?
@@ -1510,55 +1535,9 @@ fn publish_json<T: Serialize>(root: &Path, stem: &str, value: &T) -> Result<(Str
     ))
 }
 
-fn validate_sha256(value: &str, label: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .with_context(|| format!("{label} must use sha256:<64 lowercase hex>"))?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{label} must use sha256:<64 lowercase hex>"
-    );
-    Ok(())
-}
-
-fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("sha256:{:x}", Sha256::digest(bytes))
-}
-
-fn read_regular(path: &Path) -> Result<Vec<u8>> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("reading metadata for {}", path.display()))?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "{} is not a regular non-symlink file",
-        path.display()
-    );
-    let mut bytes = Vec::new();
-    File::open(path)?.read_to_end(&mut bytes)?;
-    Ok(bytes)
-}
-
-fn ensure_real_directory(path: &Path) -> Result<()> {
-    if path.exists() {
-        let metadata = fs::symlink_metadata(path)?;
-        ensure!(
-            metadata.is_dir() && !metadata.file_type().is_symlink(),
-            "{} is not a real directory",
-            path.display()
-        );
-    } else {
-        fs::create_dir_all(path)
-            .with_context(|| format!("creating sleep runtime directory {}", path.display()))?;
-    }
-    Ok(())
-}
-
 fn ensure_same_directory(left: &Path, right: &Path, label: &str) -> Result<()> {
-    ensure_real_directory(left)?;
-    ensure_real_directory(right)?;
+    ensure_directory(left, "sleep runtime directory")?;
+    ensure_directory(right, "sleep runtime directory")?;
     ensure!(
         fs::canonicalize(left)? == fs::canonicalize(right)?,
         "WorkflowV2 {label} differs from built-in runtime"
@@ -1617,7 +1596,7 @@ mod tests {
         fs::write(path, bytes).unwrap();
         PinnedLocalArtifact {
             path: path.to_owned(),
-            sha256: sha256_bytes(bytes),
+            sha256: sha256_identity(bytes),
         }
     }
 
@@ -1655,7 +1634,7 @@ mod tests {
 
     fn publish_test_policy(root: &Path, transaction_id: u64) -> String {
         let mut bytes = serde_json::to_vec(&serde_json::json!({
-            "version": 2,
+            "version": crate::builtin_dreaming::RESTEM_POLICY_VERSION,
             "parent_policy_sha256": null,
             "parent_adapter_sha256": null,
             "transaction_id": transaction_id,
@@ -1675,7 +1654,7 @@ mod tests {
         }))
         .unwrap();
         bytes.push(b'\n');
-        let receipt = sha256_bytes(&bytes);
+        let receipt = sha256_identity(&bytes);
         let policies = root.join("policies");
         fs::create_dir_all(&policies).unwrap();
         fs::write(
@@ -1736,13 +1715,33 @@ mod tests {
     }
 
     #[test]
+    fn periodic_wake_context_ring_rejects_unbounded_configuration() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut config = periodic_runtime(directory.path());
+        config.max_wake_context_records = MAX_WAKE_CONTEXT_RECORDS + 1;
+        let error = config.validate_periodic().unwrap_err().to_string();
+        assert!(error.contains("wake-context ring"), "{error}");
+
+        config.max_wake_context_records = MAX_WAKE_CONTEXT_RECORDS;
+        config.rollouts.max_context_tokens = crate::builtin_sleep_adapters::MAX_WAKE_CONTEXT_TOKENS;
+        let error = config.validate_periodic().unwrap_err().to_string();
+        assert!(error.contains("token limit"), "{error}");
+
+        config.max_wake_context_records = 64;
+        config.rollouts.max_context_tokens = 512;
+        config.rng_streams = MAX_SLEEP_RNG_STREAMS + 1;
+        let error = config.validate_periodic().unwrap_err().to_string();
+        assert!(error.contains("RNG streams"), "{error}");
+    }
+
+    #[test]
     fn periodic_loader_does_not_require_standalone_wake_artifacts() {
         let directory = tempfile::tempdir().unwrap();
         let config = periodic_runtime(directory.path());
         let path = directory.path().join("runtime.json");
         let bytes = serde_json::to_vec_pretty(&config).unwrap();
         fs::write(&path, &bytes).unwrap();
-        let digest = sha256_bytes(&bytes);
+        let digest = sha256_identity(&bytes);
 
         let factory = BuiltinSleepPhaseContextFactory::load_periodic_on_device(
             &path,
@@ -1867,6 +1866,44 @@ mod tests {
             &Device::ndarray().autodiff(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn standalone_checkpoint_load_does_not_reopen_a_replaced_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let model_def = parse_mal(model_source()).unwrap();
+        let device = Device::ndarray().autodiff();
+        device.seed(41);
+        let model = Transformer::new(&model_def, &device).unwrap();
+        let expected = crate::tensor_sleep::model_parameter_hash(&model).unwrap();
+        let checkpoint = directory.path().join("standalone.safetensors");
+        hermes_llm::save_safetensors(&model.clone().valid(), &checkpoint).unwrap();
+        let artifact = PinnedLocalArtifact {
+            path: checkpoint.clone(),
+            sha256: sha256_identity(&fs::read(&checkpoint).unwrap()),
+        };
+
+        device.seed(43);
+        let replacement_model = Transformer::new(&model_def, &device).unwrap();
+        assert_ne!(
+            crate::tensor_sleep::model_parameter_hash(&replacement_model).unwrap(),
+            expected
+        );
+        let replacement = directory.path().join("replacement.safetensors");
+        let held = directory.path().join("held-standalone.safetensors");
+        hermes_llm::save_safetensors(&replacement_model.valid(), &replacement).unwrap();
+
+        let loaded = load_pinned_checkpoint_model_inner(&artifact, &model_def, &device, |path| {
+            fs::rename(path, &held)?;
+            fs::rename(&replacement, path)?;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(
+            crate::tensor_sleep::model_parameter_hash(&loaded).unwrap(),
+            expected,
+            "standalone sleep checkpoint loader reopened a replaced pathname"
+        );
     }
 
     #[test]
@@ -2009,7 +2046,7 @@ mod tests {
         let checkpoint_path = root.join("teacher.safetensors");
         hermes_llm::save_safetensors(&model.clone().valid(), &checkpoint_path).unwrap();
         let checkpoint_bytes = fs::read(&checkpoint_path).unwrap();
-        let checkpoint_sha256 = sha256_bytes(&checkpoint_bytes);
+        let checkpoint_sha256 = sha256_identity(&checkpoint_bytes);
 
         let bank = TierOptimizerBank::new(
             &model,
@@ -2089,7 +2126,7 @@ mod tests {
         let runtime_path = root.join("standalone-runtime.json");
         let runtime_bytes = serde_json::to_vec_pretty(&runtime).unwrap();
         fs::write(&runtime_path, &runtime_bytes).unwrap();
-        let runtime_sha256 = sha256_bytes(&runtime_bytes);
+        let runtime_sha256 = sha256_identity(&runtime_bytes);
 
         let mut sleep = sleep_config(root, suite.sha256.clone());
         sleep.standalone_trigger_clock = Some(0);

--- a/hermes-train/src/checkpoint.rs
+++ b/hermes-train/src/checkpoint.rs
@@ -9,41 +9,40 @@
 #[cfg(not(unix))]
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::fmt::Write as FmtWrite;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::fs::{self, File};
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-#[cfg(unix)]
-use std::ffi::{CStr, CString, OsStr, OsString};
-#[cfg(unix)]
-use std::os::fd::{AsRawFd, FromRawFd};
-#[cfg(unix)]
-use std::os::unix::ffi::{OsStrExt, OsStringExt};
-#[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
 use anyhow::{Context, Result, ensure};
 use burn::module::{AutodiffModule, Module, ModuleMapper, Param, ParamId};
 use burn::tensor::{Bool, Bytes, Device, Int, Tensor};
 use burn_optim::ModuleOptimizer;
 use hermes_llm::{Transformer, load_safetensors_bytes, save_safetensors};
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::muon::BatchedMuon;
+#[cfg(unix)]
+use hermes_train::artifact_io::{PinnedDirectory, StableIdentity};
+use hermes_train::artifact_io::{
+    ensure_real_directory, hash_open_file, hash_regular_file_hex, read_regular_bounded, sha256_hex,
+    sync_directory, sync_regular_file, validate_sha256_hex, validate_sha256_identity,
+    write_new_synced as write_synced_new,
+};
 use hermes_train::benchmark::{
     TRAINING_ACCOUNTING_FILE, TRAINING_ACCOUNTING_VERSION, TrainingAccounting, TrainingEvidence,
 };
-use hermes_train::builtin_sleep_adapters::WakeContextRecord;
+use hermes_train::builtin_sleep_adapters::{
+    MAX_WAKE_CONTEXT_ID_BYTES, MAX_WAKE_CONTEXT_RECORDS, MAX_WAKE_CONTEXT_TOKENS,
+    MAX_WAKE_CONTEXT_TOTAL_TOKENS, WakeContextRecord,
+};
 use hermes_train::metrics::MetricWriter;
 use hermes_train::native_sleep::NativeSleepCheckpoint;
 use hermes_train::optimizer_artifact::{
     canonical_module_optimizer_bytes, save_canonical_module_optimizer,
 };
-use hermes_train::quantization::QuantizationTransactionState;
+use hermes_train::sleep::{MemoryOptimizerScopes, UpdateClock};
+use hermes_train::workflow::MemoryUpdateMode;
 
 pub(crate) type AdamWOptimizer = ModuleOptimizer;
 
@@ -59,6 +58,11 @@ const TRAINING_STATE_FILE: &str = "training-state.json";
 const WEIGHTS_FILE: &str = "weights.safetensors";
 const ADAMW_FILE: &str = "adamw-state.bpk";
 const MUON_FILE: &str = "muon-state.bpk";
+const MAX_CHECKPOINT_METADATA_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_CHECKPOINT_MEMBER_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+const MAX_CHECKPOINT_GENERATION_FILES: usize = 1_024;
+const MAX_CHECKPOINT_GENERATION_DIRECTORIES: usize = 256;
+const MAX_CHECKPOINT_GENERATION_DEPTH: usize = 16;
 
 static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -98,10 +102,52 @@ struct GenerationSnapshot {
     access: Option<GenerationAccess>,
 }
 
+#[derive(Default)]
+struct GenerationTraversalBudget {
+    files: usize,
+    directories: usize,
+}
+
+impl GenerationTraversalBudget {
+    fn enter_directory(&mut self, depth: usize) -> Result<()> {
+        ensure!(
+            depth <= MAX_CHECKPOINT_GENERATION_DEPTH,
+            "checkpoint generation exceeds its maximum directory depth"
+        );
+        if depth > 0 {
+            self.directories = self
+                .directories
+                .checked_add(1)
+                .context("checkpoint directory count overflow")?;
+            ensure!(
+                self.directories <= MAX_CHECKPOINT_GENERATION_DIRECTORIES,
+                "checkpoint generation contains too many directories"
+            );
+        }
+        Ok(())
+    }
+
+    fn record_file(&mut self, bytes: u64) -> Result<()> {
+        self.files = self
+            .files
+            .checked_add(1)
+            .context("checkpoint file count overflow")?;
+        ensure!(
+            self.files <= MAX_CHECKPOINT_GENERATION_FILES,
+            "checkpoint generation contains too many files"
+        );
+        ensure!(
+            bytes <= MAX_CHECKPOINT_MEMBER_BYTES,
+            "checkpoint generation contains an oversized file"
+        );
+        Ok(())
+    }
+}
+
 #[cfg(unix)]
 #[derive(Debug)]
 struct GenerationAccess {
-    directory: SecureDirectory,
+    directory: PinnedDirectory,
 }
 
 #[cfg(not(unix))]
@@ -202,10 +248,34 @@ pub(crate) struct QuantizationTrainingState {
     pub(crate) fake_quant_active: bool,
     pub(crate) calibration_step: u64,
     pub(crate) manifest: Option<String>,
+    /// Canonical weights identity sealed by `manifest`. It is absent until a
+    /// final candidate exists and is checked against this checkpoint's own
+    /// authenticated weights file during both save and resume.
+    #[serde(deserialize_with = "deserialize_required_option")]
+    pub(crate) candidate_weights_sha256: Option<String>,
     pub(crate) teacher_hash: Option<String>,
-    /// Exact interruption point for an in-flight fake-quant/distillation
-    /// optimizer update. The backend validates its plan fingerprint on resume.
-    pub(crate) transaction: Option<QuantizationTransactionState>,
+}
+
+/// Checkpoint-bound memory execution strategy. The wake-only variant carries
+/// the exact typed configuration and content-addressed tier optimizer scopes,
+/// including every pending gradient accumulator and independent clock.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum TrainingMemoryUpdateState {
+    Ordinary,
+    PeriodicSleep,
+    WakeOnly {
+        config: MemoryUpdateMode,
+        optimizer_scopes: MemoryOptimizerScopes,
+    },
+}
+
+fn deserialize_required_option<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::<T>::deserialize(deserializer)
 }
 
 /// Complete version-2 trainer state.  The schema intentionally has no serde
@@ -228,6 +298,7 @@ pub(crate) struct TrainingState {
     pub(crate) data_manifest_hash: Option<String>,
     pub(crate) parameter_ids: Vec<u64>,
     pub(crate) optimizer_states: Vec<OptimizerStateRef>,
+    pub(crate) memory_update: TrainingMemoryUpdateState,
     pub(crate) sleep: Option<NativeSleepCheckpoint>,
     pub(crate) artifacts: Vec<ArtifactRef>,
     pub(crate) evaluator_hashes: Vec<String>,
@@ -258,13 +329,72 @@ impl TrainingState {
             !self.workflow_signature.trim().is_empty(),
             "checkpoint workflow signature is empty"
         );
-        validate_content_hash(&self.workflow_signature, "checkpoint workflow signature")?;
+        validate_sha256_identity(&self.workflow_signature, "checkpoint workflow signature")?;
         if let Some(hash) = &self.data_manifest_hash {
-            validate_content_hash(hash, "checkpoint data manifest hash")?;
+            validate_sha256_identity(hash, "checkpoint data manifest hash")?;
         }
         ensure!(
             self.global_step == 0 || self.tokens_seen > 0 || self.phase_kind == "evaluation",
             "non-evaluation checkpoint has optimizer progress but no token count"
+        );
+        ensure!(
+            self.global_step == 0 || self.metric_records > 0,
+            "checkpoint has optimizer progress but no committed metrics"
+        );
+        ensure!(
+            self.wake_context_buffer.len() <= MAX_WAKE_CONTEXT_RECORDS,
+            "checkpoint wake-context buffer exceeds the {MAX_WAKE_CONTEXT_RECORDS}-record limit"
+        );
+        let checkpoint_step = u64::try_from(self.global_step)
+            .context("checkpoint global step exceeds the wake-context clock")?;
+        let mut context_ids = BTreeSet::new();
+        let mut previous_context_step = None;
+        let wake_context_tokens =
+            self.wake_context_buffer
+                .iter()
+                .try_fold(0_usize, |total, record| -> Result<usize> {
+                    ensure!(
+                        !record.id.trim().is_empty()
+                            && record.id.len() <= MAX_WAKE_CONTEXT_ID_BYTES,
+                        "checkpoint wake-context id must contain 1..={MAX_WAKE_CONTEXT_ID_BYTES} bytes"
+                    );
+                    ensure!(
+                        context_ids.insert(record.id.as_str()),
+                        "checkpoint wake-context buffer repeats identity `{}`",
+                        record.id
+                    );
+                    ensure!(
+                        previous_context_step
+                            .is_none_or(|previous| previous <= record.optimizer_step)
+                            && record.optimizer_step <= checkpoint_step,
+                        "checkpoint wake-context buffer has an invalid optimizer-step order"
+                    );
+                    previous_context_step = Some(record.optimizer_step);
+                    ensure!(
+                        !record.token_ids.is_empty(),
+                        "checkpoint wake context `{}` has no tokens",
+                        record.id
+                    );
+                    ensure!(
+                        record.token_ids.len() <= MAX_WAKE_CONTEXT_TOKENS,
+                        "checkpoint wake context `{}` exceeds the {MAX_WAKE_CONTEXT_TOKENS}-token limit",
+                        record.id
+                    );
+                    ensure!(
+                        record
+                            .token_ids
+                            .iter()
+                            .all(|token| u32::try_from(*token).is_ok()),
+                        "checkpoint wake context `{}` contains a token outside the u32 vocabulary range",
+                        record.id
+                    );
+                    total
+                        .checked_add(record.token_ids.len())
+                        .context("checkpoint wake-context token count overflows usize")
+                })?;
+        ensure!(
+            wake_context_tokens <= MAX_WAKE_CONTEXT_TOTAL_TOKENS,
+            "checkpoint wake-context buffer exceeds the {MAX_WAKE_CONTEXT_TOTAL_TOKENS}-token limit"
         );
         let optimizer_scopes = self
             .optimizer_states
@@ -313,6 +443,102 @@ impl TrainingState {
                 );
             }
         }
+        match &self.memory_update {
+            TrainingMemoryUpdateState::Ordinary => ensure!(
+                self.sleep.is_none() && self.wake_context_buffer.is_empty(),
+                "ordinary checkpoint contains memory-training state"
+            ),
+            TrainingMemoryUpdateState::PeriodicSleep => ensure!(
+                self.sleep.is_some(),
+                "periodic_sleep checkpoint has no native sleep cursor"
+            ),
+            TrainingMemoryUpdateState::WakeOnly {
+                config,
+                optimizer_scopes,
+            } => {
+                config.validate("checkpoint wake_only")?;
+                ensure!(
+                    config.schedule().clock == UpdateClock::OptimizerSteps,
+                    "wake_only checkpoint uses a clock unsupported by the stock trainer"
+                );
+                ensure!(
+                    self.sleep.is_none() && self.wake_context_buffer.is_empty(),
+                    "wake_only checkpoint contains periodic-sleep state"
+                );
+                ensure!(
+                    optimizer_scopes.tiers.len() == config.schedule().tiers.len()
+                        && !optimizer_scopes.wake_parameter_ids.is_empty(),
+                    "wake_only checkpoint optimizer topology differs from its schedule"
+                );
+                let mut owned = optimizer_scopes
+                    .wake_parameter_ids
+                    .iter()
+                    .copied()
+                    .collect::<BTreeSet<_>>();
+                ensure!(
+                    owned.len() == optimizer_scopes.wake_parameter_ids.len(),
+                    "wake_only checkpoint repeats a wake parameter ID"
+                );
+                let global_clock = u64::try_from(self.global_step)
+                    .context("wake_only checkpoint global step exceeds u64")?;
+                for (index, (scope, tier)) in optimizer_scopes
+                    .tiers
+                    .iter()
+                    .zip(&config.schedule().tiers)
+                    .enumerate()
+                {
+                    let completed_boundaries = global_clock / tier.update_period;
+                    let expected_update_clock = completed_boundaries
+                        .checked_mul(tier.update_period)
+                        .context("wake_only tier update clock overflows u64")?;
+                    let expected_pending_steps = global_clock
+                        .checked_sub(expected_update_clock)
+                        .context("wake_only pending-step clock underflows")?;
+                    let expected_generation = global_clock
+                        .checked_add(completed_boundaries)
+                        .context("wake_only tier generation overflows u64")?;
+                    ensure!(
+                        scope.tier == index
+                            && scope.tier_id == tier.id
+                            && scope.update_clock == expected_update_clock
+                            && scope.accumulated_micro_steps == expected_pending_steps
+                            && scope.generation == expected_generation
+                            && scope.transfer_clock == 0
+                            && scope.transfer_generation == 0,
+                        "wake_only checkpoint tier `{}` has invalid identity or clocks",
+                        tier.id
+                    );
+                    ensure!(
+                        scope.parameter_ids.iter().all(|id| owned.insert(*id)),
+                        "wake_only checkpoint repeats a tier parameter ID"
+                    );
+                    ensure!(
+                        scope.artifact.is_some()
+                            || (scope.update_clock == 0
+                                && scope.accumulated_micro_steps == 0
+                                && scope.generation == 0),
+                        "wake_only checkpoint tier `{}` has mutable state without an immutable optimizer artifact",
+                        tier.id
+                    );
+                    if let Some(artifact) = &scope.artifact {
+                        artifact
+                            .validate_pending_steps(scope.accumulated_micro_steps)
+                            .with_context(|| {
+                                format!(
+                                    "wake_only checkpoint tier `{}` has invalid optimizer state",
+                                    tier.id
+                                )
+                            })?;
+                    }
+                }
+                let checkpoint_parameters =
+                    self.parameter_ids.iter().copied().collect::<BTreeSet<_>>();
+                ensure!(
+                    owned == checkpoint_parameters,
+                    "wake_only optimizer scopes do not exactly partition checkpoint parameters"
+                );
+            }
+        }
         let optimizer_paths = self
             .optimizer_states
             .iter()
@@ -343,34 +569,12 @@ impl TrainingState {
         for stream in &self.rng_streams {
             ensure!(!stream.name.trim().is_empty(), "RNG stream name is empty");
         }
-        ensure!(
-            self.wake_context_buffer
-                .windows(2)
-                .all(|pair| pair[0].optimizer_step <= pair[1].optimizer_step),
-            "checkpoint wake-context buffer moves backwards"
-        );
-        let context_ids = self
-            .wake_context_buffer
-            .iter()
-            .map(|record| record.id.as_str())
-            .collect::<BTreeSet<_>>();
-        ensure!(
-            context_ids.len() == self.wake_context_buffer.len(),
-            "checkpoint wake-context buffer repeats an identity"
-        );
-        for record in &self.wake_context_buffer {
-            ensure!(
-                !record.id.trim().is_empty()
-                    && !record.token_ids.is_empty()
-                    && record.token_ids.iter().all(|token| *token >= 0),
-                "checkpoint contains an invalid wake context"
-            );
-        }
         let unique_parameter_ids = self.parameter_ids.iter().collect::<BTreeSet<_>>();
         ensure!(
             unique_parameter_ids.len() == self.parameter_ids.len(),
             "checkpoint repeats a parameter ID"
         );
+        let mut artifact_references = BTreeSet::new();
         for artifact in &self.artifacts {
             ensure!(
                 !artifact.kind.trim().is_empty()
@@ -378,10 +582,19 @@ impl TrainingState {
                     && !artifact.hash.trim().is_empty(),
                 "checkpoint has an incomplete artifact reference"
             );
-            validate_content_hash(&artifact.hash, "checkpoint artifact hash")?;
+            validate_sha256_identity(&artifact.hash, "checkpoint artifact hash")?;
+            ensure!(
+                artifact_references.insert((artifact.kind.as_str(), artifact.manifest.as_str())),
+                "checkpoint repeats an artifact kind and manifest"
+            );
         }
+        let mut evaluator_hashes = BTreeSet::new();
         for hash in &self.evaluator_hashes {
-            validate_content_hash(hash, "checkpoint evaluator hash")?;
+            validate_sha256_identity(hash, "checkpoint evaluator hash")?;
+            ensure!(
+                evaluator_hashes.insert(hash.as_str()),
+                "checkpoint repeats an evaluator hash"
+            );
         }
         if let Some(quantization) = &self.quantization {
             ensure!(
@@ -389,28 +602,14 @@ impl TrainingState {
                 "checkpoint quantization format is empty"
             );
             if let Some(hash) = &quantization.teacher_hash {
-                validate_content_hash(hash, "checkpoint quantization teacher hash")?;
+                validate_sha256_identity(hash, "checkpoint quantization teacher hash")?;
             }
-            if let Some(transaction) = &quantization.transaction {
-                for (hash, label) in [
-                    (
-                        &transaction.transaction_id,
-                        "checkpoint quantization transaction id",
-                    ),
-                    (
-                        &transaction.plan_fingerprint,
-                        "checkpoint quantization plan fingerprint",
-                    ),
-                    (
-                        &transaction.pre_update_master_hash,
-                        "checkpoint quantization pre-update hash",
-                    ),
-                ] {
-                    validate_content_hash(hash, label)?;
-                }
-                if let Some(hash) = &transaction.post_update_master_hash {
-                    validate_content_hash(hash, "checkpoint quantization post-update hash")?;
-                }
+            ensure!(
+                quantization.manifest.is_some() == quantization.candidate_weights_sha256.is_some(),
+                "checkpoint quantization candidate manifest and weights identity must appear together"
+            );
+            if let Some(hash) = &quantization.candidate_weights_sha256 {
+                validate_sha256_identity(hash, "checkpoint quantization candidate weights hash")?;
             }
         }
         if let Some(sleep) = &self.sleep {
@@ -559,8 +758,9 @@ fn seal_training_checkpoint(
     let muon_state = staging.join(MUON_FILE);
 
     save_safetensors(&model.clone().valid(), &weights)?;
-    sync_regular_file(&weights)?;
+    sync_regular_file(&weights, "checkpoint weights")?;
     let (weights_bytes, weights_sha256) = hash_file(&weights)?;
+    validate_quantization_weights_binding(state, &weights_sha256)?;
     let accounting = TrainingAccounting {
         version: TRAINING_ACCOUNTING_VERSION,
         training_gpu_hours: accounting_input.training_gpu_hours,
@@ -575,9 +775,9 @@ fn seal_training_checkpoint(
         &serde_json::to_vec(&accounting)?,
     )?;
     save_canonical_module_optimizer(adamw, &adamw_state).context("failed to save AdamW state")?;
-    sync_regular_file(&adamw_state)?;
+    sync_regular_file(&adamw_state, "checkpoint AdamW state")?;
     muon.save(&muon_state)?;
-    sync_regular_file(&muon_state)?;
+    sync_regular_file(&muon_state, "checkpoint Muon state")?;
     write_synced_new(
         &staging.join(TRAINING_STATE_FILE),
         &serde_json::to_vec_pretty(state)?,
@@ -616,7 +816,7 @@ fn publish_training_evidence(
         "training evidence checkpoint generation is outside its output root"
     );
     let bytes = serde_json::to_vec(evidence)?;
-    let sha256 = sha256_bytes(&bytes);
+    let sha256 = sha256_hex(&bytes);
     let directory = output.join(TRAINING_EVIDENCE_DIRECTORY);
     fs::create_dir_all(&directory).with_context(|| {
         format!(
@@ -637,7 +837,7 @@ fn publish_training_evidence(
             );
             let existing = read_file_stable(&path, "published training evidence")?;
             ensure!(
-                sha256_bytes(&existing) == sha256 && existing == bytes,
+                sha256_hex(&existing) == sha256 && existing == bytes,
                 "content-addressed training-evidence collision or tampering at {}",
                 path.display()
             );
@@ -661,7 +861,7 @@ fn publish_training_evidence(
                         let existing =
                             read_file_stable(&path, "concurrently published training evidence")?;
                         ensure!(
-                            sha256_bytes(&existing) == sha256 && existing == bytes,
+                            sha256_hex(&existing) == sha256 && existing == bytes,
                             "content-addressed training-evidence collision at {}",
                             path.display()
                         );
@@ -741,18 +941,7 @@ fn create_staging_directory(output: &Path) -> Result<PathBuf> {
 }
 
 fn validate_generation_root(path: &Path) -> Result<()> {
-    let metadata = fs::symlink_metadata(path).with_context(|| {
-        format!(
-            "checkpoint generation root {} does not exist",
-            path.display()
-        )
-    })?;
-    ensure!(
-        metadata.is_dir() && !metadata.file_type().is_symlink(),
-        "checkpoint generation root {} is not a real directory",
-        path.display()
-    );
-    Ok(())
+    ensure_real_directory(path, "checkpoint generation root")
 }
 
 fn unique_suffix() -> String {
@@ -763,257 +952,12 @@ fn unique_suffix() -> String {
     format!("{}-{timestamp}-{sequence}", std::process::id())
 }
 
-fn write_synced_new(path: &Path, bytes: &[u8]) -> Result<()> {
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
-        .with_context(|| format!("failed to create {}", path.display()))?;
-    file.write_all(bytes)?;
-    file.sync_all()?;
-    Ok(())
-}
-
-fn sync_regular_file(path: &Path) -> Result<()> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to inspect checkpoint file {}", path.display()))?;
-    ensure!(
-        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-        "checkpoint path {} is not a regular file",
-        path.display()
-    );
-    File::open(path)?.sync_all()?;
-    Ok(())
-}
-
-fn sync_directory(path: &Path) -> Result<()> {
-    File::open(path)
-        .with_context(|| format!("failed to open directory {} for sync", path.display()))?
-        .sync_all()
-        .with_context(|| format!("failed to sync directory {}", path.display()))
-}
-
-fn sha256_bytes(bytes: &[u8]) -> String {
-    let digest = Sha256::digest(bytes);
-    let mut encoded = String::with_capacity(64);
-    for byte in digest {
-        let _ = write!(encoded, "{byte:02x}");
-    }
-    encoded
-}
-
-#[cfg(unix)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct StableFileIdentity {
-    device: u64,
-    inode: u64,
-    mode: u32,
-    length: u64,
-    modified_seconds: i64,
-    modified_nanoseconds: i64,
-    changed_seconds: i64,
-    changed_nanoseconds: i64,
-}
-
-#[cfg(unix)]
-impl StableFileIdentity {
-    fn from_metadata(metadata: &fs::Metadata) -> Self {
-        Self {
-            device: metadata.dev(),
-            inode: metadata.ino(),
-            mode: metadata.mode(),
-            length: metadata.len(),
-            modified_seconds: metadata.mtime(),
-            modified_nanoseconds: metadata.mtime_nsec(),
-            changed_seconds: metadata.ctime(),
-            changed_nanoseconds: metadata.ctime_nsec(),
-        }
-    }
-}
-
-#[cfg(all(
-    unix,
-    any(
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "visionos",
-        target_os = "freebsd"
-    )
-))]
-fn errno_slot() -> Option<*mut libc::c_int> {
-    Some(unsafe { libc::__error() })
-}
-
-#[cfg(all(
-    unix,
-    any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "emscripten",
-        target_os = "hurd",
-        target_os = "redox"
-    )
-))]
-fn errno_slot() -> Option<*mut libc::c_int> {
-    Some(unsafe { libc::__errno_location() })
-}
-
-#[cfg(all(
-    unix,
-    any(target_os = "android", target_os = "netbsd", target_os = "openbsd")
-))]
-fn errno_slot() -> Option<*mut libc::c_int> {
-    Some(unsafe { libc::__errno() })
-}
-
-#[cfg(all(
-    unix,
-    not(any(
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "tvos",
-        target_os = "watchos",
-        target_os = "visionos",
-        target_os = "freebsd",
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "emscripten",
-        target_os = "hurd",
-        target_os = "redox",
-        target_os = "android",
-        target_os = "netbsd",
-        target_os = "openbsd"
-    ))
-))]
-fn errno_slot() -> Option<*mut libc::c_int> {
-    None
-}
-
-fn hash_open_file(
-    file: &mut File,
-    capture_bytes: bool,
-    label: &str,
-) -> Result<(u64, String, Option<Vec<u8>>)> {
-    let before = file
-        .metadata()
-        .with_context(|| format!("failed to inspect opened {label}"))?;
-    ensure!(before.is_file(), "{label} is not a regular file");
-    #[cfg(unix)]
-    let before_identity = StableFileIdentity::from_metadata(&before);
-    #[cfg(not(unix))]
-    let before_modified = before.modified().ok();
-
-    let mut hasher = Sha256::new();
-    let mut captured = if capture_bytes {
-        let capacity = usize::try_from(before.len())
-            .context("checkpoint file length does not fit address space")?;
-        let mut captured = Vec::new();
-        captured
-            .try_reserve_exact(capacity)
-            .context("failed to reserve authenticated checkpoint buffer")?;
-        Some(captured)
-    } else {
-        None
-    };
-    let mut buffer = [0_u8; 1024 * 1024];
-    let mut bytes = 0_u64;
-    loop {
-        let read = file
-            .read(&mut buffer)
-            .with_context(|| format!("failed to read {label}"))?;
-        if read == 0 {
-            break;
-        }
-        let next_bytes = bytes
-            .checked_add(read as u64)
-            .context("checkpoint file length overflow")?;
-        ensure!(
-            next_bytes <= before.len(),
-            "{label} grew while it was hashed"
-        );
-        hasher.update(&buffer[..read]);
-        if let Some(captured) = &mut captured {
-            captured.extend_from_slice(&buffer[..read]);
-        }
-        bytes = next_bytes;
-    }
-    let after = file
-        .metadata()
-        .with_context(|| format!("failed to reinspect opened {label}"))?;
-    #[cfg(unix)]
-    ensure!(
-        StableFileIdentity::from_metadata(&after) == before_identity,
-        "{label} changed while it was hashed"
-    );
-    #[cfg(not(unix))]
-    ensure!(
-        after.is_file() && after.len() == before.len() && after.modified().ok() == before_modified,
-        "{label} changed while it was hashed"
-    );
-    ensure!(bytes == after.len(), "{label} changed while it was hashed");
-    let digest = hasher.finalize();
-    let mut encoded = String::with_capacity(64);
-    for byte in digest {
-        let _ = write!(encoded, "{byte:02x}");
-    }
-    Ok((bytes, encoded, captured))
-}
-
-fn read_hashed_path(
-    path: &Path,
-    capture_bytes: bool,
-    label: &str,
-) -> Result<(u64, String, Option<Vec<u8>>)> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to inspect checkpoint path {}", path.display()))?;
-    ensure!(
-        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-        "{label} is not a regular file"
-    );
-    let mut options = OpenOptions::new();
-    options.read(true);
-    #[cfg(unix)]
-    options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
-    let mut file = options
-        .open(path)
-        .with_context(|| format!("failed to open {label}"))?;
-    #[cfg(unix)]
-    ensure!(
-        StableFileIdentity::from_metadata(&file.metadata()?)
-            == StableFileIdentity::from_metadata(&metadata),
-        "{label} changed while it was opened"
-    );
-    let (bytes, sha256, captured) = hash_open_file(&mut file, capture_bytes, label)?;
-    let current = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to reinspect checkpoint path {}", path.display()))?;
-    #[cfg(unix)]
-    ensure!(
-        StableFileIdentity::from_metadata(&current) == StableFileIdentity::from_metadata(&metadata),
-        "{label} changed while it was hashed"
-    );
-    #[cfg(not(unix))]
-    ensure!(
-        current.file_type().is_file()
-            && !current.file_type().is_symlink()
-            && current.len() == metadata.len()
-            && current.modified().ok() == metadata.modified().ok(),
-        "{label} changed while it was hashed"
-    );
-    Ok((bytes, sha256, captured))
-}
-
 fn hash_file(path: &Path) -> Result<(u64, String)> {
-    let (bytes, sha256, _) =
-        read_hashed_path(path, false, &format!("checkpoint file {}", path.display()))?;
-    Ok((bytes, sha256))
+    hash_regular_file_hex(path)
 }
 
 fn read_file_stable(path: &Path, label: &str) -> Result<Vec<u8>> {
-    read_hashed_path(path, true, label)?
-        .2
-        .context("stable checkpoint read did not capture bytes")
+    read_regular_bounded(path, MAX_CHECKPOINT_METADATA_BYTES, label)
 }
 
 impl GenerationSnapshot {
@@ -1068,140 +1012,6 @@ impl GenerationSnapshot {
     }
 }
 
-#[cfg(unix)]
-#[derive(Debug)]
-struct SecureDirectory {
-    file: File,
-}
-
-#[cfg(unix)]
-impl SecureDirectory {
-    fn open_root(path: &Path) -> Result<Self> {
-        let path_metadata = fs::symlink_metadata(path).with_context(|| {
-            format!("failed to inspect checkpoint directory {}", path.display())
-        })?;
-        ensure!(
-            path_metadata.is_dir() && !path_metadata.file_type().is_symlink(),
-            "checkpoint generation {} is not a real directory",
-            path.display()
-        );
-        let file = OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_NONBLOCK)
-            .open(path)
-            .with_context(|| format!("failed to open checkpoint directory {}", path.display()))?;
-        ensure!(
-            StableFileIdentity::from_metadata(&file.metadata()?)
-                == StableFileIdentity::from_metadata(&path_metadata),
-            "checkpoint directory {} changed while it was opened",
-            path.display()
-        );
-        Ok(Self { file })
-    }
-
-    fn open_child(&self, name: &OsStr) -> Result<File> {
-        let name = CString::new(name.as_bytes()).context("checkpoint name contains a NUL byte")?;
-        // O_NONBLOCK prevents an attacker-controlled FIFO from hanging the
-        // verifier before its file type can be rejected.
-        let descriptor = unsafe {
-            libc::openat(
-                self.file.as_raw_fd(),
-                name.as_ptr(),
-                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
-                0,
-            )
-        };
-        if descriptor < 0 {
-            return Err(std::io::Error::last_os_error()).context("failed to open checkpoint entry");
-        }
-        // SAFETY: openat returned a new owned descriptor on success.
-        Ok(unsafe { File::from_raw_fd(descriptor) })
-    }
-
-    fn open_relative_file(&self, relative: &str) -> Result<File> {
-        validate_checkpoint_relative_path(relative)?;
-        let mut directory = Self {
-            file: self
-                .file
-                .try_clone()
-                .context("failed to duplicate authenticated checkpoint directory")?,
-        };
-        let mut components = Path::new(relative).components().peekable();
-        while let Some(component) = components.next() {
-            let Component::Normal(name) = component else {
-                anyhow::bail!("checkpoint path `{relative}` is not a safe relative path");
-            };
-            let child = directory
-                .open_child(name)
-                .with_context(|| format!("failed to open authenticated artifact `{relative}`"))?;
-            let metadata = child.metadata().with_context(|| {
-                format!("failed to inspect authenticated artifact `{relative}`")
-            })?;
-            if components.peek().is_none() {
-                ensure!(
-                    metadata.is_file(),
-                    "authenticated checkpoint artifact `{relative}` is not a regular file"
-                );
-                return Ok(child);
-            }
-            ensure!(
-                metadata.is_dir(),
-                "checkpoint artifact parent for `{relative}` is not a directory"
-            );
-            directory = Self { file: child };
-        }
-        anyhow::bail!("checkpoint path `{relative}` has no file name")
-    }
-
-    fn entries(&self) -> Result<Vec<OsString>> {
-        let duplicate = unsafe { libc::dup(self.file.as_raw_fd()) };
-        if duplicate < 0 {
-            return Err(std::io::Error::last_os_error())
-                .context("failed to duplicate checkpoint directory descriptor");
-        }
-        let stream = unsafe { libc::fdopendir(duplicate) };
-        if stream.is_null() {
-            let error = std::io::Error::last_os_error();
-            unsafe { libc::close(duplicate) };
-            return Err(error).context("failed to enumerate checkpoint directory");
-        }
-
-        struct DirectoryStream(*mut libc::DIR);
-        impl Drop for DirectoryStream {
-            fn drop(&mut self) {
-                unsafe { libc::closedir(self.0) };
-            }
-        }
-        let stream = DirectoryStream(stream);
-        let mut names = Vec::new();
-        loop {
-            let errno = errno_slot();
-            if let Some(slot) = errno {
-                // SAFETY: errno_slot returns this thread's errno storage.
-                unsafe { *slot = 0 };
-            }
-            // SAFETY: `stream` owns a private DIR used only by this loop. The
-            // returned entry is copied before the next call to readdir.
-            let entry = unsafe { libc::readdir(stream.0) };
-            if entry.is_null() {
-                let code = errno.map_or(0, |slot| unsafe { *slot });
-                if code != 0 {
-                    return Err(std::io::Error::from_raw_os_error(code))
-                        .context("failed while enumerating checkpoint directory");
-                }
-                break;
-            }
-            let bytes = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) }.to_bytes();
-            if bytes == b"." || bytes == b".." {
-                continue;
-            }
-            names.push(OsString::from_vec(bytes.to_vec()));
-        }
-        names.sort();
-        Ok(names)
-    }
-}
-
 impl GenerationAccess {
     fn read_authenticated(&mut self, relative: &str, expected: &GenerationFile) -> Result<Vec<u8>> {
         ensure!(
@@ -1209,7 +1019,9 @@ impl GenerationAccess {
             "checkpoint artifact identity does not match `{relative}`"
         );
         #[cfg(unix)]
-        let file = self.directory.open_relative_file(relative)?;
+        let file = self
+            .directory
+            .open_relative_file(Path::new(relative), "checkpoint generation")?;
         #[cfg(not(unix))]
         let file = self
             .files
@@ -1220,11 +1032,9 @@ impl GenerationAccess {
 }
 
 fn read_authenticated_file(mut file: File, expected: &GenerationFile) -> Result<Vec<u8>> {
-    file.seek(SeekFrom::Start(0))
-        .with_context(|| format!("failed to rewind checkpoint artifact `{}`", expected.path))?;
     let (bytes, sha256, captured) = hash_open_file(
         &mut file,
-        true,
+        Some(MAX_CHECKPOINT_MEMBER_BYTES),
         &format!("authenticated checkpoint artifact `{}`", expected.path),
     )?;
     ensure!(
@@ -1238,25 +1048,35 @@ fn read_authenticated_file(mut file: File, expected: &GenerationFile) -> Result<
 #[cfg(unix)]
 fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<GenerationSnapshot> {
     fn visit(
-        directory: &SecureDirectory,
+        directory: &PinnedDirectory,
         relative_root: &Path,
         snapshot: &mut GenerationSnapshot,
+        budget: &mut GenerationTraversalBudget,
+        depth: usize,
     ) -> Result<()> {
-        let before = StableFileIdentity::from_metadata(&directory.file.metadata()?);
-        for name in directory.entries()? {
+        budget.enter_directory(depth)?;
+        let before = directory.identity()?;
+        for name in directory.entries("checkpoint generation")? {
             let relative_path = relative_root.join(&name);
             let relative = relative_path
                 .to_str()
                 .context("checkpoint file name is not valid UTF-8")?
                 .replace(std::path::MAIN_SEPARATOR, "/");
             validate_checkpoint_relative_path(&relative)?;
-            let mut child = directory.open_child(&name).with_context(|| {
-                format!("failed to open checkpoint generation entry `{relative}`")
-            })?;
+            let mut child = directory
+                .open_child(&name, "checkpoint generation")
+                .with_context(|| {
+                    format!("failed to open checkpoint generation entry `{relative}`")
+                })?;
             let metadata = child.metadata()?;
             if metadata.is_dir() {
                 let files_before = snapshot.files.len();
-                visit(&SecureDirectory { file: child }, &relative_path, snapshot)?;
+                let child =
+                    PinnedDirectory::from_open_directory(child, "checkpoint generation child")?;
+                let child_depth = depth
+                    .checked_add(1)
+                    .context("checkpoint directory depth overflow")?;
+                visit(&child, &relative_path, snapshot, budget, child_depth)?;
                 ensure!(
                     snapshot.files.len() > files_before,
                     "checkpoint generation contains empty directory `{relative}`"
@@ -1267,28 +1087,29 @@ fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<Gener
                 metadata.is_file(),
                 "checkpoint generation contains non-file `{relative}`"
             );
+            budget.record_file(metadata.len())?;
             let capture = matches!(
                 relative.as_str(),
                 GENERATION_MANIFEST | TRAINING_STATE_FILE | TRAINING_ACCOUNTING_FILE
             );
             let (bytes, sha256, captured) = hash_open_file(
                 &mut child,
-                capture,
+                capture.then_some(MAX_CHECKPOINT_METADATA_BYTES),
                 &format!("checkpoint file `{relative}`"),
             )?;
             snapshot.record_file(relative, bytes, sha256, captured)?;
         }
         ensure!(
-            StableFileIdentity::from_metadata(&directory.file.metadata()?) == before,
+            directory.identity()? == before,
             "checkpoint directory changed while it was verified"
         );
         Ok(())
     }
 
-    let directory = SecureDirectory::open_root(root)?;
-    let root_identity = StableFileIdentity::from_metadata(&directory.file.metadata()?);
+    let (directory, root_identity) = PinnedDirectory::open(root, "checkpoint generation")?;
     let mut snapshot = GenerationSnapshot::new();
-    visit(&directory, Path::new(""), &mut snapshot)?;
+    let mut budget = GenerationTraversalBudget::default();
+    visit(&directory, Path::new(""), &mut snapshot, &mut budget, 0)?;
     let current = fs::symlink_metadata(root).with_context(|| {
         format!(
             "failed to reinspect checkpoint generation {}",
@@ -1298,7 +1119,7 @@ fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<Gener
     ensure!(
         current.is_dir()
             && !current.file_type().is_symlink()
-            && StableFileIdentity::from_metadata(&current) == root_identity,
+            && StableIdentity::from_metadata(&current) == root_identity,
         "checkpoint generation changed while it was verified"
     );
     if retain_access {
@@ -1314,9 +1135,20 @@ fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<Gener
         directory: &Path,
         snapshot: &mut GenerationSnapshot,
         retained: &mut Option<BTreeMap<String, File>>,
+        budget: &mut GenerationTraversalBudget,
+        depth: usize,
     ) -> Result<()> {
+        budget.enter_directory(depth)?;
         let before = fs::metadata(directory)?;
-        let mut entries = fs::read_dir(directory)?.collect::<std::io::Result<Vec<_>>>()?;
+        let mut entries = Vec::new();
+        for entry in fs::read_dir(directory)? {
+            entries.push(entry?);
+            ensure!(
+                entries.len()
+                    <= MAX_CHECKPOINT_GENERATION_FILES + MAX_CHECKPOINT_GENERATION_DIRECTORIES,
+                "checkpoint directory contains too many entries"
+            );
+        }
         entries.sort_by_key(std::fs::DirEntry::file_name);
         for entry in entries {
             let path = entry.path();
@@ -1328,7 +1160,10 @@ fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<Gener
             );
             if metadata.is_dir() {
                 let files_before = snapshot.files.len();
-                visit(root, &path, snapshot, retained)?;
+                let child_depth = depth
+                    .checked_add(1)
+                    .context("checkpoint directory depth overflow")?;
+                visit(root, &path, snapshot, retained, budget, child_depth)?;
                 ensure!(
                     snapshot.files.len() > files_before,
                     "checkpoint generation contains empty directory {}",
@@ -1341,6 +1176,7 @@ fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<Gener
                 "checkpoint generation contains non-file {}",
                 path.display()
             );
+            budget.record_file(metadata.len())?;
             let relative = path
                 .strip_prefix(root)?
                 .to_str()
@@ -1352,8 +1188,11 @@ fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<Gener
                 GENERATION_MANIFEST | TRAINING_STATE_FILE | TRAINING_ACCOUNTING_FILE
             );
             let mut file = File::open(&path)?;
-            let (bytes, sha256, captured) =
-                hash_open_file(&mut file, capture, &format!("checkpoint file `{relative}`"))?;
+            let (bytes, sha256, captured) = hash_open_file(
+                &mut file,
+                capture.then_some(MAX_CHECKPOINT_METADATA_BYTES),
+                &format!("checkpoint file `{relative}`"),
+            )?;
             if let Some(retained) = retained {
                 ensure!(
                     retained.insert(relative.clone(), file).is_none(),
@@ -1378,7 +1217,8 @@ fn collect_generation_snapshot(root: &Path, retain_access: bool) -> Result<Gener
     );
     let mut snapshot = GenerationSnapshot::new();
     let mut retained = retain_access.then(BTreeMap::new);
-    visit(root, root, &mut snapshot, &mut retained)?;
+    let mut budget = GenerationTraversalBudget::default();
+    visit(root, root, &mut snapshot, &mut retained, &mut budget, 0)?;
     snapshot.access = retained.map(|files| GenerationAccess { files });
     snapshot.finish()
 }
@@ -1448,29 +1288,29 @@ fn validate_training_accounting(bytes: &[u8], files: &[GenerationFile]) -> Resul
     Ok(())
 }
 
-fn validate_sha256(value: &str, label: &str) -> Result<()> {
-    ensure!(
-        value.len() == 64
-            && value
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{label} is not a lowercase SHA-256 digest"
-    );
+fn validate_quantization_weights_binding(
+    state: &TrainingState,
+    checkpoint_weights_sha256: &str,
+) -> Result<()> {
+    validate_sha256_hex(checkpoint_weights_sha256, "checkpoint model-weights digest")?;
+    if let Some(expected) = state
+        .quantization
+        .as_ref()
+        .and_then(|quantization| quantization.candidate_weights_sha256.as_deref())
+    {
+        ensure!(
+            expected == format!("sha256:{checkpoint_weights_sha256}"),
+            "quantization candidate weights differ from checkpoint model weights"
+        );
+    }
     Ok(())
-}
-
-fn validate_content_hash(value: &str, label: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .with_context(|| format!("{label} must use sha256:<64 lowercase hex>"))?;
-    validate_sha256(digest, label)
 }
 
 fn validate_generation_name(name: &str) -> Result<&str> {
     let digest = name
         .strip_prefix("sha256-")
         .context("checkpoint generation is not content-addressed")?;
-    validate_sha256(digest, "checkpoint generation digest")?;
+    validate_sha256_hex(digest, "checkpoint generation digest")?;
     Ok(digest)
 }
 
@@ -1508,7 +1348,7 @@ fn seal_generation(output: &Path, staging: &Path) -> Result<SealedGeneration> {
         files,
     };
     let manifest_bytes = serde_json::to_vec(&manifest)?;
-    let manifest_sha256 = sha256_bytes(&manifest_bytes);
+    let manifest_sha256 = sha256_hex(&manifest_bytes);
     let name = format!("sha256-{manifest_sha256}");
     write_synced_new(&staging.join(GENERATION_MANIFEST), &manifest_bytes)?;
     sync_directory(staging)?;
@@ -1618,7 +1458,7 @@ fn verify_generation_inner(
     retain_access: bool,
 ) -> Result<(GenerationManifest, TrainingState, Option<GenerationAccess>)> {
     let generation_digest = validate_generation_name(generation_name)?;
-    validate_sha256(expected_manifest_sha256, "checkpoint manifest digest")?;
+    validate_sha256_hex(expected_manifest_sha256, "checkpoint manifest digest")?;
     ensure!(
         generation_digest == expected_manifest_sha256,
         "checkpoint generation name and manifest digest differ"
@@ -1633,7 +1473,7 @@ fn verify_generation_inner(
         .with_context(|| format!("failed to verify checkpoint generation `{generation_name}`"))?;
     let manifest_bytes = manifest.context("checkpoint generation has no manifest")?;
     ensure!(
-        sha256_bytes(&manifest_bytes) == expected_manifest_sha256,
+        sha256_hex(&manifest_bytes) == expected_manifest_sha256,
         "checkpoint generation manifest digest mismatch"
     );
     let manifest: GenerationManifest = serde_json::from_slice(&manifest_bytes)?;
@@ -1663,6 +1503,12 @@ fn verify_generation_inner(
             .as_deref()
             .context("checkpoint generation is missing training-state.json")?,
     )?;
+    let checkpoint_weights = manifest
+        .files
+        .iter()
+        .find(|file| file.path == WEIGHTS_FILE)
+        .context("checkpoint generation has no model weights")?;
+    validate_quantization_weights_binding(&state, &checkpoint_weights.sha256)?;
     ensure!(
         state.version == manifest.training_state_version
             && state.global_step == manifest.global_step
@@ -1730,7 +1576,7 @@ fn verify_checkpoint_root_inner(
         pointer.version
     );
     validate_generation_name(&pointer.generation)?;
-    validate_sha256(&pointer.manifest_sha256, "checkpoint manifest digest")?;
+    validate_sha256_hex(&pointer.manifest_sha256, "checkpoint manifest digest")?;
     let generations = output.join(GENERATIONS_DIRECTORY);
     validate_generation_root(&generations)?;
     let generation = generations.join(&pointer.generation);
@@ -1770,13 +1616,17 @@ fn read_manifest_artifact(
     access.read_authenticated(relative, expected)
 }
 
+/// Load one authenticated generation and return its optimizer, typed state,
+/// and canonical `sha256:<hex>` model-weights identity. The identity is read
+/// from the generation manifest whose exact weights bytes were verified and
+/// loaded; callers can bind external artifacts without reserializing `model`.
 pub(crate) fn load_training_state(
     model: &mut Transformer,
     adamw: AdamWOptimizer,
     muon: &mut BatchedMuon,
     output: &Path,
     device: &Device,
-) -> Result<(AdamWOptimizer, TrainingState)> {
+) -> Result<(AdamWOptimizer, TrainingState, String)> {
     load_training_state_inner(model, adamw, muon, output, device, |_, _| Ok(()))
 }
 
@@ -1793,7 +1643,7 @@ fn load_training_state_inner(
     output: &Path,
     device: &Device,
     mut stage_hook: impl FnMut(ResumeLoadStage, &Path) -> Result<()>,
-) -> Result<(AdamWOptimizer, TrainingState)> {
+) -> Result<(AdamWOptimizer, TrainingState, String)> {
     let (verified_before, generation, manifest, state, access) =
         verify_checkpoint_root_inner(output, true)?;
     let mut access = access.context("checkpoint verifier did not retain generation access")?;
@@ -1802,6 +1652,12 @@ fn load_training_state_inner(
     let mut loaded_model = model.clone();
     let mut loaded_muon = muon.clone();
     restore_parameter_ids(&mut loaded_model, &state.parameter_ids)?;
+    let weights_identity = manifest
+        .files
+        .iter()
+        .find(|file| file.path == WEIGHTS_FILE)
+        .context("checkpoint manifest has no authenticated model weights")?;
+    let weights_sha256 = format!("sha256:{}", weights_identity.sha256);
     let weights = read_manifest_artifact(&mut access, &manifest, WEIGHTS_FILE)?;
     load_safetensors_bytes(
         &mut loaded_model,
@@ -1833,7 +1689,7 @@ fn load_training_state_inner(
         .context("failed to validate loaded AdamW state")?;
     ensure!(
         canonical_adamw.len() as u64 == expected_adamw.bytes
-            && sha256_bytes(&canonical_adamw) == expected_adamw.sha256,
+            && sha256_hex(&canonical_adamw) == expected_adamw.sha256,
         "loaded AdamW state is not a lossless reconstruction of its authenticated artifact"
     );
     stage_hook(ResumeLoadStage::AfterStagedLoad, &generation)?;
@@ -1846,7 +1702,7 @@ fn load_training_state_inner(
 
     *model = loaded_model;
     *muon = loaded_muon;
-    Ok((loaded_adamw, state))
+    Ok((loaded_adamw, state, weights_sha256))
 }
 
 #[cfg(test)]
@@ -1857,7 +1713,7 @@ pub(crate) fn load_training_state_with_hook(
     output: &Path,
     device: &Device,
     stage_hook: impl FnMut(ResumeLoadStage, &Path) -> Result<()>,
-) -> Result<(AdamWOptimizer, TrainingState)> {
+) -> Result<(AdamWOptimizer, TrainingState, String)> {
     load_training_state_inner(model, adamw, muon, output, device, stage_hook)
 }
 
@@ -1910,6 +1766,7 @@ mod tests {
                 gradient_accumulator: None,
                 update_clock: global_step as u64,
             }],
+            memory_update: TrainingMemoryUpdateState::Ordinary,
             sleep: None,
             artifacts: vec![],
             evaluator_hashes: vec![format!("sha256:{}", "2".repeat(64))],
@@ -1921,6 +1778,128 @@ mod tests {
             wake_context_buffer: Vec::new(),
             quantization: None,
         }
+    }
+
+    fn wake_only_state() -> TrainingState {
+        let mut state = state_at(3);
+        state.parameter_ids = vec![1, 2, 3];
+        let config: MemoryUpdateMode = serde_json::from_value(serde_json::json!({
+            "type": "wake_only",
+            "schedule": {
+                "clock": "optimizer_steps",
+                "terminal_consolidation": "distill_into_base_v1",
+                "tiers": [
+                    {"id": "fast", "update_period": 1, "reserve_slots": 1},
+                    {"id": "slow", "update_period": 2, "reserve_slots": 2}
+                ]
+            }
+        }))
+        .unwrap();
+        let optimizer_scopes: MemoryOptimizerScopes = serde_json::from_value(serde_json::json!({
+            "wake_parameter_ids": [1],
+            "tiers": [
+                {
+                    "tier": 0,
+                    "tier_id": "fast",
+                    "parameter_ids": [2],
+                    "update_clock": 3,
+                    "transfer_clock": 0,
+                    "accumulated_micro_steps": 0,
+                    "generation": 6,
+                    "transfer_generation": 0,
+                    "artifact": {
+                        "state_uri": "fast/manifest.json",
+                        "manifest_hash": format!("sha256:{}", "a".repeat(64)),
+                        "optimizer_parameter_ids": [2],
+                        "accumulator_parameter_ids": []
+                    }
+                },
+                {
+                    "tier": 1,
+                    "tier_id": "slow",
+                    "parameter_ids": [3],
+                    "update_clock": 2,
+                    "transfer_clock": 0,
+                    "accumulated_micro_steps": 1,
+                    "generation": 4,
+                    "transfer_generation": 0,
+                    "artifact": {
+                        "state_uri": "slow/manifest.json",
+                        "manifest_hash": format!("sha256:{}", "b".repeat(64)),
+                        "optimizer_parameter_ids": [3],
+                        "accumulator_parameter_ids": [3]
+                    }
+                }
+            ]
+        }))
+        .unwrap();
+        state.memory_update = TrainingMemoryUpdateState::WakeOnly {
+            config,
+            optimizer_scopes,
+        };
+        state
+    }
+
+    #[test]
+    fn wake_only_checkpoint_requires_exact_pending_accumulator_receipts() {
+        let valid = wake_only_state();
+        valid.validate().unwrap();
+
+        let mut missing_artifact = valid.clone();
+        let TrainingMemoryUpdateState::WakeOnly {
+            optimizer_scopes, ..
+        } = &mut missing_artifact.memory_update
+        else {
+            unreachable!()
+        };
+        optimizer_scopes.tiers[1].artifact = None;
+        assert!(missing_artifact.validate().is_err());
+
+        let mut missing_gradients = valid.clone();
+        let TrainingMemoryUpdateState::WakeOnly {
+            optimizer_scopes, ..
+        } = &mut missing_gradients.memory_update
+        else {
+            unreachable!()
+        };
+        optimizer_scopes.tiers[1]
+            .artifact
+            .as_mut()
+            .unwrap()
+            .accumulator_parameter_ids
+            .clear();
+        assert!(missing_gradients.validate().is_err());
+
+        let mut unexpected_gradients = valid;
+        let TrainingMemoryUpdateState::WakeOnly {
+            optimizer_scopes, ..
+        } = &mut unexpected_gradients.memory_update
+        else {
+            unreachable!()
+        };
+        optimizer_scopes.tiers[1].accumulated_micro_steps = 0;
+        assert!(unexpected_gradients.validate().is_err());
+
+        let mut stale_boundary = wake_only_state();
+        let TrainingMemoryUpdateState::WakeOnly {
+            optimizer_scopes, ..
+        } = &mut stale_boundary.memory_update
+        else {
+            unreachable!()
+        };
+        optimizer_scopes.tiers[0].update_clock = 2;
+        optimizer_scopes.tiers[0].accumulated_micro_steps = 1;
+        assert!(stale_boundary.validate().is_err());
+
+        let mut stale_generation = wake_only_state();
+        let TrainingMemoryUpdateState::WakeOnly {
+            optimizer_scopes, ..
+        } = &mut stale_generation.memory_update
+        else {
+            unreachable!()
+        };
+        optimizer_scopes.tiers[1].generation -= 1;
+        assert!(stale_generation.validate().is_err());
     }
 
     fn stage_test_generation(output: &Path, state: &TrainingState, tag: &str) -> PathBuf {
@@ -1983,6 +1962,49 @@ mod tests {
     }
 
     #[test]
+    fn checkpoint_bounds_wake_context_records_and_tokens_before_resume() {
+        let record = |index: usize, tokens: usize| WakeContextRecord {
+            id: format!("wake-{index}"),
+            optimizer_step: 0,
+            token_ids: vec![1; tokens],
+        };
+
+        let mut too_many_records = state_at(0);
+        too_many_records.wake_context_buffer = (0..=MAX_WAKE_CONTEXT_RECORDS)
+            .map(|index| record(index, 1))
+            .collect();
+        let error = too_many_records.validate().unwrap_err().to_string();
+        assert!(error.contains("record limit"), "{error}");
+
+        let mut oversized_record = state_at(0);
+        oversized_record.wake_context_buffer = vec![record(0, MAX_WAKE_CONTEXT_TOKENS + 1)];
+        let error = oversized_record.validate().unwrap_err().to_string();
+        assert!(error.contains("token limit"), "{error}");
+
+        let mut oversized_id = state_at(0);
+        let mut bad_id = record(0, 1);
+        bad_id.id = "x".repeat(MAX_WAKE_CONTEXT_ID_BYTES + 1);
+        oversized_id.wake_context_buffer = vec![bad_id];
+        let error = oversized_id.validate().unwrap_err().to_string();
+        assert!(error.contains("wake-context id"), "{error}");
+
+        let mut invalid_token = state_at(0);
+        let mut bad_token = record(0, 1);
+        bad_token.token_ids[0] = i64::from(u32::MAX) + 1;
+        invalid_token.wake_context_buffer = vec![bad_token];
+        let error = invalid_token.validate().unwrap_err().to_string();
+        assert!(error.contains("u32 vocabulary range"), "{error}");
+
+        let mut excessive_total = state_at(0);
+        let records = MAX_WAKE_CONTEXT_TOTAL_TOKENS / MAX_WAKE_CONTEXT_TOKENS + 1;
+        excessive_total.wake_context_buffer = (0..records)
+            .map(|index| record(index, MAX_WAKE_CONTEXT_TOKENS))
+            .collect();
+        let error = excessive_total.validate().unwrap_err().to_string();
+        assert!(error.contains("wake-context buffer exceeds"), "{error}");
+    }
+
+    #[test]
     fn optimizer_paths_must_be_safe_and_independent() {
         let mut traversal = state_at(7);
         traversal.optimizer_states[0].adamw = "../adamw-state.bpk".into();
@@ -2022,6 +2044,62 @@ mod tests {
         let mut state = state_at(7);
         state.parameter_ids.push(state.parameter_ids[0]);
         assert!(state.validate().is_err());
+
+        let mut state = state_at(7);
+        state
+            .evaluator_hashes
+            .push(state.evaluator_hashes[0].clone());
+        assert!(state.validate().is_err());
+
+        let mut state = state_at(7);
+        state.artifacts = vec![ArtifactRef {
+            kind: "fixture".into(),
+            manifest: "fixture.json".into(),
+            hash: format!("sha256:{}", "3".repeat(64)),
+        }];
+        state.artifacts.push(state.artifacts[0].clone());
+        assert!(state.validate().is_err());
+    }
+
+    #[test]
+    fn quantization_candidate_manifest_and_source_identity_are_atomic() {
+        let candidate = QuantizationTrainingState {
+            format: "binary_g128".into(),
+            fake_quant_active: false,
+            calibration_step: 7,
+            manifest: Some("candidate.json".into()),
+            candidate_weights_sha256: Some(format!("sha256:{}", "a".repeat(64))),
+            teacher_hash: None,
+        };
+        let mut valid = state_at(7);
+        valid.quantization = Some(candidate.clone());
+        valid.validate().unwrap();
+        let mut legacy_json = serde_json::to_value(&valid).unwrap();
+        legacy_json["quantization"]
+            .as_object_mut()
+            .unwrap()
+            .remove("candidate_weights_sha256");
+        assert!(serde_json::from_value::<TrainingState>(legacy_json).is_err());
+
+        let mut missing_source = valid.clone();
+        missing_source
+            .quantization
+            .as_mut()
+            .unwrap()
+            .candidate_weights_sha256 = None;
+        assert!(missing_source.validate().is_err());
+
+        let mut missing_manifest = valid.clone();
+        missing_manifest.quantization.as_mut().unwrap().manifest = None;
+        assert!(missing_manifest.validate().is_err());
+
+        let mut malformed_source = valid;
+        malformed_source
+            .quantization
+            .as_mut()
+            .unwrap()
+            .candidate_weights_sha256 = Some("sha256:not-a-digest".into());
+        assert!(malformed_source.validate().is_err());
     }
 
     #[test]
@@ -2147,6 +2225,26 @@ mod tests {
         .unwrap_err();
         let error = format!("{error:#}");
         assert!(error.contains("empty directory"), "{error}");
+    }
+
+    #[test]
+    fn generation_sealer_rejects_excessive_directory_depth() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut state = state_at(7);
+        let nested = (0..=MAX_CHECKPOINT_GENERATION_DEPTH)
+            .map(|index| format!("d{index}"))
+            .collect::<Vec<_>>()
+            .join("/");
+        let gradient = format!("{nested}/gradients.bpk");
+        state.optimizer_states[0].gradient_accumulator = Some(gradient.clone());
+        let staging = stage_test_generation(directory.path(), &state, "deep-generation");
+        fs::create_dir_all(staging.join(&nested)).unwrap();
+        write_synced_new(&staging.join(gradient), b"gradients").unwrap();
+
+        let error = seal_generation(directory.path(), &staging)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("maximum directory depth"), "{error}");
     }
 
     #[cfg(unix)]

--- a/hermes-train/src/corpus/compose.rs
+++ b/hermes-train/src/corpus/compose.rs
@@ -11,7 +11,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{Context, Result, ensure};
@@ -19,6 +19,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use super::pipeline::{
+    AuthenticatedCorpus, MAX_CORPUS_JSONL_RECORD_BYTES, corpus_manifest_configuration_sha256,
+    read_corpus_jsonl_record, read_corpus_metadata_file,
+};
 use super::{
     CorpusManifest, CorpusManifestBody, CorpusStageStats, ShardManifest, ShardingConfig,
     TokenTarget,
@@ -32,11 +36,21 @@ const COMPOSITION_PROGRESS_VERSION: u32 = 1;
 const PROGRESS_FILE: &str = "composition-progress.json";
 const PROGRESS_TEMP_FILE: &str = ".composition-progress.next";
 const WORK_IDENTITY_FILE: &str = "composition-work.json";
+const MAX_CURRICULUM_STAGES: usize = 64;
+const MAX_STRATA_PER_STAGE: usize = 64;
+// Composition keeps one spool descriptor per stratum open. Staying below a
+// typical per-process descriptor limit also bounds the progress matrix.
+const MAX_TOTAL_CURRICULUM_STRATA: usize = 128;
+const MAX_CURRICULUM_SELECTORS: usize = 65_536;
 
 #[cfg(test)]
 thread_local! {
     static TEST_INTERRUPTION: std::cell::RefCell<Option<(&'static str, usize)>> = const {
         std::cell::RefCell::new(None)
+    };
+    #[cfg(unix)]
+    static TEST_SOURCE_REPLACEMENT: std::cell::Cell<bool> = const {
+        std::cell::Cell::new(false)
     };
 }
 
@@ -45,6 +59,28 @@ fn set_test_interruption(boundary: &'static str, occurrence: usize) {
     TEST_INTERRUPTION.with(|configured| {
         *configured.borrow_mut() = Some((boundary, occurrence));
     });
+}
+
+#[cfg(all(test, unix))]
+fn set_test_source_replacement() {
+    TEST_SOURCE_REPLACEMENT.with(|configured| configured.set(true));
+}
+
+#[cfg(all(test, unix))]
+fn maybe_test_replace_source(path: &Path) -> Result<()> {
+    let replace = TEST_SOURCE_REPLACEMENT.with(|configured| configured.replace(false));
+    if replace {
+        let parked = path.with_extension("test-authenticated-original");
+        fs::rename(path, &parked)?;
+        fs::write(path, b"{\"record_key\":\"malicious\",\"tokens\":[9]}\n")?;
+    }
+    Ok(())
+}
+
+#[cfg(not(all(test, unix)))]
+#[inline]
+fn maybe_test_replace_source(_path: &Path) -> Result<()> {
+    Ok(())
 }
 
 #[cfg(test)]
@@ -144,12 +180,7 @@ pub struct CurriculumCompositionConfig {
 
 impl CurriculumCompositionConfig {
     pub fn load(path: &Path) -> Result<Self> {
-        let bytes = fs::read(path).with_context(|| {
-            format!(
-                "failed to read curriculum composition configuration {}",
-                path.display()
-            )
-        })?;
+        let bytes = read_corpus_metadata_file(path, "curriculum composition configuration")?;
         let config: Self = serde_json::from_slice(&bytes).with_context(|| {
             format!("invalid curriculum composition JSON in {}", path.display())
         })?;
@@ -176,9 +207,34 @@ impl CurriculumCompositionConfig {
             !self.stages.is_empty(),
             "curriculum composition requires at least one stage"
         );
+        ensure!(
+            self.stages.len() <= MAX_CURRICULUM_STAGES,
+            "curriculum composition exceeds the {MAX_CURRICULUM_STAGES}-stage limit"
+        );
         let mut names = BTreeSet::new();
+        let mut total_strata = 0usize;
+        let mut total_selectors = 0usize;
         for stage in &self.stages {
             stage.validate()?;
+            total_strata = total_strata
+                .checked_add(stage.strata.len())
+                .context("curriculum stratum count overflows usize")?;
+            ensure!(
+                total_strata <= MAX_TOTAL_CURRICULUM_STRATA,
+                "curriculum composition exceeds the {MAX_TOTAL_CURRICULUM_STRATA}-stratum limit"
+            );
+            total_selectors = total_selectors
+                .checked_add(stage.when.selector_count()?)
+                .context("curriculum selector count overflows usize")?;
+            for stratum in &stage.strata {
+                total_selectors = total_selectors
+                    .checked_add(stratum.when.selector_count()?)
+                    .context("curriculum selector count overflows usize")?;
+            }
+            ensure!(
+                total_selectors <= MAX_CURRICULUM_SELECTORS,
+                "curriculum composition exceeds the {MAX_CURRICULUM_SELECTORS}-selector limit"
+            );
             ensure!(
                 names.insert(stage.name.as_str()),
                 "duplicate curriculum stage `{}`",
@@ -205,21 +261,15 @@ impl CurriculumCompositionConfig {
     ) -> Result<(PathBuf, CurriculumManifest)> {
         self.validate()?;
         let source_path = resolve_relative(config_path, &self.source_manifest);
-        ensure_regular_file(&source_path, "source corpus manifest")?;
-        let source: CorpusManifest = serde_json::from_slice(
-            &fs::read(&source_path)
-                .with_context(|| format!("failed to read {}", source_path.display()))?,
-        )
-        .with_context(|| format!("invalid corpus manifest {}", source_path.display()))?;
+        let authenticated_source = AuthenticatedCorpus::open_data_path(&source_path)?
+            .context("source_manifest must identify an authenticated corpus manifest")?;
+        let source = authenticated_source.manifest().clone();
         ensure!(
             source.manifest_sha256 == self.source_manifest_sha256,
             "source corpus manifest identity changed: expected {}, got {}",
             self.source_manifest_sha256,
             source.manifest_sha256
         );
-        let source_root = source_path.parent().unwrap_or_else(|| Path::new("."));
-        ensure_real_directory(source_root, "source corpus root")?;
-        source.verify(source_root)?;
 
         create_and_validate_directory(output_root, "curriculum output root")?;
         create_and_validate_directory(work_directory, "curriculum work directory")?;
@@ -267,20 +317,24 @@ impl CurriculumCompositionConfig {
                 open_or_create_spools(&work_path, self, &source, &identity, &mut progress)?;
             if !progress.state.spooling_complete {
                 for shard_index in progress.state.next_source_shard..source.build.shards.len() {
-                    spool_source_shard(
-                        &source.build.shards[shard_index],
-                        source_root,
-                        &self.stages,
-                        &mut spools,
-                    )?;
+                    authenticated_source.with_shard(shard_index, |path, file| {
+                        maybe_test_replace_source(path)?;
+                        spool_source_shard(
+                            &source.build.shards[shard_index],
+                            path,
+                            file,
+                            &self.stages,
+                            &mut spools,
+                        )
+                    })?;
                     finish_spools(&mut spools)?;
                     progress.state.next_source_shard = shard_index + 1;
                     capture_spool_checkpoints(&spools, &mut progress.state.spools)?;
                     persist_progress(&progress_path, &mut progress)?;
                     maybe_test_interrupt("source_shard")?;
                 }
-                source
-                    .verify(source_root)
+                authenticated_source
+                    .ensure_still_published()
                     .context("source corpus changed while curriculum spools were being prepared")?;
                 progress.state.spooling_complete = true;
                 persist_progress(&progress_path, &mut progress)?;
@@ -312,8 +366,6 @@ impl CurriculumCompositionConfig {
                 progress.state.completed_stages.push(summary);
                 persist_progress(&progress_path, &mut progress)?;
             }
-        } else {
-            validate_staging_tree(self, &source, &identity, &staging_path, &progress)?;
         }
 
         let body = CurriculumManifestBody {
@@ -640,12 +692,12 @@ pub enum CurriculumUnmatchedPolicy {
 impl CurriculumStageConfig {
     fn validate(&self) -> Result<()> {
         validate_component("curriculum stage name", &self.name)?;
-        validate_token_target(&self.token_target)?;
-        ensure!(
-            self.sharding.max_tokens_per_shard > 0,
-            "stage `{}` max_tokens_per_shard must be positive",
-            self.name
-        );
+        self.token_target
+            .validate()
+            .with_context(|| format!("invalid token target for stage `{}`", self.name))?;
+        self.sharding
+            .validate()
+            .with_context(|| format!("invalid sharding for stage `{}`", self.name))?;
         ensure!(
             self.max_fraction_deviation.is_finite()
                 && (0.0..=1.0).contains(&self.max_fraction_deviation),
@@ -653,10 +705,11 @@ impl CurriculumStageConfig {
             self.name
         );
         ensure!(
-            !self.strata.is_empty(),
-            "stage `{}` requires at least one stratum",
+            (1..=MAX_STRATA_PER_STAGE).contains(&self.strata.len()),
+            "stage `{}` requires 1..={MAX_STRATA_PER_STAGE} strata",
             self.name
         );
+        self.when.validate("stage predicate")?;
         let mut names = BTreeSet::new();
         let mut total_weight = 0_u64;
         for stratum in &self.strata {
@@ -673,6 +726,7 @@ impl CurriculumStageConfig {
                 self.name,
                 stratum.name
             );
+            stratum.when.validate("stratum predicate")?;
             total_weight = total_weight
                 .checked_add(stratum.weight)
                 .context("curriculum stratum weights overflow u64")?;
@@ -705,6 +759,27 @@ pub struct CurriculumPredicate {
 }
 
 impl CurriculumPredicate {
+    fn validate(&self, label: &str) -> Result<()> {
+        ensure!(
+            self.topics
+                .iter()
+                .chain(&self.difficulties)
+                .chain(&self.views)
+                .all(|value| !value.trim().is_empty()),
+            "{label} contains an empty selector"
+        );
+        self.selector_count().map(|_| ())
+    }
+
+    fn selector_count(&self) -> Result<usize> {
+        self.topics
+            .len()
+            .checked_add(self.difficulties.len())
+            .and_then(|count| count.checked_add(self.views.len()))
+            .and_then(|count| count.checked_add(self.metadata_equals.len()))
+            .context("curriculum predicate selector count overflows usize")
+    }
+
     fn matches(&self, record: &TokenizedCorpusRecord) -> bool {
         matches_optional(&self.topics, record.topic.as_deref())
             && matches_optional(&self.difficulties, record.difficulty.as_deref())
@@ -754,11 +829,35 @@ pub struct CurriculumManifest {
 impl CurriculumManifest {
     pub fn verify(&self, root: &Path) -> Result<()> {
         ensure_real_directory(root, "curriculum manifest root")?;
+        self.verify_structure()?;
+        for stage in &self.build.stages {
+            let path = safe_join(root, &stage.manifest_path)?;
+            let authenticated = AuthenticatedCorpus::open_data_path(&path)?
+                .context("curriculum stage path must identify an authenticated corpus manifest")?;
+            let manifest = authenticated.manifest();
+            ensure!(
+                manifest.manifest_sha256 == stage.manifest_sha256,
+                "stage `{}` manifest identity changed",
+                stage.name
+            );
+            ensure!(
+                manifest.build.stats.emitted_views == stage.records
+                    && manifest.build.stats.exposure_tokens == stage.tokens,
+                "stage `{}` summary does not match its corpus manifest",
+                stage.name
+            );
+            authenticated.ensure_still_published()?;
+        }
+        Ok(())
+    }
+
+    fn verify_structure(&self) -> Result<()> {
         ensure!(
             self.build.version == CURRICULUM_COMPOSITION_VERSION,
             "unsupported curriculum manifest version {}",
             self.build.version
         );
+        validate_component("curriculum manifest build_id", &self.build.build_id)?;
         ensure!(
             is_sha256(&self.build.config_sha256) && is_sha256(&self.build.source_manifest_sha256),
             "curriculum manifest contains an invalid content identity"
@@ -789,24 +888,6 @@ impl CurriculumManifest {
                 "curriculum manifest repeats stage `{}`",
                 stage.name
             );
-            let path = safe_join(root, &stage.manifest_path)?;
-            ensure_regular_file(&path, "curriculum stage manifest")?;
-            let manifest: CorpusManifest = serde_json::from_slice(&fs::read(&path)?)
-                .with_context(|| format!("invalid stage manifest {}", path.display()))?;
-            ensure!(
-                manifest.manifest_sha256 == stage.manifest_sha256,
-                "stage `{}` manifest identity changed",
-                stage.name
-            );
-            let stage_root = path.parent().unwrap_or_else(|| Path::new("."));
-            ensure_real_directory(stage_root, "curriculum stage root")?;
-            manifest.verify(stage_root)?;
-            ensure!(
-                manifest.build.stats.emitted_views == stage.records
-                    && manifest.build.stats.exposure_tokens == stage.tokens,
-                "stage `{}` summary does not match its corpus manifest",
-                stage.name
-            );
             ensure!(
                 stage
                     .stratum_records
@@ -823,6 +904,16 @@ impl CurriculumManifest {
                     .try_fold(0_u64, |total, value| { total.checked_add(*value) })
                     == Some(stage.tokens),
                 "stage `{}` stratum token counts do not sum to the stage total",
+                stage.name
+            );
+            ensure!(
+                stage.stratum_records.keys().eq(stage.stratum_tokens.keys()),
+                "stage `{}` record and token strata differ",
+                stage.name
+            );
+            ensure!(
+                stage.records > 0 && stage.tokens > 0,
+                "stage `{}` is empty",
                 stage.name
             );
         }
@@ -863,20 +954,22 @@ struct SpoolWriter {
 
 fn spool_source_shard(
     shard: &ShardManifest,
-    source_root: &Path,
+    path: &Path,
+    file: &mut File,
     stages: &[CurriculumStageConfig],
     spools: &mut [Vec<SpoolWriter>],
 ) -> Result<()> {
-    let path = safe_join(source_root, &shard.path)?;
-    let mut reader = open_source_shard(&path)?;
+    let mut reader = BufReader::new(file);
     let mut line = Vec::new();
     let mut line_number = 0_u64;
+    let mut tokens = 0_u64;
     loop {
-        line.clear();
-        if reader.read_until(b'\n', &mut line)? == 0 {
+        if read_corpus_jsonl_record(&mut reader, &mut line, "source corpus row")? == 0 {
             break;
         }
-        line_number += 1;
+        line_number = line_number
+            .checked_add(1)
+            .context("source corpus row count overflows u64")?;
         while line
             .last()
             .is_some_and(|byte| matches!(byte, b'\n' | b'\r'))
@@ -895,7 +988,16 @@ fn spool_source_shard(
             )
         })?;
         record.validate()?;
+        tokens = checked_add(tokens, record.tokens.len())?;
         let canonical = serde_json::to_vec(&record)?;
+        ensure!(
+            canonical
+                .len()
+                .checked_add(1)
+                .is_some_and(|line_bytes| line_bytes <= MAX_CORPUS_JSONL_RECORD_BYTES),
+            "canonical source row at {}:{line_number} exceeds the JSONL record limit of {MAX_CORPUS_JSONL_RECORD_BYTES}",
+            path.display()
+        );
         for (stage_index, stage) in stages.iter().enumerate() {
             if !stage.when.matches(&record) {
                 continue;
@@ -935,19 +1037,19 @@ fn spool_source_shard(
             spool.bytes = checked_add(spool.bytes, canonical.len() + 1)?;
         }
     }
+    ensure!(
+        line_number == shard.records,
+        "source shard {} yielded {line_number} records but its manifest declares {}",
+        path.display(),
+        shard.records
+    );
+    ensure!(
+        tokens == shard.tokens,
+        "source shard {} yielded {tokens} tokens but its manifest declares {}",
+        path.display(),
+        shard.tokens
+    );
     Ok(())
-}
-
-fn open_source_shard(path: &Path) -> Result<Box<dyn BufRead>> {
-    let file = File::open(path)
-        .with_context(|| format!("failed to open source shard {}", path.display()))?;
-    if path.extension().is_some_and(|extension| extension == "zst") {
-        let decoder = zstd::stream::read::Decoder::new(file)
-            .with_context(|| format!("failed to decode source shard {}", path.display()))?;
-        Ok(Box::new(BufReader::new(decoder)))
-    } else {
-        Ok(Box::new(BufReader::new(file)))
-    }
 }
 
 fn finish_spools(spools: &mut [Vec<SpoolWriter>]) -> Result<()> {
@@ -1045,9 +1147,10 @@ fn open_or_create_spools(
         }
         Some(PathKind::File) => {
             ensure_regular_file(&identity_path, "curriculum work identity")?;
-            let actual: CompositionWorkIdentity =
-                serde_json::from_slice(&fs::read(&identity_path)?)
-                    .context("invalid curriculum work identity")?;
+            let actual: CompositionWorkIdentity = serde_json::from_slice(
+                &read_corpus_metadata_file(&identity_path, "curriculum work identity")?,
+            )
+            .context("invalid curriculum work identity")?;
             ensure!(
                 actual == expected_identity,
                 "curriculum work identity changed during resume"
@@ -1207,8 +1310,11 @@ fn validate_spool_tree(
     validate_work_entries(work_path, &state.spools)?;
     let identity_path = work_path.join(WORK_IDENTITY_FILE);
     ensure_regular_file(&identity_path, "curriculum work identity")?;
-    let identity: CompositionWorkIdentity = serde_json::from_slice(&fs::read(&identity_path)?)
-        .context("invalid curriculum work identity")?;
+    let identity: CompositionWorkIdentity = serde_json::from_slice(&read_corpus_metadata_file(
+        &identity_path,
+        "curriculum work identity",
+    )?)
+    .context("invalid curriculum work identity")?;
     ensure!(
         identity
             == (CompositionWorkIdentity {
@@ -1387,8 +1493,9 @@ fn verify_stage_replay(
         let mut shard_records = 0_u64;
         let mut shard_tokens = 0_u64;
         loop {
-            actual.clear();
-            if reader.read_until(b'\n', &mut actual)? == 0 {
+            if read_corpus_jsonl_record(&mut reader, &mut actual, "completed curriculum shard row")?
+                == 0
+            {
                 break;
             }
             trim_line_ending(&mut actual);
@@ -1408,9 +1515,12 @@ fn verify_stage_replay(
                     )
                 })
                 .expect("validated stage has strata");
-            expected.clear();
             ensure!(
-                spool_readers[selected].read_until(b'\n', &mut expected)? > 0,
+                read_corpus_jsonl_record(
+                    &mut spool_readers[selected],
+                    &mut expected,
+                    "curriculum spool row",
+                )? > 0,
                 "completed stage `{}` consumes beyond its durable spool",
                 stage.name
             );
@@ -1553,8 +1663,11 @@ fn validate_staging_tree(
     let root_manifest_path = staging_root.join("curriculum-manifest.json");
     if path_kind(&root_manifest_path)?.is_some() {
         ensure_regular_file(&root_manifest_path, "root curriculum manifest")?;
-        let actual: CurriculumManifest = serde_json::from_slice(&fs::read(&root_manifest_path)?)
-            .context("invalid root curriculum manifest")?;
+        let actual: CurriculumManifest = serde_json::from_slice(&read_corpus_metadata_file(
+            &root_manifest_path,
+            "root curriculum manifest",
+        )?)
+        .context("invalid root curriculum manifest")?;
         let body = CurriculumManifestBody {
             version: composition.version,
             build_id: composition.build_id.clone(),
@@ -1568,7 +1681,10 @@ fn validate_staging_tree(
             build: body,
         };
         ensure!(actual == expected, "root curriculum manifest changed");
-        actual.verify(staging_root)?;
+        // Every completed stage was authenticated by the loop immediately
+        // above. Revalidating the root structure must not stream the entire
+        // multi-billion-token curriculum a second time.
+        actual.verify_structure()?;
         if let Some(expected_hash) = &progress.state.root_manifest_sha256 {
             ensure!(
                 expected_hash == &actual.manifest_sha256,
@@ -1602,27 +1718,19 @@ fn verify_completed_stage(
     let stage_root = staging_root.join(&stage.name);
     ensure_real_directory(&stage_root, "completed curriculum stage")?;
     let manifest_path = stage_root.join("manifest.json");
-    ensure_regular_file(&manifest_path, "completed stage manifest")?;
-    let manifest: CorpusManifest = serde_json::from_slice(&fs::read(&manifest_path)?)
-        .with_context(|| format!("invalid stage manifest {}", manifest_path.display()))?;
+    let authenticated = AuthenticatedCorpus::open_data_path(&manifest_path)?
+        .context("completed stage must contain an authenticated corpus manifest")?;
+    let manifest = authenticated.manifest();
     ensure!(
         manifest.manifest_sha256 == summary.manifest_sha256,
         "completed stage `{}` manifest identity changed",
         stage.name
     );
-    let stage_identity = canonical_json_sha256(&serde_json::json!({
-        "composition_sha256": composition_sha256,
-        "source_manifest_sha256": source.manifest_sha256,
-        "stage": stage,
-    }))?;
     ensure!(
-        manifest.build.config_sha256 == stage_identity
-            && manifest.build.build_id == stage.name
-            && manifest.build.config.build_id == stage.name,
+        manifest.build.build_id == stage.name && manifest.build.config.build_id == stage.name,
         "completed stage `{}` configuration identity changed",
         stage.name
     );
-    manifest.verify(&stage_root)?;
     ensure!(
         manifest.build.stats.emitted_views == summary.records
             && manifest.build.stats.exposure_tokens == summary.tokens,
@@ -1644,6 +1752,7 @@ fn verify_completed_stage(
         stage.name
     );
     ensure_exact_stage_entries(&stage_root, &manifest.build.shards, true)?;
+    authenticated.ensure_still_published()?;
     Ok(())
 }
 
@@ -1690,8 +1799,11 @@ fn publish_or_verify_stage_manifest(stage_root: &Path, expected: &CorpusManifest
         None => write_new_json(&path, expected)?,
         Some(PathKind::File) => {
             ensure_regular_file(&path, "stage manifest")?;
-            let actual: CorpusManifest = serde_json::from_slice(&fs::read(&path)?)
-                .context("invalid existing stage manifest")?;
+            let actual: CorpusManifest = serde_json::from_slice(&read_corpus_metadata_file(
+                &path,
+                "existing stage manifest",
+            )?)
+            .context("invalid existing stage manifest")?;
             ensure!(
                 actual.manifest_sha256 == expected.manifest_sha256
                     && canonical_json_sha256(&actual.build)?
@@ -1716,8 +1828,11 @@ fn publish_or_verify_root_manifest(
         None => write_new_json(&path, expected)?,
         Some(PathKind::File) => {
             ensure_regular_file(&path, "root curriculum manifest")?;
-            let actual: CurriculumManifest = serde_json::from_slice(&fs::read(&path)?)
-                .context("invalid existing root curriculum manifest")?;
+            let actual: CurriculumManifest = serde_json::from_slice(&read_corpus_metadata_file(
+                &path,
+                "existing root curriculum manifest",
+            )?)
+            .context("invalid existing root curriculum manifest")?;
             ensure!(
                 actual == *expected,
                 "existing root curriculum manifest differs from deterministic resumed output"
@@ -1814,8 +1929,8 @@ fn compose_stage(
             })
             .expect("validated stage has strata");
         let prior_offset = readers[selected].stream_position()?;
-        buffer.clear();
-        let read = readers[selected].read_until(b'\n', &mut buffer)?;
+        let read =
+            read_corpus_jsonl_record(&mut readers[selected], &mut buffer, "curriculum spool row")?;
         ensure!(
             read > 0,
             "stage `{}` stratum `{}` exhausted after {} tokens; available={} while stage target={} (adjust weights, predicates, or target)",
@@ -1902,11 +2017,6 @@ fn compose_stage(
     corpus_config.token_target = stage.token_target.clone();
     corpus_config.sharding = stage.sharding.clone();
     corpus_config.validate()?;
-    let stage_identity = canonical_json_sha256(&serde_json::json!({
-        "composition_sha256": composition_sha256,
-        "source_manifest_sha256": source.manifest_sha256,
-        "stage": stage,
-    }))?;
     let stratum_records = stage
         .strata
         .iter()
@@ -1938,24 +2048,25 @@ fn compose_stage(
         exposure_tokens: stage_progress.total_tokens,
         ..CorpusStageStats::default()
     };
-    let body = CorpusManifestBody {
+    let deduplicator = serde_json::json!({
+        "type": "stratified_curriculum_composition",
+        "composition_sha256": composition_sha256,
+        "source_manifest_sha256": source.manifest_sha256,
+        "seed": composition.seed,
+        "stage": stage.name,
+        "stratum_records": stratum_records,
+        "stratum_tokens": stratum_tokens,
+        "available_stratum_records": available_stratum_records,
+        "available_stratum_tokens": available_stratum_tokens,
+    });
+    let mut body = CorpusManifestBody {
         version: source.build.version,
         build_id: stage.name.clone(),
-        config_sha256: stage_identity,
+        config_sha256: String::new(),
         config: corpus_config,
         discovery: source.build.discovery.clone(),
         materializer: source.build.materializer.clone(),
-        deduplicator: serde_json::json!({
-            "type": "stratified_curriculum_composition",
-            "composition_sha256": composition_sha256,
-            "source_manifest_sha256": source.manifest_sha256,
-            "seed": composition.seed,
-            "stage": stage.name,
-            "stratum_records": stratum_records,
-            "stratum_tokens": stratum_tokens,
-            "available_stratum_records": available_stratum_records,
-            "available_stratum_tokens": available_stratum_tokens,
-        }),
+        deduplicator,
         tokenizer: source.build.tokenizer.clone(),
         stats,
         desired_token_target_reached: true,
@@ -1963,12 +2074,17 @@ fn compose_stage(
         difficulty_counts: stage_progress.difficulty_counts.clone(),
         shards: stage_progress.shards.clone(),
     };
+    body.config_sha256 = corpus_manifest_configuration_sha256(&body)?;
     let manifest = CorpusManifest {
         manifest_sha256: canonical_json_sha256(&body)?,
         build: body,
     };
     publish_or_verify_stage_manifest(&stage_root, &manifest)?;
-    manifest.verify(&stage_root)?;
+    // Rows came from authenticated, parsed spools and `RawShardWriter`
+    // computed the exact hashes and counters while writing them. The common
+    // pre-publication validation below performs the one full independent
+    // readback (and resume validates completed output before trusting it), so
+    // rereading every multi-billion-token stage here would be redundant.
     ensure_exact_stage_entries(&stage_root, &manifest.build.shards, true)?;
     sync_directory(&stage_root)?;
 
@@ -2078,25 +2194,44 @@ impl RawShardWriter {
 
     fn would_rotate(&self, tokens: u64) -> bool {
         self.open.as_ref().is_some_and(|shard| {
-            shard.records > 0 && shard.tokens.saturating_add(tokens) > self.max_tokens
+            shard.records > 0
+                && shard
+                    .tokens
+                    .checked_add(tokens)
+                    .is_none_or(|total| total > self.max_tokens)
         })
     }
 
     fn push(&mut self, json: &[u8], tokens: u64) -> Result<()> {
         ensure!(
+            tokens <= self.max_tokens,
+            "one curriculum record contains {tokens} tokens, exceeding max_tokens_per_shard {}",
+            self.max_tokens
+        );
+        ensure!(
             !self.would_rotate(tokens),
             "curriculum shard must be checkpointed before rotation"
+        );
+        ensure!(
+            json.len()
+                .checked_add(1)
+                .is_some_and(|line_bytes| line_bytes <= MAX_CORPUS_JSONL_RECORD_BYTES),
+            "curriculum JSONL row exceeds the record limit of {MAX_CORPUS_JSONL_RECORD_BYTES} bytes"
         );
         if self.open.is_none() {
             self.open()?;
         }
         let shard = self.open.as_mut().expect("shard is open");
+        // Validate accounting before mutating the file so an arithmetic error
+        // cannot leave an unindexed row in the in-progress shard.
+        let records = checked_add(shard.records, 1)?;
+        let total_tokens = checked_add(shard.tokens, tokens)?;
         shard.writer.write_all(json)?;
         shard.writer.write_all(b"\n")?;
         shard.hasher.update(json);
         shard.hasher.update(b"\n");
-        shard.records = checked_add(shard.records, 1)?;
-        shard.tokens = checked_add(shard.tokens, tokens)?;
+        shard.records = records;
+        shard.tokens = total_tokens;
         Ok(())
     }
 
@@ -2138,15 +2273,6 @@ impl RawShardWriter {
             sha256: hex(&shard.hasher.finalize()),
         }))
     }
-}
-
-fn validate_token_target(target: &TokenTarget) -> Result<()> {
-    ensure!(target.minimum > 0, "minimum token target must be positive");
-    ensure!(
-        target.minimum <= target.desired && target.desired <= target.maximum,
-        "token targets must satisfy minimum <= desired <= maximum"
-    );
-    Ok(())
 }
 
 fn validate_component(label: &str, value: &str) -> Result<()> {
@@ -2312,15 +2438,19 @@ fn load_progress(path: &Path) -> Result<Option<CompositionProgress>> {
                 sync_directory(parent)?;
             }
             ensure_regular_file(path, "composition progress")?;
-            let progress: CompositionProgress = serde_json::from_slice(&fs::read(path)?)
-                .context("invalid composition progress JSON")?;
+            let progress: CompositionProgress =
+                serde_json::from_slice(&read_corpus_metadata_file(path, "composition progress")?)
+                    .context("invalid composition progress JSON")?;
             progress.verify_hash()?;
             Ok(Some(progress))
         }
         (None, Some(PathKind::File)) => {
             ensure_regular_file(&temporary, "composition progress temporary file")?;
-            let progress: CompositionProgress = serde_json::from_slice(&fs::read(&temporary)?)
-                .context("invalid composition progress recovery JSON")?;
+            let progress: CompositionProgress = serde_json::from_slice(&read_corpus_metadata_file(
+                &temporary,
+                "composition progress temporary file",
+            )?)
+            .context("invalid composition progress recovery JSON")?;
             progress.verify_hash()?;
             fs::rename(&temporary, path)?;
             sync_directory(parent)?;
@@ -2556,19 +2686,21 @@ mod tests {
                 revision: "1".to_owned(),
             },
         };
-        let body = CorpusManifestBody {
+        let deduplicator = json!({"type": "test"});
+        let tokenizer = TokenizerSnapshot {
+            implementation: "test".to_owned(),
+            revision: "1".to_owned(),
+            vocabulary_size: 10,
+        };
+        let mut body = CorpusManifestBody {
             version: 2,
             build_id: "source".to_owned(),
-            config_sha256: "source-config".to_owned(),
+            config_sha256: String::new(),
             config,
             discovery: component.clone(),
             materializer: component,
-            deduplicator: json!({"type": "test"}),
-            tokenizer: TokenizerSnapshot {
-                implementation: "test".to_owned(),
-                revision: "1".to_owned(),
-                vocabulary_size: 10,
-            },
+            deduplicator,
+            tokenizer,
             stats: CorpusStageStats {
                 unique_records: records,
                 unique_tokens: tokens,
@@ -2586,6 +2718,7 @@ mod tests {
                 sha256: hex(&Sha256::digest(&bytes)),
             }],
         };
+        body.config_sha256 = corpus_manifest_configuration_sha256(&body).unwrap();
         let manifest = CorpusManifest {
             manifest_sha256: canonical_json_sha256(&body).unwrap(),
             build: body,
@@ -2716,6 +2849,79 @@ mod tests {
     }
 
     #[test]
+    fn composition_validation_bounds_spool_geometry_and_rejects_empty_selectors() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let (source_path, source) = source_corpus(source_dir.path());
+
+        let mut too_many_strata = config(&source_path, &source);
+        let prototype = too_many_strata.stages[0].strata[0].clone();
+        too_many_strata.stages[0].strata = (0..=MAX_STRATA_PER_STAGE)
+            .map(|index| CurriculumStratumConfig {
+                name: format!("stratum-{index}"),
+                ..prototype.clone()
+            })
+            .collect();
+        assert!(too_many_strata.validate().is_err());
+
+        let mut empty_selector = config(&source_path, &source);
+        empty_selector.stages[0].strata[0].when.topics = vec!["".to_owned()];
+        assert!(empty_selector.validate().is_err());
+    }
+
+    #[test]
+    fn curriculum_manifest_requires_matching_record_and_token_strata() {
+        let body = CurriculumManifestBody {
+            version: CURRICULUM_COMPOSITION_VERSION,
+            build_id: "curriculum".to_owned(),
+            config_sha256: "0".repeat(64),
+            source_manifest_sha256: "1".repeat(64),
+            seed: 1,
+            stages: vec![CurriculumStageSummary {
+                name: "stage".to_owned(),
+                manifest_path: "stage/manifest.json".to_owned(),
+                manifest_sha256: "2".repeat(64),
+                records: 1,
+                tokens: 1,
+                stratum_records: BTreeMap::from([("records-only".to_owned(), 1)]),
+                stratum_tokens: BTreeMap::from([("tokens-only".to_owned(), 1)]),
+            }],
+        };
+        let manifest = CurriculumManifest {
+            manifest_sha256: canonical_json_sha256(&body).unwrap(),
+            build: body,
+        };
+        let error = manifest.verify_structure().unwrap_err().to_string();
+        assert!(error.contains("record and token strata differ"), "{error}");
+    }
+
+    #[test]
+    fn raw_shard_writer_rejects_one_record_larger_than_the_shard_limit() {
+        let root = tempfile::tempdir().unwrap();
+        let mut writer = RawShardWriter::resume(root.path(), 2, 0).unwrap();
+
+        let error = writer.push(br#"{"tokens":[1,2,3]}"#, 3).unwrap_err();
+        let error = error.to_string();
+        assert!(
+            error.contains("one curriculum record contains 3 tokens"),
+            "{error}"
+        );
+        assert!(error.contains("max_tokens_per_shard 2"), "{error}");
+        assert!(fs::read_dir(root.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn raw_shard_writer_rotates_when_token_accounting_would_overflow() {
+        let root = tempfile::tempdir().unwrap();
+        let mut writer = RawShardWriter::resume(root.path(), u64::MAX, 0).unwrap();
+        writer.open().unwrap();
+        let shard = writer.open.as_mut().unwrap();
+        shard.records = 1;
+        shard.tokens = u64::MAX;
+
+        assert!(writer.would_rotate(1));
+    }
+
+    #[test]
     fn resumes_exactly_after_source_and_stage_shard_interruptions() {
         let source_dir = tempfile::tempdir().unwrap();
         let (source_path, source) = source_corpus(source_dir.path());
@@ -2827,6 +3033,43 @@ mod tests {
             resumed_publish.manifest_sha256,
             clean_manifest.manifest_sha256
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_replacement_during_spooling_never_advances_durable_progress() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let (source_path, source) = source_corpus(source_dir.path());
+        let config = config(&source_path, &source);
+        let config_path = source_dir.path().join("composition.json");
+        write_new_json(&config_path, &config).unwrap();
+        let output = tempfile::tempdir().unwrap();
+        let work = tempfile::tempdir().unwrap();
+
+        set_test_source_replacement();
+        let error = config
+            .run(&config_path, output.path(), work.path())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("corpus shard"), "{error}");
+
+        let staging = output.path().join(".education.building");
+        let progress = load_progress(&staging.join(PROGRESS_FILE))
+            .unwrap()
+            .unwrap();
+        assert_eq!(progress.state.next_source_shard, 0);
+        assert!(!progress.state.spooling_complete);
+        assert!(!output.path().join("education").exists());
+
+        let published = source_dir.path().join(&source.build.shards[0].path);
+        let parked = published.with_extension("test-authenticated-original");
+        fs::remove_file(&published).unwrap();
+        fs::rename(parked, published).unwrap();
+
+        let (result_path, manifest) = config
+            .run(&config_path, output.path(), work.path())
+            .unwrap();
+        manifest.verify(&result_path).unwrap();
     }
 
     #[test]

--- a/hermes-train/src/corpus/config.rs
+++ b/hermes-train/src/corpus/config.rs
@@ -7,6 +7,19 @@ use serde_json::Value;
 /// Current on-disk corpus configuration and manifest schema.
 pub const CORPUS_SCHEMA_VERSION: u32 = 2;
 
+// These limits bound work derived from one small configuration before the
+// pipeline reaches a byte-bounded remote response or shard writer. They are
+// deliberately far above the production recipe while preventing values such
+// as `usize::MAX` from turning a typo or hostile recipe into an allocation or
+// CPU denial of service.
+const MAX_DISCOVERY_QUERIES: usize = 4_096;
+const MAX_DISCOVERY_HITS: usize = 1_000_000_000;
+pub(super) const MAX_DISCOVERY_BATCH_SIZE: usize = 65_536;
+const MAX_CLASSIFICATION_RULES: usize = 4_096;
+const MAX_CLASSIFICATION_TERMS: usize = 4_096;
+const MAX_TRANSFORMATIONS: usize = 1_024;
+const MAX_COPIES_PER_RECORD: usize = 4_096;
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct CorpusBuildConfig {
@@ -47,6 +60,10 @@ impl CorpusBuildConfig {
         self.deduplication.validate()?;
         self.classification.validate()?;
         ensure!(
+            self.transformations.len() <= MAX_TRANSFORMATIONS,
+            "corpus transformations exceed the {MAX_TRANSFORMATIONS}-item limit"
+        );
+        ensure!(
             self.transformations.iter().all(|item| item.copies > 0),
             "every transformation must emit at least one copy"
         );
@@ -55,6 +72,10 @@ impl CorpusBuildConfig {
             ensure!(
                 !transform.name.trim().is_empty(),
                 "transformation names must not be empty"
+            );
+            ensure!(
+                transform.name != "source",
+                "transformation name `source` is reserved for canonical corpus views"
             );
             ensure!(
                 transform_names.insert(transform.name.as_str()),
@@ -93,10 +114,15 @@ impl DiscoveryConfig {
             "corpus discovery requires at least one query"
         );
         ensure!(
-            self.materialization_batch_size > 0,
-            "materialization_batch_size must be positive"
+            self.queries.len() <= MAX_DISCOVERY_QUERIES,
+            "corpus discovery queries exceed the {MAX_DISCOVERY_QUERIES}-item limit"
+        );
+        ensure!(
+            (1..=MAX_DISCOVERY_BATCH_SIZE).contains(&self.materialization_batch_size),
+            "materialization_batch_size must be within 1..={MAX_DISCOVERY_BATCH_SIZE}"
         );
         let mut names = std::collections::BTreeSet::new();
+        let mut total_limit = 0usize;
         for query in &self.queries {
             ensure!(
                 !query.name.trim().is_empty() && !query.text.trim().is_empty(),
@@ -108,9 +134,16 @@ impl DiscoveryConfig {
                 query.name
             );
             ensure!(
-                query.limit > 0,
-                "query `{}` limit must be positive",
+                (1..=MAX_DISCOVERY_HITS).contains(&query.limit),
+                "query `{}` limit must be within 1..={MAX_DISCOVERY_HITS}",
                 query.name
+            );
+            total_limit = total_limit.checked_add(query.limit).ok_or_else(|| {
+                anyhow::anyhow!("aggregate discovery query limit overflows usize")
+            })?;
+            ensure!(
+                total_limit <= MAX_DISCOVERY_HITS,
+                "aggregate discovery query limit exceeds {MAX_DISCOVERY_HITS} hits"
             );
         }
         Ok(())
@@ -178,7 +211,7 @@ impl Default for DeduplicationConfig {
 }
 
 impl DeduplicationConfig {
-    fn validate(&self) -> Result<()> {
+    pub(super) fn validate(&self) -> Result<()> {
         ensure!(
             self.by_record_key || self.by_normalized_text,
             "deduplication must enable record-key or normalized-text matching"
@@ -198,13 +231,28 @@ pub struct ClassificationConfig {
 
 impl ClassificationConfig {
     fn validate(&self) -> Result<()> {
+        ensure!(
+            self.default_topic
+                .as_deref()
+                .is_none_or(|label| !label.trim().is_empty())
+                && self
+                    .default_difficulty
+                    .as_deref()
+                    .is_none_or(|label| !label.trim().is_empty()),
+            "classification default labels must not be empty"
+        );
         validate_rules("topic", &self.topic_rules)?;
         validate_rules("difficulty", &self.difficulty_rules)
     }
 }
 
 fn validate_rules(kind: &str, rules: &[ClassificationRule]) -> Result<()> {
+    ensure!(
+        rules.len() <= MAX_CLASSIFICATION_RULES,
+        "{kind} classification rules exceed the {MAX_CLASSIFICATION_RULES}-item limit"
+    );
     let mut labels = std::collections::BTreeSet::new();
+    let mut total_terms = 0usize;
     for rule in rules {
         ensure!(
             !rule.label.trim().is_empty(),
@@ -215,9 +263,19 @@ fn validate_rules(kind: &str, rules: &[ClassificationRule]) -> Result<()> {
             "duplicate {kind} classification label `{}`",
             rule.label
         );
+        total_terms = total_terms
+            .checked_add(rule.any_terms.len())
+            .and_then(|count| count.checked_add(rule.all_terms.len()))
+            .and_then(|count| count.checked_add(rule.none_terms.len()))
+            .ok_or_else(|| anyhow::anyhow!("{kind} classification term count overflows usize"))?;
+        ensure!(
+            total_terms <= MAX_CLASSIFICATION_TERMS,
+            "{kind} classification terms exceed the {MAX_CLASSIFICATION_TERMS}-item limit"
+        );
         ensure!(
             !rule.any_terms.is_empty()
                 || !rule.all_terms.is_empty()
+                || !rule.none_terms.is_empty()
                 || !rule.metadata_equals.is_empty(),
             "{kind} rule `{}` has no predicates",
             rule.label
@@ -302,6 +360,10 @@ impl RepetitionConfig {
     fn validate(&self) -> Result<()> {
         ensure!(self.base_copies > 0, "base_copies must be positive");
         ensure!(
+            self.max_copies_per_record <= MAX_COPIES_PER_RECORD,
+            "max_copies_per_record exceeds the {MAX_COPIES_PER_RECORD}-copy limit"
+        );
+        ensure!(
             self.max_copies_per_record >= self.base_copies,
             "max_copies_per_record must cover base_copies"
         );
@@ -311,6 +373,13 @@ impl RepetitionConfig {
                 .chain(self.difficulty_copies.values())
                 .all(|copies| *copies > 0 && *copies <= self.max_copies_per_record),
             "configured repetition copies must be positive and within max_copies_per_record"
+        );
+        ensure!(
+            self.topic_copies
+                .keys()
+                .chain(self.difficulty_copies.keys())
+                .all(|label| !label.trim().is_empty()),
+            "configured repetition labels must not be empty"
         );
         Ok(())
     }
@@ -325,7 +394,7 @@ pub struct TokenTarget {
 }
 
 impl TokenTarget {
-    fn validate(&self) -> Result<()> {
+    pub(super) fn validate(&self) -> Result<()> {
         ensure!(self.minimum > 0, "minimum token target must be positive");
         ensure!(
             self.minimum <= self.desired && self.desired <= self.maximum,
@@ -346,7 +415,7 @@ pub struct ShardingConfig {
 }
 
 impl ShardingConfig {
-    fn validate(&self) -> Result<()> {
+    pub(super) fn validate(&self) -> Result<()> {
         ensure!(
             self.max_tokens_per_shard > 0,
             "max_tokens_per_shard must be positive"

--- a/hermes-train/src/corpus/materialize.rs
+++ b/hermes-train/src/corpus/materialize.rs
@@ -11,7 +11,8 @@ use postgres::{Client, Config as PostgresConfig, NoTls, Row};
 use postgres_native_tls::{MakeTlsConnector, set_postgresql_alpn};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
+
+use crate::artifact_io::{sha256_identity, validate_sha256_identity};
 
 use super::{DiscoveryHit, SourceSnapshot};
 
@@ -192,7 +193,7 @@ impl PostgresTlsTrust {
                 !certificate_pem_environment.trim().is_empty(),
                 "postgres TLS certificate_pem_environment must not be empty"
             );
-            validate_sha256_label(certificate_sha256, "postgres TLS certificate")?;
+            validate_sha256_identity(certificate_sha256, "postgres TLS certificate")?;
         }
         Ok(())
     }
@@ -342,7 +343,7 @@ fn postgres_tls_connector(
                     "postgres TLS certificate environment variable `{certificate_pem_environment}` is not set"
                 )
             })?;
-            let actual = format!("sha256:{:x}", Sha256::digest(pem.as_bytes()));
+            let actual = sha256_identity(pem.as_bytes());
             ensure!(
                 actual == *certificate_sha256,
                 "postgres TLS certificate digest does not match certificate_sha256"
@@ -426,20 +427,6 @@ fn validate_server_name(name: &str) -> Result<()> {
                         .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
             }),
         "postgres verified TLS server name `{name}` is not a valid DNS name"
-    );
-    Ok(())
-}
-
-fn validate_sha256_label(value: &str, subject: &str) -> Result<()> {
-    let Some(digest) = value.strip_prefix("sha256:") else {
-        bail!("{subject} digest must use sha256:<64 lowercase hex>");
-    };
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{subject} digest must use sha256:<64 lowercase hex>"
     );
     Ok(())
 }

--- a/hermes-train/src/corpus/pipeline.rs
+++ b/hermes-train/src/corpus/pipeline.rs
@@ -1,16 +1,27 @@
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::fmt;
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufReader, BufWriter, Read, Write};
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::path::Component;
 use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::ffi::CString;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
 use anyhow::{Context, Result, ensure};
 use hermes_llm::Tokenizer;
 use rusqlite::{Connection, OptionalExtension, params};
-use serde::{Deserialize, Serialize};
+use serde::de::{SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
+use super::config::MAX_DISCOVERY_BATCH_SIZE;
 use super::{
     ClassificationRule, CorpusBuildConfig, DeduplicationConfig, DiscoveryHit, MaterializedRecord,
     NormalizationConfig, RecordMaterializer, RecordPredicate, RepetitionConfig, SearchBackend,
@@ -18,6 +29,8 @@ use super::{
 };
 
 pub trait CorpusTokenizer: Send + Sync {
+    /// Identity of the exact encoding implementation and vocabulary. It must
+    /// change whenever [`Self::encode`] can produce different token IDs.
     fn snapshot(&self) -> TokenizerSnapshot;
     fn encode(&self, text: &str) -> Result<Vec<u32>>;
 }
@@ -28,6 +41,28 @@ pub struct TokenizerSnapshot {
     pub implementation: String,
     pub revision: String,
     pub vocabulary_size: usize,
+}
+
+impl TokenizerSnapshot {
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            !self.implementation.trim().is_empty(),
+            "tokenizer implementation must not be empty"
+        );
+        ensure!(
+            !self.revision.trim().is_empty(),
+            "tokenizer revision must not be empty"
+        );
+        ensure!(
+            self.vocabulary_size > 0,
+            "tokenizer vocabulary_size must be positive"
+        );
+        ensure!(
+            u64::try_from(self.vocabulary_size).is_ok_and(|size| size <= u64::from(u32::MAX) + 1),
+            "tokenizer vocabulary_size exceeds the u32 token-id space"
+        );
+        Ok(())
+    }
 }
 
 pub struct HermesCorpusTokenizer<'a> {
@@ -117,7 +152,7 @@ pub struct InMemoryDeduplicator {
 
 impl InMemoryDeduplicator {
     pub fn new(config: DeduplicationConfig) -> Result<Self> {
-        config.validate_for_pipeline()?;
+        config.validate()?;
         Ok(Self {
             config,
             state: InMemoryDedupState::default(),
@@ -266,7 +301,7 @@ pub struct SqliteDeduplicator {
 
 impl SqliteDeduplicator {
     pub fn open(path: &Path, config: DeduplicationConfig) -> Result<Self> {
-        config.validate_for_pipeline()?;
+        config.validate()?;
         let connection = Connection::open(path)
             .with_context(|| format!("failed to open deduplication catalog {}", path.display()))?;
         let legacy_table: i64 = connection.query_row(
@@ -532,22 +567,6 @@ impl Deduplicator for SqliteDeduplicator {
     }
 }
 
-// Keep validation private in config.rs while allowing construction of
-// pipeline-owned implementations.
-trait DeduplicationValidation {
-    fn validate_for_pipeline(&self) -> Result<()>;
-}
-
-impl DeduplicationValidation for DeduplicationConfig {
-    fn validate_for_pipeline(&self) -> Result<()> {
-        ensure!(
-            self.by_record_key || self.by_normalized_text,
-            "deduplication must enable record-key or normalized-text matching"
-        );
-        Ok(())
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct ComponentManifest {
@@ -563,6 +582,11 @@ pub struct CorpusStageStats {
     pub discovered_hits: u64,
     pub duplicate_discovery_keys: u64,
     pub materialized_records: u64,
+    /// Discovery hits the materializer did not return. Only reachable with
+    /// `require_every_record: false`, which tolerates rows that disappeared
+    /// between discovery and materialization.
+    #[serde(default)]
+    pub unmaterialized_records: u64,
     pub normalization_rejections: u64,
     pub duplicate_records: u64,
     pub unique_records: u64,
@@ -608,6 +632,21 @@ pub struct CorpusManifest {
 const CORPUS_PROGRESS_VERSION: u32 = 2;
 const CORPUS_PROGRESS_FILE: &str = "progress.json";
 const CORPUS_PROGRESS_TEMP: &str = ".progress.json.tmp";
+const MAX_CORPUS_METADATA_BYTES: u64 = 64 * 1024 * 1024;
+const VERIFIED_SHARD_READ_BUFFER_BYTES: usize = 1024 * 1024;
+
+/// Corpus rows are deliberately bounded independently of shard size. A
+/// missing JSONL delimiter must not make verification or curriculum
+/// composition allocate an entire multi-gigabyte shard. The limit still
+/// accommodates millions of token IDs in one record, far above training
+/// context sizes.
+pub(crate) const MAX_CORPUS_JSONL_RECORD_BYTES: usize = 64 * 1024 * 1024;
+const MAX_MATERIALIZED_TEXT_BYTES: usize = MAX_CORPUS_JSONL_RECORD_BYTES;
+const MAX_RENDERED_VIEW_TEXT_BYTES: usize = MAX_CORPUS_JSONL_RECORD_BYTES;
+/// Bound transformation amplification for one source record. Each individual
+/// view is bounded above, but many templates can otherwise retain hundreds of
+/// large rendered strings (and their token vectors) at once.
+const MAX_RETAINED_RENDERED_TEXT_BYTES: usize = 256 * 1024 * 1024;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -657,12 +696,418 @@ struct CorpusProgressEnvelope {
     progress: CorpusProgress,
 }
 
+/// One manifest generation whose exact shard files were authenticated once.
+///
+/// The retained root descriptor and per-shard identities are the data-plane
+/// counterpart of the manifest hash used in a training run signature. Shards
+/// are opened relative to that root and matched to their verified identities,
+/// while publication checks reject persistent replacement. This avoids both a
+/// second hash pass and one retained descriptor per shard.
+pub struct AuthenticatedCorpus {
+    root: PinnedCorpusRoot,
+    manifest_identity: StableCorpusFileIdentity,
+    manifest: CorpusManifest,
+    shards: Vec<PinnedCorpusShard>,
+}
+
+struct PinnedCorpusShard {
+    relative_path: String,
+    display_path: PathBuf,
+    identity: StableCorpusFileIdentity,
+}
+
+struct VerifiedCorpusShardReader<'a> {
+    file: &'a mut File,
+    expected: &'a StableCorpusFileIdentity,
+    path: &'a Path,
+    buffer: Box<[u8]>,
+    buffered_start: usize,
+    buffered_end: usize,
+}
+
+impl Read for VerifiedCorpusShardReader<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        if buffer.is_empty() {
+            return Ok(0);
+        }
+        if self.buffered_start == self.buffered_end {
+            let read = self.file.read(&mut self.buffer)?;
+            let observed = StableCorpusFileIdentity::from_metadata(&self.file.metadata()?);
+            if observed != *self.expected {
+                return Err(std::io::Error::other(format!(
+                    "authenticated corpus shard {} changed in place while it was streamed",
+                    self.path.display()
+                )));
+            }
+            self.buffered_start = 0;
+            self.buffered_end = read;
+            if read == 0 {
+                return Ok(0);
+            }
+        }
+        // Bytes only enter this buffer immediately before a successful
+        // identity check. A later in-place write cannot change the captured
+        // bytes, so metadata syscalls scale with MiB chunks instead of the
+        // caller's (usually 8 KiB) parser buffer.
+        let available = &self.buffer[self.buffered_start..self.buffered_end];
+        let copied = available.len().min(buffer.len());
+        buffer[..copied].copy_from_slice(&available[..copied]);
+        self.buffered_start += copied;
+        Ok(copied)
+    }
+}
+
+struct PinnedCorpusRoot {
+    path: PathBuf,
+    identity: fs::Metadata,
+    #[cfg(unix)]
+    directory: File,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct StableCorpusFileIdentity {
+    length: u64,
+    modified: Option<std::time::SystemTime>,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    mode: u32,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+}
+
+impl StableCorpusFileIdentity {
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        Self {
+            length: metadata.len(),
+            modified: metadata.modified().ok(),
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            mode: metadata.mode(),
+            #[cfg(unix)]
+            changed_seconds: metadata.ctime(),
+            #[cfg(unix)]
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+}
+
+impl PinnedCorpusRoot {
+    fn open(path: &Path) -> Result<Self> {
+        let identity = fs::symlink_metadata(path)
+            .with_context(|| format!("failed to inspect corpus root {}", path.display()))?;
+        ensure!(
+            identity.is_dir() && !identity.file_type().is_symlink(),
+            "corpus root {} is not a real directory",
+            path.display()
+        );
+        #[cfg(unix)]
+        let directory = {
+            let directory = OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW)
+                .open(path)
+                .with_context(|| {
+                    format!("failed to securely open corpus root {}", path.display())
+                })?;
+            ensure!(
+                same_file_object(&directory.metadata()?, &identity),
+                "corpus root {} changed while it was opened",
+                path.display()
+            );
+            directory
+        };
+        Ok(Self {
+            path: path.to_owned(),
+            identity,
+            #[cfg(unix)]
+            directory,
+        })
+    }
+
+    fn open_file(&self, relative: &str, label: &str) -> Result<File> {
+        let mut components = Path::new(relative).components();
+        ensure!(
+            matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none(),
+            "{label} path `{relative}` is not one safe relative component"
+        );
+        #[cfg(unix)]
+        {
+            let name = CString::new(relative).context("corpus file name contains NUL")?;
+            // SAFETY: the root descriptor remains owned by `self`; openat
+            // returns a newly owned descriptor and O_NOFOLLOW rejects a
+            // symlink at the authenticated leaf.
+            let descriptor = unsafe {
+                libc::openat(
+                    self.directory.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK,
+                    0,
+                )
+            };
+            if descriptor < 0 {
+                return Err(std::io::Error::last_os_error()).with_context(|| {
+                    format!(
+                        "failed to open {label} {}",
+                        self.path.join(relative).display()
+                    )
+                });
+            }
+            // SAFETY: openat returned a newly owned descriptor on success.
+            let file = unsafe { File::from_raw_fd(descriptor) };
+            ensure!(
+                file.metadata()?.is_file(),
+                "{label} {} is not a regular file",
+                self.path.join(relative).display()
+            );
+            Ok(file)
+        }
+        #[cfg(not(unix))]
+        {
+            open_regular_non_symlink(&self.path.join(relative), label)
+        }
+    }
+
+    fn ensure_same_file(
+        &self,
+        relative: &str,
+        expected: &StableCorpusFileIdentity,
+        label: &str,
+    ) -> Result<()> {
+        let file = self.open_file(relative, label)?;
+        let observed = file
+            .metadata()
+            .with_context(|| format!("failed to reinspect published {label} `{relative}`"))?;
+        ensure!(
+            StableCorpusFileIdentity::from_metadata(&observed) == *expected,
+            "published {label} {} changed after corpus authentication",
+            self.path.join(relative).display()
+        );
+        Ok(())
+    }
+
+    fn ensure_still_published(&self) -> Result<()> {
+        ensure_path_still_same_object(&self.path, &self.identity, "corpus root")
+    }
+}
+
+impl AuthenticatedCorpus {
+    /// Open a directory or explicit `manifest.json` input as one authenticated
+    /// corpus generation. Non-manifest files return `None` so callers can keep
+    /// their existing generic input behavior.
+    pub fn open_data_path(path: &Path) -> Result<Option<Self>> {
+        let manifest_path = if path.is_dir() {
+            Some(path.join("manifest.json"))
+        } else if path.file_name().is_some_and(|name| name == "manifest.json") {
+            Some(path.to_owned())
+        } else {
+            None
+        };
+        manifest_path
+            .map(|path| Self::open_manifest(&path))
+            .transpose()
+    }
+
+    fn open_manifest(manifest_path: &Path) -> Result<Self> {
+        ensure!(
+            manifest_path
+                .file_name()
+                .is_some_and(|name| name == "manifest.json"),
+            "corpus manifest path must end in manifest.json"
+        );
+        let root_path = manifest_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let root = PinnedCorpusRoot::open(root_path)?;
+        let manifest_file = root.open_file("manifest.json", "corpus manifest")?;
+        let (manifest_bytes, manifest_identity) =
+            read_stable_corpus_file(manifest_file, "corpus manifest")?;
+        let manifest: CorpusManifest = serde_json::from_slice(&manifest_bytes)
+            .with_context(|| format!("invalid corpus manifest {}", manifest_path.display()))?;
+        let shards = manifest.verify_with_root(&root)?;
+        root.ensure_same_file("manifest.json", &manifest_identity, "corpus manifest")?;
+        root.ensure_still_published()?;
+        Ok(Self {
+            root,
+            manifest_identity,
+            manifest,
+            shards,
+        })
+    }
+
+    /// Parsed manifest whose exact bytes and referenced shards were verified.
+    pub fn manifest(&self) -> &CorpusManifest {
+        &self.manifest
+    }
+
+    /// Number of immutable shards in this corpus generation.
+    pub fn shard_count(&self) -> usize {
+        self.shards.len()
+    }
+
+    fn shard_path(&self, index: usize) -> Result<&Path> {
+        self.shards
+            .get(index)
+            .map(|shard| shard.display_path.as_path())
+            .with_context(|| format!("authenticated corpus has no shard {index}"))
+    }
+
+    fn open_shard(&self, index: usize) -> Result<File> {
+        let shard = self
+            .shards
+            .get(index)
+            .with_context(|| format!("authenticated corpus has no shard {index}"))?;
+        let file = self.root.open_file(&shard.relative_path, "corpus shard")?;
+        let observed = file.metadata().with_context(|| {
+            format!(
+                "failed to inspect authenticated corpus shard {}",
+                shard.display_path.display()
+            )
+        })?;
+        ensure!(
+            StableCorpusFileIdentity::from_metadata(&observed) == shard.identity,
+            "authenticated corpus shard {} changed after verification",
+            shard.display_path.display()
+        );
+        Ok(file)
+    }
+
+    fn ensure_open_shard_still_published(&self, index: usize, file: &File) -> Result<()> {
+        let shard = self
+            .shards
+            .get(index)
+            .with_context(|| format!("authenticated corpus has no shard {index}"))?;
+        let observed = file.metadata().with_context(|| {
+            format!(
+                "failed to reinspect authenticated corpus shard {}",
+                shard.display_path.display()
+            )
+        })?;
+        ensure!(
+            StableCorpusFileIdentity::from_metadata(&observed) == shard.identity,
+            "authenticated corpus shard {} changed while it was read",
+            shard.display_path.display()
+        );
+        self.root
+            .ensure_same_file(&shard.relative_path, &shard.identity, "corpus shard")?;
+        self.root
+            .ensure_same_file("manifest.json", &self.manifest_identity, "corpus manifest")?;
+        self.root.ensure_still_published()
+    }
+
+    /// Stream one shard through an exact verified handle and always perform
+    /// the matching handle/path identity check before returning.
+    pub fn with_shard<T>(
+        &self,
+        index: usize,
+        read: impl FnOnce(&Path, &mut File) -> Result<T>,
+    ) -> Result<T> {
+        let path = self.shard_path(index)?.to_owned();
+        let mut file = self.open_shard(index)?;
+        let result = read(&path, &mut file);
+        self.ensure_open_shard_still_published(index, &file)?;
+        result
+    }
+
+    /// Stream one shard while checking the retained handle after each bounded
+    /// read. This prevents an in-place mutation from yielding a mixed record
+    /// that reaches a concurrent consumer before the enclosing final check.
+    pub fn with_verified_shard<T>(
+        &self,
+        index: usize,
+        read: impl FnOnce(&Path, &mut dyn Read) -> Result<T>,
+    ) -> Result<T> {
+        let path = self.shard_path(index)?.to_owned();
+        let mut file = self.open_shard(index)?;
+        let shard = self
+            .shards
+            .get(index)
+            .with_context(|| format!("authenticated corpus has no shard {index}"))?;
+        let result = {
+            let mut verified = VerifiedCorpusShardReader {
+                file: &mut file,
+                expected: &shard.identity,
+                path: &path,
+                buffer: vec![0_u8; VERIFIED_SHARD_READ_BUFFER_BYTES].into_boxed_slice(),
+                buffered_start: 0,
+                buffered_end: 0,
+            };
+            read(&path, &mut verified)
+        };
+        self.ensure_open_shard_still_published(index, &file)?;
+        result
+    }
+
+    /// Reject persistent publication replacement or in-place mutation while
+    /// allowing the retained generation to survive a transient A -> B -> A
+    /// pathname swap.
+    pub fn ensure_still_published(&self) -> Result<()> {
+        self.root.ensure_still_published()?;
+        self.root
+            .ensure_same_file("manifest.json", &self.manifest_identity, "corpus manifest")?;
+        for shard in &self.shards {
+            self.root
+                .ensure_same_file(&shard.relative_path, &shard.identity, "corpus shard")?;
+        }
+        self.root.ensure_still_published()
+    }
+}
+
 impl CorpusManifest {
     /// Verify the content-addressed manifest and every immutable token shard.
     /// Training calls this before accepting a prepared corpus so a copied or
     /// partially replaced build cannot silently change a resumed run.
     pub fn verify(&self, root: &Path) -> Result<()> {
+        let root = PinnedCorpusRoot::open(root)?;
+        self.verify_with_root(&root)?;
+        Ok(())
+    }
+
+    fn verify_with_root(&self, root: &PinnedCorpusRoot) -> Result<Vec<PinnedCorpusShard>> {
         self.build.config.validate()?;
+        ensure!(
+            self.build.version == self.build.config.version,
+            "corpus manifest version differs from its embedded configuration"
+        );
+        ensure!(
+            self.build.build_id == self.build.config.build_id,
+            "corpus manifest build_id differs from its embedded configuration"
+        );
+        for (label, component) in [
+            ("discovery", &self.build.discovery),
+            ("materializer", &self.build.materializer),
+        ] {
+            ensure!(
+                !component.name.trim().is_empty(),
+                "corpus {label} component name must not be empty"
+            );
+        }
+        self.build
+            .discovery
+            .snapshot
+            .validate()
+            .context("invalid corpus discovery snapshot")?;
+        self.build
+            .materializer
+            .snapshot
+            .validate()
+            .context("invalid corpus materializer snapshot")?;
+        self.build
+            .tokenizer
+            .validate()
+            .context("invalid corpus tokenizer snapshot")?;
+        ensure!(
+            self.build.config_sha256 == corpus_manifest_configuration_sha256(&self.build)?,
+            "corpus manifest configuration hash does not match its embedded components"
+        );
         ensure!(
             self.manifest_sha256 == canonical_json_sha256(&serde_json::to_value(&self.build)?)?,
             "corpus manifest body hash does not match manifest_sha256"
@@ -671,24 +1116,24 @@ impl CorpusManifest {
             !self.build.shards.is_empty(),
             "corpus manifest has no shards"
         );
-        let mut paths = HashSet::new();
         let mut records = 0u64;
         let mut tokens = 0u64;
-        for shard in &self.build.shards {
+        let mut verified_shards = Vec::with_capacity(self.build.shards.len());
+        for (index, shard) in self.build.shards.iter().enumerate() {
+            let expected_path = format!("shard-{index:05}.tokens.jsonl");
+            ensure!(
+                shard.path == expected_path,
+                "corpus shard sequence is non-canonical: expected `{expected_path}`, got `{}`",
+                shard.path
+            );
             let relative = Path::new(&shard.path);
             ensure!(
                 !relative.as_os_str().is_empty()
                     && !relative.is_absolute()
-                    && relative.components().all(|component| matches!(
-                        component,
-                        Component::Normal(_) | Component::CurDir
-                    )),
+                    && relative
+                        .components()
+                        .all(|component| matches!(component, Component::Normal(_))),
                 "corpus shard path `{}` is not a safe relative path",
-                shard.path
-            );
-            ensure!(
-                paths.insert(shard.path.as_str()),
-                "corpus manifest repeats shard `{}`",
                 shard.path
             );
             ensure!(
@@ -696,38 +1141,101 @@ impl CorpusManifest {
                 "corpus shard `{}` is empty",
                 shard.path
             );
-            let path = root.join(relative);
-            let metadata = fs::symlink_metadata(&path)
-                .with_context(|| format!("corpus shard {} is missing", path.display()))?;
             ensure!(
-                metadata.file_type().is_file(),
-                "corpus shard {} is not a regular, non-symlink file",
-                path.display()
+                shard.tokens <= self.build.config.sharding.max_tokens_per_shard,
+                "corpus shard `{}` exceeds configured max_tokens_per_shard",
+                shard.path
             );
-            let mut input = BufReader::new(
-                File::open(&path)
-                    .with_context(|| format!("failed to open corpus shard {}", path.display()))?,
-            );
+            let path = root.path.join(relative);
+            let file = root.open_file(&shard.path, "corpus shard")?;
+            let before = StableCorpusFileIdentity::from_metadata(&file.metadata()?);
+            let mut input = BufReader::new(file);
             let mut hasher = Sha256::new();
-            let mut buffer = [0u8; 1024 * 1024];
+            let mut line = Vec::new();
+            let mut shard_records = 0u64;
+            let mut shard_tokens = 0u64;
             loop {
-                let read = input.read(&mut buffer)?;
+                line.clear();
+                let read = read_corpus_jsonl_record(
+                    &mut input,
+                    &mut line,
+                    "authenticated corpus shard row",
+                )?;
                 if read == 0 {
                     break;
                 }
-                hasher.update(&buffer[..read]);
+                hasher.update(&line);
+                let record: ManifestShardRecord =
+                    serde_json::from_slice(&line).with_context(|| {
+                        format!(
+                            "corpus shard {} contains an invalid JSONL row {}",
+                            path.display(),
+                            shard_records.saturating_add(1)
+                        )
+                    })?;
+                ensure!(
+                    record.tokens.0 > 0,
+                    "corpus shard {} contains an empty token row {}",
+                    path.display(),
+                    shard_records.saturating_add(1)
+                );
+                if let Some(maximum_token) = record.tokens.1 {
+                    ensure!(
+                        u64::from(maximum_token)
+                            < u64::try_from(self.build.tokenizer.vocabulary_size)
+                                .context("tokenizer vocabulary_size exceeds u64")?,
+                        "corpus shard {} row {} contains token id {maximum_token} outside vocabulary size {}",
+                        path.display(),
+                        shard_records.saturating_add(1),
+                        self.build.tokenizer.vocabulary_size
+                    );
+                }
+                shard_records = shard_records
+                    .checked_add(1)
+                    .context("corpus shard record count overflows u64")?;
+                shard_tokens = shard_tokens
+                    .checked_add(record.tokens.0)
+                    .context("corpus shard token count overflows u64")?;
             }
+            let after = StableCorpusFileIdentity::from_metadata(
+                &input
+                    .get_ref()
+                    .metadata()
+                    .with_context(|| format!("failed to pin corpus shard {}", path.display()))?,
+            );
+            ensure!(
+                after == before,
+                "corpus shard {} changed while it was verified",
+                path.display()
+            );
             ensure!(
                 hex(&hasher.finalize()) == shard.sha256,
                 "corpus shard {} hash does not match its manifest",
                 path.display()
             );
+            ensure!(
+                shard_records == shard.records,
+                "corpus shard {} contains {shard_records} records but its manifest declares {}",
+                path.display(),
+                shard.records
+            );
+            ensure!(
+                shard_tokens == shard.tokens,
+                "corpus shard {} contains {shard_tokens} tokens but its manifest declares {}",
+                path.display(),
+                shard.tokens
+            );
             records = records
-                .checked_add(shard.records)
+                .checked_add(shard_records)
                 .context("corpus shard record count overflows u64")?;
             tokens = tokens
-                .checked_add(shard.tokens)
+                .checked_add(shard_tokens)
                 .context("corpus shard token count overflows u64")?;
+            verified_shards.push(PinnedCorpusShard {
+                relative_path: shard.path.clone(),
+                display_path: path,
+                identity: before,
+            });
         }
         ensure!(
             records == self.build.stats.emitted_views,
@@ -738,11 +1246,27 @@ impl CorpusManifest {
             "corpus manifest exposure-token total does not match its shards"
         );
         ensure!(
+            self.build
+                .config
+                .token_target
+                .accepts(self.build.stats.unique_tokens),
+            "corpus manifest unique-token total is outside its configured target range"
+        );
+        ensure!(
             self.build.desired_token_target_reached
                 == (self.build.stats.unique_tokens >= self.build.config.token_target.desired),
             "corpus desired-token flag disagrees with token totals"
         );
-        Ok(())
+        validate_stage_stats(
+            &self.build.stats,
+            &self.build.topic_counts,
+            &self.build.difficulty_counts,
+        )?;
+        for shard in &verified_shards {
+            root.ensure_same_file(&shard.relative_path, &shard.identity, "corpus shard")?;
+        }
+        root.ensure_still_published()?;
+        Ok(verified_shards)
     }
 }
 
@@ -759,10 +1283,86 @@ struct TokenizedCorpusRecord<'a> {
     tokens: &'a [u32],
 }
 
+#[derive(Deserialize)]
+struct ManifestShardRecord {
+    tokens: ManifestTokenCount,
+}
+
+struct ManifestTokenCount(u64, Option<u32>);
+
+impl<'de> Deserialize<'de> for ManifestTokenCount {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TokenCountVisitor;
+
+        impl<'de> Visitor<'de> for TokenCountVisitor {
+            type Value = ManifestTokenCount;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an array of unsigned 32-bit token identifiers")
+            }
+
+            fn visit_seq<A>(self, mut sequence: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut count = 0u64;
+                let mut maximum = None;
+                while let Some(token) = sequence.next_element::<u32>()? {
+                    count = count.checked_add(1).ok_or_else(|| {
+                        <A::Error as serde::de::Error>::custom("token count overflows u64")
+                    })?;
+                    maximum = Some(maximum.map_or(token, |current: u32| current.max(token)));
+                }
+                Ok(ManifestTokenCount(count, maximum))
+            }
+        }
+
+        deserializer.deserialize_seq(TokenCountVisitor)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum MaterializationBatchOutcome {
     Continue,
     TargetBoundaryReached,
+}
+
+/// Lowercasing immutable classification terms once keeps classification cost
+/// proportional to corpus text rather than repeatedly allocating one string
+/// per rule and term for every materialized document.
+struct CaseFoldedRuleTerms {
+    any: Vec<String>,
+    all: Vec<String>,
+    none: Vec<String>,
+}
+
+impl CaseFoldedRuleTerms {
+    fn compile(rule: &ClassificationRule) -> Self {
+        Self {
+            any: rule
+                .any_terms
+                .iter()
+                .map(|term| term.to_lowercase())
+                .collect(),
+            all: rule
+                .all_terms
+                .iter()
+                .map(|term| term.to_lowercase())
+                .collect(),
+            none: rule
+                .none_terms
+                .iter()
+                .map(|term| term.to_lowercase())
+                .collect(),
+        }
+    }
+
+    fn uses_text(&self) -> bool {
+        !self.any.is_empty() || !self.all.is_empty() || !self.none.is_empty()
+    }
 }
 
 pub struct CorpusPipeline<'a> {
@@ -771,6 +1371,9 @@ pub struct CorpusPipeline<'a> {
     materializer: &'a dyn RecordMaterializer,
     tokenizer: &'a dyn CorpusTokenizer,
     deduplicator: &'a mut dyn Deduplicator,
+    topic_rule_terms: Vec<CaseFoldedRuleTerms>,
+    difficulty_rule_terms: Vec<CaseFoldedRuleTerms>,
+    classification_uses_text: bool,
 }
 
 impl<'a> CorpusPipeline<'a> {
@@ -783,15 +1386,34 @@ impl<'a> CorpusPipeline<'a> {
     ) -> Result<Self> {
         config.validate()?;
         ensure!(
-            search.page_size() > 0,
-            "search backend page size must be positive"
+            (1..=MAX_DISCOVERY_BATCH_SIZE).contains(&search.page_size()),
+            "search backend page size must be within 1..={MAX_DISCOVERY_BATCH_SIZE}"
         );
+        let topic_rule_terms = config
+            .classification
+            .topic_rules
+            .iter()
+            .map(CaseFoldedRuleTerms::compile)
+            .collect::<Vec<_>>();
+        let difficulty_rule_terms = config
+            .classification
+            .difficulty_rules
+            .iter()
+            .map(CaseFoldedRuleTerms::compile)
+            .collect::<Vec<_>>();
+        let classification_uses_text = topic_rule_terms
+            .iter()
+            .chain(&difficulty_rule_terms)
+            .any(CaseFoldedRuleTerms::uses_text);
         Ok(Self {
             config,
             search,
             materializer,
             tokenizer,
             deduplicator,
+            topic_rule_terms,
+            difficulty_rule_terms,
+            classification_uses_text,
         })
     }
 
@@ -801,25 +1423,45 @@ impl<'a> CorpusPipeline<'a> {
     /// same durable store after its output shards have been synced.
     pub fn run(&mut self, output_root: &Path) -> Result<(PathBuf, CorpusManifest)> {
         let discovery_snapshot = self.search.snapshot()?;
+        discovery_snapshot
+            .validate()
+            .context("search backend returned an invalid source snapshot")?;
         let materializer_snapshot = self.materializer.snapshot()?;
+        materializer_snapshot
+            .validate()
+            .context("record materializer returned an invalid source snapshot")?;
         let discovery_configuration = self.search.configuration()?;
         let materializer_configuration = self.materializer.configuration()?;
-        let config_value = serde_json::to_value(&self.config)?;
-        let config_sha256 = canonical_json_sha256(&serde_json::json!({
-            "corpus": config_value,
-            "search": discovery_configuration,
-            "materializer": materializer_configuration,
-            "deduplicator": self.deduplicator.configuration(),
-            "tokenizer": self.tokenizer.snapshot(),
-        }))?;
+        let deduplicator_configuration = self.deduplicator.configuration();
+        let tokenizer_snapshot = self.tokenizer.snapshot();
+        tokenizer_snapshot
+            .validate()
+            .context("corpus tokenizer returned an invalid snapshot")?;
+        let search_name = self.search.name().to_owned();
+        let materializer_name = self.materializer.name().to_owned();
+        ensure!(
+            !search_name.trim().is_empty(),
+            "search backend name is empty"
+        );
+        ensure!(
+            !materializer_name.trim().is_empty(),
+            "record materializer name is empty"
+        );
+        let config_sha256 = corpus_configuration_sha256(
+            &self.config,
+            &discovery_configuration,
+            &materializer_configuration,
+            &deduplicator_configuration,
+            &tokenizer_snapshot,
+        )?;
         let identity = CorpusBuildIdentity {
             build_id: self.config.build_id.clone(),
             config_sha256: config_sha256.clone(),
-            search_name: self.search.name().to_owned(),
+            search_name: search_name.clone(),
             discovery_snapshot: discovery_snapshot.clone(),
-            materializer_name: self.materializer.name().to_owned(),
+            materializer_name: materializer_name.clone(),
             materializer_snapshot: materializer_snapshot.clone(),
-            tokenizer: self.tokenizer.snapshot(),
+            tokenizer: tokenizer_snapshot.clone(),
         };
 
         fs::create_dir_all(output_root).with_context(|| {
@@ -828,6 +1470,17 @@ impl<'a> CorpusPipeline<'a> {
                 output_root.display()
             )
         })?;
+        let output_metadata = fs::symlink_metadata(output_root).with_context(|| {
+            format!(
+                "failed to inspect corpus output root {}",
+                output_root.display()
+            )
+        })?;
+        ensure!(
+            output_metadata.is_dir() && !output_metadata.file_type().is_symlink(),
+            "corpus output root {} must be a real directory",
+            output_root.display()
+        );
         let final_path = output_root.join(&self.config.build_id);
         let staging_path = output_root.join(format!(".{}.building", self.config.build_id));
         if final_path.exists() {
@@ -917,6 +1570,14 @@ impl<'a> CorpusPipeline<'a> {
                         "search backend returned {returned} hits for query `{}` after a request limit of {request_limit}",
                         query.name
                     );
+                    for (index, hit) in page.hits.iter().enumerate() {
+                        hit.validate().with_context(|| {
+                            format!(
+                                "search backend returned an invalid hit {index} for query `{}` at offset {offset}",
+                                query.name
+                            )
+                        })?;
+                    }
                     let next_offset = offset
                         .checked_add(returned)
                         .context("search pagination offset overflows usize")?;
@@ -1033,6 +1694,7 @@ impl<'a> CorpusPipeline<'a> {
                             &mut progress.stats,
                             &mut progress.topic_counts,
                             &mut progress.difficulty_counts,
+                            tokenizer_snapshot.vocabulary_size,
                         )?;
                         progress.shards = writer.checkpoint()?;
                         sync_directory(&staging_path)?;
@@ -1075,6 +1737,26 @@ impl<'a> CorpusPipeline<'a> {
             self.materializer.snapshot()? == materializer_snapshot,
             "record materializer snapshot changed during corpus build"
         );
+        ensure!(
+            self.search.snapshot()? == discovery_snapshot,
+            "search backend snapshot changed during corpus build"
+        );
+        ensure!(
+            self.search.configuration()? == discovery_configuration,
+            "search backend configuration changed during corpus build"
+        );
+        ensure!(
+            self.materializer.configuration()? == materializer_configuration,
+            "record materializer configuration changed during corpus build"
+        );
+        ensure!(
+            self.deduplicator.configuration() == deduplicator_configuration,
+            "deduplicator configuration changed during corpus build"
+        );
+        ensure!(
+            self.tokenizer.snapshot() == tokenizer_snapshot,
+            "tokenizer snapshot changed during corpus build"
+        );
 
         let body = CorpusManifestBody {
             version: self.config.version,
@@ -1082,17 +1764,17 @@ impl<'a> CorpusPipeline<'a> {
             config_sha256,
             config: self.config.clone(),
             discovery: ComponentManifest {
-                name: self.search.name().to_owned(),
+                name: search_name,
                 configuration: discovery_configuration,
                 snapshot: discovery_snapshot,
             },
             materializer: ComponentManifest {
-                name: self.materializer.name().to_owned(),
+                name: materializer_name,
                 configuration: materializer_configuration,
                 snapshot: materializer_snapshot,
             },
-            deduplicator: self.deduplicator.configuration(),
-            tokenizer: self.tokenizer.snapshot(),
+            deduplicator: deduplicator_configuration,
+            tokenizer: tokenizer_snapshot,
             stats: progress.stats.clone(),
             desired_token_target_reached: progress.stats.unique_tokens
                 >= self.config.token_target.desired,
@@ -1137,6 +1819,7 @@ impl<'a> CorpusPipeline<'a> {
         stats: &mut CorpusStageStats,
         topic_counts: &mut BTreeMap<String, u64>,
         difficulty_counts: &mut BTreeMap<String, u64>,
+        vocabulary_size: usize,
     ) -> Result<MaterializationBatchOutcome> {
         let materialized = self.materializer.materialize(hit_batch).with_context(|| {
             format!(
@@ -1147,7 +1830,27 @@ impl<'a> CorpusPipeline<'a> {
         })?;
         stats.materialized_records = checked_add(stats.materialized_records, materialized.len())?;
         let ordered = order_materialized(hit_batch, materialized)?;
+        let unmaterialized = hit_batch
+            .len()
+            .checked_sub(ordered.len())
+            .context("materializer returned more records than its discovery batch")?;
+        if unmaterialized > 0 {
+            stats.unmaterialized_records =
+                checked_add(stats.unmaterialized_records, unmaterialized)?;
+            tracing::warn!(
+                "{} returned {unmaterialized} fewer records than the {} discovery hits requested; \
+                 those documents are permanently skipped because require_every_record is disabled",
+                self.materializer.name(),
+                hit_batch.len()
+            );
+        }
         for mut record in ordered {
+            ensure!(
+                record.text.len() <= MAX_MATERIALIZED_TEXT_BYTES,
+                "materialized record `{}` contains {} text bytes, exceeding the {MAX_MATERIALIZED_TEXT_BYTES}-byte limit",
+                record.record_key,
+                record.text.len()
+            );
             let Some(normalized) = normalize(&record.text, &self.config.normalization) else {
                 stats.normalization_rejections = checked_add(stats.normalization_rejections, 1)?;
                 continue;
@@ -1166,6 +1869,7 @@ impl<'a> CorpusPipeline<'a> {
                 "tokenizer emitted no tokens for `{}`",
                 record.record_key
             );
+            validate_token_ids(&canonical_tokens, vocabulary_size, &record.record_key)?;
             let prospective_unique_tokens =
                 checked_add(stats.unique_tokens, canonical_tokens.len())?;
             if prospective_unique_tokens > self.config.token_target.maximum {
@@ -1183,14 +1887,21 @@ impl<'a> CorpusPipeline<'a> {
 
             self.deduplicator
                 .insert_unseen(&record.record_key, &record.text)?;
+            let case_folded_text = self
+                .classification_uses_text
+                .then(|| record.text.to_lowercase());
             let topic = classify(
                 &record,
+                case_folded_text.as_deref(),
                 &self.config.classification.topic_rules,
+                &self.topic_rule_terms,
                 self.config.classification.default_topic.as_deref(),
             );
             let difficulty = classify(
                 &record,
+                case_folded_text.as_deref(),
                 &self.config.classification.difficulty_rules,
+                &self.difficulty_rule_terms,
                 self.config.classification.default_difficulty.as_deref(),
             );
             if let Some(topic) = &topic {
@@ -1202,30 +1913,38 @@ impl<'a> CorpusPipeline<'a> {
             stats.unique_records = checked_add(stats.unique_records, 1)?;
             stats.unique_tokens = prospective_unique_tokens;
 
-            let views = render_views(
+            let rendered = render_views(
                 &record,
                 topic.as_deref(),
                 difficulty.as_deref(),
                 &self.config.transformations,
                 &self.config.repetition,
-            );
-            for view in views {
-                let tokens = if view.name == "source" && view.copy == 0 {
-                    canonical_tokens.clone()
-                } else {
-                    self.tokenizer.encode(&view.text).with_context(|| {
-                        format!(
-                            "failed to tokenize view `{}` for `{}`",
-                            view.name, record.record_key
-                        )
-                    })?
-                };
-                ensure!(
-                    !tokens.is_empty(),
-                    "tokenizer emitted no tokens for view `{}` of `{}`",
-                    view.name,
-                    record.record_key
-                );
+            )?;
+            let mut tokenized_texts = (0..rendered.texts.len()).map(|_| None).collect::<Vec<_>>();
+            tokenized_texts[0] = Some(canonical_tokens);
+            for view in rendered.views {
+                if tokenized_texts[view.text_index].is_none() {
+                    let tokens = self
+                        .tokenizer
+                        .encode(&rendered.texts[view.text_index])
+                        .with_context(|| {
+                            format!(
+                                "failed to tokenize view `{}` for `{}`",
+                                view.name, record.record_key
+                            )
+                        })?;
+                    ensure!(
+                        !tokens.is_empty(),
+                        "tokenizer emitted no tokens for view `{}` of `{}`",
+                        view.name,
+                        record.record_key
+                    );
+                    validate_token_ids(&tokens, vocabulary_size, &record.record_key)?;
+                    tokenized_texts[view.text_index] = Some(tokens);
+                }
+                let tokens = tokenized_texts[view.text_index]
+                    .as_ref()
+                    .expect("view text was tokenized");
                 writer.push(TokenizedCorpusRecord {
                     record_key: &record.record_key,
                     uris: &record.uris,
@@ -1234,7 +1953,7 @@ impl<'a> CorpusPipeline<'a> {
                     view: &view.name,
                     copy: view.copy,
                     metadata: &record.metadata,
-                    tokens: &tokens,
+                    tokens,
                 })?;
                 stats.emitted_views = checked_add(stats.emitted_views, 1)?;
                 stats.exposure_tokens = checked_add(stats.exposure_tokens, tokens.len())?;
@@ -1383,6 +2102,54 @@ fn validate_progress(
             && shard_tokens == progress.stats.exposure_tokens,
         "corpus progress shard totals disagree with stage statistics"
     );
+    validate_stage_stats(
+        &progress.stats,
+        &progress.topic_counts,
+        &progress.difficulty_counts,
+    )?;
+    Ok(())
+}
+
+fn validate_stage_stats(
+    stats: &CorpusStageStats,
+    topic_counts: &BTreeMap<String, u64>,
+    difficulty_counts: &BTreeMap<String, u64>,
+) -> Result<()> {
+    ensure!(
+        stats.duplicate_discovery_keys <= stats.discovered_hits,
+        "corpus duplicate-discovery count exceeds discovered hits"
+    );
+    ensure!(
+        stats.unique_records <= stats.emitted_views,
+        "corpus unique-record count exceeds emitted views"
+    );
+    ensure!(
+        stats.unique_tokens <= stats.exposure_tokens,
+        "corpus unique-token count exceeds exposure tokens"
+    );
+    ensure!(
+        (stats.unique_records == 0) == (stats.unique_tokens == 0),
+        "corpus unique-record and unique-token emptiness disagree"
+    );
+    ensure!(
+        (stats.emitted_views == 0) == (stats.exposure_tokens == 0),
+        "corpus emitted-view and exposure-token emptiness disagree"
+    );
+    for (label, counts) in [("topic", topic_counts), ("difficulty", difficulty_counts)] {
+        let classified = counts.values().try_fold(0u64, |total, count| {
+            total
+                .checked_add(*count)
+                .context("corpus classification count overflows u64")
+        })?;
+        ensure!(
+            classified <= stats.unique_records,
+            "corpus {label} counts exceed unique records"
+        );
+        ensure!(
+            counts.keys().all(|value| !value.trim().is_empty()),
+            "corpus {label} counts contain an empty label"
+        );
+    }
     Ok(())
 }
 
@@ -1432,7 +2199,7 @@ fn reconcile_progress_mirror(
                 metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
                 "corpus progress journal is not a regular file"
             );
-            let current_bytes = fs::read(&path)?;
+            let current_bytes = read_corpus_metadata_file(&path, "corpus progress journal")?;
             if current_bytes == authoritative_bytes {
                 return Ok(());
             }
@@ -1502,12 +2269,15 @@ fn reconcile_staging_files(staging: &Path, committed: &[ShardManifest]) -> Resul
 }
 
 fn is_shard_name(name: &str) -> bool {
-    name.len() == "shard-00000.tokens.jsonl".len()
-        && name.starts_with("shard-")
-        && name.ends_with(".tokens.jsonl")
-        && name.as_bytes()[6..11]
-            .iter()
-            .all(|byte| byte.is_ascii_digit())
+    let Some(index) = name
+        .strip_prefix("shard-")
+        .and_then(|name| name.strip_suffix(".tokens.jsonl"))
+    else {
+        return false;
+    };
+    index.len() >= 5
+        && index.bytes().all(|byte| byte.is_ascii_digit())
+        && (index.len() == 5 || !index.starts_with('0'))
 }
 
 fn write_progress_mirror(staging: &Path, bytes: &[u8]) -> Result<()> {
@@ -1570,20 +2340,9 @@ fn load_published_manifest(
     root: &Path,
     identity: &CorpusBuildIdentity,
 ) -> Result<(PathBuf, CorpusManifest)> {
-    let metadata = fs::symlink_metadata(root)?;
-    ensure!(
-        metadata.is_dir() && !metadata.file_type().is_symlink(),
-        "published corpus {} is not a real directory",
-        root.display()
-    );
-    let manifest_path = root.join("manifest.json");
-    let metadata = fs::symlink_metadata(&manifest_path)?;
-    ensure!(
-        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-        "published corpus manifest is not a regular file"
-    );
-    let manifest: CorpusManifest = serde_json::from_slice(&fs::read(&manifest_path)?)?;
-    manifest.verify(root)?;
+    let authenticated = AuthenticatedCorpus::open_data_path(root)?
+        .context("published corpus path must contain an authenticated manifest")?;
+    let manifest = authenticated.manifest().clone();
     ensure!(
         manifest.build.build_id == identity.build_id
             && manifest.build.config_sha256 == identity.config_sha256
@@ -1594,6 +2353,7 @@ fn load_published_manifest(
             && manifest.build.tokenizer == identity.tokenizer,
         "published corpus identity differs from this requested build"
     );
+    authenticated.ensure_still_published()?;
     Ok((root.to_owned(), manifest))
 }
 
@@ -1601,10 +2361,14 @@ fn order_materialized(
     hits: &[DiscoveryHit],
     records: Vec<MaterializedRecord>,
 ) -> Result<Vec<MaterializedRecord>> {
-    let mut by_key: HashMap<_, _> = records
-        .into_iter()
-        .map(|record| (record.record_key.clone(), record))
-        .collect();
+    let mut by_key = HashMap::with_capacity(records.len());
+    for record in records {
+        let record_key = record.record_key.clone();
+        ensure!(
+            by_key.insert(record_key.clone(), record).is_none(),
+            "materializer returned duplicate record key `{record_key}`"
+        );
+    }
     let mut ordered = Vec::with_capacity(by_key.len());
     for hit in hits {
         if let Some(record) = by_key.remove(&hit.record_key) {
@@ -1616,6 +2380,18 @@ fn order_materialized(
         "materializer returned records absent from its discovery batch"
     );
     Ok(ordered)
+}
+
+fn validate_token_ids(tokens: &[u32], vocabulary_size: usize, record_key: &str) -> Result<()> {
+    let vocabulary_size =
+        u64::try_from(vocabulary_size).context("tokenizer vocabulary_size exceeds u64")?;
+    if let Some(maximum_token) = tokens.iter().copied().max() {
+        ensure!(
+            u64::from(maximum_token) < vocabulary_size,
+            "tokenizer emitted token id {maximum_token} outside vocabulary size {vocabulary_size} for `{record_key}`"
+        );
+    }
+    Ok(())
 }
 
 fn normalize(text: &str, config: &NormalizationConfig) -> Option<String> {
@@ -1643,7 +2419,9 @@ fn normalize(text: &str, config: &NormalizationConfig) -> Option<String> {
         }
         text = normalized;
     }
-    if config.normalize_newlines {
+    // Capping blank lines is independent of CRLF conversion: a recipe that
+    // disables `normalize_newlines` still gets the cap it configured.
+    {
         let maximum_newlines = config.max_consecutive_blank_lines.saturating_add(1);
         let mut normalized = String::with_capacity(text.len());
         let mut newlines = 0usize;
@@ -1668,34 +2446,41 @@ fn normalize(text: &str, config: &NormalizationConfig) -> Option<String> {
 
 fn classify(
     record: &MaterializedRecord,
+    case_folded_text: Option<&str>,
     rules: &[ClassificationRule],
+    folded_terms: &[CaseFoldedRuleTerms],
     default: Option<&str>,
 ) -> Option<String> {
-    let lowercase = record.text.to_lowercase();
+    debug_assert_eq!(rules.len(), folded_terms.len());
     rules
         .iter()
-        .filter_map(|rule| {
-            let matched_any = rule
-                .any_terms
+        .zip(folded_terms)
+        .filter_map(|(rule, terms)| {
+            let matched_any = terms
+                .any
                 .iter()
-                .filter(|term| lowercase.contains(&term.to_lowercase()))
+                .filter(|term| case_folded_text.is_some_and(|text| text.contains(*term)))
                 .count();
-            let matched_all = rule
-                .all_terms
+            let matched_all = terms
+                .all
                 .iter()
-                .filter(|term| lowercase.contains(&term.to_lowercase()))
+                .filter(|term| case_folded_text.is_some_and(|text| text.contains(*term)))
                 .count();
-            let matches = (rule.any_terms.is_empty() || matched_any > 0)
-                && matched_all == rule.all_terms.len()
-                && rule
-                    .none_terms
+            let matches = (terms.any.is_empty() || matched_any > 0)
+                && matched_all == terms.all.len()
+                && terms
+                    .none
                     .iter()
-                    .all(|term| !lowercase.contains(&term.to_lowercase()))
+                    .all(|term| case_folded_text.is_some_and(|text| !text.contains(term)))
                 && rule
                     .metadata_equals
                     .iter()
                     .all(|(name, expected)| record.metadata.get(name) == Some(expected));
-            matches.then_some((rule, rule.metadata_equals.len(), matched_any + matched_all))
+            matches.then_some((
+                rule,
+                rule.metadata_equals.len(),
+                matched_any + matched_all + terms.none.len(),
+            ))
         })
         .max_by(
             |(left, left_metadata, left_terms), (right, right_metadata, right_terms)| {
@@ -1714,16 +2499,21 @@ fn classify(
 struct RenderedView {
     name: String,
     copy: usize,
-    text: String,
+    text_index: usize,
 }
 
-fn render_views(
-    record: &MaterializedRecord,
+struct RenderedViews<'a> {
+    texts: Vec<Cow<'a, str>>,
+    views: Vec<RenderedView>,
+}
+
+fn render_views<'a>(
+    record: &'a MaterializedRecord,
     topic: Option<&str>,
     difficulty: Option<&str>,
     transforms: &[TransformationConfig],
     repetition: &RepetitionConfig,
-) -> Vec<RenderedView> {
+) -> Result<RenderedViews<'a>> {
     let base_copies = repetition
         .topic_copies
         .get(topic.unwrap_or_default())
@@ -1739,23 +2529,59 @@ fn render_views(
         .map(|copy| RenderedView {
             name: "source".to_owned(),
             copy,
-            text: record.text.clone(),
+            text_index: 0,
         })
         .collect::<Vec<_>>();
+    let mut texts = vec![Cow::Borrowed(record.text.as_str())];
+    let mut retained_text_bytes = record.text.len();
     for transform in transforms {
+        let remaining = repetition.max_copies_per_record.saturating_sub(views.len());
+        if remaining == 0 {
+            break;
+        }
         if !predicate_matches(&transform.when, record, topic, difficulty) {
             continue;
         }
-        for copy in 0..transform.copies {
+        let rendered = render_template(&transform.template, record, topic, difficulty)?;
+        let text_index = match texts
+            .iter()
+            .position(|existing| existing.as_ref() == rendered)
+        {
+            Some(index) => index,
+            None => {
+                retained_text_bytes = checked_retained_rendered_text_bytes(
+                    retained_text_bytes,
+                    rendered.len(),
+                    &record.record_key,
+                )?;
+                texts.push(Cow::Owned(rendered));
+                texts.len() - 1
+            }
+        };
+        for copy in 0..transform.copies.min(remaining) {
             views.push(RenderedView {
                 name: transform.name.clone(),
                 copy,
-                text: render_template(&transform.template, record, topic, difficulty),
+                text_index,
             });
         }
     }
-    views.truncate(repetition.max_copies_per_record);
-    views
+    Ok(RenderedViews { texts, views })
+}
+
+fn checked_retained_rendered_text_bytes(
+    current: usize,
+    additional: usize,
+    record_key: &str,
+) -> Result<usize> {
+    let retained = current
+        .checked_add(additional)
+        .context("retained rendered-view byte count overflows usize")?;
+    ensure!(
+        retained <= MAX_RETAINED_RENDERED_TEXT_BYTES,
+        "rendered variants for record `{record_key}` exceed the {MAX_RETAINED_RENDERED_TEXT_BYTES}-byte aggregate limit"
+    );
+    Ok(retained)
 }
 
 fn predicate_matches(
@@ -1779,19 +2605,127 @@ fn render_template(
     record: &MaterializedRecord,
     topic: Option<&str>,
     difficulty: Option<&str>,
-) -> String {
-    let mut rendered = template
-        .replace("${text}", &record.text)
-        .replace("${topic}", topic.unwrap_or_default())
-        .replace("${difficulty}", difficulty.unwrap_or_default());
-    for (name, value) in &record.metadata {
-        let replacement = value
-            .as_str()
-            .map(str::to_owned)
-            .unwrap_or_else(|| value.to_string());
-        rendered = rendered.replace(&format!("${{metadata.{name}}}"), &replacement);
+) -> Result<String> {
+    fn append(rendered: &mut String, value: &str) -> Result<()> {
+        let next = rendered
+            .len()
+            .checked_add(value.len())
+            .context("rendered corpus view byte count overflows usize")?;
+        ensure!(
+            next <= MAX_RENDERED_VIEW_TEXT_BYTES,
+            "rendered corpus view exceeds the {MAX_RENDERED_VIEW_TEXT_BYTES}-byte limit"
+        );
+        rendered.push_str(value);
+        Ok(())
     }
-    rendered
+
+    let mut rendered = String::with_capacity(template.len().min(MAX_RENDERED_VIEW_TEXT_BYTES));
+    let mut cursor = 0usize;
+    while let Some(relative_open) = template[cursor..].find("${") {
+        let open = cursor + relative_open;
+        append(&mut rendered, &template[cursor..open])?;
+        let value_start = open + 2;
+        let Some(relative_close) = template[value_start..].find('}') else {
+            append(&mut rendered, &template[open..])?;
+            return Ok(rendered);
+        };
+        let close = value_start + relative_close;
+        let name = &template[value_start..close];
+        let replacement = match name {
+            "text" => Some(Cow::Borrowed(record.text.as_str())),
+            "topic" => Some(Cow::Borrowed(topic.unwrap_or_default())),
+            "difficulty" => Some(Cow::Borrowed(difficulty.unwrap_or_default())),
+            name => name
+                .strip_prefix("metadata.")
+                .and_then(|name| record.metadata.get(name))
+                .map(|value| match value.as_str() {
+                    Some(value) => Cow::Borrowed(value),
+                    None => Cow::Owned(value.to_string()),
+                }),
+        };
+        match replacement {
+            Some(value) => append(&mut rendered, &value)?,
+            None => append(&mut rendered, &template[open..=close])?,
+        }
+        cursor = close + 1;
+    }
+    append(&mut rendered, &template[cursor..])?;
+    Ok(rendered)
+}
+
+#[cfg(test)]
+mod transformation_tests {
+    use super::*;
+
+    #[test]
+    fn template_expansion_is_single_pass_and_does_not_reinterpret_record_values() {
+        let record = MaterializedRecord {
+            record_key: "record".to_owned(),
+            text: "${metadata.first}".to_owned(),
+            uris: Vec::new(),
+            metadata: BTreeMap::from([
+                (
+                    "first".to_owned(),
+                    Value::String("${metadata.second}".to_owned()),
+                ),
+                ("second".to_owned(), Value::from(7)),
+            ]),
+        };
+        let rendered = render_template(
+            "${text}|${metadata.first}|${metadata.second}|${topic}|${unknown}",
+            &record,
+            Some("${difficulty}"),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            rendered,
+            "${metadata.first}|${metadata.second}|7|${difficulty}|${unknown}"
+        );
+    }
+
+    #[test]
+    fn compiled_classification_terms_preserve_case_insensitive_matching() {
+        let record = MaterializedRecord {
+            record_key: "record".to_owned(),
+            text: "A GRAMMAR handbook".to_owned(),
+            uris: Vec::new(),
+            metadata: BTreeMap::new(),
+        };
+        let rules = vec![ClassificationRule {
+            label: "language".to_owned(),
+            priority: 0,
+            any_terms: vec!["Grammar".to_owned()],
+            all_terms: Vec::new(),
+            none_terms: vec!["mathematics".to_owned()],
+            metadata_equals: BTreeMap::new(),
+        }];
+        let folded = rules
+            .iter()
+            .map(CaseFoldedRuleTerms::compile)
+            .collect::<Vec<_>>();
+        let text = record.text.to_lowercase();
+        assert_eq!(
+            classify(&record, Some(&text), &rules, &folded, Some("other")),
+            Some("language".to_owned())
+        );
+    }
+
+    #[test]
+    fn retained_rendered_text_accounting_rejects_limits_and_overflow() {
+        assert_eq!(
+            checked_retained_rendered_text_bytes(MAX_RETAINED_RENDERED_TEXT_BYTES - 1, 1, "record")
+                .unwrap(),
+            MAX_RETAINED_RENDERED_TEXT_BYTES
+        );
+        let error =
+            checked_retained_rendered_text_bytes(MAX_RETAINED_RENDERED_TEXT_BYTES, 1, "record")
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("record"), "{error}");
+        assert!(error.contains("aggregate limit"), "{error}");
+        assert!(checked_retained_rendered_text_bytes(usize::MAX, 1, "record").is_err());
+    }
 }
 
 struct OpenShard {
@@ -1827,24 +2761,50 @@ impl ImmutableShardWriter {
         })
     }
 
+    fn would_rotate(&self, token_count: u64) -> bool {
+        self.open.as_ref().is_some_and(|shard| {
+            shard.records > 0
+                && shard
+                    .tokens
+                    .checked_add(token_count)
+                    .is_none_or(|total| total > self.max_tokens)
+        })
+    }
+
     fn push(&mut self, record: TokenizedCorpusRecord<'_>) -> Result<()> {
         let token_count = u64::try_from(record.tokens.len())?;
-        if self.open.as_ref().is_some_and(|shard| {
-            shard.records > 0 && shard.tokens.saturating_add(token_count) > self.max_tokens
-        }) {
+        ensure!(
+            token_count <= self.max_tokens,
+            "one corpus view contains {token_count} tokens, exceeding max_tokens_per_shard {}",
+            self.max_tokens
+        );
+        if self.would_rotate(token_count) {
             self.close()?;
         }
         if self.open.is_none() {
             self.open()?;
         }
         let bytes = serde_json::to_vec(&record)?;
+        ensure!(
+            bytes
+                .len()
+                .checked_add(1)
+                .is_some_and(|line_bytes| line_bytes <= MAX_CORPUS_JSONL_RECORD_BYTES),
+            "serialized corpus view is {} bytes before its newline, exceeding the JSONL record limit of {MAX_CORPUS_JSONL_RECORD_BYTES}",
+            bytes.len()
+        );
         let shard = self.open.as_mut().expect("shard was opened");
+        // Validate accounting before mutating the shard. This keeps an
+        // arithmetic failure from writing a row that cannot be represented by
+        // the durable manifest.
+        let records = checked_add(shard.records, 1)?;
+        let total_tokens = checked_add(shard.tokens, record.tokens.len())?;
         shard.writer.write_all(&bytes)?;
         shard.writer.write_all(b"\n")?;
         shard.hasher.update(&bytes);
         shard.hasher.update(b"\n");
-        shard.records = checked_add(shard.records, 1)?;
-        shard.tokens = checked_add(shard.tokens, record.tokens.len())?;
+        shard.records = records;
+        shard.tokens = total_tokens;
         Ok(())
     }
 
@@ -1892,9 +2852,233 @@ impl ImmutableShardWriter {
     }
 }
 
-fn canonical_json_sha256(value: &Value) -> Result<String> {
+pub(crate) fn canonical_json_sha256(value: &Value) -> Result<String> {
     let canonical = canonicalize(value);
     Ok(hex(&Sha256::digest(serde_json::to_vec(&canonical)?)))
+}
+
+fn corpus_configuration_sha256(
+    config: &CorpusBuildConfig,
+    discovery: &Value,
+    materializer: &Value,
+    deduplicator: &Value,
+    tokenizer: &TokenizerSnapshot,
+) -> Result<String> {
+    canonical_json_sha256(&serde_json::json!({
+        "corpus": config,
+        "search": discovery,
+        "materializer": materializer,
+        "deduplicator": deduplicator,
+        "tokenizer": tokenizer,
+    }))
+}
+
+pub(crate) fn corpus_manifest_configuration_sha256(body: &CorpusManifestBody) -> Result<String> {
+    corpus_configuration_sha256(
+        &body.config,
+        &body.discovery.configuration,
+        &body.materializer.configuration,
+        &body.deduplicator,
+        &body.tokenizer,
+    )
+}
+
+fn read_stable_corpus_file(
+    mut file: File,
+    label: &str,
+) -> Result<(Vec<u8>, StableCorpusFileIdentity)> {
+    read_stable_corpus_file_with_limit(&mut file, label, MAX_CORPUS_METADATA_BYTES)
+}
+
+/// Capture a small corpus configuration, journal, or manifest through one
+/// regular-file handle. Both the allocation and concurrent-growth window are
+/// bounded, and persistent pathname replacement is rejected before the bytes
+/// are returned to a caller.
+pub(crate) fn read_corpus_metadata_file(path: &Path, label: &str) -> Result<Vec<u8>> {
+    let published = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect {label} {}", path.display()))?;
+    ensure!(
+        published.is_file() && !published.file_type().is_symlink(),
+        "{label} {} is not a regular non-symlink file",
+        path.display()
+    );
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+    let file = options
+        .open(path)
+        .with_context(|| format!("failed to open {label} {}", path.display()))?;
+    ensure!(
+        StableCorpusFileIdentity::from_metadata(&file.metadata()?)
+            == StableCorpusFileIdentity::from_metadata(&published),
+        "{label} {} changed while it was opened",
+        path.display()
+    );
+    let (bytes, identity) = read_stable_corpus_file(file, label)?;
+    let final_metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to reinspect {label} {}", path.display()))?;
+    ensure!(
+        final_metadata.is_file()
+            && !final_metadata.file_type().is_symlink()
+            && StableCorpusFileIdentity::from_metadata(&final_metadata) == identity,
+        "published {label} {} changed while it was read",
+        path.display()
+    );
+    Ok(bytes)
+}
+
+fn read_stable_corpus_file_with_limit(
+    file: &mut File,
+    label: &str,
+    maximum_bytes: u64,
+) -> Result<(Vec<u8>, StableCorpusFileIdentity)> {
+    let before = file
+        .metadata()
+        .with_context(|| format!("failed to inspect opened {label}"))?;
+    ensure!(before.is_file(), "opened {label} is not a regular file");
+    ensure!(
+        before.len() <= maximum_bytes,
+        "opened {label} is {} bytes, exceeding the limit of {maximum_bytes}",
+        before.len()
+    );
+    let identity = StableCorpusFileIdentity::from_metadata(&before);
+    let capacity = usize::try_from(before.len())
+        .with_context(|| format!("{label} is too large for this address space"))?;
+    let bytes = read_bounded(file, capacity, label)?;
+    let after = file
+        .metadata()
+        .with_context(|| format!("failed to reinspect opened {label}"))?;
+    ensure!(
+        StableCorpusFileIdentity::from_metadata(&after) == identity
+            && bytes.len() as u64 == after.len(),
+        "opened {label} changed while it was read"
+    );
+    Ok((bytes, identity))
+}
+
+pub(crate) fn read_corpus_jsonl_record(
+    reader: &mut (impl BufRead + ?Sized),
+    output: &mut Vec<u8>,
+    label: &str,
+) -> Result<usize> {
+    read_jsonl_record_bounded(reader, output, MAX_CORPUS_JSONL_RECORD_BYTES, label)
+}
+
+fn read_jsonl_record_bounded(
+    reader: &mut (impl BufRead + ?Sized),
+    output: &mut Vec<u8>,
+    maximum_bytes: usize,
+    label: &str,
+) -> Result<usize> {
+    ensure!(maximum_bytes > 0, "{label} byte limit must be positive");
+    output.clear();
+    let capture_bytes = maximum_bytes
+        .checked_add(1)
+        .context("corpus JSONL record limit overflows usize")?;
+    let read = reader
+        .take(u64::try_from(capture_bytes).context("corpus JSONL record limit exceeds u64")?)
+        .read_until(b'\n', output)
+        .with_context(|| format!("failed to read {label}"))?;
+    let payload_bytes = output
+        .len()
+        .checked_sub(usize::from(output.last() == Some(&b'\n')))
+        .context("corpus JSONL record byte count underflows usize")?;
+    ensure!(
+        payload_bytes <= maximum_bytes,
+        "{label} exceeds the maximum of {maximum_bytes} bytes"
+    );
+    Ok(read)
+}
+
+fn read_bounded(reader: &mut impl Read, capacity: usize, label: &str) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(capacity)
+        .with_context(|| format!("failed to reserve buffer for {label}"))?;
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .with_context(|| format!("failed to read opened {label}"))?;
+        if read == 0 {
+            break;
+        }
+        ensure!(
+            bytes
+                .len()
+                .checked_add(read)
+                .is_some_and(|length| length <= capacity),
+            "opened {label} grew while it was read"
+        );
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+    Ok(bytes)
+}
+
+#[cfg(not(unix))]
+fn open_regular_non_symlink(path: &Path, label: &str) -> Result<File> {
+    let expected = fs::symlink_metadata(path)
+        .with_context(|| format!("{label} {} is missing", path.display()))?;
+    ensure!(
+        expected.file_type().is_file() && !expected.file_type().is_symlink(),
+        "{label} {} is not a regular, non-symlink file",
+        path.display()
+    );
+
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    let file = options
+        .open(path)
+        .with_context(|| format!("failed to securely open {label} {}", path.display()))?;
+    let opened = file
+        .metadata()
+        .with_context(|| format!("failed to inspect opened {label} {}", path.display()))?;
+    ensure!(
+        opened.file_type().is_file(),
+        "opened {label} {} is not a regular file",
+        path.display()
+    );
+    #[cfg(unix)]
+    ensure!(
+        same_file_object(&opened, &expected),
+        "{label} {} changed while it was opened",
+        path.display()
+    );
+    #[cfg(not(unix))]
+    ensure!(
+        opened.len() == expected.len() && opened.modified().ok() == expected.modified().ok(),
+        "{label} {} changed while it was opened",
+        path.display()
+    );
+    Ok(file)
+}
+
+fn ensure_path_still_same_object(path: &Path, expected: &fs::Metadata, label: &str) -> Result<()> {
+    let published = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to reinspect {label} {}", path.display()))?;
+    ensure!(
+        published.is_dir()
+            && !published.file_type().is_symlink()
+            && same_file_object(expected, &published),
+        "published {label} {} changed during verification",
+        path.display()
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+fn same_file_object(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(not(unix))]
+fn same_file_object(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+    left.file_type() == right.file_type()
+        && left.len() == right.len()
+        && left.modified().ok() == right.modified().ok()
 }
 
 fn canonicalize(value: &Value) -> Value {
@@ -1940,4 +3124,97 @@ fn increment_label(counts: &mut BTreeMap<String, u64>, label: &str) -> Result<()
         .checked_add(1)
         .context("classification count overflows u64")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod path_identity_tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    #[test]
+    fn bounded_capture_rejects_growth_beyond_the_opened_length() {
+        let error = read_bounded(&mut Cursor::new(b"growth"), 5, "test file")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("grew while it was read"), "{error}");
+    }
+
+    #[test]
+    fn bounded_jsonl_reader_stops_after_one_byte_over_the_limit() {
+        let mut input = BufReader::new(Cursor::new(b"012345678\n"));
+        let mut row = Vec::new();
+        let error = read_jsonl_record_bounded(&mut input, &mut row, 8, "test row")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("maximum of 8 bytes"), "{error}");
+        assert_eq!(row.len(), 9);
+    }
+
+    #[test]
+    fn bounded_jsonl_reader_accepts_a_row_exactly_at_the_limit() {
+        let mut input = BufReader::new(Cursor::new(b"12345678\ntrailing"));
+        let mut row = Vec::new();
+        assert_eq!(
+            read_jsonl_record_bounded(&mut input, &mut row, 8, "test row").unwrap(),
+            9
+        );
+        assert_eq!(row, b"12345678\n");
+    }
+
+    #[test]
+    fn shard_name_recognizes_indices_beyond_the_minimum_padding_width() {
+        assert!(is_shard_name("shard-00000.tokens.jsonl"));
+        assert!(is_shard_name("shard-99999.tokens.jsonl"));
+        assert!(is_shard_name("shard-100000.tokens.jsonl"));
+        assert!(!is_shard_name("shard-000001.tokens.jsonl"));
+        assert!(!is_shard_name("shard-1234.tokens.jsonl"));
+        assert!(!is_shard_name("shard-1234x.tokens.jsonl"));
+    }
+
+    #[test]
+    fn immutable_shard_writer_rotates_when_token_accounting_would_overflow() {
+        let root = tempfile::tempdir().unwrap();
+        let mut writer = ImmutableShardWriter::resume(root.path(), u64::MAX, Vec::new()).unwrap();
+        writer.open().unwrap();
+        let shard = writer.open.as_mut().unwrap();
+        shard.records = 1;
+        shard.tokens = u64::MAX;
+
+        assert!(writer.would_rotate(1));
+    }
+
+    #[test]
+    fn stable_manifest_capture_rejects_an_oversized_opened_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("manifest.json");
+        fs::write(&path, b"123456").unwrap();
+        let mut file = File::open(path).unwrap();
+        let error = read_stable_corpus_file_with_limit(&mut file, "test manifest", 5)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("exceeding the limit of 5"), "{error}");
+    }
+
+    #[test]
+    fn opened_regular_file_rejects_a_persistent_published_replacement() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("shard.jsonl");
+        fs::write(&path, b"generation-a").unwrap();
+        let pinned_root = PinnedCorpusRoot::open(root.path()).unwrap();
+        let opened = pinned_root.open_file("shard.jsonl", "test shard").unwrap();
+        let identity = StableCorpusFileIdentity::from_metadata(&opened.metadata().unwrap());
+
+        fs::rename(&path, root.path().join("generation-a.jsonl")).unwrap();
+        fs::write(&path, b"generation-b").unwrap();
+
+        let error = pinned_root
+            .ensure_same_file("shard.jsonl", &identity, "test shard")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("changed after corpus authentication"),
+            "{error}"
+        );
+    }
 }

--- a/hermes-train/src/corpus/recipe.rs
+++ b/hermes-train/src/corpus/recipe.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use super::pipeline::read_corpus_metadata_file;
 use super::{
     CorpusBuildConfig, CorpusManifest, CorpusPipeline, CorpusTokenizer, PostgresRecordMaterializer,
     PostgresRecordMaterializerConfig, SearchApiClient, SearchApiConfig, SqliteDeduplicator,
@@ -21,8 +22,7 @@ pub struct SearchApiPostgresCorpusRecipe {
 
 impl SearchApiPostgresCorpusRecipe {
     pub fn load(path: &Path) -> Result<Self> {
-        let bytes = fs::read(path)
-            .with_context(|| format!("failed to read corpus recipe {}", path.display()))?;
+        let bytes = read_corpus_metadata_file(path, "corpus recipe")?;
         let recipe: Self = serde_json::from_slice(&bytes)
             .with_context(|| format!("invalid corpus recipe JSON in {}", path.display()))?;
         recipe.corpus.validate()?;

--- a/hermes-train/src/corpus/search.rs
+++ b/hermes-train/src/corpus/search.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::env;
+use std::io::Read;
 use std::thread;
 use std::time::Duration;
 
@@ -8,12 +9,31 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
 
 use super::DiscoveryQuery;
+use super::config::MAX_DISCOVERY_BATCH_SIZE;
+
+const MAX_SEARCH_TIMEOUT_SECONDS: u64 = 3_600;
+const MAX_SEARCH_RETRY_DELAY_MS: u64 = 300_000;
+const MAX_SEARCH_RESPONSE_BYTES: usize = 256 * 1024 * 1024;
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct SourceSnapshot {
     pub provider: String,
     pub revision: String,
+}
+
+impl SourceSnapshot {
+    pub(crate) fn validate(&self) -> Result<()> {
+        ensure!(
+            !self.provider.trim().is_empty(),
+            "source snapshot provider must not be empty"
+        );
+        ensure!(
+            !self.revision.trim().is_empty(),
+            "source snapshot revision must not be empty"
+        );
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -25,6 +45,17 @@ pub struct DiscoveryHit {
     pub uris: Vec<String>,
     pub metadata: BTreeMap<String, Value>,
     pub inline_text: Option<String>,
+}
+
+impl DiscoveryHit {
+    pub(crate) fn validate(&self) -> Result<()> {
+        ensure!(
+            !self.record_key.trim().is_empty(),
+            "discovery hit record key must not be empty"
+        );
+        ensure!(self.score.is_finite(), "discovery hit score must be finite");
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -76,6 +107,11 @@ pub struct SearchApiConfig {
     pub retry_initial_ms: u64,
     #[serde(default = "default_retry_max_ms")]
     pub retry_max_ms: u64,
+    /// Hard response-body limit applied before JSON parsing. Search pages are
+    /// metadata-only in the production recipe, so an unexpectedly enormous
+    /// body is an error rather than an unbounded allocation.
+    #[serde(default = "default_max_response_bytes")]
+    pub max_response_bytes: usize,
     pub auth: Option<SearchApiAuthConfig>,
 }
 
@@ -95,30 +131,109 @@ fn default_retry_max_ms() -> u64 {
     30_000
 }
 
+fn default_max_response_bytes() -> usize {
+    64 * 1024 * 1024
+}
+
 impl SearchApiConfig {
     pub fn validate(&self) -> Result<()> {
         ensure!(
             self.endpoint.starts_with("http://") || self.endpoint.starts_with("https://"),
             "search_api endpoint must use HTTP or HTTPS"
         );
-        ensure!(self.page_size > 0, "search_api page_size must be positive");
         ensure!(
-            self.timeout_seconds > 0,
-            "search_api timeout_seconds must be positive"
+            (1..=MAX_DISCOVERY_BATCH_SIZE).contains(&self.page_size),
+            "search_api page_size must be within 1..={MAX_DISCOVERY_BATCH_SIZE}"
+        );
+        ensure!(
+            (1..=MAX_SEARCH_TIMEOUT_SECONDS).contains(&self.timeout_seconds),
+            "search_api timeout_seconds must be within 1..={MAX_SEARCH_TIMEOUT_SECONDS}"
+        );
+        ensure!(
+            self.max_retries <= 32,
+            "search_api max_retries must not exceed 32"
         );
         ensure!(
             self.retry_initial_ms > 0 && self.retry_initial_ms <= self.retry_max_ms,
             "search_api retry delays must be positive and ordered"
         );
+        ensure!(
+            self.retry_max_ms <= MAX_SEARCH_RETRY_DELAY_MS,
+            "search_api retry_max_ms must not exceed {MAX_SEARCH_RETRY_DELAY_MS}"
+        );
+        ensure!(
+            (1..=MAX_SEARCH_RESPONSE_BYTES).contains(&self.max_response_bytes),
+            "search_api max_response_bytes must be within 1..={MAX_SEARCH_RESPONSE_BYTES}"
+        );
         self.request_mapping.validate(&self.request_template)?;
         self.response_mapping.validate()?;
         self.fusion.validate(&self.request_template)?;
         self.snapshot.validate(&self.request_template)?;
+        self.validate_request_write_targets()?;
         if let Some(auth) = &self.auth {
             ensure!(
                 !auth.header.trim().is_empty() && !auth.environment.trim().is_empty(),
                 "search_api auth header and environment must not be empty"
             );
+        }
+        Ok(())
+    }
+
+    fn validate_request_write_targets(&self) -> Result<()> {
+        let mut targets = vec![
+            (
+                "query".to_owned(),
+                self.request_mapping.query_pointer.as_str(),
+            ),
+            (
+                "offset".to_owned(),
+                self.request_mapping.offset_pointer.as_str(),
+            ),
+            (
+                "limit".to_owned(),
+                self.request_mapping.limit_pointer.as_str(),
+            ),
+            (
+                "snapshot revision".to_owned(),
+                self.snapshot.request_revision_pointer.as_str(),
+            ),
+            (
+                "fusion marker".to_owned(),
+                self.fusion.marker_pointer.as_str(),
+            ),
+            (
+                "sparse vector field".to_owned(),
+                self.fusion.sparse.vector_field_pointer.as_str(),
+            ),
+            (
+                "dense vector field".to_owned(),
+                self.fusion.dense.vector_field_pointer.as_str(),
+            ),
+        ];
+        targets.extend(
+            self.request_mapping
+                .parameter_pointers
+                .iter()
+                .map(|(name, pointer)| (format!("query parameter `{name}`"), pointer.as_str())),
+        );
+        targets.extend(
+            self.request_mapping
+                .disabled_reranker_pointers
+                .iter()
+                .enumerate()
+                .map(|(index, pointer)| (format!("disabled reranker {index}"), pointer.as_str())),
+        );
+        if let Some(pointer) = &self.request_mapping.return_documents_pointer {
+            targets.push(("return documents".to_owned(), pointer));
+        }
+
+        for (index, (left_name, left)) in targets.iter().enumerate() {
+            for (right_name, right) in &targets[index + 1..] {
+                ensure!(
+                    !json_pointer_writes_overlap(left, right),
+                    "search_api request write targets `{left_name}` (`{left}`) and `{right_name}` (`{right}`) overlap"
+                );
+            }
         }
         Ok(())
     }
@@ -346,6 +461,17 @@ fn validate_json_pointer(pointer: &str) -> Result<()> {
     Ok(())
 }
 
+fn json_pointer_writes_overlap(left: &str, right: &str) -> bool {
+    fn contains(ancestor: &str, descendant: &str) -> bool {
+        ancestor.is_empty()
+            || ancestor == descendant
+            || descendant
+                .strip_prefix(ancestor)
+                .is_some_and(|suffix| suffix.starts_with('/'))
+    }
+    contains(left, right) || contains(right, left)
+}
+
 fn ensure_pointer(value: &Value, pointer: &str) -> Result<()> {
     validate_json_pointer(pointer)?;
     ensure!(
@@ -368,6 +494,7 @@ pub struct UreqSearchApiTransport {
     max_retries: usize,
     retry_initial_ms: u64,
     retry_max_ms: u64,
+    max_response_bytes: usize,
 }
 
 impl UreqSearchApiTransport {
@@ -394,6 +521,7 @@ impl UreqSearchApiTransport {
             max_retries: config.max_retries,
             retry_initial_ms: config.retry_initial_ms,
             retry_max_ms: config.retry_max_ms,
+            max_response_bytes: config.max_response_bytes,
         })
     }
 }
@@ -405,15 +533,16 @@ impl SearchApiTransport for UreqSearchApiTransport {
                 .agent
                 .post(endpoint)
                 .set("Content-Type", "application/json")
-                .set("X-Request-Source", "hermes-train-corpus");
+                .set("X-Request-Source", "training-corpus");
             if let Some((header, value)) = &self.auth {
                 request = request.set(header, value);
             }
             match request.send_json(body) {
                 Ok(response) => {
-                    return response
-                        .into_json::<Value>()
-                        .context("search_api returned invalid JSON");
+                    return parse_bounded_json_response(
+                        response.into_reader(),
+                        self.max_response_bytes,
+                    );
                 }
                 Err(ureq::Error::Status(status, response)) => {
                     let retryable = matches!(status, 429 | 500 | 502 | 503 | 504);
@@ -439,6 +568,29 @@ impl SearchApiTransport for UreqSearchApiTransport {
         }
         unreachable!("bounded search_api retry loop always returns")
     }
+}
+
+fn parse_bounded_json_response(mut reader: impl Read, maximum_bytes: usize) -> Result<Value> {
+    ensure!(
+        maximum_bytes > 0,
+        "search_api max_response_bytes must be positive"
+    );
+    let maximum =
+        u64::try_from(maximum_bytes).context("search_api max_response_bytes exceeds u64")?;
+    let capture = maximum
+        .checked_add(1)
+        .context("search_api response limit overflows u64")?;
+    let mut bytes = Vec::new();
+    reader
+        .by_ref()
+        .take(capture)
+        .read_to_end(&mut bytes)
+        .context("failed to read search_api response")?;
+    ensure!(
+        bytes.len() <= maximum_bytes,
+        "search_api response exceeds max_response_bytes {maximum_bytes}"
+    );
+    serde_json::from_slice(&bytes).context("search_api returned invalid JSON")
 }
 
 pub struct SearchApiClient<T = UreqSearchApiTransport> {
@@ -469,6 +621,11 @@ where
         limit: usize,
     ) -> Result<Value> {
         ensure!(limit > 0, "search_api request limit must be positive");
+        ensure!(
+            limit <= self.config.page_size,
+            "search_api request limit {limit} exceeds configured page_size {}",
+            self.config.page_size
+        );
         let mut request = self.config.request_template.clone();
         set_pointer(
             &mut request,
@@ -570,20 +727,36 @@ where
                 )
             })?;
         let mut hits = Vec::with_capacity(raw_hits.len());
-        for raw in raw_hits {
+        let mut metadata_matches = mapping
+            .metadata_pointers
+            .keys()
+            .map(|name| (name.as_str(), 0usize))
+            .collect::<BTreeMap<_, _>>();
+        for (index, raw) in raw_hits.iter().enumerate() {
             let record_key = scalar_string(raw.pointer(&mapping.record_key_pointer))
                 .context("search_api hit has no scalar record key")?;
             ensure!(
                 !record_key.is_empty(),
                 "search_api hit record key must not be empty"
             );
-            let score = mapping
-                .score_pointer
-                .as_ref()
-                .and_then(|pointer| raw.pointer(pointer))
-                .and_then(Value::as_f64)
-                .unwrap_or(0.0);
-            let score = if score.is_finite() { score } else { 0.0 };
+            let score = match &mapping.score_pointer {
+                Some(pointer) => {
+                    let score = raw
+                        .pointer(pointer)
+                        .with_context(|| {
+                            format!("search_api hit {index} has no configured score at `{pointer}`")
+                        })?
+                        .as_f64()
+                        .with_context(|| {
+                            format!(
+                                "search_api hit {index} score `{pointer}` must be a finite number"
+                            )
+                        })?;
+                    validate_finite_score(score, pointer)
+                        .with_context(|| format!("invalid search_api hit {index}"))?
+                }
+                None => 0.0,
+            };
             let uris = mapping
                 .uris_pointer
                 .as_ref()
@@ -594,16 +767,22 @@ where
             let inline_text = mapping
                 .inline_text_pointer
                 .as_ref()
-                .and_then(|pointer| raw.pointer(pointer))
-                .and_then(Value::as_str)
-                .map(str::to_owned);
+                .and_then(|pointer| raw.pointer(pointer).map(|value| (pointer, value)))
+                .map(|(pointer, value)| {
+                    value.as_str().map(str::to_owned).with_context(|| {
+                        format!("search_api hit {index} inline text `{pointer}` must be a string")
+                    })
+                })
+                .transpose()?;
             let metadata = mapping
                 .metadata_pointers
                 .iter()
                 .filter_map(|(name, pointer)| {
-                    raw.pointer(pointer)
-                        .cloned()
-                        .map(|value| (name.clone(), value))
+                    let value = raw.pointer(pointer)?.clone();
+                    if let Some(matched) = metadata_matches.get_mut(name.as_str()) {
+                        *matched += 1;
+                    }
+                    Some((name.clone(), value))
                 })
                 .collect();
             hits.push(DiscoveryHit {
@@ -614,17 +793,52 @@ where
                 inline_text,
             });
         }
+        // A configured metadata pointer that matches nothing silently disables
+        // every classification rule and transformation predicate keyed on it.
+        for (name, matched) in &metadata_matches {
+            if *matched == 0 && !hits.is_empty() {
+                tracing::warn!(
+                    "search_api metadata pointer `{}` (`{}`) matched none of the {} hits on this page; \
+                     rules keyed on this metadata will not fire",
+                    name,
+                    mapping.metadata_pointers[*name],
+                    hits.len()
+                );
+            }
+        }
         let total_hits = mapping
             .total_hits_pointer
             .as_ref()
-            .and_then(|pointer| response.pointer(pointer))
-            .and_then(Value::as_u64);
+            .map(|pointer| {
+                response
+                    .pointer(pointer)
+                    .with_context(|| {
+                        format!(
+                            "search_api response has no configured total_hits at `{pointer}`"
+                        )
+                    })?
+                    .as_u64()
+                    .with_context(|| {
+                        format!(
+                            "search_api total_hits `{pointer}` must be a nonnegative integer fitting u64"
+                        )
+                    })
+            })
+            .transpose()?;
         Ok(DiscoveryPage {
             hits,
             total_hits,
             snapshot,
         })
     }
+}
+
+fn validate_finite_score(score: f64, pointer: &str) -> Result<f64> {
+    ensure!(
+        score.is_finite(),
+        "search_api score `{pointer}` must be finite"
+    );
+    Ok(score)
 }
 
 impl<T> SearchBackend for SearchApiClient<T>
@@ -658,8 +872,16 @@ where
             .transport
             .post_json(&self.config.endpoint, &request)
             .with_context(|| format!("search_api query `{}` failed", query.name))?;
-        self.parse_response(&response)
-            .with_context(|| format!("invalid search_api response for query `{}`", query.name))
+        let page = self
+            .parse_response(&response)
+            .with_context(|| format!("invalid search_api response for query `{}`", query.name))?;
+        ensure!(
+            page.hits.len() <= limit,
+            "search_api returned {} hits for query `{}` after a request limit of {limit}",
+            page.hits.len(),
+            query.name
+        );
+        Ok(page)
     }
 }
 
@@ -693,5 +915,32 @@ fn strings(value: &Value) -> Result<Vec<String>> {
             })
             .collect(),
         _ => bail!("URI mapping must resolve to a string or string array"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::{parse_bounded_json_response, validate_finite_score};
+
+    #[test]
+    fn configured_score_validation_rejects_non_finite_values() {
+        for score in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let error = validate_finite_score(score, "/rank").unwrap_err();
+            assert!(error.to_string().contains("must be finite"), "{error:#}");
+        }
+    }
+
+    #[test]
+    fn response_capture_is_bounded_before_json_parsing() {
+        assert_eq!(
+            parse_bounded_json_response(Cursor::new(br#"{"ok":true}"#), 11).unwrap()["ok"],
+            true
+        );
+        let error = parse_bounded_json_response(Cursor::new(br#"{"ok":true}"#), 10)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("max_response_bytes 10"), "{error}");
     }
 }

--- a/hermes-train/src/corpus/tests.rs
+++ b/hermes-train/src/corpus/tests.rs
@@ -1,10 +1,11 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, ensure};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 
 use super::*;
 
@@ -106,8 +107,36 @@ fn search_api_config() -> SearchApiConfig {
         max_retries: 0,
         retry_initial_ms: 1,
         retry_max_ms: 1,
+        max_response_bytes: 1024 * 1024,
         auth: None,
     }
+}
+
+fn discover_search_response(config: SearchApiConfig, response: Value) -> Result<DiscoveryPage> {
+    let (transport, _) = MockSearchTransport::new(vec![response]);
+    SearchApiClient::with_transport(config, transport)?.discover(
+        &DiscoveryQuery {
+            name: "probe".to_owned(),
+            text: "probe".to_owned(),
+            limit: 1,
+            parameters: BTreeMap::new(),
+        },
+        0,
+        1,
+    )
+}
+
+fn valid_search_response() -> Value {
+    json!({
+        "snapshot": {"provider": "search-test", "revision": "index-42"},
+        "results": {
+            "count": 1,
+            "items": [{
+                "primary_key": "record-1",
+                "rank": 0.75
+            }]
+        }
+    })
 }
 
 #[test]
@@ -193,6 +222,52 @@ fn search_api_rejects_a_vector_field_outside_its_declared_fusion_clause() {
 }
 
 #[test]
+fn search_api_rejects_overlapping_request_write_targets() {
+    let cases = [
+        {
+            let mut config = search_api_config();
+            config.request_mapping.disabled_reranker_pointers[0] =
+                config.fusion.marker_pointer.clone();
+            ("reranker and fusion marker", config)
+        },
+        {
+            let mut config = search_api_config();
+            config.request_mapping.offset_pointer = config.request_mapping.query_pointer.clone();
+            ("query and pagination", config)
+        },
+        {
+            let mut config = search_api_config();
+            config.request_mapping.parameter_pointers.insert(
+                "types".to_owned(),
+                config.request_mapping.limit_pointer.clone(),
+            );
+            ("parameter and pagination", config)
+        },
+        {
+            let mut config = search_api_config();
+            config.snapshot.request_revision_pointer = config.fusion.marker_pointer.clone();
+            ("snapshot and fusion marker", config)
+        },
+        {
+            let mut config = search_api_config();
+            config.request_mapping.return_documents_pointer =
+                Some(config.fusion.sparse.clause_pointer.clone());
+            ("ancestor and descendant", config)
+        },
+    ];
+
+    for (name, config) in cases {
+        let (transport, _) = MockSearchTransport::new(vec![]);
+        let error = SearchApiClient::with_transport(config, transport)
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(error.contains("write targets"), "{name}: {error}");
+        assert!(error.contains("overlap"), "{name}: {error}");
+    }
+}
+
+#[test]
 fn search_api_rejects_missing_or_drifted_remote_snapshot_proof() {
     for response in [
         json!({"results": {"count": 0, "items": []}}),
@@ -218,6 +293,127 @@ fn search_api_rejects_missing_or_drifted_remote_snapshot_proof() {
         let error = format!("{error:#}");
         assert!(error.contains("snapshot"), "{error}");
     }
+}
+
+#[test]
+fn search_api_rejects_missing_or_malformed_configured_numeric_response_fields() {
+    let cases = [
+        {
+            let mut response = valid_search_response();
+            response["results"]["items"][0]
+                .as_object_mut()
+                .unwrap()
+                .remove("rank");
+            ("missing score", response, "configured score")
+        },
+        {
+            let mut response = valid_search_response();
+            response["results"]["items"][0]["rank"] = json!("high");
+            ("wrong score type", response, "finite number")
+        },
+        {
+            let mut response = valid_search_response();
+            response["results"].as_object_mut().unwrap().remove("count");
+            ("missing total", response, "configured total_hits")
+        },
+        {
+            let mut response = valid_search_response();
+            response["results"]["count"] = json!("one");
+            (
+                "wrong total type",
+                response,
+                "nonnegative integer fitting u64",
+            )
+        },
+        {
+            let mut response = valid_search_response();
+            response["results"]["count"] = json!(-1);
+            (
+                "negative total",
+                response,
+                "nonnegative integer fitting u64",
+            )
+        },
+    ];
+
+    for (name, response, expected) in cases {
+        let error = format!(
+            "{:#}",
+            discover_search_response(search_api_config(), response).unwrap_err()
+        );
+        assert!(error.contains(expected), "{name}: {error}");
+    }
+}
+
+#[test]
+fn absent_numeric_response_mappings_keep_explicit_defaults() {
+    let mut config = search_api_config();
+    config.response_mapping.score_pointer = None;
+    config.response_mapping.total_hits_pointer = None;
+    let response = json!({
+        "snapshot": {"provider": "search-test", "revision": "index-42"},
+        "results": {"items": [{"primary_key": "record-1"}]}
+    });
+
+    let page = discover_search_response(config, response).unwrap();
+    assert_eq!(page.total_hits, None);
+    assert_eq!(page.hits[0].score, 0.0);
+}
+
+#[test]
+fn search_api_enforces_configured_page_and_resource_limits() {
+    let mut response = valid_search_response();
+    response["results"]["count"] = json!(2);
+    response["results"]["items"] = json!([
+        {"primary_key": "record-1", "rank": 0.75},
+        {"primary_key": "record-2", "rank": 0.50}
+    ]);
+    let error = discover_search_response(search_api_config(), response)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("request limit of 1"), "{error}");
+
+    for (name, mutate) in [
+        (
+            "page size",
+            (|config: &mut SearchApiConfig| config.page_size = usize::MAX)
+                as fn(&mut SearchApiConfig),
+        ),
+        (
+            "response bytes",
+            (|config: &mut SearchApiConfig| config.max_response_bytes = usize::MAX)
+                as fn(&mut SearchApiConfig),
+        ),
+        (
+            "timeout",
+            (|config: &mut SearchApiConfig| config.timeout_seconds = u64::MAX)
+                as fn(&mut SearchApiConfig),
+        ),
+        (
+            "retry delay",
+            (|config: &mut SearchApiConfig| config.retry_max_ms = u64::MAX)
+                as fn(&mut SearchApiConfig),
+        ),
+    ] {
+        let mut config = search_api_config();
+        mutate(&mut config);
+        assert!(config.validate().is_err(), "accepted hostile {name}");
+    }
+}
+
+#[test]
+fn search_api_rejects_a_malformed_configured_inline_text() {
+    let mut config = search_api_config();
+    config.response_mapping.inline_text_pointer = Some("/body".to_owned());
+    let mut response = valid_search_response();
+    response["results"]["items"][0]["body"] = json!(["not", "text"]);
+
+    let error = format!(
+        "{:#}",
+        discover_search_response(config, response).unwrap_err()
+    );
+    assert!(error.contains("inline text"), "{error}");
+    assert!(error.contains("must be a string"), "{error}");
 }
 
 struct MockPostgresExecutor {
@@ -425,6 +621,37 @@ struct AdversarialSearchBackend {
     pages: Mutex<VecDeque<DiscoveryPage>>,
 }
 
+struct SnapshotOnlySearchBackend {
+    snapshot: SourceSnapshot,
+}
+
+impl SearchBackend for SnapshotOnlySearchBackend {
+    fn name(&self) -> &str {
+        "snapshot_only_search"
+    }
+
+    fn configuration(&self) -> Result<Value> {
+        Ok(json!({"type": "snapshot_only"}))
+    }
+
+    fn snapshot(&self) -> Result<SourceSnapshot> {
+        Ok(self.snapshot.clone())
+    }
+
+    fn page_size(&self) -> usize {
+        1
+    }
+
+    fn discover(
+        &self,
+        _query: &DiscoveryQuery,
+        _offset: usize,
+        _limit: usize,
+    ) -> Result<DiscoveryPage> {
+        unreachable!("invalid initial snapshots fail before discovery")
+    }
+}
+
 impl SearchBackend for AdversarialSearchBackend {
     fn name(&self) -> &str {
         "adversarial_search"
@@ -529,6 +756,59 @@ struct SnapshotMaterializer {
     revision: &'static str,
 }
 
+struct DuplicateKeyMaterializer;
+
+impl RecordMaterializer for DuplicateKeyMaterializer {
+    fn name(&self) -> &str {
+        "duplicate_key_store"
+    }
+
+    fn configuration(&self) -> Result<Value> {
+        Ok(json!({"type": "adversarial_duplicates"}))
+    }
+
+    fn snapshot(&self) -> Result<SourceSnapshot> {
+        Ok(SourceSnapshot {
+            provider: "duplicate_key_store".to_owned(),
+            revision: "stable".to_owned(),
+        })
+    }
+
+    fn materialize(&self, hits: &[DiscoveryHit]) -> Result<Vec<MaterializedRecord>> {
+        let mut records = MockMaterializer.materialize(hits)?;
+        records.push(
+            records
+                .first()
+                .expect("pipeline sends a non-empty batch")
+                .clone(),
+        );
+        Ok(records)
+    }
+}
+
+struct OmittingMaterializer;
+
+impl RecordMaterializer for OmittingMaterializer {
+    fn name(&self) -> &str {
+        "omitting_store"
+    }
+
+    fn configuration(&self) -> Result<Value> {
+        Ok(json!({"type": "omits_deleted_rows"}))
+    }
+
+    fn snapshot(&self) -> Result<SourceSnapshot> {
+        MockMaterializer.snapshot()
+    }
+
+    fn materialize(&self, hits: &[DiscoveryHit]) -> Result<Vec<MaterializedRecord>> {
+        // Model a row deleted between discovery and materialization.
+        let mut records = MockMaterializer.materialize(hits)?;
+        records.retain(|record| record.record_key != "b");
+        Ok(records)
+    }
+}
+
 impl RecordMaterializer for SnapshotMaterializer {
     fn name(&self) -> &str {
         "mock_store"
@@ -567,6 +847,59 @@ impl CorpusTokenizer for MockTokenizer {
             .enumerate()
             .map(|(index, _)| index as u32 + 1)
             .collect())
+    }
+}
+
+struct FixedTokenizer {
+    snapshot: TokenizerSnapshot,
+    tokens: Vec<u32>,
+}
+
+impl CorpusTokenizer for FixedTokenizer {
+    fn snapshot(&self) -> TokenizerSnapshot {
+        self.snapshot.clone()
+    }
+
+    fn encode(&self, _text: &str) -> Result<Vec<u32>> {
+        Ok(self.tokens.clone())
+    }
+}
+
+struct DriftingTokenizer {
+    encoded: Mutex<bool>,
+}
+
+impl CorpusTokenizer for DriftingTokenizer {
+    fn snapshot(&self) -> TokenizerSnapshot {
+        TokenizerSnapshot {
+            implementation: "drifting".to_owned(),
+            revision: if *self.encoded.lock().unwrap() {
+                "2".to_owned()
+            } else {
+                "1".to_owned()
+            },
+            vocabulary_size: 100,
+        }
+    }
+
+    fn encode(&self, text: &str) -> Result<Vec<u32>> {
+        *self.encoded.lock().unwrap() = true;
+        MockTokenizer.encode(text)
+    }
+}
+
+struct CountingTokenizer {
+    calls: Mutex<usize>,
+}
+
+impl CorpusTokenizer for CountingTokenizer {
+    fn snapshot(&self) -> TokenizerSnapshot {
+        MockTokenizer.snapshot()
+    }
+
+    fn encode(&self, text: &str) -> Result<Vec<u32>> {
+        *self.calls.lock().unwrap() += 1;
+        MockTokenizer.encode(text)
     }
 }
 
@@ -661,6 +994,47 @@ fn pipeline_config() -> CorpusBuildConfig {
     }
 }
 
+#[test]
+fn corpus_config_bounds_work_amplification_before_pipeline_execution() {
+    let mut config = pipeline_config();
+    config.discovery.materialization_batch_size = usize::MAX;
+    assert!(config.validate().is_err());
+
+    let mut config = pipeline_config();
+    config.discovery.queries[0].limit = usize::MAX;
+    assert!(config.validate().is_err());
+
+    let mut config = pipeline_config();
+    config.repetition.max_copies_per_record = usize::MAX;
+    assert!(config.validate().is_err());
+
+    let mut config = pipeline_config();
+    config.transformations = (0..1_025)
+        .map(|index| TransformationConfig {
+            name: format!("transform-{index}"),
+            template: "${text}".to_owned(),
+            copies: 1,
+            when: RecordPredicate::default(),
+        })
+        .collect();
+    assert!(config.validate().is_err());
+
+    let mut config = pipeline_config();
+    config.transformations[0].name = "source".to_owned();
+    assert!(config.validate().is_err());
+
+    let mut config = pipeline_config();
+    config.classification.topic_rules = vec![ClassificationRule {
+        label: "non-mathematics".to_owned(),
+        priority: 0,
+        any_terms: Vec::new(),
+        all_terms: Vec::new(),
+        none_terms: vec!["mathematics".to_owned()],
+        metadata_equals: BTreeMap::new(),
+    }];
+    config.validate().unwrap();
+}
+
 fn target_boundary_config(
     build_id: &str,
     minimum: u64,
@@ -675,6 +1049,199 @@ fn target_boundary_config(
         maximum,
     };
     config
+}
+
+fn build_test_corpus(
+    config: CorpusBuildConfig,
+    tokenizer: &dyn CorpusTokenizer,
+) -> (tempfile::TempDir, std::path::PathBuf, CorpusManifest) {
+    let root = tempfile::tempdir().unwrap();
+    let backend = MockSearchBackend {
+        calls: Mutex::new(Vec::new()),
+        fail_once_at: Mutex::new(None),
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let (path, manifest) =
+        CorpusPipeline::new(config, &backend, &MockMaterializer, tokenizer, &mut dedup)
+            .unwrap()
+            .run(root.path())
+            .unwrap();
+    (root, path, manifest)
+}
+
+fn rehash_manifest_body(manifest: &mut CorpusManifest) {
+    manifest.manifest_sha256 =
+        super::pipeline::canonical_json_sha256(&serde_json::to_value(&manifest.build).unwrap())
+            .unwrap();
+}
+
+fn rehash_manifest_configuration_and_body(manifest: &mut CorpusManifest) {
+    manifest.build.config_sha256 =
+        super::pipeline::corpus_manifest_configuration_sha256(&manifest.build).unwrap();
+    rehash_manifest_body(manifest);
+}
+
+#[test]
+fn pipeline_rejects_invalid_generic_source_snapshots_before_io() {
+    for (label, snapshot) in [
+        (
+            "provider",
+            SourceSnapshot {
+                provider: " ".to_owned(),
+                revision: "stable".to_owned(),
+            },
+        ),
+        (
+            "revision",
+            SourceSnapshot {
+                provider: "mock".to_owned(),
+                revision: String::new(),
+            },
+        ),
+    ] {
+        let root = tempfile::tempdir().unwrap();
+        let backend = SnapshotOnlySearchBackend { snapshot };
+        let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+        let error = CorpusPipeline::new(
+            pipeline_config(),
+            &backend,
+            &MockMaterializer,
+            &MockTokenizer,
+            &mut dedup,
+        )
+        .unwrap()
+        .run(root.path())
+        .unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("source snapshot"), "{label}: {error}");
+        assert!(error.contains(label), "{label}: {error}");
+    }
+
+    let root = tempfile::tempdir().unwrap();
+    let backend = MockSearchBackend {
+        calls: Mutex::new(Vec::new()),
+        fail_once_at: Mutex::new(None),
+    };
+    let materializer = SnapshotMaterializer { revision: "" };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let error = CorpusPipeline::new(
+        pipeline_config(),
+        &backend,
+        &materializer,
+        &MockTokenizer,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(root.path())
+    .unwrap_err();
+    let error = format!("{error:#}");
+    assert!(error.contains("materializer"), "{error}");
+    assert!(error.contains("revision"), "{error}");
+}
+
+#[test]
+fn pipeline_rejects_empty_generic_discovery_keys() {
+    let root = tempfile::tempdir().unwrap();
+    let backend = AdversarialSearchBackend {
+        page_size: 2,
+        pages: Mutex::new([discovery_page(&[""], Some(1))].into_iter().collect()),
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let error = CorpusPipeline::new(
+        pipeline_config(),
+        &backend,
+        &MockMaterializer,
+        &MockTokenizer,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(root.path())
+    .unwrap_err();
+    let error = format!("{error:#}");
+    assert!(error.contains("invalid hit"), "{error}");
+    assert!(error.contains("record key must not be empty"), "{error}");
+}
+
+#[test]
+fn pipeline_rejects_non_finite_generic_discovery_scores() {
+    for score in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let root = tempfile::tempdir().unwrap();
+        let mut hit = discovery_hit("invalid-score");
+        hit.score = score;
+        let backend = AdversarialSearchBackend {
+            page_size: 1,
+            pages: Mutex::new(
+                [DiscoveryPage {
+                    hits: vec![hit],
+                    total_hits: Some(1),
+                    snapshot: SourceSnapshot {
+                        provider: "mock".to_owned(),
+                        revision: "stable".to_owned(),
+                    },
+                }]
+                .into_iter()
+                .collect(),
+            ),
+        };
+        let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+        let error = CorpusPipeline::new(
+            pipeline_config(),
+            &backend,
+            &MockMaterializer,
+            &MockTokenizer,
+            &mut dedup,
+        )
+        .unwrap()
+        .run(root.path())
+        .unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("invalid hit"), "{score}: {error}");
+        assert!(error.contains("score must be finite"), "{score}: {error}");
+    }
+}
+
+#[test]
+fn pipeline_counts_records_the_materializer_omitted() {
+    let root = tempfile::tempdir().unwrap();
+    let backend = MockSearchBackend {
+        calls: Mutex::new(Vec::new()),
+        fail_once_at: Mutex::new(None),
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let (_, manifest) = CorpusPipeline::new(
+        pipeline_config(),
+        &backend,
+        &OmittingMaterializer,
+        &MockTokenizer,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(root.path())
+    .unwrap();
+    assert_eq!(manifest.build.stats.unmaterialized_records, 1);
+    assert_eq!(manifest.build.stats.materialized_records, 2);
+}
+
+#[test]
+fn pipeline_rejects_duplicate_keys_from_generic_materializers() {
+    let root = tempfile::tempdir().unwrap();
+    let backend = MockSearchBackend {
+        calls: Mutex::new(Vec::new()),
+        fail_once_at: Mutex::new(None),
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let error = CorpusPipeline::new(
+        pipeline_config(),
+        &backend,
+        &DuplicateKeyMaterializer,
+        &MockTokenizer,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(root.path())
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("duplicate record key"), "{error}");
 }
 
 #[test]
@@ -846,6 +1413,459 @@ fn pipeline_runs_all_stages_and_publishes_immutable_manifest() {
         .write_all(b"tampered")
         .unwrap();
     assert!(manifest.verify(&path).is_err());
+}
+
+#[test]
+fn authenticated_corpus_reuses_the_verified_shard_generation() {
+    let (_root, path, manifest) = build_test_corpus(pipeline_config(), &MockTokenizer);
+    let corpus = AuthenticatedCorpus::open_data_path(&path)
+        .unwrap()
+        .expect("a corpus directory must produce an authenticated binding");
+
+    assert_eq!(corpus.manifest().manifest_sha256, manifest.manifest_sha256);
+    assert_eq!(corpus.shard_count(), manifest.build.shards.len());
+    for index in 0..corpus.shard_count() {
+        let expected = fs::read(path.join(&manifest.build.shards[index].path)).unwrap();
+        let mut actual = Vec::new();
+        corpus
+            .with_shard(index, |_path, shard| {
+                shard.read_to_end(&mut actual)?;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(actual, expected);
+    }
+    corpus.ensure_still_published().unwrap();
+
+    let standalone = path.join("ordinary.jsonl");
+    fs::write(&standalone, b"{\"text\":\"ordinary\"}\n").unwrap();
+    assert!(
+        AuthenticatedCorpus::open_data_path(&standalone)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn verified_corpus_reader_rejects_in_place_mutation_before_returning_more_bytes() {
+    let (_root, path, manifest) = build_test_corpus(pipeline_config(), &MockTokenizer);
+    let corpus = AuthenticatedCorpus::open_data_path(&path)
+        .unwrap()
+        .expect("a corpus directory must produce an authenticated binding");
+    let published = path.join(&manifest.build.shards[0].path);
+    let expected = fs::read(&published).unwrap();
+
+    let mut rest = Vec::new();
+    let error = corpus
+        .with_verified_shard(0, |_path, shard| {
+            let mut first = [0_u8; 1];
+            shard.read_exact(&mut first)?;
+            fs::OpenOptions::new()
+                .append(true)
+                .open(&published)?
+                .write_all(b"tampered")?;
+            shard.read_to_end(&mut rest)?;
+            Ok(())
+        })
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("changed"), "{error}");
+    assert_eq!(
+        rest,
+        expected[1..],
+        "only bytes captured and authenticated before the mutation may escape the verified reader"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn authenticated_corpus_rejects_persistent_manifest_and_shard_replacements() {
+    fn replace_with_same_bytes(path: &std::path::Path) {
+        let replacement = path.with_extension("replacement");
+        fs::write(&replacement, fs::read(path).unwrap()).unwrap();
+        fs::rename(&replacement, path).unwrap();
+    }
+
+    let (_manifest_root, manifest_path, _manifest) =
+        build_test_corpus(pipeline_config(), &MockTokenizer);
+    let manifest_binding = AuthenticatedCorpus::open_data_path(&manifest_path)
+        .unwrap()
+        .unwrap();
+    replace_with_same_bytes(&manifest_path.join("manifest.json"));
+    let error = manifest_binding
+        .ensure_still_published()
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("corpus manifest"), "{error}");
+
+    let mut config = pipeline_config();
+    config.build_id = "persistent-shard-replacement".to_owned();
+    let (_shard_root, shard_path, manifest) = build_test_corpus(config, &MockTokenizer);
+    let shard_binding = AuthenticatedCorpus::open_data_path(&shard_path)
+        .unwrap()
+        .unwrap();
+    replace_with_same_bytes(&shard_path.join(&manifest.build.shards[0].path));
+    let error = shard_binding
+        .ensure_still_published()
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("corpus shard"), "{error}");
+
+    let mut config = pipeline_config();
+    config.build_id = "replacement-during-shard-read".to_owned();
+    let (_during_root, during_path, manifest) = build_test_corpus(config, &MockTokenizer);
+    let during_binding = AuthenticatedCorpus::open_data_path(&during_path)
+        .unwrap()
+        .unwrap();
+    let published = during_path.join(&manifest.build.shards[0].path);
+    let parked = during_path.join("parked-original.jsonl");
+    let expected = fs::read(&published).unwrap();
+    let error = during_binding
+        .with_shard(0, |_path, opened| {
+            fs::rename(&published, &parked)?;
+            fs::write(&published, &expected)?;
+            let mut observed = Vec::new();
+            opened.read_to_end(&mut observed)?;
+            assert_eq!(
+                observed, expected,
+                "the opened handle must remain generation A"
+            );
+            Ok(())
+        })
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("corpus shard"), "{error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn authenticated_corpus_rejects_symlinked_root_manifest_and_shard() {
+    use std::os::unix::fs::symlink;
+
+    let (root, path, manifest) = build_test_corpus(pipeline_config(), &MockTokenizer);
+    let root_alias = root.path().join("root-alias");
+    symlink(&path, &root_alias).unwrap();
+    assert!(AuthenticatedCorpus::open_data_path(&root_alias).is_err());
+
+    let manifest_path = path.join("manifest.json");
+    let real_manifest = path.join("real-manifest.json");
+    fs::rename(&manifest_path, &real_manifest).unwrap();
+    symlink("real-manifest.json", &manifest_path).unwrap();
+    assert!(AuthenticatedCorpus::open_data_path(&manifest_path).is_err());
+    fs::remove_file(&manifest_path).unwrap();
+    fs::rename(&real_manifest, &manifest_path).unwrap();
+
+    let shard_path = path.join(&manifest.build.shards[0].path);
+    let real_shard = path.join("real-shard.jsonl");
+    fs::rename(&shard_path, &real_shard).unwrap();
+    symlink("real-shard.jsonl", &shard_path).unwrap();
+    assert!(AuthenticatedCorpus::open_data_path(&path).is_err());
+}
+
+#[test]
+fn manifest_verification_recounts_actual_shard_rows_and_tokens() {
+    let root = tempfile::tempdir().unwrap();
+    let backend = MockSearchBackend {
+        calls: Mutex::new(Vec::new()),
+        fail_once_at: Mutex::new(None),
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let (path, manifest) = CorpusPipeline::new(
+        pipeline_config(),
+        &backend,
+        &MockMaterializer,
+        &MockTokenizer,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(root.path())
+    .unwrap();
+
+    let mut forged_records = manifest.clone();
+    forged_records.build.shards[0].records += 1;
+    forged_records.build.stats.emitted_views += 1;
+    forged_records.manifest_sha256 = super::pipeline::canonical_json_sha256(
+        &serde_json::to_value(&forged_records.build).unwrap(),
+    )
+    .unwrap();
+    let error = forged_records.verify(&path).unwrap_err().to_string();
+    assert!(
+        error.contains("records but its manifest declares"),
+        "{error}"
+    );
+
+    let mut forged_tokens = manifest;
+    forged_tokens.build.shards[0].tokens += 1;
+    forged_tokens.build.stats.exposure_tokens += 1;
+    forged_tokens.manifest_sha256 = super::pipeline::canonical_json_sha256(
+        &serde_json::to_value(&forged_tokens.build).unwrap(),
+    )
+    .unwrap();
+    let error = forged_tokens.verify(&path).unwrap_err().to_string();
+    assert!(
+        error.contains("tokens but its manifest declares"),
+        "{error}"
+    );
+}
+
+#[test]
+fn manifest_verification_rejects_rehashed_cross_field_forgery() {
+    let (_root, path, manifest) = build_test_corpus(pipeline_config(), &MockTokenizer);
+
+    let mut wrong_version = manifest.clone();
+    wrong_version.build.version += 1;
+    rehash_manifest_body(&mut wrong_version);
+    let error = wrong_version.verify(&path).unwrap_err().to_string();
+    assert!(error.contains("version differs"), "{error}");
+
+    let mut wrong_build = manifest.clone();
+    wrong_build.build.build_id.push_str("-forged");
+    rehash_manifest_body(&mut wrong_build);
+    let error = wrong_build.verify(&path).unwrap_err().to_string();
+    assert!(error.contains("build_id differs"), "{error}");
+
+    let mut changed_component = manifest.clone();
+    changed_component.build.discovery.configuration["forged"] = json!(true);
+    rehash_manifest_body(&mut changed_component);
+    let error = changed_component.verify(&path).unwrap_err().to_string();
+    assert!(error.contains("configuration hash"), "{error}");
+
+    let mut changed_hash = manifest.clone();
+    changed_hash.build.config_sha256 = "0".repeat(64);
+    rehash_manifest_body(&mut changed_hash);
+    let error = changed_hash.verify(&path).unwrap_err().to_string();
+    assert!(error.contains("configuration hash"), "{error}");
+
+    let mut impossible_stats = manifest.clone();
+    impossible_stats.build.stats.unique_records = impossible_stats.build.stats.emitted_views + 1;
+    rehash_manifest_body(&mut impossible_stats);
+    let error = impossible_stats.verify(&path).unwrap_err().to_string();
+    assert!(error.contains("unique-record count"), "{error}");
+
+    let mut impossible_topics = manifest.clone();
+    impossible_topics.build.topic_counts = BTreeMap::from([(
+        "forged".to_owned(),
+        impossible_topics.build.stats.unique_records + 1,
+    )]);
+    rehash_manifest_body(&mut impossible_topics);
+    let error = impossible_topics.verify(&path).unwrap_err().to_string();
+    assert!(error.contains("topic counts"), "{error}");
+
+    let mut empty_component_name = manifest;
+    empty_component_name.build.materializer.name = " ".to_owned();
+    rehash_manifest_body(&mut empty_component_name);
+    let error = empty_component_name.verify(&path).unwrap_err().to_string();
+    assert!(error.contains("component name"), "{error}");
+}
+
+#[test]
+fn manifest_verification_rejects_noncanonical_paths_and_symlinked_roots() {
+    let (root, path, manifest) = build_test_corpus(pipeline_config(), &MockTokenizer);
+
+    let mut noncanonical = manifest.clone();
+    noncanonical.build.shards[0].path = format!("./{}", noncanonical.build.shards[0].path);
+    rehash_manifest_body(&mut noncanonical);
+    let error = noncanonical.verify(&path).unwrap_err().to_string();
+    assert!(error.contains("non-canonical"), "{error}");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+
+        let alias = root.path().join("corpus-alias");
+        symlink(&path, &alias).unwrap();
+        let error = manifest.verify(&alias).unwrap_err().to_string();
+        assert!(error.contains("real directory"), "{error}");
+    }
+}
+
+#[test]
+fn manifest_verification_rejects_out_of_vocabulary_tokens_and_shard_limit_forgery() {
+    let (_root, path, manifest) = build_test_corpus(pipeline_config(), &MockTokenizer);
+
+    let mut out_of_vocabulary = manifest.clone();
+    let shard_path = path.join(&out_of_vocabulary.build.shards[0].path);
+    let mut rows = fs::read_to_string(&shard_path)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    rows[0]["tokens"][0] = json!(out_of_vocabulary.build.tokenizer.vocabulary_size);
+    let mut bytes = Vec::new();
+    for row in rows {
+        bytes.extend(serde_json::to_vec(&row).unwrap());
+        bytes.push(b'\n');
+    }
+    fs::write(&shard_path, &bytes).unwrap();
+    out_of_vocabulary.build.shards[0].sha256 = format!("{:x}", Sha256::digest(&bytes));
+    rehash_manifest_body(&mut out_of_vocabulary);
+    let error = out_of_vocabulary.verify(&path).unwrap_err().to_string();
+    assert!(error.contains("outside vocabulary size"), "{error}");
+
+    // Restore the authenticated shard before exercising an independent
+    // manifest/configuration forgery against the same immutable build.
+    let (_other_root, other_path, mut too_small_shards) =
+        build_test_corpus(pipeline_config(), &MockTokenizer);
+    too_small_shards.build.config.sharding.max_tokens_per_shard = 1;
+    rehash_manifest_configuration_and_body(&mut too_small_shards);
+    let error = too_small_shards
+        .verify(&other_path)
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("exceeds configured"), "{error}");
+}
+
+#[test]
+fn pipeline_rejects_invalid_drifting_and_out_of_vocabulary_tokenizers() {
+    let backend = MockSearchBackend {
+        calls: Mutex::new(Vec::new()),
+        fail_once_at: Mutex::new(None),
+    };
+    let root = tempfile::tempdir().unwrap();
+    let invalid = FixedTokenizer {
+        snapshot: TokenizerSnapshot {
+            implementation: "invalid".to_owned(),
+            revision: "1".to_owned(),
+            vocabulary_size: 0,
+        },
+        tokens: vec![0],
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let error = CorpusPipeline::new(
+        pipeline_config(),
+        &backend,
+        &MockMaterializer,
+        &invalid,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(root.path())
+    .unwrap_err();
+    assert!(format!("{error:#}").contains("vocabulary_size must be positive"));
+    assert!(backend.calls.lock().unwrap().is_empty());
+
+    let root = tempfile::tempdir().unwrap();
+    let out_of_vocabulary = FixedTokenizer {
+        snapshot: TokenizerSnapshot {
+            implementation: "invalid-output".to_owned(),
+            revision: "1".to_owned(),
+            vocabulary_size: 2,
+        },
+        tokens: vec![2],
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let error = CorpusPipeline::new(
+        pipeline_config(),
+        &backend,
+        &MockMaterializer,
+        &out_of_vocabulary,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(root.path())
+    .unwrap_err();
+    assert!(format!("{error:#}").contains("outside vocabulary size"));
+
+    let root = tempfile::tempdir().unwrap();
+    let drifting = DriftingTokenizer {
+        encoded: Mutex::new(false),
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let error = CorpusPipeline::new(
+        pipeline_config(),
+        &backend,
+        &MockMaterializer,
+        &drifting,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(root.path())
+    .unwrap_err();
+    assert!(format!("{error:#}").contains("tokenizer snapshot changed"));
+}
+
+#[test]
+fn pipeline_rejects_a_single_view_larger_than_its_shard_limit() {
+    let mut config = pipeline_config();
+    config.build_id = "oversized-view".to_owned();
+    config.sharding.max_tokens_per_shard = 2;
+    let root = tempfile::tempdir().unwrap();
+    let backend = MockSearchBackend {
+        calls: Mutex::new(Vec::new()),
+        fail_once_at: Mutex::new(None),
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+    let error = CorpusPipeline::new(
+        config,
+        &backend,
+        &MockMaterializer,
+        &MockTokenizer,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(root.path())
+    .unwrap_err();
+    let error = format!("{error:#}");
+    assert!(
+        error.contains("one corpus view contains 3 tokens"),
+        "{error}"
+    );
+    assert!(error.contains("max_tokens_per_shard 2"), "{error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn pipeline_rejects_a_symlinked_output_root() {
+    use std::os::unix::fs::symlink;
+
+    let parent = tempfile::tempdir().unwrap();
+    let target = parent.path().join("real-output");
+    fs::create_dir(&target).unwrap();
+    let alias = parent.path().join("output-alias");
+    symlink(&target, &alias).unwrap();
+    let backend = MockSearchBackend {
+        calls: Mutex::new(Vec::new()),
+        fail_once_at: Mutex::new(None),
+    };
+    let mut dedup = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+
+    let error = CorpusPipeline::new(
+        pipeline_config(),
+        &backend,
+        &MockMaterializer,
+        &MockTokenizer,
+        &mut dedup,
+    )
+    .unwrap()
+    .run(&alias)
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("output root"), "{error}");
+    assert!(error.contains("real directory"), "{error}");
+    assert!(backend.calls.lock().unwrap().is_empty());
+}
+
+#[test]
+fn pipeline_tokenizes_identical_repeated_views_once_per_record() {
+    let mut config = pipeline_config();
+    config.build_id = "tokenization-cache".to_owned();
+    config.repetition.base_copies = 2;
+    config.repetition.max_copies_per_record = 4;
+    config.transformations[0].copies = 2;
+    let tokenizer = CountingTokenizer {
+        calls: Mutex::new(0),
+    };
+
+    let (_root, _path, manifest) = build_test_corpus(config, &tokenizer);
+
+    assert_eq!(manifest.build.stats.unique_records, 2);
+    assert_eq!(manifest.build.stats.emitted_views, 8);
+    assert_eq!(
+        *tokenizer.calls.lock().unwrap(),
+        4,
+        "each record has only source and transformed token content"
+    );
 }
 
 #[test]

--- a/hermes-train/src/data.rs
+++ b/hermes-train/src/data.rs
@@ -9,6 +9,7 @@ use std::ffi::{CString, OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd};
@@ -19,20 +20,19 @@ use std::os::unix::fs::OpenOptionsExt;
 
 use anyhow::{Context, Result, ensure};
 use hermes_llm::Tokenizer;
-use hermes_train::corpus::CorpusManifest;
+use hermes_train::corpus::AuthenticatedCorpus;
+use hermes_train::task::TaskConfig;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 use sha2::{Digest, Sha256};
 
-use crate::wake::ObjectiveConfig;
-
 mod batch;
 mod structured;
 
-use batch::EncodedText;
 pub(crate) use batch::{
-    BatchStats, LanguageBatch, RetrievalBatch, TrainingBatch, TrainingSample, make_batch,
+    BatchStats, EncodedText, LanguageBatch, RetrievalBatch, TrainingBatch, TrainingSample,
+    make_batch,
 };
 use structured::visit_structured_samples;
 
@@ -44,6 +44,441 @@ const TOKEN_CACHE_MAGIC: &[u8; 8] = b"HERTOK01";
 const TOKEN_CACHE_INDEX_MAGIC: &[u8; 8] = b"HERTIX01";
 const TOKEN_CACHE_INDEX_BYTES: usize = 144;
 const MAX_CACHED_DOCUMENT_TOKENS: usize = 100_000_000;
+/// One malformed input record must not make training allocate an entire
+/// (possibly decompressed) multi-gigabyte source. For JSONL this bound excludes
+/// the terminal LF, matching corpus serialization limits. It remains far above
+/// supported model context sizes.
+const MAX_TRAINING_RECORD_BYTES: usize = 64 * 1024 * 1024;
+/// `TOKENIZE_BATCH` bounds dispatch overhead, while this independently bounds
+/// the raw text retained before batch tokenization.
+const MAX_TOKENIZE_BATCH_BYTES: usize = MAX_TRAINING_RECORD_BYTES;
+#[cfg(not(test))]
+const AUTHENTICATED_READ_BUFFER_BYTES: usize = 1024 * 1024;
+#[cfg(test)]
+const AUTHENTICATED_READ_BUFFER_BYTES: usize = 4 * 1024;
+
+/// The exact immutable data generation assigned to one workflow phase.
+///
+/// Both variants retain authenticated handles for the lifetime of training.
+/// Consequently, run-signature construction, planning, token-cache creation,
+/// and every epoch all refer to the same generation instead of hashing a path
+/// and reopening whatever that path happens to name later.
+#[derive(Clone)]
+pub(crate) struct PhaseDataBinding {
+    configured_path: PathBuf,
+    source: BoundPhaseData,
+}
+
+#[derive(Clone)]
+enum BoundPhaseData {
+    Corpus {
+        signature_identity: String,
+        corpus: Arc<AuthenticatedCorpus>,
+    },
+    Direct(Arc<AuthenticatedPhaseFile>),
+}
+
+impl PhaseDataBinding {
+    pub(crate) fn open(path: &Path) -> Result<Self> {
+        if let Some(corpus) = AuthenticatedCorpus::open_data_path(path)? {
+            let signature_identity = format!("sha256:{}", corpus.manifest().manifest_sha256);
+            return Ok(Self {
+                configured_path: path.to_owned(),
+                source: BoundPhaseData::Corpus {
+                    signature_identity,
+                    corpus: Arc::new(corpus),
+                },
+            });
+        }
+        Ok(Self {
+            configured_path: path.to_owned(),
+            source: BoundPhaseData::Direct(Arc::new(AuthenticatedPhaseFile::open(path)?)),
+        })
+    }
+
+    pub(crate) fn signature_identity(&self) -> &str {
+        match &self.source {
+            BoundPhaseData::Corpus {
+                signature_identity, ..
+            } => signature_identity,
+            BoundPhaseData::Direct(file) => &file.signature_identity,
+        }
+    }
+
+    pub(crate) fn authenticated_corpus(&self) -> Option<&AuthenticatedCorpus> {
+        match &self.source {
+            BoundPhaseData::Corpus { corpus, .. } => Some(corpus),
+            BoundPhaseData::Direct(_) => None,
+        }
+    }
+
+    fn configured_path(&self) -> &Path {
+        &self.configured_path
+    }
+
+    fn ensure_matches_path(&self, path: &Path) -> Result<()> {
+        ensure!(
+            path == self.configured_path(),
+            "phase data binding for {} cannot be used to read {}",
+            self.configured_path().display(),
+            path.display()
+        );
+        Ok(())
+    }
+
+    /// Reject replacement, symlinking, or in-place mutation of the published
+    /// input, including on token-cache paths that do not need source bytes.
+    pub(crate) fn ensure_still_published(&self) -> Result<()> {
+        match &self.source {
+            BoundPhaseData::Corpus { corpus, .. } => corpus.ensure_still_published(),
+            BoundPhaseData::Direct(file) => file.ensure_still_published(),
+        }
+    }
+
+    /// Stream every source through authenticated handles. The final identity
+    /// check deliberately runs even when the visitor errors or exits early.
+    fn with_readers(
+        &self,
+        path: &Path,
+        mut visit: impl FnMut(&Path, &mut dyn BufRead) -> Result<bool>,
+    ) -> Result<bool> {
+        self.ensure_matches_path(path)?;
+        self.ensure_still_published()?;
+        let result = match &self.source {
+            BoundPhaseData::Corpus { corpus, .. } => (|| -> Result<bool> {
+                let mut keep_going = true;
+                for index in 0..corpus.shard_count() {
+                    keep_going = corpus.with_verified_shard(index, |source_path, file| {
+                        with_decoded_reader(source_path, file, |reader| visit(source_path, reader))
+                    })?;
+                    if !keep_going {
+                        break;
+                    }
+                }
+                Ok(keep_going)
+            })(),
+            BoundPhaseData::Direct(file) => {
+                file.with_reader(|source_path, reader| visit(source_path, reader))
+            }
+        };
+        // Integrity errors take precedence over visitor errors: callers must
+        // never mistake an errored or shortened pass over mutated data for a
+        // harmless application-level failure.
+        self.ensure_still_published()?;
+        result
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct StablePhaseFileIdentity {
+    length: u64,
+    modified: Option<std::time::SystemTime>,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    mode: u32,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+}
+
+impl StablePhaseFileIdentity {
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt;
+
+        Self {
+            length: metadata.len(),
+            modified: metadata.modified().ok(),
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            mode: metadata.mode(),
+            #[cfg(unix)]
+            changed_seconds: metadata.ctime(),
+            #[cfg(unix)]
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+}
+
+struct AuthenticatedPhaseFile {
+    path: PathBuf,
+    identity: StablePhaseFileIdentity,
+    signature_identity: String,
+    file: Mutex<File>,
+}
+
+impl AuthenticatedPhaseFile {
+    #[cfg(not(unix))]
+    fn open(path: &Path) -> Result<Self> {
+        anyhow::bail!(
+            "exact direct phase-data binding for {} requires stable Unix file identities; use an immutable prepared-corpus manifest on this platform",
+            path.display()
+        )
+    }
+
+    #[cfg(unix)]
+    fn open(path: &Path) -> Result<Self> {
+        let mut file = open_published_phase_file(path)?;
+        let identity = StablePhaseFileIdentity::from_metadata(&file.metadata()?);
+        let signature_identity = hash_stable_phase_file(&mut file, &identity, path)?;
+        ensure_published_phase_file(path, &identity)?;
+        Ok(Self {
+            path: path.to_owned(),
+            identity,
+            signature_identity,
+            file: Mutex::new(file),
+        })
+    }
+
+    fn with_reader(
+        &self,
+        read: impl FnOnce(&Path, &mut dyn BufRead) -> Result<bool>,
+    ) -> Result<bool> {
+        let mut file = self
+            .file
+            .lock()
+            .map_err(|_| anyhow::anyhow!("phase-data handle lock was poisoned"))?;
+        file.rewind()
+            .with_context(|| format!("failed to rewind phase data {}", self.path.display()))?;
+        let verified = VerifiedPhaseReader {
+            file: &mut file,
+            expected: &self.identity,
+            path: &self.path,
+        };
+        with_decoded_reader(&self.path, verified, |reader| read(&self.path, reader))
+    }
+
+    fn ensure_still_published(&self) -> Result<()> {
+        let file = self
+            .file
+            .lock()
+            .map_err(|_| anyhow::anyhow!("phase-data handle lock was poisoned"))?;
+        let observed =
+            StablePhaseFileIdentity::from_metadata(&file.metadata().with_context(|| {
+                format!("failed to inspect open phase data {}", self.path.display())
+            })?);
+        ensure!(
+            observed == self.identity,
+            "phase data {} changed in place after authentication",
+            self.path.display()
+        );
+        ensure_published_phase_file(&self.path, &self.identity)
+    }
+}
+
+/// Detect in-place mutation before any bytes from that read reach parsing,
+/// tokenization, prefetch, or a durable trainer checkpoint. A large outer
+/// buffer keeps this to roughly one `fstat` per MiB for uncompressed inputs.
+struct VerifiedPhaseReader<'a> {
+    file: &'a mut File,
+    expected: &'a StablePhaseFileIdentity,
+    path: &'a Path,
+}
+
+impl Read for VerifiedPhaseReader<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        let read = self.file.read(buffer)?;
+        let observed = StablePhaseFileIdentity::from_metadata(&self.file.metadata()?);
+        if observed != *self.expected {
+            return Err(std::io::Error::other(format!(
+                "phase data {} changed in place while it was streamed",
+                self.path.display()
+            )));
+        }
+        Ok(read)
+    }
+}
+
+#[cfg(unix)]
+fn open_published_phase_file(path: &Path) -> Result<File> {
+    let inspected = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect phase data {}", path.display()))?;
+    ensure!(
+        inspected.file_type().is_file() && !inspected.file_type().is_symlink(),
+        "phase data {} must be a regular non-symlink file",
+        path.display()
+    );
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .with_context(|| format!("failed to securely open phase data {}", path.display()))?;
+    let opened = file.metadata()?;
+    ensure!(
+        opened.file_type().is_file(),
+        "opened phase data {} is not a regular file",
+        path.display()
+    );
+    ensure!(
+        StablePhaseFileIdentity::from_metadata(&opened)
+            == StablePhaseFileIdentity::from_metadata(&inspected),
+        "phase data {} changed while it was opened",
+        path.display()
+    );
+    Ok(file)
+}
+
+#[cfg(unix)]
+fn ensure_published_phase_file(path: &Path, expected: &StablePhaseFileIdentity) -> Result<()> {
+    let published = open_published_phase_file(path)?;
+    ensure!(
+        StablePhaseFileIdentity::from_metadata(&published.metadata()?) == *expected,
+        "published phase data {} changed after authentication",
+        path.display()
+    );
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn ensure_published_phase_file(path: &Path, _expected: &StablePhaseFileIdentity) -> Result<()> {
+    anyhow::bail!(
+        "exact direct phase-data binding for {} requires stable Unix file identities",
+        path.display()
+    )
+}
+
+#[cfg(unix)]
+fn hash_stable_phase_file(
+    file: &mut File,
+    expected: &StablePhaseFileIdentity,
+    path: &Path,
+) -> Result<String> {
+    file.rewind()?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut bytes_read = 0_u64;
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("failed to hash phase data {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        bytes_read = bytes_read
+            .checked_add(u64::try_from(read)?)
+            .context("phase-data byte count overflows u64")?;
+        hasher.update(&buffer[..read]);
+    }
+    let observed = StablePhaseFileIdentity::from_metadata(&file.metadata()?);
+    ensure!(
+        observed == *expected && bytes_read == expected.length,
+        "phase data {} changed while its run-signature identity was computed",
+        path.display()
+    );
+    file.rewind()?;
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
+fn with_decoded_reader<T, R: Read>(
+    path: &Path,
+    reader: R,
+    read: impl FnOnce(&mut dyn BufRead) -> Result<T>,
+) -> Result<T> {
+    if path.extension().is_some_and(|extension| extension == "zst") {
+        let compressed = BufReader::with_capacity(AUTHENTICATED_READ_BUFFER_BYTES, reader);
+        let decoder = zstd::stream::read::Decoder::with_buffer(compressed)
+            .with_context(|| format!("failed to open zstd stream {}", path.display()))?;
+        let mut reader = BufReader::new(decoder);
+        read(&mut reader)
+    } else {
+        let mut reader = BufReader::with_capacity(AUTHENTICATED_READ_BUFFER_BYTES, reader);
+        read(&mut reader)
+    }
+}
+
+fn read_training_jsonl_record_bounded<'a>(
+    reader: &mut (impl BufRead + ?Sized),
+    output: &'a mut Vec<u8>,
+    maximum_bytes: usize,
+    path: &Path,
+    line_number: usize,
+) -> Result<Option<&'a str>> {
+    ensure!(
+        maximum_bytes > 0,
+        "training JSONL record byte limit must be positive"
+    );
+    output.clear();
+    let capture_bytes = maximum_bytes
+        .checked_add(1)
+        .context("training JSONL record byte limit overflows usize")?;
+    let read = reader
+        .take(u64::try_from(capture_bytes).context("training JSONL record byte limit exceeds u64")?)
+        .read_until(b'\n', output)
+        .with_context(|| {
+            format!(
+                "failed to read training JSONL record at {}:{line_number}",
+                path.display()
+            )
+        })?;
+    if read == 0 {
+        return Ok(None);
+    }
+    let record_bytes = output
+        .len()
+        .checked_sub(usize::from(output.last() == Some(&b'\n')))
+        .context("training JSONL record byte count underflows usize")?;
+    ensure!(
+        record_bytes <= maximum_bytes,
+        "training JSONL record at {}:{line_number} exceeds the maximum of {maximum_bytes} bytes before its newline",
+        path.display()
+    );
+    let record = std::str::from_utf8(output).with_context(|| {
+        format!(
+            "training JSONL record at {}:{line_number} is not UTF-8",
+            path.display()
+        )
+    })?;
+    Ok(Some(record))
+}
+
+pub(super) fn read_training_jsonl_record<'a>(
+    reader: &mut (impl BufRead + ?Sized),
+    output: &'a mut Vec<u8>,
+    path: &Path,
+    line_number: usize,
+) -> Result<Option<&'a str>> {
+    read_training_jsonl_record_bounded(reader, output, MAX_TRAINING_RECORD_BYTES, path, line_number)
+}
+
+fn read_training_text_document_bounded(
+    reader: &mut (impl BufRead + ?Sized),
+    maximum_bytes: usize,
+    path: &Path,
+) -> Result<String> {
+    ensure!(
+        maximum_bytes > 0,
+        "training text document byte limit must be positive"
+    );
+    let capture_bytes = maximum_bytes
+        .checked_add(1)
+        .context("training text document byte limit overflows usize")?;
+    let mut document = Vec::new();
+    reader
+        .take(
+            u64::try_from(capture_bytes)
+                .context("training text document byte limit exceeds u64")?,
+        )
+        .read_to_end(&mut document)
+        .with_context(|| format!("failed to read training text document {}", path.display()))?;
+    ensure!(
+        document.len() <= maximum_bytes,
+        "training text document {} exceeds the maximum of {maximum_bytes} bytes",
+        path.display()
+    );
+    String::from_utf8(document).with_context(|| {
+        format!(
+            "training text document {} is not valid UTF-8",
+            path.display()
+        )
+    })
+}
 
 struct TokenCacheWriter {
     writer: BufWriter<File>,
@@ -110,6 +545,20 @@ impl TokenCacheWriter {
         }
         write_token_cache_index_atomic(&self.location, &index.encode())?;
         self.index_invalidated = false;
+        Ok(())
+    }
+
+    /// Discard all derived records after an authoritative-input integrity
+    /// failure. Keeping even an unindexed prefix is unsafe: a later retry would
+    /// replay it and skip the corresponding source documents.
+    fn reset_to_empty(&mut self) -> Result<()> {
+        self.writer.flush().context("flushing failed token cache")?;
+        reset_open_token_cache(&self.location, self.writer.get_mut())?;
+        self.digest = Sha256::new();
+        self.digest.update(TOKEN_CACHE_MAGIC);
+        self.documents = 0;
+        self.stream_tokens = 0;
+        self.index_invalidated = true;
         Ok(())
     }
 }
@@ -412,6 +861,17 @@ impl TokenCacheLocation {
         }
     }
 
+    fn open_existing_cache_for_reset(&self) -> Result<Option<File>> {
+        #[cfg(unix)]
+        {
+            self.open_child(&self.cache_name, libc::O_RDWR)
+        }
+        #[cfg(not(unix))]
+        {
+            self.open_child_portable(&self.cache_name, false, true)
+        }
+    }
+
     fn open_index(&self) -> Result<Option<File>> {
         #[cfg(unix)]
         {
@@ -596,6 +1056,51 @@ fn invalidate_token_cache_index(location: &TokenCacheLocation) -> Result<()> {
     Ok(())
 }
 
+fn reset_token_cache_path(path: &Path) -> Result<()> {
+    let Some(location) = TokenCacheLocation::open(path, false)? else {
+        return Ok(());
+    };
+    let Some(mut cache) = location.open_existing_cache_for_reset()? else {
+        invalidate_token_cache_index(&location)?;
+        return Ok(());
+    };
+    reset_open_token_cache(&location, &mut cache)
+}
+
+fn reset_open_token_cache(location: &TokenCacheLocation, cache: &mut File) -> Result<()> {
+    invalidate_token_cache_index(location)?;
+    cache.set_len(0).context("truncating failed token cache")?;
+    cache
+        .seek(SeekFrom::Start(0))
+        .context("rewinding failed token cache")?;
+    cache
+        .write_all(TOKEN_CACHE_MAGIC)
+        .context("rewriting failed token-cache header")?;
+    cache.sync_all().context("syncing reset token cache")
+}
+
+fn ensure_token_cache_unchanged(
+    reader: &mut BufReader<File>,
+    expected: &TokenCacheFileIdentity,
+    location: &TokenCacheLocation,
+    path: &Path,
+) -> Result<()> {
+    let observed = TokenCacheFileIdentity::from_metadata(&reader.get_ref().metadata()?);
+    if observed != *expected {
+        reset_open_token_cache(location, reader.get_mut()).with_context(|| {
+            format!(
+                "failed to reset {} after detecting an in-place mutation",
+                path.display()
+            )
+        })?;
+        anyhow::bail!(
+            "token cache {} changed while it was replayed; the derived cache was reset",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
 /// Return the causal sample count from a durably completed token cache without
 /// replaying its records. Missing, torn, stale, or corrupt metadata returns
 /// `None`, so callers can safely fall back to [`count_samples`].
@@ -628,10 +1133,12 @@ pub(crate) fn indexed_causal_sample_count(
 fn replay_token_cache(
     path: &Path,
     eos_token: u32,
+    vocab_size: usize,
     packer: &mut SamplePacker,
     count: &mut usize,
     visit: &mut impl FnMut(TrainingSample) -> Result<bool>,
 ) -> Result<(usize, bool, Option<TokenCacheWriter>, bool)> {
+    ensure!(vocab_size > 0, "tokenizer vocabulary must not be empty");
     let location = TokenCacheLocation::open(path, true)?
         .context("token-cache directory disappeared while it was opened")?;
     let mut cache = location
@@ -674,16 +1181,36 @@ fn replay_token_cache(
         cache.write_all(TOKEN_CACHE_MAGIC)?;
         cache.sync_all()?;
     }
+    let replay_identity = TokenCacheFileIdentity::from_metadata(&cache.metadata()?);
     cache.rewind()?;
 
     let mut reader = BufReader::new(cache);
     let mut magic = [0_u8; 8];
     reader.read_exact(&mut magic)?;
-    ensure!(
-        &magic == TOKEN_CACHE_MAGIC,
-        "token cache {} has an unsupported format",
-        path.display()
-    );
+    if &magic != TOKEN_CACHE_MAGIC {
+        // Token caches are derived data. An unrecognized header cannot be
+        // replayed safely, but it also must not permanently wedge training:
+        // reset it and rebuild from the authenticated authoritative corpus in
+        // this invocation.
+        let mut cache = reader.into_inner();
+        reset_open_token_cache(&location, &mut cache)?;
+        cache.seek(SeekFrom::End(0))?;
+        let mut digest = Sha256::new();
+        digest.update(TOKEN_CACHE_MAGIC);
+        return Ok((
+            0,
+            true,
+            Some(TokenCacheWriter {
+                writer: BufWriter::new(cache),
+                location,
+                digest,
+                documents: 0,
+                stream_tokens: 0,
+                index_invalidated: true,
+            }),
+            false,
+        ));
+    }
     let mut valid_bytes = TOKEN_CACHE_MAGIC.len() as u64;
     let mut documents = 0usize;
     let mut stream_tokens = 0_u64;
@@ -722,6 +1249,19 @@ fn replay_token_cache(
             }
             return Err(error.into());
         }
+        let invalid_token = bytes
+            .chunks_exact(4)
+            .map(|bytes| u32::from_le_bytes(bytes.try_into().expect("four-byte token chunk")))
+            .find(|token| usize::try_from(*token).map_or(true, |token| token >= vocab_size));
+        if let Some(token) = invalid_token {
+            let mut cache = reader.into_inner();
+            reset_open_token_cache(&location, &mut cache)?;
+            anyhow::bail!(
+                "token cache {} contains token id {token} outside tokenizer vocabulary size {vocab_size}; the derived cache was reset and will be rebuilt on retry",
+                path.display()
+            );
+        }
+        ensure_token_cache_unchanged(&mut reader, &replay_identity, &location, path)?;
         valid_bytes = valid_bytes
             .checked_add(4 + byte_len as u64)
             .context("token cache offset overflows u64")?;
@@ -737,10 +1277,17 @@ fn replay_token_cache(
             .chunks_exact(4)
             .map(|bytes| i64::from(u32::from_le_bytes(bytes.try_into().unwrap())))
             .chain(std::iter::once(i64::from(eos_token)));
-        if !packer.push(tokens, count, visit)? {
+        let keep_going = packer.push(tokens, count, visit);
+        // A visitor can stop or fail before the whole-cache digest check. The
+        // opened cache incarnation must therefore still be checked at that
+        // boundary so a concurrent in-place mutation cannot affect a model
+        // update and then hide behind the early return.
+        ensure_token_cache_unchanged(&mut reader, &replay_identity, &location, path)?;
+        if !keep_going? {
             return Ok((documents, false, None, false));
         }
     }
+    ensure_token_cache_unchanged(&mut reader, &replay_identity, &location, path)?;
     let mut cache = reader.into_inner();
     let verified_complete = if let Some(expected) = expected_index.take() {
         ensure!(
@@ -810,18 +1357,6 @@ fn replay_token_cache(
         }),
         false,
     ))
-}
-
-fn open_data(path: &Path) -> Result<Box<dyn BufRead>> {
-    let file = File::open(path)
-        .with_context(|| format!("failed to open training data {}", path.display()))?;
-    if path.extension().is_some_and(|ext| ext == "zst") {
-        let decoder = zstd::stream::read::Decoder::new(file)
-            .with_context(|| format!("failed to open zstd stream {}", path.display()))?;
-        Ok(Box::new(BufReader::new(decoder)))
-    } else {
-        Ok(Box::new(BufReader::new(file)))
-    }
 }
 
 struct ShuffleBuffer {
@@ -903,71 +1438,91 @@ impl SamplePacker {
     }
 }
 
-fn push_documents(
-    documents: &mut Vec<String>,
-    tokenizer: &Tokenizer,
-    packer: &mut SamplePacker,
-    count: &mut usize,
-    visit: &mut impl FnMut(TrainingSample) -> Result<bool>,
-    cache: &mut Option<TokenCacheWriter>,
-) -> Result<bool> {
-    if documents.is_empty() {
-        return Ok(true);
-    }
-    let encodings = tokenizer.encode_batch(std::mem::take(documents), false)?;
-    for tokens in encodings {
-        if let Some(cache) = cache {
-            cache.append(&tokens)?;
+struct DocumentTokenizationBatch {
+    documents: Vec<String>,
+    bytes: usize,
+}
+
+impl DocumentTokenizationBatch {
+    fn new() -> Self {
+        Self {
+            documents: Vec::with_capacity(TOKENIZE_BATCH),
+            bytes: 0,
         }
-        let tokens = tokens
-            .into_iter()
-            .map(i64::from)
-            .chain(std::iter::once(i64::from(tokenizer.eos_token_id())));
-        if !packer.push(tokens, count, visit)? {
+    }
+
+    fn flush(
+        &mut self,
+        tokenizer: &Tokenizer,
+        packer: &mut SamplePacker,
+        count: &mut usize,
+        visit: &mut impl FnMut(TrainingSample) -> Result<bool>,
+        cache: &mut Option<TokenCacheWriter>,
+    ) -> Result<bool> {
+        if self.documents.is_empty() {
+            debug_assert_eq!(self.bytes, 0);
+            return Ok(true);
+        }
+        let documents = std::mem::take(&mut self.documents);
+        self.bytes = 0;
+        let encodings = tokenizer.encode_batch(documents, false)?;
+        for tokens in encodings {
+            if let Some(cache) = cache {
+                cache.append(&tokens)?;
+            }
+            let tokens = tokens
+                .into_iter()
+                .map(i64::from)
+                .chain(std::iter::once(i64::from(tokenizer.eos_token_id())));
+            if !packer.push(tokens, count, visit)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn queue(
+        &mut self,
+        document: String,
+        tokenizer: &Tokenizer,
+        packer: &mut SamplePacker,
+        count: &mut usize,
+        visit: &mut impl FnMut(TrainingSample) -> Result<bool>,
+        cache: &mut Option<TokenCacheWriter>,
+    ) -> Result<bool> {
+        ensure!(
+            document.len() <= MAX_TOKENIZE_BATCH_BYTES,
+            "training document is {} bytes, exceeding the tokenization batch limit of {MAX_TOKENIZE_BATCH_BYTES}",
+            document.len()
+        );
+        let prospective_bytes = self
+            .bytes
+            .checked_add(document.len())
+            .context("tokenization batch byte count overflows usize")?;
+        if !self.documents.is_empty()
+            && prospective_bytes > MAX_TOKENIZE_BATCH_BYTES
+            && !self.flush(tokenizer, packer, count, visit, cache)?
+        {
             return Ok(false);
         }
+        self.bytes = self
+            .bytes
+            .checked_add(document.len())
+            .context("tokenization batch byte count overflows usize")?;
+        self.documents.push(document);
+        if (self.documents.len() == TOKENIZE_BATCH || self.bytes >= MAX_TOKENIZE_BATCH_BYTES)
+            && !self.flush(tokenizer, packer, count, visit, cache)?
+        {
+            return Ok(false);
+        }
+        Ok(true)
     }
-    Ok(true)
 }
 
 fn is_jsonl(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.ends_with(".jsonl") || name.ends_with(".jsonl.zst"))
-}
-
-fn causal_data_paths(path: &Path) -> Result<Vec<std::path::PathBuf>> {
-    let manifest_path = if path.is_dir() {
-        Some(path.join("manifest.json"))
-    } else if path.file_name().is_some_and(|name| name == "manifest.json") {
-        Some(path.to_owned())
-    } else {
-        None
-    };
-    let Some(manifest_path) = manifest_path else {
-        return Ok(vec![path.to_owned()]);
-    };
-    let manifest: CorpusManifest = serde_json::from_slice(&fs::read(&manifest_path)?)
-        .with_context(|| format!("invalid corpus manifest {}", manifest_path.display()))?;
-    ensure!(
-        !manifest.build.shards.is_empty(),
-        "corpus manifest has no shards"
-    );
-    let root = manifest_path.parent().unwrap_or_else(|| Path::new("."));
-    manifest
-        .build
-        .shards
-        .iter()
-        .map(|shard| {
-            let shard_path = root.join(&shard.path);
-            ensure!(
-                shard_path.is_file(),
-                "corpus shard {} is missing",
-                shard_path.display()
-            );
-            Ok(shard_path)
-        })
-        .collect()
 }
 
 fn token_array(
@@ -1010,22 +1565,104 @@ fn token_array(
         .map(Some)
 }
 
+struct CausalVisitOutcome {
+    count: usize,
+    cache: Option<TokenCacheWriter>,
+    publish_cache: bool,
+}
+
+impl CausalVisitOutcome {
+    fn reset_cache(&mut self, token_cache: Option<&Path>) -> Result<()> {
+        match &mut self.cache {
+            Some(cache) => cache.reset_to_empty(),
+            None => match token_cache {
+                Some(path) => reset_token_cache_path(path),
+                None => Ok(()),
+            },
+        }
+    }
+}
+
 fn visit_causal_samples(
     path: &Path,
     tokenizer: &Tokenizer,
     seq_len: usize,
     token_cache: Option<&Path>,
+    data_binding: &PhaseDataBinding,
     mut visit: impl FnMut(TrainingSample) -> Result<bool>,
 ) -> Result<usize> {
+    // Both checks are intentional. The first rejects a replacement already
+    // present when an epoch begins. The second covers token-cache fast paths,
+    // early visitor exits, and mutation during streaming. Reads in between use
+    // only the descriptors captured during run-signature authentication.
+    data_binding.ensure_matches_path(path)?;
+    if let Err(identity_error) = data_binding.ensure_still_published() {
+        if let Some(path) = token_cache {
+            reset_token_cache_path(path)?;
+        }
+        return Err(identity_error);
+    }
+    let mut result = visit_causal_samples_inner(
+        path,
+        tokenizer,
+        seq_len,
+        token_cache,
+        data_binding,
+        &mut visit,
+    );
+    // This check runs before inspecting `result`, so mutation is reported even
+    // if tokenization or the caller's visitor failed or stopped early.
+    if let Err(identity_error) = data_binding.ensure_still_published() {
+        match &mut result {
+            Ok(outcome) => outcome.reset_cache(token_cache)?,
+            Err(_) => {
+                // The inner path resets whenever it owns a writer. This covers
+                // failures during cache replay, before such a writer exists.
+                if let Some(path) = token_cache {
+                    reset_token_cache_path(path)?;
+                }
+            }
+        }
+        return Err(identity_error);
+    }
+    let mut outcome = result?;
+    if outcome.publish_cache
+        && let Some(cache) = &mut outcome.cache
+    {
+        cache.publish_index()?;
+        // Close the small commit window as well. If publication changes while
+        // the sidecar is being committed, revoke the completion proof before
+        // returning the integrity error.
+        if let Err(identity_error) = data_binding.ensure_still_published() {
+            cache.reset_to_empty().with_context(|| {
+                format!(
+                    "failed to reset token cache after phase-data integrity failure: {identity_error:#}"
+                )
+            })?;
+            return Err(identity_error);
+        }
+    }
+    Ok(outcome.count)
+}
+
+fn visit_causal_samples_inner(
+    path: &Path,
+    tokenizer: &Tokenizer,
+    seq_len: usize,
+    token_cache: Option<&Path>,
+    data_binding: &PhaseDataBinding,
+    visit: &mut impl FnMut(TrainingSample) -> Result<bool>,
+) -> Result<CausalVisitOutcome> {
     let mut count = 0;
     let mut packer = SamplePacker::new(seq_len);
     let (cached_documents, keep_going, mut cache, cache_complete) = match token_cache {
         Some(path) => replay_token_cache(
             path,
             tokenizer.eos_token_id(),
+            tokenizer.vocab_size(),
             &mut packer,
             &mut count,
-            &mut visit,
+            visit,
         )?,
         None => (0, true, None, false),
     };
@@ -1038,116 +1675,150 @@ fn visit_causal_samples(
         );
     }
     if !keep_going {
-        return Ok(count);
+        return Ok(CausalVisitOutcome {
+            count,
+            cache: None,
+            publish_cache: false,
+        });
     }
     if cache_complete {
-        return Ok(count);
+        return Ok(CausalVisitOutcome {
+            count,
+            cache: None,
+            publish_cache: false,
+        });
     }
     let mut document_number = 0usize;
-    let mut documents = Vec::with_capacity(TOKENIZE_BATCH);
-    for source_path in causal_data_paths(path)? {
-        let mut reader = open_data(&source_path)?;
-        if is_jsonl(&source_path) {
-            let mut line = String::new();
-            let mut line_number = 0usize;
-            loop {
-                line.clear();
-                if reader.read_line(&mut line)? == 0 {
-                    break;
-                }
-                line_number = line_number
-                    .checked_add(1)
-                    .context("JSONL line count overflows usize")?;
-                if line.trim().is_empty() {
-                    continue;
-                }
-                document_number = document_number
-                    .checked_add(1)
-                    .context("JSONL document count overflows usize")?;
-                if document_number <= cached_documents {
-                    continue;
-                }
-                let value: serde_json::Value = serde_json::from_str(&line).with_context(|| {
-                    format!("invalid JSONL at {}:{line_number}", source_path.display())
-                })?;
-                if let Some(tokens) = token_array(&value, &source_path, line_number)? {
-                    ensure!(
-                        tokens
-                            .iter()
-                            .all(|token| (*token as usize) < tokenizer.vocab_size()),
-                        "tokenized corpus row at {}:{line_number} contains a token outside vocabulary size {}",
-                        source_path.display(),
-                        tokenizer.vocab_size()
-                    );
-                    if !push_documents(
-                        &mut documents,
-                        tokenizer,
-                        &mut packer,
-                        &mut count,
-                        &mut visit,
-                        &mut cache,
-                    )? {
-                        return Ok(count);
+    let mut documents = DocumentTokenizationBatch::new();
+    let scan_result = (|| -> Result<bool> {
+        let fully_read = data_binding.with_readers(path, |source_path, reader| {
+            if is_jsonl(source_path) {
+                let mut line = Vec::new();
+                let mut line_number = 0usize;
+                loop {
+                    let next_line_number = line_number
+                        .checked_add(1)
+                        .context("JSONL line count overflows usize")?;
+                    let Some(line) = read_training_jsonl_record(
+                        reader,
+                        &mut line,
+                        source_path,
+                        next_line_number,
+                    )?
+                    else {
+                        break;
+                    };
+                    line_number = next_line_number;
+                    if line.trim().is_empty() {
+                        continue;
                     }
-                    if let Some(cache) = &mut cache {
-                        cache.append(&tokens)?;
+                    document_number = document_number
+                        .checked_add(1)
+                        .context("JSONL document count overflows usize")?;
+                    if document_number <= cached_documents {
+                        continue;
                     }
-                    if !packer.push(
-                        tokens
-                            .into_iter()
-                            .map(i64::from)
-                            .chain(std::iter::once(i64::from(tokenizer.eos_token_id()))),
-                        &mut count,
-                        &mut visit,
-                    )? {
-                        return Ok(count);
-                    }
-                } else {
-                    let document = required_string(&value, "text", &source_path, line_number)?;
-                    documents.push(document.to_owned());
-                    if documents.len() == TOKENIZE_BATCH
-                        && !push_documents(
-                            &mut documents,
+                    let value: serde_json::Value =
+                        serde_json::from_str(line).with_context(|| {
+                            format!("invalid JSONL at {}:{line_number}", source_path.display())
+                        })?;
+                    if let Some(tokens) = token_array(&value, source_path, line_number)? {
+                        ensure!(
+                            tokens
+                                .iter()
+                                .all(|token| (*token as usize) < tokenizer.vocab_size()),
+                            "tokenized corpus row at {}:{line_number} contains a token outside vocabulary size {}",
+                            source_path.display(),
+                            tokenizer.vocab_size()
+                        );
+                        if !documents.flush(
                             tokenizer,
                             &mut packer,
                             &mut count,
-                            &mut visit,
+                            visit,
                             &mut cache,
-                        )?
-                    {
-                        return Ok(count);
+                        )? {
+                            return Ok(false);
+                        }
+                        if let Some(cache) = &mut cache {
+                            cache.append(&tokens)?;
+                        }
+                        if !packer.push(
+                            tokens
+                                .into_iter()
+                                .map(i64::from)
+                                .chain(std::iter::once(i64::from(tokenizer.eos_token_id()))),
+                            &mut count,
+                            visit,
+                        )? {
+                            return Ok(false);
+                        }
+                    } else {
+                        let document = required_string(&value, "text", source_path, line_number)?;
+                        if !documents.queue(
+                            document.to_owned(),
+                            tokenizer,
+                            &mut packer,
+                            &mut count,
+                            visit,
+                            &mut cache,
+                        )? {
+                            return Ok(false);
+                        }
+                    }
+                }
+            } else {
+                document_number = document_number
+                    .checked_add(1)
+                    .context("document count overflows usize")?;
+                if document_number > cached_documents {
+                    let document = read_training_text_document_bounded(
+                        reader,
+                        MAX_TRAINING_RECORD_BYTES,
+                        source_path,
+                    )?;
+                    if !documents.queue(
+                        document,
+                        tokenizer,
+                        &mut packer,
+                        &mut count,
+                        visit,
+                        &mut cache,
+                    )? {
+                        return Ok(false);
                     }
                 }
             }
-        } else {
-            document_number = document_number
-                .checked_add(1)
-                .context("document count overflows usize")?;
-            if document_number > cached_documents {
-                let mut document = String::new();
-                reader.read_to_string(&mut document)?;
-                documents.push(document);
-            }
+            Ok(true)
+        })?;
+        if !fully_read {
+            return Ok(false);
         }
-    }
-    if !push_documents(
-        &mut documents,
-        tokenizer,
-        &mut packer,
-        &mut count,
-        &mut visit,
-        &mut cache,
-    )? {
-        return Ok(count);
-    }
-    ensure!(
-        document_number >= cached_documents,
-        "authoritative corpus has {document_number} documents but token cache has {cached_documents}; remove the stale cache"
-    );
-    if let Some(cache) = &mut cache {
-        cache.publish_index()?;
-    }
-    Ok(count)
+        if !documents.flush(tokenizer, &mut packer, &mut count, visit, &mut cache)? {
+            return Ok(false);
+        }
+        ensure!(
+            document_number >= cached_documents,
+            "authoritative corpus has {document_number} documents but token cache has {cached_documents}; remove the stale cache"
+        );
+        Ok(true)
+    })();
+    let publish_cache = match scan_result {
+        Ok(fully_read) => fully_read,
+        Err(error) => {
+            if let Some(cache) = &mut cache {
+                cache.reset_to_empty()?;
+            } else if let Some(path) = token_cache {
+                reset_token_cache_path(path)?;
+            }
+            return Err(error);
+        }
+    };
+    Ok(CausalVisitOutcome {
+        count,
+        cache,
+        publish_cache,
+    })
 }
 
 fn required_string<'a>(
@@ -1176,18 +1847,37 @@ fn required_string<'a>(
 /// Visit fixed-shape objective samples in source order.
 fn visit_samples_in_order(
     path: &Path,
-    objective: &ObjectiveConfig,
+    objective: &TaskConfig,
     tokenizer: &Tokenizer,
     seq_len: usize,
     token_cache: Option<&Path>,
-    visit: impl FnMut(TrainingSample) -> Result<bool>,
+    data_binding: &PhaseDataBinding,
+    mut visit: impl FnMut(TrainingSample) -> Result<bool>,
 ) -> Result<usize> {
     ensure!(seq_len > 0, "sequence_length must be positive");
     match objective {
-        ObjectiveConfig::CausalLm => {
-            visit_causal_samples(path, tokenizer, seq_len, token_cache, visit)
+        TaskConfig::CausalLm {} => {
+            visit_causal_samples(path, tokenizer, seq_len, token_cache, data_binding, visit)
         }
-        _ => visit_structured_samples(path, objective, tokenizer, seq_len, visit),
+        _ => {
+            ensure!(
+                data_binding.authenticated_corpus().is_none(),
+                "prepared corpus manifests are only valid for causal-LM phases"
+            );
+            let mut count = None;
+            data_binding.with_readers(path, |source_path, reader| {
+                count = Some(visit_structured_samples(
+                    source_path,
+                    reader,
+                    objective,
+                    tokenizer,
+                    seq_len,
+                    &mut visit,
+                )?);
+                Ok(true)
+            })?;
+            count.context("direct structured phase data produced no reader")
+        }
     }
 }
 
@@ -1196,11 +1886,12 @@ pub(crate) struct SampleStreamConfig<'a> {
     pub(crate) shuffle_buffer: usize,
     pub(crate) seed: u64,
     pub(crate) token_cache: Option<&'a Path>,
+    pub(crate) data_binding: &'a PhaseDataBinding,
 }
 
 pub(crate) fn visit_samples(
     path: &Path,
-    objective: &ObjectiveConfig,
+    objective: &TaskConfig,
     tokenizer: &Tokenizer,
     config: SampleStreamConfig<'_>,
     mut visit: impl FnMut(TrainingSample) -> Result<bool>,
@@ -1212,6 +1903,7 @@ pub(crate) fn visit_samples(
             tokenizer,
             config.seq_len,
             config.token_cache,
+            config.data_binding,
             visit,
         );
     }
@@ -1224,6 +1916,7 @@ pub(crate) fn visit_samples(
         tokenizer,
         config.seq_len,
         config.token_cache,
+        config.data_binding,
         |sample| {
             if let Some(sample) = shuffler.push(sample) {
                 keep_going = visit(sample)?;
@@ -1244,24 +1937,323 @@ pub(crate) fn visit_samples(
 
 pub(crate) fn count_samples(
     path: &Path,
-    objective: &ObjectiveConfig,
+    objective: &TaskConfig,
     tokenizer: &Tokenizer,
     seq_len: usize,
     token_cache: Option<&Path>,
+    data_binding: &PhaseDataBinding,
 ) -> Result<usize> {
-    visit_samples_in_order(path, objective, tokenizer, seq_len, token_cache, |_| {
-        Ok(true)
-    })
+    visit_samples_in_order(
+        path,
+        objective,
+        tokenizer,
+        seq_len,
+        token_cache,
+        data_binding,
+        |_| Ok(true),
+    )
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::fs;
-    use std::io::{Cursor, Read};
+    use std::io::Cursor;
 
     use burn::tensor::Device;
+    use hermes_train::corpus::{
+        CORPUS_SCHEMA_VERSION, ClassificationConfig, CorpusBuildConfig, CorpusPipeline,
+        CorpusTokenizer, DeduplicationConfig, DiscoveryConfig, DiscoveryHit, DiscoveryPage,
+        DiscoveryQuery, InMemoryDeduplicator, InlineRecordMaterializer, NormalizationConfig,
+        RepetitionConfig, SearchBackend, ShardingConfig, SourceSnapshot, TokenTarget,
+        TokenizerSnapshot,
+    };
+    use hermes_train::task::{TaskAdapter, TaskExample};
+    use serde_json::Value;
 
     use super::*;
+
+    #[test]
+    fn bounded_training_jsonl_reader_accepts_exact_limit_and_stops_at_delimiter() {
+        let mut input = BufReader::new(Cursor::new(b"12345678\n{}\n"));
+        let mut record = Vec::new();
+        assert_eq!(
+            read_training_jsonl_record_bounded(
+                &mut input,
+                &mut record,
+                8,
+                Path::new("training.jsonl"),
+                1,
+            )
+            .unwrap(),
+            Some("12345678\n")
+        );
+        assert_eq!(
+            read_training_jsonl_record_bounded(
+                &mut input,
+                &mut record,
+                8,
+                Path::new("training.jsonl"),
+                2,
+            )
+            .unwrap(),
+            Some("{}\n")
+        );
+    }
+
+    #[test]
+    fn bounded_training_jsonl_reader_captures_only_one_byte_past_limit() {
+        let mut input = BufReader::new(Cursor::new(b"123456789trailing"));
+        let mut record = Vec::new();
+        let error = read_training_jsonl_record_bounded(
+            &mut input,
+            &mut record,
+            8,
+            Path::new("oversized.jsonl"),
+            7,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("oversized.jsonl:7"), "{error}");
+        assert!(error.contains("maximum of 8 bytes"), "{error}");
+        assert_eq!(record.len(), 9);
+    }
+
+    #[test]
+    fn bounded_training_jsonl_reader_rejects_malformed_utf8() {
+        let mut input = BufReader::new(Cursor::new(b"{\"text\":\"\xff\"}\n"));
+        let mut record = Vec::new();
+        let error = read_training_jsonl_record_bounded(
+            &mut input,
+            &mut record,
+            32,
+            Path::new("invalid.jsonl"),
+            3,
+        )
+        .unwrap_err();
+        let error = format!("{error:#}");
+
+        assert!(error.contains("invalid.jsonl:3"), "{error}");
+        assert!(error.contains("not UTF-8"), "{error}");
+    }
+
+    #[test]
+    fn bounded_training_text_reader_preserves_one_multiline_document_at_the_limit() {
+        let mut input = BufReader::new(Cursor::new(b"one\ntwo\n"));
+        assert_eq!(
+            read_training_text_document_bounded(&mut input, 8, Path::new("document.txt")).unwrap(),
+            "one\ntwo\n"
+        );
+    }
+
+    #[test]
+    fn bounded_training_text_reader_stops_one_byte_past_the_limit() {
+        let mut input = BufReader::new(Cursor::new(b"123456789trailing"));
+        let error = read_training_text_document_bounded(&mut input, 8, Path::new("oversized.txt"))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("oversized.txt"), "{error}");
+        assert!(error.contains("maximum of 8 bytes"), "{error}");
+    }
+
+    #[test]
+    fn bounded_training_text_reader_rejects_malformed_utf8() {
+        let mut input = BufReader::new(Cursor::new(b"text-\xff"));
+        let error = read_training_text_document_bounded(&mut input, 8, Path::new("invalid.txt"))
+            .unwrap_err();
+        let error = format!("{error:#}");
+
+        assert!(error.contains("invalid.txt"), "{error}");
+        assert!(error.contains("not valid UTF-8"), "{error}");
+    }
+
+    #[test]
+    fn malformed_jsonl_utf8_resets_a_partial_token_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_path = dir.path().join("data.jsonl");
+        let cache_path = dir.path().join("tokens.bin");
+        let tokenizer = write_test_tokenizer(dir.path());
+        fs::write(&data_path, b"{\"tokens\":[1,2]}\n{\"text\":\"\xff\"}\n").unwrap();
+        let binding = PhaseDataBinding::open(&data_path).unwrap();
+
+        let error = visit_causal_samples(
+            &data_path,
+            &tokenizer,
+            2,
+            Some(&cache_path),
+            &binding,
+            |_| Ok(true),
+        )
+        .unwrap_err();
+        let error = format!("{error:#}");
+
+        assert!(error.contains("data.jsonl:2"), "{error}");
+        assert!(error.contains("not UTF-8"), "{error}");
+        assert_eq!(fs::read(&cache_path).unwrap(), TOKEN_CACHE_MAGIC);
+        assert!(!token_cache_index_path(&cache_path).exists());
+    }
+
+    #[test]
+    fn structured_training_uses_the_bounded_utf8_reader() {
+        let dir = tempfile::tempdir().unwrap();
+        let tokenizer = write_test_tokenizer(dir.path());
+        let task = TaskConfig::Summarization {
+            instruction: "Summarize.".into(),
+        };
+        let mut reader = BufReader::new(Cursor::new(b"{\"document\":\"\xff\"}\n"));
+
+        let error = visit_structured_samples(
+            Path::new("structured.jsonl"),
+            &mut reader,
+            &task,
+            &tokenizer,
+            64,
+            |_| Ok(true),
+        )
+        .unwrap_err();
+        let error = format!("{error:#}");
+
+        assert!(error.contains("structured.jsonl:1"), "{error}");
+        assert!(error.contains("not UTF-8"), "{error}");
+    }
+
+    #[test]
+    fn bounded_raw_text_path_remains_one_multiline_causal_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let tokenizer = write_test_tokenizer(dir.path());
+        let text = "one two three\nfour five six\n";
+        let text_path = dir.path().join("document.txt");
+        let jsonl_path = dir.path().join("document.jsonl");
+        fs::write(&text_path, text).unwrap();
+        fs::write(
+            &jsonl_path,
+            format!("{}\n", serde_json::json!({"text": text})),
+        )
+        .unwrap();
+
+        let collect = |path: &Path| {
+            let binding = PhaseDataBinding::open(path).unwrap();
+            let mut samples = Vec::new();
+            visit_causal_samples(path, &tokenizer, 4, None, &binding, |sample| {
+                let TrainingSample::Causal { tokens } = sample else {
+                    panic!("expected causal sample")
+                };
+                samples.push(tokens);
+                Ok(true)
+            })
+            .unwrap();
+            samples
+        };
+
+        let raw_samples = collect(&text_path);
+        assert!(!raw_samples.is_empty());
+        assert_eq!(raw_samples, collect(&jsonl_path));
+    }
+
+    struct OneRecordSearch;
+
+    impl SearchBackend for OneRecordSearch {
+        fn name(&self) -> &str {
+            "one_record"
+        }
+
+        fn configuration(&self) -> Result<Value> {
+            Ok(serde_json::json!({"type": "one_record"}))
+        }
+
+        fn snapshot(&self) -> Result<SourceSnapshot> {
+            Ok(SourceSnapshot {
+                provider: "test".into(),
+                revision: "one".into(),
+            })
+        }
+
+        fn page_size(&self) -> usize {
+            1
+        }
+
+        fn discover(
+            &self,
+            _query: &DiscoveryQuery,
+            offset: usize,
+            _limit: usize,
+        ) -> Result<DiscoveryPage> {
+            Ok(DiscoveryPage {
+                hits: if offset == 0 {
+                    vec![DiscoveryHit {
+                        record_key: "record".into(),
+                        score: 1.0,
+                        uris: Vec::new(),
+                        metadata: BTreeMap::new(),
+                        inline_text: Some("source text".into()),
+                    }]
+                } else {
+                    Vec::new()
+                },
+                total_hits: Some(1),
+                snapshot: self.snapshot()?,
+            })
+        }
+    }
+
+    struct TwoTokenCorpusTokenizer;
+
+    impl CorpusTokenizer for TwoTokenCorpusTokenizer {
+        fn snapshot(&self) -> TokenizerSnapshot {
+            TokenizerSnapshot {
+                implementation: "test".into(),
+                revision: "one".into(),
+                vocabulary_size: 16,
+            }
+        }
+
+        fn encode(&self, _text: &str) -> Result<Vec<u32>> {
+            Ok(vec![1, 2])
+        }
+    }
+
+    fn write_authenticated_test_corpus(root: &Path) -> PathBuf {
+        let config = CorpusBuildConfig {
+            version: CORPUS_SCHEMA_VERSION,
+            build_id: "bound-corpus".into(),
+            discovery: DiscoveryConfig {
+                queries: vec![DiscoveryQuery {
+                    name: "all".into(),
+                    text: "all".into(),
+                    limit: 1,
+                    parameters: BTreeMap::new(),
+                }],
+                materialization_batch_size: 1,
+            },
+            normalization: NormalizationConfig::default(),
+            deduplication: DeduplicationConfig::default(),
+            classification: ClassificationConfig::default(),
+            transformations: Vec::new(),
+            repetition: RepetitionConfig::default(),
+            token_target: TokenTarget {
+                minimum: 2,
+                desired: 2,
+                maximum: 2,
+            },
+            sharding: ShardingConfig {
+                max_tokens_per_shard: 2,
+            },
+        };
+        let mut deduplicator = InMemoryDeduplicator::new(DeduplicationConfig::default()).unwrap();
+        CorpusPipeline::new(
+            config,
+            &OneRecordSearch,
+            &InlineRecordMaterializer,
+            &TwoTokenCorpusTokenizer,
+            &mut deduplicator,
+        )
+        .unwrap()
+        .run(root)
+        .unwrap()
+        .0
+    }
 
     #[test]
     fn zstd_data_reader_streams_decompressed_text() {
@@ -1271,10 +2263,157 @@ mod tests {
         let compressed = zstd::stream::encode_all(Cursor::new(source), 1).unwrap();
         fs::write(&path, compressed).unwrap();
 
-        let mut reader = open_data(&path).unwrap();
         let mut decoded = String::new();
-        reader.read_to_string(&mut decoded).unwrap();
+        let binding = PhaseDataBinding::open(&path).unwrap();
+        binding
+            .with_readers(&path, |_path, reader| {
+                reader.read_to_string(&mut decoded)?;
+                Ok(true)
+            })
+            .unwrap();
         assert_eq!(decoded.as_bytes(), source);
+    }
+
+    #[test]
+    fn training_record_limit_applies_after_zstd_decompression() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.jsonl.zst");
+        fs::write(
+            &path,
+            zstd::stream::encode_all(Cursor::new(b"123456789decompressed"), 1).unwrap(),
+        )
+        .unwrap();
+        let binding = PhaseDataBinding::open(&path).unwrap();
+
+        let error = binding
+            .with_readers(&path, |source_path, reader| {
+                let mut record = Vec::new();
+                read_training_jsonl_record_bounded(reader, &mut record, 8, source_path, 1)?;
+                Ok(true)
+            })
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("maximum of 8 bytes"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_binding_reads_the_opened_generation_and_rejects_path_swap() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.jsonl");
+        let parked = dir.path().join("opened.jsonl");
+        let generation_a = b"{\"text\":\"generation-a\"}\n";
+        fs::write(&path, generation_a).unwrap();
+        let binding = PhaseDataBinding::open(&path).unwrap();
+
+        let mut observed = Vec::new();
+        let error = binding
+            .with_readers(&path, |_source, reader| {
+                reader.read_to_end(&mut observed)?;
+                fs::rename(&path, &parked)?;
+                fs::write(&path, b"{\"text\":\"generation-b\"}\n")?;
+                Ok(true)
+            })
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(observed, generation_a);
+        assert!(error.contains("phase data"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_zstd_binding_pins_compressed_generation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.jsonl.zst");
+        let parked = dir.path().join("opened.jsonl.zst");
+        let generation_a = b"{\"text\":\"compressed-a\"}\n";
+        fs::write(
+            &path,
+            zstd::stream::encode_all(Cursor::new(generation_a), 1).unwrap(),
+        )
+        .unwrap();
+        let binding = PhaseDataBinding::open(&path).unwrap();
+
+        let mut observed = Vec::new();
+        assert!(
+            binding
+                .with_readers(&path, |_source, reader| {
+                    reader.read_to_end(&mut observed)?;
+                    fs::rename(&path, &parked)?;
+                    fs::write(
+                        &path,
+                        zstd::stream::encode_all(Cursor::new(b"{\"text\":\"compressed-b\"}\n"), 1)?,
+                    )?;
+                    Ok(true)
+                })
+                .is_err()
+        );
+        assert_eq!(observed, generation_a);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_binding_rejects_symlink_at_bind_and_after_bind() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.jsonl");
+        let alias = dir.path().join("alias.jsonl");
+        fs::write(&target, b"{\"text\":\"target\"}\n").unwrap();
+        std::os::unix::fs::symlink(&target, &alias).unwrap();
+        assert!(PhaseDataBinding::open(&alias).is_err());
+
+        let path = dir.path().join("data.jsonl");
+        let parked = dir.path().join("parked.jsonl");
+        fs::write(&path, b"{\"text\":\"opened\"}\n").unwrap();
+        let binding = PhaseDataBinding::open(&path).unwrap();
+        fs::rename(&path, &parked).unwrap();
+        std::os::unix::fs::symlink(&parked, &path).unwrap();
+        assert!(binding.ensure_still_published().is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_binding_checks_identity_after_error_and_early_exit() {
+        for visitor_errors in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("data.jsonl");
+            fs::write(&path, b"{\"text\":\"opened\"}\n").unwrap();
+            let binding = PhaseDataBinding::open(&path).unwrap();
+
+            let result = binding.with_readers(&path, |_source, _reader| {
+                fs::write(&path, b"{\"text\":\"changed-in-place\"}\n")?;
+                if visitor_errors {
+                    anyhow::bail!("visitor failed")
+                }
+                Ok(false)
+            });
+            let error = format!("{:#}", result.unwrap_err());
+            assert!(error.contains("changed in place"), "{error}");
+            assert!(!error.contains("visitor failed"), "{error}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn corpus_binding_checks_manifest_identity_after_visitor_error() {
+        let root = tempfile::tempdir().unwrap();
+        let corpus_path = write_authenticated_test_corpus(root.path());
+        let manifest_path = corpus_path.join("manifest.json");
+        let replacement = corpus_path.join("replacement-manifest.json");
+        let binding = PhaseDataBinding::open(&corpus_path).unwrap();
+
+        let error = binding
+            .with_readers(&corpus_path, |_source, _reader| {
+                fs::write(&replacement, fs::read(&manifest_path)?)?;
+                fs::rename(&replacement, &manifest_path)?;
+                anyhow::bail!("visitor failed")
+            })
+            .unwrap_err();
+        let error = format!("{error:#}");
+
+        assert!(error.contains("corpus manifest"), "{error}");
+        assert!(!error.contains("visitor failed"), "{error}");
     }
 
     #[test]
@@ -1348,7 +2487,7 @@ mod tests {
         let mut samples = Vec::new();
         let mut count = 0;
         let (documents, keep_going, mut writer, _) =
-            replay_token_cache(&path, 0, &mut packer, &mut count, &mut |sample| {
+            replay_token_cache(&path, 0, 257, &mut packer, &mut count, &mut |sample| {
                 samples.push(sample);
                 Ok(true)
             })
@@ -1368,17 +2507,58 @@ mod tests {
         let mut replay = SamplePacker::new(3);
         let mut replay_count = 0;
         let (documents, _, _, _) =
-            replay_token_cache(&path, 0, &mut replay, &mut replay_count, &mut |_| Ok(true))
-                .unwrap();
+            replay_token_cache(&path, 0, 257, &mut replay, &mut replay_count, &mut |_| {
+                Ok(true)
+            })
+            .unwrap();
         assert_eq!(documents, 3);
         assert_eq!(replay_count, 2);
+    }
+
+    #[test]
+    fn invalid_cache_header_is_rebuilt_and_pretokenized_rows_are_cached_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_path = dir.path().join("data.jsonl");
+        let cache_path = dir.path().join("tokens.bin");
+        let tokenizer = write_test_tokenizer(dir.path());
+        fs::write(&data_path, b"{\"tokens\":[1,2]}\n{\"tokens\":[3,4]}\n").unwrap();
+        fs::write(&cache_path, b"BADTOK01untrusted-derived-bytes").unwrap();
+        let binding = PhaseDataBinding::open(&data_path).unwrap();
+
+        let collect = || {
+            let mut samples = Vec::new();
+            let count = visit_causal_samples(
+                &data_path,
+                &tokenizer,
+                2,
+                Some(&cache_path),
+                &binding,
+                |sample| {
+                    let TrainingSample::Causal { tokens } = sample else {
+                        panic!("expected causal sample")
+                    };
+                    samples.push(tokens);
+                    Ok(true)
+                },
+            )
+            .unwrap();
+            (count, samples)
+        };
+
+        let first = collect();
+        assert_eq!(first.0, 2);
+        assert_eq!(
+            indexed_causal_sample_count(&cache_path, 2).unwrap(),
+            Some(2)
+        );
+        assert_eq!(collect(), first, "cache replay changed the training stream");
     }
 
     fn write_test_token_cache(path: &Path, documents: &[&[u32]], complete: bool) {
         let mut packer = SamplePacker::new(4);
         let mut count = 0;
         let (_, keep_going, mut writer, _) =
-            replay_token_cache(path, 0, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
+            replay_token_cache(path, 0, 257, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
         assert!(keep_going);
         let writer = writer.as_mut().unwrap();
         for document in documents {
@@ -1389,6 +2569,161 @@ mod tests {
         } else {
             writer.flush().unwrap();
         }
+    }
+
+    fn write_test_tokenizer(directory: &Path) -> Tokenizer {
+        let allowed: Vec<u8> = (33..=126).chain(161..=172).chain(174..=255).collect();
+        let mut byte_to_unicode = ['\0'; 256];
+        for &byte in &allowed {
+            byte_to_unicode[byte as usize] = byte as char;
+        }
+        let mut offset = 0_u32;
+        for byte in 0..=255_u8 {
+            if byte_to_unicode[byte as usize] == '\0' {
+                byte_to_unicode[byte as usize] = char::from_u32(256 + offset).unwrap();
+                offset += 1;
+            }
+        }
+        let mut vocabulary = serde_json::Map::new();
+        for (id, piece) in byte_to_unicode.into_iter().enumerate() {
+            vocabulary.insert(piece.to_string(), serde_json::json!(id));
+        }
+        vocabulary.insert("<eos>".to_owned(), serde_json::json!(256));
+        let tokenizer = serde_json::json!({
+            "model": {
+                "type": "BPE",
+                "vocab": vocabulary,
+                "merges": [],
+            },
+            "added_tokens": [{
+                "id": 256,
+                "content": "<eos>",
+                "single_word": false,
+                "lstrip": false,
+                "rstrip": false,
+                "normalized": false,
+                "special": true,
+            }],
+            "pre_tokenizer": {
+                "type": "ByteLevel",
+                "add_prefix_space": false,
+                "use_regex": true,
+            },
+            "decoder": { "type": "ByteLevel" },
+        });
+        let path = directory.join("tokenizer.json");
+        fs::write(&path, serde_json::to_vec(&tokenizer).unwrap()).unwrap();
+        Tokenizer::from_file(path).unwrap()
+    }
+
+    fn update_causal_digest(
+        digest: &mut Sha256,
+        samples: &mut usize,
+        sample: TrainingSample,
+    ) -> Result<bool> {
+        let TrainingSample::Causal { tokens } = sample else {
+            anyhow::bail!("expected a causal sample")
+        };
+        *samples += 1;
+        digest.update((tokens.len() as u64).to_le_bytes());
+        for token in tokens {
+            digest.update(token.to_le_bytes());
+        }
+        Ok(true)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identity_failure_resets_partial_cache_before_restored_generation_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_path = dir.path().join("data.jsonl");
+        let cache_path = dir.path().join("tokens.bin");
+        let tokenizer = write_test_tokenizer(dir.path());
+        let line = "{\"tokens\":[1,2,3,4,5,6,7,8]}\n";
+        let original = line.repeat(1_000).into_bytes();
+        assert!(original.len() > AUTHENTICATED_READ_BUFFER_BYTES * 2);
+        fs::write(&data_path, &original).unwrap();
+        let binding = PhaseDataBinding::open(&data_path).unwrap();
+
+        let mut mutated = false;
+        let result = visit_causal_samples(
+            &data_path,
+            &tokenizer,
+            128,
+            Some(&cache_path),
+            &binding,
+            |_| {
+                if !mutated {
+                    let mut file = OpenOptions::new().write(true).open(&data_path)?;
+                    file.seek(SeekFrom::Start(
+                        (AUTHENTICATED_READ_BUFFER_BYTES * 2) as u64,
+                    ))?;
+                    file.write_all(b"!")?;
+                    file.sync_all()?;
+                    mutated = true;
+                }
+                Ok(true)
+            },
+        );
+        let error = format!("{:#}", result.unwrap_err());
+        assert!(error.contains("changed in place"), "{error}");
+        assert_eq!(fs::read(&cache_path).unwrap(), TOKEN_CACHE_MAGIC);
+        assert!(!token_cache_index_path(&cache_path).exists());
+
+        fs::write(&data_path, &original).unwrap();
+        let restored = PhaseDataBinding::open(&data_path).unwrap();
+        let mut retry_digest = Sha256::new();
+        let mut retry_samples = 0;
+        let retry_count = visit_causal_samples(
+            &data_path,
+            &tokenizer,
+            128,
+            Some(&cache_path),
+            &restored,
+            |sample| update_causal_digest(&mut retry_digest, &mut retry_samples, sample),
+        )
+        .unwrap();
+        assert!(token_cache_index_path(&cache_path).is_file());
+
+        let mut reference_digest = Sha256::new();
+        let mut reference_samples = 0;
+        let reference_count =
+            visit_causal_samples(&data_path, &tokenizer, 128, None, &restored, |sample| {
+                update_causal_digest(&mut reference_digest, &mut reference_samples, sample)
+            })
+            .unwrap();
+        assert_eq!(retry_count, reference_count);
+        assert_eq!(retry_samples, reference_samples);
+        assert_eq!(retry_digest.finalize(), reference_digest.finalize());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn completed_cache_fast_path_still_rejects_direct_data_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let data_path = dir.path().join("data.jsonl");
+        let parked = dir.path().join("opened.jsonl");
+        let cache_path = dir.path().join("tokens.bin");
+        let tokenizer = write_test_tokenizer(dir.path());
+        fs::write(&data_path, b"{\"tokens\":[1,2]}\n").unwrap();
+        let binding = PhaseDataBinding::open(&data_path).unwrap();
+        write_test_token_cache(&cache_path, &[&[1, 2]], true);
+
+        fs::rename(&data_path, &parked).unwrap();
+        fs::write(&data_path, b"{\"tokens\":[3,4]}\n").unwrap();
+        assert!(
+            visit_causal_samples(
+                &data_path,
+                &tokenizer,
+                1,
+                Some(&cache_path),
+                &binding,
+                |_| Ok(true),
+            )
+            .is_err()
+        );
+        assert_eq!(fs::read(&cache_path).unwrap(), TOKEN_CACHE_MAGIC);
+        assert!(!token_cache_index_path(&cache_path).exists());
     }
 
     #[test]
@@ -1411,7 +2746,8 @@ mod tests {
         let mut packer = SamplePacker::new(4);
         let mut replayed = 0;
         let (_, _, _, complete) =
-            replay_token_cache(&path, 0, &mut packer, &mut replayed, &mut |_| Ok(true)).unwrap();
+            replay_token_cache(&path, 0, 257, &mut packer, &mut replayed, &mut |_| Ok(true))
+                .unwrap();
         assert!(complete, "verified caches must not require a source rescan");
         assert_eq!(replayed, 1);
     }
@@ -1432,7 +2768,7 @@ mod tests {
         let mut packer = SamplePacker::new(3);
         let mut count = 0;
         let (documents, keep_going, _, complete) =
-            replay_token_cache(&path, 0, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
+            replay_token_cache(&path, 0, 257, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
         assert_eq!(documents, 2);
         assert_eq!(count, 1);
         assert!(keep_going);
@@ -1472,7 +2808,7 @@ mod tests {
         let mut count = 0;
         let mut samples = Vec::new();
         let (documents, keep_going, mut writer, complete) =
-            replay_token_cache(&path, 0, &mut packer, &mut count, &mut |sample| {
+            replay_token_cache(&path, 0, 257, &mut packer, &mut count, &mut |sample| {
                 samples.push(sample);
                 Ok(true)
             })
@@ -1507,10 +2843,61 @@ mod tests {
         let mut packer = SamplePacker::new(2);
         let mut count = 0;
         let (_, _, mut writer, _) =
-            replay_token_cache(&changed, 0, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
+            replay_token_cache(&changed, 0, 257, &mut packer, &mut count, &mut |_| Ok(true))
+                .unwrap();
         writer.as_mut().unwrap().append(&[]).unwrap();
         assert!(!token_cache_index_path(&changed).exists());
         assert_eq!(indexed_causal_sample_count(&changed, 2).unwrap(), None);
+    }
+
+    #[test]
+    fn out_of_vocabulary_cached_tokens_are_never_emitted_and_reset_the_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        write_test_token_cache(&path, &[&[300, 1, 2]], true);
+        assert_eq!(indexed_causal_sample_count(&path, 2).unwrap(), Some(1));
+
+        let mut packer = SamplePacker::new(2);
+        let mut count = 0;
+        let mut visited = 0;
+        let error = replay_token_cache(&path, 0, 257, &mut packer, &mut count, &mut |_| {
+            visited += 1;
+            Ok(true)
+        })
+        .err()
+        .expect("out-of-vocabulary cache must fail")
+        .to_string();
+
+        assert!(error.contains("outside tokenizer vocabulary"), "{error}");
+        assert_eq!(visited, 0, "an invalid cached token reached the visitor");
+        assert_eq!(count, 0);
+        assert_eq!(fs::read(&path).unwrap(), TOKEN_CACHE_MAGIC);
+        assert!(!token_cache_index_path(&path).exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn completed_cache_identity_is_checked_when_the_visitor_stops_early() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.bin");
+        write_test_token_cache(&path, &[&[1, 2, 3], &[4, 5, 6]], true);
+
+        let mut packer = SamplePacker::new(2);
+        let mut count = 0;
+        let error = replay_token_cache(&path, 0, 257, &mut packer, &mut count, &mut |_| {
+            let mut cache = OpenOptions::new().write(true).open(&path)?;
+            cache.seek(SeekFrom::Start(TOKEN_CACHE_MAGIC.len() as u64 + 4))?;
+            cache.write_all(&9_u32.to_le_bytes())?;
+            cache.sync_all()?;
+            Ok(false)
+        })
+        .err()
+        .expect("mutated cache must fail")
+        .to_string();
+
+        assert!(error.contains("changed while it was replayed"), "{error}");
+        assert_eq!(fs::read(&path).unwrap(), TOKEN_CACHE_MAGIC);
+        assert!(!token_cache_index_path(&path).exists());
     }
 
     #[test]
@@ -1528,7 +2915,7 @@ mod tests {
         let mut packer = SamplePacker::new(3);
         let mut count = 0;
         let (documents, _, _, complete) =
-            replay_token_cache(&path, 0, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
+            replay_token_cache(&path, 0, 257, &mut packer, &mut count, &mut |_| Ok(true)).unwrap();
         assert_eq!(documents, 0);
         assert_eq!(count, 0);
         assert!(!complete);
@@ -1565,7 +2952,7 @@ mod tests {
 
         let mut packer = SamplePacker::new(3);
         let mut count = 0;
-        let error = replay_token_cache(&path, 0, &mut packer, &mut count, &mut |_| Ok(true))
+        let error = replay_token_cache(&path, 0, 257, &mut packer, &mut count, &mut |_| Ok(true))
             .err()
             .unwrap()
             .to_string();
@@ -1586,7 +2973,10 @@ mod tests {
         let mut packer = SamplePacker::new(3);
         let mut count = 0;
         assert!(
-            replay_token_cache(&cache_path, 0, &mut packer, &mut count, &mut |_| Ok(true)).is_err()
+            replay_token_cache(&cache_path, 0, 257, &mut packer, &mut count, &mut |_| Ok(
+                true
+            ),)
+            .is_err()
         );
         assert_eq!(fs::read(&victim).unwrap(), b"do not touch");
 
@@ -1606,6 +2996,7 @@ mod tests {
             replay_token_cache(
                 &linked_root.join("other.tokens"),
                 0,
+                257,
                 &mut linked_packer,
                 &mut linked_count,
                 &mut |_| Ok(true),
@@ -1648,7 +3039,7 @@ mod tests {
         let mut visit = |_| Ok(true);
 
         let (documents, keep_going, writer, _) =
-            replay_token_cache(&path, 0, &mut packer, &mut count, &mut visit).unwrap();
+            replay_token_cache(&path, 0, 257, &mut packer, &mut count, &mut visit).unwrap();
 
         assert_eq!(documents, 0);
         assert!(keep_going);
@@ -1669,6 +3060,94 @@ mod tests {
             token_array(&serde_json::json!({"text": "raw"}), path, 7).unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn retrieval_wake_encoding_consumes_the_task_adapter_segments() {
+        fn expected_text(
+            tokenizer: &Tokenizer,
+            text: &hermes_train::task::SegmentedText,
+            seq_len: usize,
+        ) -> EncodedText {
+            let mut tokens = text
+                .segments
+                .iter()
+                .flat_map(|segment| tokenizer.encode(segment, false).unwrap())
+                .map(i64::from)
+                .collect::<Vec<_>>();
+            tokens.push(i64::from(tokenizer.eos_token_id()));
+            let end_position = tokens.len() - 1;
+            tokens.resize(seq_len, i64::from(tokenizer.eos_token_id()));
+            EncodedText {
+                tokens,
+                end_position,
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let tokenizer = write_test_tokenizer(dir.path());
+        let path = dir.path().join("retrieval.jsonl");
+        let record = serde_json::json!({
+            "query": "needle",
+            "positive": "positive",
+            "negatives": ["negative"]
+        });
+        fs::write(&path, format!("{record}\n")).unwrap();
+        let objective = TaskConfig::RetrievalRepresentation {
+            temperature: 0.05,
+            layer: None,
+            query_prefix: "query-prefix:".into(),
+            document_prefix: "document-prefix:".into(),
+        };
+        let binding = PhaseDataBinding::open(&path).unwrap();
+        let mut observed = Vec::new();
+        assert_eq!(
+            visit_samples_in_order(
+                &path,
+                &objective,
+                &tokenizer,
+                64,
+                None,
+                &binding,
+                |sample| {
+                    observed.push(sample);
+                    Ok(true)
+                },
+            )
+            .unwrap(),
+            1
+        );
+
+        let TaskExample::RetrievalRepresentation {
+            query,
+            documents,
+            positive_index,
+        } = objective.construct_example(&record).unwrap()
+        else {
+            panic!("expected retrieval task example")
+        };
+        let TrainingSample::Retrieval {
+            query: actual_query,
+            documents: actual_documents,
+            truncated_tokens,
+        } = observed.pop().unwrap()
+        else {
+            panic!("expected retrieval training sample")
+        };
+        assert_eq!(positive_index, 0);
+        let expected_query = expected_text(&tokenizer, &query, 64);
+        assert_eq!(actual_query.tokens, expected_query.tokens);
+        assert_eq!(actual_query.end_position, expected_query.end_position);
+        let expected_documents = documents
+            .iter()
+            .map(|document| expected_text(&tokenizer, document, 64))
+            .collect::<Vec<_>>();
+        assert_eq!(actual_documents.len(), expected_documents.len());
+        for (actual, expected) in actual_documents.iter().zip(expected_documents) {
+            assert_eq!(actual.tokens, expected.tokens);
+            assert_eq!(actual.end_position, expected.end_position);
+        }
+        assert_eq!(truncated_tokens, 0);
     }
 
     #[test]

--- a/hermes-train/src/data/structured.rs
+++ b/hermes-train/src/data/structured.rs
@@ -5,33 +5,25 @@ use std::path::Path;
 
 use anyhow::{Context, Result, ensure};
 use hermes_llm::Tokenizer;
+use hermes_train::task::{
+    SegmentedText, SupervisedPromptSegments, TaskAdapter, TaskConfig, TaskExample,
+};
 
-use super::{EncodedText, TrainingSample, is_jsonl, open_data, required_string};
-use crate::wake::ObjectiveConfig;
+use super::{EncodedText, TrainingSample, is_jsonl, read_training_jsonl_record};
 
-fn optional_string<'a>(
+fn supervised_prompt_segments<'a>(
     value: &'a serde_json::Value,
-    field: &str,
+    task: &TaskConfig,
     path: &Path,
     line_number: usize,
-) -> Result<Option<&'a str>> {
-    match value.get(field) {
-        None | Some(serde_json::Value::Null) => Ok(None),
-        Some(value) => {
-            let text = value.as_str().with_context(|| {
-                format!(
-                    "optional `{field}` at {}:{line_number} must be a string",
-                    path.display()
-                )
-            })?;
-            ensure!(
-                !text.trim().is_empty(),
-                "optional `{field}` at {}:{line_number} must not be empty",
-                path.display()
-            );
-            Ok(Some(text))
-        }
-    }
+) -> Result<SupervisedPromptSegments<'a>> {
+    task.construct_supervised_prompt(value).with_context(|| {
+        format!(
+            "invalid `{}` record at {}:{line_number}",
+            task.name(),
+            path.display()
+        )
+    })
 }
 
 fn encode_tokens(tokenizer: &Tokenizer, text: &str) -> Result<Vec<i64>> {
@@ -103,26 +95,50 @@ fn make_supervised_sample(
 
 fn encode_retrieval_text(
     tokenizer: &Tokenizer,
-    prefix: &str,
-    text: &str,
+    text: &SegmentedText,
     seq_len: usize,
 ) -> Result<(EncodedText, usize)> {
-    let prefix = encode_tokens(tokenizer, prefix)?;
-    let content = encode_tokens(tokenizer, text)?;
-    ensure!(!content.is_empty(), "retrieval text tokenized to empty");
-    let fixed_tokens = prefix
-        .len()
-        .checked_add(1)
-        .context("retrieval prefix token count overflows usize")?;
+    text.validate()?;
+    let encoded = text
+        .segments
+        .iter()
+        .map(|segment| encode_tokens(tokenizer, segment))
+        .collect::<Result<Vec<_>>>()?;
+    let fixed_tokens = encoded
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| Some(*index) != text.truncatable_segment)
+        .try_fold(1usize, |total, (_, segment)| {
+            total
+                .checked_add(segment.len())
+                .context("retrieval fixed-token count overflows usize")
+        })?;
     ensure!(
-        fixed_tokens < seq_len,
-        "retrieval prefix and EOS leave no content room at sequence_length {seq_len}"
+        fixed_tokens <= seq_len,
+        "retrieval fixed segments and EOS require {fixed_tokens} tokens but sequence_length is {seq_len}"
     );
-    let kept_content = content.len().min(seq_len - fixed_tokens);
-    let truncated_tokens = content.len() - kept_content;
+    let (kept_truncatable, truncated_tokens) = match text.truncatable_segment {
+        Some(index) => {
+            let available = seq_len - fixed_tokens;
+            let kept = encoded[index].len().min(available);
+            if text.truncatable_segment_required {
+                ensure!(
+                    kept > 0,
+                    "retrieval fixed segments and EOS leave no token for required segment {index} at sequence_length {seq_len}"
+                );
+            }
+            (kept, encoded[index].len() - kept)
+        }
+        None => (0, 0),
+    };
     let mut tokens = Vec::with_capacity(seq_len);
-    tokens.extend(prefix);
-    tokens.extend_from_slice(&content[..kept_content]);
+    for (index, segment) in encoded.into_iter().enumerate() {
+        if Some(index) == text.truncatable_segment {
+            tokens.extend_from_slice(&segment[..kept_truncatable]);
+        } else {
+            tokens.extend(segment);
+        }
+    }
     tokens.push(i64::from(tokenizer.eos_token_id()));
     let end_position = tokens.len() - 1;
     tokens.resize(seq_len, i64::from(tokenizer.eos_token_id()));
@@ -135,193 +151,88 @@ fn encode_retrieval_text(
     ))
 }
 
-fn retrieval_negatives<'a>(
-    value: &'a serde_json::Value,
-    path: &Path,
-    line_number: usize,
-) -> Result<Vec<&'a str>> {
-    let Some(value) = value.get("negatives") else {
-        return Ok(Vec::new());
-    };
-    let values = value.as_array().with_context(|| {
-        format!(
-            "optional `negatives` at {}:{line_number} must be an array of strings",
-            path.display()
-        )
-    })?;
-    values
-        .iter()
-        .enumerate()
-        .map(|(index, value)| {
-            let text = value.as_str().with_context(|| {
-                format!(
-                    "`negatives[{index}]` at {}:{line_number} must be a string",
-                    path.display()
-                )
-            })?;
-            ensure!(
-                !text.trim().is_empty(),
-                "`negatives[{index}]` at {}:{line_number} must not be empty",
-                path.display()
-            );
-            Ok(text)
-        })
-        .collect()
-}
-
 fn structured_sample(
     value: &serde_json::Value,
-    objective: &ObjectiveConfig,
+    objective: &TaskConfig,
     tokenizer: &Tokenizer,
     seq_len: usize,
     path: &Path,
     line_number: usize,
 ) -> Result<TrainingSample> {
     match objective {
-        ObjectiveConfig::CausalLm => unreachable!("causal data has a separate streaming path"),
-        ObjectiveConfig::Summarization { instruction } => {
-            let document = required_string(value, "document", path, line_number)?;
-            let summary = required_string(value, "summary", path, line_number)?;
+        TaskConfig::CausalLm {} => unreachable!("causal data has a separate streaming path"),
+        TaskConfig::Summarization { .. }
+        | TaskConfig::RetrievalPlanning { .. }
+        | TaskConfig::InstructionTuning { .. }
+        | TaskConfig::QaReasoning { .. } => {
+            let segments = supervised_prompt_segments(value, objective, path, line_number)?;
             make_supervised_sample(
                 tokenizer,
-                &format!("{instruction}\n\nDocument:\n"),
-                document,
-                "\n\nSummary:\n",
-                summary,
+                &segments.prefix,
+                &segments.source,
+                &segments.suffix,
+                &segments.target,
                 seq_len,
-                true,
+                segments.source_required,
             )
             .with_context(|| format!("cannot encode {}:{line_number}", path.display()))
         }
-        ObjectiveConfig::RetrievalPlanning { instruction } => {
-            let request = required_string(value, "request", path, line_number)?;
-            let plan = required_string(value, "plan", path, line_number)?;
-            let context = optional_string(value, "context", path, line_number)?;
-            let (prefix, source) = match context {
-                Some(context) => (
-                    format!("{instruction}\n\nRequest:\n{request}\n\nContext:\n"),
-                    context,
-                ),
-                None => (format!("{instruction}\n\nRequest:\n{request}\n"), ""),
+        TaskConfig::RetrievalRepresentation { .. } => {
+            let TaskExample::RetrievalRepresentation {
+                query,
+                documents: task_documents,
+                positive_index,
+            } = objective.construct_example(value).with_context(|| {
+                format!(
+                    "invalid `{}` record at {}:{line_number}",
+                    objective.name(),
+                    path.display()
+                )
+            })?
+            else {
+                unreachable!("retrieval-representation adapter returned another example type")
             };
-            make_supervised_sample(
-                tokenizer,
-                &prefix,
-                source,
-                "\nPlan:\n",
-                plan,
-                seq_len,
-                context.is_some(),
-            )
-            .with_context(|| format!("cannot encode {}:{line_number}", path.display()))
-        }
-        ObjectiveConfig::InstructionTuning { instruction } => {
-            let prompt = required_string(value, "instruction", path, line_number)?;
-            let response = required_string(value, "response", path, line_number)?;
-            let system = optional_string(value, "system", path, line_number)?;
-            let input = optional_string(value, "input", path, line_number)?;
-            let mut prefix = String::new();
-            if let Some(system) = system {
-                prefix.push_str("System:\n");
-                prefix.push_str(system);
-                prefix.push_str("\n\n");
-            }
-            prefix.push_str(instruction);
-            prefix.push_str("\n\nInstruction:\n");
-            prefix.push_str(prompt);
-            let (suffix, source_required) = match input {
-                Some(_) => ("\n\nResponse:\n", true),
-                None => ("\nResponse:\n", false),
-            };
-            make_supervised_sample(
-                tokenizer,
-                &prefix,
-                input.unwrap_or(""),
-                suffix,
-                response,
-                seq_len,
-                source_required,
-            )
-            .with_context(|| format!("cannot encode {}:{line_number}", path.display()))
-        }
-        ObjectiveConfig::QaReasoning {
-            instruction,
-            require_reasoning,
-        } => {
-            let question = required_string(value, "question", path, line_number)?;
-            let answer = required_string(value, "answer", path, line_number)?;
-            let reasoning = optional_string(value, "reasoning", path, line_number)?;
             ensure!(
-                !*require_reasoning || reasoning.is_some(),
-                "qa_reasoning at {}:{line_number} requires `reasoning`",
-                path.display()
+                positive_index < task_documents.len(),
+                "retrieval task adapter returned an out-of-range positive index"
             );
-            let target = match reasoning {
-                Some(reasoning) => format!("Reasoning:\n{reasoning}\n\nAnswer:\n{answer}"),
-                None => answer.to_owned(),
-            };
-            make_supervised_sample(
-                tokenizer,
-                &format!("{instruction}\n\nQuestion:\n"),
-                question,
-                "\n\nResponse:\n",
-                &target,
-                seq_len,
-                true,
-            )
-            .with_context(|| format!("cannot encode {}:{line_number}", path.display()))
-        }
-        ObjectiveConfig::ContrastiveRetrieval {
-            query_prefix,
-            document_prefix,
-            ..
-        } => {
-            let query = required_string(value, "query", path, line_number)?;
-            let positive = required_string(value, "positive", path, line_number)?;
-            let negatives = retrieval_negatives(value, path, line_number)?;
-            let (query, mut truncated_tokens) =
-                encode_retrieval_text(tokenizer, query_prefix, query, seq_len).with_context(
-                    || format!("cannot encode query at {}:{line_number}", path.display()),
-                )?;
-            let (positive, truncated) =
-                encode_retrieval_text(tokenizer, document_prefix, positive, seq_len).with_context(
-                    || format!("cannot encode positive at {}:{line_number}", path.display()),
-                )?;
-            truncated_tokens = truncated_tokens
-                .checked_add(truncated)
-                .context("retrieval truncated-token count overflows usize")?;
-            let document_count = negatives
-                .len()
-                .checked_add(1)
-                .context("retrieval document count overflows usize")?;
-            let mut documents = Vec::with_capacity(document_count);
-            documents.push(positive);
-            for (index, negative) in negatives.into_iter().enumerate() {
-                let (negative, truncated) =
-                    encode_retrieval_text(tokenizer, document_prefix, negative, seq_len)
-                        .with_context(|| {
-                            format!(
-                                "cannot encode negative {index} at {}:{line_number}",
-                                path.display()
-                            )
-                        })?;
+            let (query, mut truncated_tokens) = encode_retrieval_text(tokenizer, &query, seq_len)
+                .with_context(|| {
+                format!("cannot encode query at {}:{line_number}", path.display())
+            })?;
+            let mut documents = Vec::with_capacity(task_documents.len());
+            for (index, document) in task_documents.iter().enumerate() {
+                let (document, truncated) = encode_retrieval_text(tokenizer, document, seq_len)
+                    .with_context(|| {
+                        format!(
+                            "cannot encode retrieval document {index} at {}:{line_number}",
+                            path.display()
+                        )
+                    })?;
                 truncated_tokens = truncated_tokens
                     .checked_add(truncated)
                     .context("retrieval truncated-token count overflows usize")?;
-                documents.push(negative);
+                documents.push(document);
             }
+            documents.swap(0, positive_index);
             Ok(TrainingSample::Retrieval {
                 query,
                 documents,
                 truncated_tokens,
             })
         }
+        TaskConfig::RetrievalRanking { .. }
+        | TaskConfig::PairwisePreference {}
+        | TaskConfig::VerifiableRl { .. } => {
+            unreachable!("wake projection rejects tasks unsupported by structured training")
+        }
     }
 }
 
 pub(super) fn visit_structured_samples(
     path: &Path,
-    objective: &ObjectiveConfig,
+    reader: &mut dyn BufRead,
+    objective: &TaskConfig,
     tokenizer: &Tokenizer,
     seq_len: usize,
     mut visit: impl FnMut(TrainingSample) -> Result<bool>,
@@ -332,22 +243,22 @@ pub(super) fn visit_structured_samples(
         objective.name(),
         path.display()
     );
-    let mut reader = open_data(path)?;
-    let mut line = String::new();
+    let mut line = Vec::new();
     let mut line_number = 0usize;
     let mut count = 0usize;
     loop {
-        line.clear();
-        if reader.read_line(&mut line)? == 0 {
-            break;
-        }
-        line_number = line_number
+        let next_line_number = line_number
             .checked_add(1)
             .context("JSONL line count overflows usize")?;
+        let Some(line) = read_training_jsonl_record(reader, &mut line, path, next_line_number)?
+        else {
+            break;
+        };
+        line_number = next_line_number;
         if line.trim().is_empty() {
             continue;
         }
-        let value: serde_json::Value = serde_json::from_str(&line)
+        let value: serde_json::Value = serde_json::from_str(line)
             .with_context(|| format!("invalid JSONL at {}:{line_number}", path.display()))?;
         let sample = structured_sample(&value, objective, tokenizer, seq_len, path, line_number)?;
         count = count
@@ -358,4 +269,176 @@ pub(super) fn visit_structured_samples(
         }
     }
     Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use hermes_train::task::TaskExample;
+    use serde_json::json;
+
+    use super::*;
+
+    fn assert_supervised_contract(
+        task: TaskConfig,
+        record: serde_json::Value,
+        expected: SupervisedPromptSegments<'_>,
+    ) {
+        let segments =
+            supervised_prompt_segments(&record, &task, Path::new("contract.jsonl"), 7).unwrap();
+        assert_eq!(segments, expected);
+        let expected_prompt = expected.prompt();
+        let expected_segments = vec![
+            expected.prefix.into_owned(),
+            expected.source.into_owned(),
+            expected.suffix.into_owned(),
+        ];
+        let expected_target = expected.target.into_owned();
+        let TaskExample::SupervisedGeneration { prompt, target } =
+            task.construct_example(&record).unwrap()
+        else {
+            panic!(
+                "wake task `{}` returned the wrong example type",
+                task.name()
+            );
+        };
+        assert_eq!(prompt.segments, expected_segments);
+        assert_eq!(prompt.render(), expected_prompt);
+        assert_eq!(prompt.truncatable_segment, Some(1));
+        assert_eq!(
+            prompt.truncatable_segment_required,
+            expected.source_required
+        );
+        assert_eq!(target, expected_target);
+    }
+
+    #[test]
+    fn wake_uses_task_adapter_supervised_prompt_goldens() {
+        assert_supervised_contract(
+            TaskConfig::Summarization {
+                instruction: "Summarize faithfully.".into(),
+            },
+            json!({"document": "Long source.", "summary": "Short target."}),
+            SupervisedPromptSegments {
+                prefix: "Summarize faithfully.\n\nDocument:\n".into(),
+                source: "Long source.".into(),
+                suffix: "\n\nSummary:\n".into(),
+                target: "Short target.".into(),
+                source_required: true,
+            },
+        );
+
+        for (context, expected_source, expected_suffix, source_required) in [
+            (
+                Some("Official documentation."),
+                "Official documentation.",
+                "\nPlan:\n",
+                true,
+            ),
+            (None, "", "Plan:\n", false),
+        ] {
+            let mut record = json!({"request": "Find the API.", "plan": "Search, then read."});
+            if let Some(context) = context {
+                record["context"] = json!(context);
+            }
+            assert_supervised_contract(
+                TaskConfig::RetrievalPlanning {
+                    instruction: "Plan retrieval.".into(),
+                },
+                record,
+                SupervisedPromptSegments {
+                    prefix: if source_required {
+                        "Plan retrieval.\n\nRequest:\nFind the API.\n\nContext:\n".into()
+                    } else {
+                        "Plan retrieval.\n\nRequest:\nFind the API.\n".into()
+                    },
+                    source: expected_source.into(),
+                    suffix: expected_suffix.into(),
+                    target: "Search, then read.".into(),
+                    source_required,
+                },
+            );
+        }
+
+        for (system, input, expected_prefix, expected_source, source_required) in [
+            (
+                Some("Be concise."),
+                Some("Bonjour"),
+                "System:\nBe concise.\n\nFollow the request.\n\nInstruction:\nTranslate.\n\nInput:\n",
+                "Bonjour",
+                true,
+            ),
+            (
+                Some("Be concise."),
+                None,
+                "System:\nBe concise.\n\nFollow the request.\n\nInstruction:\nTranslate.",
+                "",
+                false,
+            ),
+            (
+                None,
+                Some("Bonjour"),
+                "Follow the request.\n\nInstruction:\nTranslate.\n\nInput:\n",
+                "Bonjour",
+                true,
+            ),
+            (
+                None,
+                None,
+                "Follow the request.\n\nInstruction:\nTranslate.",
+                "",
+                false,
+            ),
+        ] {
+            let mut record = json!({"instruction": "Translate.", "response": "Hello"});
+            if let Some(system) = system {
+                record["system"] = json!(system);
+            }
+            if let Some(input) = input {
+                record["input"] = json!(input);
+            }
+            assert_supervised_contract(
+                TaskConfig::InstructionTuning {
+                    instruction: "Follow the request.".into(),
+                },
+                record,
+                SupervisedPromptSegments {
+                    prefix: expected_prefix.into(),
+                    source: expected_source.into(),
+                    suffix: "\n\nResponse:\n".into(),
+                    target: "Hello".into(),
+                    source_required,
+                },
+            );
+        }
+
+        for (reasoning, require_reasoning, expected_target) in [
+            (
+                Some("Add the operands."),
+                true,
+                "Reasoning:\nAdd the operands.\n\nAnswer:\n4",
+            ),
+            (None, false, "4"),
+        ] {
+            let mut record = json!({"question": "2 + 2?", "answer": "4"});
+            if let Some(reasoning) = reasoning {
+                record["reasoning"] = json!(reasoning);
+            }
+            assert_supervised_contract(
+                TaskConfig::QaReasoning {
+                    instruction: "Reason carefully.".into(),
+                    require_reasoning,
+                },
+                record,
+                SupervisedPromptSegments {
+                    prefix: "Reason carefully.\n\nQuestion:\n".into(),
+                    source: "2 + 2?".into(),
+                    suffix: "\n\nResponse:\n".into(),
+                    target: expected_target.into(),
+                    source_required: true,
+                },
+            );
+        }
+    }
 }

--- a/hermes-train/src/device_sampler.rs
+++ b/hermes-train/src/device_sampler.rs
@@ -9,7 +9,7 @@
 use std::collections::VecDeque;
 use std::ffi::OsStr;
 use std::io::{BufRead, BufReader, Read};
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
 use std::sync::{Arc, Mutex};
@@ -23,8 +23,10 @@ use crate::metrics::{DeviceUtilizationMetrics, MetricEvent};
 // Enough for a multi-minute sleep/checkpoint boundary at the default cadence,
 // while remaining a fixed and tiny memory budget.
 const DEFAULT_CHANNEL_CAPACITY: usize = 256;
+const MAX_CHANNEL_CAPACITY: usize = 4_096;
 const MAX_DIAGNOSTICS: usize = 16;
 const MAX_DIAGNOSTIC_BYTES: usize = 4 * 1024;
+const MAX_SAMPLE_BYTES: usize = 64 * 1024;
 const MEBIBYTE: u64 = 1024 * 1024;
 
 /// Exact process/query configuration. The device selector is passed as a
@@ -59,8 +61,8 @@ impl NvidiaSmiSamplerConfig {
         );
         validate_physical_device_selector(&self.physical_device)?;
         ensure!(
-            self.channel_capacity > 0,
-            "device sample channel capacity must be positive"
+            (1..=MAX_CHANNEL_CAPACITY).contains(&self.channel_capacity),
+            "device sample channel capacity must be in 1..={MAX_CHANNEL_CAPACITY}"
         );
         Ok(())
     }
@@ -290,15 +292,14 @@ fn run_reader(
         .name("hermes-nvidia-smi-stderr".into())
         .spawn(move || read_bounded(stderr, MAX_DIAGNOSTIC_BYTES));
     let mut output = BufReader::new(stdout);
-    let mut line = String::new();
+    let mut line = Vec::new();
     let mut last_collected_at_unix_ms = 0_u64;
     loop {
-        line.clear();
-        match output.read_line(&mut line) {
-            Ok(0) => break,
-            Ok(_) => match collection_timestamp(&mut last_collected_at_unix_ms).and_then(
+        match read_sample_line_bounded(&mut output, &mut line, MAX_SAMPLE_BYTES) {
+            Ok(None) => break,
+            Ok(Some(line)) => match collection_timestamp(&mut last_collected_at_unix_ms).and_then(
                 |collected_at_unix_ms| {
-                    parse_nvidia_smi_line(&line, interval, collected_at_unix_ms)
+                    parse_nvidia_smi_line(line, interval, collected_at_unix_ms)
                         .map(|metrics| (collected_at_unix_ms, metrics))
                 },
             ) {
@@ -323,9 +324,7 @@ fn run_reader(
                     push_diagnostic(
                         diagnostics,
                         dropped_diagnostics,
-                        DeviceSamplerDiagnostic::ProcessExited(format!(
-                            "failed to read stdout: {error}"
-                        )),
+                        DeviceSamplerDiagnostic::InvalidSample(error.to_string()),
                     );
                 }
                 break;
@@ -345,13 +344,7 @@ fn run_reader(
     // Terminate and reap the private process group before the join; telemetry
     // remains fail-soft and Drop can safely call the same idempotent cleanup.
     if unexpected_eof && status.is_none() {
-        stop_child(child);
-        status = {
-            let mut child = lock_unpoisoned(child);
-            child
-                .as_mut()
-                .and_then(|process| process.try_wait().ok().flatten())
-        };
+        status = stop_child(child);
     }
     let stderr = stderr_reader
         .ok()
@@ -375,22 +368,78 @@ fn run_reader(
     }
 }
 
-fn stop_child(child: &Mutex<Option<Child>>) {
-    let mut child = lock_unpoisoned(child);
-    if let Some(process) = child.as_mut() {
-        #[cfg(unix)]
-        {
-            let process_group = -(process.id() as i32);
-            // SAFETY: the child was placed in a private process group before
-            // spawn; a negative pid targets only that group. Failure is
-            // harmless because `Child::kill` below remains the fallback.
-            unsafe {
-                libc::kill(process_group, libc::SIGKILL);
-            }
+fn read_sample_line_bounded<'a>(
+    reader: &mut (impl BufRead + ?Sized),
+    output: &'a mut Vec<u8>,
+    maximum_bytes: usize,
+) -> Result<Option<&'a str>> {
+    ensure!(
+        maximum_bytes > 0,
+        "device sample byte limit must be positive"
+    );
+    output.clear();
+    let capture_bytes = maximum_bytes
+        .checked_add(1)
+        .context("device sample byte limit overflows usize")?;
+    loop {
+        let available = reader
+            .fill_buf()
+            .context("failed to read nvidia-smi stdout")?;
+        if available.is_empty() {
+            break;
         }
-        let _ = process.kill();
-        let _ = process.wait();
+        let through_delimiter = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(available.len(), |position| position + 1);
+        let remaining = capture_bytes
+            .checked_sub(output.len())
+            .context("device sample capture length overflow")?;
+        let copied = through_delimiter.min(remaining);
+        output.extend_from_slice(&available[..copied]);
+        reader.consume(copied);
+        if copied < through_delimiter
+            || output.len() == capture_bytes
+            || output.last() == Some(&b'\n')
+        {
+            break;
+        }
     }
+    if output.is_empty() {
+        return Ok(None);
+    }
+    let payload_bytes = output
+        .len()
+        .checked_sub(usize::from(output.last() == Some(&b'\n')))
+        .context("device sample byte count underflows usize")?;
+    ensure!(
+        payload_bytes <= maximum_bytes,
+        "nvidia-smi sample exceeds the maximum of {maximum_bytes} bytes"
+    );
+    let line = std::str::from_utf8(output).context("nvidia-smi sample is not UTF-8")?;
+    Ok(Some(line))
+}
+
+/// Terminate and reap the sampler's private process group, returning its exit
+/// status. Takes the handle so the raw group signal is issued at most once:
+/// reaping frees the pid, and the kernel may hand the same pid — and therefore
+/// the same process-group id — to an unrelated process afterwards.
+fn stop_child(child: &Mutex<Option<Child>>) -> Option<ExitStatus> {
+    let mut guard = lock_unpoisoned(child);
+    let mut process = guard.take()?;
+    #[cfg(unix)]
+    {
+        let process_group = -(process.id() as i32);
+        // SAFETY: the child was placed in a private process group before
+        // spawn; a negative pid targets only that group, and the process is
+        // still unreaped here so that group id cannot have been recycled.
+        // Failure is harmless because `Child::kill` below remains the fallback.
+        unsafe {
+            libc::kill(process_group, libc::SIGKILL);
+        }
+    }
+    let _ = process.kill();
+    process.wait().ok()
 }
 
 fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
@@ -532,6 +581,7 @@ fn unavailable(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::io::Cursor;
     use std::path::Path;
     use std::time::{Duration, Instant};
 
@@ -539,6 +589,29 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     use super::*;
+
+    #[test]
+    fn sample_reader_bounds_payload_and_validates_utf8() {
+        let mut output = Vec::new();
+        let mut exact = Cursor::new(b"12345678\nnext".to_vec());
+        assert_eq!(
+            read_sample_line_bounded(&mut exact, &mut output, 8).unwrap(),
+            Some("12345678\n")
+        );
+
+        let mut oversized = Cursor::new(b"123456789\n".to_vec());
+        let error = read_sample_line_bounded(&mut oversized, &mut output, 8)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("maximum of 8 bytes"), "{error}");
+        assert_eq!(output.len(), 9);
+
+        let mut invalid = Cursor::new(vec![0xff, b'\n']);
+        let error = read_sample_line_bounded(&mut invalid, &mut output, 8)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not UTF-8"), "{error}");
+    }
 
     #[test]
     fn parser_converts_units_and_accepts_unavailable_optional_fields() {
@@ -594,6 +667,14 @@ mod tests {
     }
 
     #[test]
+    fn sampler_channel_allocation_is_operationally_bounded() {
+        let mut config = NvidiaSmiSamplerConfig::new(Duration::from_secs(1), "0").unwrap();
+        config.channel_capacity = MAX_CHANNEL_CAPACITY + 1;
+        let error = config.validate().unwrap_err().to_string();
+        assert!(error.contains("1..="), "{error}");
+    }
+
+    #[test]
     fn unavailable_program_is_fail_soft_and_observable() {
         let config = NvidiaSmiSamplerConfig::new(Duration::from_secs(1), "0").unwrap();
         let (sampler, diagnostic) = NvidiaSmiSampler::start_fail_soft_with_program(
@@ -637,7 +718,7 @@ mod tests {
         let program = directory.path().join("closed-stdout-nvidia-smi");
         executable(
             &program,
-            "#!/bin/sh\nprintf 'helper closed stdout\\n' >&2\nexec 1>&-\nsleep 30\n",
+            "#!/bin/sh\nprintf 'helper closed stdout\\n' >&2\nexec 1>&-\nexec sleep 30\n",
         );
         let config = NvidiaSmiSamplerConfig::new(Duration::from_secs(1), "0").unwrap();
         let started = Instant::now();

--- a/hermes-train/src/lib.rs
+++ b/hermes-train/src/lib.rs
@@ -1,6 +1,11 @@
 //! Reusable training workflow, task, and data-preparation contracts.
 
 pub mod acceptance;
+/// Internal, security-sensitive artifact I/O shared by the library and the
+/// `hermes-train` binary. This is public only because Cargo builds those as
+/// separate crates; it is not a stable user-facing API.
+#[doc(hidden)]
+pub mod artifact_io;
 pub mod benchmark;
 pub mod benchmark_worker;
 pub mod builtin_dreaming;
@@ -12,8 +17,11 @@ pub mod metrics;
 pub mod native_host;
 pub mod native_sleep;
 pub mod optimizer_artifact;
+mod pinned_executable;
 pub mod posttrain;
 pub mod promotion;
+#[cfg(unix)]
+mod protocol_process;
 pub mod qat_candidate;
 pub mod quantization;
 pub mod resource_worker;

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
-use std::io::{BufReader, Read, Write};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::{Duration, Instant};
@@ -12,10 +13,10 @@ use burn_nn::loss::CrossEntropyLossConfig;
 use burn_optim::{AdamWConfig, GradientsAccumulator, GradientsParams};
 use clap::{Parser, Subcommand, ValueEnum};
 use hermes_llm::{
-    BlockDef, ModelDef, Tokenizer, Transformer, load_safetensors, save_safetensors,
-    upgrade_safetensors_to_memory,
+    BlockDef, ModelDef, Tokenizer, Transformer, save_safetensors, upgrade_safetensors_to_memory,
 };
 use hermes_train::acceptance::{AcceptancePolicy, PromotionReport};
+use hermes_train::artifact_io::{hash_regular_file, read_regular_bounded};
 use hermes_train::benchmark::{
     AblationId, BenchmarkRunConfig, BenchmarkRunner, BenchmarkTarget, VerifiedBenchmarkRun,
     VerifiedBenchmarkSuite, VerifiedResourceComparison, evaluate_verified_promotion,
@@ -26,16 +27,16 @@ use hermes_train::builtin_sleep_runtime::{
     BuiltinPeriodicSleepBoundaryDriver, BuiltinSleepPhaseContextFactory,
 };
 use hermes_train::corpus::{
-    CorpusManifest, CurriculumCompositionConfig, HermesCorpusTokenizer,
-    SearchApiPostgresCorpusRecipe,
+    CurriculumCompositionConfig, HermesCorpusTokenizer, SearchApiPostgresCorpusRecipe,
 };
 use hermes_train::device_sampler::{
     DeviceSamplerDrain, NvidiaSmiSampler, NvidiaSmiSamplerConfig, validate_physical_device_selector,
 };
 use hermes_train::metrics::{
-    MetricContext, MetricEvent, MetricPhase, MetricPhaseKind, MetricWriter, OptimizationMetrics,
-    PhaseBoundary, PhaseTimingMetrics, QuantizationFormat as MetricQuantizationFormat,
-    QuantizationMetrics, QuantizationStage, ThroughputMetrics, validate_metric_prefix_for_run,
+    MemoryTier as MetricMemoryTier, MetricContext, MetricEvent, MetricPhase, MetricPhaseKind,
+    MetricWriter, OptimizationMetrics, PhaseBoundary, PhaseTimingMetrics,
+    QuantizationFormat as MetricQuantizationFormat, QuantizationMetrics, QuantizationStage,
+    ThroughputMetrics, TierUpdateMetrics, TierUpdateOutcome, validate_metric_prefix_for_run,
     validate_metric_snapshot_for_run,
 };
 use hermes_train::native_sleep::{
@@ -44,20 +45,32 @@ use hermes_train::native_sleep::{
 };
 use hermes_train::posttrain::forward_kl_distillation_tensor;
 use hermes_train::promotion::NativePromotionExecutor;
-use hermes_train::qat_candidate::{open_qat_candidate, publish_qat_candidate};
+#[cfg(test)]
+use hermes_train::qat_candidate::open_qat_candidate;
+use hermes_train::qat_candidate::{
+    open_qat_candidate_addressed, publish_qat_candidate,
+    publish_qat_candidate_from_authenticated_source,
+};
 use hermes_train::quantization::{
     BONSAI_GROUP_SIZE, QuantizationRecipe, UltraQuantFormat, WorkflowQuantizationPlan,
     WorkflowQuantizationTraining, export_safetensors_archive, fake_quantized_transformer,
 };
 use hermes_train::resource_worker::{ExternalResourceEvaluator, run_resource_benchmark};
 use hermes_train::runtime::{
-    ALL_PHASE_KINDS, ExecutorRegistry, ImmutableModelCheckpoint, RuntimeStatus, WorkflowRunState,
-    run_until_yield_or_complete, workflow_signature as runtime_workflow_signature,
+    ALL_PHASE_KINDS, ExecutorRegistry, ImmutableArtifact, ImmutableModelCheckpoint, RuntimeStatus,
+    WorkflowRunState, run_until_yield_or_complete,
+    workflow_signature as runtime_workflow_signature,
 };
-use hermes_train::tier_optimizer::TierOptimizerBank;
-use hermes_train::worker::{AtomicRuntimeCheckpoint, ExternalPhaseExecutor};
+use hermes_train::task::{TaskAdapter, TaskConfig};
+use hermes_train::tensor_sleep::TensorTransactionStore;
+use hermes_train::tier_optimizer::{
+    DurableTierOptimizerPublisher, TierOptimizerBank, WakeOnlyTierUpdate,
+};
+use hermes_train::worker::{
+    AtomicRuntimeCheckpoint, ExternalPhaseExecutor, PHASE_WORKER_PROTOCOL_VERSION,
+};
 use hermes_train::workflow::{
-    PhaseKind, ResolvedWorkflow, load_workflow as load_workflow_v2,
+    MemoryUpdateMode, PhaseKind, ResolvedWorkflow, load_workflow as load_workflow_v2,
     validate_sleep_schedule_for_model, validate_workflow_for_model,
 };
 use serde::Serialize;
@@ -71,25 +84,27 @@ mod wake;
 
 use checkpoint::{
     AdamWOptimizer, ArtifactRef, CheckpointPublication, OptimizerStateRef,
-    QuantizationTrainingState, RngStreamState, TRAINING_STATE_VERSION, TrainingState,
-    load_training_state, parameter_ids, save_training_checkpoint_with_evidence,
+    QuantizationTrainingState, RngStreamState, TRAINING_STATE_VERSION, TrainingMemoryUpdateState,
+    TrainingState, load_training_state, parameter_ids, save_training_checkpoint_with_evidence,
     verify_checkpoint_generation, verify_checkpoint_root,
 };
 #[cfg(test)]
 use data::TrainingSample;
 use data::{
-    BatchStats, SampleStreamConfig, TrainingBatch, count_samples, indexed_causal_sample_count,
-    make_batch, visit_samples,
+    BatchStats, PhaseDataBinding, SampleStreamConfig, TrainingBatch, count_samples,
+    indexed_causal_sample_count, make_batch, visit_samples,
 };
 use muon::BatchedMuon;
-use wake::{ObjectiveConfig, ResolvedWakePlan, load_wake_plan};
+use wake::{ResolvedWakePlan, load_wake_plan};
 
 const MUON_LR_SCALE: f64 = 20.0;
 const FNV1A64_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const RUN_WORKFLOW_DISPATCH_IDENTITY_VERSION: u32 = 1;
 const FNV1A64_PRIME: u64 = 0x100000001b3;
 const DATA_RNG_STREAM: &str = "data";
 const MODEL_RNG_STREAM: &str = "model_dropout";
 const MODEL_RNG_DOMAIN: u64 = 0xd2b7_4407_b1ce_6e93;
+const MAX_CLI_CONTENT_ADDRESSED_JSON_BYTES: u64 = 64 * 1024 * 1024;
 
 #[derive(Parser)]
 #[command(name = "hermes-train", about = "Hermes model training")]
@@ -354,7 +369,7 @@ struct RunBenchmarkArgs {
     /// Candidate target JSON as PATH=SHA256.
     #[arg(long, value_name = "PATH=SHA256")]
     candidate: ContentAddressedPath,
-    /// Local executable implementing benchmark-worker protocol v1.
+    /// Local executable implementing benchmark-worker protocol v2.
     #[arg(long)]
     evaluator: PathBuf,
     /// Exact evaluator identity as `sha256:<64 lowercase hex>`.
@@ -362,6 +377,9 @@ struct RunBenchmarkArgs {
     evaluator_sha256: String,
     #[arg(long = "evaluator-arg", allow_hyphen_values = true)]
     evaluator_arguments: Vec<OsString>,
+    /// Hard wall-clock limit for each request and graceful worker shutdown.
+    #[arg(long, default_value_t = 3_600)]
+    evaluator_timeout_seconds: u64,
     /// Require later Manchu/Kalamang/BABILong sweep entries too.
     #[arg(long)]
     include_later_sweeps: bool,
@@ -381,7 +399,7 @@ struct RunResourceBenchmarkArgs {
     /// Acceptance policy JSON as PATH=SHA256.
     #[arg(long, value_name = "PATH=SHA256")]
     policy: ContentAddressedPath,
-    /// Local executable implementing resource-worker protocol v1.
+    /// Local executable implementing resource-worker protocol v2.
     #[arg(long)]
     evaluator: PathBuf,
     /// Exact executable identity as `sha256:<64 lowercase hex>`.
@@ -445,6 +463,9 @@ struct RunWorkflowArgs {
     executor_sha256: String,
     #[arg(long = "executor-arg", allow_hyphen_values = true)]
     executor_arguments: Vec<OsString>,
+    /// Hard wall-clock bound for each phase-worker process.
+    #[arg(long, default_value_t = 3_600)]
+    executor_timeout_seconds: u64,
     #[arg(long, default_value = "workflow-runtime.json")]
     state: PathBuf,
     /// Append-only typed JSONL metric journal emitted by the phase worker.
@@ -621,6 +642,71 @@ fn learning_rate(args: &TrainArgs, step: usize, total_steps: usize) -> f64 {
     min_lr + cosine * (args.lr - min_lr)
 }
 
+fn validate_wake_only_metric_schedule(schedule: &hermes_train::sleep::SleepSchedule) -> Result<()> {
+    let ids = schedule
+        .tiers
+        .iter()
+        .map(|tier| tier.id.as_str())
+        .collect::<Vec<_>>();
+    ensure!(
+        matches!(
+            ids.as_slice(),
+            ["fast", "slow"] | ["fast", "medium", "slow"]
+        ),
+        "the stock wake_only trainer emits typed tier metrics and therefore requires tier ids ordered as [fast, slow] or [fast, medium, slow]"
+    );
+    Ok(())
+}
+
+fn metric_memory_tier(id: &str) -> Result<MetricMemoryTier> {
+    match id {
+        "fast" => Ok(MetricMemoryTier::Fast),
+        "medium" => Ok(MetricMemoryTier::Medium),
+        "slow" => Ok(MetricMemoryTier::Slow),
+        _ => bail!("wake_only tier `{id}` has no typed metric representation"),
+    }
+}
+
+fn append_wake_only_tier_metrics(
+    metrics: &mut MetricWriter,
+    context: &MetricContext,
+    schedule: &hermes_train::sleep::SleepSchedule,
+    updates: &[WakeOnlyTierUpdate],
+) -> Result<()> {
+    validate_wake_only_metric_schedule(schedule)?;
+    ensure!(
+        updates.windows(2).all(|pair| pair[0].tier < pair[1].tier),
+        "wake_only tier update report is not ordered fastest-to-slowest"
+    );
+    for update in updates {
+        let configured = schedule
+            .tiers
+            .get(update.tier)
+            .context("wake_only tier update is outside the configured schedule")?;
+        ensure!(
+            configured.id == update.tier_id,
+            "wake_only tier update identity differs from the configured schedule"
+        );
+        metrics.append(
+            context.clone(),
+            MetricEvent::TierUpdate(TierUpdateMetrics {
+                transaction_id: update.prospective_update_sha256.clone(),
+                tier: metric_memory_tier(&update.tier_id)?,
+                receiver_tier: None,
+                tier_clock: update.trigger_clock,
+                update_period: configured.update_period,
+                accumulated_micro_steps: update.accumulated_optimizer_steps,
+                outcome: TierUpdateOutcome::Committed,
+                update_l2_norm: None,
+                reserve_slot: None,
+                reserve_generation: None,
+                optimizer_state_reset: false,
+            }),
+        )?;
+    }
+    Ok(())
+}
+
 fn validate_train_args(args: &TrainArgs) -> Result<()> {
     ensure!(
         args.lr.is_finite() && args.lr > 0.0,
@@ -653,38 +739,85 @@ fn resolve_wake_plan(args: &TrainArgs) -> Result<ResolvedWakePlan> {
 }
 
 fn validate_model_wake_plan(config: &ModelDef, workflow: &ResolvedWakePlan) -> Result<()> {
-    let memory_enabled =
-        (0..config.num_layers).any(|layer| config.block_for_layer(layer).memory.is_some());
+    let memory_layers = (0..config.num_layers)
+        .filter(|&layer| config.block_for_layer(layer).memory.is_some())
+        .count();
+    ensure!(
+        memory_layers == 0 || memory_layers == config.num_layers,
+        "model mixes {memory_layers} memory layers with {} ordinary-FFN layers; the stock trainer requires one explicit topology across every layer",
+        config.num_layers - memory_layers
+    );
     let periodic = workflow
         .phases
         .iter()
         .filter_map(|phase| phase.periodic_sleep.as_ref())
         .collect::<Vec<_>>();
-    if memory_enabled {
+    let wake_only = workflow
+        .phases
+        .iter()
+        .filter_map(|phase| phase.memory_update_mode.as_ref())
+        .collect::<Vec<_>>();
+    if memory_layers > 0 {
         ensure!(
-            !periodic.is_empty(),
-            "sleep-capable MAL models require periodic_sleep on every wake phase"
+            periodic.len() == workflow.phases.len() || wake_only.len() == workflow.phases.len(),
+            "memory MAL models require one update policy on every wake phase: periodic_sleep or memory_update_mode wake_only"
         );
-        ensure!(
-            periodic.len() == workflow.phases.len(),
-            "every phase training a sleep-capable MAL model must carry periodic_sleep so memory parameters never enter the ordinary wake optimizer"
-        );
-        ensure!(
-            periodic.iter().all(|config| *config == periodic[0]),
-            "all phases in one memory training run must use an identical periodic_sleep configuration"
-        );
-        ensure!(
-            periodic[0].schedule.clock == hermes_train::sleep::UpdateClock::OptimizerSteps,
-            "the stock train command supports periodic sleep only at optimizer_steps boundaries; model_tokens can cross multiple memory boundaries inside one indivisible optimizer update"
-        );
-        validate_sleep_schedule_for_model(config, &periodic[0].schedule, &workflow.phases[0].name)?;
+        if periodic.len() == workflow.phases.len() {
+            ensure!(
+                wake_only.is_empty(),
+                "memory phases cannot combine periodic_sleep with memory_update_mode"
+            );
+            ensure!(
+                periodic.iter().all(|config| *config == periodic[0]),
+                "all phases in one memory training run must use an identical periodic_sleep configuration"
+            );
+            ensure!(
+                periodic[0].schedule.clock == hermes_train::sleep::UpdateClock::OptimizerSteps,
+                "the stock train command supports periodic sleep only at optimizer_steps boundaries; model_tokens can cross multiple memory boundaries inside one indivisible optimizer update"
+            );
+            validate_sleep_schedule_for_model(
+                config,
+                &periodic[0].schedule,
+                &workflow.phases[0].name,
+            )?;
+        } else {
+            ensure!(
+                periodic.is_empty(),
+                "wake_only memory phases cannot install periodic_sleep"
+            );
+            ensure!(
+                wake_only.iter().all(|mode| *mode == wake_only[0]),
+                "all phases in one memory training run must use an identical memory_update_mode configuration"
+            );
+            ensure!(
+                wake_only[0].schedule().clock == hermes_train::sleep::UpdateClock::OptimizerSteps,
+                "the stock train command supports wake_only tier updates only at optimizer_steps boundaries"
+            );
+            validate_sleep_schedule_for_model(
+                config,
+                wake_only[0].schedule(),
+                &workflow.phases[0].name,
+            )?;
+            validate_wake_only_metric_schedule(wake_only[0].schedule())?;
+        }
     } else {
         ensure!(
-            periodic.is_empty(),
-            "periodic_sleep requires a MAL model with an explicit memory hierarchy"
+            periodic.is_empty() && wake_only.is_empty(),
+            "periodic_sleep and memory_update_mode require a MAL model with an explicit memory hierarchy"
         );
     }
     for phase in &workflow.phases {
+        for (field, value) in [
+            ("sequence_length", phase.sequence_length),
+            ("batch_size", phase.batch_size),
+            ("gradient_accumulation", phase.gradient_accumulation),
+        ] {
+            ensure!(
+                u32::try_from(value).is_ok(),
+                "workflow phase `{}` {field} exceeds the checkpoint-metric range",
+                phase.name
+            );
+        }
         ensure!(
             phase.sequence_length <= config.max_seq_len,
             "workflow phase `{}` sequence_length {} exceeds model max_seq_len {}",
@@ -692,10 +825,15 @@ fn validate_model_wake_plan(config: &ModelDef, workflow: &ResolvedWakePlan) -> R
             phase.sequence_length,
             config.max_seq_len
         );
-        if matches!(
-            phase.objective,
-            ObjectiveConfig::ContrastiveRetrieval { .. }
-        ) {
+        if let Some(plan) = &phase.quantization {
+            ensure!(
+                !config.embeddings.tie_weights
+                    || plan.recipe.quantize_embeddings == plan.recipe.quantize_lm_head,
+                "workflow phase `{}` assigns different embedding and lm_head quantization policies to tied model weights",
+                phase.name
+            );
+        }
+        if matches!(phase.objective, TaskConfig::RetrievalRepresentation { .. }) {
             let layer = phase
                 .objective
                 .retrieval_layer()
@@ -727,14 +865,17 @@ struct PhasePlan {
 
 fn planned_sample_count(
     data: &Path,
-    objective: &ObjectiveConfig,
+    objective: &TaskConfig,
     tokenizer: &Tokenizer,
     sequence_length: usize,
     token_cache: &Path,
+    data_binding: &PhaseDataBinding,
 ) -> Result<usize> {
-    if matches!(objective, ObjectiveConfig::CausalLm)
+    data_binding.ensure_still_published()?;
+    if matches!(objective, TaskConfig::CausalLm {})
         && let Some(samples) = indexed_causal_sample_count(token_cache, sequence_length)?
     {
+        data_binding.ensure_still_published()?;
         println!(
             "token_cache={} indexed_samples={samples}",
             token_cache.display()
@@ -747,6 +888,7 @@ fn planned_sample_count(
         tokenizer,
         sequence_length,
         Some(token_cache),
+        data_binding,
     )
 }
 
@@ -754,10 +896,12 @@ fn plan_training(
     workflow: &ResolvedWakePlan,
     tokenizer: &Tokenizer,
     token_cache_paths: &[PathBuf],
+    data_bindings: &[PhaseDataBinding],
 ) -> Result<(Vec<PhasePlan>, usize)> {
     ensure!(
-        token_cache_paths.len() == workflow.phases.len(),
-        "every workflow phase must have one resolved token-cache path"
+        token_cache_paths.len() == workflow.phases.len()
+            && data_bindings.len() == workflow.phases.len(),
+        "every workflow phase must have one token-cache path and authenticated data binding"
     );
     let mut total_steps = 0usize;
     let mut plan = Vec::with_capacity(workflow.phases.len());
@@ -771,6 +915,7 @@ fn plan_training(
                     tokenizer,
                     phase.sequence_length,
                     &token_cache_paths[phase_index],
+                    &data_bindings[phase_index],
                 )?;
                 let steps_per_epoch =
                     (samples / phase.batch_size).div_euclid(phase.gradient_accumulation);
@@ -812,19 +957,103 @@ fn plan_training(
 }
 
 fn file_sha256(path: &Path) -> Result<String> {
-    let file =
-        fs::File::open(path).with_context(|| format!("failed to hash {}", path.display()))?;
-    let mut reader = BufReader::new(file);
-    let mut hasher = Sha256::new();
-    let mut buffer = [0u8; 1024 * 1024];
-    loop {
-        let read = reader.read(&mut buffer)?;
+    hash_regular_file(path)
+        .map(|(_, sha256)| sha256)
+        .with_context(|| format!("failed to hash {}", path.display()))
+}
+
+/// Read and authenticate the exact regular-file bytes that a model loader will
+/// consume. Hashing and then reopening a pathname is insufficient because a
+/// replacement between those operations could load a different checkpoint.
+fn read_pinned_checkpoint_bytes(path: &Path, expected_sha256: &str) -> Result<Vec<u8>> {
+    read_pinned_checkpoint_bytes_after_open(path, expected_sha256, || Ok(()))
+}
+
+fn read_pinned_checkpoint_bytes_after_open(
+    path: &Path,
+    expected_sha256: &str,
+    after_open: impl FnOnce() -> Result<()>,
+) -> Result<Vec<u8>> {
+    let inspected = fs::symlink_metadata(path)
+        .with_context(|| format!("inspecting pinned checkpoint {}", path.display()))?;
+    ensure!(
+        inspected.is_file() && !inspected.file_type().is_symlink(),
+        "pinned checkpoint {} must be a regular non-symlink file",
+        path.display()
+    );
+    let mut options = fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("opening pinned checkpoint {}", path.display()))?;
+    let opened = file.metadata()?;
+    ensure!(opened.is_file(), "opened pinned checkpoint is not a file");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        ensure!(
+            inspected.dev() == opened.dev() && inspected.ino() == opened.ino(),
+            "pinned checkpoint changed while it was opened"
+        );
+    }
+    after_open()?;
+    let expected_bytes = usize::try_from(opened.len())
+        .context("pinned checkpoint is too large for this process address space")?;
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(expected_bytes)
+        .context("cannot reserve memory for pinned checkpoint bytes")?;
+    let mut buffer = [0_u8; 1024 * 1024];
+    while bytes.len() < expected_bytes {
+        let remaining = expected_bytes - bytes.len();
+        let chunk_bytes = remaining.min(buffer.len());
+        let read = file
+            .read(&mut buffer[..chunk_bytes])
+            .with_context(|| format!("reading pinned checkpoint {}", path.display()))?;
         if read == 0 {
             break;
         }
-        hasher.update(&buffer[..read]);
+        bytes.extend_from_slice(&buffer[..read]);
     }
-    Ok(format!("sha256:{:x}", hasher.finalize()))
+    let mut extra = [0_u8; 1];
+    let has_extra = file
+        .read(&mut extra)
+        .with_context(|| format!("checking pinned checkpoint length {}", path.display()))?
+        != 0;
+    let after = file.metadata()?;
+    ensure!(
+        !has_extra
+            && bytes.len() == expected_bytes
+            && after.len() == bytes.len() as u64
+            && after.len() == opened.len()
+            && after.modified().ok() == opened.modified().ok(),
+        "pinned checkpoint changed while it was read"
+    );
+    let published = fs::symlink_metadata(path)
+        .with_context(|| format!("reinspecting pinned checkpoint {}", path.display()))?;
+    ensure!(
+        published.is_file() && !published.file_type().is_symlink(),
+        "pinned checkpoint publication changed while it was read"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        ensure!(
+            published.dev() == opened.dev() && published.ino() == opened.ino(),
+            "pinned checkpoint publication changed while it was read"
+        );
+    }
+    let observed = format!("sha256:{:x}", Sha256::digest(&bytes));
+    ensure!(
+        observed == expected_sha256,
+        "pinned checkpoint hash mismatch: expected {expected_sha256}, observed {observed}"
+    );
+    Ok(bytes)
 }
 
 fn stable_cache_id(value: &str) -> String {
@@ -898,21 +1127,6 @@ fn validate_wake_rng_state(state: &TrainingState, seed: u64) -> Result<()> {
         "checkpoint model RNG seed differs from this invocation"
     );
     Ok(())
-}
-
-fn metric_phase_kind(kind: PhaseKind) -> MetricPhaseKind {
-    match kind {
-        PhaseKind::Pretrain => MetricPhaseKind::Pretrain,
-        PhaseKind::ContinuedPretrain => MetricPhaseKind::ContinuedPretrain,
-        PhaseKind::Sft => MetricPhaseKind::Sft,
-        PhaseKind::Preference => MetricPhaseKind::Preference,
-        PhaseKind::Rl => MetricPhaseKind::Rl,
-        PhaseKind::Distillation => MetricPhaseKind::Distillation,
-        PhaseKind::Sleep => MetricPhaseKind::Sleep,
-        PhaseKind::Quantization => MetricPhaseKind::Quantization,
-        PhaseKind::Evaluation => MetricPhaseKind::Evaluation,
-        PhaseKind::Promotion => MetricPhaseKind::Promotion,
-    }
 }
 
 fn start_device_sampler(args: &TrainArgs) -> Option<NvidiaSmiSampler> {
@@ -1045,18 +1259,22 @@ fn run_signature(
     Ok(format!("sha256:{:x}", Sha256::digest(encoded)))
 }
 
-fn phase_data_identity(path: &Path, tokenizer: &Tokenizer, tokenizer_hash: &str) -> Result<String> {
-    let manifest_path = if path.is_dir() {
-        Some(path.join("manifest.json"))
-    } else if path.file_name().is_some_and(|name| name == "manifest.json") {
-        Some(path.to_owned())
-    } else {
-        None
+fn bind_phase_data(
+    path: &Path,
+    tokenizer: &Tokenizer,
+    tokenizer_hash: &str,
+    cache: &mut HashMap<PathBuf, PhaseDataBinding>,
+) -> Result<PhaseDataBinding> {
+    let binding = match cache.get(path) {
+        Some(binding) => binding.clone(),
+        None => {
+            let binding = PhaseDataBinding::open(path)?;
+            cache.insert(path.to_owned(), binding.clone());
+            binding
+        }
     };
-    if let Some(manifest_path) = manifest_path {
-        let manifest: CorpusManifest = read_json(&manifest_path)?;
-        let root = manifest_path.parent().unwrap_or_else(|| Path::new("."));
-        manifest.verify(root)?;
+    if let Some(corpus) = binding.authenticated_corpus() {
+        let manifest = corpus.manifest();
         ensure!(
             manifest.build.tokenizer.vocabulary_size == tokenizer.vocab_size(),
             "corpus tokenizer vocabulary {} differs from training tokenizer vocabulary {}",
@@ -1069,9 +1287,8 @@ fn phase_data_identity(path: &Path, tokenizer: &Tokenizer, tokenizer_hash: &str)
             manifest.build.tokenizer.revision,
             tokenizer_hash
         );
-        return Ok(format!("sha256:{}", manifest.manifest_sha256));
     }
-    file_sha256(path)
+    Ok(binding)
 }
 
 fn add_batch_stats(total: &mut BatchStats, batch: BatchStats) -> Result<()> {
@@ -1098,14 +1315,26 @@ fn add_batch_stats(total: &mut BatchStats, batch: BatchStats) -> Result<()> {
     Ok(())
 }
 
+struct ObjectiveForward {
+    loss: Tensor<1>,
+    router_loss: Option<Tensor<1>>,
+    stats: BatchStats,
+    retrieval_correct: Option<Tensor<1>>,
+    /// Student outputs used by QAT distillation. Language objectives store
+    /// selected vocabulary logits; retrieval stores the unscaled similarity
+    /// matrix. Absent outside a teacher-distillation phase.
+    distillation_logits: Option<Tensor<2>>,
+}
+
 fn objective_loss(
     model: &Transformer,
     batch: TrainingBatch,
-    objective: &ObjectiveConfig,
-) -> Result<(Tensor<1>, Option<Tensor<1>>, BatchStats, Option<Tensor<1>>)> {
+    objective: &TaskConfig,
+    capture_distillation_logits: bool,
+) -> Result<ObjectiveForward> {
     let stats = batch.stats();
     let mut retrieval_correct = None;
-    let (loss, router_loss) = match batch {
+    let (loss, router_loss, distillation_logits) = match batch {
         TrainingBatch::Language(batch) => {
             let data::LanguageBatch {
                 input_ids,
@@ -1114,29 +1343,52 @@ fn objective_loss(
                 ..
             } = *batch;
             match objective {
-                ObjectiveConfig::CausalLm => {
+                TaskConfig::CausalLm {} => {
                     ensure!(
                         loss_positions.is_none(),
                         "causal_lm batch unexpectedly contains a target mask"
                     );
-                    model.forward_loss_with_router(input_ids, targets)
+                    if capture_distillation_logits {
+                        let (loss, router_loss, logits) =
+                            model.forward_loss_and_logits_with_router(input_ids, targets);
+                        (loss, router_loss, Some(logits))
+                    } else {
+                        let (loss, router_loss) =
+                            model.forward_loss_with_router(input_ids, targets);
+                        (loss, router_loss, None)
+                    }
                 }
-                ObjectiveConfig::Summarization { .. }
-                | ObjectiveConfig::RetrievalPlanning { .. }
-                | ObjectiveConfig::InstructionTuning { .. }
-                | ObjectiveConfig::QaReasoning { .. } => {
+                TaskConfig::Summarization { .. }
+                | TaskConfig::RetrievalPlanning { .. }
+                | TaskConfig::InstructionTuning { .. }
+                | TaskConfig::QaReasoning { .. } => {
                     let positions = loss_positions
                         .ok_or_else(|| anyhow::anyhow!("structured batch has no target mask"))?;
-                    model.forward_masked_loss_with_router(input_ids, targets, positions)
+                    if capture_distillation_logits {
+                        let (loss, router_loss, logits) = model
+                            .forward_masked_loss_and_logits_with_router(
+                                input_ids, targets, positions,
+                            );
+                        (loss, router_loss, Some(logits))
+                    } else {
+                        let (loss, router_loss) =
+                            model.forward_masked_loss_with_router(input_ids, targets, positions);
+                        (loss, router_loss, None)
+                    }
                 }
-                ObjectiveConfig::ContrastiveRetrieval { .. } => {
+                TaskConfig::RetrievalRepresentation { .. } => {
                     bail!("contrastive_retrieval phase produced a language batch")
+                }
+                TaskConfig::RetrievalRanking { .. }
+                | TaskConfig::PairwisePreference {}
+                | TaskConfig::VerifiableRl { .. } => {
+                    unreachable!("wake projection rejects unsupported task contracts")
                 }
             }
         }
         TrainingBatch::Retrieval(batch) => {
             ensure!(
-                matches!(objective, ObjectiveConfig::ContrastiveRetrieval { .. }),
+                matches!(objective, TaskConfig::RetrievalRepresentation { .. }),
                 "non-retrieval phase produced a retrieval batch"
             );
             let data::RetrievalBatch {
@@ -1155,9 +1407,9 @@ fn objective_loss(
                 model.forward_embeddings_with_router(query_ids, query_end_positions, layer);
             let (documents, document_router_loss) =
                 model.forward_embeddings_with_router(document_ids, document_end_positions, layer);
-            let logits = queries
-                .matmul(documents.transpose())
-                .div_scalar(temperature);
+            let similarities = queries.matmul(documents.transpose());
+            let distillation_logits = capture_distillation_logits.then(|| similarities.clone());
+            let logits = similarities.div_scalar(temperature);
             retrieval_correct = Some(
                 logits
                     .clone()
@@ -1172,88 +1424,89 @@ fn objective_loss(
                 .init(&labels.device())
                 .forward(logits, labels);
             let router_loss = sum_optional_tensors(query_router_loss, document_router_loss);
-            (loss, router_loss)
+            (loss, router_loss, distillation_logits)
         }
     };
-    Ok((loss, router_loss, stats, retrieval_correct))
+    Ok(ObjectiveForward {
+        loss,
+        router_loss,
+        stats,
+        retrieval_correct,
+        distillation_logits,
+    })
 }
 
-fn quantization_forward_kl(
-    student: &Transformer,
+fn quantization_teacher_logits(
     teacher: &Transformer,
     batch: &TrainingBatch,
-    objective: &ObjectiveConfig,
-    temperature: f64,
-) -> Result<Tensor<1>> {
-    let (teacher_logits, student_logits) = match batch {
+    objective: &TaskConfig,
+) -> Result<Tensor<2>> {
+    let teacher_logits = match batch {
         TrainingBatch::Language(batch) => {
             let [rows, sequence] = batch.input_ids.dims();
-            let vocabulary = student.config().vocab_size;
+            let vocabulary = teacher.config().vocab_size;
             ensure!(
-                teacher.config().vocab_size == vocabulary,
-                "quantization teacher/student vocabularies differ"
+                vocabulary > 1,
+                "quantization teacher vocabulary must contain at least two tokens"
             );
             match objective {
-                ObjectiveConfig::CausalLm => {
+                TaskConfig::CausalLm {} => {
                     ensure!(
                         batch.loss_positions.is_none(),
                         "causal_lm distillation batch unexpectedly contains a target mask"
                     );
-                    (
-                        teacher
-                            .forward(batch.input_ids.clone(), 0)
-                            .reshape([rows * sequence, vocabulary]),
-                        student
-                            .forward(batch.input_ids.clone(), 0)
-                            .reshape([rows * sequence, vocabulary]),
-                    )
+                    teacher
+                        .forward(batch.input_ids.clone().inner(), 0)
+                        .reshape([rows * sequence, vocabulary])
                 }
-                ObjectiveConfig::Summarization { .. }
-                | ObjectiveConfig::RetrievalPlanning { .. }
-                | ObjectiveConfig::InstructionTuning { .. }
-                | ObjectiveConfig::QaReasoning { .. } => {
+                TaskConfig::Summarization { .. }
+                | TaskConfig::RetrievalPlanning { .. }
+                | TaskConfig::InstructionTuning { .. }
+                | TaskConfig::QaReasoning { .. } => {
                     let positions = batch.loss_positions.as_ref().ok_or_else(|| {
                         anyhow::anyhow!("structured distillation batch has no target mask")
                     })?;
-                    (
-                        teacher.forward_selected_logits(batch.input_ids.clone(), positions.clone()),
-                        student.forward_selected_logits(batch.input_ids.clone(), positions.clone()),
+                    teacher.forward_selected_logits(
+                        batch.input_ids.clone().inner(),
+                        positions.clone().inner(),
                     )
                 }
-                ObjectiveConfig::ContrastiveRetrieval { .. } => {
+                TaskConfig::RetrievalRepresentation { .. } => {
                     bail!("retrieval objective produced a language distillation batch")
+                }
+                TaskConfig::RetrievalRanking { .. }
+                | TaskConfig::PairwisePreference {}
+                | TaskConfig::VerifiableRl { .. } => {
+                    unreachable!("wake projection rejects unsupported task contracts")
                 }
             }
         }
         TrainingBatch::Retrieval(batch) => {
+            ensure!(
+                matches!(objective, TaskConfig::RetrievalRepresentation { .. }),
+                "non-retrieval phase produced a retrieval distillation batch"
+            );
             let layer = objective.retrieval_layer();
             let teacher_queries = teacher.forward_embeddings(
-                batch.query_ids.clone(),
-                batch.query_end_positions.clone(),
+                batch.query_ids.clone().inner(),
+                batch.query_end_positions.clone().inner(),
                 layer,
             );
             let teacher_documents = teacher.forward_embeddings(
-                batch.document_ids.clone(),
-                batch.document_end_positions.clone(),
+                batch.document_ids.clone().inner(),
+                batch.document_end_positions.clone().inner(),
                 layer,
             );
-            let student_queries = student.forward_embeddings(
-                batch.query_ids.clone(),
-                batch.query_end_positions.clone(),
-                layer,
-            );
-            let student_documents = student.forward_embeddings(
-                batch.document_ids.clone(),
-                batch.document_end_positions.clone(),
-                layer,
-            );
-            (
-                teacher_queries.matmul(teacher_documents.transpose()),
-                student_queries.matmul(student_documents.transpose()),
-            )
+            teacher_queries.matmul(teacher_documents.transpose())
         }
     };
-    forward_kl_distillation_tensor(teacher_logits, student_logits, temperature, true)
+    debug_assert!(
+        !teacher_logits.device().is_autodiff(),
+        "frozen quantization teacher unexpectedly built an autodiff graph"
+    );
+    // The KL loss is part of the student's autodiff graph. Lift the immutable
+    // teacher values back onto that backend without replaying teacher ops.
+    Ok(Tensor::from_inner(teacher_logits))
 }
 
 fn metric_quantization_format(format: UltraQuantFormat) -> MetricQuantizationFormat {
@@ -1308,40 +1561,39 @@ fn load_quantization_teacher(
     else {
         return Ok(None);
     };
-    let metadata = fs::symlink_metadata(teacher_checkpoint).with_context(|| {
-        format!(
-            "failed to inspect frozen quantization teacher {}",
-            teacher_checkpoint.display()
-        )
-    })?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "quantization teacher must be a regular non-symlink file"
-    );
-    ensure!(
-        file_sha256(teacher_checkpoint)? == *teacher_sha256,
-        "quantization teacher checkpoint hash mismatch"
-    );
+    let teacher_bytes = read_pinned_checkpoint_bytes(teacher_checkpoint, teacher_sha256)
+        .with_context(|| {
+            format!(
+                "cannot authenticate frozen quantization teacher {}",
+                teacher_checkpoint.display()
+            )
+        })?;
     let mut teacher_config = config.clone();
     disable_quantization_teacher_dropout(&mut teacher_config);
     let mut teacher = Transformer::new(&teacher_config, device)?;
-    load_safetensors(&mut teacher, teacher_checkpoint)?;
+    hermes_llm::load_safetensors_bytes(
+        &mut teacher,
+        teacher_bytes,
+        &format!("quantization teacher {}", teacher_checkpoint.display()),
+    )?;
     Ok(Some(LoadedQuantizationTeacher {
-        model: teacher,
+        // Distillation never optimizes the teacher. Keep it on Burn's inner
+        // backend so its forward pass does not allocate an autodiff tape; the
+        // resulting logits are lifted into the student graph as constants.
+        model: teacher.valid(),
         sha256: teacher_sha256.clone(),
         temperature: *temperature,
         loss_weight: *loss_weight,
     }))
 }
 
-fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T> {
-    let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
-    serde_json::from_slice(&bytes).with_context(|| format!("invalid JSON in {}", path.display()))
-}
-
 fn read_addressed_json<T: serde::de::DeserializeOwned>(input: &ContentAddressedPath) -> Result<T> {
-    let bytes = fs::read(&input.path)
-        .with_context(|| format!("failed to read {}", input.path.display()))?;
+    let bytes = read_regular_bounded(
+        &input.path,
+        MAX_CLI_CONTENT_ADDRESSED_JSON_BYTES,
+        "content-addressed CLI JSON",
+    )
+    .with_context(|| format!("failed to read {}", input.path.display()))?;
     let actual = format!("{:x}", Sha256::digest(&bytes));
     ensure!(
         actual.eq_ignore_ascii_case(&input.sha256),
@@ -1572,6 +1824,10 @@ fn run_resource_benchmark_command(args: RunResourceBenchmarkArgs) -> Result<()> 
 }
 
 fn run_benchmark_command(args: RunBenchmarkArgs) -> Result<()> {
+    ensure!(
+        args.evaluator_timeout_seconds > 0,
+        "benchmark evaluator timeout must be positive"
+    );
     let config: BenchmarkRunConfig = read_addressed_json(&args.config)?;
     ensure!(
         config.evaluator_version == args.evaluator_sha256,
@@ -1593,7 +1849,12 @@ fn run_benchmark_command(args: RunBenchmarkArgs) -> Result<()> {
         &args.evaluator,
         args.evaluator_arguments,
         &args.evaluator_sha256,
-    )?;
+    )?
+    .with_timeout(Duration::from_secs(args.evaluator_timeout_seconds))?;
+    ensure!(
+        config.evaluator_arguments.as_slice() == evaluator.arguments(),
+        "benchmark evaluator arguments do not match the content-addressed run config"
+    );
     let run = BenchmarkRunner { config }.run(&suites, &baseline, &candidate, &mut evaluator)?;
     evaluator.finish()?;
     publish_new_json(&args.output, &run)?;
@@ -1682,28 +1943,31 @@ fn publish_new_json<T: Serialize>(output: &Path, value: &T) -> Result<()> {
     )
 }
 
-fn validate_cli_native_sleep_adapters(
+fn validate_cli_native_sleep_selection(
     workflow: &ResolvedWorkflow,
-    registry: &NativeSleepContextRegistry,
+    sleep_runtime_configured: bool,
 ) -> Result<()> {
     let standalone = workflow
         .phases
         .iter()
         .find(|phase| phase.kind == PhaseKind::Sleep);
-    if let Some(phase) = standalone {
-        ensure!(
-            registry.has_phase_factory(),
-            "workflow sleep phase `{}` requires an in-process NativeSleepPhaseContextFactory; the stock run-workflow CLI has no model/evaluator factory configured. Embed hermes-train, register the pinned adapters with NativeWorkflowAdapters, and run NativeWorkflowHost",
-            phase.name
-        );
-    }
-    let periodic = workflow
+    ensure!(
+        standalone.is_some() == sleep_runtime_configured,
+        if let Some(phase) = standalone {
+            format!(
+                "workflow sleep phase `{}` requires --sleep-runtime and --sleep-runtime-sha256",
+                phase.name
+            )
+        } else {
+            "--sleep-runtime is only valid for a workflow with a standalone sleep phase".to_owned()
+        }
+    );
+    if let Some(phase) = workflow
         .phases
         .iter()
-        .find(|phase| phase.periodic_sleep.is_some());
-    if let Some(phase) = periodic {
-        ensure!(
-            registry.has_periodic_driver(),
+        .find(|phase| phase.periodic_sleep.is_some())
+    {
+        bail!(
             "workflow phase `{}` enables periodic in-model sleep but the stock run-workflow CLI has no native wake-boundary executor configured. Embed hermes-train, register a NativePeriodicWakeExecutor, and run NativeWorkflowHost",
             phase.name
         );
@@ -1711,37 +1975,88 @@ fn validate_cli_native_sleep_adapters(
     Ok(())
 }
 
+/// Bind every implementation selected by the stock WorkflowV2 CLI into the
+/// atomic resume identity. The external worker still receives its own exact
+/// digest on the wire; this composite is only the durable dispatch identity.
+fn run_workflow_dispatch_identity(
+    external_execution_sha256: &str,
+    sleep_runtime_sha256: Option<&str>,
+) -> Result<String> {
+    let external = ImmutableArtifact::new(
+        "dispatch://external-phase-worker",
+        external_execution_sha256,
+    )?;
+    let sleep = sleep_runtime_sha256
+        .map(|sha256| ImmutableArtifact::new("dispatch://native-sleep-runtime", sha256))
+        .transpose()?;
+    let mut hasher = Sha256::new();
+    for part in [
+        b"hermes-run-workflow-dispatch".as_slice(),
+        &RUN_WORKFLOW_DISPATCH_IDENTITY_VERSION.to_le_bytes(),
+        &PHASE_WORKER_PROTOCOL_VERSION.to_le_bytes(),
+        external.sha256().as_bytes(),
+        sleep
+            .as_ref()
+            .map_or(b"none".as_slice(), |artifact| artifact.sha256().as_bytes()),
+    ] {
+        hasher.update((part.len() as u64).to_le_bytes());
+        hasher.update(part);
+    }
+    Ok(format!("sha256:{:x}", hasher.finalize()))
+}
+
 fn run_workflow_command(args: RunWorkflowArgs) -> Result<()> {
     let workflow = load_workflow_v2(&args.workflow)?;
-    let mut native_context = NativeSleepContextRegistry::new();
-    if let Some((path, sha256)) = args.sleep_runtime.zip(args.sleep_runtime_sha256) {
-        native_context
-            .register_phase_factory(BuiltinSleepPhaseContextFactory::load(path, &sha256)?)?;
-    }
-    // Fail before creating or advancing the runtime checkpoint. Native sleep
-    // cannot be delegated to the generic external worker because its typed
-    // model/evaluator objects and optimizer transaction live in process.
-    validate_cli_native_sleep_adapters(&workflow, &native_context)?;
+    ensure!(
+        args.sleep_runtime.is_some() == args.sleep_runtime_sha256.is_some(),
+        "--sleep-runtime and --sleep-runtime-sha256 must be provided together"
+    );
+    validate_cli_native_sleep_selection(&workflow, args.sleep_runtime.is_some())?;
     let executor = ExternalPhaseExecutor::new(
         &args.executor,
         args.executor_arguments,
         &args.executor_sha256,
+    )?
+    .with_timeout(Duration::from_secs(args.executor_timeout_seconds))?;
+    let dispatch_sha256 = run_workflow_dispatch_identity(
+        &executor.execution_identity(),
+        args.sleep_runtime_sha256.as_deref(),
     )?;
-    let mut checkpoint = AtomicRuntimeCheckpoint::new(&args.state, &args.executor_sha256)?;
-    match (&args.metrics, &args.run_id) {
-        (Some(metrics), Some(run_id)) => {
-            checkpoint.configure_metrics(metrics, run_id, args.resume)?;
-        }
-        (None, None) => {}
-        _ => bail!("--metrics and --run-id must be provided together"),
-    }
-    let mut state = if args.resume {
+    let mut checkpoint = AtomicRuntimeCheckpoint::new(&args.state, dispatch_sha256)?;
+
+    // Authenticate the complete dispatch identity before loading a runtime
+    // factory, whose validated configuration creates output stores. This
+    // read-only preflight also precedes metric-prefix truncation in `load`.
+    if args.resume {
         ensure!(
             args.initial_checkpoint_uri.is_none(),
             "--resume cannot replace the initial immutable checkpoint"
         );
+        checkpoint.verify_execution_identity()?;
+    }
+
+    let mut native_context = NativeSleepContextRegistry::new();
+    if let (Some(path), Some(sha256)) = (&args.sleep_runtime, &args.sleep_runtime_sha256) {
+        native_context
+            .register_phase_factory(BuiltinSleepPhaseContextFactory::load(path, sha256)?)?;
+    }
+    let mut state = if args.resume {
+        match (&args.metrics, &args.run_id) {
+            (Some(metrics), Some(run_id)) => {
+                checkpoint.configure_metrics(metrics, run_id, true)?;
+            }
+            (None, None) => {}
+            _ => bail!("--metrics and --run-id must be provided together"),
+        }
         checkpoint.load(&workflow)?
     } else {
+        match (&args.metrics, &args.run_id) {
+            (Some(metrics), Some(run_id)) => {
+                checkpoint.configure_metrics(metrics, run_id, false)?;
+            }
+            (None, None) => {}
+            _ => bail!("--metrics and --run-id must be provided together"),
+        }
         let initial_checkpoint = args
             .initial_checkpoint_uri
             .zip(args.initial_checkpoint_sha256)
@@ -1817,6 +2132,96 @@ mod tests {
     use hermes_llm::get_builtin_model;
 
     use super::*;
+
+    #[test]
+    fn coincident_wake_only_updates_emit_ordered_committed_metrics() {
+        let schedule: hermes_train::sleep::SleepSchedule =
+            serde_json::from_value(serde_json::json!({
+                "clock": "optimizer_steps",
+                "terminal_consolidation": "distill_into_base_v1",
+                "tiers": [
+                    {"id": "fast", "update_period": 1, "reserve_slots": 1},
+                    {"id": "slow", "update_period": 2, "reserve_slots": 2}
+                ]
+            }))
+            .unwrap();
+        let updates = vec![
+            WakeOnlyTierUpdate {
+                tier: 0,
+                tier_id: "fast".into(),
+                trigger_clock: 2,
+                accumulated_optimizer_steps: 1,
+                prospective_update_sha256: format!("sha256:{}", "a".repeat(64)),
+            },
+            WakeOnlyTierUpdate {
+                tier: 1,
+                tier_id: "slow".into(),
+                trigger_clock: 2,
+                accumulated_optimizer_steps: 2,
+                prospective_update_sha256: format!("sha256:{}", "b".repeat(64)),
+            },
+        ];
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        let mut metrics = MetricWriter::create(&path, "wake-only-metrics").unwrap();
+        let context = MetricContext {
+            global_step: 2,
+            phase: MetricPhase {
+                index: 0,
+                name: "wake-only".into(),
+                kind: MetricPhaseKind::Pretrain,
+            },
+            checkpoint_hash: None,
+        };
+        append_wake_only_tier_metrics(&mut metrics, &context, &schedule, &updates).unwrap();
+        metrics.sync_all().unwrap();
+        drop(metrics);
+
+        let records = fs::read_to_string(path)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str::<hermes_train::metrics::MetricRecord>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(records.len(), 2);
+        let projected = records
+            .iter()
+            .map(|record| match &record.event {
+                MetricEvent::TierUpdate(update) => (
+                    update.tier,
+                    update.update_period,
+                    update.accumulated_micro_steps,
+                    update.outcome,
+                    update.receiver_tier,
+                    update.reserve_slot,
+                    update.optimizer_state_reset,
+                ),
+                other => panic!("unexpected metric {other:?}"),
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            projected,
+            vec![
+                (
+                    MetricMemoryTier::Fast,
+                    1,
+                    1,
+                    TierUpdateOutcome::Committed,
+                    None,
+                    None,
+                    false,
+                ),
+                (
+                    MetricMemoryTier::Slow,
+                    2,
+                    2,
+                    TierUpdateOutcome::Committed,
+                    None,
+                    None,
+                    false,
+                ),
+            ]
+        );
+    }
 
     #[cfg(unix)]
     struct GenerationSwapGuard {
@@ -1928,6 +2333,54 @@ mod tests {
                 assert!(memory.tiers.iter().all(|tier| tier.ffn.dropout == 0.0));
             }
         }
+    }
+
+    #[test]
+    fn tied_model_rejects_split_qat_embedding_and_output_policies_before_training() {
+        let mut model = small_hybrid();
+        model.embeddings.tie_weights = true;
+        let workflow = ResolvedWakePlan {
+            version: 2,
+            phases: vec![wake::ResolvedWakePhase {
+                name: "invalid-tied-qat".into(),
+                phase_kind: PhaseKind::Quantization,
+                data: "unused.jsonl".into(),
+                objective: TaskConfig::CausalLm {},
+                sequence_length: 8,
+                batch_size: 1,
+                gradient_accumulation: 1,
+                epochs: 1,
+                shuffle_buffer: 1,
+                steps: Some(1),
+                loss_weight: 1.0,
+                learning_rate_scale: 1.0,
+                quantization: Some(WorkflowQuantizationPlan {
+                    recipe: QuantizationRecipe {
+                        format: UltraQuantFormat::BinaryG128,
+                        group_size: BONSAI_GROUP_SIZE,
+                        fake_quant_start_step: 0,
+                        ternary_warmup_steps: 0,
+                        distillation_weight: 0.0,
+                        quantize_embeddings: true,
+                        quantize_lm_head: false,
+                    },
+                    start_step: 0,
+                    end_step: None,
+                    warmup_format: None,
+                    warmup_steps: 0,
+                    training: WorkflowQuantizationTraining::Qat {
+                        straight_through: true,
+                    },
+                }),
+                periodic_sleep: None,
+                memory_update_mode: None,
+            }],
+        };
+
+        let error = validate_model_wake_plan(&model, &workflow)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("tied model weights"), "{error}");
     }
 
     fn small_hybrid() -> ModelDef {
@@ -2163,6 +2616,7 @@ mod tests {
         assert_eq!(args.suites.len(), 2);
         assert_eq!(args.config.sha256, digest);
         assert_eq!(args.evaluator_sha256, evaluator_hash);
+        assert_eq!(args.evaluator_timeout_seconds, 3_600);
 
         assert!(
             Cli::try_parse_from([
@@ -2229,6 +2683,74 @@ mod tests {
     }
 
     #[test]
+    fn workflow_resume_identity_binds_the_exact_native_sleep_runtime() {
+        let directory = tempfile::tempdir().unwrap();
+        let workflow: hermes_train::workflow::WorkflowV2 =
+            serde_json::from_value(serde_json::json!({
+                "version": 2,
+                "phases": [{
+                    "name": "pretrain",
+                    "type": "pretrain",
+                    "task": {"type": "causal_lm"},
+                    "data": "data.jsonl",
+                    "sequence_length": 8,
+                    "batch_size": 1,
+                    "gradient_accumulation": 1,
+                    "steps": 1
+                }]
+            }))
+            .unwrap();
+        let workflow = workflow
+            .resolve(&directory.path().join("workflow.json"))
+            .unwrap();
+        let external = format!("sha256:{}", "a".repeat(64));
+        let first_sleep = format!("sha256:{}", "b".repeat(64));
+        let replacement_sleep = format!("sha256:{}", "c".repeat(64));
+        let first_dispatch = run_workflow_dispatch_identity(&external, Some(&first_sleep)).unwrap();
+        let replacement_dispatch =
+            run_workflow_dispatch_identity(&external, Some(&replacement_sleep)).unwrap();
+        assert_ne!(first_dispatch, replacement_dispatch);
+        assert_ne!(
+            first_dispatch,
+            run_workflow_dispatch_identity(&external, None).unwrap()
+        );
+
+        let state_path = directory.path().join("runtime.json");
+        let metrics_path = directory.path().join("metrics.jsonl");
+        let state = WorkflowRunState::new(&workflow, None).unwrap();
+        let mut writer = AtomicRuntimeCheckpoint::new(&state_path, first_dispatch).unwrap();
+        writer
+            .configure_metrics(&metrics_path, "dispatch-binding", false)
+            .unwrap();
+        writer.initialize(&state).unwrap();
+        drop(writer);
+        fs::write(&metrics_path, b"uncommitted metric tail\n").unwrap();
+        let before = fs::read(&state_path).unwrap();
+        let before_metrics = fs::read(&metrics_path).unwrap();
+
+        let mut replacement =
+            AtomicRuntimeCheckpoint::new(&state_path, replacement_dispatch).unwrap();
+        replacement
+            .configure_metrics(&metrics_path, "dispatch-binding", true)
+            .unwrap();
+        let error = replacement
+            .verify_execution_identity()
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("different execution dispatch"), "{error}");
+        assert_eq!(
+            fs::read(&state_path).unwrap(),
+            before,
+            "a mismatched native runtime identity mutated workflow state"
+        );
+        assert_eq!(
+            fs::read(&metrics_path).unwrap(),
+            before_metrics,
+            "a mismatched native runtime identity truncated the metric journal"
+        );
+    }
+
+    #[test]
     fn addressed_json_rejects_changed_bytes() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("value.json");
@@ -2237,10 +2759,26 @@ mod tests {
             path,
             sha256: "0".repeat(64),
         };
-        let error = read_addressed_json::<serde_json::Value>(&input)
-            .unwrap_err()
-            .to_string();
+        let error = read_addressed_json::<serde_json::Value>(&input).unwrap_err();
+        let error = format!("{error:#}");
         assert!(error.contains("content hash mismatch"));
+    }
+
+    #[test]
+    fn addressed_json_rejects_oversized_file_before_allocation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("oversized.json");
+        let file = fs::File::create(&path).unwrap();
+        file.set_len(MAX_CLI_CONTENT_ADDRESSED_JSON_BYTES + 1)
+            .unwrap();
+        drop(file);
+        let input = ContentAddressedPath {
+            path,
+            sha256: "0".repeat(64),
+        };
+        let error = read_addressed_json::<serde_json::Value>(&input).unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("byte limit"), "{error}");
     }
 
     #[test]
@@ -2341,15 +2879,10 @@ mod tests {
             &Path::new(env!("CARGO_MANIFEST_DIR")).join("workflow.sleep.example.json"),
         )
         .unwrap();
-        let registry = NativeSleepContextRegistry::new();
-        let error = validate_cli_native_sleep_adapters(&workflow, &registry)
+        let error = validate_cli_native_sleep_selection(&workflow, false)
             .unwrap_err()
             .to_string();
-        assert!(
-            error.contains("NativeSleepPhaseContextFactory")
-                || error.contains("NativePeriodicWakeExecutor"),
-            "{error}"
-        );
+        assert!(error.contains("NativePeriodicWakeExecutor"), "{error}");
         assert!(error.contains("stock run-workflow CLI"), "{error}");
     }
 
@@ -2397,6 +2930,107 @@ mod tests {
         fs::write(&path, serde_json::to_vec_pretty(&json).unwrap()).unwrap();
         let workflow = load_wake_plan(&path).unwrap();
         (directory, workflow)
+    }
+
+    fn write_wake_only_memory_workflow() -> (tempfile::TempDir, ResolvedWakePlan) {
+        let source = Path::new(env!("CARGO_MANIFEST_DIR")).join("workflow.sleep.example.json");
+        let mut json: serde_json::Value =
+            serde_json::from_slice(&fs::read(source).unwrap()).unwrap();
+        json["phases"].as_array_mut().unwrap().truncate(1);
+        let schedule = json["phases"][0]["periodic_sleep"]["schedule"].take();
+        json["phases"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("periodic_sleep");
+        json["phases"][0]["memory_update_mode"] = serde_json::json!({
+            "type": "wake_only",
+            "schedule": schedule
+        });
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("workflow.json");
+        fs::write(&path, serde_json::to_vec_pretty(&json).unwrap()).unwrap();
+        let workflow = load_wake_plan(&path).unwrap();
+        (directory, workflow)
+    }
+
+    #[test]
+    fn wake_only_configuration_and_optimizer_scopes_are_checkpoint_bound() {
+        let (_directory, workflow) = write_wake_only_memory_workflow();
+        let config = sleep_memory_test_model();
+        validate_model_wake_plan(&config, &workflow).unwrap();
+        let device = hermes_llm::Device::ndarray().autodiff();
+        let model = Transformer::new(&config, &device).unwrap();
+        let mode = workflow.phases[0].memory_update_mode.clone().unwrap();
+        let bank =
+            TierOptimizerBank::new(&model, mode.schedule(), mode.tier_optimizer().clone()).unwrap();
+        let state = TrainingState {
+            version: TRAINING_STATE_VERSION,
+            global_step: 0,
+            phase: 0,
+            phase_id: workflow.phases[0].name.clone(),
+            phase_kind: workflow.phases[0].phase_kind.name().into(),
+            epoch: 0,
+            records_in_phase: 0,
+            steps_in_phase: 0,
+            tokens_seen: 0,
+            metric_records: 0,
+            workflow_signature: format!("sha256:{}", "a".repeat(64)),
+            data_manifest_hash: Some(format!("sha256:{}", "b".repeat(64))),
+            parameter_ids: parameter_ids(&model),
+            optimizer_states: vec![OptimizerStateRef {
+                scope: "wake".into(),
+                adamw: "adamw-state.bpk".into(),
+                muon: "muon-state.bpk".into(),
+                gradient_accumulator: None,
+                update_clock: 0,
+            }],
+            memory_update: TrainingMemoryUpdateState::WakeOnly {
+                config: mode,
+                optimizer_scopes: bank.scopes().unwrap(),
+            },
+            sleep: None,
+            artifacts: Vec::new(),
+            evaluator_hashes: Vec::new(),
+            rng_streams: vec![
+                RngStreamState {
+                    name: DATA_RNG_STREAM.into(),
+                    seed: 0,
+                    counter: 0,
+                },
+                RngStreamState {
+                    name: MODEL_RNG_STREAM.into(),
+                    seed: 0,
+                    counter: 0,
+                },
+            ],
+            wake_context_buffer: Vec::new(),
+            quantization: None,
+        };
+        state.validate().unwrap();
+        trainer::preflight_resumed_memory_mode(&workflow, &state).unwrap();
+
+        let mut replacement = workflow.clone();
+        let MemoryUpdateMode::WakeOnly { tier_optimizer, .. } =
+            replacement.phases[0].memory_update_mode.as_mut().unwrap();
+        tier_optimizer.learning_rate *= 2.0;
+        let error = trainer::preflight_resumed_memory_mode(&replacement, &state)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("differs from the exact workflow"), "{error}");
+    }
+
+    #[test]
+    fn wake_geometry_must_fit_checkpoint_metrics() {
+        if usize::BITS <= 32 {
+            return;
+        }
+        let (_directory, mut workflow) = write_wake_only_memory_workflow();
+        workflow.phases[0].batch_size = usize::try_from(u64::from(u32::MAX) + 1).unwrap();
+        let error = validate_model_wake_plan(&sleep_memory_test_model(), &workflow)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("batch_size"), "{error}");
+        assert!(error.contains("checkpoint-metric range"), "{error}");
     }
 
     #[test]
@@ -2762,14 +3396,15 @@ mod tests {
     }
 
     #[test]
-    fn quantization_distillation_masks_structured_prompts_and_freezes_teacher() {
+    fn quantization_distillation_reuses_student_forward_and_keeps_teacher_off_tape() {
         let config = small_hybrid();
         let device = hermes_llm::default_device().autodiff();
         device.seed(11);
-        let teacher = Transformer::new(&config, &device).unwrap();
+        let teacher = Transformer::new(&config, &device).unwrap().valid();
         device.seed(29);
         let student = Transformer::new(&config, &device).unwrap();
         let input_ids = Tensor::<2, Int>::from_data([[1, 2, 3, 4]], &device);
+        let targets = Tensor::<2, Int>::from_data([[2, 3, 4, 5]], &device);
         let positions = Tensor::<1, Int>::from_data([2], &device);
         let batch = make_batch(
             &[TrainingSample::Supervised {
@@ -2781,25 +3416,122 @@ mod tests {
             &device,
         )
         .unwrap();
-        let objective = ObjectiveConfig::Summarization {
+        let objective = TaskConfig::Summarization {
             instruction: "summarize".into(),
         };
-        let loss = quantization_forward_kl(&student, &teacher, &batch, &objective, 1.0).unwrap();
-        let expected = forward_kl_distillation_tensor(
-            teacher.forward_selected_logits(input_ids.clone(), positions.clone()),
-            student.forward_selected_logits(input_ids, positions),
-            1.0,
-            true,
-        )
-        .unwrap();
+        let frozen_probe =
+            teacher.forward_selected_logits(input_ids.clone().inner(), positions.clone().inner());
+        assert!(!frozen_probe.device().is_autodiff());
+        assert!(!frozen_probe.is_require_grad());
+        let teacher_logits = quantization_teacher_logits(&teacher, &batch, &objective).unwrap();
+        assert!(teacher_logits.device().is_autodiff());
+        assert!(!teacher_logits.is_require_grad());
+
+        let ObjectiveForward {
+            loss: task_loss,
+            router_loss,
+            distillation_logits,
+            ..
+        } = objective_loss(&student, batch, &objective, true).unwrap();
+        assert!(router_loss.is_none());
+        let student_logits = distillation_logits.unwrap();
+        let expected_student_logits =
+            student.forward_selected_logits(input_ids.clone(), positions.clone());
+        let actual_logits = student_logits
+            .clone()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .unwrap();
+        let expected_logits = expected_student_logits
+            .clone()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .unwrap();
+        assert_eq!(actual_logits, expected_logits);
+
+        let expected_task_loss =
+            scalar_value(student.forward_masked_loss(input_ids, targets, positions)).unwrap();
+        let actual_task_loss = scalar_value(task_loss.clone()).unwrap();
+        assert!((actual_task_loss - expected_task_loss).abs() < 1e-6);
+
+        let loss =
+            forward_kl_distillation_tensor(teacher_logits.clone(), student_logits, 1.0, true)
+                .unwrap();
+        let expected =
+            forward_kl_distillation_tensor(teacher_logits, expected_student_logits, 1.0, true)
+                .unwrap();
         let actual_value = scalar_value(loss.clone()).unwrap();
         let expected_value = scalar_value(expected).unwrap();
         assert!((actual_value - expected_value).abs() < 1e-6);
 
-        let mut gradients = loss.backward();
-        let teacher_gradients = GradientsParams::from_module(&mut gradients, &teacher);
+        let mut gradients = (task_loss + loss).backward();
         let student_gradients = GradientsParams::from_module(&mut gradients, &student);
-        assert!(teacher_gradients.is_empty());
+        assert!(!student_gradients.is_empty());
+    }
+
+    #[test]
+    fn retrieval_qat_reuses_student_embeddings_for_task_and_distillation() {
+        let config = small_hybrid();
+        let device = hermes_llm::default_device().autodiff();
+        device.seed(47);
+        let teacher = Transformer::new(&config, &device).unwrap().valid();
+        device.seed(53);
+        let student = Transformer::new(&config, &device).unwrap();
+        let encoded = |tokens| data::EncodedText {
+            tokens,
+            end_position: 1,
+        };
+        let batch = make_batch(
+            &[TrainingSample::Retrieval {
+                query: encoded(vec![1, 2, 0, 0]),
+                documents: vec![encoded(vec![3, 4, 0, 0]), encoded(vec![5, 6, 0, 0])],
+                truncated_tokens: 0,
+            }],
+            4,
+            &device,
+        )
+        .unwrap();
+        let objective = TaskConfig::RetrievalRepresentation {
+            temperature: 0.5,
+            layer: None,
+            query_prefix: "query".into(),
+            document_prefix: "document".into(),
+        };
+        let teacher_logits = quantization_teacher_logits(&teacher, &batch, &objective).unwrap();
+        assert!(teacher_logits.device().is_autodiff());
+        assert!(!teacher_logits.is_require_grad());
+        let ObjectiveForward {
+            loss: task_loss,
+            router_loss,
+            distillation_logits,
+            ..
+        } = objective_loss(&student, batch, &objective, true).unwrap();
+        assert!(router_loss.is_none());
+        let student_logits = distillation_logits.unwrap();
+
+        let query_ids = Tensor::<2, Int>::from_data([[1, 2, 0, 0]], &device);
+        let query_positions = Tensor::<1, Int>::from_data([1], &device);
+        let document_ids = Tensor::<2, Int>::from_data([[3, 4, 0, 0], [5, 6, 0, 0]], &device);
+        let document_positions = Tensor::<1, Int>::from_data([1, 5], &device);
+        let expected_logits = student
+            .forward_embeddings(query_ids, query_positions, None)
+            .matmul(
+                student
+                    .forward_embeddings(document_ids, document_positions, None)
+                    .transpose(),
+            );
+        let maximum: f32 = (student_logits.clone() - expected_logits)
+            .abs()
+            .max()
+            .into_scalar();
+        assert!(maximum < 1e-6, "retrieval QAT logits differ by {maximum}");
+
+        let distillation_loss =
+            forward_kl_distillation_tensor(teacher_logits, student_logits, 1.0, true).unwrap();
+        let mut gradients = (task_loss + distillation_loss).backward();
+        let student_gradients = GradientsParams::from_module(&mut gradients, &student);
         assert!(!student_gradients.is_empty());
     }
 
@@ -2921,6 +3653,7 @@ mod tests {
                 gradient_accumulator: None,
                 update_clock: 20,
             }],
+            memory_update: TrainingMemoryUpdateState::Ordinary,
             sleep: None,
             artifacts: Vec::new(),
             evaluator_hashes: Vec::new(),
@@ -3000,6 +3733,29 @@ mod tests {
         );
         assert!((evidence.training_gpu_hours - 2.0 / 3600.0).abs() < 1e-15);
 
+        let mut mismatched_qat_state = state.clone();
+        mismatched_qat_state.quantization = Some(QuantizationTrainingState {
+            format: "binary_g128".into(),
+            fake_quant_active: false,
+            calibration_step: state.global_step as u64,
+            manifest: Some("candidate.json".into()),
+            candidate_weights_sha256: Some(format!("sha256:{}", "0".repeat(64))),
+            teacher_hash: None,
+        });
+        let error = save_training_checkpoint_with_evidence(
+            &model,
+            &adamw_optimizer,
+            &muon_optimizer,
+            &mismatched_qat_state,
+            &mut metrics,
+            dir.path(),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("candidate weights differ"),
+            "{error:#}"
+        );
+
         let mut resumed = Transformer::new(&config, &device).unwrap();
         let mut resumed_ids = resumed.muon_parameter_ids();
         let mut resumed_muon = BatchedMuon::new(resumed_ids.clone());
@@ -3008,7 +3764,7 @@ mod tests {
             .with_epsilon(1e-8)
             .with_weight_decay(0.0)
             .init();
-        let (mut resumed_adamw, resumed_state) = load_training_state(
+        let (mut resumed_adamw, resumed_state, resumed_weights_sha256) = load_training_state(
             &mut resumed,
             resumed_adamw,
             &mut resumed_muon,
@@ -3016,6 +3772,10 @@ mod tests {
             &device,
         )
         .unwrap();
+        assert_eq!(
+            resumed_weights_sha256,
+            format!("sha256:{}", evidence.weights_sha256)
+        );
         assert_eq!(resumed_state.global_step, state.global_step);
         assert_eq!(resumed_state.phase, state.phase);
         assert_eq!(resumed_state.epoch, state.epoch);
@@ -3158,7 +3918,7 @@ mod tests {
                 .with_weight_decay(0.0)
                 .init();
             let mut swap = GenerationSwapGuard::new(generation_a.clone(), generation_b);
-            let (aba_adamw, aba_state) = checkpoint::load_training_state_with_hook(
+            let (aba_adamw, aba_state, _) = checkpoint::load_training_state_with_hook(
                 &mut aba_model,
                 aba_adamw,
                 &mut aba_muon,

--- a/hermes-train/src/metrics.rs
+++ b/hermes-train/src/metrics.rs
@@ -9,7 +9,7 @@
 //! step cannot silently produce a misleading history.
 
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -17,8 +17,17 @@ use anyhow::{Context, Result, ensure};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+#[cfg(test)]
+use crate::artifact_io::sha256_hex;
+use crate::artifact_io::validate_sha256_identity;
+
 /// Increment when the on-disk record contract changes incompatibly.
 pub const METRIC_SCHEMA_VERSION: u32 = 2;
+
+/// A metric is diagnostic evidence, not an artifact transport. Bounding each
+/// JSONL record prevents a corrupt or adversarial length-less line from
+/// consuming memory without bounding the lifetime of an append-only run.
+const MAX_METRIC_RECORD_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -34,6 +43,23 @@ pub enum MetricPhaseKind {
     Promotion,
     Quantization,
     CorpusPreparation,
+}
+
+impl From<crate::workflow::PhaseKind> for MetricPhaseKind {
+    fn from(kind: crate::workflow::PhaseKind) -> Self {
+        match kind {
+            crate::workflow::PhaseKind::Pretrain => Self::Pretrain,
+            crate::workflow::PhaseKind::ContinuedPretrain => Self::ContinuedPretrain,
+            crate::workflow::PhaseKind::Sft => Self::Sft,
+            crate::workflow::PhaseKind::Preference => Self::Preference,
+            crate::workflow::PhaseKind::Rl => Self::Rl,
+            crate::workflow::PhaseKind::Distillation => Self::Distillation,
+            crate::workflow::PhaseKind::Sleep => Self::Sleep,
+            crate::workflow::PhaseKind::Quantization => Self::Quantization,
+            crate::workflow::PhaseKind::Evaluation => Self::Evaluation,
+            crate::workflow::PhaseKind::Promotion => Self::Promotion,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -126,9 +152,9 @@ pub struct ActiveCapacityMetrics {
     /// untrainable zero-output low-rank fallback; afterward an activated slot
     /// replaces it. It therefore remains one while stored slots activate.
     pub reserve_routed_top_k: u32,
-    /// Per-token routed expert parameter-equivalent. Reserve router scoring is
-    /// excluded: candidate-pool overhead is bounded by stored capacity and is
-    /// enforced by the independent wake throughput/latency gates.
+    /// Per-token routed parameter-equivalent. This includes the fixed-width
+    /// reserve router, one low-rank reserve lane, and the ordinary FFN/MoE
+    /// routes; the independent throughput/latency gates cover their kernels.
     pub routed_active_parameters: u64,
     pub stored_parameters: u64,
     pub dream_generation: bool,
@@ -592,15 +618,26 @@ impl MetricWriter {
         let run_id = run_id.into();
         validate_identifier("run_id", &run_id)?;
         let mut file = open_existing_metric_file(path, "metric log", true)?;
-        let (bytes, stamp) = read_open_metric_file_stable(&mut file, path, "metric log")?;
-        let state = validate_log_bytes(&bytes, Some(&run_id))
-            .with_context(|| format!("validate metric log {}", path.display()))?;
-        ensure_open_metric_file_unchanged(&file, path, &stamp, "metric log")?;
+        lock_metric_writer(&file, path)?;
+        let visited = visit_open_metric_file(
+            &mut file,
+            path,
+            "metric log",
+            Some(&run_id),
+            None,
+            |_| Ok(()),
+            |_| Ok(()),
+        )
+        .with_context(|| format!("validate metric log {}", path.display()))?;
+        ensure!(
+            visited.reached_eof,
+            "complete metric validation stopped early"
+        );
         Ok(Self {
             path: path.to_owned(),
             run_id,
             output: BufWriter::new(file),
-            state,
+            state: visited.state,
         })
     }
 
@@ -617,8 +654,6 @@ impl MetricWriter {
         let path = path.as_ref();
         let run_id = run_id.into();
         validate_identifier("run_id", &run_id)?;
-        let committed_records = usize::try_from(committed_records)
-            .context("committed metric record count exceeds usize")?;
         let expected_last_step = (committed_records > 0).then_some(committed_global_step);
         Self::resume_validated_prefix(
             path,
@@ -642,8 +677,6 @@ impl MetricWriter {
         let path = path.as_ref();
         let run_id = run_id.into();
         validate_identifier("run_id", &run_id)?;
-        let committed_records = usize::try_from(committed_records)
-            .context("committed metric record count exceeds usize")?;
         Self::resume_validated_prefix(
             path,
             run_id,
@@ -656,34 +689,37 @@ impl MetricWriter {
     fn resume_validated_prefix(
         path: &Path,
         run_id: String,
-        committed_records: usize,
+        committed_records: u64,
         committed_last_global_step: Option<u64>,
         operation: &str,
     ) -> Result<Self> {
         let mut file = open_existing_metric_file(path, "metric log", true)
             .with_context(|| format!("open metric log {} for {operation}", path.display()))?;
-        let (bytes, stamp) = read_open_metric_file_stable(&mut file, path, "metric log")
-            .with_context(|| format!("read metric log {} for {operation}", path.display()))?;
-        let (end, state) = validate_committed_prefix_bytes(
-            &bytes,
+        lock_metric_writer(&file, path)?;
+        let visited = visit_open_metric_file(
+            &mut file,
             path,
-            committed_records,
-            committed_last_global_step,
+            "metric log",
             Some(&run_id),
-        )?;
+            Some(committed_records),
+            |_| Ok(()),
+            |_| Ok(()),
+        )
+        .with_context(|| format!("read metric log {} for {operation}", path.display()))?;
+        validate_committed_stream_state(&visited, committed_records, committed_last_global_step)?;
 
         // JSON validation can be substantial for a long journal. Reinspect
         // both the descriptor and its pathname after validation so an
         // in-place writer or path replacement cannot make us truncate bytes
         // other than the exact generation that was parsed above.
-        ensure_open_metric_file_unchanged(&file, path, &stamp, "metric log")?;
-        file.set_len(end as u64)
+        ensure_open_metric_file_unchanged(&file, path, &visited.stamp, "metric log")?;
+        file.set_len(visited.consumed_bytes)
             .with_context(|| format!("truncate metric log {} for {operation}", path.display()))?;
         file.sync_all()
             .with_context(|| format!("sync metric log {} after {operation}", path.display()))?;
         let truncated = opened_metric_file_stamp(&file, "metric log")?;
         ensure!(
-            truncated.same_file(&stamp) && truncated.len == end as u64,
+            truncated.same_file(&visited.stamp) && truncated.len == visited.consumed_bytes,
             "metric log changed while its committed prefix was truncated"
         );
         ensure_metric_path_matches_stamp(path, &truncated, "metric log", true)?;
@@ -692,7 +728,7 @@ impl MetricWriter {
             path: path.to_owned(),
             run_id,
             output: BufWriter::new(file),
-            state,
+            state: visited.state,
         })
     }
 
@@ -752,6 +788,10 @@ impl MetricWriter {
 
         let mut encoded = serde_json::to_vec(&record).context("serialize metric record")?;
         encoded.push(b'\n');
+        ensure!(
+            encoded.len() <= MAX_METRIC_RECORD_BYTES,
+            "metric record exceeds the {MAX_METRIC_RECORD_BYTES}-byte JSONL limit"
+        );
         self.output
             .write_all(&encoded)
             .with_context(|| format!("append metric log {}", self.path.display()))?;
@@ -772,7 +812,9 @@ impl MetricWriter {
         self.output
             .get_ref()
             .sync_data()
-            .with_context(|| format!("sync metric data {}", self.path.display()))
+            .with_context(|| format!("sync metric data {}", self.path.display()))?;
+        let current = opened_metric_file_stamp(self.output.get_ref(), "metric log")?;
+        ensure_metric_path_matches_stamp(&self.path, &current, "metric log", true)
     }
 
     /// Flush and persist both file data and metadata.
@@ -781,7 +823,9 @@ impl MetricWriter {
         self.output
             .get_ref()
             .sync_all()
-            .with_context(|| format!("sync metric log {}", self.path.display()))
+            .with_context(|| format!("sync metric log {}", self.path.display()))?;
+        let current = opened_metric_file_stamp(self.output.get_ref(), "metric log")?;
+        ensure_metric_path_matches_stamp(&self.path, &current, "metric log", true)
     }
 
     /// Persist and measure exactly the prefix named by checkpoint state.
@@ -809,57 +853,6 @@ impl MetricWriter {
     }
 }
 
-fn committed_prefix_end(bytes: &[u8], committed_records: usize) -> Result<usize> {
-    if committed_records == 0 {
-        return Ok(0);
-    }
-    bytes
-        .iter()
-        .enumerate()
-        .filter_map(|(index, byte)| (*byte == b'\n').then_some(index + 1))
-        .nth(committed_records - 1)
-        .context("metric log has fewer records than the runtime checkpoint")
-}
-
-fn validate_committed_prefix_bytes(
-    bytes: &[u8],
-    path: &Path,
-    committed_records: usize,
-    committed_last_global_step: Option<u64>,
-    expected_run_id: Option<&str>,
-) -> Result<(usize, MetricLogState)> {
-    validate_committed_prefix_bytes_with(
-        bytes,
-        path,
-        committed_records,
-        committed_last_global_step,
-        expected_run_id,
-        |_| Ok(()),
-    )
-}
-
-fn validate_committed_prefix_bytes_with(
-    bytes: &[u8],
-    path: &Path,
-    committed_records: usize,
-    committed_last_global_step: Option<u64>,
-    expected_run_id: Option<&str>,
-    visitor: impl FnMut(&MetricRecord) -> Result<()>,
-) -> Result<(usize, MetricLogState)> {
-    let end = committed_prefix_end(bytes, committed_records)?;
-    let state = visit_validated_records(&bytes[..end], expected_run_id, visitor)
-        .with_context(|| format!("validate committed metric prefix in {}", path.display()))?;
-    ensure!(
-        state.records == committed_records as u64,
-        "committed metric prefix record count is inconsistent"
-    );
-    ensure!(
-        state.last_global_step == committed_last_global_step,
-        "committed metric prefix global step is inconsistent"
-    );
-    Ok((end, state))
-}
-
 /// Validate a metric log without opening it for append.
 pub fn validate_metric_log(
     path: impl AsRef<Path>,
@@ -870,11 +863,21 @@ pub fn validate_metric_log(
     }
     let path = path.as_ref();
     let mut file = open_existing_metric_file(path, "metric log", false)?;
-    let (bytes, stamp) = read_open_metric_file_stable(&mut file, path, "metric log")?;
-    let state = validate_log_bytes(&bytes, expected_run_id)
-        .with_context(|| format!("validate metric log {}", path.display()))?;
-    ensure_open_metric_file_unchanged(&file, path, &stamp, "metric log")?;
-    Ok(state)
+    let visited = visit_open_metric_file(
+        &mut file,
+        path,
+        "metric log",
+        expected_run_id,
+        None,
+        |_| Ok(()),
+        |_| Ok(()),
+    )
+    .with_context(|| format!("validate metric log {}", path.display()))?;
+    ensure!(
+        visited.reached_eof,
+        "complete metric validation stopped early"
+    );
+    Ok(visited.state)
 }
 
 /// Validate the exact journal prefix committed by a training checkpoint
@@ -914,18 +917,19 @@ fn validate_metric_prefix_impl(
     committed_global_step: u64,
     expected_run_id: Option<&str>,
 ) -> Result<MetricLogState> {
-    let bytes = read_regular_file_stable(path, "metric log")?;
-    let committed_records = usize::try_from(committed_records)
-        .context("committed metric record count exceeds usize")?;
     let expected_last_step = (committed_records > 0).then_some(committed_global_step);
-    let (_, state) = validate_committed_prefix_bytes(
-        &bytes,
+    let mut file = open_existing_metric_file(path, "metric log", false)?;
+    let visited = visit_open_metric_file(
+        &mut file,
         path,
-        committed_records,
-        expected_last_step,
+        "metric log",
         expected_run_id,
+        Some(committed_records),
+        |_| Ok(()),
+        |_| Ok(()),
     )?;
-    Ok(state)
+    validate_committed_stream_state(&visited, committed_records, expected_last_step)?;
+    Ok(visited.state)
 }
 
 /// Validate an immutable metric snapshot that contains exactly the records
@@ -965,22 +969,23 @@ fn validate_metric_snapshot_impl(
     committed_global_step: u64,
     expected_run_id: Option<&str>,
 ) -> Result<MetricLogState> {
-    let bytes = read_regular_file_stable(path, "metric snapshot")?;
-    let committed_records = usize::try_from(committed_records)
-        .context("committed metric record count exceeds usize")?;
     let expected_last_step = (committed_records > 0).then_some(committed_global_step);
-    let (end, state) = validate_committed_prefix_bytes(
-        &bytes,
+    let mut file = open_existing_metric_file(path, "metric snapshot", false)?;
+    let visited = visit_open_metric_file(
+        &mut file,
         path,
-        committed_records,
-        expected_last_step,
+        "metric snapshot",
         expected_run_id,
+        Some(committed_records),
+        |_| Ok(()),
+        |_| Ok(()),
     )?;
+    validate_committed_stream_state(&visited, committed_records, expected_last_step)?;
     ensure!(
-        end == bytes.len(),
+        visited.reached_eof,
         "immutable metric snapshot contains an uncommitted tail"
     );
-    Ok(state)
+    Ok(visited.state)
 }
 
 /// Measure committed single-accelerator work from a validated metric prefix.
@@ -996,17 +1001,16 @@ pub fn summarize_committed_training_time(
 ) -> Result<CommittedTrainingTime> {
     validate_identifier("expected run_id", expected_run_id)?;
     let path = path.as_ref();
-    let bytes = read_regular_file_stable(path, "metric log for training evidence")?;
-    let committed_records_usize = usize::try_from(committed_records)
-        .context("committed metric record count exceeds usize")?;
+    let mut file = open_existing_metric_file(path, "metric log for training evidence", false)?;
     let mut optimizer_steps = 0_u64;
     let mut elapsed_nanoseconds = 0_u64;
-    let (_, _) = validate_committed_prefix_bytes_with(
-        &bytes,
+    let visited = visit_open_metric_file(
+        &mut file,
         path,
-        committed_records_usize,
-        Some(committed_global_step),
+        "metric log for training evidence",
         Some(expected_run_id),
+        Some(committed_records),
+        |_| Ok(()),
         |record| {
             let elapsed = match &record.event {
                 MetricEvent::Throughput(metric) => {
@@ -1034,6 +1038,7 @@ pub fn summarize_committed_training_time(
             Ok(())
         },
     )?;
+    validate_committed_stream_state(&visited, committed_records, Some(committed_global_step))?;
     ensure!(
         optimizer_steps == committed_global_step,
         "throughput metrics account for {optimizer_steps} optimizer steps, checkpoint records {committed_global_step}"
@@ -1063,14 +1068,41 @@ pub fn metric_log_digests(
         validate_identifier("expected run_id", run_id)?;
     }
     let path = path.as_ref();
-    let bytes = read_regular_file_stable(path, "metric log for digest")?;
-    metric_log_digests_from_bytes(&bytes, expected_run_id)
-        .with_context(|| format!("validate metric log {} for digest", path.display()))
+    let mut file = open_existing_metric_file(path, "metric log for digest", false)?;
+    let mut raw = Sha256::new();
+    let mut semantic = Sha256::new();
+    let visited = visit_open_metric_file(
+        &mut file,
+        path,
+        "metric log for digest",
+        expected_run_id,
+        None,
+        |line| {
+            raw.update(line);
+            Ok(())
+        },
+        |record| {
+            if let Some(value) = semantic_record(record)? {
+                semantic.update(serde_json::to_vec(&canonicalize_json(value))?);
+                semantic.update(b"\n");
+            }
+            Ok(())
+        },
+    )
+    .with_context(|| format!("validate metric log {} for digest", path.display()))?;
+    ensure!(visited.reached_eof, "complete metric digest stopped early");
+    Ok(MetricLogDigests {
+        raw_sha256: format!("{:x}", raw.finalize()),
+        semantic_progress_sha256: format!("{:x}", semantic.finalize()),
+        records: visited.state.records,
+        last_global_step: visited.state.last_global_step,
+    })
 }
 
 /// Verify and digest bytes already read through a stable artifact handle. This
 /// lets higher-level evidence verification avoid a second path open between
 /// checking an artifact's raw digest and projecting semantic progress.
+#[cfg(test)]
 pub(crate) fn metric_log_digests_from_bytes(
     bytes: &[u8],
     expected_run_id: Option<&str>,
@@ -1087,18 +1119,145 @@ pub(crate) fn metric_log_digests_from_bytes(
         Ok(())
     })?;
     Ok(MetricLogDigests {
-        raw_sha256: hex_sha256(bytes),
+        raw_sha256: sha256_hex(bytes),
         semantic_progress_sha256: format!("{:x}", semantic.finalize()),
         records: state.records,
         last_global_step: state.last_global_step,
     })
 }
 
-fn read_regular_file_stable(path: &Path, label: &str) -> Result<Vec<u8>> {
-    let mut file = open_existing_metric_file(path, label, false)?;
-    let (bytes, stamp) = read_open_metric_file_stable(&mut file, path, label)?;
-    ensure_open_metric_file_unchanged(&file, path, &stamp, label)?;
-    Ok(bytes)
+#[derive(Debug)]
+struct MetricStreamVisit {
+    state: MetricLogState,
+    consumed_bytes: u64,
+    reached_eof: bool,
+    stamp: MetricFileStamp,
+}
+
+fn read_bounded_metric_line(
+    reader: &mut (impl BufRead + ?Sized),
+    line: &mut Vec<u8>,
+    maximum_bytes: usize,
+) -> Result<usize> {
+    ensure!(
+        maximum_bytes > 0,
+        "metric record byte limit must be positive"
+    );
+    line.clear();
+    let capture_bytes = maximum_bytes
+        .checked_add(1)
+        .context("metric record byte limit overflows usize")?;
+    let mut bounded = reader.take(capture_bytes as u64);
+    let read = bounded
+        .read_until(b'\n', line)
+        .context("read metric JSONL record")?;
+    ensure!(
+        line.len() <= maximum_bytes,
+        "metric record exceeds the {maximum_bytes}-byte JSONL limit"
+    );
+    Ok(read)
+}
+
+fn visit_validated_reader(
+    reader: &mut (impl BufRead + ?Sized),
+    expected_run_id: Option<&str>,
+    record_limit: Option<u64>,
+    mut raw_visitor: impl FnMut(&[u8]) -> Result<()>,
+    mut visitor: impl FnMut(&MetricRecord) -> Result<()>,
+) -> Result<(MetricLogState, u64, bool)> {
+    let mut state = MetricLogState::default();
+    let mut consumed_bytes = 0_u64;
+    let mut line = Vec::new();
+    loop {
+        if record_limit == Some(state.records) {
+            let reached_eof = reader.fill_buf()?.is_empty();
+            return Ok((state, consumed_bytes, reached_eof));
+        }
+        let read = read_bounded_metric_line(reader, &mut line, MAX_METRIC_RECORD_BYTES)?;
+        if read == 0 {
+            return Ok((state, consumed_bytes, true));
+        }
+        consumed_bytes = consumed_bytes
+            .checked_add(u64::try_from(read).context("metric record length exceeds u64")?)
+            .context("metric log byte offset overflows u64")?;
+        ensure!(
+            line.last() == Some(&b'\n'),
+            "metric log ends with a partial record; refuse unsafe resume"
+        );
+        raw_visitor(&line)?;
+        let encoded = &line[..line.len() - 1];
+        let line_number = state
+            .records
+            .checked_add(1)
+            .context("metric line number overflows u64")?;
+        ensure!(
+            !encoded.is_empty(),
+            "metric log contains an empty record at line {line_number}"
+        );
+        let record: MetricRecord = serde_json::from_slice(encoded)
+            .with_context(|| format!("decode metric record at line {line_number}"))?;
+        validate_record(&record)
+            .with_context(|| format!("invalid metric record at line {line_number}"))?;
+        validate_record_position(&record, &state)
+            .with_context(|| format!("invalid metric sequence at line {line_number}"))?;
+        if let Some(expected) = expected_run_id {
+            ensure!(
+                record.run_id == expected,
+                "metric run_id `{}` does not match requested `{expected}`",
+                record.run_id
+            );
+        }
+        visitor(&record).with_context(|| format!("process metric record at line {line_number}"))?;
+        advance_state(&mut state, &record)?;
+    }
+}
+
+fn visit_open_metric_file(
+    file: &mut File,
+    path: &Path,
+    label: &str,
+    expected_run_id: Option<&str>,
+    record_limit: Option<u64>,
+    raw_visitor: impl FnMut(&[u8]) -> Result<()>,
+    visitor: impl FnMut(&MetricRecord) -> Result<()>,
+) -> Result<MetricStreamVisit> {
+    let stamp = opened_metric_file_stamp(file, label)?;
+    ensure_metric_path_matches_stamp(path, &stamp, label, true)?;
+    file.seek(SeekFrom::Start(0))
+        .with_context(|| format!("rewind opened {label} {}", path.display()))?;
+    let (state, consumed_bytes, reached_eof) = {
+        let mut reader = BufReader::new(&mut *file);
+        visit_validated_reader(
+            &mut reader,
+            expected_run_id,
+            record_limit,
+            raw_visitor,
+            visitor,
+        )?
+    };
+    ensure_open_metric_file_unchanged(file, path, &stamp, label)?;
+    Ok(MetricStreamVisit {
+        state,
+        consumed_bytes,
+        reached_eof,
+        stamp,
+    })
+}
+
+fn validate_committed_stream_state(
+    visited: &MetricStreamVisit,
+    committed_records: u64,
+    committed_last_global_step: Option<u64>,
+) -> Result<()> {
+    ensure!(
+        visited.state.records == committed_records,
+        "metric log has fewer records than the runtime checkpoint"
+    );
+    ensure!(
+        visited.state.last_global_step == committed_last_global_step,
+        "committed metric prefix global step is inconsistent"
+    );
+    Ok(())
 }
 
 fn create_empty_metric_file(path: &Path, label: &str) -> Result<File> {
@@ -1131,6 +1290,7 @@ fn create_empty_metric_file(path: &Path, label: &str) -> Result<File> {
         );
     }
     ensure_metric_path_matches_stamp(path, &opened, label, true)?;
+    lock_metric_writer(&file, path)?;
 
     // Truncate only after the opened descriptor is proven to be the exact
     // regular file inspected above. A path swap can therefore make creation
@@ -1145,6 +1305,30 @@ fn create_empty_metric_file(path: &Path, label: &str) -> Result<File> {
     );
     ensure_metric_path_matches_stamp(path, &empty, label, true)?;
     into_append_metric_file(file, path, label)
+}
+
+#[cfg(unix)]
+fn lock_metric_writer(file: &File, path: &Path) -> Result<()> {
+    use std::os::fd::AsRawFd;
+
+    // The lock remains attached to the writer's open file description for its
+    // lifetime. It is advisory so read-only sidecars remain unaffected, while
+    // every MetricWriter in this crate fails before validation or truncation.
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if result == -1 {
+        return Err(std::io::Error::last_os_error()).with_context(|| {
+            format!(
+                "acquire exclusive metric-writer lock for {}",
+                path.display()
+            )
+        });
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn lock_metric_writer(_: &File, _: &Path) -> Result<()> {
+    Ok(())
 }
 
 fn open_existing_metric_file(path: &Path, label: &str, append: bool) -> Result<File> {
@@ -1168,6 +1352,7 @@ fn open_existing_metric_file(path: &Path, label: &str, append: bool) -> Result<F
     Ok(file)
 }
 
+#[cfg(test)]
 fn read_open_metric_file_stable(
     file: &mut File,
     path: &Path,
@@ -1379,54 +1564,19 @@ fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {
     }
 }
 
-fn hex_sha256(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
-}
-
-fn validate_log_bytes(bytes: &[u8], expected_run_id: Option<&str>) -> Result<MetricLogState> {
-    visit_validated_records(bytes, expected_run_id, |_| Ok(()))
-}
-
+#[cfg(test)]
 fn visit_validated_records(
     bytes: &[u8],
     expected_run_id: Option<&str>,
-    mut visitor: impl FnMut(&MetricRecord) -> Result<()>,
+    visitor: impl FnMut(&MetricRecord) -> Result<()>,
 ) -> Result<MetricLogState> {
-    if bytes.is_empty() {
-        return Ok(MetricLogState::default());
-    }
+    let mut reader = std::io::Cursor::new(bytes);
+    let (state, consumed_bytes, reached_eof) =
+        visit_validated_reader(&mut reader, expected_run_id, None, |_| Ok(()), visitor)?;
     ensure!(
-        bytes.last() == Some(&b'\n'),
-        "metric log ends with a partial record; refuse unsafe resume"
+        reached_eof && consumed_bytes == bytes.len() as u64,
+        "metric byte validation stopped before the exact end"
     );
-
-    let mut state = MetricLogState::default();
-    for (line_index, line) in bytes[..bytes.len() - 1]
-        .split(|byte| *byte == b'\n')
-        .enumerate()
-    {
-        ensure!(
-            !line.is_empty(),
-            "metric log contains an empty record at line {}",
-            line_index + 1
-        );
-        let record: MetricRecord = serde_json::from_slice(line)
-            .with_context(|| format!("decode metric record at line {}", line_index + 1))?;
-        validate_record(&record)
-            .with_context(|| format!("invalid metric record at line {}", line_index + 1))?;
-        validate_record_position(&record, &state)
-            .with_context(|| format!("invalid metric sequence at line {}", line_index + 1))?;
-        if let Some(expected) = expected_run_id {
-            ensure!(
-                record.run_id == expected,
-                "metric run_id `{}` does not match requested `{expected}`",
-                record.run_id
-            );
-        }
-        visitor(&record)
-            .with_context(|| format!("process metric record at line {}", line_index + 1))?;
-        advance_state(&mut state, &record)?;
-    }
     Ok(state)
 }
 
@@ -1485,7 +1635,7 @@ pub fn validate_record(record: &MetricRecord) -> Result<()> {
     validate_identifier("run_id", &record.run_id)?;
     validate_identifier("phase name", &record.phase.name)?;
     if let Some(hash) = &record.checkpoint_hash {
-        validate_sha256("checkpoint hash", hash)?;
+        validate_sha256_identity(hash, "checkpoint hash")?;
     }
     record.event.validate()?;
     if let MetricEvent::DeviceUtilization(metric) = &record.event {
@@ -1532,14 +1682,20 @@ impl MetricEvent {
                     metric.reserve_slot.is_some() == metric.reserve_generation.is_some(),
                     "reserve_slot and reserve_generation must be present together"
                 );
-                if matches!(metric.outcome, TierUpdateOutcome::RolledBack) {
-                    ensure!(
-                        !metric.optimizer_state_reset,
-                        "a rolled-back tier update cannot reset optimizer state"
-                    );
-                }
+                ensure!(
+                    !metric.optimizer_state_reset
+                        || matches!(metric.outcome, TierUpdateOutcome::Committed),
+                    "only a committed tier update can reset optimizer state"
+                );
             }
             Self::ActiveCapacity(metric) => {
+                ensure!(
+                    metric
+                        .active_reserve_experts
+                        .checked_add(metric.dormant_reserve_experts)
+                        .is_some_and(|capacity| capacity > 0),
+                    "sleep reserve capacity must be positive and fit u32"
+                );
                 ensure!(metric.routed_top_k > 0, "routed_top_k must be positive");
                 ensure!(
                     metric.reserve_routed_top_k == 1,
@@ -1550,8 +1706,10 @@ impl MetricEvent {
                     "routed_top_k exceeds persistent base experts"
                 );
                 ensure!(
-                    metric.routed_active_parameters <= metric.stored_parameters,
-                    "routed active parameters exceed stored parameters"
+                    metric.routed_active_parameters > 0
+                        && metric.stored_parameters > 0
+                        && metric.routed_active_parameters <= metric.stored_parameters,
+                    "routed and stored parameters must be positive, and routed parameters must not exceed stored parameters"
                 );
                 ensure!(
                     !metric.random_extra_expert || metric.dream_generation,
@@ -1581,6 +1739,20 @@ impl MetricEvent {
                     "wake capacity envelope is inverted"
                 );
                 ensure!(
+                    metric.minimum_observed_wake_routed_active_parameters
+                        <= metric.initial_wake_routed_active_parameters
+                        && metric.initial_wake_routed_active_parameters
+                            <= metric.maximum_observed_wake_routed_active_parameters,
+                    "initial wake capacity is outside the observed envelope"
+                );
+                ensure!(
+                    metric.minimum_observed_wake_routed_active_parameters
+                        == metric.initial_wake_routed_active_parameters
+                        && metric.maximum_observed_wake_routed_active_parameters
+                            == metric.initial_wake_routed_active_parameters,
+                    "wake routed-active parameters changed across sleep cycles"
+                );
+                ensure!(
                     metric.maximum_observed_wake_routed_active_parameters
                         <= metric.stored_parameters,
                     "wake routed parameters exceed stored parameters"
@@ -1588,8 +1760,8 @@ impl MetricEvent {
             }
             Self::DistillationDivergence(metric) => {
                 validate_identifier("transaction_id", &metric.transaction_id)?;
-                validate_sha256("teacher_hash", &metric.teacher_hash)?;
-                validate_sha256("student_hash", &metric.student_hash)?;
+                validate_sha256_identity(&metric.teacher_hash, "teacher_hash")?;
+                validate_sha256_identity(&metric.student_hash, "student_hash")?;
                 ensure!(metric.chunk_count > 0, "chunk_count must be positive");
                 ensure!(
                     metric.chunk_index < metric.chunk_count,
@@ -1609,7 +1781,7 @@ impl MetricEvent {
             }
             Self::ImitationReward(metric) => {
                 validate_identifier("transaction_id", &metric.transaction_id)?;
-                validate_sha256("semantic_judge_hash", &metric.semantic_judge_hash)?;
+                validate_sha256_identity(&metric.semantic_judge_hash, "semantic_judge_hash")?;
                 ensure!(metric.samples > 0, "imitation samples must be positive");
                 unit_interval("semantic_score_mean", metric.semantic_score_mean)?;
                 unit_interval(
@@ -1624,8 +1796,16 @@ impl MetricEvent {
             Self::DreamSelection(metric) => {
                 validate_identifier("transaction_id", &metric.transaction_id)?;
                 validate_identifier("selector_version", &metric.selector_version)?;
-                validate_sha256("reference_set_hash", &metric.reference_set_hash)?;
-                validate_sha256("selected_manifest_hash", &metric.selected_manifest_hash)?;
+                validate_sha256_identity(&metric.reference_set_hash, "reference_set_hash")?;
+                validate_sha256_identity(&metric.selected_manifest_hash, "selected_manifest_hash")?;
+                ensure!(
+                    metric.candidates_generated > 0,
+                    "dream selection requires generated candidates"
+                );
+                ensure!(
+                    metric.random_quota <= metric.candidates_generated,
+                    "random dream quota exceeds generated candidates"
+                );
                 ensure!(
                     metric.selected_random <= metric.random_quota,
                     "selected random dreams exceed the configured quota"
@@ -1635,8 +1815,8 @@ impl MetricEvent {
                     .checked_add(metric.selected_random)
                     .context("selected dream count overflows u32")?;
                 ensure!(
-                    selected <= metric.candidates_generated,
-                    "selected dreams exceed generated candidates"
+                    selected > 0 && selected <= metric.candidates_generated,
+                    "selected dream count must be in 1..=candidates_generated"
                 );
                 signed_unit_interval("gradient_cosine_mean", metric.gradient_cosine_mean)?;
                 signed_unit_interval("gradient_cosine_max", metric.gradient_cosine_max)?;
@@ -1647,9 +1827,9 @@ impl MetricEvent {
             }
             Self::DreamTrial(metric) => {
                 validate_identifier("transaction_id", &metric.transaction_id)?;
-                validate_sha256("candidate_hash", &metric.candidate_hash)?;
-                validate_sha256("adapter_hash", &metric.adapter_hash)?;
-                validate_sha256("evaluator_hash", &metric.evaluator_hash)?;
+                validate_sha256_identity(&metric.candidate_hash, "candidate_hash")?;
+                validate_sha256_identity(&metric.adapter_hash, "adapter_hash")?;
+                validate_sha256_identity(&metric.evaluator_hash, "evaluator_hash")?;
                 ensure!(metric.lora_rank > 0, "LoRA rank must be positive");
                 ensure!(metric.lora_alpha > 0.0, "LoRA alpha must be positive");
                 finite("lora_alpha", metric.lora_alpha)?;
@@ -1666,7 +1846,7 @@ impl MetricEvent {
                 validate_identifier("transaction_id", &metric.transaction_id)?;
                 validate_identifier("suite", &metric.suite)?;
                 validate_identifier("metric", &metric.metric)?;
-                validate_sha256("evaluator_hash", &metric.evaluator_hash)?;
+                validate_sha256_identity(&metric.evaluator_hash, "evaluator_hash")?;
                 finite("baseline_score", metric.baseline_score)?;
                 finite("candidate_score", metric.candidate_score)?;
                 finite("improvement", metric.improvement)?;
@@ -1725,6 +1905,17 @@ impl MetricEvent {
                         metric.average_bits_per_weight.is_some() && metric.packed_bytes.is_some(),
                         "quantization export requires packed size and bits-per-weight"
                     );
+                    ensure!(
+                        metric.tensors_quantized > 0
+                            && metric.packed_bytes.is_some_and(|bytes| bytes > 0),
+                        "non-empty quantization export requires tensors and packed bytes"
+                    );
+                }
+                if metric.stage == QuantizationStage::Export {
+                    ensure!(
+                        approximately_equal(metric.progress_fraction, 1.0),
+                        "quantization export must report complete progress"
+                    );
                 }
             }
             Self::DeviceUtilization(metric) => {
@@ -1764,6 +1955,14 @@ impl MetricEvent {
                     "elapsed_seconds must be positive"
                 );
                 finite("elapsed_seconds", metric.elapsed_seconds)?;
+                ensure!(
+                    metric.compute_tokens > 0 && metric.examples > 0,
+                    "throughput window must contain tokens and examples"
+                );
+                ensure!(
+                    metric.supervised_tokens <= metric.compute_tokens,
+                    "throughput supervised tokens exceed compute tokens"
+                );
                 nonnegative("tokens_per_second", metric.tokens_per_second)?;
                 nonnegative("examples_per_second", metric.examples_per_second)?;
                 nonnegative("input_wait_seconds", metric.input_wait_seconds)?;
@@ -1828,10 +2027,14 @@ impl MetricEvent {
                 );
             }
             Self::PostTrainingUpdate(metric) => {
-                validate_sha256("transaction_id", &metric.transaction_id)?;
-                validate_sha256("checkpoint_sha256", &metric.checkpoint_sha256)?;
-                validate_sha256("optimizer_sha256", &metric.optimizer_sha256)?;
+                validate_sha256_identity(&metric.transaction_id, "transaction_id")?;
+                validate_sha256_identity(&metric.checkpoint_sha256, "checkpoint_sha256")?;
+                validate_sha256_identity(&metric.optimizer_sha256, "optimizer_sha256")?;
                 ensure!(metric.records > 0, "post-training update is empty");
+                metric
+                    .first_record
+                    .checked_add(metric.records)
+                    .context("post-training record interval overflows u64")?;
                 ensure!(metric.optimizer_step > 0, "optimizer_step must be positive");
                 ensure!(
                     metric.rng_counter_end >= metric.rng_counter_start,
@@ -1852,6 +2055,7 @@ impl MetricEvent {
                 );
                 match metric.algorithm {
                     PostTrainingAlgorithm::Dpo => {
+                        nonnegative("post_training_loss", metric.loss)?;
                         ensure!(
                             dpo.0.is_some()
                                 && dpo.1.is_some()
@@ -1861,12 +2065,17 @@ impl MetricEvent {
                         );
                         unit_interval("preference_accuracy", dpo.0.expect("checked present"))?;
                         finite("implicit_reward_margin", dpo.1.expect("checked present"))?;
+                        let expected_rngs = metric
+                            .records
+                            .checked_mul(2)
+                            .context("DPO model RNG range overflows u64")?;
                         ensure!(
-                            metric.rng_counter_start == metric.rng_counter_end,
-                            "DPO must not consume rollout RNG"
+                            metric.rng_counter_end - metric.rng_counter_start == expected_rngs,
+                            "DPO must reserve exactly two model RNG substreams per record"
                         );
                     }
                     PostTrainingAlgorithm::ForwardKl => {
+                        nonnegative("post_training_loss", metric.loss)?;
                         ensure!(
                             dpo == (None, None)
                                 && distillation.0.is_some()
@@ -1879,8 +2088,8 @@ impl MetricEvent {
                         nonnegative("teacher_entropy", distillation.1.expect("checked present"))?;
                         unit_interval("top1_agreement", distillation.2.expect("checked present"))?;
                         ensure!(
-                            metric.rng_counter_start == metric.rng_counter_end,
-                            "forward-KL must not consume rollout RNG"
+                            metric.rng_counter_end - metric.rng_counter_start == metric.records,
+                            "forward-KL must reserve exactly one model RNG substream per record"
                         );
                     }
                     PostTrainingAlgorithm::Grpo => {
@@ -1914,20 +2123,6 @@ fn validate_identifier(name: &str, value: &str) -> Result<()> {
     ensure!(
         !value.contains(['\n', '\r']),
         "{name} must not contain a newline"
-    );
-    Ok(())
-}
-
-fn validate_sha256(name: &str, value: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .with_context(|| format!("{name} must start with `sha256:`"))?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{name} must contain 64 lowercase hexadecimal digits"
     );
     Ok(())
 }
@@ -2094,6 +2289,36 @@ mod tests {
         assert_eq!(state.last_emitted_at_unix_ms, Some(102));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn a_second_writer_cannot_validate_or_truncate_the_live_journal() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        let mut owner = MetricWriter::create(&path, "run-a").unwrap();
+        owner.append_at(context(1), throughput(), 100).unwrap();
+        owner.sync_all().unwrap();
+        let committed = fs::read(&path).unwrap();
+
+        let resume_error = MetricWriter::resume(&path, "run-a")
+            .err()
+            .expect("second resume unexpectedly acquired the journal")
+            .to_string();
+        assert!(
+            resume_error.contains("metric-writer lock"),
+            "{resume_error}"
+        );
+        let create_error = MetricWriter::create(&path, "run-b")
+            .err()
+            .expect("second create unexpectedly acquired the journal")
+            .to_string();
+        assert!(
+            create_error.contains("metric-writer lock"),
+            "{create_error}"
+        );
+        assert_eq!(fs::read(&path).unwrap(), committed);
+        assert_eq!(owner.state().records, 1);
+    }
+
     #[test]
     fn resume_rejects_partial_final_record() {
         let directory = tempfile::tempdir().unwrap();
@@ -2101,6 +2326,24 @@ mod tests {
         fs::write(&path, b"{\"partial\":true}").unwrap();
         let error = MetricWriter::resume(&path, "run-a").err().unwrap();
         assert!(format!("{error:#}").contains("partial record"));
+    }
+
+    #[test]
+    fn bounded_line_reader_rejects_a_lengthless_record_without_unbounded_growth() {
+        let mut accepted = std::io::Cursor::new(b"1234\n".to_vec());
+        let mut line = Vec::new();
+        assert_eq!(
+            read_bounded_metric_line(&mut accepted, &mut line, 5).unwrap(),
+            5
+        );
+        assert_eq!(line, b"1234\n");
+
+        let mut oversized = std::io::Cursor::new(b"12345\n".to_vec());
+        let error = read_bounded_metric_line(&mut oversized, &mut line, 5)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("5-byte JSONL limit"), "{error}");
+        assert_eq!(line.len(), 6, "reader captures only limit + 1 bytes");
     }
 
     #[cfg(unix)]
@@ -2200,6 +2443,44 @@ mod tests {
             validate_metric_log(&path, Some("run-a")).unwrap().records,
             2
         );
+    }
+
+    #[test]
+    fn checkpoint_resume_does_not_materialize_an_oversized_uncommitted_tail() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        {
+            let mut writer = MetricWriter::create(&path, "run-a").unwrap();
+            writer.append_at(context(1), throughput(), 100).unwrap();
+            writer.sync_all().unwrap();
+        }
+        let committed_len = fs::metadata(&path).unwrap().len();
+        let file = OpenOptions::new().write(true).open(&path).unwrap();
+        file.set_len(committed_len + MAX_METRIC_RECORD_BYTES as u64 * 4)
+            .unwrap();
+        file.sync_all().unwrap();
+
+        let writer = MetricWriter::resume_from_checkpoint(&path, "run-a", 1, 1).unwrap();
+        assert_eq!(writer.state().records, 1);
+        assert_eq!(fs::metadata(&path).unwrap().len(), committed_len);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_sync_rejects_a_replaced_live_journal_path() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metrics.jsonl");
+        let mut writer = MetricWriter::create(&path, "run-a").unwrap();
+        writer.append_at(context(1), throughput(), 100).unwrap();
+        writer.sync_all().unwrap();
+
+        let displaced = directory.path().join("displaced.jsonl");
+        fs::rename(&path, &displaced).unwrap();
+        fs::write(&path, b"").unwrap();
+        writer.append_at(context(2), throughput(), 101).unwrap();
+        let error = writer.sync_all().unwrap_err().to_string();
+        assert!(error.contains("replaced"), "{error}");
+        assert!(fs::read(&path).unwrap().is_empty());
     }
 
     #[test]
@@ -2360,6 +2641,7 @@ mod tests {
             .append_at(context(1), one_step_throughput(2.0), 100)
             .unwrap();
         first.sync_all().unwrap();
+        let first_bytes = fs::read(&first_path).unwrap();
 
         let mut second = MetricWriter::create(&second_path, "resumed").unwrap();
         second
@@ -2387,6 +2669,11 @@ mod tests {
         second.sync_all().unwrap();
 
         let first = metric_log_digests(&first_path, Some("uninterrupted")).unwrap();
+        assert_eq!(
+            first,
+            metric_log_digests_from_bytes(&first_bytes, Some("uninterrupted")).unwrap(),
+            "streaming and already-authenticated byte projections must agree"
+        );
         let second = metric_log_digests(&second_path, Some("resumed")).unwrap();
         assert_ne!(first.raw_sha256, second.raw_sha256);
         assert_eq!(
@@ -2500,6 +2787,27 @@ mod tests {
         off_boundary.tier_clock = 101;
         assert!(MetricEvent::TierUpdate(off_boundary).validate().is_err());
 
+        let mut invalid_reset = TierUpdateMetrics {
+            transaction_id: "txn-2".to_owned(),
+            tier: MemoryTier::Fast,
+            receiver_tier: Some(MemoryTier::Medium),
+            tier_clock: 100,
+            update_period: 10,
+            accumulated_micro_steps: 10,
+            outcome: TierUpdateOutcome::Prospective,
+            update_l2_norm: None,
+            reserve_slot: Some(1),
+            reserve_generation: Some(3),
+            optimizer_state_reset: true,
+        };
+        assert!(
+            MetricEvent::TierUpdate(invalid_reset.clone())
+                .validate()
+                .is_err()
+        );
+        invalid_reset.outcome = TierUpdateOutcome::Committed;
+        MetricEvent::TierUpdate(invalid_reset).validate().unwrap();
+
         let mut capacity = ActiveCapacityMetrics {
             tier: MemoryTier::Fast,
             active_base_experts: 8,
@@ -2515,6 +2823,21 @@ mod tests {
         MetricEvent::ActiveCapacity(capacity.clone())
             .validate()
             .unwrap();
+        let mut empty_reserve = capacity.clone();
+        empty_reserve.active_reserve_experts = 0;
+        empty_reserve.dormant_reserve_experts = 0;
+        assert!(
+            MetricEvent::ActiveCapacity(empty_reserve)
+                .validate()
+                .is_err()
+        );
+        let mut empty_accounting = capacity.clone();
+        empty_accounting.routed_active_parameters = 0;
+        assert!(
+            MetricEvent::ActiveCapacity(empty_accounting)
+                .validate()
+                .is_err()
+        );
         let mut no_distinct_expert = capacity.clone();
         no_distinct_expert.active_base_experts = 2;
         no_distinct_expert.active_reserve_experts = 7;
@@ -2551,9 +2874,27 @@ mod tests {
         envelope.minimum_observed_wake_routed_active_parameters = 81;
         envelope.maximum_observed_wake_routed_active_parameters = 80;
         assert!(
-            MetricEvent::WakeCapacityEnvelope(envelope)
+            MetricEvent::WakeCapacityEnvelope(envelope.clone())
                 .validate()
                 .is_err()
+        );
+
+        envelope.minimum_observed_wake_routed_active_parameters = 79;
+        envelope.maximum_observed_wake_routed_active_parameters = 81;
+        assert!(
+            MetricEvent::WakeCapacityEnvelope(envelope.clone())
+                .validate()
+                .is_err(),
+            "active-compute drift must fail even when the initial sample is inside the range"
+        );
+
+        envelope.minimum_observed_wake_routed_active_parameters = 79;
+        envelope.maximum_observed_wake_routed_active_parameters = 79;
+        assert!(
+            MetricEvent::WakeCapacityEnvelope(envelope)
+                .validate()
+                .is_err(),
+            "an envelope that excludes its initial sample must fail"
         );
     }
 
@@ -2604,6 +2945,24 @@ mod tests {
             selected_manifest_hash: hash('5'),
         };
         MetricEvent::DreamSelection(selection).validate().unwrap();
+
+        let empty_selection = DreamSelectionMetrics {
+            transaction_id: "txn".to_owned(),
+            selector_version: "cosine-v1".to_owned(),
+            reference_set_hash: hash('4'),
+            candidates_generated: 1,
+            selected_by_alignment: 0,
+            selected_random: 0,
+            random_quota: 0,
+            gradient_cosine_mean: 0.2,
+            gradient_cosine_max: 0.9,
+            selected_manifest_hash: hash('5'),
+        };
+        assert!(
+            MetricEvent::DreamSelection(empty_selection)
+                .validate()
+                .is_err()
+        );
 
         let mut trial = DreamTrialMetrics {
             transaction_id: "txn".to_owned(),
@@ -2688,9 +3047,17 @@ mod tests {
         };
         MetricEvent::Quantization(qat).validate().unwrap();
 
-        let mut missing_error = valid_export;
+        let mut missing_error = valid_export.clone();
         missing_error.mean_squared_error = None;
         assert!(MetricEvent::Quantization(missing_error).validate().is_err());
+
+        let mut incomplete_export = valid_export;
+        incomplete_export.progress_fraction = 0.99;
+        assert!(
+            MetricEvent::Quantization(incomplete_export)
+                .validate()
+                .is_err()
+        );
     }
 
     #[test]
@@ -2733,6 +3100,44 @@ mod tests {
                 .validate()
                 .is_err()
         );
+
+        let mut overflow = PostTrainingUpdateMetrics {
+            transaction_id: hash('a'),
+            algorithm: PostTrainingAlgorithm::Dpo,
+            epoch: 0,
+            first_record: u64::MAX,
+            records: 1,
+            optimizer_step: 1,
+            rng_counter_start: 0,
+            rng_counter_end: 2,
+            loss: 0.1,
+            checkpoint_sha256: hash('b'),
+            optimizer_sha256: hash('c'),
+            preference_accuracy: Some(1.0),
+            implicit_reward_margin: Some(1.0),
+            forward_kl: None,
+            teacher_entropy: None,
+            top1_agreement: None,
+            mean_reward: None,
+            reward_stddev: None,
+            mean_kl: None,
+            clipped_fraction: None,
+        };
+        assert!(
+            MetricEvent::PostTrainingUpdate(Box::new(overflow.clone()))
+                .validate()
+                .is_err()
+        );
+        overflow.first_record = u64::MAX - 1;
+        MetricEvent::PostTrainingUpdate(Box::new(overflow.clone()))
+            .validate()
+            .unwrap();
+        overflow.loss = -0.1;
+        assert!(
+            MetricEvent::PostTrainingUpdate(Box::new(overflow))
+                .validate()
+                .is_err()
+        );
     }
 
     #[test]
@@ -2760,6 +3165,12 @@ mod tests {
         event.validate().unwrap();
         if let MetricEvent::Throughput(metric) = &mut event {
             metric.tokens_per_second = 9_000.0;
+        }
+        assert!(event.validate().is_err());
+
+        let mut event = throughput();
+        if let MetricEvent::Throughput(metric) = &mut event {
+            metric.supervised_tokens = metric.compute_tokens + 1;
         }
         assert!(event.validate().is_err());
     }

--- a/hermes-train/src/native_host.rs
+++ b/hermes-train/src/native_host.rs
@@ -17,7 +17,9 @@ use crate::native_sleep::{
     NativeSleepPhaseContextFactory, NativeSleepPhaseExecutor, NativeSleepPhaseOutcome,
     NativeSleepProgressSink,
 };
-use crate::posttrain::{NativePostTrainingPhaseExecutor, PostTrainingExecutionContext};
+use crate::posttrain::{
+    NativePostTrainingPhaseExecutor, PostTrainingExecutionContext, validate_resumable_phase,
+};
 use crate::promotion::NativePromotionExecutor;
 use crate::runtime::{
     ALL_PHASE_KINDS, ExecutorRegistry, ImmutableModelCheckpoint, PhaseExecutionRequest,
@@ -36,13 +38,14 @@ pub struct NativeHostMetricJournal {
     pub run_id: String,
 }
 
-/// Factory which lends one concrete set of trainable/frozen adapters and its
+/// Factory which lends one concrete device-owned batch runtime and its
 /// idempotent publisher to the built-in DPO, forward-KL, or GRPO executor.
 ///
 /// The callback must be invoked exactly once. Implementations normally load
 /// the model/optimizer generation named by `request`, construct
-/// [`PostTrainingExecutionContext`], and lend it to `operation`. No adapter is
-/// stored globally or inferred by trainer core.
+/// [`PostTrainingExecutionContext`], and lend it to `operation`. The runtime
+/// may jointly own trainable and frozen models so it can fuse/batch their
+/// execution; no per-example host-score adapter is inferred by trainer core.
 pub trait NativePostTrainingContextFactory {
     fn identity(&self) -> &str;
 
@@ -180,6 +183,12 @@ impl NativeWorkflowAdapters {
                     }
                     PhaseKind::Promotion => NativeHostDispatch::NativePromotion,
                     _ if phase.post_training.is_some() => {
+                        validate_resumable_phase(phase).with_context(|| {
+                            format!(
+                                "phase `{}` is incompatible with the native post-training executor",
+                                phase.name
+                            )
+                        })?;
                         let factory = self.post_training.as_deref().with_context(|| {
                             format!(
                                 "phase `{}` has typed post_training and requires a registered native post-training context factory",
@@ -225,6 +234,10 @@ impl NativeWorkflowAdapters {
     fn dispatch_identity(&self, workflow: &ResolvedWorkflow) -> Result<String> {
         let plan = self.dispatch_plan(workflow)?;
         let signature = workflow_signature(workflow)?;
+        let external_identity = self
+            .external
+            .as_ref()
+            .map(ExternalPhaseExecutor::execution_identity);
         let mut hasher = Sha256::new();
         hash_part(&mut hasher, b"hermes-native-workflow-host");
         hash_part(&mut hasher, &NATIVE_HOST_DISPATCH_VERSION.to_le_bytes());
@@ -233,9 +246,7 @@ impl NativeWorkflowAdapters {
             hash_part(&mut hasher, &serde_json::to_vec(route)?);
         }
         for identity in [
-            self.external
-                .as_ref()
-                .map(ExternalPhaseExecutor::expected_sha256),
+            external_identity.as_deref(),
             self.sleep.phase_factory_identity(),
             self.post_training
                 .as_deref()
@@ -298,6 +309,12 @@ pub struct NativeWorkflowHost {
     context: NativeWorkflowContext,
     checkpoint: AtomicRuntimeCheckpoint,
     dispatch_sha256: String,
+    // A failed executor may have appended metrics after the last durable
+    // runtime boundary. Continuing with the same in-memory journal could make
+    // that failed-attempt tail part of a later commit. Reopening through
+    // `resume` validates and truncates the journal to the exact committed
+    // prefix before execution continues.
+    recovery_required: bool,
 }
 
 impl NativeWorkflowHost {
@@ -366,6 +383,7 @@ impl NativeWorkflowHost {
             context,
             checkpoint,
             dispatch_sha256,
+            recovery_required: false,
         })
     }
 
@@ -382,13 +400,21 @@ impl NativeWorkflowHost {
     }
 
     pub fn drive_until_yield_or_complete(&mut self) -> Result<RuntimeStatus> {
-        run_until_yield_or_complete(
+        ensure!(
+            !self.recovery_required,
+            "native workflow host must be reopened with resume after an execution or persistence error"
+        );
+        let result = run_until_yield_or_complete(
             &self.workflow,
             &mut self.state,
             &mut self.registry,
             &mut self.context,
             &mut self.checkpoint,
-        )
+        );
+        if result.is_err() {
+            self.recovery_required = true;
+        }
+        result
     }
 }
 
@@ -519,6 +545,9 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     use anyhow::bail;
 
     use super::*;
@@ -571,6 +600,12 @@ mod tests {
     fn external(path: &Path) -> ExternalPhaseExecutor {
         let bytes = b"native-host-test-worker-v1";
         fs::write(path, bytes).unwrap();
+        #[cfg(unix)]
+        {
+            let mut permissions = fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o700);
+            fs::set_permissions(path, permissions).unwrap();
+        }
         ExternalPhaseExecutor::new(path, Vec::new(), identity("native-host-test-worker-v1"))
             .unwrap()
     }
@@ -660,6 +695,58 @@ mod tests {
         let plan = adapters.dispatch_plan(&workflow).unwrap();
         assert_eq!(plan.len(), 1);
         assert_eq!(plan[0].dispatch, NativeHostDispatch::NativePostTraining);
+    }
+
+    #[test]
+    fn invalid_native_post_training_fails_before_runtime_state_creation() {
+        let temporary = tempfile::tempdir().unwrap();
+        let worker = temporary.path().join("worker");
+        let state = temporary.path().join("runtime.json");
+        let mut workflow = education_workflow();
+        workflow
+            .phases
+            .retain(|phase| phase.name == "preference-dpo");
+        assert_eq!(workflow.phases.len(), 1);
+        workflow.phases[0].shuffle_buffer = Some(32);
+
+        let error = match NativeWorkflowHost::start(
+            workflow,
+            education_adapters(&worker, false),
+            &state,
+            None,
+            None,
+        ) {
+            Ok(_) => panic!("incompatible native post-training phase unexpectedly started"),
+            Err(error) => format!("{error:#}"),
+        };
+        assert!(error.contains("deterministic input order"), "{error}");
+        assert!(!state.exists(), "invalid phase created runtime state");
+    }
+
+    #[test]
+    fn execution_error_requires_reopening_at_the_committed_prefix() {
+        let temporary = tempfile::tempdir().unwrap();
+        let worker = temporary.path().join("worker");
+        let state = temporary.path().join("runtime.json");
+        let mut host = NativeWorkflowHost::start(
+            education_workflow(),
+            education_adapters(&worker, true),
+            &state,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let first = host
+            .drive_until_yield_or_complete()
+            .unwrap_err()
+            .to_string();
+        assert!(first.contains("must not execute periodic wake"), "{first}");
+        let second = host
+            .drive_until_yield_or_complete()
+            .unwrap_err()
+            .to_string();
+        assert!(second.contains("reopened with resume"), "{second}");
     }
 
     #[test]

--- a/hermes-train/src/native_sleep.rs
+++ b/hermes-train/src/native_sleep.rs
@@ -6,15 +6,13 @@
 //! immutable candidate identity.
 
 use std::collections::BTreeSet;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 
 use anyhow::{Context, Result, bail, ensure};
 use hermes_llm::Transformer;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
+use crate::artifact_io::{hash_regular_file, validate_sha256_identity};
 use crate::metrics::{
     ActiveCapacityMetrics, DistillationDivergenceMetrics, ImitationRewardMetrics, MemoryTier,
     MetricContext, MetricDirection, MetricEvent, MetricPhase, MetricPhaseKind,
@@ -37,20 +35,6 @@ use crate::tensor_sleep::{
 use crate::workflow::InModelSleepConfig;
 
 pub const NATIVE_SLEEP_CHECKPOINT_VERSION: u32 = 1;
-
-fn validate_hash(value: &str, label: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .with_context(|| format!("{label} must use sha256:<64 lowercase hex>"))?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{label} must use sha256:<64 lowercase hex>"
-    );
-    Ok(())
-}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -86,26 +70,11 @@ impl PinnedNativeArtifact {
             !self.path.trim().is_empty(),
             "pinned sleep artifact path is empty"
         );
-        validate_hash(&self.sha256, "pinned sleep artifact hash")?;
+        validate_sha256_identity(&self.sha256, "pinned sleep artifact hash")?;
         let path = Path::new(&self.path);
-        let metadata = std::fs::symlink_metadata(path)
-            .with_context(|| format!("reading pinned sleep artifact {}", path.display()))?;
-        ensure!(
-            metadata.is_file() && !metadata.file_type().is_symlink(),
-            "pinned sleep artifact {} is not a regular non-symlink file",
-            path.display()
-        );
-        let mut file = File::open(path)?;
-        let mut hasher = Sha256::new();
-        let mut buffer = [0_u8; 1024 * 1024];
-        loop {
-            let read = file.read(&mut buffer)?;
-            if read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..read]);
-        }
-        let observed = format!("sha256:{:x}", hasher.finalize());
+        let observed = hash_regular_file(path)
+            .with_context(|| format!("reading pinned sleep artifact {}", path.display()))?
+            .1;
         ensure!(
             observed == self.sha256,
             "pinned sleep artifact {} changed: expected {}, observed {observed}",
@@ -131,7 +100,7 @@ impl NativeCheckpointRef {
             !self.uri.trim().is_empty(),
             "native checkpoint URI is empty"
         );
-        validate_hash(&self.sha256, "native checkpoint hash")
+        validate_sha256_identity(&self.sha256, "native checkpoint hash")
     }
 }
 
@@ -225,13 +194,27 @@ impl NativeSleepCheckpoint {
     }
 
     pub fn validate(&self, model: &Transformer, config: &InModelSleepConfig) -> Result<()> {
+        self.validate_state(model, config)?;
+        self.retention_suite.verify()?;
+        if let Some(journal) = &self.wake_context_journal {
+            journal
+                .verify()
+                .context("verifying pinned wake-context journal")?;
+        }
+        Ok(())
+    }
+
+    /// Validate the in-memory cursor/model relationship without touching
+    /// external artifacts. Ordinary wake steps use this path; content-pinned
+    /// files are re-authenticated before a due boundary consumes them.
+    fn validate_state(&self, model: &Transformer, config: &InModelSleepConfig) -> Result<()> {
         let schedule = &config.schedule;
         ensure!(
             self.version == NATIVE_SLEEP_CHECKPOINT_VERSION,
             "unsupported native sleep checkpoint version {}",
             self.version
         );
-        validate_hash(&self.workflow_signature, "sleep workflow signature")?;
+        validate_sha256_identity(&self.workflow_signature, "sleep workflow signature")?;
         ensure!(
             !self.phase_name.trim().is_empty(),
             "sleep phase name is empty"
@@ -243,43 +226,23 @@ impl NativeSleepCheckpoint {
                 && config.retention_suite_sha256 == self.retention_suite.sha256,
             "native checkpoint retention suite differs from WorkflowV2"
         );
-        self.retention_suite.verify()?;
-        if let Some(journal) = &self.wake_context_journal {
-            journal
-                .verify()
-                .context("verifying pinned wake-context journal")?;
+        let mut expected_evaluators = vec![
+            self.retention_suite.sha256.clone(),
+            config.imitation.semantic_judge_hash.clone(),
+            config.retention.evaluator_hash.clone(),
+        ];
+        if let Some(dreaming) = &config.dreaming {
+            expected_evaluators.push(dreaming.reference_set_hash.clone());
+            expected_evaluators.push(dreaming.trial_evaluator_hash.clone());
         }
         ensure!(
-            self.sleep
-                .evaluator_hashes
-                .contains(&self.retention_suite.sha256),
-            "native sleep state does not record the retention-suite identity"
+            self.sleep.evaluator_hashes == expected_evaluators,
+            "native sleep evaluator identities or their configured roles have drifted"
         );
-        for expected in [
-            config.imitation.semantic_judge_hash.as_str(),
-            config.retention.evaluator_hash.as_str(),
-        ] {
-            ensure!(
-                self.sleep
-                    .evaluator_hashes
-                    .iter()
-                    .any(|hash| hash == expected),
-                "native sleep state is missing configured evaluator `{expected}`"
-            );
-        }
-        if let Some(dreaming) = &config.dreaming {
-            for expected in [&dreaming.reference_set_hash, &dreaming.trial_evaluator_hash] {
-                ensure!(
-                    self.sleep.evaluator_hashes.contains(expected),
-                    "native sleep state is missing configured dream evaluator `{expected}`"
-                );
-            }
-        }
-        self.sleep.validate_resume()?;
+        let memory_statuses = model.memory_slot_statuses();
+        validate_model_memory_state(schedule, &self.sleep, &memory_statuses)?;
         if let Some(txn) = &self.sleep.pending {
-            let expected_knowledge = (config.knowledge_seeding.teacher_rollouts
-                + config.knowledge_seeding.detached_student_rollouts)
-                as u64;
+            let expected_knowledge = config.knowledge_seeding.rollout_count_u64()?;
             if let Some(reservation) = txn.knowledge_rng {
                 ensure!(
                     reservation.stream == 0 && reservation.count == expected_knowledge,
@@ -289,7 +252,7 @@ impl NativeSleepCheckpoint {
             if let Some(reservation) = txn.imitation_rng {
                 ensure!(
                     reservation.stream == 0
-                        && reservation.count == config.imitation.grpo_group_size as u64,
+                        && reservation.count == config.imitation.group_size_u64()?,
                     "native imitation RNG reservation differs from WorkflowV2"
                 );
             }
@@ -298,7 +261,9 @@ impl NativeSleepCheckpoint {
                     if let Some(reservation) = txn.dream_generation_rng {
                         ensure!(
                             reservation.stream == 0
-                                && reservation.count == dreaming.candidate_count as u64,
+                                && reservation.count
+                                    == u64::try_from(dreaming.candidate_count)
+                                        .context("dream candidate count exceeds RNG schema")?,
                             "native dream-generation RNG reservation differs from WorkflowV2"
                         );
                     }
@@ -320,6 +285,25 @@ impl NativeSleepCheckpoint {
                             .all(|trial| trial.evaluator_hash == dreaming.trial_evaluator_hash),
                         "native dream trial used an evaluator outside WorkflowV2"
                     );
+                    let retained = dreaming.retained_count()?;
+                    ensure!(
+                        txn.dream_selected.len() <= retained
+                            && txn.dream_trials.len() <= txn.dream_selected.len()
+                            && txn.dream_trial_rngs.len() <= txn.dream_selected.len(),
+                        "native dream evidence exceeds the configured selection quota"
+                    );
+                    if matches!(
+                        self.sleep.phase,
+                        SleepPhase::DreamTrials
+                            | SleepPhase::DreamPolicyUpdate
+                            | SleepPhase::Candidate
+                    ) && txn.generated_manifest.is_some()
+                    {
+                        ensure!(
+                            txn.dream_selected.len() == retained,
+                            "native dream selection differs from the configured quota"
+                        );
+                    }
                 }
                 None => ensure!(
                     txn.dream_generation_rng.is_none()
@@ -333,16 +317,16 @@ impl NativeSleepCheckpoint {
                 ),
             }
         }
-        validate_model_memory_state(schedule, &self.sleep, &model.memory_slot_statuses())?;
         self.optimizer_scopes
-            .validate_active_state(model, schedule, &self.sleep)?;
+            .validate_active_state_after_model_validation(model, schedule, &memory_statuses)?;
         ensure!(
             self.optimizer_scopes
                 .tiers
                 .iter()
-                .all(|scope| scope.update_clock <= self.sleep.clock
+                .zip(&self.sleep.tiers)
+                .all(|(scope, tier)| scope.update_clock == tier.last_update_clock
                     && scope.transfer_clock <= self.sleep.clock),
-            "native optimizer or receiver-transfer clock is ahead of the wake/sleep clock"
+            "native optimizer update clock disagrees with its sleep tier, or a receiver-transfer clock is ahead of the wake/sleep clock"
         );
         if let Some(txn) = &self.sleep.pending
             && txn.committed
@@ -351,6 +335,51 @@ impl NativeSleepCheckpoint {
                 txn.candidate_checkpoint.as_deref() == Some(self.live_checkpoint.uri.as_str())
                     && txn.candidate_hash.as_deref() == Some(self.live_checkpoint.sha256.as_str()),
                 "native live checkpoint differs from committed sleep candidate"
+            );
+        }
+        Ok(())
+    }
+
+    /// Validate only state that can change between already authenticated sleep
+    /// boundaries. Model topology, active masks, evaluator bindings, and full
+    /// optimizer ownership are revalidated at construction/resume and before a
+    /// boundary consumes them; rebuilding their parameter-ID sets on every
+    /// ordinary wake step would put a large CPU allocation in the hot path.
+    fn validate_wake_tick(&self, config: &InModelSleepConfig) -> Result<()> {
+        ensure!(
+            self.version == NATIVE_SLEEP_CHECKPOINT_VERSION,
+            "unsupported native sleep checkpoint version {}",
+            self.version
+        );
+        ensure!(
+            self.sleep.phase == SleepPhase::Wake
+                && self.sleep.pending.is_none()
+                && self.sleep.due_senders.is_empty()
+                && self.sleep.due_clocks.is_empty(),
+            "ordinary wake clock advance found an unfinished sleep boundary"
+        );
+        ensure!(
+            self.sleep.tiers.len() == config.schedule.tiers.len()
+                && self.optimizer_scopes.tiers.len() == config.schedule.tiers.len(),
+            "native sleep tier count differs from WorkflowV2"
+        );
+        for (tier, ((saved, scope), configured)) in self
+            .sleep
+            .tiers
+            .iter()
+            .zip(&self.optimizer_scopes.tiers)
+            .zip(&config.schedule.tiers)
+            .enumerate()
+        {
+            ensure!(
+                saved.id == configured.id
+                    && saved.slots.len() == configured.reserve_slots
+                    && scope.tier == tier
+                    && scope.tier_id == configured.id
+                    && scope.update_clock == saved.last_update_clock
+                    && scope.transfer_clock <= self.sleep.clock,
+                "native wake tier `{}` differs from its schedule/optimizer clock",
+                configured.id
             );
         }
         Ok(())
@@ -387,9 +416,22 @@ impl NativeSleepCheckpoint {
         config: &InModelSleepConfig,
         clock: u64,
     ) -> Result<()> {
-        self.validate(model, config)?;
-        self.sleep.advance_clock(&config.schedule, clock)?;
-        self.validate(model, config)
+        let reaches_boundary = reaches_sleep_boundary(&self.sleep, &config.schedule, clock)?;
+        if reaches_boundary {
+            self.validate_state(model, config)?;
+            self.retention_suite.verify()?;
+            if let Some(journal) = &self.wake_context_journal {
+                journal
+                    .verify()
+                    .context("verifying pinned wake-context journal")?;
+            }
+        } else {
+            self.validate_wake_tick(config)?;
+        }
+        // SleepState computes every fallible boundary decision before it
+        // mutates clocks/queues, so no full checkpoint clone is required for
+        // failure atomicity on the wake hot path.
+        self.sleep.advance_clock(&config.schedule, clock)
     }
 
     pub fn begin_next(&mut self, plan: PlannedConsolidation) -> Result<ConsolidationTxn> {
@@ -407,6 +449,37 @@ impl NativeSleepCheckpoint {
             plan.prospective_update_sha256,
         )
     }
+
+    /// Model topology paired with the durable tier optimizer scopes. Before
+    /// commit those scopes still describe the teacher; after commit they
+    /// include the activated receiver and reclaimed sender masks in `live`.
+    pub(crate) fn optimizer_scope_checkpoint(&self) -> Result<NativeCheckpointRef> {
+        match self.sleep.pending.as_ref() {
+            Some(txn) if !txn.committed => {
+                NativeCheckpointRef::new(&txn.teacher_checkpoint, &txn.teacher_hash)
+            }
+            _ => Ok(self.live_checkpoint.clone()),
+        }
+    }
+}
+
+fn reaches_sleep_boundary(
+    state: &SleepState,
+    schedule: &SleepSchedule,
+    clock: u64,
+) -> Result<bool> {
+    for (saved, configured) in state.tiers.iter().zip(&schedule.tiers) {
+        let next = saved
+            .last_boundary_clock
+            .checked_div(configured.update_period)
+            .and_then(|multiple| multiple.checked_add(1))
+            .and_then(|multiple| multiple.checked_mul(configured.update_period))
+            .context("sleep boundary clock overflow")?;
+        if next <= clock {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -423,8 +496,8 @@ impl PlannedConsolidation {
             !self.student_checkpoint.trim().is_empty(),
             "prospective student checkpoint is empty"
         );
-        validate_hash(&self.student_sha256, "prospective student hash")?;
-        validate_hash(
+        validate_sha256_identity(&self.student_sha256, "prospective student hash")?;
+        validate_sha256_identity(
             &self.prospective_update_sha256,
             "prospective optimizer-update hash",
         )
@@ -538,7 +611,7 @@ impl NativeSleepContextRegistry {
     where
         F: NativeSleepPhaseContextFactory + 'static,
     {
-        validate_hash(factory.identity(), "native sleep factory identity")?;
+        validate_sha256_identity(factory.identity(), "native sleep factory identity")?;
         ensure!(
             self.phase_factory.is_none(),
             "a native sleep phase factory is already registered"
@@ -602,7 +675,7 @@ pub struct NativeSleepPhaseExecutor {
 impl NativeSleepPhaseExecutor {
     pub fn new(workflow_signature: impl Into<String>) -> Result<Self> {
         let workflow_signature = workflow_signature.into();
-        validate_hash(&workflow_signature, "native executor workflow signature")?;
+        validate_sha256_identity(&workflow_signature, "native executor workflow signature")?;
         Ok(Self { workflow_signature })
     }
 
@@ -612,6 +685,22 @@ impl NativeSleepPhaseExecutor {
         request: &PhaseExecutionRequest,
         config: &InModelSleepConfig,
     ) -> Result<()> {
+        ensure!(
+            cursor.version == NATIVE_SLEEP_CHECKPOINT_VERSION,
+            "unsupported native sleep checkpoint version {}",
+            cursor.version
+        );
+        cursor.input_checkpoint.validate()?;
+        cursor.live_checkpoint.validate()?;
+        cursor
+            .sleep
+            .validate_resume()
+            .context("validating native sleep phase cursor")?;
+        if let Some(journal) = &cursor.wake_context_journal {
+            journal
+                .verify()
+                .context("verifying native sleep phase wake-context journal")?;
+        }
         let input = request
             .input_checkpoint
             .as_ref()
@@ -639,31 +728,19 @@ impl NativeSleepPhaseExecutor {
             "native sleep cursor retention suite differs from WorkflowV2"
         );
         cursor.retention_suite.verify()?;
-        for hash in [
-            config.imitation.semantic_judge_hash.as_str(),
-            config.retention.evaluator_hash.as_str(),
-        ] {
-            ensure!(
-                cursor
-                    .sleep
-                    .evaluator_hashes
-                    .iter()
-                    .any(|saved| saved == hash),
-                "native sleep cursor is missing evaluator `{hash}`"
-            );
-        }
+        let mut expected_evaluators = vec![
+            config.retention_suite_sha256.clone(),
+            config.imitation.semantic_judge_hash.clone(),
+            config.retention.evaluator_hash.clone(),
+        ];
         if let Some(dreaming) = &config.dreaming {
-            for expected in [&dreaming.reference_set_hash, &dreaming.trial_evaluator_hash] {
-                ensure!(
-                    cursor
-                        .sleep
-                        .evaluator_hashes
-                        .iter()
-                        .any(|saved| saved == expected),
-                    "native sleep cursor is missing dream evaluator `{expected}`"
-                );
-            }
+            expected_evaluators.push(dreaming.reference_set_hash.clone());
+            expected_evaluators.push(dreaming.trial_evaluator_hash.clone());
         }
+        ensure!(
+            cursor.sleep.evaluator_hashes == expected_evaluators,
+            "native sleep cursor evaluator identities or configured roles have drifted"
+        );
         if let Some(trigger) = config.standalone_trigger_clock {
             ensure!(
                 cursor.sleep.clock == trigger,
@@ -760,7 +837,8 @@ impl<C: NativeSleepPhaseContext> PhaseExecutor<C> for NativeSleepPhaseExecutor {
                 ensure!(
                     cursor.sleep.phase == SleepPhase::Wake
                         && cursor.sleep.pending.is_none()
-                        && cursor.sleep.due_senders.is_empty(),
+                        && cursor.sleep.due_senders.is_empty()
+                        && cursor.sleep.due_clocks.is_empty(),
                     "native sleep phase accepted before every due sender completed"
                 );
                 Ok(PhaseExecutionResult::Complete(
@@ -1029,7 +1107,7 @@ fn emit_retention_metrics<S: NativeSleepProgressSink>(
             candidate_score: f64::from(diagnostics.student_incorporation),
             improvement: f64::from(diagnostics.incorporation_gain),
             maximum_allowed_regression: 0.0,
-            passed: diagnostics.incorporation_gain >= 0.0,
+            passed: diagnostics.incorporation_gain >= config.retention.min_incorporation_gain,
         },
     ] {
         sink.metric(checkpoint, MetricEvent::RetentionDelta(metric))?;
@@ -1224,12 +1302,15 @@ fn emit_active_capacity_metrics<S: NativeSleepProgressSink>(
                 ],
                 "stored reserve experts",
             )?;
-            // Exactly one low-rank route executes on every wake pass. Before
-            // any real slot is active the model executes its deterministic
-            // zero fallback; activation replaces that lane rather than adding
-            // a route. Candidate router scoring is intentionally not counted
-            // as routed expert parameters and remains covered by measured
-            // throughput/latency gates.
+            // Router scoring covers every preallocated row even though only
+            // top-k low-rank experts execute. Before any real slot is active
+            // the model executes its deterministic zero fallback; activation
+            // replaces that lane rather than adding a route.
+            checked_add_product(
+                &mut routed_active_parameters,
+                &[reserve.capacity, hidden],
+                "fixed reserve router lanes",
+            )?;
             checked_add_product(
                 &mut routed_active_parameters,
                 &[reserve.top_k, 2, hidden, reserve.rank],
@@ -1334,12 +1415,9 @@ where
                 persist_tensor_boundary(checkpoint, backend, store, sink)?;
             }
             SleepPhase::KnowledgeSeeding => {
-                checkpoint.sleep.reserve_knowledge_rng(
-                    0,
-                    (config.knowledge_seeding.teacher_rollouts
-                        + config.knowledge_seeding.detached_student_rollouts)
-                        as u64,
-                )?;
+                checkpoint
+                    .sleep
+                    .reserve_knowledge_rng(0, config.knowledge_seeding.rollout_count_u64()?)?;
                 sink.persist(checkpoint)?;
                 let current_txn = checkpoint
                     .sleep
@@ -1354,7 +1432,7 @@ where
             SleepPhase::Imitation => {
                 checkpoint
                     .sleep
-                    .reserve_imitation_rng(0, config.imitation.grpo_group_size as u64)?;
+                    .reserve_imitation_rng(0, config.imitation.group_size_u64()?)?;
                 sink.persist(checkpoint)?;
                 let current_txn = checkpoint
                     .sleep
@@ -1459,16 +1537,15 @@ where
             restored.live_checkpoint =
                 NativeCheckpointRef::new(txn.teacher_checkpoint.clone(), txn.teacher_hash.clone())?;
             restored.validate(&backend.live_checkpoint().model, config)?;
-            emit_tier_update_metric(
+            let metric = emit_tier_update_metric(
                 &restored,
                 schedule,
                 &txn,
                 sender_accumulated_micro_steps,
                 TierUpdateOutcome::RolledBack,
                 sink,
-            )?;
-            sink.persist(&restored)?;
-            *checkpoint = restored;
+            );
+            publish_native_rollback(checkpoint, restored, metric, sink)?;
             Ok(NativeConsolidationOutcome::Rejected(
                 checkpoint.live_checkpoint.clone(),
             ))
@@ -1479,11 +1556,16 @@ where
                     "native candidate was published; retry idempotent artifact and cursor publication without rollback",
                 ));
             }
-            let restore = backend.restore_teacher(&txn);
+            if let Err(restore_error) = backend.restore_teacher(&txn) {
+                bail!(
+                    "native consolidation failed: {error:#}; teacher restore also failed: {restore_error:#}"
+                );
+            }
             let mut restored = checkpoint.clone();
             restored.sleep.rollback()?;
             restored.live_checkpoint =
                 NativeCheckpointRef::new(txn.teacher_checkpoint.clone(), txn.teacher_hash.clone())?;
+            restored.validate(&backend.live_checkpoint().model, config)?;
             let metric = emit_tier_update_metric(
                 &restored,
                 schedule,
@@ -1492,18 +1574,29 @@ where
                 TierUpdateOutcome::RolledBack,
                 sink,
             );
-            let persist = sink.persist(&restored);
-            if let Err(restore_error) = restore {
-                bail!(
-                    "native consolidation failed: {error:#}; teacher restore also failed: {restore_error:#}"
-                );
-            }
-            metric.context("emitting native sleep rollback metric")?;
-            persist.context("persisting native sleep rollback")?;
-            *checkpoint = restored;
+            publish_native_rollback(checkpoint, restored, metric, sink)?;
             Err(error)
         }
     }
+}
+
+/// Publish restored semantic state even if telemetry emission failed. Once the
+/// tensor backend has restored its teacher, leaving the durable or in-memory
+/// cursor in an in-flight subphase would make a same-process retry disagree
+/// with the backend. A failed checkpoint publication still leaves the caller
+/// pending so it can retry from the last durable boundary.
+fn publish_native_rollback<S: NativeSleepProgressSink>(
+    checkpoint: &mut NativeSleepCheckpoint,
+    restored: NativeSleepCheckpoint,
+    metric: Result<()>,
+    sink: &mut S,
+) -> Result<()> {
+    let persist = sink.persist(&restored);
+    if persist.is_ok() {
+        *checkpoint = restored;
+    }
+    metric.context("emitting native sleep rollback metric")?;
+    persist.context("persisting native sleep rollback")
 }
 
 fn persist_tensor_boundary_without_cursor<U, R, J, E, P, T>(
@@ -1727,11 +1820,12 @@ mod tests {
     use burn::tensor::{Int, Tensor};
     use burn_optim::{AdamWConfig, GradientsParams};
     use hermes_llm::{Device, Transformer, parse_mal};
+    use sha2::{Digest, Sha256};
 
     use super::*;
     use crate::sleep::{
         ImitationConfig, KnowledgeSeedingConfig, MemoryTierSchedule, TerminalConsolidation,
-        UpdateClock,
+        UpdateClock, full_scope_validation_count, reset_full_scope_validation_count,
     };
     use crate::tensor_sleep::RetentionGateConfig;
     use crate::tensor_sleep::{
@@ -1943,6 +2037,174 @@ mod tests {
     }
 
     #[derive(Default)]
+    struct CapacitySink(Vec<ActiveCapacityMetrics>);
+
+    impl NativeSleepProgressSink for CapacitySink {
+        fn persist(&mut self, _: &NativeSleepCheckpoint) -> Result<()> {
+            Ok(())
+        }
+
+        fn metric(&mut self, _: &NativeSleepCheckpoint, event: MetricEvent) -> Result<()> {
+            if let MetricEvent::ActiveCapacity(metric) = event {
+                self.0.push(metric);
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn active_capacity_metrics_include_every_fixed_reserve_router_lane() {
+        let model = model();
+        let (_, checkpoint) = checkpoint(&model);
+        let schedule = schedule();
+        let mut sink = CapacitySink::default();
+
+        emit_active_capacity_metrics(&checkpoint, &model, &schedule, &mut sink).unwrap();
+
+        assert_eq!(sink.0.len(), schedule.tiers.len());
+        let memory_stored = sink
+            .0
+            .iter()
+            .map(|metric| metric.stored_parameters)
+            .sum::<u64>();
+        let memory_routed = sink
+            .0
+            .iter()
+            .map(|metric| metric.routed_active_parameters)
+            .sum::<u64>();
+        let model_accounting = model.wake_parameter_accounting().unwrap();
+        let non_memory = model_accounting
+            .stored_parameters
+            .checked_sub(memory_stored)
+            .unwrap();
+        assert_eq!(
+            non_memory + memory_routed,
+            model_accounting.routed_active_parameters
+        );
+    }
+
+    #[derive(Default)]
+    struct RetentionSink(Vec<RetentionDeltaMetrics>);
+
+    impl NativeSleepProgressSink for RetentionSink {
+        fn persist(&mut self, _: &NativeSleepCheckpoint) -> Result<()> {
+            Ok(())
+        }
+
+        fn metric(&mut self, _: &NativeSleepCheckpoint, event: MetricEvent) -> Result<()> {
+            if let MetricEvent::RetentionDelta(metric) = event {
+                self.0.push(metric);
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn incorporation_metric_uses_the_configured_retention_threshold() {
+        let model = model();
+        let (directory, mut checkpoint) = checkpoint(&model);
+        let mut config = sleep_config(directory.path(), checkpoint.retention_suite.sha256.clone());
+        config.retention.min_incorporation_gain = 0.2;
+        checkpoint.advance_clock(&model, &config, 100).unwrap();
+        let txn = checkpoint
+            .begin_next(PlannedConsolidation {
+                student_checkpoint: "student-metric".into(),
+                student_sha256: hash('b'),
+                prospective_update_sha256: hash('c'),
+            })
+            .unwrap();
+        let diagnostics = crate::tensor_sleep::TensorSleepDiagnostics {
+            retention_anchor_kl: 0.0,
+            teacher_stable_anchor: 0.8,
+            student_stable_anchor: 0.8,
+            teacher_incorporation: 0.4,
+            student_incorporation: 0.5,
+            incorporation_gain: 0.1,
+            ..Default::default()
+        };
+        let mut sink = RetentionSink::default();
+
+        emit_retention_metrics(&checkpoint, &txn, &config, diagnostics, &mut sink).unwrap();
+
+        let incorporation = sink
+            .0
+            .iter()
+            .find(|metric| metric.metric == "incorporation")
+            .unwrap();
+        assert!(!incorporation.passed);
+    }
+
+    #[test]
+    fn native_resume_rejects_extra_or_reordered_evaluator_roles() {
+        let model = model();
+        let (directory, checkpoint) = checkpoint(&model);
+        let config = sleep_config(directory.path(), checkpoint.retention_suite.sha256.clone());
+
+        let mut extra = checkpoint.clone();
+        extra.sleep.evaluator_hashes.push(hash('9'));
+        assert!(extra.validate(&model, &config).is_err());
+
+        let mut reordered = checkpoint;
+        reordered.sleep.evaluator_hashes.swap(0, 1);
+        assert!(reordered.validate(&model, &config).is_err());
+    }
+
+    #[derive(Default)]
+    struct RecordingRollbackSink {
+        persisted: Option<NativeSleepCheckpoint>,
+        fail_persist: bool,
+    }
+
+    impl NativeSleepProgressSink for RecordingRollbackSink {
+        fn persist(&mut self, checkpoint: &NativeSleepCheckpoint) -> Result<()> {
+            if self.fail_persist {
+                bail!("injected rollback persistence failure");
+            }
+            self.persisted = Some(checkpoint.clone());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn rollback_cursor_stays_aligned_with_the_durable_backend_when_metrics_fail() {
+        let model = model();
+        let (_, mut checkpoint) = checkpoint(&model);
+        let original = checkpoint.clone();
+        let mut restored = checkpoint.clone();
+        restored.sleep.clock = 1;
+        let expected = restored.clone();
+        let mut sink = RecordingRollbackSink::default();
+
+        let error = publish_native_rollback(
+            &mut checkpoint,
+            restored,
+            Err(anyhow::anyhow!("injected metric failure")),
+            &mut sink,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("rollback metric"), "{error}");
+        assert_ne!(checkpoint, original);
+        assert_eq!(checkpoint, expected);
+        assert_eq!(sink.persisted, Some(expected));
+
+        let before_failed_persist = checkpoint.clone();
+        let mut sink = RecordingRollbackSink {
+            fail_persist: true,
+            ..Default::default()
+        };
+        let error = publish_native_rollback(&mut checkpoint, original, Ok(()), &mut sink)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("persisting native sleep rollback"),
+            "{error}"
+        );
+        assert_eq!(checkpoint, before_failed_persist);
+    }
+
+    #[derive(Default)]
     struct RollbackBoundaryDriver(Vec<(u64, usize)>);
 
     impl PeriodicSleepBoundaryDriver for RollbackBoundaryDriver {
@@ -2135,6 +2397,7 @@ mod tests {
     struct CrashUpdate {
         device: Device,
         state: u64,
+        fail_restore: bool,
     }
 
     impl ProspectiveTransformerUpdate for CrashUpdate {
@@ -2147,6 +2410,10 @@ mod tests {
             _: &ConsolidationTxn,
             snapshot: &ProspectiveUpdateSnapshot,
         ) -> Result<()> {
+            ensure!(
+                !self.fail_restore,
+                "injected native update-state restore failure"
+            );
             self.state = u64::from_le_bytes(
                 snapshot
                     .as_bytes()
@@ -2185,6 +2452,7 @@ mod tests {
 
     struct CrashRollouts {
         plan: CrashPlan,
+        fail_knowledge: bool,
     }
 
     impl ConsolidationRollouts for CrashRollouts {
@@ -2195,6 +2463,10 @@ mod tests {
             _: &Transformer,
             count: usize,
         ) -> Result<Vec<TokenRolloutBatch>> {
+            ensure!(
+                !self.fail_knowledge,
+                "injected native knowledge-rollout failure"
+            );
             self.plan.hit(CrashEdge::KnowledgeWork);
             Ok((0..count)
                 .map(|_| TokenRolloutBatch::new(1, 4, vec![1, 2, 3, 4]).unwrap())
@@ -2388,6 +2660,14 @@ mod tests {
     }
 
     impl DreamingBackend for CrashDreamBackend {
+        fn verify_committed_candidate(&mut self, txn: &ConsolidationTxn) -> Result<()> {
+            ensure!(
+                txn.candidate_hash.as_deref() == Some(hash('9').as_str()),
+                "crash backend is bound to another candidate"
+            );
+            Ok(())
+        }
+
         fn shared_checkpoint_hash(&mut self) -> Result<String> {
             Ok(hash('9'))
         }
@@ -2522,6 +2802,8 @@ mod tests {
         candidate: DurableCandidate,
         optimizer: DurableOptimizer,
         plan: CrashPlan,
+        fail_restore: bool,
+        fail_knowledge: bool,
     }
 
     struct CrashOutcome {
@@ -2551,6 +2833,8 @@ mod tests {
                 candidate: DurableCandidate::default(),
                 optimizer: DurableOptimizer::default(),
                 plan,
+                fail_restore: false,
+                fail_knowledge: false,
             }
         }
 
@@ -2571,9 +2855,11 @@ mod tests {
                 CrashUpdate {
                     device: self.seed.device.clone(),
                     state: 0,
+                    fail_restore: self.fail_restore,
                 },
                 CrashRollouts {
                     plan: self.plan.clone(),
+                    fail_knowledge: self.fail_knowledge,
                 },
                 CrashJudge,
                 CrashEvaluator {
@@ -2708,6 +2994,29 @@ mod tests {
     }
 
     #[test]
+    fn failed_native_teacher_restore_never_publishes_rollback_metadata() {
+        let seed = CrashSeed::new();
+        let mut harness = CrashHarness::new(&seed, CrashPlan::default());
+        harness.fail_knowledge = true;
+        harness.fail_restore = true;
+
+        let error = harness.attempt().unwrap_err().to_string();
+        assert!(error.contains("teacher restore also failed"), "{error}");
+        let durable = harness.journal.checkpoint.borrow().clone().unwrap();
+        assert_eq!(durable.sleep.phase, SleepPhase::KnowledgeSeeding);
+        assert!(durable.sleep.pending.is_some());
+        assert!(
+            harness
+                .journal
+                .checkpoint
+                .borrow()
+                .as_ref()
+                .is_some_and(|checkpoint| checkpoint.sleep.phase != SleepPhase::Wake),
+            "a native rollback cursor was published despite failed restoration"
+        );
+    }
+
+    #[test]
     fn retention_bytes_are_reverified_before_resume_or_mutation() {
         let model = model();
         let (directory, checkpoint) = checkpoint(&model);
@@ -2718,6 +3027,89 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("changed"), "{error}");
+    }
+
+    #[test]
+    fn wake_steps_defer_external_artifact_io_until_a_sleep_boundary() {
+        let model = model();
+        let (directory, mut checkpoint) = checkpoint(&model);
+        let config = sleep_config(directory.path(), checkpoint.retention_suite.sha256.clone());
+        fs::write(directory.path().join("retention.json"), b"drifted").unwrap();
+
+        checkpoint.advance_clock(&model, &config, 1).unwrap();
+        let before_boundary = checkpoint.clone();
+        let error = checkpoint
+            .advance_clock(&model, &config, 100)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("changed"), "{error}");
+        assert_eq!(checkpoint, before_boundary);
+    }
+
+    #[test]
+    fn ordinary_wake_ticks_skip_full_parameter_scope_validation() {
+        let model = model();
+        let (directory, mut checkpoint) = checkpoint(&model);
+        let config = sleep_config(directory.path(), checkpoint.retention_suite.sha256.clone());
+
+        reset_full_scope_validation_count();
+        checkpoint.advance_clock(&model, &config, 1).unwrap();
+        assert_eq!(full_scope_validation_count(), 0);
+
+        checkpoint.advance_clock(&model, &config, 100).unwrap();
+        assert!(
+            full_scope_validation_count() > 0,
+            "a due boundary must still revalidate the complete model scope"
+        );
+    }
+
+    #[test]
+    fn optimizer_scope_restore_uses_candidate_topology_after_commit() {
+        let mut model = model();
+        let (directory, mut checkpoint) = checkpoint(&model);
+        let config = sleep_config(directory.path(), checkpoint.retention_suite.sha256.clone());
+        checkpoint.advance_clock(&model, &config, 100).unwrap();
+        let txn = checkpoint
+            .begin_next(PlannedConsolidation {
+                student_checkpoint: "student.safetensors".into(),
+                student_sha256: hash('b'),
+                prospective_update_sha256: hash('c'),
+            })
+            .unwrap();
+
+        assert_eq!(
+            checkpoint.optimizer_scope_checkpoint().unwrap(),
+            NativeCheckpointRef::new(&txn.teacher_checkpoint, &txn.teacher_hash).unwrap()
+        );
+
+        commit_test_transaction(&mut checkpoint, &mut model, &txn, 'd');
+        let pending = checkpoint.sleep.pending.as_ref().unwrap();
+        checkpoint.live_checkpoint = NativeCheckpointRef::new(
+            pending.candidate_checkpoint.as_ref().unwrap(),
+            pending.candidate_hash.as_ref().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            checkpoint.optimizer_scope_checkpoint().unwrap(),
+            checkpoint.live_checkpoint
+        );
+    }
+
+    #[test]
+    fn resume_rejects_optimizer_update_clock_drift_from_sleep_state() {
+        let model = model();
+        let (directory, mut checkpoint) = checkpoint(&model);
+        let config = sleep_config(directory.path(), checkpoint.retention_suite.sha256.clone());
+        checkpoint.advance_clock(&model, &config, 100).unwrap();
+        checkpoint.optimizer_scopes.tiers[0].update_clock = 100;
+
+        let error = checkpoint
+            .validate(&model, &config)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("disagrees with its sleep tier"), "{error}");
     }
 
     #[test]
@@ -2795,6 +3187,7 @@ mod tests {
             .val();
         let mut state = artifact('b');
         state.optimizer_parameter_ids.push(dormant_id);
+        checkpoint.optimizer_scopes.tiers[1].generation = 1;
         checkpoint.optimizer_scopes.tiers[1].artifact = Some(state);
         let error = checkpoint
             .optimizer_scopes

--- a/hermes-train/src/pinned_executable.rs
+++ b/hermes-train/src/pinned_executable.rs
@@ -1,0 +1,540 @@
+//! Race-free execution of content-pinned local programs.
+//!
+//! Callers verify an opened file descriptor and execute a private
+//! materialization of those exact bytes. This prevents a pathname replacement
+//! between hashing an evaluator and `exec` from selecting a different file.
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[cfg(unix)]
+use std::fs::{DirBuilder, OpenOptions};
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+#[cfg(unix)]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result, ensure};
+
+use crate::artifact_io::{
+    hash_open_file_exact_length, sha256_identity_from_hex, validate_sha256_identity,
+};
+
+#[cfg(unix)]
+static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+#[cfg(unix)]
+const MAX_SHEBANG_BYTES: usize = 4 * 1024;
+
+/// An executable selected by the digest of an opened file generation.
+#[cfg(unix)]
+pub(crate) struct PinnedExecutable {
+    staged: StagedExecutable,
+}
+
+#[cfg(unix)]
+impl PinnedExecutable {
+    /// Open and verify `path`, then materialize the verified generation in a
+    /// private staging directory for execution.
+    pub(crate) fn open(
+        path: &Path,
+        expected_sha256: &str,
+        label: &str,
+        namespace: &str,
+    ) -> Result<Self> {
+        let (mut file, snapshot) = open_verified_executable(path, expected_sha256, label)?;
+        let staged =
+            stage_opened_executable(&mut file, &snapshot, expected_sha256, label, namespace)?;
+        Ok(Self { staged })
+    }
+
+    /// Verify the current path generation without preparing it for execution.
+    pub(crate) fn verify(path: &Path, expected_sha256: &str, label: &str) -> Result<()> {
+        let _ = open_verified_executable(path, expected_sha256, label)?;
+        Ok(())
+    }
+
+    pub(crate) fn command(&self) -> Command {
+        Command::new(&self.staged.path)
+    }
+
+    pub(crate) fn into_staged(self) -> StagedExecutable {
+        self.staged
+    }
+
+    #[cfg(test)]
+    pub(crate) fn staged_path(&self) -> &Path {
+        &self.staged.path
+    }
+
+    #[cfg(test)]
+    pub(crate) fn staging_directory(&self) -> &Path {
+        &self.staged.directory
+    }
+}
+
+/// Keeps the private executable pathname alive for a spawned process.
+///
+/// This is particularly important for shebang scripts: their interpreter may
+/// reopen the pathname while the child is starting.
+#[cfg(unix)]
+pub(crate) struct StagedExecutable {
+    directory: PathBuf,
+    path: PathBuf,
+}
+
+#[cfg(unix)]
+impl Drop for StagedExecutable {
+    fn drop(&mut self) {
+        if let Ok(metadata) = std::fs::metadata(&self.directory) {
+            let mut permissions = metadata.permissions();
+            permissions.set_mode(0o700);
+            let _ = std::fs::set_permissions(&self.directory, permissions);
+        }
+        let _ = std::fs::remove_file(&self.path);
+        let _ = std::fs::remove_dir(&self.directory);
+    }
+}
+
+#[cfg(unix)]
+fn open_verified_executable(
+    path: &Path,
+    expected_sha256: &str,
+    label: &str,
+) -> Result<(File, OpenedFileSnapshot)> {
+    validate_sha256_identity(expected_sha256, &format!("{label} identity"))?;
+    let path_metadata = std::fs::symlink_metadata(path)
+        .with_context(|| format!("{label} {} is unavailable", path.display()))?;
+    ensure!(
+        path_metadata.file_type().is_file() && !path_metadata.file_type().is_symlink(),
+        "{label} {} must be a regular non-symlink file",
+        path.display()
+    );
+    ensure!(
+        path_metadata.permissions().mode() & 0o111 != 0,
+        "{label} {} is not executable",
+        path.display()
+    );
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .with_context(|| format!("failed to open {label} {}", path.display()))?;
+    let opened_metadata = file.metadata()?;
+    ensure!(
+        opened_metadata.file_type().is_file(),
+        "{label} {} must be a regular file",
+        path.display()
+    );
+    ensure!(
+        path_metadata.dev() == opened_metadata.dev()
+            && path_metadata.ino() == opened_metadata.ino(),
+        "{label} {} changed identity while it was opened",
+        path.display()
+    );
+    let snapshot = OpenedFileSnapshot::from_metadata(&opened_metadata, label)?;
+    ensure!(
+        hash_opened_file(&mut file, &snapshot, label)? == expected_sha256,
+        "{label} {} does not match its pinned SHA-256",
+        path.display()
+    );
+    validate_shebang_interpreter(&mut file, &snapshot, label)?;
+    Ok((file, snapshot))
+}
+
+/// Validate the execution contract imposed by worker `env_clear()` calls.
+/// Binary executables have no shebang and pass through unchanged. Scripts must
+/// name one absolute interpreter directly; indirection through an `env`
+/// executable is rejected because it requires an ambient PATH to resolve the
+/// actual interpreter.
+#[cfg(unix)]
+fn validate_shebang_interpreter(
+    file: &mut File,
+    snapshot: &OpenedFileSnapshot,
+    label: &str,
+) -> Result<()> {
+    file.seek(SeekFrom::Start(0))?;
+    let prefix_len = usize::try_from(snapshot.len.min(MAX_SHEBANG_BYTES as u64))
+        .context("executable shebang length exceeds usize")?;
+    let mut prefix = vec![0_u8; prefix_len];
+    file.read_exact(&mut prefix)?;
+    file.seek(SeekFrom::Start(0))?;
+    if !prefix.starts_with(b"#!") {
+        return Ok(());
+    }
+    let newline = prefix.iter().position(|byte| *byte == b'\n');
+    ensure!(
+        newline.is_some() || snapshot.len <= MAX_SHEBANG_BYTES as u64,
+        "{label} shebang exceeds {MAX_SHEBANG_BYTES} bytes"
+    );
+    let directive = &prefix[2..newline.unwrap_or(prefix.len())];
+    let directive = directive
+        .strip_suffix(b"\r")
+        .unwrap_or(directive)
+        .split(|byte| *byte == b' ' || *byte == b'\t')
+        .find(|part| !part.is_empty())
+        .context("worker script shebang has no interpreter")?;
+    ensure!(
+        directive.starts_with(b"/") && !directive.contains(&0),
+        "{label} script must name an absolute shebang interpreter"
+    );
+    let basename = directive
+        .rsplit(|byte| *byte == b'/')
+        .next()
+        .unwrap_or_default();
+    ensure!(
+        basename != b"env",
+        "{label} may not use an `env` shebang interpreter; name the absolute interpreter directly"
+    );
+    snapshot.verify(file, label)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn stage_opened_executable(
+    file: &mut File,
+    source_snapshot: &OpenedFileSnapshot,
+    expected_sha256: &str,
+    label: &str,
+    namespace: &str,
+) -> Result<StagedExecutable> {
+    ensure!(
+        !namespace.is_empty()
+            && namespace
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-'),
+        "pinned executable namespace is invalid"
+    );
+    let temporary_root = std::env::temp_dir();
+    let invocation = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let mut directory = None;
+    for _ in 0..128 {
+        let sequence = STAGING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let candidate = temporary_root.join(format!(
+            ".hermes-{namespace}-{}-{invocation}-{sequence}",
+            std::process::id(),
+        ));
+        match DirBuilder::new().mode(0o700).create(&candidate) {
+            Ok(()) => {
+                directory = Some(candidate);
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "creating private {label} directory beneath {}",
+                        temporary_root.display()
+                    )
+                });
+            }
+        }
+    }
+    let directory = directory.context("could not allocate a private executable path")?;
+    let staged = StagedExecutable {
+        path: directory.join("executable"),
+        directory,
+    };
+    let mut output = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o500)
+        .open(&staged.path)
+        .with_context(|| format!("creating private {label} executable"))?;
+    copy_opened_file_exact(file, source_snapshot, &mut output, label)?;
+    output
+        .sync_all()
+        .with_context(|| format!("syncing pinned {label}"))?;
+    drop(output);
+    let mut staged_file = File::open(&staged.path)?;
+    let staged_snapshot = OpenedFileSnapshot::capture(&staged_file, label)?;
+    ensure!(
+        staged_snapshot.len == source_snapshot.len,
+        "materialized {label} has the wrong length"
+    );
+    ensure!(
+        hash_opened_file(&mut staged_file, &staged_snapshot, label)? == expected_sha256,
+        "{label} changed while it was materialized"
+    );
+
+    // Remove directory write permission once the staged file is complete. It
+    // is restored by `Drop` solely to remove the private materialization.
+    let mut permissions = std::fs::metadata(&staged.directory)?.permissions();
+    permissions.set_mode(0o500);
+    std::fs::set_permissions(&staged.directory, permissions)
+        .with_context(|| format!("sealing private {label} directory"))?;
+    Ok(staged)
+}
+
+#[derive(Clone, Copy)]
+struct OpenedFileSnapshot {
+    len: u64,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    modified_seconds: i64,
+    #[cfg(unix)]
+    modified_nanoseconds: i64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+}
+
+impl OpenedFileSnapshot {
+    fn capture(file: &File, label: &str) -> Result<Self> {
+        Self::from_metadata(&file.metadata()?, label)
+    }
+
+    fn from_metadata(metadata: &std::fs::Metadata, label: &str) -> Result<Self> {
+        ensure!(
+            metadata.file_type().is_file(),
+            "{label} is not a regular file"
+        );
+        Ok(Self {
+            len: metadata.len(),
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            modified_seconds: metadata.mtime(),
+            #[cfg(unix)]
+            modified_nanoseconds: metadata.mtime_nsec(),
+            #[cfg(unix)]
+            changed_seconds: metadata.ctime(),
+            #[cfg(unix)]
+            changed_nanoseconds: metadata.ctime_nsec(),
+        })
+    }
+
+    fn verify(&self, file: &File, label: &str) -> Result<()> {
+        let current = Self::capture(file, label)?;
+        ensure!(
+            current.len == self.len,
+            "{label} changed length while it was open"
+        );
+        #[cfg(unix)]
+        ensure!(
+            current.device == self.device
+                && current.inode == self.inode
+                && current.modified_seconds == self.modified_seconds
+                && current.modified_nanoseconds == self.modified_nanoseconds
+                && current.changed_seconds == self.changed_seconds
+                && current.changed_nanoseconds == self.changed_nanoseconds,
+            "{label} changed metadata while it was open"
+        );
+        Ok(())
+    }
+}
+
+fn hash_opened_file(file: &mut File, snapshot: &OpenedFileSnapshot, label: &str) -> Result<String> {
+    let digest = hash_open_file_exact_length(file, snapshot.len, label)?;
+    snapshot.verify(file, label)?;
+    file.seek(SeekFrom::Start(0))?;
+    sha256_identity_from_hex(&digest, &format!("{label} digest"))
+}
+
+fn copy_opened_file_exact(
+    file: &mut File,
+    snapshot: &OpenedFileSnapshot,
+    output: &mut File,
+    label: &str,
+) -> Result<()> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut buffer = [0_u8; 1024 * 1024];
+    let mut remaining = snapshot.len;
+    while remaining > 0 {
+        let limit = usize::try_from(remaining.min(buffer.len() as u64))
+            .context("opened executable copy size exceeds usize")?;
+        let read = file.read(&mut buffer[..limit])?;
+        ensure!(read != 0, "{label} was truncated while it was materialized");
+        output
+            .write_all(&buffer[..read])
+            .with_context(|| format!("materializing pinned {label}"))?;
+        remaining -= read as u64;
+    }
+    let mut trailing = [0_u8; 1];
+    ensure!(
+        file.read(&mut trailing)? == 0,
+        "{label} grew while it was materialized"
+    );
+    snapshot.verify(file, label)?;
+    file.seek(SeekFrom::Start(0))?;
+    Ok(())
+}
+
+pub(crate) fn file_sha256(path: &Path) -> Result<String> {
+    let mut file =
+        File::open(path).with_context(|| format!("failed to hash {}", path.display()))?;
+    let label = format!("file {}", path.display());
+    let snapshot = OpenedFileSnapshot::capture(&file, &label)?;
+    hash_opened_file(&mut file, &snapshot, &label)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    use std::process::Stdio;
+
+    #[cfg(unix)]
+    use super::*;
+
+    #[cfg(unix)]
+    fn executable(root: &Path, name: &str, source: &str) -> PathBuf {
+        let path = root.join(name);
+        std::fs::write(&path, source).unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_generation_survives_adversarial_path_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker = executable(
+            directory.path(),
+            "worker.sh",
+            "#!/bin/sh\nprintf 'pinned\\n'\n",
+        );
+        let hash = file_sha256(&worker).unwrap();
+        let pinned =
+            PinnedExecutable::open(&worker, &hash, "test evaluator", "test-evaluator").unwrap();
+
+        let replacement = executable(
+            directory.path(),
+            "replacement.sh",
+            "#!/bin/sh\nprintf 'replaced\\n'\n",
+        );
+        std::fs::rename(&replacement, &worker).unwrap();
+
+        let mut command = pinned.command();
+        command.stdout(Stdio::piped());
+        let output = command.output().unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"pinned\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shebang_interpreter_runs_and_private_materialization_is_cleaned_up() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker = executable(
+            directory.path(),
+            "worker.sh",
+            "#!/bin/sh\nprintf 'interpreter-ok\\n'\n",
+        );
+        let hash = file_sha256(&worker).unwrap();
+        let pinned =
+            PinnedExecutable::open(&worker, &hash, "test evaluator", "test-evaluator").unwrap();
+        let staged_path = pinned.staged_path().to_owned();
+        let staging_directory = pinned.staging_directory().to_owned();
+
+        let output = pinned.command().output().unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"interpreter-ok\n");
+        assert!(staged_path.is_file());
+        drop(pinned);
+        assert!(!staged_path.exists());
+        assert!(!staging_directory.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shebang_requires_a_direct_absolute_interpreter_without_env() {
+        let directory = tempfile::tempdir().unwrap();
+        for (name, source, expected) in [
+            (
+                "env.sh",
+                "#!/usr/bin/env sh\nexit 0\n",
+                "may not use an `env` shebang interpreter",
+            ),
+            (
+                "relative.sh",
+                "#!bin/sh\nexit 0\n",
+                "must name an absolute shebang interpreter",
+            ),
+        ] {
+            let worker = executable(directory.path(), name, source);
+            let hash = file_sha256(&worker).unwrap();
+            let error = PinnedExecutable::verify(&worker, &hash, "test worker")
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains(expected), "{error}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stable_hash_rejects_growth_and_truncation_after_open() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("mutable");
+
+        std::fs::write(&path, b"original").unwrap();
+        let mut grown = File::open(&path).unwrap();
+        let grown_snapshot = OpenedFileSnapshot::capture(&grown, "growth test").unwrap();
+        OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(b"-growth")
+            .unwrap();
+        let error = hash_opened_file(&mut grown, &grown_snapshot, "growth test")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("grew"), "{error}");
+
+        std::fs::write(&path, b"original").unwrap();
+        let mut truncated = File::open(&path).unwrap();
+        let truncated_snapshot =
+            OpenedFileSnapshot::capture(&truncated, "truncation test").unwrap();
+        OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_len(1)
+            .unwrap();
+        let error = hash_opened_file(&mut truncated, &truncated_snapshot, "truncation test")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("truncated"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialization_rejects_growth_beyond_the_opened_length() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker = executable(directory.path(), "worker.sh", "#!/bin/sh\nexit 0\n");
+        let expected_sha256 = file_sha256(&worker).unwrap();
+        let mut source = File::open(&worker).unwrap();
+        let source_snapshot = OpenedFileSnapshot::capture(&source, "growth test").unwrap();
+        OpenOptions::new()
+            .append(true)
+            .open(&worker)
+            .unwrap()
+            .write_all(b"# mutated\n")
+            .unwrap();
+
+        let error = stage_opened_executable(
+            &mut source,
+            &source_snapshot,
+            &expected_sha256,
+            "growth test",
+            "growth-test",
+        )
+        .err()
+        .unwrap()
+        .to_string();
+        assert!(error.contains("grew"), "{error}");
+    }
+}

--- a/hermes-train/src/posttrain.rs
+++ b/hermes-train/src/posttrain.rs
@@ -1,16 +1,18 @@
 //! Backend-neutral post-training objectives and executor interfaces.
 //!
 //! This module owns the mathematics and validation for preference,
-//! distillation, and verifiable-RL phases. Model execution remains injected:
-//! a backend supplies differentiable policy scores/logits and generated
-//! rollouts, while these cores return losses, metrics, and derivatives with
-//! respect to those supplied scores. No task is converted to another task
-//! shape implicitly.
+//! distillation, and verifiable-RL phases. The public scalar/tensor objectives
+//! are correctness oracles; native execution uses mandatory device-owned batch
+//! runtimes so logits, scores, and gradients never become trainer-side host
+//! vectors. No task is converted to another task shape implicitly.
 
 use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::{BufRead, BufReader, Read};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
 use anyhow::{Context, Result, bail, ensure};
 use burn::prelude::Tensor;
@@ -18,6 +20,7 @@ use burn::tensor::activation::{log_sigmoid, log_softmax as tensor_log_softmax};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+use crate::artifact_io::{sha256_identity, sha256_identity_from_hex, validate_sha256_identity};
 use crate::metrics::{
     MetricContext, MetricEvent, MetricPhase, MetricPhaseKind, PostTrainingAlgorithm,
     PostTrainingUpdateMetrics,
@@ -28,8 +31,28 @@ use crate::runtime::{
     PhaseExecutor, PhaseProduct, PhaseProgressSink,
 };
 use crate::sleep::{SleepPhase, UpdateClock};
-use crate::task::{RewardSpec, TaskAdapter, TaskConfig, TaskDataFormat, TaskExample, VerifierSpec};
+use crate::task::{
+    RewardSpec, TaskAdapter, TaskConfig, TaskDataFormat, TaskExample, TaskExecution, VerifierSpec,
+};
 use crate::workflow::{InModelSleepConfig, PhaseKind, PhaseV2};
+
+/// A malformed input without a record delimiter must not make post-training
+/// buffer an entire multi-gigabyte dataset. The limit is deliberately much
+/// larger than any supported training context while keeping memory bounded.
+const MAX_POST_TRAINING_RECORD_BYTES: usize = 64 * 1024 * 1024;
+/// One native update must remain small enough to collect and authenticate
+/// without an allocator abort. Larger effective batches should be split into
+/// additional optimizer steps rather than represented by an enormous host
+/// vector.
+pub const MAX_POST_TRAINING_UPDATE_EXAMPLES: usize = 65_536;
+/// Hard limit for the serialized input records retained by one update. This is
+/// independent of the per-record framing bound above.
+pub const MAX_POST_TRAINING_UPDATE_INPUT_BYTES: usize = 256 * 1024 * 1024;
+/// Upper bound for host-visible GRPO token metadata across one device batch.
+/// Numeric token state remains device-owned.
+pub const MAX_POST_TRAINING_ROLLOUT_TOKENS: usize = 8_388_608;
+pub const MAX_POST_TRAINING_SEQUENCE_TOKENS: usize = 1_048_576;
+pub const MAX_POST_TRAINING_ROLLOUTS_PER_PROMPT: usize = 4_096;
 
 fn default_dpo_beta() -> f64 {
     0.1
@@ -79,7 +102,8 @@ pub struct FrozenModelSpec {
     pub adapter: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact: Option<PathBuf>,
-    /// SHA-256 of the exact artifact bytes. Required for every local artifact.
+    /// Canonical `sha256:<64 lowercase hex>` identity of the exact artifact
+    /// bytes. Required for every local artifact.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sha256: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -90,28 +114,22 @@ pub struct FrozenModelSpec {
 
 impl FrozenModelSpec {
     fn validate(&self, field: &str) -> Result<()> {
-        ensure!(
-            !self.adapter.trim().is_empty(),
-            "`{field}.adapter` must not be empty"
-        );
+        validate_frozen_identifier(&self.adapter, &format!("`{field}.adapter`"))?;
         ensure!(
             self.artifact
                 .as_ref()
                 .is_none_or(|path| !path.as_os_str().is_empty()),
             "`{field}.artifact` must not be empty when set"
         );
-        ensure!(
-            self.revision
-                .as_deref()
-                .is_none_or(|revision| !revision.trim().is_empty()),
-            "`{field}.revision` must not be empty when set"
-        );
+        if let Some(revision) = self.revision.as_deref() {
+            validate_frozen_identifier(revision, &format!("`{field}.revision`"))?;
+        }
         ensure!(
             self.artifact.is_none() || self.sha256.is_some(),
             "`{field}.artifact` requires an exact `sha256`"
         );
         if let Some(sha256) = &self.sha256 {
-            validate_sha256(sha256).with_context(|| format!("invalid `{field}.sha256`"))?;
+            validate_sha256_identity(sha256, &format!("`{field}.sha256`"))?;
         }
         ensure!(
             self.sha256.is_some() || self.revision.is_some(),
@@ -120,18 +138,22 @@ impl FrozenModelSpec {
         Ok(())
     }
 
-    /// Stable identity required from an injected provider.
+    /// Stable identity required from the frozen side of a device runtime.
     pub fn immutable_identity(&self) -> Result<String> {
         self.validate("frozen_model")?;
-        Ok(match &self.sha256 {
-            Some(sha256) => format!("sha256:{}", normalize_sha256(sha256)),
-            None => format!(
-                "revision:{}",
-                self.revision
-                    .as_deref()
-                    .context("validated frozen model has no immutable identity")?
-            ),
-        })
+        if let Some(sha256) = &self.sha256 {
+            return Ok(sha256.clone());
+        }
+        let revision = self
+            .revision
+            .as_deref()
+            .context("validated frozen model has no immutable identity")?;
+        canonical_sha256(&(
+            "hermes-frozen-revision-identity-v1",
+            &self.adapter,
+            revision,
+            &self.parameters,
+        ))
     }
 
     /// Verify local artifact bytes before an executor is allowed to load them.
@@ -140,33 +162,19 @@ impl FrozenModelSpec {
         let Some(path) = &self.artifact else {
             return Ok(());
         };
-        let metadata = std::fs::symlink_metadata(path).with_context(|| {
-            format!("failed to inspect frozen model artifact {}", path.display())
-        })?;
-        ensure!(
-            metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-            "frozen model artifact {} must be a non-symlink regular file",
-            path.display()
-        );
-        let expected = normalize_sha256(
-            self.sha256
-                .as_deref()
-                .expect("validated local artifact has sha256"),
-        );
-        let mut file = File::open(path)
-            .with_context(|| format!("failed to open frozen model artifact {}", path.display()))?;
-        let mut hasher = Sha256::new();
-        let mut buffer = [0_u8; 1024 * 1024];
-        loop {
-            let read = file.read(&mut buffer).with_context(|| {
-                format!("failed to hash frozen model artifact {}", path.display())
-            })?;
-            if read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..read]);
-        }
-        let actual = format!("{:x}", hasher.finalize());
+        let expected = self
+            .sha256
+            .as_deref()
+            .expect("validated local artifact has sha256")
+            .strip_prefix("sha256:")
+            .expect("validated local artifact digest is canonical");
+        let authenticated =
+            AuthenticatedPostTrainingInput::open_labeled(path, "frozen model artifact")?;
+        let actual = authenticated
+            .identity
+            .sha256
+            .strip_prefix("sha256:")
+            .expect("authenticated digest has a sha256 prefix");
         ensure!(
             actual == expected,
             "frozen model artifact {} sha256 mismatch: expected {expected}, got {actual}",
@@ -182,6 +190,14 @@ impl FrozenModelSpec {
             *artifact = base.join(&*artifact);
         }
     }
+}
+
+fn validate_frozen_identifier(value: &str, field: &str) -> Result<()> {
+    ensure!(
+        !value.is_empty() && value.trim() == value && !value.chars().any(char::is_control),
+        "{field} must be non-empty, trimmed, and contain no control characters"
+    );
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -270,7 +286,10 @@ impl PostTrainingConfig {
                 reference,
                 sampling,
             } => {
-                ensure!(*group_size >= 2, "GRPO group_size must be at least two");
+                ensure!(
+                    (2..=MAX_POST_TRAINING_ROLLOUTS_PER_PROMPT).contains(group_size),
+                    "GRPO group_size must be in 2..={MAX_POST_TRAINING_ROLLOUTS_PER_PROMPT}"
+                );
                 ensure!(
                     clip_epsilon.is_finite() && *clip_epsilon > 0.0 && *clip_epsilon < 1.0,
                     "GRPO clip_epsilon must be finite and in (0, 1)"
@@ -311,6 +330,20 @@ impl PostTrainingConfig {
             } => {}
         }
     }
+
+    fn verify_local_artifacts(&self) -> Result<()> {
+        match self {
+            Self::Dpo { reference, .. } => reference.verify_local_artifact(),
+            Self::ForwardKl { teacher, .. } => teacher.verify_local_artifact(),
+            Self::Grpo {
+                reference: Some(reference),
+                ..
+            } => reference.verify_local_artifact(),
+            Self::Grpo {
+                reference: None, ..
+            } => Ok(()),
+        }
+    }
 }
 
 /// Sampling geometry is part of the persisted RL recipe rather than an
@@ -337,7 +370,10 @@ impl Default for RolloutSampling {
 
 impl RolloutSampling {
     pub fn validate(&self) -> Result<()> {
-        ensure!(self.max_new_tokens > 0, "max_new_tokens must be positive");
+        ensure!(
+            (1..=MAX_POST_TRAINING_SEQUENCE_TOKENS).contains(&self.max_new_tokens),
+            "max_new_tokens must be in 1..={MAX_POST_TRAINING_SEQUENCE_TOKENS}"
+        );
         ensure!(
             self.temperature.is_finite() && self.temperature > 0.0,
             "rollout temperature must be finite and positive"
@@ -350,7 +386,8 @@ impl RolloutSampling {
     }
 }
 
-/// Differentiable sequence scores supplied by policy/reference executors.
+/// Scalar correctness-oracle input. Native execution keeps these scores inside
+/// [`DpoDeviceBatchRuntime`] and never constructs this value in trainer core.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PairwiseLogProbabilities {
     pub policy_chosen: f64,
@@ -359,8 +396,8 @@ pub struct PairwiseLogProbabilities {
     pub reference_rejected: f64,
 }
 
-/// DPO scalar result. Derivatives target the aggregate policy sequence log
-/// probabilities and can be seeded into any autodiff backend.
+/// DPO scalar-oracle result. Derivatives target the aggregate policy sequence
+/// log probabilities; this is not a native runtime transport type.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct DpoLoss {
     pub loss: f64,
@@ -404,7 +441,7 @@ pub fn dpo_loss(
     let loss = (1.0 - label_smoothing) * softplus(-implicit_reward_margin)
         + label_smoothing * softplus(implicit_reward_margin);
     let d_z = sigmoid(implicit_reward_margin) - (1.0 - label_smoothing);
-    Ok(DpoLoss {
+    let result = DpoLoss {
         loss,
         policy_margin,
         reference_margin,
@@ -412,7 +449,19 @@ pub fn dpo_loss(
         preference_correct: policy_margin > reference_margin,
         d_policy_chosen: beta * d_z,
         d_policy_rejected: -beta * d_z,
-    })
+    };
+    ensure_finite(
+        &[
+            result.loss,
+            result.policy_margin,
+            result.reference_margin,
+            result.implicit_reward_margin,
+            result.d_policy_chosen,
+            result.d_policy_rejected,
+        ],
+        "derived DPO objective values",
+    )?;
+    Ok(result)
 }
 
 /// Autodiff-preserving batched DPO loss over aggregate sequence log-probs.
@@ -468,6 +517,8 @@ pub fn reduce_sequence_log_probs(values: &[f64], reduction: SequenceReduction) -
     })
 }
 
+/// Host scalar-oracle row. Native forward-KL execution keeps full vocabulary
+/// distributions inside [`ForwardKlDeviceBatchRuntime`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct DistillationToken<'a> {
     pub teacher_logits: &'a [f64],
@@ -476,6 +527,8 @@ pub struct DistillationToken<'a> {
     pub weight: f64,
 }
 
+/// Scalar-oracle output. Its gradient vectors intentionally remain available
+/// for golden tests, but are never returned by the native device-batch API.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DistillationLoss {
     /// Temperature-scaled training objective.
@@ -536,6 +589,10 @@ pub fn forward_kl_distillation(
     } else {
         1.0 / temperature
     };
+    ensure!(
+        loss_scale.is_finite() && gradient_scale.is_finite(),
+        "distillation temperature scaling overflowed"
+    );
     let mut weighted_kl = 0.0;
     let mut weighted_entropy = 0.0;
     let mut weighted_agreement = 0.0;
@@ -544,6 +601,8 @@ pub fn forward_kl_distillation(
     for token in tokens {
         let teacher_log_probs = log_softmax(token.teacher_logits, temperature);
         let student_log_probs = log_softmax(token.student_logits, temperature);
+        ensure_finite(&teacher_log_probs, "teacher log probabilities")?;
+        ensure_finite(&student_log_probs, "student log probabilities")?;
         let teacher_probs: Vec<f64> = teacher_log_probs.iter().map(|value| value.exp()).collect();
         let student_probs: Vec<f64> = student_log_probs.iter().map(|value| value.exp()).collect();
         let kl: f64 = teacher_probs
@@ -562,23 +621,33 @@ pub fn forward_kl_distillation(
         weighted_agreement +=
             token.weight * f64::from(argmax(token.teacher_logits) == argmax(token.student_logits));
         let row_scale = token.weight / total_weight * gradient_scale;
-        student_gradients.push(
-            student_probs
-                .iter()
-                .zip(&teacher_probs)
-                .map(|(student, teacher)| row_scale * (student - teacher))
-                .collect(),
-        );
+        let gradients = student_probs
+            .iter()
+            .zip(&teacher_probs)
+            .map(|(student, teacher)| row_scale * (student - teacher))
+            .collect::<Vec<_>>();
+        ensure_finite(&gradients, "distillation student gradients")?;
+        student_gradients.push(gradients);
     }
 
     let mean_forward_kl = weighted_kl / total_weight;
-    Ok(DistillationLoss {
+    let result = DistillationLoss {
         loss: loss_scale * mean_forward_kl,
         mean_forward_kl,
         teacher_entropy: weighted_entropy / total_weight,
         top1_agreement: weighted_agreement / total_weight,
         student_gradients,
-    })
+    };
+    ensure_finite(
+        &[
+            result.loss,
+            result.mean_forward_kl,
+            result.teacher_entropy,
+            result.top1_agreement,
+        ],
+        "derived distillation objective values",
+    )?;
+    Ok(result)
 }
 
 /// Autodiff-preserving forward-KL tensor core for already selected target-token
@@ -621,7 +690,8 @@ pub fn forward_kl_distillation_tensor(
     })
 }
 
-/// One on-policy/near-policy rollout in a GRPO prompt group.
+/// Scalar correctness-oracle rollout. Native GRPO scores and token ids stay
+/// opaque inside [`GrpoDeviceBatchRuntime`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct GrpoRollout<'a> {
     pub reward: f64,
@@ -630,6 +700,7 @@ pub struct GrpoRollout<'a> {
     pub reference_token_log_probs: Option<&'a [f64]>,
 }
 
+/// Scalar-oracle output; native execution returns only reduced batch metrics.
 #[derive(Clone, Debug, PartialEq)]
 pub struct GrpoLoss {
     pub loss: f64,
@@ -957,151 +1028,292 @@ pub fn grpo_loss_tensor(
     Ok(loss)
 }
 
-/// Request sent to an executor-owned rollout generator.
-#[derive(Clone, Debug, PartialEq)]
-pub struct RolloutRequest<'a> {
-    pub prompt: &'a str,
-    pub count: usize,
+/// One deterministic model-execution substream. A device runtime must use the
+/// same substream for a stochastic forward and its matching backward replay.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct ModelExecutionRng {
+    pub seed: u64,
+    pub counter: u64,
+}
+
+/// Exact half-open model RNG range reserved by the durable trainer cursor.
+/// Batch runtimes derive example-major substreams from this range without
+/// asking trainer core to make one model call per example.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct ModelExecutionRngRange {
+    seed: u64,
+    start: u64,
+    end: u64,
+}
+
+impl ModelExecutionRngRange {
+    fn reserve(seed: u64, start: u64, count: u64) -> Result<Self> {
+        ensure!(count > 0, "model RNG range must not be empty");
+        Ok(Self {
+            seed,
+            start,
+            end: start
+                .checked_add(count)
+                .context("post-training model RNG counter overflows u64")?,
+        })
+    }
+
+    pub fn len(self) -> u64 {
+        self.end - self.start
+    }
+
+    pub fn is_empty(self) -> bool {
+        self.start == self.end
+    }
+
+    pub fn seed(self) -> u64 {
+        self.seed
+    }
+
+    pub fn start(self) -> u64 {
+        self.start
+    }
+
+    pub fn end(self) -> u64 {
+        self.end
+    }
+
+    pub fn substream(self, offset: u64) -> Result<ModelExecutionRng> {
+        ensure!(
+            offset < self.len(),
+            "model RNG substream offset is out of range"
+        );
+        Ok(ModelExecutionRng {
+            seed: self.seed,
+            counter: self
+                .start
+                .checked_add(offset)
+                .context("post-training model RNG counter overflows u64")?,
+        })
+    }
+}
+
+/// Compact backend-owned evidence for a prepared device update. Implementors
+/// hash their exact batched execution without materializing logits or
+/// gradients in trainer memory. The digest must bind the input batch, base
+/// model/optimizer generation, RNG range, objective configuration, reduced
+/// metrics, and staged backward result; replay after restore must reproduce it.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DeviceExecutionReceipt {
+    pub execution_sha256: String,
+    pub model_tokens: u64,
+}
+
+impl DeviceExecutionReceipt {
+    fn validate(&self) -> Result<()> {
+        validate_sha256_identity(&self.execution_sha256, "device execution receipt")?;
+        ensure!(
+            self.model_tokens > 0,
+            "device execution reported zero model tokens"
+        );
+        Ok(())
+    }
+}
+
+/// Immutable model/optimizer generation restored before a device batch is
+/// prepared. Passing it explicitly keeps runtime receipts self-contained and
+/// prevents a backend from accidentally authenticating only the examples and
+/// objective configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct DeviceBatchBaseGeneration<'a> {
+    pub model_sha256: &'a str,
+    pub optimizer_sha256: Option<&'a str>,
+}
+
+impl DeviceBatchBaseGeneration<'_> {
+    fn validate(self) -> Result<()> {
+        validate_sha256_identity(self.model_sha256, "device-batch base model")?;
+        if let Some(optimizer_sha256) = self.optimizer_sha256 {
+            validate_sha256_identity(optimizer_sha256, "device-batch base optimizer")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct DpoDeviceBatchRequest<'a> {
+    pub examples: &'a [TaskExample],
+    pub batch_sha256: &'a str,
+    pub base: DeviceBatchBaseGeneration<'a>,
+    pub max_sequence_tokens: usize,
+    pub beta: f64,
+    pub label_smoothing: f64,
+    pub sequence_reduction: SequenceReduction,
+    /// Multiply the mean batch gradient by this value. Returned metrics remain
+    /// the unweighted per-example objective sums.
+    pub loss_weight: f64,
+    /// Exactly two example-major substreams per pair: chosen, then rejected.
+    /// Each stochastic forward and its internal backward use the same value.
+    pub rng: ModelExecutionRngRange,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct DpoDeviceBatchResult {
+    pub receipt: DeviceExecutionReceipt,
+    pub examples: u64,
+    pub loss_sum: f64,
+    pub preference_correct: u64,
+    pub implicit_reward_margin_sum: f64,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ForwardKlDeviceBatchRequest<'a> {
+    pub examples: &'a [TaskExample],
+    pub batch_sha256: &'a str,
+    pub base: DeviceBatchBaseGeneration<'a>,
+    pub max_sequence_tokens: usize,
+    pub temperature: f64,
+    pub scale_by_temperature_squared: bool,
+    pub loss_weight: f64,
+    /// Exactly one example-major student substream. Teacher execution is
+    /// frozen; the student forward and internal backward reuse this value.
+    pub rng: ModelExecutionRngRange,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct ForwardKlDeviceBatchResult {
+    pub receipt: DeviceExecutionReceipt,
+    pub examples: u64,
+    pub loss_sum: f64,
+    pub forward_kl_sum: f64,
+    pub teacher_entropy_sum: f64,
+    pub top1_agreement_sum: f64,
+}
+
+/// Host-visible portion of a rollout. Token ids and all behavior/current/
+/// reference scores remain owned by [`GrpoDeviceBatchRuntime`].
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GeneratedRolloutText {
+    pub text: String,
+    pub token_count: usize,
+}
+
+/// Opaque device generation plus the text needed by the configured verifier.
+/// `generation_sha256` must bind the complete generation request together with
+/// runtime-owned token ids and behavior-score state.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct GrpoGeneratedBatch {
+    pub generation_sha256: String,
+    pub groups: Vec<Vec<GeneratedRolloutText>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct GrpoGenerationBatchRequest<'a> {
+    pub examples: &'a [TaskExample],
+    pub batch_sha256: &'a str,
+    pub base: DeviceBatchBaseGeneration<'a>,
+    pub group_size: usize,
     pub max_sequence_tokens: usize,
     pub sampling: &'a RolloutSampling,
-    /// Stable seed owned by the durable phase cursor.
-    pub rng_seed: u64,
-    /// First counter reserved for this request. Implementations must derive
-    /// all sampling randomness from `(rng_seed, rng_counter)` and consume one
-    /// deterministic substream per requested rollout.
-    pub rng_counter: u64,
+    /// One example-major substream per rollout in each prompt group.
+    pub rng: ModelExecutionRngRange,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct GeneratedRollout {
-    pub text: String,
-    pub token_ids: Vec<u32>,
-    /// Log probabilities under the behavior policy that generated the sample.
-    pub behavior_token_log_probs: Vec<f64>,
+#[derive(Clone, Debug)]
+pub struct GrpoDeviceBatchRequest<'a> {
+    pub examples: &'a [TaskExample],
+    pub batch_sha256: &'a str,
+    pub base: DeviceBatchBaseGeneration<'a>,
+    pub generation: &'a GrpoGeneratedBatch,
+    pub rewards: &'a [Vec<f64>],
+    pub clip_epsilon: f64,
+    pub advantage_epsilon: f64,
+    pub kl_coefficient: f64,
+    pub loss_weight: f64,
+    /// One example-major rescoring substream per generated rollout; internal
+    /// policy forward/backward must reuse the same substream.
+    pub rng: ModelExecutionRngRange,
 }
 
-/// A model runtime capable of generating a pinned group of policy rollouts.
-pub trait RolloutGenerator {
-    fn identity(&self) -> &str;
-    fn generate(&mut self, request: RolloutRequest<'_>) -> Result<Vec<GeneratedRollout>>;
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct GrpoDeviceBatchResult {
+    pub receipt: DeviceExecutionReceipt,
+    pub examples: u64,
+    pub rollouts: u64,
+    pub loss_sum: f64,
+    pub mean_reward_sum: f64,
+    pub reward_stddev_sum: f64,
+    pub mean_kl_sum: f64,
+    pub clipped_fraction_sum: f64,
 }
 
-/// Frozen policy scoring used by DPO and distillation executors. Implementors
-/// must preserve token alignment and return one log-probability per supplied
-/// continuation token.
-pub trait SequenceLogProbabilityProvider {
-    /// Must equal [`FrozenModelSpec::immutable_identity`] for frozen providers.
-    fn identity(&self) -> &str;
-    fn tokenizer_identity(&self) -> &str;
-    fn continuation_log_probs(
-        &mut self,
-        prompt: &str,
-        continuation: &str,
-        max_sequence_tokens: usize,
-    ) -> Result<Vec<f64>>;
-}
-
-/// Frozen teacher distribution used by a distillation executor. Rows must be
-/// aligned with the student target-token rows for the exact task example.
-pub trait TeacherDistributionProvider {
-    fn identity(&self) -> &str;
-    fn tokenizer_identity(&self) -> &str;
-    fn token_logits(
-        &mut self,
-        example: &TaskExample,
-        max_sequence_tokens: usize,
-    ) -> Result<Vec<Vec<f64>>>;
-}
-
-/// Trainable DPO policy. Backward receives gradients for exactly the token
-/// log-probabilities returned by `continuation_log_probs`.
-pub trait PreferencePolicy: SequenceLogProbabilityProvider {
-    /// Exact cumulative number of trainable-policy model tokens processed by
-    /// this adapter. The counter must be monotonic for the lifetime of the
-    /// borrowed adapter and include every policy forward/generation executed
-    /// by the methods below. The resumable executor samples it around one
-    /// deterministic update; it never estimates tokens from sequence length.
+/// Device-owned DPO execution. A single call must batch all examples, run the
+/// trainable and frozen policies, apply backward internally, and return only a
+/// compact result. There is deliberately no per-example or host-logit fallback.
+/// `prepare_device_batch` stages gradients but must not apply the optimizer;
+/// publication invokes `optimizer_step` exactly once through an idempotent
+/// publisher after the prepared transaction is durable.
+pub trait DpoDeviceBatchRuntime {
+    fn trainable_identity(&self) -> &str;
+    fn trainable_tokenizer_identity(&self) -> &str;
+    fn frozen_identity(&self) -> &str;
+    fn frozen_tokenizer_identity(&self) -> &str;
+    /// Monotonic host-maintained counter. Reading it must not synchronize a
+    /// device or copy a tensor to the host.
     fn model_tokens_processed(&self) -> u64;
-
-    fn backward_pairwise_log_probs(
+    fn prepare_device_batch(
         &mut self,
-        example: &TaskExample,
-        chosen_gradients: &[f64],
-        rejected_gradients: &[f64],
-    ) -> Result<()>;
+        request: DpoDeviceBatchRequest<'_>,
+    ) -> Result<DpoDeviceBatchResult>;
     fn optimizer_step(&mut self, learning_rate_scale: f64) -> Result<()>;
 }
 
-/// Trainable student distribution. Backward rows are aligned one-for-one with
-/// the rows returned by `student_token_logits`.
-pub trait DistillationPolicy {
-    fn identity(&self) -> &str;
-    fn tokenizer_identity(&self) -> &str;
-    /// Exact cumulative trainable-student model-token counter. See
-    /// [`PreferencePolicy::model_tokens_processed`].
+/// Device-owned forward-KL execution. Teacher and student distributions and
+/// student gradients never cross this boundary as host vectors. Preparation
+/// stages the complete batch backward but does not apply the optimizer.
+pub trait ForwardKlDeviceBatchRuntime {
+    fn trainable_identity(&self) -> &str;
+    fn trainable_tokenizer_identity(&self) -> &str;
+    fn frozen_identity(&self) -> &str;
+    fn frozen_tokenizer_identity(&self) -> &str;
+    /// Monotonic host-maintained counter. Reading it must not synchronize a
+    /// device or copy a tensor to the host.
     fn model_tokens_processed(&self) -> u64;
-    fn student_token_logits(
+    fn prepare_device_batch(
         &mut self,
-        example: &TaskExample,
-        max_sequence_tokens: usize,
-    ) -> Result<Vec<Vec<f64>>>;
-    fn backward_student_logits(
-        &mut self,
-        example: &TaskExample,
-        gradients: &[Vec<f64>],
-    ) -> Result<()>;
+        request: ForwardKlDeviceBatchRequest<'_>,
+    ) -> Result<ForwardKlDeviceBatchResult>;
     fn optimizer_step(&mut self, learning_rate_scale: f64) -> Result<()>;
 }
 
-/// Trainable GRPO policy. Rescoring and backward preserve the generated
-/// rollout's token alignment exactly.
-pub trait GrpoPolicy: RolloutGenerator {
-    fn tokenizer_identity(&self) -> &str;
-    /// Exact cumulative trainable-policy model-token counter, including both
-    /// generation and policy rescoring. See
-    /// [`PreferencePolicy::model_tokens_processed`].
+/// Device-owned GRPO numeric execution. Generation exposes only verifier text
+/// and token counts; behavior/current/reference scores and backward remain in
+/// the runtime. `prepare_device_batch` consumes the whole verified batch once.
+/// It stages gradients but leaves optimizer application to the publisher.
+pub trait GrpoDeviceBatchRuntime {
+    fn trainable_identity(&self) -> &str;
+    fn trainable_tokenizer_identity(&self) -> &str;
+    fn frozen_identity(&self) -> Option<&str>;
+    fn frozen_tokenizer_identity(&self) -> Option<&str>;
+    /// Monotonic host-maintained counter. Reading it must not synchronize a
+    /// device or copy a tensor to the host.
     fn model_tokens_processed(&self) -> u64;
-    fn current_token_log_probs(
+    fn generate_device_batch(
         &mut self,
-        prompt: &str,
-        rollout: &GeneratedRollout,
-        max_sequence_tokens: usize,
-    ) -> Result<Vec<f64>>;
-    fn backward_rollout_log_probs(
+        request: GrpoGenerationBatchRequest<'_>,
+    ) -> Result<GrpoGeneratedBatch>;
+    fn prepare_device_batch(
         &mut self,
-        prompt: &str,
-        rollout: &GeneratedRollout,
-        gradients: &[f64],
-    ) -> Result<()>;
+        request: GrpoDeviceBatchRequest<'_>,
+    ) -> Result<GrpoDeviceBatchResult>;
     fn optimizer_step(&mut self, learning_rate_scale: f64) -> Result<()>;
 }
 
-/// Frozen reference scorer consuming the generator's exact tokenization.
-pub trait AlignedReferencePolicy {
-    fn identity(&self) -> &str;
-    fn tokenizer_identity(&self) -> &str;
-    fn rollout_token_log_probs(
-        &mut self,
-        prompt: &str,
-        rollout: &GeneratedRollout,
-        max_sequence_tokens: usize,
-    ) -> Result<Vec<f64>>;
-}
-
-/// Exactly one adapter set must match the typed algorithm on the phase.
-pub enum PostTrainingPhaseAdapters<'a> {
+/// Exactly one device-owned runtime must match the typed phase algorithm.
+pub enum PostTrainingPhaseRuntime<'a> {
     Dpo {
-        policy: &'a mut dyn PreferencePolicy,
-        reference: &'a mut dyn SequenceLogProbabilityProvider,
+        runtime: &'a mut dyn DpoDeviceBatchRuntime,
     },
     ForwardKl {
-        policy: &'a mut dyn DistillationPolicy,
-        teacher: &'a mut dyn TeacherDistributionProvider,
+        runtime: &'a mut dyn ForwardKlDeviceBatchRuntime,
     },
     Grpo {
-        policy: &'a mut dyn GrpoPolicy,
-        reference: Option<&'a mut dyn AlignedReferencePolicy>,
+        runtime: &'a mut dyn GrpoDeviceBatchRuntime,
         verifier: &'a dyn RewardVerifier,
     },
 }
@@ -1118,35 +1330,22 @@ pub struct PostTrainingPhaseReport {
     pub metrics: BTreeMap<String, f64>,
 }
 
-fn validate_frozen_provider(
+fn validate_frozen_runtime(
     spec: &FrozenModelSpec,
-    provider_identity: &str,
-    provider_tokenizer: &str,
+    runtime_identity: &str,
+    runtime_tokenizer: &str,
     policy_tokenizer: &str,
 ) -> Result<()> {
-    spec.verify_local_artifact()?;
     let expected = spec.immutable_identity()?;
     ensure!(
-        provider_identity == expected,
-        "frozen provider identity mismatch: expected `{expected}`, got `{provider_identity}`"
+        runtime_identity == expected,
+        "frozen runtime identity mismatch: expected `{expected}`, got `{runtime_identity}`"
     );
     ensure!(
-        !provider_tokenizer.trim().is_empty() && provider_tokenizer == policy_tokenizer,
-        "frozen provider and trainable policy tokenizer identities differ"
+        !runtime_tokenizer.trim().is_empty() && runtime_tokenizer == policy_tokenizer,
+        "frozen and trainable runtime tokenizer identities differ"
     );
     Ok(())
-}
-
-fn distribute_sequence_gradient(
-    aggregate_gradient: f64,
-    token_count: usize,
-    reduction: SequenceReduction,
-) -> Vec<f64> {
-    let value = match reduction {
-        SequenceReduction::Sum => aggregate_gradient,
-        SequenceReduction::Mean => aggregate_gradient / token_count as f64,
-    };
-    vec![value; token_count]
 }
 
 fn post_training_algorithm_name(config: &PostTrainingConfig) -> &'static str {
@@ -1158,7 +1357,7 @@ fn post_training_algorithm_name(config: &PostTrainingConfig) -> &'static str {
 }
 
 /// Serialized native post-training cursor contract.
-pub const POST_TRAINING_CURSOR_VERSION: u32 = 2;
+pub const POST_TRAINING_CURSOR_VERSION: u32 = 3;
 pub const POST_TRAINING_RESUME_VERSION: u32 = 1;
 
 /// Authenticated cumulative wake clock bound to one immutable model
@@ -1211,9 +1410,9 @@ impl PostTrainingClockReceipt {
     }
 
     fn validate(&self) -> Result<()> {
-        validate_prefixed_sha256(&self.authority_identity, "post-training clock authority")?;
-        validate_prefixed_sha256(&self.checkpoint_sha256, "post-training clock checkpoint")?;
-        validate_prefixed_sha256(&self.receipt_sha256, "post-training clock receipt")?;
+        validate_sha256_identity(&self.authority_identity, "post-training clock authority")?;
+        validate_sha256_identity(&self.checkpoint_sha256, "post-training clock checkpoint")?;
+        validate_sha256_identity(&self.receipt_sha256, "post-training clock receipt")?;
         ensure!(
             self.receipt_sha256 == canonical_sha256(&self.body())?,
             "post-training clock receipt does not match its content"
@@ -1273,58 +1472,229 @@ pub struct PinnedPostTrainingInput {
 }
 
 impl PinnedPostTrainingInput {
-    fn from_path(path: &Path) -> Result<Self> {
-        let metadata = std::fs::symlink_metadata(path)
-            .with_context(|| format!("failed to inspect post-training input {}", path.display()))?;
+    fn validate(&self) -> Result<()> {
         ensure!(
-            metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-            "post-training input {} must be a non-symlink regular file",
-            path.display()
+            !self.path.trim().is_empty(),
+            "post-training input path is empty"
         );
-        let path_text = path
-            .to_str()
-            .context("post-training input path is not valid UTF-8")?
-            .to_owned();
-        let mut file = File::open(path)
-            .with_context(|| format!("failed to open post-training input {}", path.display()))?;
-        let mut hasher = Sha256::new();
-        let mut buffer = [0_u8; 1024 * 1024];
-        loop {
-            let read = file.read(&mut buffer).with_context(|| {
-                format!("failed to hash post-training input {}", path.display())
-            })?;
-            if read == 0 {
-                break;
-            }
-            hasher.update(&buffer[..read]);
-        }
-        Ok(Self {
-            path: path_text,
-            sha256: format!("sha256:{:x}", hasher.finalize()),
-            bytes: metadata.len(),
-        })
-    }
-
-    fn verify(&self, path: &Path) -> Result<()> {
-        validate_prefixed_sha256(&self.sha256, "post-training input")?;
-        let actual = Self::from_path(path)?;
-        ensure!(
-            &actual == self,
-            "post-training input identity changed: expected {} ({} bytes), got {} ({} bytes)",
-            self.sha256,
-            self.bytes,
-            actual.sha256,
-            actual.bytes
-        );
-        Ok(())
+        validate_sha256_identity(&self.sha256, "post-training input")
     }
 }
 
-/// All runtime adapters are pinned into the cursor. Frozen model identities
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct StablePostTrainingFileIdentity {
+    device: u64,
+    inode: u64,
+    mode: u32,
+    length: u64,
+    modified_seconds: i64,
+    modified_nanoseconds: i64,
+    changed_seconds: i64,
+    changed_nanoseconds: i64,
+}
+
+#[cfg(unix)]
+impl StablePostTrainingFileIdentity {
+    fn from_metadata(metadata: &fs::Metadata) -> Self {
+        Self {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            mode: metadata.mode(),
+            length: metadata.len(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+            changed_seconds: metadata.ctime(),
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+}
+
+/// One authenticated file description used for both the durable input digest
+/// and every task record consumed during this execution attempt. Keeping the
+/// opened file prevents a pathname replacement from substituting bytes after
+/// the cursor has been content-addressed.
+struct AuthenticatedPostTrainingInput {
+    description: &'static str,
+    path: PathBuf,
+    identity: PinnedPostTrainingInput,
+    file: File,
+    #[cfg(unix)]
+    stable_identity: StablePostTrainingFileIdentity,
+    #[cfg(not(unix))]
+    modified: Option<std::time::SystemTime>,
+}
+
+impl AuthenticatedPostTrainingInput {
+    fn open(path: &Path) -> Result<Self> {
+        Self::open_labeled(path, "post-training input")
+    }
+
+    fn open_labeled(path: &Path, description: &'static str) -> Result<Self> {
+        let path_metadata = fs::symlink_metadata(path)
+            .with_context(|| format!("failed to inspect {description} {}", path.display()))?;
+        ensure!(
+            path_metadata.file_type().is_file() && !path_metadata.file_type().is_symlink(),
+            "{description} {} must be a non-symlink regular file",
+            path.display()
+        );
+        let mut options = OpenOptions::new();
+        options.read(true);
+        #[cfg(unix)]
+        options.custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK);
+        let mut file = options
+            .open(path)
+            .with_context(|| format!("failed to open {description} {}", path.display()))?;
+        let opened_metadata = file.metadata().with_context(|| {
+            format!("failed to inspect opened {description} {}", path.display())
+        })?;
+        ensure!(
+            opened_metadata.is_file(),
+            "{description} {} must remain a regular file while opening",
+            path.display()
+        );
+        #[cfg(unix)]
+        let stable_identity = StablePostTrainingFileIdentity::from_metadata(&path_metadata);
+        #[cfg(unix)]
+        ensure!(
+            StablePostTrainingFileIdentity::from_metadata(&opened_metadata) == stable_identity,
+            "{description} {} changed while it was opened",
+            path.display()
+        );
+        #[cfg(not(unix))]
+        let modified = path_metadata.modified().ok();
+        #[cfg(not(unix))]
+        ensure!(
+            opened_metadata.len() == path_metadata.len()
+                && opened_metadata.modified().ok() == modified,
+            "{description} {} changed while it was opened",
+            path.display()
+        );
+
+        let expected_bytes = opened_metadata.len();
+        let mut bytes = 0_u64;
+        let mut hasher = Sha256::new();
+        let mut buffer = [0_u8; 1024 * 1024];
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .with_context(|| format!("failed to hash {description} {}", path.display()))?;
+            if read == 0 {
+                break;
+            }
+            bytes = bytes
+                .checked_add(read as u64)
+                .context("post-training input byte count overflows u64")?;
+            ensure!(
+                bytes <= expected_bytes,
+                "{description} {} grew while it was hashed",
+                path.display()
+            );
+            hasher.update(&buffer[..read]);
+        }
+        ensure!(
+            bytes == expected_bytes,
+            "{description} {} changed while it was hashed",
+            path.display()
+        );
+        file.seek(SeekFrom::Start(0))
+            .with_context(|| format!("failed to rewind {description} {}", path.display()))?;
+        let path_text = path
+            .to_str()
+            .with_context(|| format!("{description} path is not valid UTF-8"))?
+            .to_owned();
+        let source = Self {
+            description,
+            path: path.to_owned(),
+            identity: PinnedPostTrainingInput {
+                path: path_text,
+                sha256: format!("sha256:{:x}", hasher.finalize()),
+                bytes,
+            },
+            file,
+            #[cfg(unix)]
+            stable_identity,
+            #[cfg(not(unix))]
+            modified,
+        };
+        source.ensure_still_published()?;
+        Ok(source)
+    }
+
+    fn ensure_still_published(&self) -> Result<()> {
+        let opened = self.file.metadata().with_context(|| {
+            format!(
+                "failed to reinspect opened {} {}",
+                self.description,
+                self.path.display()
+            )
+        })?;
+        let published = fs::symlink_metadata(&self.path).with_context(|| {
+            format!(
+                "failed to reinspect {} {}",
+                self.description,
+                self.path.display()
+            )
+        })?;
+        #[cfg(unix)]
+        ensure!(
+            StablePostTrainingFileIdentity::from_metadata(&opened) == self.stable_identity
+                && StablePostTrainingFileIdentity::from_metadata(&published)
+                    == self.stable_identity,
+            "{} {} changed after it was authenticated",
+            self.description,
+            self.path.display()
+        );
+        #[cfg(not(unix))]
+        ensure!(
+            opened.is_file()
+                && published.file_type().is_file()
+                && !published.file_type().is_symlink()
+                && opened.len() == self.identity.bytes
+                && published.len() == self.identity.bytes
+                && opened.modified().ok() == self.modified
+                && published.modified().ok() == self.modified,
+            "{} {} changed after it was authenticated",
+            self.description,
+            self.path.display()
+        );
+        Ok(())
+    }
+
+    fn reader(&mut self) -> Result<Box<dyn BufRead>> {
+        self.ensure_still_published()?;
+        self.file.seek(SeekFrom::Start(0)).with_context(|| {
+            format!(
+                "failed to rewind post-training input {}",
+                self.path.display()
+            )
+        })?;
+        // `try_clone` retains the authenticated inode. The retained base
+        // handle is never read concurrently and rewinds the shared offset only
+        // after the previous reader has been dropped at an epoch boundary.
+        let file = self.file.try_clone().with_context(|| {
+            format!(
+                "failed to clone post-training input {}",
+                self.path.display()
+            )
+        })?;
+        if self.path.extension().is_some_and(|ext| ext == "zst") {
+            Ok(Box::new(BufReader::new(
+                zstd::stream::read::Decoder::new(file).with_context(|| {
+                    format!("failed to open zstd task data {}", self.path.display())
+                })?,
+            )))
+        } else {
+            Ok(Box::new(BufReader::new(file)))
+        }
+    }
+}
+
+/// All model runtimes are pinned into the cursor. Frozen model identities
 /// additionally remain bound to their WorkflowV2 `FrozenModelSpec`.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct PostTrainingAdapterIdentities {
+pub struct PostTrainingRuntimeIdentities {
     pub trainable: String,
     pub tokenizer: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1443,7 +1813,17 @@ impl PostTrainingUpdateSummary {
             self.examples > 0 && self.model_tokens > 0 && self.loss_sum.is_finite(),
             "post-training update summary is empty or non-finite"
         );
-        validate_prefixed_sha256(&self.execution_sha256, "post-training execution")?;
+        if matches!(
+            &self.objective,
+            PostTrainingObjectiveSummary::Dpo { .. }
+                | PostTrainingObjectiveSummary::ForwardKl { .. }
+        ) {
+            ensure!(
+                self.loss_sum >= 0.0,
+                "DPO/forward-KL loss sum must be non-negative"
+            );
+        }
+        validate_sha256_identity(&self.execution_sha256, "post-training execution")?;
         self.objective.validate(self.examples)
     }
 }
@@ -1578,12 +1958,16 @@ impl PreparedPostTrainingUpdate {
     }
 
     fn validate(&self) -> Result<()> {
-        validate_prefixed_sha256(&self.phase_sha256, "post-training phase")?;
-        validate_prefixed_sha256(
+        validate_sha256_identity(&self.phase_sha256, "post-training phase")?;
+        validate_sha256_identity(
             &self.previous_receipt_chain_sha256,
             "post-training receipt chain",
         )?;
-        validate_prefixed_sha256(&self.batch_sha256, "post-training batch")?;
+        validate_sha256_identity(&self.batch_sha256, "post-training batch")?;
+        self.base_model.validate()?;
+        if let Some(optimizer) = &self.base_optimizer {
+            optimizer.validate()?;
+        }
         self.summary.validate()?;
         match (&self.clock_before, &self.clock_after) {
             (Some(before), Some(after)) => {
@@ -1614,10 +1998,45 @@ impl PreparedPostTrainingUpdate {
                 || (self.end.epoch == self.start.epoch && self.end.record > self.start.record),
             "post-training update does not advance its input cursor"
         );
-        ensure!(
-            self.rng_end >= self.rng_start,
-            "post-training RNG range is inverted"
-        );
+        let reserved_rngs = self
+            .rng_end
+            .checked_sub(self.rng_start)
+            .context("post-training RNG range is inverted")?;
+        match &self.summary.objective {
+            PostTrainingObjectiveSummary::Dpo { .. } => {
+                let expected = self
+                    .summary
+                    .examples
+                    .checked_mul(2)
+                    .context("DPO model RNG range overflows u64")?;
+                ensure!(
+                    reserved_rngs == expected,
+                    "DPO prepared update must reserve exactly two model RNG substreams per example"
+                );
+            }
+            PostTrainingObjectiveSummary::ForwardKl { .. } => ensure!(
+                reserved_rngs == self.summary.examples,
+                "forward-KL prepared update must reserve exactly one model RNG substream per example"
+            ),
+            PostTrainingObjectiveSummary::Grpo { .. } => {
+                let per_group = self
+                    .summary
+                    .examples
+                    .checked_mul(2)
+                    .context("GRPO model RNG range overflows u64")?;
+                ensure!(
+                    reserved_rngs % per_group == 0,
+                    "GRPO prepared update has an incomplete model RNG group"
+                );
+                let group_size = reserved_rngs / per_group;
+                let maximum = u64::try_from(MAX_POST_TRAINING_ROLLOUTS_PER_PROMPT)
+                    .expect("GRPO group-size limit fits u64");
+                ensure!(
+                    (2..=maximum).contains(&group_size),
+                    "GRPO prepared update model RNG range encodes an invalid group size"
+                );
+            }
+        }
         ensure!(
             self.transaction_id == self.computed_transaction_id()?,
             "post-training transaction id does not match its content"
@@ -1634,7 +2053,17 @@ pub struct PostTrainingCommittedState {
     pub optimizer: Option<ImmutableArtifact>,
 }
 
-/// The publisher's proof that the attached trainable adapter was restored to
+impl PostTrainingCommittedState {
+    fn validate(&self) -> Result<()> {
+        self.model.validate()?;
+        if let Some(optimizer) = &self.optimizer {
+            optimizer.validate()?;
+        }
+        Ok(())
+    }
+}
+
+/// The publisher's proof that the attached trainable runtime was restored to
 /// the exact committed model/optimizer generation before recomputation.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PostTrainingRestoreReceipt {
@@ -1722,6 +2151,8 @@ impl PostTrainingUpdateReceipt {
     }
 
     fn validate(&self, plan: &PreparedPostTrainingUpdate, publisher: &str) -> Result<()> {
+        self.checkpoint.validate()?;
+        self.optimizer.validate()?;
         ensure!(
             self.transaction_id == plan.transaction_id,
             "optimizer receipt belongs to another update transaction"
@@ -1738,7 +2169,7 @@ impl PostTrainingUpdateReceipt {
             !self.receipt_uri.trim().is_empty(),
             "optimizer receipt URI is empty"
         );
-        validate_prefixed_sha256(&self.receipt_sha256, "optimizer receipt")?;
+        validate_sha256_identity(&self.receipt_sha256, "optimizer receipt")?;
         ensure!(
             self.receipt_sha256 == self.computed_sha256()?,
             "optimizer receipt hash does not match its content"
@@ -1758,7 +2189,7 @@ impl PostTrainingUpdateReceipt {
     }
 }
 
-/// Adapter which atomically owns model/optimizer restoration and immutable
+/// Publisher which atomically owns model/optimizer restoration and immutable
 /// update publication. It may keep a transaction table in local or remote
 /// durable storage, but publication must be idempotent by the plan's content
 /// hash. On a retry it returns the original receipt without invoking `apply`.
@@ -1774,7 +2205,9 @@ pub trait PostTrainingUpdatePublisher {
     ) -> Result<PostTrainingRestoreReceipt>;
 
     /// Apply and durably publish one update. Implementations must key the
-    /// operation by `plan.transaction_id` and never overwrite an artifact.
+    /// operation by `plan.transaction_id` and never overwrite an artifact. A
+    /// new transaction invokes `apply` exactly once; an idempotent retry
+    /// returns its original receipt without invoking `apply`.
     fn publish_update(
         &mut self,
         plan: &PreparedPostTrainingUpdate,
@@ -1844,14 +2277,16 @@ impl PostTrainingBoundaryReceipt {
         input: &PostTrainingCommittedState,
         expected_clock: PostTrainingClockValues,
     ) -> Result<()> {
+        input.validate()?;
+        self.state.validate()?;
         ensure!(
             self.transaction_id == transaction_id
                 && self.hook_identity == hook_identity
                 && self.input_model_sha256 == input.model.sha256(),
             "periodic-sleep boundary receipt belongs to another boundary"
         );
-        validate_prefixed_sha256(&self.receipt_sha256, "periodic-sleep receipt")?;
-        validate_prefixed_sha256(
+        validate_sha256_identity(&self.receipt_sha256, "periodic-sleep receipt")?;
+        validate_sha256_identity(
             &self.native_sleep_checkpoint_sha256,
             "periodic-sleep native checkpoint",
         )?;
@@ -1911,7 +2346,7 @@ pub struct NativePostTrainingBoundaryController<R> {
 
 impl<R: NativePostTrainingSleepRuntime> NativePostTrainingBoundaryController<R> {
     pub fn new(runtime: R) -> Result<Self> {
-        validate_prefixed_sha256(runtime.identity(), "native post-training sleep runtime")?;
+        validate_sha256_identity(runtime.identity(), "native post-training sleep runtime")?;
         Ok(Self { runtime })
     }
 
@@ -1950,9 +2385,10 @@ impl<R: NativePostTrainingSleepRuntime> PostTrainingBoundaryHook
         resume: Option<NativeSleepCheckpoint>,
         progress: &mut dyn NativeSleepProgressSink,
     ) -> Result<PostTrainingBoundaryReceipt> {
-        validate_prefixed_sha256(request.transaction_id, "post-training sleep transaction")?;
-        validate_prefixed_sha256(request.workflow_signature, "post-training sleep workflow")?;
+        validate_sha256_identity(request.transaction_id, "post-training sleep transaction")?;
+        validate_sha256_identity(request.workflow_signature, "post-training sleep workflow")?;
         request.clock_before.validate()?;
+        request.input.validate()?;
         ensure!(
             request.clock_before.authority_identity == self.identity()
                 && request.clock_before.checkpoint_sha256 == request.input.model.sha256(),
@@ -1986,6 +2422,11 @@ impl<R: NativePostTrainingSleepRuntime> PostTrainingBoundaryHook
                 && checkpoint.phase_name == request.phase_name,
             "native post-training sleep cursor belongs to another workflow phase"
         );
+        ensure!(
+            checkpoint.input_checkpoint.uri == request.input.model.uri()
+                && checkpoint.input_checkpoint.sha256 == request.input.model.sha256(),
+            "native post-training sleep cursor belongs to another boundary input checkpoint"
+        );
         if !resumed {
             ensure!(
                 checkpoint.live_checkpoint.uri == request.input.model.uri()
@@ -2006,6 +2447,16 @@ impl<R: NativePostTrainingSleepRuntime> PostTrainingBoundaryHook
         let state = self
             .runtime
             .advance_and_drain(request, &mut checkpoint, progress)?;
+        checkpoint.live_checkpoint.validate()?;
+        checkpoint.sleep.validate_resume()?;
+        state.validate()?;
+        ensure!(
+            checkpoint.workflow_signature == request.workflow_signature
+                && checkpoint.phase_name == request.phase_name
+                && checkpoint.input_checkpoint.uri == request.input.model.uri()
+                && checkpoint.input_checkpoint.sha256 == request.input.model.sha256(),
+            "post-training sleep runtime changed its workflow/boundary identity"
+        );
         let target = request.clock_after.selected(request.config.schedule.clock);
         ensure!(
             checkpoint.sleep.clock == target
@@ -2132,7 +2583,7 @@ impl PostTrainingProgress {
         &self,
         phase: &PhaseV2,
         algorithm: &str,
-        identities: &PostTrainingAdapterIdentities,
+        identities: &PostTrainingRuntimeIdentities,
     ) -> Result<PostTrainingPhaseReport> {
         ensure!(
             self.examples > 0 && self.optimizer_steps > 0,
@@ -2198,7 +2649,7 @@ pub struct PostTrainingCursor {
     pub phase_sha256: String,
     pub input_checkpoint: ImmutableModelCheckpoint,
     pub input_data: PinnedPostTrainingInput,
-    pub adapters: PostTrainingAdapterIdentities,
+    pub runtime_identities: PostTrainingRuntimeIdentities,
     pub publisher_identity: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub boundary_hook_identity: Option<String>,
@@ -2225,7 +2676,7 @@ impl PostTrainingCursor {
         workflow_signature: String,
         request: &PhaseExecutionRequest,
         input_data: PinnedPostTrainingInput,
-        adapters: PostTrainingAdapterIdentities,
+        runtime_identities: PostTrainingRuntimeIdentities,
         publisher_identity: String,
         boundary_hook_identity: Option<String>,
         clock: Option<PostTrainingClockReceipt>,
@@ -2249,7 +2700,7 @@ impl PostTrainingCursor {
             phase_sha256,
             input_checkpoint: input_checkpoint.clone(),
             input_data,
-            adapters,
+            runtime_identities,
             publisher_identity,
             boundary_hook_identity,
             input_clock: clock.clone(),
@@ -2282,11 +2733,14 @@ impl PostTrainingCursor {
             "unsupported post-training cursor version {}",
             self.version
         );
-        validate_prefixed_sha256(&self.workflow_signature, "workflow signature")?;
-        validate_prefixed_sha256(&self.phase_sha256, "post-training phase")?;
-        validate_prefixed_sha256(&self.publisher_identity, "post-training publisher")?;
+        validate_sha256_identity(&self.workflow_signature, "workflow signature")?;
+        validate_sha256_identity(&self.phase_sha256, "post-training phase")?;
+        self.input_checkpoint.validate()?;
+        self.input_data.validate()?;
+        self.committed.validate()?;
+        validate_sha256_identity(&self.publisher_identity, "post-training publisher")?;
         if let Some(identity) = &self.boundary_hook_identity {
-            validate_prefixed_sha256(identity, "post-training boundary hook")?;
+            validate_sha256_identity(identity, "post-training boundary hook")?;
         }
         match (&self.boundary_hook_identity, &self.input_clock, &self.clock) {
             (Some(identity), Some(input_clock), Some(clock)) => {
@@ -2324,7 +2778,7 @@ impl PostTrainingCursor {
             (None, None, None) => {}
             _ => bail!("post-training cursor has a partial periodic-sleep clock binding"),
         }
-        validate_prefixed_sha256(&self.receipt_chain_sha256, "post-training receipt chain")?;
+        validate_sha256_identity(&self.receipt_chain_sha256, "post-training receipt chain")?;
         ensure!(
             self.progress.examples >= self.progress.optimizer_steps,
             "post-training progress has more updates than examples"
@@ -2339,12 +2793,14 @@ impl PostTrainingCursor {
                 );
             }
             (Some(receipt), steps) if steps > 0 => {
-                validate_prefixed_sha256(&receipt.transaction_id, "post-training transaction")?;
-                validate_prefixed_sha256(
+                receipt.checkpoint.validate()?;
+                receipt.optimizer.validate()?;
+                validate_sha256_identity(&receipt.transaction_id, "post-training transaction")?;
+                validate_sha256_identity(
                     &receipt.previous_receipt_chain_sha256,
                     "previous post-training receipt chain",
                 )?;
-                validate_prefixed_sha256(&receipt.receipt_sha256, "optimizer receipt")?;
+                validate_sha256_identity(&receipt.receipt_sha256, "optimizer receipt")?;
                 ensure!(
                     receipt.publisher_identity == self.publisher_identity
                         && receipt.receipt_sha256 == receipt.computed_sha256()?,
@@ -2360,11 +2816,11 @@ impl PostTrainingCursor {
                     "post-training committed optimizer is missing after an update"
                 );
                 if let Some(boundary) = &self.last_boundary_receipt {
-                    validate_prefixed_sha256(
+                    validate_sha256_identity(
                         &boundary.transaction_id,
                         "periodic-sleep transaction",
                     )?;
-                    validate_prefixed_sha256(&boundary.receipt_sha256, "periodic-sleep receipt")?;
+                    validate_sha256_identity(&boundary.receipt_sha256, "periodic-sleep receipt")?;
                     ensure!(
                         self.boundary_hook_identity.as_deref()
                             == Some(boundary.hook_identity.as_str())
@@ -2437,6 +2893,7 @@ impl PostTrainingBoundaryInFlight {
         publisher_identity: &str,
         config: &InModelSleepConfig,
     ) -> Result<()> {
+        self.published_state.validate()?;
         let before = expected
             .clock_before
             .as_ref()
@@ -2470,6 +2927,11 @@ impl PostTrainingBoundaryInFlight {
         if let Some(native) = &self.native_sleep {
             native.live_checkpoint.validate()?;
             native.sleep.validate_resume()?;
+            ensure!(
+                native.input_checkpoint.uri == self.published_state.model.uri()
+                    && native.input_checkpoint.sha256 == self.published_state.model.sha256(),
+                "in-flight native sleep cursor belongs to another published update"
+            );
             ensure!(
                 native.sleep.clock >= before.selected(config.schedule.clock)
                     && native.sleep.clock <= after.selected(config.schedule.clock),
@@ -2537,10 +2999,13 @@ impl PostTrainingResumeEnvelope {
     }
 }
 
-/// One phase's concrete adapters. It is intentionally borrowed and contains
-/// no site-specific loader, storage client, or global singleton.
+/// One phase's concrete device runtime. It is intentionally borrowed and
+/// contains no site-specific loader, storage client, or global singleton. The
+/// runtime and publisher must refer to the same model state: restoring a
+/// committed publisher generation must also discard any previously staged
+/// device batch before deterministic replay.
 pub struct PostTrainingExecutionContext<'a> {
-    pub adapters: PostTrainingPhaseAdapters<'a>,
+    pub runtime: PostTrainingPhaseRuntime<'a>,
     pub publisher: &'a mut dyn PostTrainingUpdatePublisher,
     pub boundary_hook: Option<&'a mut dyn PostTrainingBoundaryHook>,
     /// Authenticated cumulative clocks from the exact input checkpoint.
@@ -2576,7 +3041,7 @@ impl NativePostTrainingPhaseExecutor {
         update_budget: usize,
     ) -> Result<Self> {
         let workflow_signature = workflow_signature.into();
-        validate_prefixed_sha256(&workflow_signature, "workflow signature")?;
+        validate_sha256_identity(&workflow_signature, "workflow signature")?;
         ensure!(
             update_budget > 0,
             "post-training update budget must be positive"
@@ -2604,7 +3069,7 @@ impl<'a> PhaseExecutor<PostTrainingExecutionContext<'a>> for NativePostTrainingP
         let outcome = drive_resumable_post_training_phase(
             &self.workflow_signature,
             request,
-            &mut context.adapters,
+            &mut context.runtime,
             context.publisher,
             &mut context.boundary_hook,
             context.starting_clock.as_ref(),
@@ -2633,7 +3098,7 @@ impl<'a> PhaseExecutor<PostTrainingExecutionContext<'a>> for NativePostTrainingP
 pub fn drive_resumable_post_training_phase(
     workflow_signature: &str,
     request: &PhaseExecutionRequest,
-    adapters: &mut PostTrainingPhaseAdapters<'_>,
+    runtime: &mut PostTrainingPhaseRuntime<'_>,
     publisher: &mut dyn PostTrainingUpdatePublisher,
     boundary_hook: &mut Option<&mut dyn PostTrainingBoundaryHook>,
     starting_clock: Option<&PostTrainingClockReceipt>,
@@ -2641,35 +3106,31 @@ pub fn drive_resumable_post_training_phase(
     update_budget: usize,
     progress: &mut dyn PhaseProgressSink,
 ) -> Result<ResumablePostTrainingOutcome> {
-    validate_prefixed_sha256(workflow_signature, "workflow signature")?;
+    validate_sha256_identity(workflow_signature, "workflow signature")?;
     ensure!(
         update_budget > 0,
         "post-training update budget must be positive"
     );
     let phase = &request.phase;
     validate_resumable_phase(phase)?;
-    let data = phase
-        .data
-        .as_deref()
-        .context("native post-training phase has no data")?;
-    let actual_input = PinnedPostTrainingInput::from_path(data)?;
-    let identities = validate_and_capture_adapter_identities(phase, adapters)?;
-    validate_prefixed_sha256(publisher.identity(), "post-training publisher")?;
+    let input_checkpoint = request
+        .input_checkpoint
+        .as_ref()
+        .context("native post-training requires an immutable input checkpoint")?;
+    input_checkpoint.validate()?;
+    let identities = validate_and_capture_runtime_identities(phase, runtime)?;
+    validate_sha256_identity(publisher.identity(), "post-training publisher")?;
     let (hook_identity, initial_clock) = match (
         &phase.periodic_sleep,
         boundary_hook.as_deref(),
         starting_clock,
     ) {
         (Some(_), Some(hook), Some(clock)) => {
-            validate_prefixed_sha256(hook.identity(), "post-training boundary hook")?;
+            validate_sha256_identity(hook.identity(), "post-training boundary hook")?;
             clock.validate()?;
-            let input = request
-                .input_checkpoint
-                .as_ref()
-                .context("native post-training requires an immutable input checkpoint")?;
             ensure!(
                 clock.authority_identity == hook.identity()
-                    && clock.checkpoint_sha256 == input.sha256(),
+                    && clock.checkpoint_sha256 == input_checkpoint.sha256(),
                 "post-training starting clock is not authenticated for its input/hook"
             );
             (Some(hook.identity().to_owned()), Some(clock.clone()))
@@ -2692,6 +3153,21 @@ pub fn drive_resumable_post_training_phase(
         ),
         (None, None, None) => (None, None),
     };
+    // Perform large immutable-file hashes once per execution attempt, after
+    // cheap runtime, publisher, and boundary-clock preflight. Rehashing a
+    // multi-gigabyte teacher/reference for every update would serialize the
+    // hot loop on storage.
+    phase
+        .post_training
+        .as_ref()
+        .expect("validated native post-training algorithm")
+        .verify_local_artifacts()?;
+    let data = phase
+        .data
+        .as_deref()
+        .context("native post-training phase has no data")?;
+    let authenticated_input = AuthenticatedPostTrainingInput::open(data)?;
+    let actual_input = authenticated_input.identity.clone();
     let phase_sha256 = canonical_sha256(phase)?;
     let (resume_cursor, mut in_flight) = resume
         .map(PostTrainingResumeEnvelope::into_parts)
@@ -2708,22 +3184,17 @@ pub fn drive_resumable_post_training_phase(
                     && cursor.phase_sha256 == phase_sha256,
                 "native post-training cursor belongs to another workflow phase"
             );
-            let input = request
-                .input_checkpoint
-                .as_ref()
-                .context("native post-training requires an immutable input checkpoint")?;
             ensure!(
-                &cursor.input_checkpoint == input,
+                &cursor.input_checkpoint == input_checkpoint,
                 "native post-training cursor belongs to another input checkpoint"
             );
             ensure!(
                 cursor.input_data == actual_input,
                 "native post-training cursor belongs to different input bytes"
             );
-            actual_input.verify(data)?;
             ensure!(
-                cursor.adapters == identities,
-                "native post-training adapter/provider identity changed across resume"
+                cursor.runtime_identities == identities,
+                "native post-training device-runtime identity changed across resume"
             );
             ensure!(
                 cursor.publisher_identity == publisher.identity(),
@@ -2749,6 +3220,16 @@ pub fn drive_resumable_post_training_phase(
             initial_clock,
         )?,
     };
+    let mut batches = PostTrainingBatchStream::new(
+        authenticated_input,
+        phase
+            .task
+            .as_ref()
+            .expect("validated post-training task")
+            .clone(),
+        cursor.position,
+        u64::try_from(phase.epochs_or_default()).context("epoch count exceeds u64")?,
+    )?;
     ensure!(
         in_flight.is_none()
             || (phase.periodic_sleep.is_some()
@@ -2760,18 +3241,27 @@ pub fn drive_resumable_post_training_phase(
     let mut updates_this_drive = 0usize;
     loop {
         cursor.validate_internal()?;
-        validate_and_capture_adapter_identities(phase, adapters).and_then(|current| {
+        validate_and_capture_runtime_identities(phase, runtime).and_then(|current| {
             ensure!(
-                current == cursor.adapters,
-                "native post-training adapter/provider identity drifted during execution"
+                current == cursor.runtime_identities,
+                "native post-training device-runtime identity drifted during execution"
             );
             Ok(())
         })?;
+        // Runtime identity callbacks are external code and can take long
+        // enough for the published input path to change.  Bracket the restore
+        // itself so an already-invalid phase never pays for, or observes side
+        // effects from, restoring a model generation it can no longer use.
+        batches.ensure_still_published()?;
         validate_restore_receipt(
             &publisher.restore_committed(&cursor.committed)?,
             publisher.identity(),
             &cursor.committed,
         )?;
+        // Restoration is deployment-controlled and may perform arbitrary I/O.
+        // Recheck the authenticated pathname before either returning a final
+        // product or consuming another batch from the retained description.
+        batches.ensure_still_published()?;
 
         if phase_is_complete(phase, &cursor)? {
             ensure!(
@@ -2786,20 +3276,14 @@ pub fn drive_resumable_post_training_phase(
                         .as_ref()
                         .expect("validated post-training config"),
                 ),
-                &cursor.adapters,
+                &cursor.runtime_identities,
             )?;
             return Ok(ResumablePostTrainingOutcome::Complete { cursor, report });
         }
 
         let update_examples = update_examples(phase)?;
         let start = cursor.position;
-        let batch = collect_post_training_batch(
-            data,
-            phase.task.as_ref().expect("validated post-training task"),
-            start,
-            update_examples,
-            u64::try_from(phase.epochs_or_default()).context("epoch count exceeds u64")?,
-        )?;
+        let batch = batches.next_batch(update_examples)?;
         ensure!(
             !batch.examples.is_empty(),
             "post-training phase `{}` reached no data before its configured end",
@@ -2810,7 +3294,9 @@ pub fn drive_resumable_post_training_phase(
         let prepared_computation = accumulate_resumable_update(
             phase,
             &batch.examples,
-            adapters,
+            &batch_sha256,
+            &cursor.committed,
+            runtime,
             cursor.rng.seed,
             rng_start,
         )?;
@@ -2852,6 +3338,10 @@ pub fn drive_resumable_post_training_phase(
                 ))?)?;
             }
         }
+        // The prepared update is durable, but no model mutation may be
+        // published from a batch whose pathname stopped naming the exact
+        // authenticated file after preparation.
+        batches.ensure_still_published()?;
 
         let (receipt, published_state) = match &in_flight {
             Some(boundary) => {
@@ -2867,7 +3357,7 @@ pub fn drive_resumable_post_training_phase(
             }
             None => {
                 let learning_rate_scale = phase.learning_rate_scale_or_default();
-                let mut apply = || optimizer_step(adapters, learning_rate_scale);
+                let mut apply = || optimizer_step(runtime, learning_rate_scale);
                 let receipt = publisher.publish_update(&expected, &mut apply)?;
                 receipt.validate(&expected, publisher.identity())?;
                 let published_state = PostTrainingCommittedState {
@@ -2877,11 +3367,16 @@ pub fn drive_resumable_post_training_phase(
                 (receipt, published_state)
             }
         };
+        // A publisher can take long enough for the source pathname to change.
+        // Reject before paying to restore the new generation or entering an
+        // optional sleep boundary; its immutable artifacts remain unreferenced.
+        batches.ensure_still_published()?;
         validate_restore_receipt(
             &publisher.restore_committed(&published_state)?,
             publisher.identity(),
             &published_state,
         )?;
+        batches.ensure_still_published()?;
 
         let (committed, boundary_receipt) =
             match (phase.periodic_sleep.as_ref(), boundary_hook.as_deref_mut()) {
@@ -2972,6 +3467,10 @@ pub fn drive_resumable_post_training_phase(
                 }
                 _ => unreachable!("boundary-hook presence validated before execution"),
             };
+        // Publication is immutable, so a late input replacement can leave an
+        // unreferenced artifact but must not advance the durable phase cursor
+        // or become its final product.
+        batches.ensure_still_published()?;
 
         let next_chain = canonical_sha256(&(
             "post_training_receipt_chain_v1",
@@ -2999,9 +3498,11 @@ pub fn drive_resumable_post_training_phase(
         let metric = update_metric(&expected, &receipt)?;
         metric.validate()?;
         progress.metric(metric_context(request, &next)?, metric)?;
+        batches.ensure_still_published()?;
         progress.checkpoint(serde_json::to_value(PostTrainingResumeEnvelope::wake(
             next.clone(),
         ))?)?;
+        batches.ensure_still_published()?;
         cursor = next;
         updates_this_drive += 1;
 
@@ -3014,7 +3515,7 @@ pub fn drive_resumable_post_training_phase(
                         .as_ref()
                         .expect("validated post-training config"),
                 ),
-                &cursor.adapters,
+                &cursor.runtime_identities,
             )?;
             return Ok(ResumablePostTrainingOutcome::Complete { cursor, report });
         }
@@ -3088,7 +3589,15 @@ impl NativeSleepProgressSink for PostTrainingSleepProgressBridge<'_> {
     }
 }
 
-fn validate_resumable_phase(phase: &PhaseV2) -> Result<()> {
+/// Validate the exact phase surface consumed by the built-in native
+/// post-training executor. Native host dispatch calls this before creating a
+/// runtime checkpoint so a syntactically valid WorkflowV2 phase cannot fail
+/// only after durable state has already been published.
+pub(crate) fn validate_resumable_phase(phase: &PhaseV2) -> Result<()> {
+    ensure!(
+        !phase.name.trim().is_empty(),
+        "native post-training phase name must not be empty"
+    );
     ensure!(
         matches!(
             phase.kind,
@@ -3105,19 +3614,68 @@ fn validate_resumable_phase(phase: &PhaseV2) -> Result<()> {
         phase.parameters.is_empty(),
         "native post-training rejects unconsumed raw parameters"
     );
-    phase
+    ensure!(
+        phase.memory_update_mode.is_none(),
+        "native post-training does not implement memory_update_mode; use periodic_sleep or a tier-aware phase executor"
+    );
+    let task = phase
         .task
         .as_ref()
-        .context("native post-training phase has no task")?
-        .validate()?;
-    phase
+        .context("native post-training phase has no task")?;
+    task.validate()?;
+    let execution = task.contract().execution;
+    match phase.kind {
+        PhaseKind::Preference => ensure!(
+            execution == TaskExecution::PairwisePreference,
+            "native DPO requires a pairwise-preference task"
+        ),
+        PhaseKind::Distillation => ensure!(
+            matches!(
+                execution,
+                TaskExecution::AutoregressiveTokenPrediction | TaskExecution::SupervisedGeneration
+            ),
+            "native forward-KL requires an autoregressive or supervised-generation task"
+        ),
+        PhaseKind::Rl => ensure!(
+            execution == TaskExecution::VerifiableReward,
+            "native GRPO requires a verifiable-reward task"
+        ),
+        _ => unreachable!("phase kind was restricted above"),
+    }
+    let data = phase
         .data
         .as_ref()
         .context("native post-training phase has no data")?;
-    phase
+    ensure!(
+        !data.as_os_str().is_empty(),
+        "native post-training phase has an empty data path"
+    );
+    let sequence_length = phase
         .sequence_length
         .context("native post-training phase has no sequence_length")?;
-    update_examples(phase)?;
+    ensure!(
+        (1..=MAX_POST_TRAINING_SEQUENCE_TOKENS).contains(&sequence_length),
+        "native post-training sequence_length must be between 1 and {MAX_POST_TRAINING_SEQUENCE_TOKENS}"
+    );
+    ensure!(
+        phase.epochs_or_default() > 0,
+        "native post-training epochs must be positive"
+    );
+    ensure!(
+        phase.steps.is_none_or(|steps| steps > 0),
+        "native post-training steps must be positive when set"
+    );
+    let loss_weight = phase.loss_weight_or_default();
+    ensure!(
+        loss_weight.is_finite() && loss_weight > 0.0,
+        "native post-training loss_weight must be finite and positive"
+    );
+    let learning_rate_scale = phase.learning_rate_scale_or_default();
+    ensure!(
+        learning_rate_scale.is_finite() && learning_rate_scale > 0.0,
+        "native post-training learning_rate_scale must be finite and positive"
+    );
+    let update_examples = update_examples(phase)?;
     let config = phase
         .post_training
         .as_ref()
@@ -3135,6 +3693,21 @@ fn validate_resumable_phase(phase: &PhaseV2) -> Result<()> {
             "GRPO max_new_tokens exceeds sequence_length"
         );
     }
+    if let PostTrainingConfig::Grpo {
+        group_size,
+        sampling,
+        ..
+    } = config
+    {
+        let update_tokens = group_size
+            .checked_mul(sampling.max_new_tokens)
+            .and_then(|tokens| tokens.checked_mul(update_examples))
+            .context("GRPO rollout-update token geometry overflows usize")?;
+        ensure!(
+            update_tokens <= MAX_POST_TRAINING_ROLLOUT_TOKENS,
+            "GRPO rollout update exceeds the {MAX_POST_TRAINING_ROLLOUT_TOKENS}-token native limit"
+        );
+    }
     Ok(())
 }
 
@@ -3149,6 +3722,10 @@ fn update_examples(phase: &PhaseV2) -> Result<usize> {
         )
         .context("native post-training update example count overflows usize")?;
     ensure!(examples > 0, "native post-training update batch is empty");
+    ensure!(
+        examples <= MAX_POST_TRAINING_UPDATE_EXAMPLES,
+        "native post-training update has {examples} examples, exceeding the limit of {MAX_POST_TRAINING_UPDATE_EXAMPLES}"
+    );
     Ok(examples)
 }
 
@@ -3165,125 +3742,330 @@ fn phase_is_complete(phase: &PhaseV2, cursor: &PostTrainingCursor) -> Result<boo
         >= u64::try_from(phase.epochs_or_default()).context("epoch count exceeds u64")?)
 }
 
+#[derive(Debug)]
 struct CollectedPostTrainingBatch {
     examples: Vec<TaskExample>,
     end: PostTrainingRecordPosition,
 }
 
-fn collect_post_training_batch(
-    path: &Path,
-    task: &TaskConfig,
-    start: PostTrainingRecordPosition,
-    target: usize,
-    epochs: u64,
-) -> Result<CollectedPostTrainingBatch> {
-    ensure!(
-        start.epoch < epochs,
-        "post-training input cursor is already at end"
-    );
-    let mut epoch = start.epoch;
-    let mut record = start.record;
-    let mut examples = Vec::with_capacity(target);
-    while epoch < epochs && examples.len() < target {
-        let mut seen = 0_u64;
-        let wanted = record;
-        let mut has_unconsumed_record = false;
-        visit_task_examples_while(path, task, |example| {
-            let index = seen;
-            seen = seen
-                .checked_add(1)
-                .context("post-training per-epoch record counter overflows u64")?;
-            if index < wanted {
-                return Ok(true);
-            }
-            if examples.len() == target {
-                has_unconsumed_record = true;
-                return Ok(false);
-            }
-            examples.push(example);
-            record = seen;
-            Ok(true)
-        })?;
-        ensure!(
-            wanted <= seen,
-            "post-training cursor record {} exceeds epoch {} length {}",
-            wanted,
-            epoch,
-            seen
-        );
-        if examples.len() == target {
-            if !has_unconsumed_record {
-                epoch = epoch
-                    .checked_add(1)
-                    .context("post-training epoch cursor overflows u64")?;
-                record = 0;
-            }
-            break;
-        }
-        epoch = epoch
-            .checked_add(1)
-            .context("post-training epoch cursor overflows u64")?;
-        record = 0;
-    }
-    if examples.len() < target {
-        epoch = epochs;
-        record = 0;
-    }
-    Ok(CollectedPostTrainingBatch {
-        examples,
-        end: PostTrainingRecordPosition { epoch, record },
-    })
+#[derive(Debug)]
+struct RawPostTrainingRecord {
+    line: String,
+    line_number: usize,
 }
 
+fn read_post_training_record_bounded(
+    reader: &mut (impl BufRead + ?Sized),
+    output: &mut Vec<u8>,
+    maximum_bytes: usize,
+) -> Result<usize> {
+    ensure!(
+        maximum_bytes > 0,
+        "post-training record byte limit must be positive"
+    );
+    output.clear();
+    let capture_bytes = maximum_bytes
+        .checked_add(1)
+        .context("post-training record byte limit overflows usize")?;
+    let read = reader
+        .take(u64::try_from(capture_bytes).context("post-training record byte limit exceeds u64")?)
+        .read_until(b'\n', output)
+        .context("failed to read post-training record")?;
+    let payload_bytes = output
+        .len()
+        .checked_sub(usize::from(output.last() == Some(&b'\n')))
+        .context("post-training record framing underflow")?;
+    ensure!(
+        payload_bytes <= maximum_bytes,
+        "post-training record exceeds the maximum of {maximum_bytes} bytes"
+    );
+    Ok(read)
+}
+
+/// Sequential batch reader over one authenticated file description. Resume
+/// performs at most one prefix scan to the durable record cursor; ordinary
+/// updates continue from the existing buffered reader instead of reopening
+/// and rescanning the file from record zero.
+struct PostTrainingBatchStream {
+    source: AuthenticatedPostTrainingInput,
+    task: TaskConfig,
+    reader: Box<dyn BufRead>,
+    jsonl: bool,
+    line: Vec<u8>,
+    line_number: usize,
+    epoch: u64,
+    record: u64,
+    records_in_epoch: u64,
+    epochs: u64,
+    lookahead: Option<RawPostTrainingRecord>,
+}
+
+impl PostTrainingBatchStream {
+    fn new(
+        mut source: AuthenticatedPostTrainingInput,
+        task: TaskConfig,
+        start: PostTrainingRecordPosition,
+        epochs: u64,
+    ) -> Result<Self> {
+        ensure!(
+            start.epoch < epochs || (start.epoch == epochs && start.record == 0),
+            "post-training input cursor exceeds the configured epoch range"
+        );
+        task.validate()?;
+        let jsonl =
+            task.contract().data_format == TaskDataFormat::Jsonl || is_jsonl_path(&source.path);
+        ensure!(
+            task.contract().data_format != TaskDataFormat::Jsonl || jsonl,
+            "task `{}` requires JSONL framing",
+            task.name()
+        );
+        let reader = source.reader()?;
+        let mut stream = Self {
+            source,
+            task,
+            reader,
+            jsonl,
+            line: Vec::new(),
+            line_number: 0,
+            epoch: start.epoch,
+            record: 0,
+            records_in_epoch: 0,
+            epochs,
+            lookahead: None,
+        };
+        while stream.record < start.record {
+            ensure!(
+                stream.read_record()?.is_some(),
+                "post-training cursor record {} exceeds epoch {} length {}",
+                start.record,
+                start.epoch,
+                stream.records_in_epoch
+            );
+            stream.record = stream
+                .record
+                .checked_add(1)
+                .context("post-training record cursor overflows u64")?;
+        }
+        stream.source.ensure_still_published()?;
+        Ok(stream)
+    }
+
+    fn read_raw_record(&mut self) -> Result<Option<RawPostTrainingRecord>> {
+        loop {
+            let read = read_post_training_record_bounded(
+                &mut self.reader,
+                &mut self.line,
+                MAX_POST_TRAINING_RECORD_BYTES,
+            )
+            .with_context(|| {
+                format!(
+                    "failed to read task data {}:{}",
+                    self.source.path.display(),
+                    self.line_number.saturating_add(1)
+                )
+            })?;
+            if read == 0 {
+                return Ok(None);
+            }
+            self.line_number = self
+                .line_number
+                .checked_add(1)
+                .context("task-data line counter overflows usize")?;
+            let line = String::from_utf8(std::mem::take(&mut self.line)).with_context(|| {
+                format!(
+                    "task data is not UTF-8 at {}:{}",
+                    self.source.path.display(),
+                    self.line_number
+                )
+            })?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            return Ok(Some(RawPostTrainingRecord {
+                line,
+                line_number: self.line_number,
+            }));
+        }
+    }
+
+    fn construct_record(&mut self, raw: RawPostTrainingRecord) -> Result<(TaskExample, usize)> {
+        let input_bytes = raw.line.len();
+        let record = if self.jsonl {
+            serde_json::from_str(&raw.line).with_context(|| {
+                format!(
+                    "invalid JSON task record at {}:{}",
+                    self.source.path.display(),
+                    raw.line_number
+                )
+            })?
+        } else {
+            serde_json::json!({"text": raw.line.trim_end_matches(['\r', '\n'])})
+        };
+        let example = self.task.construct_example(&record).with_context(|| {
+            format!(
+                "invalid task record at {}:{}",
+                self.source.path.display(),
+                raw.line_number
+            )
+        })?;
+        self.records_in_epoch = self
+            .records_in_epoch
+            .checked_add(1)
+            .context("post-training per-epoch record counter overflows u64")?;
+        Ok((example, input_bytes))
+    }
+
+    fn read_record(&mut self) -> Result<Option<(TaskExample, usize)>> {
+        self.read_raw_record()?
+            .map(|raw| self.construct_record(raw))
+            .transpose()
+    }
+
+    fn ensure_still_published(&self) -> Result<()> {
+        self.source.ensure_still_published()
+    }
+
+    fn advance_epoch(&mut self) -> Result<()> {
+        ensure!(
+            self.records_in_epoch > 0,
+            "task data {} contains no examples",
+            self.source.path.display()
+        );
+        self.source.ensure_still_published()?;
+        self.epoch = self
+            .epoch
+            .checked_add(1)
+            .context("post-training epoch cursor overflows u64")?;
+        self.record = 0;
+        self.records_in_epoch = 0;
+        self.line_number = 0;
+        if self.epoch < self.epochs {
+            // Drop the cloned handle before rewinding the retained base file;
+            // both descriptors intentionally refer to the same open file.
+            self.reader = Box::new(std::io::empty());
+            self.reader = self.source.reader()?;
+        }
+        Ok(())
+    }
+
+    fn next_batch(&mut self, target: usize) -> Result<CollectedPostTrainingBatch> {
+        ensure!(target > 0, "post-training target batch is empty");
+        ensure!(
+            target <= MAX_POST_TRAINING_UPDATE_EXAMPLES,
+            "post-training target batch exceeds {MAX_POST_TRAINING_UPDATE_EXAMPLES} examples"
+        );
+        self.source.ensure_still_published()?;
+        let mut examples = Vec::with_capacity(target);
+        let mut input_bytes = 0usize;
+        while self.epoch < self.epochs && examples.len() < target {
+            let raw = match self.lookahead.take() {
+                Some(raw) => Some(raw),
+                None => self.read_raw_record()?,
+            };
+            match raw {
+                Some(raw) => {
+                    let next_input_bytes = input_bytes
+                        .checked_add(raw.line.len())
+                        .context("post-training update input byte count overflows usize")?;
+                    ensure!(
+                        next_input_bytes <= MAX_POST_TRAINING_UPDATE_INPUT_BYTES,
+                        "post-training update input exceeds the {MAX_POST_TRAINING_UPDATE_INPUT_BYTES}-byte limit"
+                    );
+                    let (example, record_bytes) = self.construct_record(raw)?;
+                    input_bytes = input_bytes
+                        .checked_add(record_bytes)
+                        .context("post-training update input byte count overflows usize")?;
+                    debug_assert_eq!(input_bytes, next_input_bytes);
+                    examples.push(example);
+                    self.record = self
+                        .record
+                        .checked_add(1)
+                        .context("post-training record cursor overflows u64")?;
+                }
+                None => self.advance_epoch()?,
+            }
+        }
+
+        // Resolve the exact-EOF case now so a batch ending on the last record
+        // durably records the next epoch boundary instead of requiring an
+        // empty follow-up update attempt. Preserve one framed but unparsed
+        // record as lookahead when more data remains in this epoch: a phase
+        // ending at its step limit must not validate data it never consumes.
+        if examples.len() == target && self.epoch < self.epochs {
+            match self.read_raw_record()? {
+                Some(raw) => self.lookahead = Some(raw),
+                None => self.advance_epoch()?,
+            }
+        }
+        self.source.ensure_still_published()?;
+        Ok(CollectedPostTrainingBatch {
+            examples,
+            end: PostTrainingRecordPosition {
+                epoch: self.epoch,
+                record: self.record,
+            },
+        })
+    }
+}
+
+#[derive(Debug)]
 struct PreparedComputation {
     summary: PostTrainingUpdateSummary,
     rng_end: u64,
 }
 
-fn validate_and_capture_adapter_identities(
+fn validate_and_capture_runtime_identities(
     phase: &PhaseV2,
-    adapters: &mut PostTrainingPhaseAdapters<'_>,
-) -> Result<PostTrainingAdapterIdentities> {
+    runtime: &mut PostTrainingPhaseRuntime<'_>,
+) -> Result<PostTrainingRuntimeIdentities> {
     let config = phase
         .post_training
         .as_ref()
         .context("post-training phase has no typed algorithm")?;
-    match (config, adapters) {
+    match (config, runtime) {
         (
             PostTrainingConfig::Dpo {
                 reference: spec, ..
             },
-            PostTrainingPhaseAdapters::Dpo { policy, reference },
+            PostTrainingPhaseRuntime::Dpo { runtime },
         ) => {
-            validate_frozen_provider(
+            validate_frozen_runtime(
                 spec,
-                reference.identity(),
-                reference.tokenizer_identity(),
-                policy.tokenizer_identity(),
+                runtime.frozen_identity(),
+                runtime.frozen_tokenizer_identity(),
+                runtime.trainable_tokenizer_identity(),
             )?;
-            validate_adapter_identity(policy.identity(), "trainable DPO policy")?;
-            Ok(PostTrainingAdapterIdentities {
-                trainable: policy.identity().to_owned(),
-                tokenizer: policy.tokenizer_identity().to_owned(),
-                frozen: Some(reference.identity().to_owned()),
+            validate_runtime_identity(runtime.trainable_identity(), "trainable DPO policy")?;
+            validate_runtime_identity(runtime.trainable_tokenizer_identity(), "DPO tokenizer")?;
+            Ok(PostTrainingRuntimeIdentities {
+                trainable: runtime.trainable_identity().to_owned(),
+                tokenizer: runtime.trainable_tokenizer_identity().to_owned(),
+                frozen: Some(runtime.frozen_identity().to_owned()),
                 verifier: None,
             })
         }
         (
             PostTrainingConfig::ForwardKl { teacher: spec, .. },
-            PostTrainingPhaseAdapters::ForwardKl { policy, teacher },
+            PostTrainingPhaseRuntime::ForwardKl { runtime },
         ) => {
-            validate_frozen_provider(
+            validate_frozen_runtime(
                 spec,
-                teacher.identity(),
-                teacher.tokenizer_identity(),
-                policy.tokenizer_identity(),
+                runtime.frozen_identity(),
+                runtime.frozen_tokenizer_identity(),
+                runtime.trainable_tokenizer_identity(),
             )?;
-            validate_adapter_identity(policy.identity(), "trainable distillation policy")?;
-            Ok(PostTrainingAdapterIdentities {
-                trainable: policy.identity().to_owned(),
-                tokenizer: policy.tokenizer_identity().to_owned(),
-                frozen: Some(teacher.identity().to_owned()),
+            validate_runtime_identity(
+                runtime.trainable_identity(),
+                "trainable distillation policy",
+            )?;
+            validate_runtime_identity(
+                runtime.trainable_tokenizer_identity(),
+                "distillation tokenizer",
+            )?;
+            Ok(PostTrainingRuntimeIdentities {
+                trainable: runtime.trainable_identity().to_owned(),
+                tokenizer: runtime.trainable_tokenizer_identity().to_owned(),
+                frozen: Some(runtime.frozen_identity().to_owned()),
                 verifier: None,
             })
         }
@@ -3293,61 +4075,75 @@ fn validate_and_capture_adapter_identities(
                 kl_coefficient,
                 ..
             },
-            PostTrainingPhaseAdapters::Grpo {
-                policy,
-                reference,
-                verifier,
-            },
+            PostTrainingPhaseRuntime::Grpo { runtime, verifier },
         ) => {
-            match (reference_spec.as_ref(), reference.as_deref()) {
-                (Some(spec), Some(provider)) => validate_frozen_provider(
+            ensure!(
+                runtime.frozen_identity().is_some()
+                    == runtime.frozen_tokenizer_identity().is_some(),
+                "GRPO device runtime has a partial frozen-reference identity"
+            );
+            match (reference_spec.as_ref(), runtime.frozen_identity()) {
+                (Some(spec), Some(identity)) => validate_frozen_runtime(
                     spec,
-                    provider.identity(),
-                    provider.tokenizer_identity(),
-                    policy.tokenizer_identity(),
+                    identity,
+                    runtime
+                        .frozen_tokenizer_identity()
+                        .expect("checked frozen tokenizer present"),
+                    runtime.trainable_tokenizer_identity(),
                 )?,
-                (Some(_), None) => bail!("GRPO phase requires its frozen reference adapter"),
-                (None, Some(_)) => bail!("GRPO phase supplied an unconfigured reference adapter"),
+                (Some(_), None) => bail!("GRPO phase requires its frozen reference runtime"),
+                (None, Some(_)) => bail!("GRPO phase supplied an unconfigured reference runtime"),
                 (None, None) => ensure!(
                     *kl_coefficient == 0.0,
                     "GRPO without a reference requires zero KL coefficient"
                 ),
             }
-            validate_adapter_identity(policy.identity(), "trainable GRPO policy")?;
-            validate_adapter_identity(verifier.adapter_name(), "GRPO verifier")?;
-            Ok(PostTrainingAdapterIdentities {
-                trainable: policy.identity().to_owned(),
-                tokenizer: policy.tokenizer_identity().to_owned(),
-                frozen: reference
-                    .as_deref()
-                    .map(|provider| provider.identity().to_owned()),
-                verifier: Some(verifier.adapter_name().to_owned()),
+            validate_runtime_identity(runtime.trainable_identity(), "trainable GRPO policy")?;
+            validate_runtime_identity(runtime.trainable_tokenizer_identity(), "GRPO tokenizer")?;
+            validate_sha256_identity(verifier.identity(), "GRPO verifier implementation")?;
+            let TaskConfig::VerifiableRl {
+                verifier: verifier_spec,
+            } = phase.task.as_ref().expect("validated post-training task")
+            else {
+                bail!("GRPO phase requires a verifiable-RL task");
+            };
+            ensure!(
+                verifier.adapter_name() == verifier_spec.adapter,
+                "verifier adapter mismatch: task requires `{}`, executor supplied `{}`",
+                verifier_spec.adapter,
+                verifier.adapter_name()
+            );
+            Ok(PostTrainingRuntimeIdentities {
+                trainable: runtime.trainable_identity().to_owned(),
+                tokenizer: runtime.trainable_tokenizer_identity().to_owned(),
+                frozen: runtime.frozen_identity().map(str::to_owned),
+                verifier: Some(verifier.identity().to_owned()),
             })
         }
-        _ => bail!("post-training algorithm and adapter set do not match"),
+        _ => bail!("post-training algorithm and device runtime do not match"),
     }
 }
 
 fn optimizer_step(
-    adapters: &mut PostTrainingPhaseAdapters<'_>,
+    runtime: &mut PostTrainingPhaseRuntime<'_>,
     learning_rate_scale: f64,
 ) -> Result<()> {
-    match adapters {
-        PostTrainingPhaseAdapters::Dpo { policy, .. } => policy.optimizer_step(learning_rate_scale),
-        PostTrainingPhaseAdapters::ForwardKl { policy, .. } => {
-            policy.optimizer_step(learning_rate_scale)
+    match runtime {
+        PostTrainingPhaseRuntime::Dpo { runtime } => runtime.optimizer_step(learning_rate_scale),
+        PostTrainingPhaseRuntime::ForwardKl { runtime } => {
+            runtime.optimizer_step(learning_rate_scale)
         }
-        PostTrainingPhaseAdapters::Grpo { policy, .. } => {
-            policy.optimizer_step(learning_rate_scale)
+        PostTrainingPhaseRuntime::Grpo { runtime, .. } => {
+            runtime.optimizer_step(learning_rate_scale)
         }
     }
 }
 
-fn adapter_model_tokens_processed(adapters: &PostTrainingPhaseAdapters<'_>) -> u64 {
-    match adapters {
-        PostTrainingPhaseAdapters::Dpo { policy, .. } => policy.model_tokens_processed(),
-        PostTrainingPhaseAdapters::ForwardKl { policy, .. } => policy.model_tokens_processed(),
-        PostTrainingPhaseAdapters::Grpo { policy, .. } => policy.model_tokens_processed(),
+fn runtime_model_tokens_processed(runtime: &PostTrainingPhaseRuntime<'_>) -> u64 {
+    match runtime {
+        PostTrainingPhaseRuntime::Dpo { runtime } => runtime.model_tokens_processed(),
+        PostTrainingPhaseRuntime::ForwardKl { runtime } => runtime.model_tokens_processed(),
+        PostTrainingPhaseRuntime::Grpo { runtime, .. } => runtime.model_tokens_processed(),
     }
 }
 
@@ -3357,7 +4153,7 @@ fn exact_model_token_delta(start: u64, end: u64) -> Result<u64> {
         .context("trainable-policy model-token counter regressed during an update")?;
     ensure!(
         delta > 0,
-        "trainable-policy adapter reported zero model tokens for a non-empty update"
+        "trainable device runtime reported zero model tokens for a non-empty update"
     );
     Ok(delta)
 }
@@ -3365,22 +4161,40 @@ fn exact_model_token_delta(start: u64, end: u64) -> Result<u64> {
 fn accumulate_resumable_update(
     phase: &PhaseV2,
     examples: &[TaskExample],
-    adapters: &mut PostTrainingPhaseAdapters<'_>,
+    batch_sha256: &str,
+    base_state: &PostTrainingCommittedState,
+    runtime: &mut PostTrainingPhaseRuntime<'_>,
     rng_seed: u64,
     rng_start: u64,
 ) -> Result<PreparedComputation> {
-    let model_tokens_start = adapter_model_tokens_processed(adapters);
+    ensure!(
+        !examples.is_empty() && examples.len() <= MAX_POST_TRAINING_UPDATE_EXAMPLES,
+        "post-training prepared update example geometry is invalid"
+    );
+    let model_tokens_start = runtime_model_tokens_processed(runtime);
     let sequence_length = phase.sequence_length.expect("validated sequence length");
+    ensure!(
+        sequence_length <= MAX_POST_TRAINING_SEQUENCE_TOKENS,
+        "post-training sequence length exceeds the native limit"
+    );
+    validate_sha256_identity(batch_sha256, "post-training batch")?;
+    base_state.validate()?;
+    let base = DeviceBatchBaseGeneration {
+        model_sha256: base_state.model.sha256(),
+        optimizer_sha256: base_state.optimizer.as_ref().map(ImmutableArtifact::sha256),
+    };
+    base.validate()?;
     let loss_weight = phase.loss_weight_or_default();
-    let batch_scale = loss_weight / examples.len() as f64;
+    ensure!(
+        loss_weight.is_finite() && loss_weight > 0.0,
+        "post-training loss weight must be finite and positive"
+    );
+    let example_count = u64::try_from(examples.len()).context("batch size exceeds u64")?;
     let config = phase
         .post_training
         .as_ref()
         .expect("validated post-training config");
-    let mut trace = Sha256::new();
-    trace_serialized(&mut trace, &phase.name)?;
-    trace_serialized(&mut trace, examples)?;
-    match (config, adapters) {
+    match (config, runtime) {
         (
             PostTrainingConfig::Dpo {
                 beta,
@@ -3388,97 +4202,68 @@ fn accumulate_resumable_update(
                 sequence_reduction,
                 ..
             },
-            PostTrainingPhaseAdapters::Dpo { policy, reference },
+            PostTrainingPhaseRuntime::Dpo { runtime },
         ) => {
-            let mut loss_sum = 0.0;
-            let mut preference_correct = 0_u64;
-            let mut implicit_reward_margin_sum = 0.0;
             for example in examples {
-                let TaskExample::PairwisePreference {
-                    prompt,
-                    chosen,
-                    rejected,
-                } = example
-                else {
+                if !matches!(example, TaskExample::PairwisePreference { .. }) {
                     bail!("DPO executor received a non-pairwise task example");
-                };
-                let policy_chosen =
-                    policy.continuation_log_probs(prompt, chosen, sequence_length)?;
-                let policy_rejected =
-                    policy.continuation_log_probs(prompt, rejected, sequence_length)?;
-                let reference_chosen =
-                    reference.continuation_log_probs(prompt, chosen, sequence_length)?;
-                let reference_rejected =
-                    reference.continuation_log_probs(prompt, rejected, sequence_length)?;
-                let objective = dpo_loss(
-                    PairwiseLogProbabilities {
-                        policy_chosen: reduce_sequence_log_probs(
-                            &policy_chosen,
-                            *sequence_reduction,
-                        )?,
-                        policy_rejected: reduce_sequence_log_probs(
-                            &policy_rejected,
-                            *sequence_reduction,
-                        )?,
-                        reference_chosen: reduce_sequence_log_probs(
-                            &reference_chosen,
-                            *sequence_reduction,
-                        )?,
-                        reference_rejected: reduce_sequence_log_probs(
-                            &reference_rejected,
-                            *sequence_reduction,
-                        )?,
-                    },
-                    *beta,
-                    *label_smoothing,
-                )?;
-                let chosen_gradients = distribute_sequence_gradient(
-                    objective.d_policy_chosen * batch_scale,
-                    policy_chosen.len(),
-                    *sequence_reduction,
-                );
-                let rejected_gradients = distribute_sequence_gradient(
-                    objective.d_policy_rejected * batch_scale,
-                    policy_rejected.len(),
-                    *sequence_reduction,
-                );
-                trace_serialized(
-                    &mut trace,
-                    &(
-                        &policy_chosen,
-                        &policy_rejected,
-                        &reference_chosen,
-                        &reference_rejected,
-                        objective.loss,
-                        &chosen_gradients,
-                        &rejected_gradients,
-                    ),
-                )?;
-                policy.backward_pairwise_log_probs(
-                    example,
-                    &chosen_gradients,
-                    &rejected_gradients,
-                )?;
-                loss_sum += objective.loss;
-                preference_correct += u64::from(objective.preference_correct);
-                implicit_reward_margin_sum += objective.implicit_reward_margin;
+                }
             }
+            let rng = ModelExecutionRngRange::reserve(
+                rng_seed,
+                rng_start,
+                example_count
+                    .checked_mul(2)
+                    .context("DPO model RNG range overflows u64")?,
+            )?;
+            let result = runtime.prepare_device_batch(DpoDeviceBatchRequest {
+                examples,
+                batch_sha256,
+                base,
+                max_sequence_tokens: sequence_length,
+                beta: *beta,
+                label_smoothing: *label_smoothing,
+                sequence_reduction: *sequence_reduction,
+                loss_weight,
+                rng,
+            })?;
+            result.receipt.validate()?;
+            ensure!(
+                result.examples == example_count,
+                "DPO device runtime returned a partial batch summary"
+            );
             let model_tokens =
-                exact_model_token_delta(model_tokens_start, policy.model_tokens_processed())?;
+                exact_model_token_delta(model_tokens_start, runtime.model_tokens_processed())?;
+            ensure!(
+                result.receipt.model_tokens == model_tokens,
+                "DPO device receipt disagrees with the runtime model-token counter"
+            );
+            let execution_sha256 = canonical_sha256(&(
+                "dpo_device_batch_v1",
+                batch_sha256,
+                base,
+                sequence_length,
+                beta,
+                label_smoothing,
+                sequence_reduction,
+                loss_weight,
+                rng,
+                &result,
+            ))?;
             let summary = PostTrainingUpdateSummary {
-                examples: u64::try_from(examples.len()).context("batch size exceeds u64")?,
+                examples: example_count,
                 model_tokens,
-                loss_sum,
-                execution_sha256: format!("sha256:{:x}", trace.finalize()),
+                loss_sum: result.loss_sum,
+                execution_sha256,
                 objective: PostTrainingObjectiveSummary::Dpo {
-                    preference_correct,
-                    implicit_reward_margin_sum,
+                    preference_correct: result.preference_correct,
+                    implicit_reward_margin_sum: result.implicit_reward_margin_sum,
                 },
             };
             summary.validate()?;
             Ok(PreparedComputation {
                 summary,
-                rng_end: rng_start,
+                rng_end: rng.end,
             })
         }
         (
@@ -3487,63 +4272,64 @@ fn accumulate_resumable_update(
                 scale_by_temperature_squared,
                 ..
             },
-            PostTrainingPhaseAdapters::ForwardKl { policy, teacher },
+            PostTrainingPhaseRuntime::ForwardKl { runtime },
         ) => {
-            let mut loss_sum = 0.0;
-            let mut forward_kl_sum = 0.0;
-            let mut teacher_entropy_sum = 0.0;
-            let mut top1_agreement_sum = 0.0;
             for example in examples {
-                let teacher_logits = teacher.token_logits(example, sequence_length)?;
-                let student_logits = policy.student_token_logits(example, sequence_length)?;
-                ensure!(
-                    teacher_logits.len() == student_logits.len(),
-                    "teacher/student target-token row counts differ"
-                );
-                let tokens: Vec<_> = teacher_logits
-                    .iter()
-                    .zip(&student_logits)
-                    .map(|(teacher_logits, student_logits)| DistillationToken {
-                        teacher_logits,
-                        student_logits,
-                        weight: 1.0,
-                    })
-                    .collect();
-                let objective =
-                    forward_kl_distillation(&tokens, *temperature, *scale_by_temperature_squared)?;
-                let mut gradients = objective.student_gradients;
-                for row in &mut gradients {
-                    for value in row {
-                        *value *= batch_scale;
-                    }
+                if !matches!(
+                    example,
+                    TaskExample::Autoregressive { .. } | TaskExample::SupervisedGeneration { .. }
+                ) {
+                    bail!("forward-KL executor received an incompatible task example");
                 }
-                trace_serialized(
-                    &mut trace,
-                    &(&teacher_logits, &student_logits, objective.loss, &gradients),
-                )?;
-                policy.backward_student_logits(example, &gradients)?;
-                loss_sum += objective.loss;
-                forward_kl_sum += objective.mean_forward_kl;
-                teacher_entropy_sum += objective.teacher_entropy;
-                top1_agreement_sum += objective.top1_agreement;
             }
+            let rng = ModelExecutionRngRange::reserve(rng_seed, rng_start, example_count)?;
+            let result = runtime.prepare_device_batch(ForwardKlDeviceBatchRequest {
+                examples,
+                batch_sha256,
+                base,
+                max_sequence_tokens: sequence_length,
+                temperature: *temperature,
+                scale_by_temperature_squared: *scale_by_temperature_squared,
+                loss_weight,
+                rng,
+            })?;
+            result.receipt.validate()?;
+            ensure!(
+                result.examples == example_count,
+                "forward-KL device runtime returned a partial batch summary"
+            );
             let model_tokens =
-                exact_model_token_delta(model_tokens_start, policy.model_tokens_processed())?;
+                exact_model_token_delta(model_tokens_start, runtime.model_tokens_processed())?;
+            ensure!(
+                result.receipt.model_tokens == model_tokens,
+                "forward-KL device receipt disagrees with the runtime model-token counter"
+            );
+            let execution_sha256 = canonical_sha256(&(
+                "forward_kl_device_batch_v1",
+                batch_sha256,
+                base,
+                sequence_length,
+                temperature,
+                scale_by_temperature_squared,
+                loss_weight,
+                rng,
+                &result,
+            ))?;
             let summary = PostTrainingUpdateSummary {
-                examples: u64::try_from(examples.len()).context("batch size exceeds u64")?,
+                examples: example_count,
                 model_tokens,
-                loss_sum,
-                execution_sha256: format!("sha256:{:x}", trace.finalize()),
+                loss_sum: result.loss_sum,
+                execution_sha256,
                 objective: PostTrainingObjectiveSummary::ForwardKl {
-                    forward_kl_sum,
-                    teacher_entropy_sum,
-                    top1_agreement_sum,
+                    forward_kl_sum: result.forward_kl_sum,
+                    teacher_entropy_sum: result.teacher_entropy_sum,
+                    top1_agreement_sum: result.top1_agreement_sum,
                 },
             };
             summary.validate()?;
             Ok(PreparedComputation {
                 summary,
-                rng_end: rng_start,
+                rng_end: rng.end,
             })
         }
         (
@@ -3555,133 +4341,138 @@ fn accumulate_resumable_update(
                 sampling,
                 ..
             },
-            PostTrainingPhaseAdapters::Grpo {
-                policy,
-                reference,
-                verifier,
-            },
+            PostTrainingPhaseRuntime::Grpo { runtime, verifier },
         ) => {
             let task = phase.task.as_ref().expect("validated task");
-            let mut loss_sum = 0.0;
-            let mut mean_reward_sum = 0.0;
-            let mut reward_stddev_sum = 0.0;
-            let mut mean_kl_sum = 0.0;
-            let mut clipped_fraction_sum = 0.0;
-            let mut rng_counter = rng_start;
             for example in examples {
-                let TaskExample::VerifiableRollout { prompt, .. } = example else {
+                if !matches!(example, TaskExample::VerifiableRollout { .. }) {
                     bail!("GRPO executor received a non-verifiable task example");
-                };
-                let generated = policy.generate(RolloutRequest {
-                    prompt,
-                    count: *group_size,
-                    max_sequence_tokens: sequence_length,
-                    sampling,
-                    rng_seed,
-                    rng_counter,
-                })?;
-                rng_counter = rng_counter
-                    .checked_add(u64::try_from(*group_size).context("GRPO group exceeds u64")?)
-                    .context("GRPO RNG counter overflows u64")?;
+                }
+            }
+            let group_count = u64::try_from(*group_size).context("GRPO group exceeds u64")?;
+            let rollouts = example_count
+                .checked_mul(group_count)
+                .context("GRPO rollout count overflows u64")?;
+            let generation_rng = ModelExecutionRngRange::reserve(rng_seed, rng_start, rollouts)?;
+            let scoring_rng =
+                ModelExecutionRngRange::reserve(rng_seed, generation_rng.end, rollouts)?;
+            let generated = runtime.generate_device_batch(GrpoGenerationBatchRequest {
+                examples,
+                batch_sha256,
+                base,
+                group_size: *group_size,
+                max_sequence_tokens: sequence_length,
+                sampling,
+                rng: generation_rng,
+            })?;
+            validate_sha256_identity(&generated.generation_sha256, "GRPO device generation")?;
+            ensure!(
+                generated.groups.len() == examples.len(),
+                "GRPO device runtime returned {} prompt groups, expected {}",
+                generated.groups.len(),
+                examples.len()
+            );
+            let mut rewards = Vec::with_capacity(examples.len());
+            let mut rollout_tokens = 0usize;
+            let mut rollout_text_bytes = 0usize;
+            for (example_index, (example, group)) in
+                examples.iter().zip(&generated.groups).enumerate()
+            {
                 ensure!(
-                    generated.len() == *group_size,
-                    "rollout generator returned {} candidates, expected {group_size}",
-                    generated.len()
+                    group.len() == *group_size,
+                    "GRPO device runtime returned {} rollouts for prompt {example_index}, expected {group_size}",
+                    group.len()
                 );
-                let mut rewards = Vec::with_capacity(*group_size);
-                let mut current_scores = Vec::with_capacity(*group_size);
-                let mut reference_scores = Vec::with_capacity(*group_size);
-                for (index, rollout) in generated.iter().enumerate() {
+                let mut group_rewards = Vec::with_capacity(*group_size);
+                for (rollout_index, rollout) in group.iter().enumerate() {
                     ensure!(
                         !rollout.text.trim().is_empty(),
-                        "rollout {index} completion is empty"
+                        "rollout {example_index}:{rollout_index} completion is empty"
                     );
                     ensure!(
-                        !rollout.token_ids.is_empty()
-                            && rollout.token_ids.len() == rollout.behavior_token_log_probs.len(),
-                        "rollout {index} token ids and behavior log-probs are not aligned"
+                        rollout.token_count > 0
+                            && rollout.token_count <= sampling.max_new_tokens
+                            && rollout.token_count <= sequence_length,
+                        "rollout {example_index}:{rollout_index} exceeds its configured token limit"
                     );
-                    ensure_finite(
-                        &rollout.behavior_token_log_probs,
-                        "rollout behavior log probabilities",
-                    )?;
-                    rewards.push(verify_rollout(task, example, *verifier, &rollout.text)?.reward);
-                    current_scores.push(policy.current_token_log_probs(
-                        prompt,
-                        rollout,
-                        sequence_length,
-                    )?);
-                    reference_scores.push(match reference.as_deref_mut() {
-                        Some(reference) => Some(reference.rollout_token_log_probs(
-                            prompt,
-                            rollout,
-                            sequence_length,
-                        )?),
-                        None => None,
-                    });
+                    rollout_tokens = rollout_tokens
+                        .checked_add(rollout.token_count)
+                        .context("GRPO rollout token count overflows usize")?;
+                    ensure!(
+                        rollout_tokens <= MAX_POST_TRAINING_ROLLOUT_TOKENS,
+                        "GRPO rollout group exceeds the native token limit"
+                    );
+                    rollout_text_bytes = rollout_text_bytes
+                        .checked_add(rollout.text.len())
+                        .context("GRPO rollout text byte count overflows usize")?;
+                    ensure!(
+                        rollout_text_bytes <= MAX_POST_TRAINING_UPDATE_INPUT_BYTES,
+                        "GRPO rollout text exceeds the native byte limit"
+                    );
+                    group_rewards
+                        .push(verify_rollout(task, example, *verifier, &rollout.text)?.reward);
                 }
-                let scalar_rollouts: Vec<_> = generated
-                    .iter()
-                    .enumerate()
-                    .map(|(index, rollout)| GrpoRollout {
-                        reward: rewards[index],
-                        current_token_log_probs: &current_scores[index],
-                        behavior_token_log_probs: &rollout.behavior_token_log_probs,
-                        reference_token_log_probs: reference_scores[index].as_deref(),
-                    })
-                    .collect();
-                let objective = grpo_loss(
-                    &scalar_rollouts,
-                    *clip_epsilon,
-                    *advantage_epsilon,
-                    *kl_coefficient,
-                )?;
-                let scaled_gradients: Vec<Vec<f64>> = objective
-                    .current_log_prob_gradients
-                    .iter()
-                    .map(|row| row.iter().map(|value| value * batch_scale).collect())
-                    .collect();
-                trace_serialized(
-                    &mut trace,
-                    &(
-                        &generated,
-                        &rewards,
-                        &current_scores,
-                        &reference_scores,
-                        objective.loss,
-                        &scaled_gradients,
-                    ),
-                )?;
-                for (index, rollout) in generated.iter().enumerate() {
-                    policy.backward_rollout_log_probs(prompt, rollout, &scaled_gradients[index])?;
-                }
-                loss_sum += objective.loss;
-                mean_reward_sum += objective.mean_reward;
-                reward_stddev_sum += objective.reward_stddev;
-                mean_kl_sum += objective.mean_kl;
-                clipped_fraction_sum += objective.clipped_fraction;
+                rewards.push(group_rewards);
             }
+            let result = runtime.prepare_device_batch(GrpoDeviceBatchRequest {
+                examples,
+                batch_sha256,
+                base,
+                generation: &generated,
+                rewards: &rewards,
+                clip_epsilon: *clip_epsilon,
+                advantage_epsilon: *advantage_epsilon,
+                kl_coefficient: *kl_coefficient,
+                loss_weight,
+                rng: scoring_rng,
+            })?;
+            result.receipt.validate()?;
+            ensure!(
+                result.examples == example_count && result.rollouts == rollouts,
+                "GRPO device runtime returned a partial batch summary"
+            );
             let model_tokens =
-                exact_model_token_delta(model_tokens_start, policy.model_tokens_processed())?;
+                exact_model_token_delta(model_tokens_start, runtime.model_tokens_processed())?;
+            ensure!(
+                result.receipt.model_tokens == model_tokens,
+                "GRPO device receipt disagrees with the runtime model-token counter"
+            );
+            let verification_sha256 = canonical_sha256(&(&generated, &rewards))?;
+            let execution_sha256 = canonical_sha256(&(
+                "grpo_device_batch_v1",
+                batch_sha256,
+                base,
+                sequence_length,
+                group_size,
+                clip_epsilon,
+                advantage_epsilon,
+                kl_coefficient,
+                sampling,
+                loss_weight,
+                generation_rng,
+                scoring_rng,
+                verification_sha256,
+                &result,
+            ))?;
             let summary = PostTrainingUpdateSummary {
-                examples: u64::try_from(examples.len()).context("batch size exceeds u64")?,
+                examples: example_count,
                 model_tokens,
-                loss_sum,
-                execution_sha256: format!("sha256:{:x}", trace.finalize()),
+                loss_sum: result.loss_sum,
+                execution_sha256,
                 objective: PostTrainingObjectiveSummary::Grpo {
-                    mean_reward_sum,
-                    reward_stddev_sum,
-                    mean_kl_sum,
-                    clipped_fraction_sum,
+                    mean_reward_sum: result.mean_reward_sum,
+                    reward_stddev_sum: result.reward_stddev_sum,
+                    mean_kl_sum: result.mean_kl_sum,
+                    clipped_fraction_sum: result.clipped_fraction_sum,
                 },
             };
             summary.validate()?;
             Ok(PreparedComputation {
                 summary,
-                rng_end: rng_counter,
+                rng_end: scoring_rng.end,
             })
         }
-        _ => bail!("post-training algorithm and adapter set do not match"),
+        _ => bail!("post-training algorithm and device runtime do not match"),
     }
 }
 
@@ -3690,6 +4481,7 @@ fn validate_restore_receipt(
     publisher_identity: &str,
     state: &PostTrainingCommittedState,
 ) -> Result<()> {
+    state.validate()?;
     ensure!(
         receipt.publisher_identity == publisher_identity
             && receipt.model_sha256 == state.model.sha256()
@@ -3768,12 +4560,13 @@ fn metric_context(
     request: &PhaseExecutionRequest,
     cursor: &PostTrainingCursor,
 ) -> Result<MetricContext> {
-    let kind = match request.phase.kind {
-        PhaseKind::Preference => MetricPhaseKind::Preference,
-        PhaseKind::Distillation => MetricPhaseKind::Distillation,
-        PhaseKind::Rl => MetricPhaseKind::Rl,
-        _ => bail!("unsupported post-training metric phase"),
-    };
+    ensure!(
+        matches!(
+            request.phase.kind,
+            PhaseKind::Preference | PhaseKind::Distillation | PhaseKind::Rl
+        ),
+        "unsupported post-training metric phase"
+    );
     Ok(MetricContext {
         global_step: cursor
             .clock
@@ -3784,13 +4577,13 @@ fn metric_context(
         phase: MetricPhase {
             index: u32::try_from(request.phase_index).context("phase index exceeds u32")?,
             name: request.phase.name.clone(),
-            kind,
+            kind: request.phase.kind.into(),
         },
         checkpoint_hash: Some(cursor.committed.model.sha256().to_owned()),
     })
 }
 
-fn validate_adapter_identity(identity: &str, name: &str) -> Result<()> {
+fn validate_runtime_identity(identity: &str, name: &str) -> Result<()> {
     ensure!(
         !identity.trim().is_empty() && !identity.contains(['\n', '\r']),
         "{name} identity must be non-empty and single-line"
@@ -3798,34 +4591,51 @@ fn validate_adapter_identity(identity: &str, name: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_prefixed_sha256(value: &str, name: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .with_context(|| format!("{name} must use sha256:<64 lowercase hex>"))?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{name} must use sha256:<64 lowercase hex>"
-    );
-    Ok(())
+struct JsonDigestWriter {
+    digest: Sha256,
+    bytes: u64,
+}
+
+impl JsonDigestWriter {
+    fn new() -> Self {
+        Self {
+            digest: Sha256::new(),
+            bytes: 0,
+        }
+    }
+
+    fn finish(self) -> (u64, String) {
+        (self.bytes, format!("{:x}", self.digest.finalize()))
+    }
+}
+
+impl Write for JsonDigestWriter {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.bytes = self
+            .bytes
+            .checked_add(u64::try_from(buffer.len()).map_err(std::io::Error::other)?)
+            .ok_or_else(|| std::io::Error::other("serialized JSON length overflows u64"))?;
+        self.digest.update(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialized_json_digest<T: Serialize + ?Sized>(
+    value: &T,
+    context: &'static str,
+) -> Result<(u64, String)> {
+    let mut writer = JsonDigestWriter::new();
+    serde_json::to_writer(&mut writer, value).context(context)?;
+    Ok(writer.finish())
 }
 
 fn canonical_sha256(value: &impl Serialize) -> Result<String> {
-    let bytes = serde_json::to_vec(value).context("failed to serialize content-addressed value")?;
-    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
-}
-
-fn trace_serialized<T: Serialize + ?Sized>(hasher: &mut Sha256, value: &T) -> Result<()> {
-    let bytes = serde_json::to_vec(value).context("failed to serialize execution trace")?;
-    hasher.update(
-        u64::try_from(bytes.len())
-            .context("execution trace component exceeds u64")?
-            .to_le_bytes(),
-    );
-    hasher.update(bytes);
-    Ok(())
+    let (_, digest) = serialized_json_digest(value, "failed to serialize content-addressed value")?;
+    sha256_identity_from_hex(&digest, "serialized JSON digest")
 }
 
 fn deterministic_rng_seed(workflow: &str, phase: &str, checkpoint: &str) -> u64 {
@@ -3840,10 +4650,7 @@ fn deterministic_rng_seed(workflow: &str, phase: &str, checkpoint: &str) -> u64 
 }
 
 fn empty_receipt_chain() -> String {
-    format!(
-        "sha256:{:x}",
-        Sha256::digest(b"post_training_receipt_chain_v1")
-    )
+    sha256_identity(b"post_training_receipt_chain_v1")
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -3864,6 +4671,10 @@ pub struct Verification {
 /// Named, executor-injected reward implementation. The adapter name must
 /// exactly match the task's verifier spec before it can score a rollout.
 pub trait RewardVerifier {
+    /// Content identity of the verifier implementation. Task parameters are
+    /// already part of the phase hash; this identity prevents another binary
+    /// with the same adapter name from changing rewards after resume.
+    fn identity(&self) -> &str;
     fn adapter_name(&self) -> &str;
     fn verify(&self, spec: &VerifierSpec, request: VerificationRequest<'_>)
     -> Result<Verification>;
@@ -3897,7 +4708,7 @@ pub fn verify_rollout(
             task.name()
         );
     };
-    verifier.verify(
+    let verification = verifier.verify(
         &spec,
         VerificationRequest {
             prompt,
@@ -3905,7 +4716,19 @@ pub fn verify_rollout(
             verifier_payload,
             reference_answer: reference_answer.as_deref(),
         },
-    )
+    )?;
+    ensure!(
+        verification.reward.is_finite(),
+        "verifier returned a non-finite reward"
+    );
+    ensure!(
+        verification
+            .components
+            .iter()
+            .all(|(name, value)| !name.trim().is_empty() && value.is_finite()),
+        "verifier returned an empty component name or non-finite component value"
+    );
+    Ok(verification)
 }
 
 /// Built-in deterministic verifier for exact-answer curricula. Arbitrary test
@@ -3930,6 +4753,10 @@ impl Default for ExactAnswerParameters {
 }
 
 impl RewardVerifier for ExactAnswerVerifier {
+    fn identity(&self) -> &str {
+        "sha256:ff08a60a76f25d2e611dd1e1755fcfe137e92913fa1ee1b8e1d59552ecce928b"
+    }
+
     fn adapter_name(&self) -> &str {
         "exact_answer"
     }
@@ -3989,12 +4816,25 @@ pub fn visit_task_examples(
 pub fn visit_task_examples_while(
     path: &Path,
     task: &TaskConfig,
+    visit: impl FnMut(TaskExample) -> Result<bool>,
+) -> Result<usize> {
+    visit_task_examples_while_with_record_limit(path, task, MAX_POST_TRAINING_RECORD_BYTES, visit)
+}
+
+fn visit_task_examples_while_with_record_limit(
+    path: &Path,
+    task: &TaskConfig,
+    maximum_record_bytes: usize,
     mut visit: impl FnMut(TaskExample) -> Result<bool>,
 ) -> Result<usize> {
     task.validate()?;
+    ensure!(
+        maximum_record_bytes > 0,
+        "task record byte limit must be positive"
+    );
     let file =
         File::open(path).with_context(|| format!("failed to open task data {}", path.display()))?;
-    let reader: Box<dyn BufRead> = if path.extension().is_some_and(|ext| ext == "zst") {
+    let mut reader: Box<dyn BufRead> = if path.extension().is_some_and(|ext| ext == "zst") {
         Box::new(BufReader::new(
             zstd::stream::read::Decoder::new(file)
                 .with_context(|| format!("failed to open zstd task data {}", path.display()))?,
@@ -4010,10 +4850,23 @@ pub fn visit_task_examples_while(
     );
 
     let mut count = 0usize;
-    for (line_index, line) in reader.lines().enumerate() {
-        let line_number = line_index + 1;
-        let line = line.with_context(|| {
-            format!("failed to read task data {}:{line_number}", path.display())
+    let mut line_number = 0usize;
+    let mut line_bytes = Vec::new();
+    loop {
+        let next_line = line_number
+            .checked_add(1)
+            .context("task-data line counter overflows usize")?;
+        let read =
+            read_post_training_record_bounded(&mut *reader, &mut line_bytes, maximum_record_bytes)
+                .with_context(|| {
+                    format!("failed to read task data {}:{next_line}", path.display())
+                })?;
+        if read == 0 {
+            break;
+        }
+        line_number = next_line;
+        let line = String::from_utf8(std::mem::take(&mut line_bytes)).with_context(|| {
+            format!("task data is not UTF-8 at {}:{line_number}", path.display())
         })?;
         if line.trim().is_empty() {
             continue;
@@ -4052,22 +4905,6 @@ fn is_jsonl_path(path: &Path) -> bool {
         .and_then(|name| name.to_str())
         .unwrap_or_default();
     name.ends_with(".jsonl") || name.ends_with(".jsonl.zst")
-}
-
-fn normalize_sha256(value: &str) -> String {
-    value
-        .strip_prefix("sha256:")
-        .unwrap_or(value)
-        .to_ascii_lowercase()
-}
-
-fn validate_sha256(value: &str) -> Result<()> {
-    let value = normalize_sha256(value);
-    ensure!(
-        value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()),
-        "sha256 must contain exactly 64 hexadecimal digits"
-    );
-    Ok(())
 }
 
 fn ensure_finite(values: &[f64], name: &str) -> Result<()> {
@@ -4139,6 +4976,42 @@ mod tests {
         assert!(
             (actual - expected).abs() < 1e-12,
             "expected {expected:.16}, got {actual:.16}"
+        );
+    }
+
+    #[test]
+    fn post_training_record_reader_enforces_a_hard_allocation_bound() {
+        let mut accepted = std::io::Cursor::new(b"12345\nrest".to_vec());
+        let mut output = Vec::new();
+        assert_eq!(
+            read_post_training_record_bounded(&mut accepted, &mut output, 5).unwrap(),
+            6
+        );
+        assert_eq!(output, b"12345\n");
+
+        let mut oversized = std::io::Cursor::new(b"123456\n".to_vec());
+        let error = read_post_training_record_bounded(&mut oversized, &mut output, 5)
+            .expect_err("delimiter beyond the byte limit must be rejected");
+        assert!(error.to_string().contains("maximum of 5 bytes"));
+
+        let mut empty = std::io::Cursor::new(Vec::<u8>::new());
+        assert!(read_post_training_record_bounded(&mut empty, &mut output, 0).is_err());
+    }
+
+    #[test]
+    fn streaming_json_digest_matches_canonical_json_bytes() {
+        let value = json!({
+            "algorithm": "forward_kl",
+            "rows": [[1.0, 2.0], [3.0, 4.0]],
+            "enabled": true
+        });
+        let encoded = serde_json::to_vec(&value).unwrap();
+        let (bytes, digest) = serialized_json_digest(&value, "test serialization").unwrap();
+        assert_eq!(bytes, u64::try_from(encoded.len()).unwrap());
+        assert_eq!(digest, format!("{:x}", Sha256::digest(&encoded)));
+        assert_eq!(
+            canonical_sha256(&value).unwrap(),
+            format!("sha256:{digest}")
         );
     }
 
@@ -4581,6 +5454,10 @@ mod tests {
     fn verifier_adapter_mismatch_is_not_coerced() {
         struct WrongVerifier;
         impl RewardVerifier for WrongVerifier {
+            fn identity(&self) -> &str {
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+            }
+
             fn adapter_name(&self) -> &str {
                 "unit_tests"
             }
@@ -4610,6 +5487,126 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("adapter mismatch"), "{error}");
+    }
+
+    #[test]
+    fn grpo_verifier_mismatch_rejects_before_generating_rollouts() {
+        struct WrongVerifier;
+
+        impl RewardVerifier for WrongVerifier {
+            fn identity(&self) -> &str {
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+            }
+
+            fn adapter_name(&self) -> &str {
+                "wrong_verifier"
+            }
+
+            fn verify(
+                &self,
+                _spec: &VerifierSpec,
+                _request: VerificationRequest<'_>,
+            ) -> Result<Verification> {
+                unreachable!("verifier mismatch must reject during adapter preflight")
+            }
+        }
+
+        let (_dir, request) = test_request(TestPostTrainingAlgorithm::Grpo);
+        let mut publisher = TestUpdatePublisher::new(false);
+        let mut policy = TestGrpoRuntime::new();
+        let mut adapters = PostTrainingPhaseRuntime::Grpo {
+            runtime: &mut policy,
+            verifier: &WrongVerifier,
+        };
+        let error = drive_resumable_post_training_phase(
+            &test_sha("wrong-verifier-preflight"),
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut None,
+            None,
+            None,
+            usize::MAX,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("verifier adapter mismatch"), "{error}");
+        assert_eq!(policy.model_tokens, 0);
+        assert_eq!(publisher.restore_calls, 0);
+    }
+
+    #[test]
+    fn grpo_rejects_non_finite_verifier_reward_before_numeric_batch() {
+        struct NonFiniteVerifier;
+
+        impl RewardVerifier for NonFiniteVerifier {
+            fn identity(&self) -> &str {
+                "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+            }
+
+            fn adapter_name(&self) -> &str {
+                "exact_answer"
+            }
+
+            fn verify(
+                &self,
+                _spec: &VerifierSpec,
+                _request: VerificationRequest<'_>,
+            ) -> Result<Verification> {
+                Ok(Verification {
+                    reward: f64::NAN,
+                    passed: false,
+                    components: BTreeMap::new(),
+                })
+            }
+        }
+
+        let (_dir, mut request) = test_request(TestPostTrainingAlgorithm::Grpo);
+        request.phase.steps = Some(1);
+        let mut publisher = TestUpdatePublisher::new(false);
+        let mut runtime = TestGrpoRuntime::new();
+        let mut phase_runtime = PostTrainingPhaseRuntime::Grpo {
+            runtime: &mut runtime,
+            verifier: &NonFiniteVerifier,
+        };
+        let error = drive_resumable_post_training_phase(
+            &test_sha("non-finite-verifier-reward"),
+            &request,
+            &mut phase_runtime,
+            &mut publisher,
+            &mut None,
+            None,
+            None,
+            usize::MAX,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("non-finite reward"), "{error}");
+        assert_eq!(runtime.generation_calls, 1);
+        assert_eq!(runtime.prepare_calls, 0);
+        assert_eq!(runtime.optimizer_steps, 0);
+        assert_eq!(publisher.apply_calls, 0);
+    }
+
+    #[test]
+    fn deserialized_post_training_state_revalidates_artifact_identities() {
+        let empty_uri: PostTrainingCommittedState = serde_json::from_value(json!({
+            "model": {"uri": "", "sha256": test_sha("model")}
+        }))
+        .unwrap();
+        let error = empty_uri.validate().unwrap_err().to_string();
+        assert!(error.contains("checkpoint URI is empty"), "{error}");
+
+        let malformed_optimizer: PostTrainingCommittedState = serde_json::from_value(json!({
+            "model": {"uri": "test://model", "sha256": test_sha("model")},
+            "optimizer": {"uri": "test://optimizer", "sha256": "not-a-digest"}
+        }))
+        .unwrap();
+        let error = malformed_optimizer.validate().unwrap_err().to_string();
+        assert!(error.contains("artifact digest"), "{error}");
     }
 
     #[test]
@@ -4646,52 +5643,385 @@ mod tests {
         assert!(error.contains("invalid JSON"), "{error}");
     }
 
-    const ABC_SHA256: &str = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    #[test]
+    fn task_example_reader_rejects_oversized_plain_record_before_visiting() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("oversized.txt");
+        fs::write(&path, format!("{}\n", "x".repeat(65))).unwrap();
+        let task: TaskConfig = serde_json::from_value(json!({"type": "causal_lm"})).unwrap();
+        let mut visits = 0usize;
+        let error = visit_task_examples_while_with_record_limit(&path, &task, 64, |_| {
+            visits += 1;
+            Ok(true)
+        })
+        .unwrap_err();
+        let error = format!("{error:#}");
 
-    struct TestSequencePolicy {
-        identity: String,
-        backward_calls: usize,
-        optimizer_steps: usize,
-        model_tokens: u64,
+        assert!(error.contains("maximum of 64 bytes"), "{error}");
+        assert_eq!(visits, 0);
     }
 
-    impl SequenceLogProbabilityProvider for TestSequencePolicy {
-        fn identity(&self) -> &str {
+    #[test]
+    fn task_example_reader_rejects_oversized_zstd_record_before_visiting() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("oversized.txt.zst");
+        let payload = format!("{}\n", "x".repeat(65));
+        let compressed = zstd::stream::encode_all(payload.as_bytes(), 0).unwrap();
+        fs::write(&path, compressed).unwrap();
+        let task: TaskConfig = serde_json::from_value(json!({"type": "causal_lm"})).unwrap();
+        let mut visits = 0usize;
+        let error = visit_task_examples_while_with_record_limit(&path, &task, 64, |_| {
+            visits += 1;
+            Ok(true)
+        })
+        .unwrap_err();
+        let error = format!("{error:#}");
+
+        assert!(error.contains("maximum of 64 bytes"), "{error}");
+        assert_eq!(visits, 0);
+    }
+
+    #[test]
+    fn task_example_reader_early_stop_does_not_read_later_oversized_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("early-stop.txt");
+        fs::write(&path, format!("first\n{}\n", "x".repeat(65))).unwrap();
+        let task: TaskConfig = serde_json::from_value(json!({"type": "causal_lm"})).unwrap();
+        let mut visits = 0usize;
+        let count = visit_task_examples_while_with_record_limit(&path, &task, 64, |_| {
+            visits += 1;
+            Ok(false)
+        })
+        .unwrap();
+
+        assert_eq!(count, 1);
+        assert_eq!(visits, 1);
+    }
+
+    #[test]
+    fn authenticated_post_training_batches_stream_sequentially_across_epochs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("preference.jsonl");
+        let rows = ["p0", "p1", "p2"]
+            .into_iter()
+            .map(|prompt| json!({"prompt": prompt, "chosen": "yes", "rejected": "no"}))
+            .map(|row| serde_json::to_string(&row).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        fs::write(&path, rows).unwrap();
+        let task: TaskConfig =
+            serde_json::from_value(json!({"type": "pairwise_preference"})).unwrap();
+        let source = AuthenticatedPostTrainingInput::open(&path).unwrap();
+        let mut stream = PostTrainingBatchStream::new(
+            source,
+            task,
+            PostTrainingRecordPosition {
+                epoch: 0,
+                record: 0,
+            },
+            2,
+        )
+        .unwrap();
+
+        let error = stream
+            .next_batch(MAX_POST_TRAINING_UPDATE_EXAMPLES + 1)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("target batch exceeds"), "{error}");
+
+        let first = stream.next_batch(2).unwrap();
+        assert_eq!(first.end.epoch, 0);
+        assert_eq!(first.end.record, 2);
+        assert!(matches!(
+            &first.examples[..],
+            [
+                TaskExample::PairwisePreference { prompt: first, .. },
+                TaskExample::PairwisePreference { prompt: second, .. }
+            ] if first == "p0" && second == "p1"
+        ));
+
+        let second = stream.next_batch(2).unwrap();
+        assert_eq!(second.end.epoch, 1);
+        assert_eq!(second.end.record, 1);
+        assert!(matches!(
+            &second.examples[..],
+            [
+                TaskExample::PairwisePreference { prompt: first, .. },
+                TaskExample::PairwisePreference { prompt: second, .. }
+            ] if first == "p2" && second == "p0"
+        ));
+
+        let final_batch = stream.next_batch(2).unwrap();
+        assert_eq!(final_batch.end.epoch, 2);
+        assert_eq!(final_batch.end.record, 0);
+        assert!(matches!(
+            &final_batch.examples[..],
+            [
+                TaskExample::PairwisePreference { prompt: first, .. },
+                TaskExample::PairwisePreference { prompt: second, .. }
+            ] if first == "p1" && second == "p2"
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authenticated_post_training_stream_rejects_path_replacement_before_consumption() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("preference.jsonl");
+        let replacement = dir.path().join("replacement.jsonl");
+        fs::write(
+            &path,
+            serde_json::to_string(
+                &json!({"prompt": "original", "chosen": "yes", "rejected": "no"}),
+            )
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+        fs::write(
+            &replacement,
+            serde_json::to_string(
+                &json!({"prompt": "replaced", "chosen": "yes", "rejected": "no"}),
+            )
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+        let task: TaskConfig =
+            serde_json::from_value(json!({"type": "pairwise_preference"})).unwrap();
+        let source = AuthenticatedPostTrainingInput::open(&path).unwrap();
+        let mut stream = PostTrainingBatchStream::new(
+            source,
+            task,
+            PostTrainingRecordPosition {
+                epoch: 0,
+                record: 0,
+            },
+            1,
+        )
+        .unwrap();
+
+        fs::rename(&replacement, &path).unwrap();
+        let error = stream.next_batch(1).unwrap_err().to_string();
+        assert!(
+            error.contains("changed after it was authenticated"),
+            "{error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authenticated_post_training_stream_rejects_same_inode_mutation() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("preference.jsonl");
+        let original = serde_json::to_string(
+            &json!({"prompt": "original", "chosen": "yes", "rejected": "no"}),
+        )
+        .unwrap()
+            + "\n";
+        let modified = serde_json::to_string(
+            &json!({"prompt": "modified", "chosen": "yes", "rejected": "no"}),
+        )
+        .unwrap()
+            + "\n";
+        assert_eq!(original.len(), modified.len());
+        fs::write(&path, original).unwrap();
+        let inode = fs::metadata(&path).unwrap().ino();
+        let task: TaskConfig =
+            serde_json::from_value(json!({"type": "pairwise_preference"})).unwrap();
+        let source = AuthenticatedPostTrainingInput::open(&path).unwrap();
+        let mut stream = PostTrainingBatchStream::new(
+            source,
+            task,
+            PostTrainingRecordPosition {
+                epoch: 0,
+                record: 0,
+            },
+            1,
+        )
+        .unwrap();
+
+        fs::write(&path, modified).unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().ino(), inode);
+        let error = stream.next_batch(1).unwrap_err().to_string();
+        assert!(
+            error.contains("changed after it was authenticated"),
+            "{error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authenticated_post_training_input_rejects_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.jsonl");
+        let link = dir.path().join("input.jsonl");
+        fs::write(
+            &target,
+            "{\"prompt\":\"p\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n",
+        )
+        .unwrap();
+        symlink(&target, &link).unwrap();
+
+        let error = match AuthenticatedPostTrainingInput::open(&link) {
+            Ok(_) => panic!("symlinked post-training input unexpectedly authenticated"),
+            Err(error) => error.to_string(),
+        };
+        assert!(error.contains("non-symlink regular file"), "{error}");
+    }
+
+    const ABC_SHA256: &str =
+        "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    fn test_device_receipt(content: &impl Serialize, model_tokens: u64) -> DeviceExecutionReceipt {
+        DeviceExecutionReceipt {
+            execution_sha256: canonical_sha256(content).unwrap(),
+            model_tokens,
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum TestDpoFault {
+        MalformedReceipt,
+        PartialSummary,
+        TokenCountMismatch,
+        NonFiniteSummary,
+        NegativeLoss,
+    }
+
+    struct TestDpoRuntime {
+        identity: String,
+        frozen_identity: String,
+        frozen_tokenizer_identity: String,
+        prepare_calls: usize,
+        optimizer_steps: usize,
+        model_tokens: u64,
+        rng_ranges: Vec<ModelExecutionRngRange>,
+        fault: Option<TestDpoFault>,
+    }
+
+    impl TestDpoRuntime {
+        fn new(identity: impl Into<String>) -> Self {
+            Self {
+                identity: identity.into(),
+                frozen_identity: test_sha("abc"),
+                frozen_tokenizer_identity: "tokenizer-sha256:test".to_owned(),
+                prepare_calls: 0,
+                optimizer_steps: 0,
+                model_tokens: 0,
+                rng_ranges: Vec::new(),
+                fault: None,
+            }
+        }
+    }
+
+    impl DpoDeviceBatchRuntime for TestDpoRuntime {
+        fn trainable_identity(&self) -> &str {
             &self.identity
         }
 
-        fn tokenizer_identity(&self) -> &str {
+        fn trainable_tokenizer_identity(&self) -> &str {
             "tokenizer-sha256:test"
         }
 
-        fn continuation_log_probs(
-            &mut self,
-            _prompt: &str,
-            continuation: &str,
-            _max_sequence_tokens: usize,
-        ) -> Result<Vec<f64>> {
-            self.model_tokens += 1;
-            Ok(vec![if continuation == "yes" { -0.2 } else { -0.8 }])
+        fn frozen_identity(&self) -> &str {
+            &self.frozen_identity
         }
-    }
 
-    impl PreferencePolicy for TestSequencePolicy {
+        fn frozen_tokenizer_identity(&self) -> &str {
+            &self.frozen_tokenizer_identity
+        }
+
         fn model_tokens_processed(&self) -> u64 {
             self.model_tokens
         }
 
-        fn backward_pairwise_log_probs(
+        fn prepare_device_batch(
             &mut self,
-            _example: &TaskExample,
-            chosen_gradients: &[f64],
-            rejected_gradients: &[f64],
-        ) -> Result<()> {
+            request: DpoDeviceBatchRequest<'_>,
+        ) -> Result<DpoDeviceBatchResult> {
+            validate_sha256_identity(request.batch_sha256, "test DPO batch")?;
+            request.base.validate()?;
+            let examples = u64::try_from(request.examples.len()).unwrap();
             ensure!(
-                chosen_gradients.len() == 1 && rejected_gradients.len() == 1,
-                "unexpected test gradient shape"
+                request.rng.len() == examples * 2,
+                "test DPO runtime received the wrong RNG geometry"
             );
-            self.backward_calls += 1;
-            Ok(())
+            let mut loss_sum = 0.0;
+            let mut preference_correct = 0;
+            let mut implicit_reward_margin_sum = 0.0;
+            for (index, example) in request.examples.iter().enumerate() {
+                let TaskExample::PairwisePreference { .. } = example else {
+                    bail!("test DPO runtime received another task type");
+                };
+                let offset = u64::try_from(index).unwrap() * 2;
+                let chosen_rng = request.rng.substream(offset)?;
+                let rejected_rng = request.rng.substream(offset + 1)?;
+                let chosen_jitter =
+                    ((chosen_rng.seed ^ chosen_rng.counter) & 0xffff) as f64 * f64::EPSILON;
+                let rejected_jitter =
+                    ((rejected_rng.seed ^ rejected_rng.counter) & 0xffff) as f64 * f64::EPSILON;
+                let objective = dpo_loss(
+                    PairwiseLogProbabilities {
+                        policy_chosen: -0.2 + chosen_jitter,
+                        policy_rejected: -0.8 + rejected_jitter,
+                        reference_chosen: -0.5,
+                        reference_rejected: -0.5,
+                    },
+                    request.beta,
+                    request.label_smoothing,
+                )?;
+                loss_sum += objective.loss;
+                preference_correct += u64::from(objective.preference_correct);
+                implicit_reward_margin_sum += objective.implicit_reward_margin;
+            }
+            ensure!(request.loss_weight.is_finite(), "invalid test loss weight");
+            self.prepare_calls += 1;
+            self.rng_ranges.push(request.rng);
+            let model_tokens = examples * 2;
+            self.model_tokens += model_tokens;
+            let mut result = DpoDeviceBatchResult {
+                receipt: test_device_receipt(
+                    &(
+                        "test-dpo-device-v1",
+                        request.batch_sha256,
+                        request.base,
+                        request.max_sequence_tokens,
+                        request.beta,
+                        request.label_smoothing,
+                        request.sequence_reduction,
+                        request.loss_weight,
+                        request.rng,
+                        loss_sum,
+                        preference_correct,
+                        implicit_reward_margin_sum,
+                        "backward-staged",
+                    ),
+                    model_tokens,
+                ),
+                examples,
+                loss_sum,
+                preference_correct,
+                implicit_reward_margin_sum,
+            };
+            match self.fault {
+                Some(TestDpoFault::MalformedReceipt) => {
+                    result.receipt.execution_sha256 = "not-a-digest".to_owned();
+                }
+                Some(TestDpoFault::PartialSummary) => result.examples -= 1,
+                Some(TestDpoFault::TokenCountMismatch) => {
+                    result.receipt.model_tokens += 1;
+                }
+                Some(TestDpoFault::NonFiniteSummary) => result.loss_sum = f64::NAN,
+                Some(TestDpoFault::NegativeLoss) => result.loss_sum = -1.0,
+                None => {}
+            }
+            Ok(result)
         }
 
         fn optimizer_step(&mut self, learning_rate_scale: f64) -> Result<()> {
@@ -4701,39 +6031,53 @@ mod tests {
         }
     }
 
-    struct TestReference;
-
-    impl SequenceLogProbabilityProvider for TestReference {
-        fn identity(&self) -> &str {
-            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-        }
-
-        fn tokenizer_identity(&self) -> &str {
-            "tokenizer-sha256:test"
-        }
-
-        fn continuation_log_probs(
-            &mut self,
-            _prompt: &str,
-            _continuation: &str,
-            _max_sequence_tokens: usize,
-        ) -> Result<Vec<f64>> {
-            Ok(vec![-0.5])
-        }
+    #[test]
+    fn dpo_device_runtime_rejects_tokenizer_misalignment_before_model_work() {
+        let (_dir, request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        let mut runtime = TestDpoRuntime::new("candidate:dpo");
+        runtime.frozen_tokenizer_identity = "tokenizer-sha256:drifted".to_owned();
+        let mut adapters = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut runtime,
+        };
+        let error = validate_and_capture_runtime_identities(&request.phase, &mut adapters)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("tokenizer identities differ"), "{error}");
+        assert_eq!(runtime.prepare_calls, 0);
     }
 
-    struct TestStudent {
-        gradients: Vec<Vec<Vec<f64>>>,
+    struct TestForwardKlRuntime {
+        prepare_calls: usize,
         optimizer_steps: usize,
         model_tokens: u64,
+        rng_ranges: Vec<ModelExecutionRngRange>,
     }
 
-    impl DistillationPolicy for TestStudent {
-        fn identity(&self) -> &str {
+    impl TestForwardKlRuntime {
+        fn new() -> Self {
+            Self {
+                prepare_calls: 0,
+                optimizer_steps: 0,
+                model_tokens: 0,
+                rng_ranges: Vec::new(),
+            }
+        }
+    }
+
+    impl ForwardKlDeviceBatchRuntime for TestForwardKlRuntime {
+        fn trainable_identity(&self) -> &str {
             "candidate:student"
         }
 
-        fn tokenizer_identity(&self) -> &str {
+        fn trainable_tokenizer_identity(&self) -> &str {
+            "tokenizer-sha256:test"
+        }
+
+        fn frozen_identity(&self) -> &str {
+            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        }
+
+        fn frozen_tokenizer_identity(&self) -> &str {
             "tokenizer-sha256:test"
         }
 
@@ -4741,22 +6085,78 @@ mod tests {
             self.model_tokens
         }
 
-        fn student_token_logits(
+        fn prepare_device_batch(
             &mut self,
-            _example: &TaskExample,
-            _max_sequence_tokens: usize,
-        ) -> Result<Vec<Vec<f64>>> {
-            self.model_tokens += 1;
-            Ok(vec![vec![0.0, 0.0]])
-        }
-
-        fn backward_student_logits(
-            &mut self,
-            _example: &TaskExample,
-            gradients: &[Vec<f64>],
-        ) -> Result<()> {
-            self.gradients.push(gradients.to_vec());
-            Ok(())
+            request: ForwardKlDeviceBatchRequest<'_>,
+        ) -> Result<ForwardKlDeviceBatchResult> {
+            validate_sha256_identity(request.batch_sha256, "test forward-KL batch")?;
+            request.base.validate()?;
+            let examples = u64::try_from(request.examples.len()).unwrap();
+            ensure!(
+                request.rng.len() == examples,
+                "test forward-KL runtime received the wrong RNG geometry"
+            );
+            let teacher = [3.0_f64.ln(), 0.0];
+            let mut loss_sum = 0.0;
+            let mut forward_kl_sum = 0.0;
+            let mut teacher_entropy_sum = 0.0;
+            let mut top1_agreement_sum = 0.0;
+            for (index, example) in request.examples.iter().enumerate() {
+                ensure!(
+                    matches!(
+                        example,
+                        TaskExample::Autoregressive { .. }
+                            | TaskExample::SupervisedGeneration { .. }
+                    ),
+                    "test forward-KL runtime received another task type"
+                );
+                let execution_rng = request.rng.substream(u64::try_from(index).unwrap())?;
+                let jitter =
+                    ((execution_rng.seed ^ execution_rng.counter) & 0xffff) as f64 * f64::EPSILON;
+                let student = [jitter, 0.0];
+                let objective = forward_kl_distillation(
+                    &[DistillationToken {
+                        teacher_logits: &teacher,
+                        student_logits: &student,
+                        weight: 1.0,
+                    }],
+                    request.temperature,
+                    request.scale_by_temperature_squared,
+                )?;
+                loss_sum += objective.loss;
+                forward_kl_sum += objective.mean_forward_kl;
+                teacher_entropy_sum += objective.teacher_entropy;
+                top1_agreement_sum += objective.top1_agreement;
+            }
+            ensure!(request.loss_weight.is_finite(), "invalid test loss weight");
+            self.prepare_calls += 1;
+            self.rng_ranges.push(request.rng);
+            self.model_tokens += examples;
+            Ok(ForwardKlDeviceBatchResult {
+                receipt: test_device_receipt(
+                    &(
+                        "test-forward-kl-device-v1",
+                        request.batch_sha256,
+                        request.base,
+                        request.max_sequence_tokens,
+                        request.temperature,
+                        request.scale_by_temperature_squared,
+                        request.loss_weight,
+                        request.rng,
+                        loss_sum,
+                        forward_kl_sum,
+                        teacher_entropy_sum,
+                        top1_agreement_sum,
+                        "backward-staged",
+                    ),
+                    examples,
+                ),
+                examples,
+                loss_sum,
+                forward_kl_sum,
+                teacher_entropy_sum,
+                top1_agreement_sum,
+            })
         }
 
         fn optimizer_step(&mut self, learning_rate_scale: f64) -> Result<()> {
@@ -4766,87 +6166,206 @@ mod tests {
         }
     }
 
-    struct TestTeacher;
-
-    impl TeacherDistributionProvider for TestTeacher {
-        fn identity(&self) -> &str {
-            "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
-        }
-
-        fn tokenizer_identity(&self) -> &str {
-            "tokenizer-sha256:test"
-        }
-
-        fn token_logits(
-            &mut self,
-            _example: &TaskExample,
-            _max_sequence_tokens: usize,
-        ) -> Result<Vec<Vec<f64>>> {
-            Ok(vec![vec![3.0_f64.ln(), 0.0]])
-        }
-    }
-
-    struct TestGrpoPolicy {
-        backward_calls: usize,
+    struct TestGrpoRuntime {
+        generation_calls: usize,
+        prepare_calls: usize,
         optimizer_steps: usize,
         model_tokens: u64,
+        rollout_tokens: usize,
+        has_reference: bool,
+        generation_ranges: Vec<ModelExecutionRngRange>,
+        scoring_ranges: Vec<ModelExecutionRngRange>,
     }
 
-    impl RolloutGenerator for TestGrpoPolicy {
-        fn identity(&self) -> &str {
+    impl TestGrpoRuntime {
+        fn new() -> Self {
+            Self {
+                generation_calls: 0,
+                prepare_calls: 0,
+                optimizer_steps: 0,
+                model_tokens: 0,
+                rollout_tokens: 1,
+                has_reference: false,
+                generation_ranges: Vec::new(),
+                scoring_ranges: Vec::new(),
+            }
+        }
+
+        fn with_reference() -> Self {
+            Self {
+                has_reference: true,
+                ..Self::new()
+            }
+        }
+    }
+
+    impl GrpoDeviceBatchRuntime for TestGrpoRuntime {
+        fn trainable_identity(&self) -> &str {
             "candidate:policy"
         }
 
-        fn generate(&mut self, request: RolloutRequest<'_>) -> Result<Vec<GeneratedRollout>> {
-            ensure!(request.count == 2, "test expected a two-rollout group");
-            ensure!(
-                request.max_sequence_tokens == 128,
-                "test sequence length was not propagated"
-            );
-            self.model_tokens += u64::try_from(request.count).unwrap();
-            Ok(vec![
-                GeneratedRollout {
-                    text: "ok".to_owned(),
-                    token_ids: vec![1],
-                    behavior_token_log_probs: vec![0.0],
-                },
-                GeneratedRollout {
-                    text: "wrong".to_owned(),
-                    token_ids: vec![2],
-                    behavior_token_log_probs: vec![0.0],
-                },
-            ])
-        }
-    }
-
-    impl GrpoPolicy for TestGrpoPolicy {
-        fn tokenizer_identity(&self) -> &str {
+        fn trainable_tokenizer_identity(&self) -> &str {
             "tokenizer-sha256:test"
+        }
+
+        fn frozen_identity(&self) -> Option<&str> {
+            self.has_reference.then_some(
+                "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            )
+        }
+
+        fn frozen_tokenizer_identity(&self) -> Option<&str> {
+            self.has_reference.then_some("tokenizer-sha256:test")
         }
 
         fn model_tokens_processed(&self) -> u64 {
             self.model_tokens
         }
 
-        fn current_token_log_probs(
+        fn generate_device_batch(
             &mut self,
-            _prompt: &str,
-            _rollout: &GeneratedRollout,
-            _max_sequence_tokens: usize,
-        ) -> Result<Vec<f64>> {
-            self.model_tokens += 1;
-            Ok(vec![0.0])
+            request: GrpoGenerationBatchRequest<'_>,
+        ) -> Result<GrpoGeneratedBatch> {
+            validate_sha256_identity(request.batch_sha256, "test GRPO batch")?;
+            request.base.validate()?;
+            let examples = u64::try_from(request.examples.len()).unwrap();
+            let group_size = u64::try_from(request.group_size).unwrap();
+            ensure!(
+                request.rng.len() == examples * group_size,
+                "test GRPO generator received the wrong RNG geometry"
+            );
+            self.generation_calls += 1;
+            self.generation_ranges.push(request.rng);
+            self.model_tokens += examples * group_size;
+            let groups = request
+                .examples
+                .iter()
+                .map(|_| {
+                    (0..request.group_size)
+                        .map(|index| GeneratedRolloutText {
+                            text: if index == 0 { "ok" } else { "wrong" }.to_owned(),
+                            token_count: self.rollout_tokens,
+                        })
+                        .collect()
+                })
+                .collect();
+            Ok(GrpoGeneratedBatch {
+                generation_sha256: canonical_sha256(&(
+                    "test-grpo-generation-v1",
+                    request.batch_sha256,
+                    request.base,
+                    request.group_size,
+                    request.max_sequence_tokens,
+                    request.sampling,
+                    request.rng,
+                    self.rollout_tokens,
+                ))?,
+                groups,
+            })
         }
 
-        fn backward_rollout_log_probs(
+        fn prepare_device_batch(
             &mut self,
-            _prompt: &str,
-            _rollout: &GeneratedRollout,
-            gradients: &[f64],
-        ) -> Result<()> {
-            ensure!(gradients.len() == 1, "unexpected test gradient shape");
-            self.backward_calls += 1;
-            Ok(())
+            request: GrpoDeviceBatchRequest<'_>,
+        ) -> Result<GrpoDeviceBatchResult> {
+            validate_sha256_identity(request.batch_sha256, "test GRPO batch")?;
+            request.base.validate()?;
+            let examples = u64::try_from(request.examples.len()).unwrap();
+            let rollouts = request
+                .generation
+                .groups
+                .iter()
+                .try_fold(0_u64, |total, group| {
+                    total.checked_add(u64::try_from(group.len()).unwrap())
+                })
+                .context("test GRPO rollout count overflow")?;
+            ensure!(
+                request.rng.len() == rollouts,
+                "test GRPO scorer received the wrong RNG geometry"
+            );
+            ensure!(
+                request.rewards.len() == request.generation.groups.len(),
+                "test GRPO rewards are not grouped"
+            );
+            let mut loss_sum = 0.0;
+            let mut mean_reward_sum = 0.0;
+            let mut reward_stddev_sum = 0.0;
+            let mut mean_kl_sum = 0.0;
+            let mut clipped_fraction_sum = 0.0;
+            for (group, rewards) in request.generation.groups.iter().zip(request.rewards) {
+                ensure!(
+                    group.len() == rewards.len(),
+                    "test GRPO reward count differs"
+                );
+                let current: Vec<_> = group
+                    .iter()
+                    .map(|rollout| vec![0.0; rollout.token_count])
+                    .collect();
+                let behavior = current.clone();
+                let reference: Option<Vec<_>> = self.has_reference.then(|| {
+                    group
+                        .iter()
+                        .map(|rollout| vec![-0.1; rollout.token_count])
+                        .collect()
+                });
+                let scalar: Vec<_> = rewards
+                    .iter()
+                    .enumerate()
+                    .map(|(index, reward)| GrpoRollout {
+                        reward: *reward,
+                        current_token_log_probs: &current[index],
+                        behavior_token_log_probs: &behavior[index],
+                        reference_token_log_probs: reference
+                            .as_ref()
+                            .map(|rows| rows[index].as_slice()),
+                    })
+                    .collect();
+                let objective = grpo_loss(
+                    &scalar,
+                    request.clip_epsilon,
+                    request.advantage_epsilon,
+                    request.kl_coefficient,
+                )?;
+                loss_sum += objective.loss;
+                mean_reward_sum += objective.mean_reward;
+                reward_stddev_sum += objective.reward_stddev;
+                mean_kl_sum += objective.mean_kl;
+                clipped_fraction_sum += objective.clipped_fraction;
+            }
+            ensure!(request.loss_weight.is_finite(), "invalid test loss weight");
+            self.prepare_calls += 1;
+            self.scoring_ranges.push(request.rng);
+            self.model_tokens += rollouts;
+            Ok(GrpoDeviceBatchResult {
+                receipt: test_device_receipt(
+                    &(
+                        "test-grpo-device-v1",
+                        request.batch_sha256,
+                        request.base,
+                        &request.generation.generation_sha256,
+                        request.rewards,
+                        request.clip_epsilon,
+                        request.advantage_epsilon,
+                        request.kl_coefficient,
+                        request.loss_weight,
+                        request.rng,
+                        loss_sum,
+                        mean_reward_sum,
+                        reward_stddev_sum,
+                        mean_kl_sum,
+                        clipped_fraction_sum,
+                        "backward-staged",
+                    ),
+                    rollouts * 2,
+                ),
+                examples,
+                rollouts,
+                loss_sum,
+                mean_reward_sum,
+                reward_stddev_sum,
+                mean_kl_sum,
+                clipped_fraction_sum,
+            })
         }
 
         fn optimizer_step(&mut self, learning_rate_scale: f64) -> Result<()> {
@@ -4858,7 +6377,7 @@ mod tests {
 
     #[test]
     fn post_training_configuration_is_strict_and_pinned() {
-        let digest = "0000000000000000000000000000000000000000000000000000000000000000";
+        let digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
         let config: PostTrainingConfig = serde_json::from_value(json!({
             "algorithm": "dpo",
             "reference": {
@@ -4869,6 +6388,18 @@ mod tests {
         }))
         .unwrap();
         config.validate().unwrap();
+
+        let noncanonical: PostTrainingConfig = serde_json::from_value(json!({
+            "algorithm": "dpo",
+            "reference": {
+                "adapter": "hermes_checkpoint",
+                "artifact": "reference",
+                "sha256": digest.trim_start_matches("sha256:")
+            }
+        }))
+        .unwrap();
+        let error = noncanonical.validate().unwrap_err().to_string();
+        assert!(error.contains("sha256:<64 lowercase hex>"), "{error}");
 
         let unpinned: PostTrainingConfig = serde_json::from_value(json!({
             "algorithm": "forward_kl",
@@ -4890,6 +6421,290 @@ mod tests {
     }
 
     #[test]
+    fn revision_identity_binds_the_loader_and_its_parameters() {
+        let base = FrozenModelSpec {
+            adapter: "remote_model".to_owned(),
+            artifact: None,
+            sha256: None,
+            revision: Some("commit-123".to_owned()),
+            parameters: BTreeMap::from([("model".to_owned(), json!("owner/teacher"))]),
+        };
+        let identity = base.immutable_identity().unwrap();
+        validate_sha256_identity(&identity, "revision identity").unwrap();
+        assert_eq!(identity, base.clone().immutable_identity().unwrap());
+
+        let mut another_adapter = base.clone();
+        another_adapter.adapter = "another_remote_model".to_owned();
+        assert_ne!(identity, another_adapter.immutable_identity().unwrap());
+
+        let mut another_model = base.clone();
+        another_model
+            .parameters
+            .insert("model".to_owned(), json!("owner/another-teacher"));
+        assert_ne!(identity, another_model.immutable_identity().unwrap());
+
+        let mut ambiguous = base;
+        ambiguous.revision = Some(" commit-123".to_owned());
+        let error = ambiguous.immutable_identity().unwrap_err().to_string();
+        assert!(error.contains("trimmed"), "{error}");
+    }
+
+    #[test]
+    fn native_post_training_rejects_unbounded_geometry_before_model_use() {
+        let (_directory, mut request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        request.phase.batch_size = Some(MAX_POST_TRAINING_UPDATE_EXAMPLES + 1);
+        let mut publisher = TestUpdatePublisher::new(false);
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
+        let mut adapters = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut policy,
+        };
+        let mut no_hook = None;
+        let error = drive_resumable_post_training_phase(
+            &test_sha("bounded-geometry"),
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            None,
+            usize::MAX,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("exceeding the limit"), "{error}");
+        assert_eq!(policy.model_tokens, 0);
+        assert_eq!(publisher.restore_calls, 0);
+
+        let (_directory, mut request) = test_request(TestPostTrainingAlgorithm::Grpo);
+        request.phase.sequence_length = Some(MAX_POST_TRAINING_SEQUENCE_TOKENS);
+        let Some(PostTrainingConfig::Grpo {
+            group_size,
+            sampling,
+            ..
+        }) = request.phase.post_training.as_mut()
+        else {
+            panic!("test request is not GRPO");
+        };
+        *group_size = 9;
+        sampling.max_new_tokens = MAX_POST_TRAINING_SEQUENCE_TOKENS;
+        let error = validate_resumable_phase(&request.phase)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("rollout update exceeds"), "{error}");
+    }
+
+    #[test]
+    fn native_post_training_revalidates_optimizer_scalars() {
+        let (_directory, mut request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        request.phase.loss_weight = Some(-1.0);
+        let error = validate_resumable_phase(&request.phase)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("loss_weight"), "{error}");
+
+        request.phase.loss_weight = Some(1.0);
+        request.phase.learning_rate_scale = Some(f64::NAN);
+        let error = validate_resumable_phase(&request.phase)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("learning_rate_scale"), "{error}");
+    }
+
+    #[test]
+    fn native_post_training_rejects_unimplemented_memory_update_mode() {
+        let (_directory, mut request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        request.phase.memory_update_mode = Some(
+            serde_json::from_value(json!({
+                "type": "wake_only",
+                "schedule": {
+                    "clock": "optimizer_steps",
+                    "terminal_consolidation": "distill_into_base_v1",
+                    "tiers": [
+                        {"id": "fast", "update_period": 2, "reserve_slots": 1},
+                        {"id": "slow", "update_period": 4, "reserve_slots": 1}
+                    ]
+                }
+            }))
+            .unwrap(),
+        );
+
+        let error = validate_resumable_phase(&request.phase)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("does not implement memory_update_mode"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn malformed_device_batch_receipts_never_reach_optimizer_publication() {
+        for (fault, expected) in [
+            (TestDpoFault::MalformedReceipt, "device execution receipt"),
+            (TestDpoFault::PartialSummary, "partial batch summary"),
+            (TestDpoFault::TokenCountMismatch, "model-token counter"),
+            (TestDpoFault::NonFiniteSummary, "empty or non-finite"),
+            (TestDpoFault::NegativeLoss, "must be non-negative"),
+        ] {
+            let (_directory, mut request) = test_request(TestPostTrainingAlgorithm::Dpo);
+            request.phase.steps = Some(1);
+            let mut publisher = TestUpdatePublisher::new(false);
+            let mut runtime = TestDpoRuntime::new("candidate:dpo");
+            runtime.fault = Some(fault);
+            let mut adapters = PostTrainingPhaseRuntime::Dpo {
+                runtime: &mut runtime,
+            };
+            let error = drive_resumable_post_training_phase(
+                &test_sha("adversarial-device-receipt"),
+                &request,
+                &mut adapters,
+                &mut publisher,
+                &mut None,
+                None,
+                None,
+                usize::MAX,
+                &mut TestPhaseProgress::default(),
+            )
+            .unwrap_err()
+            .to_string();
+            assert!(error.contains(expected), "{error}");
+            assert_eq!(runtime.prepare_calls, 1);
+            assert_eq!(runtime.optimizer_steps, 0);
+            assert_eq!(publisher.apply_calls, 0);
+        }
+    }
+
+    #[test]
+    fn each_update_uses_one_device_batch_call_per_algorithm() {
+        {
+            let (_directory, mut request) = test_request(TestPostTrainingAlgorithm::Dpo);
+            request.phase.batch_size = Some(2);
+            request.phase.steps = Some(1);
+            let mut publisher = TestUpdatePublisher::new(false);
+            let mut runtime = TestDpoRuntime::new("candidate:dpo");
+            let mut adapters = PostTrainingPhaseRuntime::Dpo {
+                runtime: &mut runtime,
+            };
+            let outcome = drive_resumable_post_training_phase(
+                &test_sha("batched-dpo"),
+                &request,
+                &mut adapters,
+                &mut publisher,
+                &mut None,
+                None,
+                None,
+                usize::MAX,
+                &mut TestPhaseProgress::default(),
+            )
+            .unwrap();
+            let ResumablePostTrainingOutcome::Complete { cursor, .. } = outcome else {
+                panic!("batched DPO did not complete");
+            };
+            assert_eq!(runtime.prepare_calls, 1);
+            assert_eq!(runtime.rng_ranges[0].len(), 4);
+            assert_eq!(cursor.progress.examples, 2);
+        }
+
+        {
+            let (directory, mut request) = test_request(TestPostTrainingAlgorithm::ForwardKl);
+            let data = directory.path().join("instruction-distillation.jsonl");
+            std::fs::write(
+                &data,
+                concat!(
+                    "{\"instruction\":\"first\",\"response\":\"one\"}\n",
+                    "{\"instruction\":\"second\",\"response\":\"two\"}\n"
+                ),
+            )
+            .unwrap();
+            request.phase.task = Some(TaskConfig::InstructionTuning {
+                instruction: "Follow the instruction.".to_owned(),
+            });
+            request.phase.data = Some(data);
+            request.phase.batch_size = Some(2);
+            request.phase.steps = Some(1);
+            let mut publisher = TestUpdatePublisher::new(false);
+            let mut runtime = TestForwardKlRuntime::new();
+            let mut adapters = PostTrainingPhaseRuntime::ForwardKl {
+                runtime: &mut runtime,
+            };
+            drive_resumable_post_training_phase(
+                &test_sha("batched-forward-kl"),
+                &request,
+                &mut adapters,
+                &mut publisher,
+                &mut None,
+                None,
+                None,
+                usize::MAX,
+                &mut TestPhaseProgress::default(),
+            )
+            .unwrap();
+            assert_eq!(runtime.prepare_calls, 1);
+            assert_eq!(runtime.rng_ranges[0].len(), 2);
+        }
+
+        {
+            let (_directory, mut request) = test_request(TestPostTrainingAlgorithm::Grpo);
+            request.phase.batch_size = Some(2);
+            request.phase.steps = Some(1);
+            let mut publisher = TestUpdatePublisher::new(false);
+            let mut runtime = TestGrpoRuntime::new();
+            let mut adapters = PostTrainingPhaseRuntime::Grpo {
+                runtime: &mut runtime,
+                verifier: &ExactAnswerVerifier,
+            };
+            drive_resumable_post_training_phase(
+                &test_sha("batched-grpo"),
+                &request,
+                &mut adapters,
+                &mut publisher,
+                &mut None,
+                None,
+                None,
+                usize::MAX,
+                &mut TestPhaseProgress::default(),
+            )
+            .unwrap();
+            assert_eq!(runtime.generation_calls, 1);
+            assert_eq!(runtime.prepare_calls, 1);
+            assert_eq!(runtime.generation_ranges[0].len(), 4);
+            assert_eq!(runtime.scoring_ranges[0].len(), 4);
+        }
+    }
+
+    #[test]
+    fn grpo_rejects_oversized_generated_rollouts_before_scoring_or_backward() {
+        let (_directory, mut request) = test_request(TestPostTrainingAlgorithm::Grpo);
+        request.phase.steps = Some(1);
+        let mut publisher = TestUpdatePublisher::new(false);
+        let mut policy = TestGrpoRuntime::new();
+        policy.rollout_tokens = 33;
+        let mut adapters = PostTrainingPhaseRuntime::Grpo {
+            runtime: &mut policy,
+            verifier: &ExactAnswerVerifier,
+        };
+        let mut no_hook = None;
+        let error = drive_resumable_post_training_phase(
+            &test_sha("oversized-rollout"),
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            None,
+            usize::MAX,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("configured token limit"), "{error}");
+        assert_eq!(policy.model_tokens, 2, "only generation may have run");
+        assert_eq!(policy.prepare_calls, 0);
+        assert_eq!(publisher.apply_calls, 0);
+    }
+
+    #[test]
     fn frozen_local_artifacts_are_verified_and_changed_bytes_are_rejected() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("teacher.safetensors");
@@ -4898,7 +6713,8 @@ mod tests {
             adapter: "hermes_checkpoint".to_owned(),
             artifact: Some(path.clone()),
             sha256: Some(
-                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".to_owned(),
+                "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+                    .to_owned(),
             ),
             revision: None,
             parameters: BTreeMap::new(),
@@ -4923,7 +6739,8 @@ mod tests {
             adapter: "hermes_checkpoint".to_owned(),
             artifact: Some(link),
             sha256: Some(
-                "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad".to_owned(),
+                "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+                    .to_owned(),
             ),
             revision: None,
             parameters: BTreeMap::new(),
@@ -4938,6 +6755,7 @@ mod tests {
         fail_checkpoint_call: Option<usize>,
         durable: Option<serde_json::Value>,
         metrics: Vec<(MetricContext, MetricEvent)>,
+        replace_input_after_metric: Option<(PathBuf, PathBuf)>,
     }
 
     impl PhaseProgressSink for TestPhaseProgress {
@@ -4953,6 +6771,9 @@ mod tests {
         fn metric(&mut self, context: MetricContext, event: MetricEvent) -> Result<()> {
             event.validate()?;
             self.metrics.push((context, event));
+            if let Some((replacement, input)) = self.replace_input_after_metric.take() {
+                fs::rename(replacement, input)?;
+            }
             Ok(())
         }
     }
@@ -4961,8 +6782,11 @@ mod tests {
         identity: String,
         fail_before_publication_once: bool,
         apply_calls: usize,
+        restore_calls: usize,
         plans: BTreeMap<String, PreparedPostTrainingUpdate>,
         receipts: BTreeMap<String, PostTrainingUpdateReceipt>,
+        replace_input_after_restore: Option<(PathBuf, PathBuf)>,
+        replace_input_after_publication: Option<(PathBuf, PathBuf)>,
     }
 
     impl TestUpdatePublisher {
@@ -4971,8 +6795,11 @@ mod tests {
                 identity: test_sha("publisher-v1"),
                 fail_before_publication_once,
                 apply_calls: 0,
+                restore_calls: 0,
                 plans: BTreeMap::new(),
                 receipts: BTreeMap::new(),
+                replace_input_after_restore: None,
+                replace_input_after_publication: None,
             }
         }
     }
@@ -4986,6 +6813,10 @@ mod tests {
             &mut self,
             state: &PostTrainingCommittedState,
         ) -> Result<PostTrainingRestoreReceipt> {
+            self.restore_calls += 1;
+            if let Some((replacement, input)) = self.replace_input_after_restore.take() {
+                fs::rename(replacement, input)?;
+            }
             Ok(PostTrainingRestoreReceipt::for_state(
                 self.identity.clone(),
                 state,
@@ -5029,6 +6860,9 @@ mod tests {
             self.plans.insert(plan.transaction_id.clone(), plan.clone());
             self.receipts
                 .insert(plan.transaction_id.clone(), receipt.clone());
+            if let Some((replacement, input)) = self.replace_input_after_publication.take() {
+                fs::rename(replacement, input)?;
+            }
             Ok(receipt)
         }
     }
@@ -5321,17 +7155,10 @@ mod tests {
                 .context("test host phase has no post-training config")?
             {
                 PostTrainingConfig::Dpo { .. } => {
-                    let mut policy = TestSequencePolicy {
-                        identity: "candidate:dpo".to_owned(),
-                        backward_calls: 0,
-                        optimizer_steps: 0,
-                        model_tokens: 0,
-                    };
-                    let mut reference = TestReference;
+                    let mut policy = TestDpoRuntime::new("candidate:dpo");
                     let mut context = PostTrainingExecutionContext {
-                        adapters: PostTrainingPhaseAdapters::Dpo {
-                            policy: &mut policy,
-                            reference: &mut reference,
+                        runtime: PostTrainingPhaseRuntime::Dpo {
+                            runtime: &mut policy,
                         },
                         publisher: &mut publisher,
                         boundary_hook: Some(&mut controller),
@@ -5340,16 +7167,10 @@ mod tests {
                     operation(&mut context)
                 }
                 PostTrainingConfig::ForwardKl { .. } => {
-                    let mut policy = TestStudent {
-                        gradients: Vec::new(),
-                        optimizer_steps: 0,
-                        model_tokens: 0,
-                    };
-                    let mut teacher = TestTeacher;
+                    let mut policy = TestForwardKlRuntime::new();
                     let mut context = PostTrainingExecutionContext {
-                        adapters: PostTrainingPhaseAdapters::ForwardKl {
-                            policy: &mut policy,
-                            teacher: &mut teacher,
+                        runtime: PostTrainingPhaseRuntime::ForwardKl {
+                            runtime: &mut policy,
                         },
                         publisher: &mut publisher,
                         boundary_hook: Some(&mut controller),
@@ -5358,15 +7179,10 @@ mod tests {
                     operation(&mut context)
                 }
                 PostTrainingConfig::Grpo { .. } => {
-                    let mut policy = TestGrpoPolicy {
-                        backward_calls: 0,
-                        optimizer_steps: 0,
-                        model_tokens: 0,
-                    };
+                    let mut policy = TestGrpoRuntime::new();
                     let mut context = PostTrainingExecutionContext {
-                        adapters: PostTrainingPhaseAdapters::Grpo {
-                            policy: &mut policy,
-                            reference: None,
+                        runtime: PostTrainingPhaseRuntime::Grpo {
+                            runtime: &mut policy,
                             verifier: &ExactAnswerVerifier,
                         },
                         publisher: &mut publisher,
@@ -5387,7 +7203,7 @@ mod tests {
     }
 
     fn test_sha(label: &str) -> String {
-        format!("sha256:{:x}", Sha256::digest(label.as_bytes()))
+        sha256_identity(label.as_bytes())
     }
 
     fn test_request(
@@ -5502,21 +7318,56 @@ mod tests {
     }
 
     fn install_periodic_sleep(request: &mut PhaseExecutionRequest) {
-        let workflow = crate::workflow::load_workflow(
-            &Path::new(env!("CARGO_MANIFEST_DIR")).join("workflow.education.example.json"),
-        )
-        .unwrap();
-        request.phase.periodic_sleep = Some(
-            workflow
-                .phases
-                .first()
-                .and_then(|phase| phase.periodic_sleep.clone())
-                .expect("education workflow has periodic sleep"),
-        );
+        let workflow: serde_json::Value =
+            serde_json::from_str(include_str!("../workflow.education.example.json")).unwrap();
+        let sleep = workflow
+            .get("phases")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|phases| phases.first())
+            .and_then(|phase| phase.get("periodic_sleep"))
+            .cloned()
+            .expect("education workflow has periodic sleep");
+        request.phase.periodic_sleep = Some(serde_json::from_value(sleep).unwrap());
+    }
+
+    fn install_positive_grpo_reference(directory: &Path, request: &mut PhaseExecutionRequest) {
+        let artifact = directory.join("grpo-reference.safetensors");
+        fs::write(&artifact, b"abc").unwrap();
+        let PostTrainingConfig::Grpo {
+            kl_coefficient,
+            reference,
+            ..
+        } = request.phase.post_training.as_mut().unwrap()
+        else {
+            panic!("positive GRPO reference installed on a non-GRPO phase");
+        };
+        *kl_coefficient = 0.04;
+        *reference = Some(FrozenModelSpec {
+            adapter: "test".to_owned(),
+            artifact: Some(artifact),
+            sha256: Some(ABC_SHA256.to_owned()),
+            revision: None,
+            parameters: BTreeMap::new(),
+        });
     }
 
     fn run_interruption_case(algorithm: TestPostTrainingAlgorithm, after_publication: bool) {
-        let (_dir, request) = test_request(algorithm);
+        run_interruption_case_with_grpo_reference(algorithm, after_publication, false);
+    }
+
+    fn run_interruption_case_with_grpo_reference(
+        algorithm: TestPostTrainingAlgorithm,
+        after_publication: bool,
+        positive_grpo_kl: bool,
+    ) {
+        assert!(
+            !positive_grpo_kl || matches!(algorithm, TestPostTrainingAlgorithm::Grpo),
+            "a positive GRPO reference is only valid for GRPO"
+        );
+        let (directory, mut request) = test_request(algorithm);
+        if positive_grpo_kl {
+            install_positive_grpo_reference(directory.path(), &mut request);
+        }
         let workflow = test_sha("workflow-v2");
         let mut publisher = TestUpdatePublisher::new(!after_publication);
         let mut first_sink = TestPhaseProgress {
@@ -5524,36 +7375,22 @@ mod tests {
             ..TestPhaseProgress::default()
         };
         let mut no_hook = None;
-        let mut dpo_policy = TestSequencePolicy {
-            identity: "candidate:dpo".to_owned(),
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut dpo_reference = TestReference;
-        let mut student = TestStudent {
-            gradients: Vec::new(),
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut teacher = TestTeacher;
-        let mut grpo_policy = TestGrpoPolicy {
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
+        let mut dpo_policy = TestDpoRuntime::new("candidate:dpo");
+        let mut student = TestForwardKlRuntime::new();
+        let mut grpo_policy = if positive_grpo_kl {
+            TestGrpoRuntime::with_reference()
+        } else {
+            TestGrpoRuntime::new()
         };
         let mut adapters = match algorithm {
-            TestPostTrainingAlgorithm::Dpo => PostTrainingPhaseAdapters::Dpo {
-                policy: &mut dpo_policy,
-                reference: &mut dpo_reference,
+            TestPostTrainingAlgorithm::Dpo => PostTrainingPhaseRuntime::Dpo {
+                runtime: &mut dpo_policy,
             },
-            TestPostTrainingAlgorithm::ForwardKl => PostTrainingPhaseAdapters::ForwardKl {
-                policy: &mut student,
-                teacher: &mut teacher,
+            TestPostTrainingAlgorithm::ForwardKl => PostTrainingPhaseRuntime::ForwardKl {
+                runtime: &mut student,
             },
-            TestPostTrainingAlgorithm::Grpo => PostTrainingPhaseAdapters::Grpo {
-                policy: &mut grpo_policy,
-                reference: None,
+            TestPostTrainingAlgorithm::Grpo => PostTrainingPhaseRuntime::Grpo {
+                runtime: &mut grpo_policy,
                 verifier: &ExactAnswerVerifier,
             },
         };
@@ -5604,12 +7441,44 @@ mod tests {
         assert_eq!(publisher.apply_calls, 2);
         assert_eq!(cursor.progress.optimizer_steps, 2);
         assert_eq!(cursor.progress.examples, 2);
-        assert_eq!(
-            cursor.rng.counter > 0,
-            matches!(algorithm, TestPostTrainingAlgorithm::Grpo)
-        );
+        let expected_rng_counter = match algorithm {
+            TestPostTrainingAlgorithm::Dpo => 4,
+            TestPostTrainingAlgorithm::ForwardKl => 2,
+            TestPostTrainingAlgorithm::Grpo => 8,
+        };
+        assert_eq!(cursor.rng.counter, expected_rng_counter);
         assert_eq!(report.optimizer_steps, 2);
         assert_eq!(resumed_sink.metrics.len(), 2);
+        if positive_grpo_kl {
+            assert!(report.metrics["mean_kl"] > 0.0);
+            let expected_reference = test_sha("abc");
+            assert_eq!(
+                report.frozen_model_identity.as_deref(),
+                Some(expected_reference.as_str())
+            );
+        }
+        match algorithm {
+            TestPostTrainingAlgorithm::Dpo => {
+                assert_eq!(dpo_policy.prepare_calls, 3);
+                assert_eq!(dpo_policy.rng_ranges[0], dpo_policy.rng_ranges[1]);
+                assert_eq!(dpo_policy.rng_ranges[2].start, 2);
+            }
+            TestPostTrainingAlgorithm::ForwardKl => {
+                assert_eq!(student.prepare_calls, 3);
+                assert_eq!(student.rng_ranges[0], student.rng_ranges[1]);
+                assert_eq!(student.rng_ranges[2].start, 1);
+            }
+            TestPostTrainingAlgorithm::Grpo => {
+                assert_eq!(grpo_policy.generation_calls, 3);
+                assert_eq!(grpo_policy.prepare_calls, 3);
+                assert_eq!(
+                    grpo_policy.generation_ranges[0],
+                    grpo_policy.generation_ranges[1]
+                );
+                assert_eq!(grpo_policy.scoring_ranges[0], grpo_policy.scoring_ranges[1]);
+                assert_eq!(grpo_policy.generation_ranges[2].start, 4);
+            }
+        }
     }
 
     fn run_periodic_boundary_interruption_case(
@@ -5637,36 +7506,18 @@ mod tests {
             fail_checkpoint_call: after_boundary_publication.then_some(4),
             ..TestPhaseProgress::default()
         };
-        let mut dpo_policy = TestSequencePolicy {
-            identity: "candidate:dpo".to_owned(),
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut dpo_reference = TestReference;
-        let mut student = TestStudent {
-            gradients: Vec::new(),
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut teacher = TestTeacher;
-        let mut grpo_policy = TestGrpoPolicy {
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
+        let mut dpo_policy = TestDpoRuntime::new("candidate:dpo");
+        let mut student = TestForwardKlRuntime::new();
+        let mut grpo_policy = TestGrpoRuntime::new();
         let mut adapters = match algorithm {
-            TestPostTrainingAlgorithm::Dpo => PostTrainingPhaseAdapters::Dpo {
-                policy: &mut dpo_policy,
-                reference: &mut dpo_reference,
+            TestPostTrainingAlgorithm::Dpo => PostTrainingPhaseRuntime::Dpo {
+                runtime: &mut dpo_policy,
             },
-            TestPostTrainingAlgorithm::ForwardKl => PostTrainingPhaseAdapters::ForwardKl {
-                policy: &mut student,
-                teacher: &mut teacher,
+            TestPostTrainingAlgorithm::ForwardKl => PostTrainingPhaseRuntime::ForwardKl {
+                runtime: &mut student,
             },
-            TestPostTrainingAlgorithm::Grpo => PostTrainingPhaseAdapters::Grpo {
-                policy: &mut grpo_policy,
-                reference: None,
+            TestPostTrainingAlgorithm::Grpo => PostTrainingPhaseRuntime::Grpo {
+                runtime: &mut grpo_policy,
                 verifier: &ExactAnswerVerifier,
             },
         };
@@ -5728,6 +7579,271 @@ mod tests {
         assert!(cursor.last_boundary_receipt.is_some());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn late_input_replacement_cannot_commit_a_published_update() {
+        let (dir, mut request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        request.phase.steps = Some(1);
+        let input = request.phase.data.clone().unwrap();
+        let replacement = dir.path().join("replacement-preference.jsonl");
+        fs::write(
+            &replacement,
+            concat!(
+                "{\"prompt\":\"changed-1\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n",
+                "{\"prompt\":\"changed-2\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n"
+            ),
+        )
+        .unwrap();
+        let mut publisher = TestUpdatePublisher::new(false);
+        publisher.replace_input_after_publication = Some((replacement, input));
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
+        let mut adapters = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut policy,
+        };
+        let mut no_hook = None;
+        let mut progress = TestPhaseProgress::default();
+        let error = drive_resumable_post_training_phase(
+            &test_sha("late-input-replacement"),
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            None,
+            usize::MAX,
+            &mut progress,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("changed after it was authenticated"),
+            "{error}"
+        );
+        assert_eq!(publisher.apply_calls, 1);
+        assert_eq!(
+            publisher.restore_calls, 1,
+            "changed input should reject before restoring the published update"
+        );
+        let envelope: PostTrainingResumeEnvelope =
+            serde_json::from_value(progress.durable.unwrap()).unwrap();
+        let (cursor, boundary) = envelope.into_parts().unwrap();
+        assert!(boundary.is_none());
+        assert!(cursor.pending.is_some());
+        assert_eq!(cursor.progress.optimizer_steps, 0);
+        assert_eq!(cursor.committed.model, cursor.input_checkpoint);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn metric_callback_input_replacement_cannot_commit_the_phase_cursor() {
+        let (dir, mut request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        request.phase.steps = Some(1);
+        let input = request.phase.data.clone().unwrap();
+        let replacement = dir.path().join("replacement-after-metric.jsonl");
+        fs::write(
+            &replacement,
+            concat!(
+                "{\"prompt\":\"changed-1\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n",
+                "{\"prompt\":\"changed-2\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n"
+            ),
+        )
+        .unwrap();
+        let mut publisher = TestUpdatePublisher::new(false);
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
+        let mut adapters = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut policy,
+        };
+        let mut no_hook = None;
+        let mut progress = TestPhaseProgress {
+            replace_input_after_metric: Some((replacement, input)),
+            ..TestPhaseProgress::default()
+        };
+        let error = drive_resumable_post_training_phase(
+            &test_sha("metric-input-replacement"),
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            None,
+            usize::MAX,
+            &mut progress,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("changed after it was authenticated"),
+            "{error}"
+        );
+        assert_eq!(progress.checkpoint_calls, 1);
+        let envelope: PostTrainingResumeEnvelope =
+            serde_json::from_value(progress.durable.unwrap()).unwrap();
+        let (cursor, boundary) = envelope.into_parts().unwrap();
+        assert!(boundary.is_none());
+        assert!(cursor.pending.is_some());
+        assert_eq!(cursor.progress.optimizer_steps, 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn completed_resume_rechecks_input_after_restoring_its_final_checkpoint() {
+        let (dir, mut request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        request.phase.steps = Some(1);
+        let workflow = test_sha("completed-resume-input-replacement");
+        let mut publisher = TestUpdatePublisher::new(false);
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
+        let mut adapters = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut policy,
+        };
+        let mut no_hook = None;
+        let complete = drive_resumable_post_training_phase(
+            &workflow,
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            None,
+            usize::MAX,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap();
+        let ResumablePostTrainingOutcome::Complete { cursor, .. } = complete else {
+            panic!("one-step phase did not complete");
+        };
+
+        let input = request.phase.data.clone().unwrap();
+        let replacement = dir.path().join("replacement-on-final-restore.jsonl");
+        fs::write(
+            &replacement,
+            concat!(
+                "{\"prompt\":\"changed-1\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n",
+                "{\"prompt\":\"changed-2\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n"
+            ),
+        )
+        .unwrap();
+        publisher.replace_input_after_restore = Some((replacement, input));
+
+        let error = drive_resumable_post_training_phase(
+            &workflow,
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            Some(PostTrainingResumeEnvelope::wake(cursor)),
+            usize::MAX,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("changed after it was authenticated"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn completed_exact_eof_cursor_replays_without_another_update() {
+        let (_dir, request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        let workflow = test_sha("completed-exact-eof-resume");
+        let mut publisher = TestUpdatePublisher::new(false);
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
+        let mut adapters = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut policy,
+        };
+        let mut no_hook = None;
+        let complete = drive_resumable_post_training_phase(
+            &workflow,
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            None,
+            usize::MAX,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap();
+        let ResumablePostTrainingOutcome::Complete { cursor, report } = complete else {
+            panic!("two-record phase did not complete");
+        };
+        assert_eq!(
+            cursor.position,
+            PostTrainingRecordPosition {
+                epoch: 1,
+                record: 0
+            }
+        );
+        assert_eq!(report.optimizer_steps, 2);
+
+        let replayed = drive_resumable_post_training_phase(
+            &workflow,
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            Some(PostTrainingResumeEnvelope::wake(cursor.clone())),
+            usize::MAX,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap();
+        let ResumablePostTrainingOutcome::Complete {
+            cursor: replayed,
+            report,
+        } = replayed
+        else {
+            panic!("completed exact-EOF cursor unexpectedly yielded");
+        };
+        assert_eq!(replayed, cursor);
+        assert_eq!(report.optimizer_steps, 2);
+        assert_eq!(
+            publisher.apply_calls, 2,
+            "completed replay applied an update"
+        );
+    }
+
+    #[test]
+    fn step_limited_phase_does_not_parse_unconsumed_lookahead() {
+        let (_dir, mut request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        request.phase.steps = Some(1);
+        fs::write(
+            request.phase.data.as_ref().unwrap(),
+            concat!(
+                "{\"prompt\":\"used\",\"chosen\":\"yes\",\"rejected\":\"no\"}\n",
+                "this record is outside the configured step limit\n"
+            ),
+        )
+        .unwrap();
+        let workflow = test_sha("step-limited-raw-lookahead");
+        let mut publisher = TestUpdatePublisher::new(false);
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
+        let mut adapters = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut policy,
+        };
+        let mut no_hook = None;
+        let complete = drive_resumable_post_training_phase(
+            &workflow,
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            None,
+            usize::MAX,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap();
+        let ResumablePostTrainingOutcome::Complete { cursor, report } = complete else {
+            panic!("one-step phase did not complete");
+        };
+        assert_eq!(cursor.position.epoch, 0);
+        assert_eq!(cursor.position.record, 1);
+        assert_eq!(report.optimizer_steps, 1);
+        assert_eq!(publisher.apply_calls, 1);
+    }
+
     #[test]
     fn dpo_resumes_before_optimizer_publication_without_double_apply() {
         run_interruption_case(TestPostTrainingAlgorithm::Dpo, false);
@@ -5756,6 +7872,53 @@ mod tests {
     #[test]
     fn grpo_resumes_after_optimizer_publication_without_double_apply() {
         run_interruption_case(TestPostTrainingAlgorithm::Grpo, true);
+    }
+
+    #[test]
+    fn positive_kl_grpo_resumes_before_optimizer_publication_exactly() {
+        run_interruption_case_with_grpo_reference(TestPostTrainingAlgorithm::Grpo, false, true);
+    }
+
+    #[test]
+    fn positive_kl_grpo_resumes_after_optimizer_publication_exactly() {
+        run_interruption_case_with_grpo_reference(TestPostTrainingAlgorithm::Grpo, true, true);
+    }
+
+    #[test]
+    fn prepared_update_rejects_rehashed_but_forged_rng_geometry() {
+        let (_directory, request) = test_request(TestPostTrainingAlgorithm::Dpo);
+        let mut publisher = TestUpdatePublisher::new(true);
+        let mut runtime = TestDpoRuntime::new("candidate:dpo");
+        let mut phase_runtime = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut runtime,
+        };
+        let mut progress = TestPhaseProgress::default();
+        let error = drive_resumable_post_training_phase(
+            &test_sha("forged-rng-geometry"),
+            &request,
+            &mut phase_runtime,
+            &mut publisher,
+            &mut None,
+            None,
+            None,
+            usize::MAX,
+            &mut progress,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("injected interruption"), "{error}");
+        let envelope: PostTrainingResumeEnvelope =
+            serde_json::from_value(progress.durable.unwrap()).unwrap();
+        let (mut cursor, boundary) = envelope.into_parts().unwrap();
+        assert!(boundary.is_none());
+        let pending = cursor.pending.as_mut().unwrap();
+        pending.rng_end += 1;
+        pending.transaction_id = pending.computed_transaction_id().unwrap();
+        let error = cursor.validate_internal().unwrap_err().to_string();
+        assert!(
+            error.contains("exactly two model RNG substreams"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -5809,16 +7972,9 @@ mod tests {
         )
         .unwrap();
         let mut publisher = TestUpdatePublisher::new(false);
-        let mut policy = TestSequencePolicy {
-            identity: "candidate:dpo".to_owned(),
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut reference = TestReference;
-        let mut adapters = PostTrainingPhaseAdapters::Dpo {
-            policy: &mut policy,
-            reference: &mut reference,
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
+        let mut adapters = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut policy,
         };
         let mut hook: Option<&mut dyn PostTrainingBoundaryHook> = Some(&mut controller);
         let outcome = drive_resumable_post_training_phase(
@@ -5872,14 +8028,9 @@ mod tests {
         )
         .unwrap();
         let mut publisher = TestUpdatePublisher::new(false);
-        let mut policy = TestGrpoPolicy {
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut adapters = PostTrainingPhaseAdapters::Grpo {
-            policy: &mut policy,
-            reference: None,
+        let mut policy = TestGrpoRuntime::new();
+        let mut adapters = PostTrainingPhaseRuntime::Grpo {
+            runtime: &mut policy,
             verifier: &ExactAnswerVerifier,
         };
         let mut hook: Option<&mut dyn PostTrainingBoundaryHook> = Some(&mut controller);
@@ -5927,21 +8078,14 @@ mod tests {
             )
             .unwrap();
             let mut publisher = TestUpdatePublisher::new(false);
-            let mut policy = TestSequencePolicy {
-                identity: "candidate:dpo".to_owned(),
-                backward_calls: 0,
-                optimizer_steps: 0,
-                model_tokens: 0,
-            };
-            let mut reference = TestReference;
+            let mut policy = TestDpoRuntime::new("candidate:dpo");
             let mut first_sink = TestPhaseProgress {
                 fail_checkpoint_call: Some(failed_checkpoint),
                 ..TestPhaseProgress::default()
             };
             {
-                let mut adapters = PostTrainingPhaseAdapters::Dpo {
-                    policy: &mut policy,
-                    reference: &mut reference,
+                let mut adapters = PostTrainingPhaseRuntime::Dpo {
+                    runtime: &mut policy,
                 };
                 let mut hook: Option<&mut dyn PostTrainingBoundaryHook> = Some(&mut controller);
                 let first = drive_resumable_post_training_phase(
@@ -5970,9 +8114,8 @@ mod tests {
             let (_, boundary) = resume.clone().into_parts().unwrap();
             assert!(boundary.is_some(), "boundary publication was not durable");
             let outcome = {
-                let mut adapters = PostTrainingPhaseAdapters::Dpo {
-                    policy: &mut policy,
-                    reference: &mut reference,
+                let mut adapters = PostTrainingPhaseRuntime::Dpo {
+                    runtime: &mut policy,
                 };
                 let mut hook: Option<&mut dyn PostTrainingBoundaryHook> = Some(&mut controller);
                 drive_resumable_post_training_phase(
@@ -6003,16 +8146,9 @@ mod tests {
         install_periodic_sleep(&mut request);
         let mut publisher = TestUpdatePublisher::new(false);
         let mut hook = TestBoundaryHook::new(false);
-        let mut policy = TestSequencePolicy {
-            identity: "candidate:dpo".to_owned(),
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut reference = TestReference;
-        let mut adapters = PostTrainingPhaseAdapters::Dpo {
-            policy: &mut policy,
-            reference: &mut reference,
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
+        let mut adapters = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut policy,
         };
         let mut boundary_hook: Option<&mut dyn PostTrainingBoundaryHook> = Some(&mut hook);
         let error = drive_resumable_post_training_phase(
@@ -6221,23 +8357,16 @@ mod tests {
     }
 
     #[test]
-    fn resume_rejects_cursor_tamper_and_adapter_drift() {
+    fn resume_rejects_cursor_tamper_and_device_runtime_drift() {
         let (_dir, request) = test_request(TestPostTrainingAlgorithm::Dpo);
         let workflow = test_sha("workflow-v2");
         let mut publisher = TestUpdatePublisher::new(false);
         let mut sink = TestPhaseProgress::default();
         let mut no_hook = None;
-        let mut policy = TestSequencePolicy {
-            identity: "candidate:dpo".to_owned(),
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut reference = TestReference;
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
         let cursor = {
-            let mut adapters = PostTrainingPhaseAdapters::Dpo {
-                policy: &mut policy,
-                reference: &mut reference,
+            let mut adapters = PostTrainingPhaseRuntime::Dpo {
+                runtime: &mut policy,
             };
             let yielded = drive_resumable_post_training_phase(
                 &workflow,
@@ -6279,9 +8408,8 @@ mod tests {
         };
 
         policy.identity = "candidate:drifted".to_owned();
-        let mut drifted = PostTrainingPhaseAdapters::Dpo {
-            policy: &mut policy,
-            reference: &mut reference,
+        let mut drifted = PostTrainingPhaseRuntime::Dpo {
+            runtime: &mut policy,
         };
         let error = drive_resumable_post_training_phase(
             &workflow,
@@ -6300,23 +8428,92 @@ mod tests {
     }
 
     #[test]
+    fn grpo_resume_rejects_verifier_implementation_drift() {
+        struct VersionedExactVerifier(&'static str);
+
+        impl RewardVerifier for VersionedExactVerifier {
+            fn identity(&self) -> &str {
+                self.0
+            }
+
+            fn adapter_name(&self) -> &str {
+                ExactAnswerVerifier.adapter_name()
+            }
+
+            fn verify(
+                &self,
+                spec: &VerifierSpec,
+                request: VerificationRequest<'_>,
+            ) -> Result<Verification> {
+                ExactAnswerVerifier.verify(spec, request)
+            }
+        }
+
+        let (_dir, request) = test_request(TestPostTrainingAlgorithm::Grpo);
+        let workflow = test_sha("workflow-v2-verifier-identity");
+        let mut publisher = TestUpdatePublisher::new(false);
+        let mut policy = TestGrpoRuntime::new();
+        let mut no_hook = None;
+        let first = VersionedExactVerifier(
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        );
+        let cursor = {
+            let mut adapters = PostTrainingPhaseRuntime::Grpo {
+                runtime: &mut policy,
+                verifier: &first,
+            };
+            let outcome = drive_resumable_post_training_phase(
+                &workflow,
+                &request,
+                &mut adapters,
+                &mut publisher,
+                &mut no_hook,
+                None,
+                None,
+                1,
+                &mut TestPhaseProgress::default(),
+            )
+            .unwrap();
+            let ResumablePostTrainingOutcome::Yielded(cursor) = outcome else {
+                panic!("one-update budget should yield");
+            };
+            cursor
+        };
+
+        let second = VersionedExactVerifier(
+            "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        );
+        let mut adapters = PostTrainingPhaseRuntime::Grpo {
+            runtime: &mut policy,
+            verifier: &second,
+        };
+        let error = drive_resumable_post_training_phase(
+            &workflow,
+            &request,
+            &mut adapters,
+            &mut publisher,
+            &mut no_hook,
+            None,
+            Some(PostTrainingResumeEnvelope::wake(cursor)),
+            1,
+            &mut TestPhaseProgress::default(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("identity changed across resume"), "{error}");
+    }
+
+    #[test]
     fn native_executor_integrates_with_phase_executor_contract() {
         let (_dir, request) = test_request(TestPostTrainingAlgorithm::Dpo);
         let workflow = test_sha("workflow-v2");
         let mut executor = NativePostTrainingPhaseExecutor::new(&workflow).unwrap();
         let mut publisher = TestUpdatePublisher::new(false);
-        let mut policy = TestSequencePolicy {
-            identity: "candidate:dpo".to_owned(),
-            backward_calls: 0,
-            optimizer_steps: 0,
-            model_tokens: 0,
-        };
-        let mut reference = TestReference;
+        let mut policy = TestDpoRuntime::new("candidate:dpo");
         {
             let mut context = PostTrainingExecutionContext {
-                adapters: PostTrainingPhaseAdapters::Dpo {
-                    policy: &mut policy,
-                    reference: &mut reference,
+                runtime: PostTrainingPhaseRuntime::Dpo {
+                    runtime: &mut policy,
                 },
                 publisher: &mut publisher,
                 boundary_hook: None,

--- a/hermes-train/src/promotion.rs
+++ b/hermes-train/src/promotion.rs
@@ -6,18 +6,21 @@
 //! deterministic immutable decision. A rejected decision is retained for
 //! audit but can never produce a [`PhaseProduct::Release`].
 
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::fs;
 use std::path::{Component, Path, PathBuf};
 
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, ensure};
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 
 use crate::acceptance::{AcceptancePolicy, PromotionReport};
+#[cfg(test)]
+use crate::artifact_io::sha256_hex;
+use crate::artifact_io::{
+    atomic_write_new, json_sha256_identity, read_regular_bounded, sha256_identity,
+};
 use crate::benchmark::{
-    AblationId, BenchmarkTarget, ModelRepresentationIdentity, VerifiedBenchmarkRun,
-    VerifiedResourceComparison, evaluate_verified_promotion,
+    AblationId, ModelRepresentationIdentity, VerifiedBenchmarkRun, VerifiedResourceComparison,
+    evaluate_verified_promotion,
 };
 use crate::runtime::{
     ImmutableArtifact, ImmutableModelCheckpoint, PhaseExecutionRequest, PhaseExecutionResult,
@@ -26,6 +29,7 @@ use crate::runtime::{
 use crate::workflow::{PhaseKind, PromotionConfig, PromotionEvidenceRef};
 
 pub const PROMOTION_DECISION_VERSION: u32 = 2;
+const MAX_PROMOTION_JSON_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Complete auditable authorization record. The acceptance report is nested
 /// beside the exact checkpoint and every immutable input identity so the
@@ -116,14 +120,6 @@ fn evaluate_and_publish(
         comparisons.push(VerifiedBenchmarkRun::load(&run.path, run.raw_sha256())?);
     }
 
-    // Benchmark runs pin both checkpoint manifests and trainer-produced
-    // training evidence. Re-verify those files at promotion time rather than
-    // relying only on the earlier benchmark invocation.
-    for run in &comparisons {
-        verify_target(&run.run.metadata.baseline, &run.path)?;
-        verify_target(&run.run.metadata.candidate, &run.path)?;
-    }
-
     let benchmark_candidate = &selected.run.metadata.candidate;
     let runtime_digest = candidate
         .sha256()
@@ -148,7 +144,7 @@ fn evaluate_and_publish(
         &policy,
         config.policy.raw_sha256(),
     )?;
-    let config_sha256 = canonical_sha256(config)?;
+    let config_sha256 = json_sha256_identity(config)?;
     let decision = VerifiedPromotionDecision {
         version: PROMOTION_DECISION_VERSION,
         phase_index: request.phase_index,
@@ -174,7 +170,7 @@ fn evaluate_and_publish(
         report,
     };
     let bytes = decision_bytes(&decision)?;
-    let decision_sha256 = format!("sha256:{:x}", Sha256::digest(&bytes));
+    let decision_sha256 = sha256_identity(&bytes);
     let directory = prepare_artifact_directory(&config.artifact_directory)?;
     let path = directory.join(format!(
         "sha256-{}.json",
@@ -182,25 +178,13 @@ fn evaluate_and_publish(
             .strip_prefix("sha256:")
             .expect("locally constructed digest")
     ));
-    publish_idempotent(&path, &bytes)?;
+    atomic_write_new(&path, &bytes)?;
     let uri = path
         .to_str()
         .context("promotion decision path is not valid UTF-8")?
         .to_owned();
     let artifact = ImmutableArtifact::new(uri, decision_sha256)?;
     Ok((decision, artifact))
-}
-
-fn verify_target(target: &BenchmarkTarget, run_source: &Path) -> Result<()> {
-    let mut resolved = target.clone();
-    resolved.resolve_paths(run_source);
-    resolved.verify().map(|_| ()).with_context(|| {
-        format!(
-            "failed to verify benchmark target `{}` referenced by {}",
-            resolved.id,
-            run_source.display()
-        )
-    })
 }
 
 fn verify_evidence_ref(reference: &PromotionEvidenceRef, label: &str) -> Result<()> {
@@ -218,9 +202,9 @@ fn read_addressed_json<T: serde::de::DeserializeOwned>(
     reference: &PromotionEvidenceRef,
     label: &str,
 ) -> Result<T> {
-    let bytes = fs::read(&reference.path)
+    let bytes = read_regular_bounded(&reference.path, MAX_PROMOTION_JSON_BYTES, label)
         .with_context(|| format!("failed to read {label} {}", reference.path.display()))?;
-    let actual = format!("sha256:{:x}", Sha256::digest(&bytes));
+    let actual = sha256_identity(&bytes);
     ensure!(
         actual == reference.sha256,
         "{label} hash mismatch for {}: expected {}, got {}",
@@ -230,13 +214,6 @@ fn read_addressed_json<T: serde::de::DeserializeOwned>(
     );
     serde_json::from_slice(&bytes)
         .with_context(|| format!("invalid {label} JSON in {}", reference.path.display()))
-}
-
-fn canonical_sha256<T: Serialize>(value: &T) -> Result<String> {
-    Ok(format!(
-        "sha256:{:x}",
-        Sha256::digest(serde_json::to_vec(value)?)
-    ))
 }
 
 fn decision_bytes(decision: &VerifiedPromotionDecision) -> Result<Vec<u8>> {
@@ -338,86 +315,6 @@ fn prepare_artifact_directory(path: &Path) -> Result<PathBuf> {
     Ok(directory)
 }
 
-fn publish_idempotent(path: &Path, expected: &[u8]) -> Result<()> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) => {
-            ensure!(
-                metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-                "promotion decision {} must be a regular non-symlink file",
-                path.display()
-            );
-            ensure!(
-                fs::read(path)? == expected,
-                "existing promotion decision {} does not contain the derived bytes",
-                path.display()
-            );
-            return Ok(());
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => {
-            return Err(error)
-                .with_context(|| format!("inspect promotion decision {}", path.display()));
-        }
-    }
-
-    let parent = path
-        .parent()
-        .context("promotion decision path has no parent")?;
-    let file_name = path
-        .file_name()
-        .context("promotion decision path has no file name")?;
-    for attempt in 0..100_u32 {
-        let temporary = parent.join(format!(
-            ".{}.{}.{}.tmp",
-            file_name.to_string_lossy(),
-            std::process::id(),
-            attempt
-        ));
-        let mut file = match OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temporary)
-        {
-            Ok(file) => file,
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => {
-                return Err(error).context("create promotion decision temporary file");
-            }
-        };
-        let publication = (|| -> Result<()> {
-            file.write_all(expected)?;
-            file.sync_all()?;
-            match fs::hard_link(&temporary, path) {
-                Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    let metadata = fs::symlink_metadata(path)?;
-                    ensure!(
-                        metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-                        "concurrent promotion decision is not a regular file"
-                    );
-                    ensure!(
-                        fs::read(path)? == expected,
-                        "concurrent promotion decision contains different bytes"
-                    );
-                }
-                Err(error) => return Err(error).context("publish promotion decision"),
-            }
-            fs::remove_file(&temporary)?;
-            File::open(parent)?.sync_all()?;
-            Ok(())
-        })();
-        if publication.is_err() {
-            drop(file);
-            let _ = fs::remove_file(&temporary);
-        }
-        return publication;
-    }
-    bail!(
-        "failed to allocate a promotion decision temporary file beside {}",
-        path.display()
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -431,17 +328,18 @@ mod tests {
     use crate::benchmark::{
         BENCHMARK_MANIFEST_VERSION, BenchmarkArtifact, BenchmarkEvaluator, BenchmarkRun,
         BenchmarkRunConfig, BenchmarkRunner, BenchmarkSpec, BenchmarkSuiteManifest,
-        EvaluationMeasurement, EvaluationRequest, MetricDirection, TargetRole, TrainingEvidence,
-        VerifiedBenchmarkSuite, required_catalog,
+        BenchmarkTarget, EvaluationMeasurement, EvaluationRequest, MetricDirection, TargetRole,
+        TrainingEvidence, VerifiedBenchmarkSuite, required_catalog,
     };
     use crate::runtime::{
         ExecutorRegistry, RuntimeBoundary, RuntimeCheckpoint, RuntimeStatus, WorkflowRunState,
         run_next_phase,
     };
     use crate::workflow::{ResolvedWorkflow, WorkflowV2};
+    use anyhow::bail;
 
     fn raw_sha256(bytes: &[u8]) -> String {
-        format!("{:x}", Sha256::digest(bytes))
+        sha256_hex(bytes)
     }
 
     fn write_json<T: Serialize>(path: &Path, value: &T) -> String {
@@ -456,7 +354,13 @@ mod tests {
         let output = root.join(id);
         let staging = output.join("generations").join("staging");
         fs::create_dir_all(&staging).unwrap();
-        let raw_weights = vec![0_u8; 100 * 4];
+        let salt = id.bytes().enumerate().fold(0_u64, |sum, (index, byte)| {
+            sum.wrapping_add((index as u64 + 1).wrapping_mul(u64::from(byte)))
+        }) as f32;
+        let raw_weights = (0..100)
+            .map(|index| ((index as f32 + salt) * 0.03125).sin())
+            .flat_map(f32::to_le_bytes)
+            .collect::<Vec<_>>();
         let view = TensorView::new(Dtype::F32, vec![100], &raw_weights).unwrap();
         let weights = safetensors::tensor::serialize([("weight", view)], None).unwrap();
         let weights_sha256 = raw_sha256(&weights);
@@ -805,6 +709,7 @@ mod tests {
                     evaluator_version:
                         "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
                             .into(),
+                    evaluator_arguments: Vec::new(),
                     paired_seeds: vec![11, 22, 33],
                     order_seed: 7,
                     gpu_hours_per_evaluation: 0.01,

--- a/hermes-train/src/protocol_process.rs
+++ b/hermes-train/src/protocol_process.rs
@@ -1,0 +1,371 @@
+//! Deadline-bounded supervision for local JSONL worker processes.
+//!
+//! Protocol pipes are nonblocking and owned by the supervising thread. This
+//! is intentional: a blocking reader thread cannot be joined safely when an
+//! unauthorized descendant calls `setsid(2)` and retains a copied pipe after
+//! the worker leader exits. The supervisor instead drains bytes that are
+//! currently available, treats leader exit as the protocol boundary, closes
+//! its pipe ends, and reaps only the child it actually owns.
+
+#![cfg(unix)]
+
+use std::io::{Read, Write};
+use std::os::fd::{AsRawFd, RawFd};
+use std::process::{Child, ChildStdin, ChildStdout, ExitStatus};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail, ensure};
+
+use crate::pinned_executable::StagedExecutable;
+
+const READ_CHUNK_BYTES: usize = 8 * 1024;
+const MAX_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+pub(crate) enum ProtocolRead {
+    Pending,
+    Line(Vec<u8>),
+    Eof,
+}
+
+/// One child leader plus its nonblocking protocol pipes and staged executable.
+///
+/// The child must have been spawned as the leader of a fresh process group.
+/// `Drop` kills that group, closes both host pipe ends, and reaps the leader.
+/// Descendants that deliberately escape with `setsid(2)` cannot strand a host
+/// thread because this type never performs a blocking pipe read or join.
+pub(crate) struct SupervisedProcess {
+    child: Child,
+    input: Option<ChildStdin>,
+    output: Option<ChildStdout>,
+    output_buffer: Vec<u8>,
+    output_eof: bool,
+    status: Option<ExitStatus>,
+    process_group_terminated: bool,
+    label: &'static str,
+    max_message_bytes: usize,
+    _executable: StagedExecutable,
+}
+
+impl SupervisedProcess {
+    pub(crate) fn new(
+        mut child: Child,
+        executable: StagedExecutable,
+        label: &'static str,
+        max_message_bytes: usize,
+    ) -> Result<Self> {
+        ensure!(
+            max_message_bytes > 0,
+            "protocol message bound must be positive"
+        );
+        let Some(input) = child.stdin.take() else {
+            terminate_child(&mut child);
+            bail!("{label} stdin is unavailable");
+        };
+        let Some(output) = child.stdout.take() else {
+            terminate_child(&mut child);
+            bail!("{label} stdout is unavailable");
+        };
+        if let Err(error) = set_nonblocking(&input).and_then(|()| set_nonblocking(&output)) {
+            terminate_child(&mut child);
+            return Err(error).with_context(|| format!("configuring {label} protocol pipes"));
+        }
+        Ok(Self {
+            child,
+            input: Some(input),
+            output: Some(output),
+            output_buffer: Vec::new(),
+            output_eof: false,
+            status: None,
+            process_group_terminated: false,
+            label,
+            max_message_bytes,
+            _executable: executable,
+        })
+    }
+
+    /// Write as much of one already-bounded request as the pipe accepts.
+    pub(crate) fn write_available(&mut self, request: &[u8], written: &mut usize) -> Result<()> {
+        ensure!(
+            *written <= request.len(),
+            "{} request cursor exceeds its encoded length",
+            self.label
+        );
+        while *written < request.len() {
+            let input = self
+                .input
+                .as_mut()
+                .with_context(|| format!("{} stdin is closed", self.label))?;
+            match input.write(&request[*written..]) {
+                Ok(0) => bail!("{} stopped accepting its request", self.label),
+                Ok(count) => *written += count,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+                Err(error) => {
+                    return Err(error).with_context(|| format!("writing {} request", self.label));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn close_input(&mut self) {
+        self.input.take();
+    }
+
+    /// Whether bytes have been received that do not yet form a complete frame.
+    /// Persistent protocols use this to prevent partial output from being
+    /// silently carried across request boundaries.
+    pub(crate) fn has_buffered_output(&self) -> bool {
+        !self.output_buffer.is_empty()
+    }
+
+    /// Return one complete bounded JSONL frame without ever blocking.
+    pub(crate) fn read_line(&mut self) -> Result<ProtocolRead> {
+        loop {
+            if let Some(newline) = self.output_buffer.iter().position(|byte| *byte == b'\n') {
+                let line_len = newline + 1;
+                ensure!(
+                    line_len <= self.max_message_bytes,
+                    "{} emitted a JSONL message larger than {} bytes",
+                    self.label,
+                    self.max_message_bytes
+                );
+                let trailing = self.output_buffer.split_off(line_len);
+                let line = std::mem::replace(&mut self.output_buffer, trailing);
+                return Ok(ProtocolRead::Line(line));
+            }
+            if self.output_eof {
+                ensure!(
+                    self.output_buffer.is_empty(),
+                    "{} emitted an unterminated JSONL message",
+                    self.label
+                );
+                return Ok(ProtocolRead::Eof);
+            }
+
+            let output = self
+                .output
+                .as_mut()
+                .with_context(|| format!("{} stdout is closed", self.label))?;
+            let mut chunk = [0_u8; READ_CHUNK_BYTES];
+            match output.read(&mut chunk) {
+                Ok(0) => self.output_eof = true,
+                Ok(count) => {
+                    let new_len = self
+                        .output_buffer
+                        .len()
+                        .checked_add(count)
+                        .with_context(|| format!("{} response length overflow", self.label))?;
+                    // If this chunk contains a newline, the exact frame bound
+                    // is checked at the top of the loop. Otherwise all bytes
+                    // belong to one still-incomplete frame and are bounded now.
+                    if !chunk[..count].contains(&b'\n') {
+                        ensure!(
+                            new_len <= self.max_message_bytes,
+                            "{} emitted a JSONL message larger than {} bytes",
+                            self.label,
+                            self.max_message_bytes
+                        );
+                    }
+                    self.output_buffer.extend_from_slice(&chunk[..count]);
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    return Ok(ProtocolRead::Pending);
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| format!("reading {} response", self.label));
+                }
+            }
+        }
+    }
+
+    /// Validate the bytes left after every currently available frame has been
+    /// drained. This is used when the leader exits but an escaped descendant
+    /// keeps the pipe from reaching EOF.
+    pub(crate) fn finish_output_at_leader_exit(&self) -> Result<()> {
+        ensure!(
+            self.output_buffer.is_empty(),
+            "{} emitted an unterminated JSONL message",
+            self.label
+        );
+        Ok(())
+    }
+
+    pub(crate) fn try_wait(&mut self) -> Result<Option<ExitStatus>> {
+        if let Some(status) = self.status {
+            return Ok(Some(status));
+        }
+        if !self.process_group_terminated {
+            // Peek with WNOWAIT so an exited leader is detected while it is
+            // still an unreaped zombie: the zombie keeps the pid/pgid
+            // reserved, so the group SIGKILL below cannot land on a recycled
+            // process group. Only afterwards is the leader actually reaped.
+            if !leader_exited_unreaped(&self.child, self.label)? {
+                return Ok(None);
+            }
+            self.terminate_process_group();
+        }
+        let status = self
+            .child
+            .try_wait()
+            .with_context(|| format!("waiting for {}", self.label))?;
+        if let Some(status) = status {
+            self.status = Some(status);
+        }
+        Ok(status)
+    }
+
+    pub(crate) fn wait_for_activity(&self, want_write: bool, deadline: Instant) -> Result<()> {
+        let output = (!self.output_eof)
+            .then(|| self.output.as_ref().map(AsRawFd::as_raw_fd))
+            .flatten();
+        let input = want_write
+            .then(|| self.input.as_ref().map(AsRawFd::as_raw_fd))
+            .flatten();
+        wait_for_pipe_activity(output, input, deadline, self.label)
+    }
+
+    /// Kill the worker's original process group, including ordinary helpers.
+    /// A malicious descendant may have escaped that group with `setsid(2)`;
+    /// closing our pipe ends still guarantees bounded host return in that case.
+    pub(crate) fn terminate_process_group(&mut self) {
+        if self.process_group_terminated {
+            return;
+        }
+        kill_process_group(self.child.id());
+        self.process_group_terminated = true;
+    }
+
+    pub(crate) fn terminate(&mut self) {
+        self.close_input();
+        self.output.take();
+        self.terminate_process_group();
+        if self.status.is_none() {
+            let _ = self.child.kill();
+            if let Ok(status) = self.child.wait() {
+                self.status = Some(status);
+            }
+        }
+    }
+}
+
+impl Drop for SupervisedProcess {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
+fn set_nonblocking(stream: &impl AsRawFd) -> Result<()> {
+    let descriptor = stream.as_raw_fd();
+    // SAFETY: `descriptor` is owned by `stream` for both fcntl calls.
+    let flags = unsafe { libc::fcntl(descriptor, libc::F_GETFL) };
+    ensure!(
+        flags >= 0,
+        "failed to inspect protocol pipe flags: {}",
+        std::io::Error::last_os_error()
+    );
+    // SAFETY: the same live descriptor is updated without changing ownership.
+    let changed = unsafe { libc::fcntl(descriptor, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    ensure!(
+        changed == 0,
+        "failed to configure a nonblocking protocol pipe: {}",
+        std::io::Error::last_os_error()
+    );
+    Ok(())
+}
+
+fn wait_for_pipe_activity(
+    output: Option<RawFd>,
+    input: Option<RawFd>,
+    deadline: Instant,
+    label: &str,
+) -> Result<()> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let wait = remaining.min(MAX_POLL_INTERVAL);
+    let timeout_millis = wait.as_millis().clamp(1, i32::MAX as u128) as i32;
+    let mut descriptors = [
+        libc::pollfd {
+            fd: output.unwrap_or(-1),
+            events: libc::POLLIN | libc::POLLHUP | libc::POLLERR,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: input.unwrap_or(-1),
+            events: libc::POLLOUT | libc::POLLHUP | libc::POLLERR,
+            revents: 0,
+        },
+    ];
+    loop {
+        // SAFETY: `descriptors` is live and has exactly the supplied length.
+        let result = unsafe {
+            libc::poll(
+                descriptors.as_mut_ptr(),
+                descriptors.len() as libc::nfds_t,
+                timeout_millis,
+            )
+        };
+        if result >= 0 {
+            return Ok(());
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error).with_context(|| format!("waiting for {label} protocol activity"));
+        }
+        ensure!(
+            Instant::now() < deadline,
+            "{label} exceeded its execution deadline"
+        );
+    }
+}
+
+/// Report whether the leader has exited without reaping it, so its zombie
+/// keeps the pid/pgid reserved until after the group is killed.
+fn leader_exited_unreaped(child: &Child, label: &str) -> Result<bool> {
+    let pid = child.id() as libc::id_t;
+    loop {
+        // SAFETY: `info` is a plain-data out-parameter zeroed before every
+        // attempt; WNOWAIT leaves the child owned by `child` for later reaping.
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                pid,
+                &mut info,
+                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+            )
+        };
+        if rc == 0 {
+            return Ok(siginfo_pid(&info) != 0);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error).with_context(|| format!("peeking exit of {label}"));
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn siginfo_pid(info: &libc::siginfo_t) -> libc::pid_t {
+    // SAFETY: the caller obtained `info` from a successful waitid(WEXITED)
+    // call, where the pid union member is valid.
+    unsafe { info.si_pid() }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn siginfo_pid(info: &libc::siginfo_t) -> libc::pid_t {
+    info.si_pid
+}
+
+fn kill_process_group(child_id: u32) {
+    if let Ok(group) = i32::try_from(child_id) {
+        // SAFETY: callers place `child_id` in a fresh process group at spawn.
+        unsafe {
+            libc::kill(-group, libc::SIGKILL);
+        }
+    }
+}
+
+fn terminate_child(child: &mut Child) {
+    kill_process_group(child.id());
+    let _ = child.kill();
+    let _ = child.wait();
+}

--- a/hermes-train/src/qat_candidate.rs
+++ b/hermes-train/src/qat_candidate.rs
@@ -7,8 +7,7 @@
 //! returns the existing artifact only when the model bytes and recipe match.
 
 use std::collections::BTreeSet;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -16,7 +15,12 @@ use anyhow::{Context, Result, bail, ensure};
 use burn::module::AutodiffModule;
 use hermes_llm::{Transformer, save_safetensors};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+
+use crate::artifact_io::{
+    ensure_directory, ensure_real_directory, hash_regular_file, read_regular_bounded,
+    sha256_identity as sha256_label, sync_directory, sync_regular_file, validate_sha256_identity,
+    write_new_synced,
+};
 
 use crate::quantization::{
     QuantizationManifest, QuantizationRecipe, QuantizedArchive, export_safetensors_archive,
@@ -27,6 +31,7 @@ const CANDIDATE_MANIFEST: &str = "candidate.json";
 const WEIGHTS_FILE: &str = "weights.safetensors";
 const ARCHIVE_DIRECTORY: &str = "hquant";
 const ARCHIVE_MANIFEST: &str = "manifest.json";
+const MAX_QAT_JSON_BYTES: u64 = 16 * 1024 * 1024;
 static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// Exact aggregate measurements derived from the validated archive manifest.
@@ -73,6 +78,7 @@ pub struct QatCandidateManifest {
 #[derive(Clone, Debug, PartialEq)]
 pub struct QatCandidatePublication {
     pub candidate_key: String,
+    pub recipe: QuantizationRecipe,
     pub candidate_root: PathBuf,
     pub candidate_manifest_path: PathBuf,
     pub candidate_manifest_sha256: String,
@@ -97,7 +103,35 @@ pub fn publish_qat_candidate(
     key: &str,
     recipe: &QuantizationRecipe,
 ) -> Result<QatCandidatePublication> {
-    publish_qat_candidate_with_hook(model, root, key, recipe, |_, _| Ok(()))
+    publish_qat_candidate_with_hook(model, root, key, recipe, None, |_, _| Ok(()))
+}
+
+/// Publish or reopen a candidate bound to an independently authenticated
+/// canonical model snapshot.
+///
+/// When `root/key` is already sealed, `source_weights_sha256` avoids
+/// serializing `model` again. Because a crash may leave an orphan candidate
+/// whose manifest has not yet been sealed into trainer state, adoption still
+/// reproduces that archive once from its canonical weights. Callers must
+/// obtain the digest from immutable provenance such as a verified trainer
+/// checkpoint or a content-addressed sleep checkpoint; mutable in-memory state
+/// is not a valid source of this identity.
+pub fn publish_qat_candidate_from_authenticated_source(
+    model: &Transformer,
+    root: &Path,
+    key: &str,
+    recipe: &QuantizationRecipe,
+    source_weights_sha256: &str,
+) -> Result<QatCandidatePublication> {
+    validate_sha256_identity(source_weights_sha256, "QAT source weights identity")?;
+    publish_qat_candidate_with_hook(
+        model,
+        root,
+        key,
+        recipe,
+        Some(source_weights_sha256),
+        |_, _| Ok(()),
+    )
 }
 
 /// Reopen an already published candidate and authenticate its receipt,
@@ -108,7 +142,39 @@ pub fn open_qat_candidate(candidate_root: &Path) -> Result<QatCandidatePublicati
         .and_then(|name| name.to_str())
         .context("QAT candidate key is not UTF-8")?;
     validate_candidate_key(key)?;
-    validate_candidate(candidate_root, key)
+    // Without an independently sealed receipt, internally consistent hashes
+    // are not provenance: a forged archive can rehash its own wrong codes and
+    // claim the canonical source digest. Reproduce the deterministic encoding
+    // here; checkpoint/benchmark resume uses the addressed fast path below.
+    validate_candidate_reproduced(candidate_root, key)
+}
+
+/// Reopen a candidate whose exact receipt bytes are sealed by an immutable
+/// trainer checkpoint or benchmark manifest.
+///
+/// The small receipt is authenticated before any model weights or archive
+/// members are read, avoiding expensive validation of a candidate that cannot
+/// match the caller's durable identity.
+pub fn open_qat_candidate_addressed(
+    candidate_root: &Path,
+    expected_candidate_manifest_sha256: &str,
+) -> Result<QatCandidatePublication> {
+    validate_sha256_identity(
+        expected_candidate_manifest_sha256,
+        "QAT candidate manifest identity",
+    )?;
+    let key = candidate_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("QAT candidate key is not UTF-8")?;
+    validate_candidate_key(key)?;
+    validate_candidate_inner_with_hook(
+        candidate_root,
+        key,
+        false,
+        Some(expected_candidate_manifest_sha256),
+        || Ok(()),
+    )
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -123,6 +189,7 @@ fn publish_qat_candidate_with_hook<F>(
     root: &Path,
     key: &str,
     recipe: &QuantizationRecipe,
+    source_weights_sha256: Option<&str>,
     mut hook: F,
 ) -> Result<QatCandidatePublication>
 where
@@ -140,20 +207,46 @@ where
         );
     }
 
+    // A sealed source digest is sufficient to bind an existing candidate to
+    // the trainer checkpoint. Authenticate the candidate first; only a new
+    // publication needs to materialize canonical SafeTensors bytes from the
+    // accelerator-backed model.
+    if let Some(expected) = source_weights_sha256
+        && candidate_root.exists()
+    {
+        let publication = validate_candidate_reproduced(&candidate_root, key)?;
+        ensure!(
+            publication.weights_sha256 == expected,
+            "QAT candidate key '{key}' is bound to different model weights"
+        );
+        let existing: QatCandidateManifest = read_json_regular(
+            &publication.candidate_manifest_path,
+            "QAT candidate manifest",
+        )?;
+        ensure!(
+            existing.recipe == *recipe,
+            "QAT candidate key '{key}' is already bound to a different quantization recipe"
+        );
+        return Ok(publication);
+    }
+
     let staging_path = allocate_staging_directory(root, key)?;
     let mut staging = StagingDirectory::new(staging_path);
     let staged_weights = staging.path().join(WEIGHTS_FILE);
     save_safetensors(&model.clone().valid(), &staged_weights)
         .context("failed to snapshot trained QAT weights")?;
-    OpenOptions::new()
-        .read(true)
-        .open(&staged_weights)?
-        .sync_all()?;
-    let (weights_bytes, weights_sha256) = hash_regular_file(&staged_weights, "QAT weights")?;
+    sync_regular_file(&staged_weights, "QAT weights")?;
+    let (weights_bytes, weights_sha256) = hash_regular_file(&staged_weights)?;
+    if let Some(expected) = source_weights_sha256 {
+        ensure!(
+            weights_sha256 == expected,
+            "canonical QAT weights {weights_sha256} differ from authenticated source {expected}"
+        );
+    }
     hook(PublicationPoint::WeightsSynced, &mut staging)?;
 
     if candidate_root.exists() {
-        let publication = validate_candidate(&candidate_root, key)?;
+        let publication = validate_candidate_reproduced(&candidate_root, key)?;
         ensure!(
             publication.weights_sha256 == weights_sha256,
             "QAT candidate key '{key}' is already bound to different model weights"
@@ -174,8 +267,11 @@ where
         .context("failed to export trained QAT weights as HQUANT")?;
     let archive = QuantizedArchive::open(&staged_archive)
         .context("failed to reopen staged HQUANT archive")?;
+    // `export_safetensors_archive` performs the one expensive deterministic
+    // derivation check for a newly created archive. Reopening it here only
+    // needs to authenticate the exact members and their sealed source digest.
     archive
-        .verify_source_checkpoint(&staged_weights)
+        .verify_source_identity(&weights_sha256)
         .context("staged HQUANT archive is not bound to its canonical weights")?;
     ensure!(
         archive.manifest().recipe == *recipe,
@@ -183,8 +279,7 @@ where
     );
     let archive_content_sha256 = archive.content_hash()?;
     let archive_manifest_path = staged_archive.join(ARCHIVE_MANIFEST);
-    let (_, archive_manifest_sha256) =
-        hash_regular_file(&archive_manifest_path, "HQUANT manifest")?;
+    let (_, archive_manifest_sha256) = hash_regular_file(&archive_manifest_path)?;
     let metrics = aggregate_metrics(archive.manifest())?;
     hook(PublicationPoint::ArchiveVerified, &mut staging)?;
 
@@ -201,15 +296,21 @@ where
         recipe: recipe.clone(),
         metrics,
     };
+    let candidate_manifest_bytes = serde_json::to_vec_pretty(&manifest)?;
+    let staged_candidate_manifest_sha256 = sha256_label(&candidate_manifest_bytes);
     write_new_synced(
         &staging.path().join(CANDIDATE_MANIFEST),
-        &serde_json::to_vec_pretty(&manifest)?,
+        &candidate_manifest_bytes,
     )?;
     sync_directory(staging.path())?;
     hook(PublicationPoint::ManifestSynced, &mut staging)?;
 
     // Validate through the same public-facing path logic before publication.
-    validate_candidate(staging.path(), key)?;
+    let staged_publication = validate_candidate(staging.path(), key)?;
+    ensure!(
+        staged_publication.candidate_manifest_sha256 == staged_candidate_manifest_sha256,
+        "staged QAT candidate manifest changed during validation"
+    );
     match fs::rename(staging.path(), &candidate_root) {
         Ok(()) => staging.disarm(),
         Err(_error) if candidate_root.exists() => {
@@ -220,13 +321,9 @@ where
                 publication.weights_sha256 == weights_sha256,
                 "concurrent QAT publication bound key '{key}' to different model weights"
             );
-            let existing: QatCandidateManifest = read_json_regular(
-                &publication.candidate_manifest_path,
-                "QAT candidate manifest",
-            )?;
             ensure!(
-                existing.recipe == *recipe,
-                "concurrent QAT publication bound key '{key}' to a different recipe"
+                publication.candidate_manifest_sha256 == staged_candidate_manifest_sha256,
+                "concurrent QAT publication bound key '{key}' to different candidate bytes"
             );
             return Ok(publication);
         }
@@ -238,8 +335,9 @@ where
 
     let publication = validate_candidate(&candidate_root, key)?;
     ensure!(
-        publication.weights_sha256 == weights_sha256,
-        "published QAT candidate weights changed during final validation"
+        publication.weights_sha256 == weights_sha256
+            && publication.candidate_manifest_sha256 == staged_candidate_manifest_sha256,
+        "published QAT candidate changed during final validation"
     );
     Ok(publication)
 }
@@ -331,11 +429,47 @@ fn aggregate_metrics(manifest: &QuantizationManifest) -> Result<QatArchiveMetric
 }
 
 fn validate_candidate(root: &Path, expected_key: &str) -> Result<QatCandidatePublication> {
+    validate_candidate_inner(root, expected_key, false)
+}
+
+fn validate_candidate_reproduced(
+    root: &Path,
+    expected_key: &str,
+) -> Result<QatCandidatePublication> {
+    validate_candidate_inner(root, expected_key, true)
+        .context("existing QAT candidate does not reproduce its canonical weights")
+}
+
+fn validate_candidate_inner(
+    root: &Path,
+    expected_key: &str,
+    reproduce_source: bool,
+) -> Result<QatCandidatePublication> {
+    validate_candidate_inner_with_hook(root, expected_key, reproduce_source, None, || Ok(()))
+}
+
+fn validate_candidate_inner_with_hook(
+    root: &Path,
+    expected_key: &str,
+    reproduce_source: bool,
+    expected_candidate_manifest_sha256: Option<&str>,
+    after_manifest: impl FnOnce() -> Result<()>,
+) -> Result<QatCandidatePublication> {
     ensure_real_directory(root, "QAT candidate")?;
     validate_candidate_inventory(root)?;
     let candidate_manifest_path = root.join(CANDIDATE_MANIFEST);
-    let manifest_bytes = read_regular(&candidate_manifest_path, "QAT candidate manifest")?;
+    let manifest_bytes = read_regular_bounded(
+        &candidate_manifest_path,
+        MAX_QAT_JSON_BYTES,
+        "QAT candidate manifest",
+    )?;
     let candidate_manifest_sha256 = sha256_label(&manifest_bytes);
+    if let Some(expected) = expected_candidate_manifest_sha256 {
+        ensure!(
+            candidate_manifest_sha256 == expected,
+            "QAT candidate receipt identity mismatch"
+        );
+    }
     let manifest: QatCandidateManifest =
         serde_json::from_slice(&manifest_bytes).context("invalid QAT candidate manifest")?;
     ensure!(
@@ -355,25 +489,29 @@ fn validate_candidate(root: &Path, expected_key: &str) -> Result<QatCandidatePub
         "QAT candidate uses a non-canonical artifact layout"
     );
     manifest.recipe.validate()?;
+    after_manifest()?;
 
     let weights_path = root.join(WEIGHTS_FILE);
-    let (weights_bytes, weights_sha256) = hash_regular_file(&weights_path, "QAT weights")?;
+    let (weights_bytes, weights_sha256) = hash_regular_file(&weights_path)?;
     ensure!(
         weights_bytes == manifest.weights_bytes && weights_sha256 == manifest.weights_sha256,
         "QAT candidate weights do not match their manifest"
     );
 
     let archive_path = root.join(ARCHIVE_DIRECTORY);
-    let archive = QuantizedArchive::open(&archive_path)
-        .context("QAT candidate contains an invalid HQUANT archive")?;
-    archive.verify_source_checkpoint(&weights_path)?;
+    let archive =
+        QuantizedArchive::open_addressed(&archive_path, &manifest.archive_manifest_sha256)
+            .context("QAT candidate contains an invalid HQUANT archive")?;
+    archive.verify_source_identity(&weights_sha256)?;
+    if reproduce_source {
+        archive.verify_source_checkpoint(&weights_path)?;
+    }
     ensure!(
         archive.manifest().recipe == manifest.recipe,
         "QAT candidate archive recipe does not match its manifest"
     );
     let archive_manifest_path = archive_path.join(ARCHIVE_MANIFEST);
-    let (_, archive_manifest_sha256) =
-        hash_regular_file(&archive_manifest_path, "HQUANT manifest")?;
+    let archive_manifest_sha256 = archive.manifest_sha256().to_owned();
     let archive_content_sha256 = archive.content_hash()?;
     ensure!(
         archive_manifest_sha256 == manifest.archive_manifest_sha256
@@ -388,6 +526,7 @@ fn validate_candidate(root: &Path, expected_key: &str) -> Result<QatCandidatePub
 
     Ok(QatCandidatePublication {
         candidate_key: manifest.candidate_key,
+        recipe: manifest.recipe,
         candidate_root: root.to_path_buf(),
         candidate_manifest_path,
         candidate_manifest_sha256,
@@ -414,7 +553,10 @@ fn validate_candidate_inventory(root: &Path) -> Result<()> {
             .file_name()
             .into_string()
             .map_err(|_| anyhow::anyhow!("QAT candidate contains a non-UTF-8 entry"))?;
-        actual.insert(name);
+        ensure!(
+            expected.contains(&name) && actual.insert(name),
+            "QAT candidate contains missing or unverified top-level entries"
+        );
     }
     ensure!(
         actual == expected,
@@ -449,36 +591,6 @@ fn validate_candidate_key(key: &str) -> Result<()> {
     Ok(())
 }
 
-fn ensure_directory(path: &Path, label: &str) -> Result<()> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) => {
-            ensure!(
-                metadata.is_dir() && !metadata.file_type().is_symlink(),
-                "{label} must be a real directory: {}",
-                path.display()
-            );
-            Ok(())
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            fs::create_dir_all(path)
-                .with_context(|| format!("failed to create {label} {}", path.display()))?;
-            ensure_real_directory(path, label)
-        }
-        Err(error) => Err(error).with_context(|| format!("failed to inspect {}", path.display())),
-    }
-}
-
-fn ensure_real_directory(path: &Path, label: &str) -> Result<()> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to inspect {label} {}", path.display()))?;
-    ensure!(
-        metadata.is_dir() && !metadata.file_type().is_symlink(),
-        "{label} must be a real directory: {}",
-        path.display()
-    );
-    Ok(())
-}
-
 fn allocate_staging_directory(root: &Path, key: &str) -> Result<PathBuf> {
     for _ in 0..1024 {
         let sequence = STAGING_SEQUENCE.fetch_add(1, Ordering::Relaxed);
@@ -504,64 +616,8 @@ fn checked_sum(mut values: impl Iterator<Item = u64>, label: &str) -> Result<u64
 }
 
 fn read_json_regular<T: for<'de> Deserialize<'de>>(path: &Path, label: &str) -> Result<T> {
-    serde_json::from_slice(&read_regular(path, label)?)
+    serde_json::from_slice(&read_regular_bounded(path, MAX_QAT_JSON_BYTES, label)?)
         .with_context(|| format!("invalid {label} {}", path.display()))
-}
-
-fn read_regular(path: &Path, label: &str) -> Result<Vec<u8>> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to inspect {label} {}", path.display()))?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "{label} must be a regular file: {}",
-        path.display()
-    );
-    fs::read(path).with_context(|| format!("failed to read {label} {}", path.display()))
-}
-
-fn hash_regular_file(path: &Path, label: &str) -> Result<(u64, String)> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to inspect {label} {}", path.display()))?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "{label} must be a regular file: {}",
-        path.display()
-    );
-    let mut input = File::open(path)?;
-    let mut digest = Sha256::new();
-    let mut bytes = 0u64;
-    let mut buffer = [0u8; 1024 * 1024];
-    loop {
-        let read = input.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        digest.update(&buffer[..read]);
-        bytes = bytes
-            .checked_add(u64::try_from(read).context("file chunk length exceeds u64")?)
-            .context("artifact byte count overflows u64")?;
-    }
-    Ok((bytes, format!("sha256:{:x}", digest.finalize())))
-}
-
-fn sha256_label(bytes: &[u8]) -> String {
-    format!("sha256:{:x}", Sha256::digest(bytes))
-}
-
-fn write_new_synced(path: &Path, bytes: &[u8]) -> Result<()> {
-    let mut output = OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .open(path)
-        .with_context(|| format!("failed to create immutable file {}", path.display()))?;
-    output.write_all(bytes)?;
-    output.sync_all()?;
-    Ok(())
-}
-
-fn sync_directory(path: &Path) -> Result<()> {
-    File::open(path)?.sync_all()?;
-    Ok(())
 }
 
 struct StagingDirectory {
@@ -637,6 +693,19 @@ mod tests {
         }
     }
 
+    fn copy_tree(source: &Path, destination: &Path) {
+        fs::create_dir(destination).unwrap();
+        for entry in fs::read_dir(source).unwrap() {
+            let entry = entry.unwrap();
+            let target = destination.join(entry.file_name());
+            if entry.file_type().unwrap().is_dir() {
+                copy_tree(&entry.path(), &target);
+            } else {
+                fs::copy(entry.path(), target).unwrap();
+            }
+        }
+    }
+
     #[test]
     fn publishes_validated_candidate_with_exact_metrics_and_replays_idempotently() {
         let directory = tempfile::tempdir().unwrap();
@@ -645,6 +714,16 @@ mod tests {
         let first = publish_qat_candidate(&model, directory.path(), "step-42", &recipe).unwrap();
         let second = publish_qat_candidate(&model, directory.path(), "step-42", &recipe).unwrap();
         assert_eq!(first, second);
+        assert_eq!(
+            open_qat_candidate_addressed(&first.candidate_root, &first.candidate_manifest_sha256,)
+                .unwrap(),
+            first
+        );
+        let wrong_receipt = format!("sha256:{}", "0".repeat(64));
+        let error = open_qat_candidate_addressed(&first.candidate_root, &wrong_receipt)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("receipt identity mismatch"), "{error}");
         assert!(first.metrics.quantized_tensors > 0);
         assert!(first.metrics.quantized_elements > 0);
         assert!(first.metrics.packed_bytes > 0);
@@ -652,15 +731,11 @@ mod tests {
         assert!(first.metrics.weighted_mean_squared_error >= 0.0);
         assert!(first.metrics.maximum_absolute_error >= 0.0);
         assert_eq!(
-            hash_regular_file(&first.candidate_manifest_path, "candidate")
-                .unwrap()
-                .1,
+            hash_regular_file(&first.candidate_manifest_path).unwrap().1,
             first.candidate_manifest_sha256
         );
         assert_eq!(
-            hash_regular_file(&first.archive_manifest_path, "archive manifest")
-                .unwrap()
-                .1,
+            hash_regular_file(&first.archive_manifest_path).unwrap().1,
             first.archive_manifest_sha256
         );
         let archive = QuantizedArchive::open(&first.archive_path).unwrap();
@@ -678,6 +753,96 @@ mod tests {
         assert_eq!(
             first.metrics.archive_weight_elements,
             first.metrics.quantized_elements + first.metrics.floating_elements
+        );
+    }
+
+    #[test]
+    fn authenticated_source_retry_reopens_without_serializing_mutable_model_state() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_model = model(32);
+        let recipe = recipe(UltraQuantFormat::BinaryG128);
+        let first =
+            publish_qat_candidate(&source_model, directory.path(), "sealed", &recipe).unwrap();
+
+        // The in-memory model is intentionally unrelated. The trusted input to
+        // this retry is the digest from an immutable checkpoint generation.
+        // A hook failure would prove that publication tried to serialize the
+        // mutable model instead of taking the authenticated existing-key path.
+        let unrelated_model = model(33);
+        let reopened = publish_qat_candidate_with_hook(
+            &unrelated_model,
+            directory.path(),
+            "sealed",
+            &recipe,
+            Some(&first.weights_sha256),
+            |point, _| bail!("unexpected serialization boundary {point:?}"),
+        )
+        .unwrap();
+        assert_eq!(reopened, first);
+
+        let wrong_source = format!("sha256:{}", "0".repeat(64));
+        let error = publish_qat_candidate_from_authenticated_source(
+            &unrelated_model,
+            directory.path(),
+            "sealed",
+            &recipe,
+            &wrong_source,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("different model weights"), "{error}");
+    }
+
+    #[test]
+    fn orphan_adoption_rejects_an_internally_rehashed_wrong_archive() {
+        let directory = tempfile::tempdir().unwrap();
+        let recipe = recipe(UltraQuantFormat::BinaryG128);
+        let source_model = model(32);
+        let source =
+            publish_qat_candidate(&source_model, directory.path(), "source", &recipe).unwrap();
+        let wrong_model = model(33);
+        let forged =
+            publish_qat_candidate(&wrong_model, directory.path(), "forged", &recipe).unwrap();
+
+        // Forge a candidate whose outer and inner hashes are all
+        // self-consistent and claim the authenticated source identity, while
+        // retaining quantized tensors derived from a different model.
+        fs::copy(&source.weights_path, &forged.weights_path).unwrap();
+        let mut archive_manifest: QuantizationManifest =
+            read_json_regular(&forged.archive_manifest_path, "HQUANT manifest").unwrap();
+        archive_manifest.base_checkpoint_hash = source.weights_sha256.clone();
+        let archive_manifest_bytes = serde_json::to_vec_pretty(&archive_manifest).unwrap();
+        fs::write(&forged.archive_manifest_path, &archive_manifest_bytes).unwrap();
+        let forged_archive = QuantizedArchive::open(&forged.archive_path).unwrap();
+
+        let mut candidate_manifest: QatCandidateManifest =
+            read_json_regular(&forged.candidate_manifest_path, "QAT candidate manifest").unwrap();
+        candidate_manifest.weights_bytes = fs::metadata(&source.weights_path).unwrap().len();
+        candidate_manifest.weights_sha256 = source.weights_sha256.clone();
+        candidate_manifest.archive_manifest_sha256 = sha256_label(&archive_manifest_bytes);
+        candidate_manifest.archive_content_sha256 = forged_archive.content_hash().unwrap();
+        fs::write(
+            &forged.candidate_manifest_path,
+            serde_json::to_vec_pretty(&candidate_manifest).unwrap(),
+        )
+        .unwrap();
+
+        let error = open_qat_candidate(&forged.candidate_root).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("does not reproduce its canonical weights"),
+            "{error:#}"
+        );
+        let error = publish_qat_candidate_from_authenticated_source(
+            &wrong_model,
+            directory.path(),
+            "forged",
+            &recipe,
+            &source.weights_sha256,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("does not reproduce its canonical weights"),
+            "{error:#}"
         );
     }
 
@@ -727,6 +892,7 @@ mod tests {
                 directory.path(),
                 &key,
                 &recipe,
+                None,
                 |point, staging| {
                     if point == fault {
                         // Leaving the staging directory emulates abrupt process
@@ -757,6 +923,44 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_adoption_requires_the_exact_locally_derived_receipt() {
+        let directory = tempfile::tempdir().unwrap();
+        let model = model(32);
+        let recipe = recipe(UltraQuantFormat::BinaryG128);
+        let key = "concurrent-receipt";
+        let competing = directory.path().join(key);
+        let error = publish_qat_candidate_with_hook(
+            &model,
+            directory.path(),
+            key,
+            &recipe,
+            None,
+            |point, staging| {
+                if point == PublicationPoint::ManifestSynced {
+                    copy_tree(staging.path(), &competing);
+                    let manifest: QatCandidateManifest = read_json_regular(
+                        &competing.join(CANDIDATE_MANIFEST),
+                        "competing candidate manifest",
+                    )?;
+                    // The candidate is semantically equivalent and internally
+                    // valid, but it is not the exact receipt derived by this
+                    // publication attempt.
+                    fs::write(
+                        competing.join(CANDIDATE_MANIFEST),
+                        serde_json::to_vec(&manifest)?,
+                    )?;
+                }
+                Ok(())
+            },
+        )
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("different candidate bytes"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
     fn tampering_is_rejected_without_replacing_the_candidate() {
         let directory = tempfile::tempdir().unwrap();
         let model = model(32);
@@ -772,8 +976,47 @@ mod tests {
         fs::write(&member, corrupt).unwrap();
 
         let error = publish_qat_candidate(&model, directory.path(), "tamper", &recipe).unwrap_err();
-        assert!(error.to_string().contains("invalid HQUANT archive"));
+        assert!(
+            format!("{error:#}").contains("invalid HQUANT archive"),
+            "{error:#}"
+        );
+        let fast_error = publish_qat_candidate_from_authenticated_source(
+            &model,
+            directory.path(),
+            "tamper",
+            &recipe,
+            &publication.weights_sha256,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{fast_error:#}").contains("invalid HQUANT archive"),
+            "{fast_error:#}"
+        );
         assert!(publication.candidate_root.exists());
+    }
+
+    #[test]
+    fn candidate_root_swap_after_manifest_capture_is_rejected() {
+        let directory = tempfile::tempdir().unwrap();
+        let first_store = directory.path().join("first-store");
+        let second_store = directory.path().join("second-store");
+        let recipe = recipe(UltraQuantFormat::BinaryG128);
+        let first = publish_qat_candidate(&model(32), &first_store, "stable", &recipe).unwrap();
+        let second = publish_qat_candidate(&model(33), &second_store, "stable", &recipe).unwrap();
+        let published = first.candidate_root.clone();
+        let replacement = second.candidate_root.clone();
+        let parked = directory.path().join("parked-candidate");
+
+        let error = validate_candidate_inner_with_hook(&published, "stable", false, None, || {
+            fs::rename(&published, &parked)?;
+            fs::rename(&replacement, &published)?;
+            Ok(())
+        })
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("weights do not match"),
+            "{error:#}"
+        );
     }
 
     #[test]
@@ -788,6 +1031,9 @@ mod tests {
             publish_qat_candidate(&model, directory.path(), "closed", &recipe).unwrap();
         fs::write(publication.candidate_root.join("extra"), b"unverified").unwrap();
         let error = publish_qat_candidate(&model, directory.path(), "closed", &recipe).unwrap_err();
-        assert!(error.to_string().contains("unverified top-level"));
+        assert!(
+            format!("{error:#}").contains("unverified top-level"),
+            "{error:#}"
+        );
     }
 }

--- a/hermes-train/src/quantization.rs
+++ b/hermes-train/src/quantization.rs
@@ -9,8 +9,11 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
-use std::io::{Cursor, Read, Write};
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::path::{Component, Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 
 use anyhow::{Context, Result, bail, ensure};
 use burn::module::{Module, ModuleMapper, Param, ParamId};
@@ -19,19 +22,29 @@ use burn::tensor::Device;
 use burn::tensor::{IndexingUpdateOp, Int, Tensor, TensorData};
 use half::{bf16, f16};
 use hermes_llm::Transformer;
-use safetensors::{Dtype, SafeTensors};
+use safetensors::Dtype;
+use safetensors::tensor::{Metadata as SafeTensorMetadata, TensorInfo};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
+use crate::artifact_io::{
+    StableIdentity, hash_open_file, sha256_identity, validate_sha256_identity,
+};
 use crate::workflow::{QuantizationConfig, QuantizationFormat, QuantizationTraining};
 
 const MAGIC: &[u8; 8] = b"HQUANT1\0";
 const CODEC_VERSION: u16 = 1;
 pub const QUANTIZATION_ARCHIVE_VERSION: u32 = 2;
-pub const QUANTIZATION_TRANSACTION_VERSION: u32 = 1;
 const ARCHIVE_VERSION: u32 = QUANTIZATION_ARCHIVE_VERSION;
-const TRANSACTION_VERSION: u32 = QUANTIZATION_TRANSACTION_VERSION;
 pub const BONSAI_GROUP_SIZE: usize = 128;
+const MAX_QUANTIZATION_MANIFEST_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_QUANTIZATION_ARCHIVE_MEMBERS: usize = 65_536;
+const MAX_QUANTIZATION_ARCHIVE_DIRECTORIES: usize = 4_096;
+const MAX_QUANTIZATION_ARCHIVE_DEPTH: usize = 32;
+const MAX_QUANTIZATION_MEMBER_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+const MAX_SAFETENSORS_HEADER_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_TENSOR_RANK: usize = 32;
+const MAX_TENSOR_NAME_BYTES: usize = 4_096;
+const MAX_ARCHIVE_MEMBER_PATH_BYTES: usize = 4_096;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -164,7 +177,7 @@ impl WorkflowQuantizationPlan {
                     !teacher_checkpoint.as_os_str().is_empty(),
                     "quantization distillation requires teacher_checkpoint"
                 );
-                validate_sha256_label(teacher_sha256)?;
+                validate_sha256_identity(teacher_sha256, "quantization teacher identity")?;
                 ensure!(
                     temperature.is_finite() && *temperature > 0.0,
                     "quantization distillation temperature must be finite and positive"
@@ -266,7 +279,7 @@ impl WorkflowQuantizationPlan {
                     !teacher_checkpoint.as_os_str().is_empty(),
                     "quantization teacher checkpoint is empty"
                 );
-                validate_sha256_label(teacher_sha256)?;
+                validate_sha256_identity(teacher_sha256, "quantization teacher identity")?;
                 ensure!(
                     temperature.is_finite() && *temperature > 0.0,
                     "quantization teacher temperature must be finite and positive"
@@ -281,12 +294,12 @@ impl WorkflowQuantizationPlan {
                 );
             }
         }
-        self.start_step
+        let target_start = self
+            .start_step
             .checked_add(self.warmup_steps)
             .context("quantization warmup schedule overflows u64")?;
         ensure!(
-            self.end_step
-                .is_none_or(|end| { end > self.start_step.saturating_add(self.warmup_steps) }),
+            self.end_step.is_none_or(|end| end > target_start),
             "quantization interval ends before the target format becomes active"
         );
         Ok(())
@@ -329,11 +342,6 @@ impl WorkflowQuantizationPlan {
                 .map_or_else(|| "unbounded".to_owned(), |end| end.to_string())
         );
         Ok(())
-    }
-
-    pub fn fingerprint(&self) -> Result<String> {
-        self.validate()?;
-        Ok(sha256_label(&serde_json::to_vec(self)?))
     }
 }
 
@@ -393,7 +401,10 @@ impl QuantizationRecipe {
             return None;
         }
         if self.format == UltraQuantFormat::BinaryG128
-            && step < self.fake_quant_start_step + self.ternary_warmup_steps
+            && step
+                < self
+                    .fake_quant_start_step
+                    .saturating_add(self.ternary_warmup_steps)
         {
             return Some(UltraQuantFormat::TernaryG128);
         }
@@ -412,19 +423,34 @@ pub struct PackedTensor {
 }
 
 impl PackedTensor {
-    pub fn elements(&self) -> usize {
-        self.shape.iter().product()
+    pub fn elements(&self) -> Result<usize> {
+        ensure!(
+            (1..=MAX_TENSOR_RANK).contains(&self.shape.len()),
+            "packed tensor rank must be in 1..={MAX_TENSOR_RANK}"
+        );
+        checked_elements(&self.shape)
     }
 
     /// Codec payload rate (codes plus FP16 group scales), excluding the small
     /// HQUANT container header/checksum. Archive accounting uses actual files.
-    pub fn bits_per_weight(&self) -> f64 {
-        8.0 * (self.codes.len() + self.scales.len() * 2) as f64 / self.elements() as f64
+    pub fn bits_per_weight(&self) -> Result<f64> {
+        validate_packed(self)?;
+        let payload_bytes = self
+            .scales
+            .len()
+            .checked_mul(std::mem::size_of::<u16>())
+            .and_then(|scale_bytes| scale_bytes.checked_add(self.codes.len()))
+            .context("packed tensor payload size overflows usize")?;
+        Ok(8.0 * payload_bytes as f64 / self.elements()? as f64)
     }
 
     pub fn decode(&self) -> Result<Vec<f32>> {
         validate_packed(self)?;
-        let mut output = Vec::with_capacity(self.elements());
+        let elements = self.elements()?;
+        let mut output = Vec::new();
+        output
+            .try_reserve_exact(elements)
+            .context("reserving decoded quantized tensor")?;
         for group in 0..self.scales.len() {
             let scale = f16::from_bits(self.scales[group]).to_f32();
             match self.format {
@@ -470,7 +496,7 @@ impl PackedTensor {
                 }
             }
         }
-        output.truncate(self.elements());
+        output.truncate(elements);
         Ok(output)
     }
 
@@ -519,6 +545,10 @@ impl PackedTensor {
         let format = UltraQuantFormat::from_tag(read_u8(&mut input)?)?;
         let group_size = usize::from(read_u16(&mut input)?);
         let rank = usize::from(read_u8(&mut input)?);
+        ensure!(
+            (1..=MAX_TENSOR_RANK).contains(&rank),
+            "packed tensor rank must be in 1..={MAX_TENSOR_RANK}"
+        );
         let mut shape = Vec::with_capacity(rank);
         for _ in 0..rank {
             shape.push(
@@ -588,7 +618,8 @@ impl PackedTensor {
     }
 
     pub fn load(path: &Path) -> Result<Self> {
-        let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+        let bytes =
+            read_regular_file_bounded(path, MAX_QUANTIZATION_MEMBER_BYTES, "packed tensor")?;
         Self::from_bytes(&bytes)
     }
 
@@ -598,6 +629,7 @@ impl PackedTensor {
     /// not presented as a production GEMM kernel.
     pub fn matrix_vector(&self, input: &[f32]) -> Result<Vec<f32>> {
         validate_packed(self)?;
+        let elements = self.elements()?;
         ensure!(
             self.shape.len() == 2,
             "packed linear weight must be rank two"
@@ -614,18 +646,15 @@ impl PackedTensor {
             let mut sum = 0.0f32;
             for (column, activation) in input.iter().enumerate() {
                 let index = row * columns + column;
-                sum += self.value_at(index)? * activation;
+                sum += self.value_at(index, elements)? * activation;
             }
             *output = sum;
         }
         Ok(output)
     }
 
-    fn value_at(&self, index: usize) -> Result<f32> {
-        ensure!(
-            index < self.elements(),
-            "packed tensor index is out of bounds"
-        );
+    fn value_at(&self, index: usize, elements: usize) -> Result<f32> {
+        ensure!(index < elements, "packed tensor index is out of bounds");
         let group = index / self.group_size;
         let local = index % self.group_size;
         let scale = f16::from_bits(self.scales[group]).to_f32();
@@ -902,631 +931,6 @@ pub fn fake_quantized_transformer(
     Ok((staged, mapper.mapped))
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct QuantizationStepResult {
-    pub format: Option<UltraQuantFormat>,
-    pub task_loss: f64,
-    pub distillation_forward_kl: Option<f64>,
-    pub quantized_matrices: usize,
-}
-
-/// Accelerator/model adapter for straight-through fake-quantized training.
-/// Full-precision master weights remain authoritative; temporary quantized
-/// forward tensors are always restored before an optimizer update is applied.
-pub trait QuantizationTrainingBackend {
-    type Gradients;
-
-    fn master_weights_hash(&mut self) -> Result<String>;
-    fn stage_fake_quantized_forward(
-        &mut self,
-        format: UltraQuantFormat,
-        group_size: usize,
-        embeddings: bool,
-        lm_head: bool,
-    ) -> Result<usize>;
-    fn compute_straight_through_gradients(
-        &mut self,
-        distillation_weight: f64,
-    ) -> Result<(Self::Gradients, f64, Option<f64>)>;
-    fn restore_master_weights(&mut self) -> Result<()>;
-    fn apply_master_update(&mut self, gradients: Self::Gradients) -> Result<()>;
-}
-
-/// Execute one QAT step with cleanup on every error. Before fake-quant starts,
-/// this still uses the same backend gradient/apply path without staging a
-/// quantized forward, which makes progressive schedules checkpoint-stable.
-pub fn run_quantization_step<B: QuantizationTrainingBackend>(
-    backend: &mut B,
-    recipe: &QuantizationRecipe,
-    step: u64,
-) -> Result<QuantizationStepResult> {
-    recipe.validate()?;
-    let master_hash = backend.master_weights_hash()?;
-    let format = recipe.forward_format(step);
-    let quantized_matrices = match format {
-        Some(format) => backend.stage_fake_quantized_forward(
-            format,
-            recipe.group_size,
-            recipe.quantize_embeddings,
-            recipe.quantize_lm_head,
-        )?,
-        None => 0,
-    };
-    let computed = backend.compute_straight_through_gradients(recipe.distillation_weight);
-    let restore = backend.restore_master_weights();
-    if let Err(error) = restore {
-        return match computed {
-            Ok(_) => Err(error.context("failed to restore full-precision masters after QAT")),
-            Err(compute_error) => bail!(
-                "QAT gradient computation failed: {compute_error:#}; master restore also failed: {error:#}"
-            ),
-        };
-    }
-    ensure!(
-        backend.master_weights_hash()? == master_hash,
-        "fake-quantized forward mutated full-precision master weights"
-    );
-    let (gradients, task_loss, distillation_forward_kl) = computed?;
-    ensure!(task_loss.is_finite(), "QAT task loss is non-finite");
-    if let Some(divergence) = distillation_forward_kl {
-        ensure!(
-            divergence.is_finite() && divergence >= 0.0,
-            "QAT distillation divergence is invalid"
-        );
-    }
-    backend.apply_master_update(gradients)?;
-    Ok(QuantizationStepResult {
-        format,
-        task_loss,
-        distillation_forward_kl,
-        quantized_matrices,
-    })
-}
-
-/// Durable state of one optimizer step. The state is intentionally independent
-/// of trainer checkpoint internals so it can be embedded in the strict v2
-/// checkpoint and atomically persisted by the caller.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct QuantizationTransactionState {
-    pub version: u32,
-    pub transaction_id: String,
-    pub plan_fingerprint: String,
-    pub optimizer_step: u64,
-    pub format: Option<UltraQuantFormat>,
-    pub substep: QuantizationSubstep,
-    pub pre_update_master_hash: String,
-    pub quantized_matrices: Option<usize>,
-    pub gradient_handle: Option<String>,
-    pub task_loss: Option<f64>,
-    pub distillation_forward_kl: Option<f64>,
-    pub post_update_master_hash: Option<String>,
-    pub failure: Option<String>,
-}
-
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum QuantizationSubstep {
-    Prepared,
-    ForwardStaged,
-    GradientsComputed,
-    MastersRestored,
-    UpdateApplied,
-    Complete,
-    Aborted,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct DurableGradientResult {
-    /// Backend-owned durable handle. Calling the compute operation again with
-    /// the same transaction id must return the same logical gradients/handle.
-    pub gradient_handle: String,
-    pub task_loss: f64,
-    pub distillation_forward_kl: Option<f64>,
-}
-
-/// Backend contract for interruption-safe QAT and quantization distillation.
-/// Every method ending in `_once` must be idempotent for a transaction id.
-/// In particular, `apply_master_update_once` must never apply an optimizer
-/// update twice after a crash between the update and its checkpoint callback.
-pub trait DurableQuantizationBackend {
-    fn master_weights_hash(&mut self) -> Result<String>;
-
-    fn stage_fake_quantized_forward_once(
-        &mut self,
-        transaction_id: &str,
-        format: UltraQuantFormat,
-        group_size: usize,
-        embeddings: bool,
-        lm_head: bool,
-    ) -> Result<usize>;
-
-    fn compute_gradients_once(
-        &mut self,
-        transaction_id: &str,
-        training: &WorkflowQuantizationTraining,
-    ) -> Result<DurableGradientResult>;
-
-    fn restore_master_weights_once(&mut self, transaction_id: &str) -> Result<()>;
-
-    fn apply_master_update_once(
-        &mut self,
-        transaction_id: &str,
-        gradient_handle: &str,
-    ) -> Result<()>;
-
-    /// Restore full-precision masters and make a failed transaction terminal.
-    /// Repeating this operation must be harmless.
-    fn abort_transaction_once(&mut self, transaction_id: &str) -> Result<()>;
-
-    /// Release backend-side temporary tensors/gradient handles only after the
-    /// complete state is durably published. Repeating cleanup must be harmless.
-    fn clear_transaction_once(&mut self, transaction_id: &str) -> Result<()>;
-}
-
-/// Callback used at every substep boundary. Implementations must atomically
-/// and durably publish the supplied state before returning success.
-pub trait QuantizationCheckpointCallback {
-    fn checkpoint_quantization(&mut self, state: &QuantizationTransactionState) -> Result<()>;
-}
-
-impl<F> QuantizationCheckpointCallback for F
-where
-    F: FnMut(&QuantizationTransactionState) -> Result<()>,
-{
-    fn checkpoint_quantization(&mut self, state: &QuantizationTransactionState) -> Result<()> {
-        self(state)
-    }
-}
-
-/// Atomic JSON state store for runtimes that keep the quantization transaction
-/// beside (or as an artifact referenced by) the model checkpoint generation.
-/// Publication fsyncs the file and parent directory before returning.
-#[derive(Clone, Debug)]
-pub struct AtomicQuantizationStateStore {
-    path: PathBuf,
-}
-
-impl AtomicQuantizationStateStore {
-    pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
-        let path = path.into();
-        ensure!(
-            !path.as_os_str().is_empty(),
-            "quantization state path is empty"
-        );
-        if let Some(parent) = path.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            fs::create_dir_all(parent).with_context(|| {
-                format!(
-                    "failed to create quantization state directory {}",
-                    parent.display()
-                )
-            })?;
-        }
-        if path.exists() {
-            let metadata = fs::symlink_metadata(&path)?;
-            ensure!(
-                metadata.is_file() && !metadata.file_type().is_symlink(),
-                "quantization state path must be a regular file"
-            );
-        }
-        Ok(Self { path })
-    }
-
-    pub fn path(&self) -> &Path {
-        &self.path
-    }
-
-    pub fn load(
-        &self,
-        plan: &WorkflowQuantizationPlan,
-    ) -> Result<Option<QuantizationTransactionState>> {
-        if !self.path.exists() {
-            return Ok(None);
-        }
-        let metadata = fs::symlink_metadata(&self.path)?;
-        ensure!(
-            metadata.is_file() && !metadata.file_type().is_symlink(),
-            "quantization state path must be a regular file"
-        );
-        let state: QuantizationTransactionState = serde_json::from_slice(
-            &fs::read(&self.path)
-                .with_context(|| format!("failed to read {}", self.path.display()))?,
-        )
-        .with_context(|| format!("invalid quantization state {}", self.path.display()))?;
-        state.validate_for(plan)?;
-        Ok(Some(state))
-    }
-
-    /// Resume the requested optimizer step, or prepare it after a previously
-    /// completed earlier step. In-progress future/backward mismatches fail
-    /// closed instead of applying an update under the wrong global step.
-    pub fn load_or_prepare<B: DurableQuantizationBackend>(
-        &self,
-        backend: &mut B,
-        plan: &WorkflowQuantizationPlan,
-        optimizer_step: u64,
-    ) -> Result<QuantizationTransactionState> {
-        match self.load(plan)? {
-            None => QuantizationTransactionState::prepare(backend, plan, optimizer_step),
-            Some(state) if state.optimizer_step == optimizer_step => Ok(state),
-            Some(state)
-                if state.optimizer_step < optimizer_step
-                    && state.substep == QuantizationSubstep::Complete =>
-            {
-                QuantizationTransactionState::prepare(backend, plan, optimizer_step)
-            }
-            Some(state) => bail!(
-                "quantization state is at step {} ({:?}), requested step {optimizer_step}",
-                state.optimizer_step,
-                state.substep
-            ),
-        }
-    }
-}
-
-impl QuantizationCheckpointCallback for AtomicQuantizationStateStore {
-    fn checkpoint_quantization(&mut self, state: &QuantizationTransactionState) -> Result<()> {
-        write_atomic_synced(&self.path, &serde_json::to_vec_pretty(state)?)
-    }
-}
-
-impl QuantizationTransactionState {
-    pub fn is_terminal(&self) -> bool {
-        matches!(
-            self.substep,
-            QuantizationSubstep::Complete | QuantizationSubstep::Aborted
-        )
-    }
-
-    pub fn prepare<B: DurableQuantizationBackend>(
-        backend: &mut B,
-        plan: &WorkflowQuantizationPlan,
-        optimizer_step: u64,
-    ) -> Result<Self> {
-        plan.validate()?;
-        let plan_fingerprint = plan.fingerprint()?;
-        let pre_update_master_hash = backend.master_weights_hash()?;
-        validate_sha256_label(&pre_update_master_hash)
-            .context("quantization backend returned an invalid master hash")?;
-        let transaction_id =
-            transaction_id(&plan_fingerprint, optimizer_step, &pre_update_master_hash);
-        let state = Self {
-            version: TRANSACTION_VERSION,
-            transaction_id,
-            plan_fingerprint,
-            optimizer_step,
-            format: plan.format_at(optimizer_step),
-            substep: QuantizationSubstep::Prepared,
-            pre_update_master_hash,
-            quantized_matrices: None,
-            gradient_handle: None,
-            task_loss: None,
-            distillation_forward_kl: None,
-            post_update_master_hash: None,
-            failure: None,
-        };
-        state.validate_for(plan)?;
-        Ok(state)
-    }
-
-    pub fn validate_for(&self, plan: &WorkflowQuantizationPlan) -> Result<()> {
-        plan.validate()?;
-        ensure!(
-            self.version == TRANSACTION_VERSION,
-            "unsupported quantization transaction version {}",
-            self.version
-        );
-        ensure!(
-            self.plan_fingerprint == plan.fingerprint()?,
-            "quantization transaction plan fingerprint mismatch"
-        );
-        ensure!(
-            self.format == plan.format_at(self.optimizer_step),
-            "quantization transaction forward format does not match its plan"
-        );
-        validate_sha256_label(&self.transaction_id)
-            .context("quantization transaction id is not content-addressed")?;
-        validate_sha256_label(&self.plan_fingerprint)
-            .context("quantization plan fingerprint is not content-addressed")?;
-        validate_sha256_label(&self.pre_update_master_hash)
-            .context("quantization pre-update master hash is not content-addressed")?;
-        ensure!(
-            self.transaction_id
-                == transaction_id(
-                    &self.plan_fingerprint,
-                    self.optimizer_step,
-                    &self.pre_update_master_hash,
-                ),
-            "quantization transaction id is invalid"
-        );
-
-        let staged = matches!(
-            self.substep,
-            QuantizationSubstep::ForwardStaged
-                | QuantizationSubstep::GradientsComputed
-                | QuantizationSubstep::MastersRestored
-                | QuantizationSubstep::UpdateApplied
-                | QuantizationSubstep::Complete
-        );
-        ensure!(
-            staged == self.quantized_matrices.is_some(),
-            "quantization transaction staged-count invariant failed"
-        );
-        let gradients = matches!(
-            self.substep,
-            QuantizationSubstep::GradientsComputed
-                | QuantizationSubstep::MastersRestored
-                | QuantizationSubstep::UpdateApplied
-                | QuantizationSubstep::Complete
-        );
-        ensure!(
-            gradients == (self.gradient_handle.is_some() && self.task_loss.is_some()),
-            "quantization transaction gradient invariant failed"
-        );
-        if let Some(handle) = &self.gradient_handle {
-            ensure!(
-                !handle.trim().is_empty(),
-                "quantization gradient handle is empty"
-            );
-        }
-        if let Some(task_loss) = self.task_loss {
-            ensure!(
-                task_loss.is_finite(),
-                "quantization task loss is non-finite"
-            );
-        }
-        if let Some(divergence) = self.distillation_forward_kl {
-            ensure!(
-                gradients && divergence.is_finite() && divergence >= 0.0,
-                "quantization distillation divergence is invalid"
-            );
-        }
-        let applied = matches!(
-            self.substep,
-            QuantizationSubstep::UpdateApplied | QuantizationSubstep::Complete
-        );
-        ensure!(
-            applied == self.post_update_master_hash.is_some(),
-            "quantization transaction post-update hash invariant failed"
-        );
-        if let Some(hash) = &self.post_update_master_hash {
-            validate_sha256_label(hash)
-                .context("quantization post-update master hash is not content-addressed")?;
-        }
-        ensure!(
-            (self.substep == QuantizationSubstep::Aborted) == self.failure.is_some(),
-            "quantization transaction failure invariant failed"
-        );
-        Ok(())
-    }
-
-    pub fn result(&self) -> Result<QuantizationStepResult> {
-        ensure!(
-            self.substep == QuantizationSubstep::Complete,
-            "quantization transaction is not complete"
-        );
-        Ok(QuantizationStepResult {
-            format: self.format,
-            task_loss: self
-                .task_loss
-                .context("complete transaction has no task loss")?,
-            distillation_forward_kl: self.distillation_forward_kl,
-            quantized_matrices: self
-                .quantized_matrices
-                .context("complete transaction has no staged matrix count")?,
-        })
-    }
-}
-
-/// Resume a QAT/distillation step from any durably checkpointed substep.
-///
-/// The callback runs before the first mutation and after every successful
-/// transition. A callback failure stops execution immediately and leaves the
-/// backend transaction available for an exact retry.
-pub fn run_durable_quantization_step<B, C>(
-    backend: &mut B,
-    checkpoints: &mut C,
-    plan: &WorkflowQuantizationPlan,
-    state: &mut QuantizationTransactionState,
-) -> Result<QuantizationStepResult>
-where
-    B: DurableQuantizationBackend,
-    C: QuantizationCheckpointCallback,
-{
-    state.validate_for(plan)?;
-    checkpoints.checkpoint_quantization(state)?;
-    loop {
-        match state.substep {
-            QuantizationSubstep::Prepared => {
-                let staged = match state.format {
-                    Some(format) => backend.stage_fake_quantized_forward_once(
-                        &state.transaction_id,
-                        format,
-                        plan.recipe.group_size,
-                        plan.recipe.quantize_embeddings,
-                        plan.recipe.quantize_lm_head,
-                    ),
-                    None => Ok(0),
-                };
-                let count = match staged {
-                    Ok(count) => count,
-                    Err(error) => {
-                        return abort_quantization_transaction(
-                            backend,
-                            checkpoints,
-                            plan,
-                            state,
-                            error.context("failed to stage fake-quantized forward"),
-                        );
-                    }
-                };
-                if backend.master_weights_hash()? != state.pre_update_master_hash {
-                    return abort_quantization_transaction(
-                        backend,
-                        checkpoints,
-                        plan,
-                        state,
-                        anyhow::anyhow!("fake-quant staging mutated full-precision master weights"),
-                    );
-                }
-                state.quantized_matrices = Some(count);
-                state.substep = QuantizationSubstep::ForwardStaged;
-                state.validate_for(plan)?;
-                checkpoints.checkpoint_quantization(state)?;
-            }
-            QuantizationSubstep::ForwardStaged => {
-                let computed =
-                    match backend.compute_gradients_once(&state.transaction_id, &plan.training) {
-                        Ok(computed) => computed,
-                        Err(error) => {
-                            return abort_quantization_transaction(
-                                backend,
-                                checkpoints,
-                                plan,
-                                state,
-                                error.context("failed to compute quantization gradients"),
-                            );
-                        }
-                    };
-                let invalid = if computed.gradient_handle.trim().is_empty() {
-                    Some("quantization backend returned an empty gradient handle")
-                } else if !computed.task_loss.is_finite() {
-                    Some("quantization task loss is non-finite")
-                } else if computed
-                    .distillation_forward_kl
-                    .is_some_and(|value| !value.is_finite() || value < 0.0)
-                {
-                    Some("quantization distillation divergence is invalid")
-                } else {
-                    None
-                };
-                if let Some(invalid) = invalid {
-                    return abort_quantization_transaction(
-                        backend,
-                        checkpoints,
-                        plan,
-                        state,
-                        anyhow::anyhow!(invalid),
-                    );
-                }
-                state.gradient_handle = Some(computed.gradient_handle);
-                state.task_loss = Some(computed.task_loss);
-                state.distillation_forward_kl = computed.distillation_forward_kl;
-                state.substep = QuantizationSubstep::GradientsComputed;
-                state.validate_for(plan)?;
-                checkpoints.checkpoint_quantization(state)?;
-            }
-            QuantizationSubstep::GradientsComputed => {
-                backend
-                    .restore_master_weights_once(&state.transaction_id)
-                    .context("failed to restore full-precision masters")?;
-                ensure!(
-                    backend.master_weights_hash()? == state.pre_update_master_hash,
-                    "restored QAT masters do not match their pre-update hash"
-                );
-                state.substep = QuantizationSubstep::MastersRestored;
-                state.validate_for(plan)?;
-                checkpoints.checkpoint_quantization(state)?;
-            }
-            QuantizationSubstep::MastersRestored => {
-                backend
-                    .apply_master_update_once(
-                        &state.transaction_id,
-                        state
-                            .gradient_handle
-                            .as_deref()
-                            .context("restored transaction has no gradient handle")?,
-                    )
-                    .context("failed to atomically apply quantization master update")?;
-                let post_hash = backend.master_weights_hash()?;
-                ensure!(
-                    !post_hash.trim().is_empty(),
-                    "quantization backend returned an empty post-update hash"
-                );
-                state.post_update_master_hash = Some(post_hash);
-                state.substep = QuantizationSubstep::UpdateApplied;
-                state.validate_for(plan)?;
-                checkpoints.checkpoint_quantization(state)?;
-            }
-            QuantizationSubstep::UpdateApplied => {
-                ensure!(
-                    backend.master_weights_hash()?
-                        == *state
-                            .post_update_master_hash
-                            .as_ref()
-                            .context("applied transaction has no post-update hash")?,
-                    "quantization model changed before transaction completion"
-                );
-                state.substep = QuantizationSubstep::Complete;
-                state.validate_for(plan)?;
-                checkpoints.checkpoint_quantization(state)?;
-                backend
-                    .clear_transaction_once(&state.transaction_id)
-                    .context("failed to clear completed quantization transaction")?;
-                return state.result();
-            }
-            QuantizationSubstep::Complete => {
-                ensure!(
-                    backend.master_weights_hash()?
-                        == *state
-                            .post_update_master_hash
-                            .as_ref()
-                            .context("complete transaction has no post-update hash")?,
-                    "completed quantization transaction model hash mismatch"
-                );
-                backend.clear_transaction_once(&state.transaction_id)?;
-                return state.result();
-            }
-            QuantizationSubstep::Aborted => bail!(
-                "quantization transaction `{}` is aborted: {}",
-                state.transaction_id,
-                state.failure.as_deref().unwrap_or("unknown failure")
-            ),
-        }
-    }
-}
-
-fn abort_quantization_transaction<B, C>(
-    backend: &mut B,
-    checkpoints: &mut C,
-    plan: &WorkflowQuantizationPlan,
-    state: &mut QuantizationTransactionState,
-    cause: anyhow::Error,
-) -> Result<QuantizationStepResult>
-where
-    B: DurableQuantizationBackend,
-    C: QuantizationCheckpointCallback,
-{
-    backend
-        .abort_transaction_once(&state.transaction_id)
-        .with_context(|| format!("{cause:#}; also failed to abort quantization transaction"))?;
-    ensure!(
-        backend.master_weights_hash()? == state.pre_update_master_hash,
-        "aborted quantization transaction did not restore master weights"
-    );
-    state.quantized_matrices = None;
-    state.gradient_handle = None;
-    state.task_loss = None;
-    state.distillation_forward_kl = None;
-    state.post_update_master_hash = None;
-    state.failure = Some(format!("{cause:#}"));
-    state.substep = QuantizationSubstep::Aborted;
-    state.validate_for(plan)?;
-    checkpoints.checkpoint_quantization(state)?;
-    Err(cause)
-}
-
-fn transaction_id(plan_fingerprint: &str, step: u64, master_hash: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(b"hermes-quantization-transaction-v1\0");
-    hasher.update(plan_fingerprint.as_bytes());
-    hasher.update(step.to_le_bytes());
-    hasher.update(master_hash.as_bytes());
-    format!("sha256:{:x}", hasher.finalize())
-}
-
 fn optimal_ternary(group: &[f32]) -> (f32, Vec<u8>) {
     let mut ranked = group
         .iter()
@@ -1578,7 +982,7 @@ fn validate_packed(packed: &PackedTensor) -> Result<()> {
         packed.group_size == BONSAI_GROUP_SIZE,
         "packed tensor is not g128"
     );
-    let elements = checked_elements(&packed.shape)?;
+    let elements = packed.elements()?;
     ensure!(elements > 0, "packed tensor is empty");
     let groups = elements.div_ceil(packed.group_size);
     ensure!(
@@ -1762,6 +1166,7 @@ impl QuantizationManifest {
 pub struct QuantizedArchive {
     root: PathBuf,
     manifest: QuantizationManifest,
+    manifest_sha256: String,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -1785,6 +1190,28 @@ pub trait QuantizedModelBackend {
 
 impl QuantizedArchive {
     pub fn open(root: &Path) -> Result<Self> {
+        Self::open_inner(root, None)
+    }
+
+    /// Open an archive whose exact manifest bytes are sealed by an enclosing
+    /// immutable receipt. Member hashes are read only from those authenticated
+    /// bytes, so pathname replacement cannot mix one manifest with another
+    /// archive generation.
+    pub(crate) fn open_addressed(root: &Path, expected_manifest_sha256: &str) -> Result<Self> {
+        validate_sha256_identity(expected_manifest_sha256, "quantization manifest identity")
+            .context("invalid expected quantization manifest identity")?;
+        Self::open_inner(root, Some(expected_manifest_sha256))
+    }
+
+    fn open_inner(root: &Path, expected_manifest_sha256: Option<&str>) -> Result<Self> {
+        Self::open_inner_with_hook(root, expected_manifest_sha256, || Ok(()))
+    }
+
+    fn open_inner_with_hook(
+        root: &Path,
+        expected_manifest_sha256: Option<&str>,
+        after_manifest: impl FnOnce() -> Result<()>,
+    ) -> Result<Self> {
         let metadata = fs::symlink_metadata(root)
             .with_context(|| format!("failed to inspect quantized archive {}", root.display()))?;
         ensure!(
@@ -1802,38 +1229,69 @@ impl QuantizedArchive {
             manifest_metadata.is_file() && !manifest_metadata.file_type().is_symlink(),
             "quantization manifest must be a regular file"
         );
-        let manifest: QuantizationManifest = serde_json::from_slice(
-            &fs::read(&manifest_path)
-                .with_context(|| format!("failed to read {}", manifest_path.display()))?,
-        )
-        .context("invalid quantization manifest")?;
+        let manifest_bytes = read_regular_file_bounded(
+            &manifest_path,
+            MAX_QUANTIZATION_MANIFEST_BYTES,
+            "quantization manifest",
+        )?;
+        let manifest_sha256 = sha256_identity(&manifest_bytes);
+        if let Some(expected) = expected_manifest_sha256 {
+            ensure!(
+                manifest_sha256 == expected,
+                "quantization manifest identity mismatch"
+            );
+        }
+        let manifest: QuantizationManifest =
+            serde_json::from_slice(&manifest_bytes).context("invalid quantization manifest")?;
         manifest.true_average_bits_per_weight()?;
         ensure!(
             manifest.version == ARCHIVE_VERSION,
             "unsupported quantization manifest version {}",
             manifest.version
         );
-        validate_sha256_label(&manifest.base_checkpoint_hash)
-            .context("quantization manifest has an invalid source checkpoint hash")?;
+        validate_sha256_identity(
+            &manifest.base_checkpoint_hash,
+            "quantization source checkpoint identity",
+        )
+        .context("quantization manifest has an invalid source checkpoint hash")?;
         ensure!(
             !manifest.matrices.is_empty(),
             "quantization archive contains no quantized matrices"
         );
+        ensure!(
+            manifest
+                .matrices
+                .len()
+                .checked_add(manifest.floating_tensors.len())
+                .is_some_and(|members| members <= MAX_QUANTIZATION_ARCHIVE_MEMBERS),
+            "quantization archive exceeds its {MAX_QUANTIZATION_ARCHIVE_MEMBERS}-member limit"
+        );
+        after_manifest()?;
 
         let mut names = BTreeSet::new();
         let mut files = BTreeSet::new();
         for matrix in &manifest.matrices {
             validate_member_identity(&matrix.name, &matrix.file, &mut names, &mut files)?;
             ensure!(
-                matrix.shape.len() >= 2,
-                "quantized matrix `{}` must have rank at least two",
-                matrix.name
+                (2..=MAX_TENSOR_RANK).contains(&matrix.shape.len()),
+                "quantized matrix `{}` rank must be in 2..={MAX_TENSOR_RANK}",
+                matrix.name,
             );
             ensure!(
                 matrix.elements
                     == u64::try_from(checked_elements(&matrix.shape)?)
                         .context("matrix element count exceeds u64")?,
                 "quantized matrix `{}` element count mismatch",
+                matrix.name
+            );
+            ensure!(
+                matrix.packed_bytes
+                    == packed_tensor_storage_bytes(
+                        &matrix.shape,
+                        matrix.format,
+                        manifest.recipe.group_size,
+                    )?,
+                "quantized matrix `{}` packed byte count does not match its shape and format",
                 matrix.name
             );
             ensure!(
@@ -1861,6 +1319,12 @@ impl QuantizedArchive {
         }
         for tensor in &manifest.floating_tensors {
             validate_member_identity(&tensor.name, &tensor.file, &mut names, &mut files)?;
+            ensure!(
+                tensor.shape.len() <= MAX_TENSOR_RANK,
+                "floating tensor `{}` has unsupported rank {}",
+                tensor.name,
+                tensor.shape.len()
+            );
             let elements = checked_elements(&tensor.shape)?;
             ensure!(
                 tensor.elements
@@ -1882,6 +1346,7 @@ impl QuantizedArchive {
         Ok(Self {
             root: root.to_path_buf(),
             manifest,
+            manifest_sha256,
         })
     }
 
@@ -1889,32 +1354,49 @@ impl QuantizedArchive {
         &self.manifest
     }
 
+    pub(crate) fn manifest_sha256(&self) -> &str {
+        &self.manifest_sha256
+    }
+
     /// Content identity of the parsed manifest. Since every member SHA-256 is
     /// embedded in schema v2, this also identifies the complete archive.
     pub fn content_hash(&self) -> Result<String> {
-        Ok(sha256_label(&serde_json::to_vec(&self.manifest)?))
+        Ok(sha256_identity(&serde_json::to_vec(&self.manifest)?))
     }
 
-    /// Bind this archive to the complete source checkpoint, rather than only
-    /// trusting the source hash copied into the manifest. Every source tensor
-    /// must appear exactly once in the archive under the recipe-selected
-    /// representation. Quantized members are deterministically regenerated
-    /// and their diagnostics are recomputed; floating members must be exact
-    /// byte copies.
-    pub fn verify_source_checkpoint(&self, checkpoint: &Path) -> Result<()> {
-        let source = read_regular_file(checkpoint, "source checkpoint")?;
-        self.verify_source_safetensors(&source)
-    }
-
-    fn verify_source_safetensors(&self, source: &[u8]) -> Result<()> {
+    /// Authenticate the archive's source identity without regenerating its
+    /// quantized tensors.
+    ///
+    /// `source_sha256` must come from an independently authenticated source
+    /// checkpoint (for example, a sealed trainer generation). [`Self::open`]
+    /// has already authenticated every archive member against the hashes in
+    /// the manifest, so this comparison binds those exact bytes to that exact
+    /// source without repeating a potentially multi-gigabyte quantization.
+    pub fn verify_source_identity(&self, source_sha256: &str) -> Result<()> {
+        validate_sha256_identity(source_sha256, "quantization source checkpoint identity")
+            .context("invalid source checkpoint identity")?;
         ensure!(
-            sha256_label(source) == self.manifest.base_checkpoint_hash,
+            self.manifest.base_checkpoint_hash == source_sha256,
             "quantized archive source checkpoint hash mismatch"
         );
+        Ok(())
+    }
 
-        let tensors = SafeTensors::deserialize(source).context("invalid source safetensors")?;
+    /// Reproduce the complete archive from a source checkpoint.
+    ///
+    /// This deliberately expensive derivation check is required once while a
+    /// new archive is created. Routine authenticated reopens should use
+    /// [`Self::verify_source_identity`] instead: member hashes plus the sealed
+    /// source digest already preserve the same immutable binding.
+    pub fn verify_source_checkpoint(&self, checkpoint: &Path) -> Result<()> {
+        let mut source = StreamingSafetensors::open(checkpoint, "source checkpoint")?;
+        self.verify_source_safetensors(&mut source)
+    }
+
+    fn verify_source_safetensors(&self, source: &mut StreamingSafetensors) -> Result<()> {
+        self.verify_source_identity(source.sha256())?;
         ensure!(
-            !tensors.is_empty(),
+            !source.tensors.is_empty(),
             "source safetensors checkpoint contains no tensors"
         );
         let matrices = self
@@ -1934,36 +1416,33 @@ impl QuantizedArchive {
             .chain(floating.keys())
             .map(|name| (*name).to_owned())
             .collect::<BTreeSet<_>>();
-        let source_names = tensors
-            .names()
-            .into_iter()
-            .map(str::to_owned)
-            .collect::<BTreeSet<_>>();
+        let source_names = source.tensors.keys().cloned().collect::<BTreeSet<_>>();
         ensure!(
             archive_names == source_names,
             "quantized archive tensor inventory differs from source checkpoint: expected {source_names:?}, got {archive_names:?}"
         );
 
-        for (name, tensor) in tensors.iter() {
-            let elements = checked_elements(tensor.shape())?;
+        for (name, tensor) in source.tensor_entries() {
+            let elements = checked_elements(&tensor.shape)?;
             let elements_u64 =
                 u64::try_from(elements).context("source tensor element count exceeds u64")?;
-            if should_quantize(name, tensor.shape(), tensor.dtype(), &self.manifest.recipe) {
-                let matrix = matrices.get(name).with_context(|| {
+            let tensor_bytes = source.read_tensor(&tensor)?;
+            if should_quantize(&name, &tensor.shape, tensor.dtype, &self.manifest.recipe) {
+                let matrix = matrices.get(name.as_str()).with_context(|| {
                     format!("source tensor `{name}` must be a quantized matrix under this recipe")
                 })?;
                 ensure!(
-                    matrix.shape == tensor.shape() && matrix.elements == elements_u64,
+                    matrix.shape == tensor.shape && matrix.elements == elements_u64,
                     "quantized matrix `{name}` shape or element count differs from source checkpoint"
                 );
-                let values = tensor_as_f32(tensor.dtype(), tensor.data())?;
+                let values = tensor_as_f32(tensor.dtype, &tensor_bytes)?;
                 ensure!(
                     values.len() == elements,
                     "source tensor `{name}` data length does not match its shape"
                 );
                 let expected = quantize_tensor(
                     &values,
-                    tensor.shape().to_vec(),
+                    tensor.shape.clone(),
                     self.manifest.recipe.format,
                     self.manifest.recipe.group_size,
                 )?;
@@ -1984,23 +1463,23 @@ impl QuantizedArchive {
                     "quantized matrix `{name}` maximum error was not derived from source"
                 );
             } else {
-                let archived = floating.get(name).with_context(|| {
+                let archived = floating.get(name.as_str()).with_context(|| {
                     format!("source tensor `{name}` must remain floating under this recipe")
                 })?;
-                let dtype = format!("{:?}", tensor.dtype());
+                let dtype = format!("{:?}", tensor.dtype);
                 ensure!(
                     archived.dtype == dtype
-                        && archived.shape == tensor.shape()
+                        && archived.shape == tensor.shape
                         && archived.elements == elements_u64,
                     "floating tensor `{name}` metadata differs from source checkpoint"
                 );
                 ensure!(
-                    self.load_floating_entry(archived)?.bytes == tensor.data(),
+                    self.load_floating_entry(archived)?.bytes == tensor_bytes,
                     "floating tensor `{name}` bytes differ from source checkpoint"
                 );
             }
         }
-        Ok(())
+        source.ensure_unchanged()
     }
 
     pub fn load_matrix(&self, name: &str) -> Result<PackedTensor> {
@@ -2082,8 +1561,8 @@ pub fn export_safetensors_archive(
     recipe: &QuantizationRecipe,
 ) -> Result<QuantizationManifest> {
     recipe.validate()?;
-    let source = read_regular_file(checkpoint, "source checkpoint")?;
-    let source_hash = sha256_label(&source);
+    let mut source = StreamingSafetensors::open(checkpoint, "source checkpoint")?;
+    let source_hash = source.sha256().to_owned();
     if output.exists() {
         let archive = QuantizedArchive::open(output).with_context(|| {
             format!(
@@ -2096,14 +1575,16 @@ pub fn export_safetensors_archive(
                 && archive.manifest.recipe == *recipe,
             "existing quantization output does not match this checkpoint and recipe"
         );
+        // Unlike trainer resume, this standalone API has no externally sealed
+        // candidate receipt. Reproduce an existing output before accepting it
+        // rather than treating its mutable manifest as provenance.
         archive
-            .verify_source_safetensors(&source)
+            .verify_source_safetensors(&mut source)
             .context("existing quantization output does not reproduce its source checkpoint")?;
         return Ok(archive.manifest.clone());
     }
-    let tensors = SafeTensors::deserialize(&source).context("invalid safetensors checkpoint")?;
     ensure!(
-        !tensors.is_empty(),
+        !source.tensors.is_empty(),
         "safetensors checkpoint contains no tensors"
     );
 
@@ -2119,22 +1600,22 @@ pub fn export_safetensors_archive(
     let export = (|| {
         let mut matrices = Vec::new();
         let mut floating_tensors = Vec::new();
-        let mut tensor_entries = tensors.iter().collect::<Vec<_>>();
-        tensor_entries.sort_by(|left, right| left.0.cmp(right.0));
+        let tensor_entries = source.tensor_entries();
         for (index, (name, tensor)) in tensor_entries.into_iter().enumerate() {
-            let elements = checked_elements(tensor.shape())?;
+            let elements = checked_elements(&tensor.shape)?;
             let elements_u64 =
                 u64::try_from(elements).context("tensor element count exceeds u64")?;
-            let identifier = format!("{index:06}-{}", safe_file_component(name));
-            if should_quantize(name, tensor.shape(), tensor.dtype(), recipe) {
-                let values = tensor_as_f32(tensor.dtype(), tensor.data())?;
+            let identifier = format!("{index:06}-{}", safe_file_component(&name));
+            let tensor_bytes = source.read_tensor(&tensor)?;
+            if should_quantize(&name, &tensor.shape, tensor.dtype, recipe) {
+                let values = tensor_as_f32(tensor.dtype, &tensor_bytes)?;
                 ensure!(
                     values.len() == elements,
                     "tensor `{name}` data length does not match its shape"
                 );
                 let packed = quantize_tensor(
                     &values,
-                    tensor.shape().to_vec(),
+                    tensor.shape.clone(),
                     recipe.format,
                     recipe.group_size,
                 )?;
@@ -2145,32 +1626,33 @@ pub fn export_safetensors_archive(
                 let bytes = packed.to_bytes()?;
                 write_file_synced(&temporary.join(&relative), &bytes)?;
                 matrices.push(QuantizedMatrixManifest {
-                    name: name.to_owned(),
-                    shape: tensor.shape().to_vec(),
+                    name: name.clone(),
+                    shape: tensor.shape.clone(),
                     elements: elements_u64,
                     format: recipe.format,
                     file: path_to_manifest(&relative)?,
                     packed_bytes: u64::try_from(bytes.len())
                         .context("packed tensor size exceeds u64")?,
-                    sha256: sha256_label(&bytes),
+                    sha256: sha256_identity(&bytes),
                     mean_squared_error,
                     maximum_absolute_error,
                 });
             } else {
                 let relative = PathBuf::from("floating").join(format!("{identifier}.bin"));
-                write_file_synced(&temporary.join(&relative), tensor.data())?;
+                write_file_synced(&temporary.join(&relative), &tensor_bytes)?;
                 floating_tensors.push(FloatingTensorManifest {
-                    name: name.to_owned(),
-                    dtype: format!("{:?}", tensor.dtype()),
-                    shape: tensor.shape().to_vec(),
+                    name: name.clone(),
+                    dtype: format!("{:?}", tensor.dtype),
+                    shape: tensor.shape.clone(),
                     elements: elements_u64,
                     file: path_to_manifest(&relative)?,
-                    bytes: u64::try_from(tensor.data().len())
+                    bytes: u64::try_from(tensor_bytes.len())
                         .context("floating tensor size exceeds u64")?,
-                    sha256: sha256_label(tensor.data()),
+                    sha256: sha256_identity(&tensor_bytes),
                 });
             }
         }
+        source.ensure_unchanged()?;
         ensure!(
             !matrices.is_empty(),
             "checkpoint contains no eligible floating-point matrices"
@@ -2195,11 +1677,15 @@ pub fn export_safetensors_archive(
         // structs is incorrect here because serde_json may round diagnostic
         // floating-point values to a neighboring representation.
         ensure!(
-            fs::read(output.join("manifest.json"))? == manifest_bytes,
+            read_regular_file_bounded(
+                &output.join("manifest.json"),
+                MAX_QUANTIZATION_MANIFEST_BYTES,
+                "published quantization manifest",
+            )? == manifest_bytes,
             "published quantization manifest bytes changed during validation"
         );
         QuantizedArchive::open(output)?
-            .verify_source_safetensors(&source)
+            .verify_source_checkpoint(checkpoint)
             .context("published quantization archive does not reproduce its source checkpoint")?;
         Ok(manifest)
     })();
@@ -2324,12 +1810,20 @@ fn validate_member_identity(
 ) -> Result<()> {
     ensure!(!name.trim().is_empty(), "archive tensor name is empty");
     ensure!(
+        name.len() <= MAX_TENSOR_NAME_BYTES,
+        "archive tensor name exceeds its {MAX_TENSOR_NAME_BYTES}-byte limit"
+    );
+    ensure!(
         names.insert(name.to_owned()),
         "archive repeats tensor name `{name}`"
     );
     ensure!(
         !file.trim().is_empty(),
         "archive tensor `{name}` has no file"
+    );
+    ensure!(
+        file.len() <= MAX_ARCHIVE_MEMBER_PATH_BYTES,
+        "archive member path exceeds its {MAX_ARCHIVE_MEMBER_PATH_BYTES}-byte limit"
     );
     ensure!(
         files.insert(file.to_owned()),
@@ -2375,12 +1869,29 @@ fn checked_archive_member(root: &Path, relative: &str) -> Result<PathBuf> {
 /// could carry different unverified payloads, and an unnoticed temporary file
 /// could later be mistaken for part of the immutable archive.
 fn validate_archive_inventory(root: &Path, members: &BTreeSet<String>) -> Result<()> {
-    fn visit(root: &Path, directory: &Path, files: &mut BTreeSet<String>) -> Result<()> {
-        let mut entries = fs::read_dir(directory)
-            .with_context(|| format!("failed to read archive directory {}", directory.display()))?
-            .collect::<std::io::Result<Vec<_>>>()?;
-        entries.sort_by_key(std::fs::DirEntry::file_name);
+    fn visit(
+        root: &Path,
+        directory: &Path,
+        depth: usize,
+        entries_seen: &mut usize,
+        files: &mut BTreeSet<String>,
+    ) -> Result<()> {
+        ensure!(
+            depth <= MAX_QUANTIZATION_ARCHIVE_DEPTH,
+            "quantized archive exceeds its {MAX_QUANTIZATION_ARCHIVE_DEPTH}-directory depth limit"
+        );
+        let entries = fs::read_dir(directory)
+            .with_context(|| format!("failed to read archive directory {}", directory.display()))?;
         for entry in entries {
+            let entry = entry?;
+            *entries_seen = entries_seen
+                .checked_add(1)
+                .context("quantized archive entry count overflow")?;
+            ensure!(
+                *entries_seen
+                    <= MAX_QUANTIZATION_ARCHIVE_MEMBERS + MAX_QUANTIZATION_ARCHIVE_DIRECTORIES + 1,
+                "quantized archive exceeds its bounded file/directory inventory"
+            );
             let path = entry.path();
             let metadata = fs::symlink_metadata(&path)?;
             ensure!(
@@ -2389,7 +1900,7 @@ fn validate_archive_inventory(root: &Path, members: &BTreeSet<String>) -> Result
                 path.display()
             );
             if metadata.is_dir() {
-                visit(root, &path, files)?;
+                visit(root, &path, depth + 1, entries_seen, files)?;
                 continue;
             }
             ensure!(
@@ -2413,7 +1924,8 @@ fn validate_archive_inventory(root: &Path, members: &BTreeSet<String>) -> Result
     let mut expected = members.clone();
     expected.insert("manifest.json".to_owned());
     let mut actual = BTreeSet::new();
-    visit(root, root, &mut actual)?;
+    let mut entries_seen = 0;
+    visit(root, root, 0, &mut entries_seen, &mut actual)?;
     ensure!(
         actual == expected,
         "quantized archive file inventory differs from its manifest: expected {expected:?}, got {actual:?}"
@@ -2427,30 +1939,59 @@ fn read_verified_member(
     declared_sha256: &str,
 ) -> Result<Vec<u8>> {
     ensure!(
-        declared_sha256.starts_with("sha256:") && declared_sha256.len() == 71,
-        "archive member {} has an invalid SHA-256 label",
+        declared_bytes <= MAX_QUANTIZATION_MEMBER_BYTES,
+        "archive member {} exceeds its {MAX_QUANTIZATION_MEMBER_BYTES}-byte limit",
         path.display()
     );
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("failed to inspect archive member {}", path.display()))?;
+    validate_sha256_identity(declared_sha256, "quantization archive member identity")
+        .with_context(|| {
+            format!(
+                "archive member {} has an invalid SHA-256 label",
+                path.display()
+            )
+        })?;
+    let bytes = read_regular_file_exact(path, declared_bytes, "archive member")?;
     ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "archive member {} is not a regular file",
-        path.display()
-    );
-    ensure!(
-        metadata.len() == declared_bytes,
-        "archive member {} size mismatch",
-        path.display()
-    );
-    let bytes = fs::read(path)
-        .with_context(|| format!("failed to read archive member {}", path.display()))?;
-    ensure!(
-        sha256_label(&bytes) == declared_sha256,
+        sha256_identity(&bytes) == declared_sha256,
         "archive member {} SHA-256 mismatch",
         path.display()
     );
     Ok(bytes)
+}
+
+fn packed_tensor_storage_bytes(
+    shape: &[usize],
+    format: UltraQuantFormat,
+    group_size: usize,
+) -> Result<u64> {
+    ensure!(group_size == BONSAI_GROUP_SIZE, "packed tensor is not g128");
+    let elements = checked_elements(shape)?;
+    ensure!(elements > 0, "packed tensor is empty");
+    let rank = u64::try_from(shape.len()).context("packed tensor rank exceeds u64")?;
+    ensure!(rank <= u64::from(u8::MAX), "packed tensor rank exceeds u8");
+    let groups = elements.div_ceil(group_size);
+    let codes_per_group = match format {
+        UltraQuantFormat::BinaryG128 => group_size / 8,
+        UltraQuantFormat::TernaryG128 => group_size / 4,
+        UltraQuantFormat::TernaryEntropyG128 => group_size.div_ceil(5),
+    };
+    let payload = groups
+        .checked_mul(2)
+        .and_then(|scales| {
+            groups
+                .checked_mul(codes_per_group)
+                .and_then(|codes| scales.checked_add(codes))
+        })
+        .context("packed tensor payload size overflows usize")?;
+    let payload = u64::try_from(payload).context("packed tensor payload exceeds u64")?;
+    // Fixed header/checksum plus one u64 for every dimension.
+    38_u64
+        .checked_add(
+            rank.checked_mul(8)
+                .context("packed tensor shape header overflows u64")?,
+        )
+        .and_then(|bytes| bytes.checked_add(payload))
+        .context("packed tensor storage size overflows u64")
 }
 
 fn tensor_storage_bytes(dtype: &str, elements: usize) -> Result<u64> {
@@ -2471,85 +2012,244 @@ fn tensor_storage_bytes(dtype: &str, elements: usize) -> Result<u64> {
         .context("tensor storage byte count overflows u64")
 }
 
-fn sha256_label(bytes: &[u8]) -> String {
-    format!("sha256:{:x}", Sha256::digest(bytes))
+struct StreamingSafetensors {
+    file: fs::File,
+    path: PathBuf,
+    label: String,
+    identity: StableIdentity,
+    sha256: String,
+    data_start: u64,
+    tensors: BTreeMap<String, TensorInfo>,
 }
 
-fn read_regular_file(path: &Path, label: &str) -> Result<Vec<u8>> {
-    let metadata = fs::symlink_metadata(path)
+impl StreamingSafetensors {
+    fn open(path: &Path, label: &str) -> Result<Self> {
+        let mut file = open_regular_file(path, label)?;
+        let metadata = file
+            .metadata()
+            .with_context(|| format!("failed to inspect opened {label} {}", path.display()))?;
+        ensure!(metadata.is_file(), "opened {label} is not a regular file");
+        let identity = StableIdentity::from_metadata(&metadata);
+        let (_, digest, _) = hash_open_file(&mut file, None, label)?;
+        file.seek(SeekFrom::Start(0))?;
+
+        let mut length_bytes = [0_u8; 8];
+        file.read_exact(&mut length_bytes)
+            .with_context(|| format!("{label} has a truncated safetensors header"))?;
+        let header_bytes = u64::from_le_bytes(length_bytes);
+        ensure!(
+            header_bytes <= MAX_SAFETENSORS_HEADER_BYTES,
+            "{label} safetensors header exceeds its {MAX_SAFETENSORS_HEADER_BYTES}-byte limit"
+        );
+        let header_len = usize::try_from(header_bytes)
+            .with_context(|| format!("{label} safetensors header exceeds this address space"))?;
+        let mut header = Vec::new();
+        header
+            .try_reserve_exact(header_len)
+            .with_context(|| format!("reserving {label} safetensors header"))?;
+        header.resize(header_len, 0);
+        file.read_exact(&mut header)
+            .with_context(|| format!("{label} safetensors header is truncated"))?;
+        let parsed: SafeTensorMetadata = serde_json::from_slice(&header)
+            .with_context(|| format!("invalid {label} safetensors metadata"))?;
+        let data_start = 8_u64
+            .checked_add(header_bytes)
+            .context("safetensors data offset overflows u64")?;
+        let data_bytes =
+            u64::try_from(parsed.data_len()).context("safetensors payload length exceeds u64")?;
+        ensure!(
+            data_start.checked_add(data_bytes) == Some(metadata.len()),
+            "{label} safetensors metadata does not cover the exact file"
+        );
+        let tensors = parsed
+            .tensors()
+            .into_iter()
+            .map(|(name, info)| (name, info.clone()))
+            .collect::<BTreeMap<_, _>>();
+        ensure!(
+            !tensors.is_empty() && tensors.len() <= MAX_QUANTIZATION_ARCHIVE_MEMBERS,
+            "{label} tensor inventory must contain 1..={MAX_QUANTIZATION_ARCHIVE_MEMBERS} entries"
+        );
+        for (name, tensor) in &tensors {
+            ensure!(
+                !name.trim().is_empty() && name.len() <= MAX_TENSOR_NAME_BYTES,
+                "{label} contains an invalid or oversized tensor name"
+            );
+            ensure!(
+                tensor.shape.len() <= MAX_TENSOR_RANK,
+                "{label} tensor `{name}` has unsupported rank {}",
+                tensor.shape.len()
+            );
+        }
+        Ok(Self {
+            file,
+            path: path.to_owned(),
+            label: label.to_owned(),
+            identity,
+            sha256: format!("sha256:{digest}"),
+            data_start,
+            tensors,
+        })
+    }
+
+    fn sha256(&self) -> &str {
+        &self.sha256
+    }
+
+    fn tensor_entries(&self) -> Vec<(String, TensorInfo)> {
+        self.tensors
+            .iter()
+            .map(|(name, tensor)| (name.clone(), tensor.clone()))
+            .collect()
+    }
+
+    fn read_tensor(&mut self, tensor: &TensorInfo) -> Result<Vec<u8>> {
+        let bytes = tensor
+            .data_offsets
+            .1
+            .checked_sub(tensor.data_offsets.0)
+            .context("safetensors tensor offsets move backwards")?;
+        let bytes_u64 = u64::try_from(bytes).context("safetensors tensor size exceeds u64")?;
+        ensure!(
+            bytes_u64 <= MAX_QUANTIZATION_MEMBER_BYTES,
+            "source tensor exceeds its {MAX_QUANTIZATION_MEMBER_BYTES}-byte materialization limit"
+        );
+        let offset = self
+            .data_start
+            .checked_add(
+                u64::try_from(tensor.data_offsets.0)
+                    .context("safetensors tensor offset exceeds u64")?,
+            )
+            .context("safetensors tensor file offset overflows u64")?;
+        self.file.seek(SeekFrom::Start(offset))?;
+        let mut data = Vec::new();
+        data.try_reserve_exact(bytes)
+            .context("reserving source tensor buffer")?;
+        data.resize(bytes, 0);
+        self.file.read_exact(&mut data).with_context(|| {
+            format!(
+                "source tensor payload is truncated in {}",
+                self.path.display()
+            )
+        })?;
+        Ok(data)
+    }
+
+    fn ensure_unchanged(&mut self) -> Result<()> {
+        ensure!(
+            StableIdentity::from_metadata(&self.file.metadata()?) == self.identity,
+            "{} {} changed while tensors were streamed",
+            self.label,
+            self.path.display()
+        );
+        let (_, digest, _) = hash_open_file(&mut self.file, None, &self.label)?;
+        ensure!(
+            format!("sha256:{digest}") == self.sha256,
+            "{} {} changed while tensors were streamed",
+            self.label,
+            self.path.display()
+        );
+        Ok(())
+    }
+}
+
+fn open_regular_file(path: &Path, label: &str) -> Result<fs::File> {
+    let inspected = fs::symlink_metadata(path)
         .with_context(|| format!("failed to inspect {label} {}", path.display()))?;
     ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "{label} must be a regular file: {}",
+        inspected.is_file() && !inspected.file_type().is_symlink(),
+        "{label} {} must be a regular non-symlink file",
         path.display()
     );
-    fs::read(path).with_context(|| format!("failed to read {label} {}", path.display()))
+    #[cfg(unix)]
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+        .with_context(|| format!("failed to open {label} {}", path.display()))?;
+    #[cfg(not(unix))]
+    let file = fs::File::open(path)
+        .with_context(|| format!("failed to open {label} {}", path.display()))?;
+    let opened = file
+        .metadata()
+        .with_context(|| format!("failed to inspect opened {label} {}", path.display()))?;
+    ensure!(
+        StableIdentity::from_metadata(&opened) == StableIdentity::from_metadata(&inspected),
+        "{label} {} changed while it was opened",
+        path.display()
+    );
+    Ok(file)
 }
 
-fn validate_sha256_label(value: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .context("SHA-256 identity must use sha256:<64 lowercase hex>")?;
+fn read_regular_file_exact(path: &Path, expected: u64, label: &str) -> Result<Vec<u8>> {
+    read_open_regular_file_exact(open_regular_file(path, label)?, path, expected, label)
+}
+
+fn read_open_regular_file_exact(
+    mut file: fs::File,
+    path: &Path,
+    expected: u64,
+    label: &str,
+) -> Result<Vec<u8>> {
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("failed to inspect opened {label} {}", path.display()))?;
     ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "SHA-256 identity must use sha256:<64 lowercase hex>"
+        metadata.is_file() && metadata.len() == expected,
+        "{label} {} is not a regular file of the declared size",
+        path.display()
     );
-    Ok(())
+    let capacity = usize::try_from(expected)
+        .with_context(|| format!("{label} {} exceeds this address space", path.display()))?;
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(capacity)
+        .with_context(|| format!("reserving {expected} bytes for {label} {}", path.display()))?;
+    let mut buffer = [0_u8; 1024 * 1024];
+    while bytes.len() < capacity {
+        let remaining = capacity - bytes.len();
+        let chunk = remaining.min(buffer.len());
+        let read = file
+            .read(&mut buffer[..chunk])
+            .with_context(|| format!("failed to read opened {label} {}", path.display()))?;
+        ensure!(
+            read > 0,
+            "{label} {} was truncated while read",
+            path.display()
+        );
+        bytes.extend_from_slice(&buffer[..read]);
+    }
+    let mut tail = [0_u8; 1];
+    ensure!(
+        file.read(&mut tail)
+            .with_context(|| format!("failed to finish reading {label} {}", path.display()))?
+            == 0,
+        "{label} {} grew while read",
+        path.display()
+    );
+    Ok(bytes)
+}
+
+fn read_regular_file_bounded(path: &Path, maximum: u64, label: &str) -> Result<Vec<u8>> {
+    let file = open_regular_file(path, label)?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("failed to inspect opened {label} {}", path.display()))?;
+    ensure!(metadata.is_file(), "{label} is not a regular file");
+    ensure!(
+        metadata.len() <= maximum,
+        "{label} {} exceeds the {maximum}-byte limit",
+        path.display()
+    );
+    // Consume the already-opened descriptor so pathname replacement cannot
+    // change either the allocation bound or the returned bytes.
+    read_open_regular_file_exact(file, path, metadata.len(), label)
 }
 
 fn write_file_synced(path: &Path, bytes: &[u8]) -> Result<()> {
     let mut file = fs::File::create(path)?;
     file.write_all(bytes)?;
     file.sync_all()?;
-    Ok(())
-}
-
-fn write_atomic_synced(path: &Path, bytes: &[u8]) -> Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let file_name = path
-        .file_name()
-        .context("atomic output path has no file name")?;
-    let mut temporary = None;
-    for attempt in 0..1024u32 {
-        let mut temporary_name = file_name.to_os_string();
-        temporary_name.push(format!(".tmp-{}-{attempt}", std::process::id()));
-        let candidate = parent.join(temporary_name);
-        match fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&candidate)
-        {
-            Ok(mut file) => {
-                if let Err(error) = (|| {
-                    file.write_all(bytes)?;
-                    file.sync_all()?;
-                    Ok::<_, std::io::Error>(())
-                })() {
-                    let _ = fs::remove_file(&candidate);
-                    return Err(error).with_context(|| {
-                        format!("failed to write atomic file {}", candidate.display())
-                    });
-                }
-                temporary = Some(candidate);
-                break;
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => {
-                return Err(error).with_context(|| {
-                    format!("failed to create atomic file {}", candidate.display())
-                });
-            }
-        }
-    }
-    let temporary = temporary.context("could not allocate an atomic temporary file")?;
-    if let Err(error) = fs::rename(&temporary, path) {
-        let _ = fs::remove_file(&temporary);
-        return Err(error).with_context(|| format!("failed to publish {}", path.display()));
-    }
-    fs::File::open(parent)?.sync_all()?;
     Ok(())
 }
 
@@ -2588,6 +2288,21 @@ mod tests {
         (0..BONSAI_GROUP_SIZE * 2)
             .map(|index| ((index as f32 * 0.37).sin() * 2.0) + (index % 7) as f32 * 0.01)
             .collect()
+    }
+
+    #[test]
+    fn archive_inventory_rejects_excessive_directory_depth_without_recursive_overflow() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(directory.path().join("manifest.json"), b"{}").unwrap();
+        let mut nested = directory.path().to_path_buf();
+        for depth in 0..=MAX_QUANTIZATION_ARCHIVE_DEPTH {
+            nested.push(format!("level-{depth}"));
+            fs::create_dir(&nested).unwrap();
+        }
+        let error = validate_archive_inventory(directory.path(), &BTreeSet::new())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("depth limit"), "{error}");
     }
 
     #[test]
@@ -2683,7 +2398,7 @@ mod tests {
     }
 
     #[test]
-    fn transformer_qat_and_archive_select_the_same_matrix_set() {
+    fn transformer_qat_and_archive_select_the_exact_same_matrix_names() {
         use burn::module::AutodiffModule;
 
         let device = Device::default().autodiff();
@@ -2705,22 +2420,81 @@ mod tests {
             }
         }
         let model = Transformer::new(&config, &device).unwrap();
-        let selected = model.ultra_quant_parameter_ids(true, true).unwrap();
         let directory = tempfile::tempdir().unwrap();
         let checkpoint = directory.path().join("weights.safetensors");
         hermes_llm::save_safetensors(&model.valid(), &checkpoint).unwrap();
-        let output = directory.path().join("weights.hquant");
-        let recipe = QuantizationRecipe {
-            format: UltraQuantFormat::BinaryG128,
-            group_size: BONSAI_GROUP_SIZE,
-            fake_quant_start_step: 0,
-            ternary_warmup_steps: 0,
-            distillation_weight: 0.0,
-            quantize_embeddings: true,
-            quantize_lm_head: true,
-        };
-        let manifest = export_safetensors_archive(&checkpoint, &output, &recipe).unwrap();
-        assert_eq!(manifest.matrices.len(), selected.len());
+        for (ordinal, (quantize_embeddings, quantize_lm_head)) in
+            [(false, false), (false, true), (true, false), (true, true)]
+                .into_iter()
+                .enumerate()
+        {
+            let expected = model
+                .ultra_quant_parameter_names(quantize_embeddings, quantize_lm_head)
+                .unwrap()
+                .into_iter()
+                .collect::<BTreeSet<_>>();
+            let output = directory.path().join(format!("weights-{ordinal}.hquant"));
+            let recipe = QuantizationRecipe {
+                format: UltraQuantFormat::BinaryG128,
+                group_size: BONSAI_GROUP_SIZE,
+                fake_quant_start_step: 0,
+                ternary_warmup_steps: 0,
+                distillation_weight: 0.0,
+                quantize_embeddings,
+                quantize_lm_head,
+            };
+            let manifest = export_safetensors_archive(&checkpoint, &output, &recipe).unwrap();
+            let actual = manifest
+                .matrices
+                .into_iter()
+                .map(|matrix| matrix.name)
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                actual, expected,
+                "QAT ParamIds and archive names differ for embeddings={quantize_embeddings}, lm_head={quantize_lm_head}"
+            );
+        }
+
+        config.embeddings.tie_weights = true;
+        let tied = Transformer::new(&config, &device).unwrap();
+        let tied_checkpoint = directory.path().join("tied-weights.safetensors");
+        hermes_llm::save_safetensors(&tied.valid(), &tied_checkpoint).unwrap();
+        for (ordinal, quantize_tied_weight) in [false, true].into_iter().enumerate() {
+            let expected = tied
+                .ultra_quant_parameter_names(quantize_tied_weight, quantize_tied_weight)
+                .unwrap()
+                .into_iter()
+                .collect::<BTreeSet<_>>();
+            let output = directory
+                .path()
+                .join(format!("tied-weights-{ordinal}.hquant"));
+            let recipe = QuantizationRecipe {
+                format: UltraQuantFormat::BinaryG128,
+                group_size: BONSAI_GROUP_SIZE,
+                fake_quant_start_step: 0,
+                ternary_warmup_steps: 0,
+                distillation_weight: 0.0,
+                quantize_embeddings: quantize_tied_weight,
+                quantize_lm_head: quantize_tied_weight,
+            };
+            let manifest = export_safetensors_archive(&tied_checkpoint, &output, &recipe).unwrap();
+            let actual = manifest
+                .matrices
+                .into_iter()
+                .map(|matrix| matrix.name)
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                actual, expected,
+                "tied QAT/archive names differ for quantize_tied_weight={quantize_tied_weight}"
+            );
+        }
+        for (quantize_embeddings, quantize_lm_head) in [(false, true), (true, false)] {
+            let error = tied
+                .ultra_quant_parameter_names(quantize_embeddings, quantize_lm_head)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("tied embedding/output weights"), "{error}");
+        }
     }
 
     #[test]
@@ -2734,10 +2508,41 @@ mod tests {
         .unwrap();
         assert_eq!(packed.codes.len(), 32);
         assert_eq!(packed.scales.len(), 2);
-        assert!((packed.bits_per_weight() - 1.125).abs() < 1e-9);
+        assert!((packed.bits_per_weight().unwrap() - 1.125).abs() < 1e-9);
         let decoded = packed.decode().unwrap();
         assert_eq!(decoded.len(), weights().len());
         assert!(decoded.iter().all(|value| value.is_finite()));
+    }
+
+    #[test]
+    fn malformed_public_packed_tensor_geometry_returns_errors_without_panicking() {
+        let malformed = PackedTensor {
+            format: UltraQuantFormat::BinaryG128,
+            shape: vec![usize::MAX, 2],
+            group_size: BONSAI_GROUP_SIZE,
+            scales: Vec::new(),
+            codes: Vec::new(),
+        };
+
+        for error in [
+            malformed.elements().unwrap_err(),
+            malformed.bits_per_weight().unwrap_err(),
+            malformed.decode().unwrap_err(),
+            malformed.to_bytes().unwrap_err(),
+            malformed.matrix_vector(&[0.0, 0.0]).unwrap_err(),
+        ] {
+            assert!(
+                format!("{error:#}").contains("element count overflows"),
+                "{error:#}"
+            );
+        }
+
+        let invalid_rank = PackedTensor {
+            shape: Vec::new(),
+            ..malformed
+        };
+        let error = invalid_rank.bits_per_weight().unwrap_err();
+        assert!(format!("{error:#}").contains("rank must be"), "{error:#}");
     }
 
     #[test]
@@ -2758,8 +2563,8 @@ mod tests {
         .unwrap();
         assert_eq!(dense.decode().unwrap(), entropy.decode().unwrap());
         assert!(entropy.codes.len() < dense.codes.len());
-        assert_eq!(dense.bits_per_weight(), 2.125);
-        assert_eq!(entropy.bits_per_weight(), 1.75);
+        assert_eq!(dense.bits_per_weight().unwrap(), 2.125);
+        assert_eq!(entropy.bits_per_weight().unwrap(), 1.75);
     }
 
     #[test]
@@ -2871,6 +2676,18 @@ mod tests {
         let path = directory.path().join("matrix.hquant");
         packed.save_atomic(&path).unwrap();
         assert_eq!(PackedTensor::load(&path).unwrap(), packed);
+    }
+
+    #[test]
+    fn packed_tensor_load_rejects_oversized_file_before_allocation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("oversized.hquant");
+        let file = fs::File::create(&path).unwrap();
+        file.set_len(MAX_QUANTIZATION_MEMBER_BYTES + 1).unwrap();
+        drop(file);
+
+        let error = PackedTensor::load(&path).unwrap_err().to_string();
+        assert!(error.contains("byte limit"), "{error}");
     }
 
     #[test]
@@ -3154,6 +2971,22 @@ mod tests {
     }
 
     #[test]
+    fn archive_rejects_impossible_packed_size_before_loading_member() {
+        let directory = tempfile::tempdir().unwrap();
+        let (_, output, _) =
+            export_source_verification_fixture(directory.path(), "oversized-member");
+        let mut manifest = read_archive_manifest(&output);
+        manifest.matrices[0].packed_bytes += 1;
+        write_archive_manifest(&output, &manifest);
+
+        let error = QuantizedArchive::open(&output).unwrap_err().to_string();
+        assert!(
+            error.contains("packed byte count does not match"),
+            "{error}"
+        );
+    }
+
+    #[test]
     fn existing_archive_retry_rejects_reencoded_matrix() {
         let directory = tempfile::tempdir().unwrap();
         let (checkpoint, output, recipe) =
@@ -3166,7 +2999,7 @@ mod tests {
         let bytes = packed.to_bytes().unwrap();
         fs::write(&path, &bytes).unwrap();
         matrix.packed_bytes = bytes.len() as u64;
-        matrix.sha256 = sha256_label(&bytes);
+        matrix.sha256 = sha256_identity(&bytes);
         write_archive_manifest(&output, &manifest);
 
         assert!(QuantizedArchive::open(&output).is_ok());
@@ -3212,17 +3045,74 @@ mod tests {
         let matrix = &mut manifest.matrices[0];
         let path = output.join(&matrix.file);
         let mut packed = PackedTensor::from_bytes(&fs::read(&path).unwrap()).unwrap();
-        packed.shape = vec![packed.elements(), 1];
+        packed.shape = vec![packed.elements().unwrap(), 1];
         let bytes = packed.to_bytes().unwrap();
         fs::write(&path, &bytes).unwrap();
         matrix.shape = packed.shape;
         matrix.packed_bytes = bytes.len() as u64;
-        matrix.sha256 = sha256_label(&bytes);
+        matrix.sha256 = sha256_identity(&bytes);
         write_archive_manifest(&output, &manifest);
         assert!(QuantizedArchive::open(&output).is_ok());
         let error = export_safetensors_archive(&checkpoint, &output, &recipe).unwrap_err();
         assert!(
             format!("{error:#}").contains("shape or element count differs"),
+            "{error:#}"
+        );
+    }
+
+    fn alter_first_packed_member(output: &Path) {
+        let mut manifest = read_archive_manifest(output);
+        let matrix = &mut manifest.matrices[0];
+        let path = output.join(&matrix.file);
+        let mut packed = PackedTensor::from_bytes(&fs::read(&path).unwrap()).unwrap();
+        packed.codes[0] ^= 1;
+        let bytes = packed.to_bytes().unwrap();
+        fs::write(&path, &bytes).unwrap();
+        matrix.packed_bytes = bytes.len() as u64;
+        matrix.sha256 = sha256_identity(&bytes);
+        write_archive_manifest(output, &manifest);
+    }
+
+    #[test]
+    fn addressed_open_rejects_archive_swap_after_manifest_capture() {
+        let directory = tempfile::tempdir().unwrap();
+        let (_, published, _) = export_source_verification_fixture(directory.path(), "published");
+        let (_, replacement, _) =
+            export_source_verification_fixture(directory.path(), "replacement");
+        alter_first_packed_member(&replacement);
+        let expected = sha256_identity(&fs::read(published.join("manifest.json")).unwrap());
+        let parked = directory.path().join("parked.hquant");
+
+        let error = QuantizedArchive::open_inner_with_hook(&published, Some(&expected), || {
+            fs::rename(&published, &parked)?;
+            fs::rename(&replacement, &published)?;
+            Ok(())
+        })
+        .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("SHA-256 mismatch"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn addressed_archive_load_rejects_member_root_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let (_, published, _) =
+            export_source_verification_fixture(directory.path(), "published-load");
+        let (_, replacement, _) =
+            export_source_verification_fixture(directory.path(), "replacement-load");
+        alter_first_packed_member(&replacement);
+        let expected = sha256_identity(&fs::read(published.join("manifest.json")).unwrap());
+        let archive = QuantizedArchive::open_addressed(&published, &expected).unwrap();
+        let matrix_name = archive.manifest().matrices[0].name.clone();
+        let parked = directory.path().join("parked-load.hquant");
+        fs::rename(&published, parked).unwrap();
+        fs::rename(&replacement, &published).unwrap();
+
+        let error = archive.load_matrix(&matrix_name).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("SHA-256 mismatch"),
             "{error:#}"
         );
     }
@@ -3415,278 +3305,5 @@ mod tests {
             self.floating.clear();
             Ok(())
         }
-    }
-
-    #[derive(Default)]
-    struct MockDurableQat {
-        master: u64,
-        staged: BTreeSet<String>,
-        applied: BTreeSet<String>,
-        aborted: BTreeSet<String>,
-        cleared: BTreeSet<String>,
-        apply_invocations: usize,
-        fail_compute: bool,
-    }
-
-    impl DurableQuantizationBackend for MockDurableQat {
-        fn master_weights_hash(&mut self) -> Result<String> {
-            Ok(sha256_label(&self.master.to_le_bytes()))
-        }
-
-        fn stage_fake_quantized_forward_once(
-            &mut self,
-            transaction_id: &str,
-            _: UltraQuantFormat,
-            group_size: usize,
-            _: bool,
-            _: bool,
-        ) -> Result<usize> {
-            ensure!(group_size == BONSAI_GROUP_SIZE, "unexpected group size");
-            ensure!(
-                !self.aborted.contains(transaction_id),
-                "transaction is aborted"
-            );
-            self.staged.insert(transaction_id.to_owned());
-            Ok(7)
-        }
-
-        fn compute_gradients_once(
-            &mut self,
-            transaction_id: &str,
-            training: &WorkflowQuantizationTraining,
-        ) -> Result<DurableGradientResult> {
-            ensure!(
-                self.staged.contains(transaction_id),
-                "forward was not staged"
-            );
-            ensure!(
-                matches!(training, WorkflowQuantizationTraining::Qat { .. }),
-                "unexpected training mode"
-            );
-            if self.fail_compute {
-                bail!("injected compute failure");
-            }
-            Ok(DurableGradientResult {
-                gradient_handle: format!("gradient:{transaction_id}"),
-                task_loss: 2.5,
-                distillation_forward_kl: Some(0.25),
-            })
-        }
-
-        fn restore_master_weights_once(&mut self, transaction_id: &str) -> Result<()> {
-            self.staged.remove(transaction_id);
-            Ok(())
-        }
-
-        fn apply_master_update_once(
-            &mut self,
-            transaction_id: &str,
-            gradient_handle: &str,
-        ) -> Result<()> {
-            ensure!(
-                gradient_handle == format!("gradient:{transaction_id}"),
-                "gradient handle mismatch"
-            );
-            self.apply_invocations += 1;
-            if self.applied.insert(transaction_id.to_owned()) {
-                self.master += 1;
-            }
-            Ok(())
-        }
-
-        fn abort_transaction_once(&mut self, transaction_id: &str) -> Result<()> {
-            self.staged.remove(transaction_id);
-            self.aborted.insert(transaction_id.to_owned());
-            Ok(())
-        }
-
-        fn clear_transaction_once(&mut self, transaction_id: &str) -> Result<()> {
-            self.staged.remove(transaction_id);
-            self.cleared.insert(transaction_id.to_owned());
-            Ok(())
-        }
-    }
-
-    struct RecordingCheckpoint {
-        fail_on: Option<usize>,
-        calls: usize,
-        durable: Option<QuantizationTransactionState>,
-    }
-
-    impl QuantizationCheckpointCallback for RecordingCheckpoint {
-        fn checkpoint_quantization(&mut self, state: &QuantizationTransactionState) -> Result<()> {
-            self.calls += 1;
-            if self.fail_on == Some(self.calls) {
-                bail!("injected checkpoint failure");
-            }
-            self.durable = Some(state.clone());
-            Ok(())
-        }
-    }
-
-    fn durable_plan() -> WorkflowQuantizationPlan {
-        let config: QuantizationConfig = serde_json::from_value(serde_json::json!({
-            "format": "binary_g128",
-            "start_step": 0,
-            "training": {"type": "qat"}
-        }))
-        .unwrap();
-        WorkflowQuantizationPlan::from_workflow(&config).unwrap()
-    }
-
-    #[test]
-    fn qat_resumes_idempotently_from_every_durable_substep() {
-        let plan = durable_plan();
-        // Calls 2..=6 fail immediately after each state transition. Restoring
-        // the last successful callback emulates a process crash exactly.
-        for fail_on in 2..=6 {
-            let mut backend = MockDurableQat::default();
-            let mut state = QuantizationTransactionState::prepare(&mut backend, &plan, 4).unwrap();
-            let mut checkpoints = RecordingCheckpoint {
-                fail_on: Some(fail_on),
-                calls: 0,
-                durable: None,
-            };
-            assert!(
-                run_durable_quantization_step(&mut backend, &mut checkpoints, &plan, &mut state,)
-                    .is_err()
-            );
-            state = checkpoints.durable.take().unwrap();
-            let mut resumed = RecordingCheckpoint {
-                fail_on: None,
-                calls: 0,
-                durable: None,
-            };
-            let result =
-                run_durable_quantization_step(&mut backend, &mut resumed, &plan, &mut state)
-                    .unwrap();
-            assert_eq!(result.format, Some(UltraQuantFormat::BinaryG128));
-            assert_eq!(result.quantized_matrices, 7);
-            assert_eq!(backend.master, 1, "failed at callback {fail_on}");
-            assert!(backend.applied.contains(&state.transaction_id));
-            assert!(backend.cleared.contains(&state.transaction_id));
-            assert_eq!(state.substep, QuantizationSubstep::Complete);
-        }
-    }
-
-    #[test]
-    fn failed_qat_compute_restores_masters_and_persists_terminal_abort() {
-        let plan = durable_plan();
-        let mut backend = MockDurableQat {
-            fail_compute: true,
-            ..Default::default()
-        };
-        let mut state = QuantizationTransactionState::prepare(&mut backend, &plan, 1).unwrap();
-        let mut checkpoints = RecordingCheckpoint {
-            fail_on: None,
-            calls: 0,
-            durable: None,
-        };
-        assert!(
-            run_durable_quantization_step(&mut backend, &mut checkpoints, &plan, &mut state,)
-                .is_err()
-        );
-        assert_eq!(state.substep, QuantizationSubstep::Aborted);
-        assert_eq!(backend.master, 0);
-        assert!(backend.aborted.contains(&state.transaction_id));
-        assert_eq!(checkpoints.durable, Some(state));
-    }
-
-    #[test]
-    fn atomic_qat_state_store_roundtrips_and_rejects_corruption() {
-        let plan = durable_plan();
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("checkpoint/quantization-state.json");
-        let mut store = AtomicQuantizationStateStore::new(&path).unwrap();
-        assert!(store.load(&plan).unwrap().is_none());
-
-        let mut backend = MockDurableQat::default();
-        let mut state = QuantizationTransactionState::prepare(&mut backend, &plan, 8).unwrap();
-        run_durable_quantization_step(&mut backend, &mut store, &plan, &mut state).unwrap();
-        let mut loaded = store.load(&plan).unwrap().unwrap();
-        assert_eq!(loaded, state);
-        run_durable_quantization_step(&mut backend, &mut store, &plan, &mut loaded).unwrap();
-        assert_eq!(backend.master, 1);
-        let next = store.load_or_prepare(&mut backend, &plan, 9).unwrap();
-        assert_eq!(next.optimizer_step, 9);
-        assert_eq!(next.substep, QuantizationSubstep::Prepared);
-        assert!(store.load_or_prepare(&mut backend, &plan, 7).is_err());
-
-        let mut document: serde_json::Value =
-            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        document["transaction_id"] = serde_json::json!("tampered");
-        fs::write(&path, serde_json::to_vec_pretty(&document).unwrap()).unwrap();
-        assert!(store.load(&plan).is_err());
-
-        document = serde_json::to_value(&state).unwrap();
-        document["pre_update_master_hash"] = serde_json::json!("master:0");
-        fs::write(&path, serde_json::to_vec_pretty(&document).unwrap()).unwrap();
-        assert!(store.load(&plan).is_err());
-    }
-
-    #[derive(Default)]
-    struct MockQat {
-        staged: bool,
-        master: u64,
-        applied: usize,
-    }
-
-    impl QuantizationTrainingBackend for MockQat {
-        type Gradients = u64;
-
-        fn master_weights_hash(&mut self) -> Result<String> {
-            Ok(self.master.to_string())
-        }
-
-        fn stage_fake_quantized_forward(
-            &mut self,
-            _: UltraQuantFormat,
-            group_size: usize,
-            _: bool,
-            _: bool,
-        ) -> Result<usize> {
-            assert_eq!(group_size, BONSAI_GROUP_SIZE);
-            self.staged = true;
-            Ok(3)
-        }
-
-        fn compute_straight_through_gradients(
-            &mut self,
-            _: f64,
-        ) -> Result<(Self::Gradients, f64, Option<f64>)> {
-            Ok((1, 2.0, Some(0.25)))
-        }
-
-        fn restore_master_weights(&mut self) -> Result<()> {
-            self.staged = false;
-            Ok(())
-        }
-
-        fn apply_master_update(&mut self, gradients: Self::Gradients) -> Result<()> {
-            assert!(!self.staged);
-            self.master += gradients;
-            self.applied += 1;
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn qat_restores_master_before_applying_straight_through_update() {
-        let mut backend = MockQat::default();
-        let recipe = QuantizationRecipe {
-            format: UltraQuantFormat::BinaryG128,
-            group_size: BONSAI_GROUP_SIZE,
-            fake_quant_start_step: 10,
-            ternary_warmup_steps: 5,
-            distillation_weight: 1.0,
-            quantize_embeddings: true,
-            quantize_lm_head: true,
-        };
-        let full_precision = run_quantization_step(&mut backend, &recipe, 9).unwrap();
-        assert_eq!(full_precision.format, None);
-        let ternary = run_quantization_step(&mut backend, &recipe, 10).unwrap();
-        assert_eq!(ternary.format, Some(UltraQuantFormat::TernaryG128));
-        assert_eq!(ternary.quantized_matrices, 3);
-        assert_eq!(backend.applied, 2);
     }
 }

--- a/hermes-train/src/resource_worker.rs
+++ b/hermes-train/src/resource_worker.rs
@@ -7,17 +7,20 @@
 
 use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufRead, BufReader, Read, Write};
+#[cfg(test)]
+use std::io::{BufRead, BufReader};
+use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::mpsc;
-use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail, ensure};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+
+use crate::artifact_io::{
+    json_sha256_identity, sha256_hex, validate_sha256_hex, validate_sha256_identity,
+};
 
 use crate::acceptance::{
     AcceptancePolicy, CapacityObservation, ExactResumeArtifact, ExactResumeEvidence,
@@ -28,6 +31,12 @@ use crate::benchmark::{
     BenchmarkTarget, ModelRepresentationIdentity, VerifiedBenchmarkRun, VerifiedResourceComparison,
     verified_resource_benchmark_context, verify_resource_comparison_artifacts,
 };
+#[cfg(unix)]
+use crate::pinned_executable::PinnedExecutable;
+#[cfg(test)]
+use crate::pinned_executable::file_sha256 as pinned_file_sha256;
+#[cfg(unix)]
+use crate::protocol_process::{ProtocolRead, SupervisedProcess};
 const MAX_RESOURCE_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_RESOURCE_EVALUATOR_TIMEOUT: Duration = Duration::from_secs(3_600);
 static TEMPORARY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -176,6 +185,10 @@ impl ExternalResourceEvaluator {
             !timeout.is_zero(),
             "resource evaluator timeout must be positive"
         );
+        ensure!(
+            Instant::now().checked_add(timeout).is_some(),
+            "resource evaluator timeout is too large for the monotonic clock"
+        );
         self.timeout = timeout;
         Ok(self)
     }
@@ -188,22 +201,33 @@ impl ExternalResourceEvaluator {
         &self.arguments
     }
 
-    pub fn verify_identity(&self) -> Result<()> {
-        validate_prefixed_sha256(&self.expected_sha256, "resource evaluator")?;
+    fn validate_path_identity(&self) -> Result<()> {
+        validate_sha256_identity(&self.expected_sha256, "resource evaluator")?;
         let resolved =
             validate_real_path(&self.executable, RealPathKind::File, "resource evaluator")?;
         ensure!(
             resolved == self.executable,
             "resource evaluator path identity changed"
         );
-        ensure!(
-            stable_file_sha256(&self.executable, "resource evaluator")? == self.expected_sha256,
-            "resource evaluator {} does not match its pinned SHA-256",
-            self.executable.display()
-        );
         Ok(())
     }
 
+    #[cfg(unix)]
+    pub fn verify_identity(&self) -> Result<()> {
+        self.validate_path_identity()?;
+        PinnedExecutable::verify(
+            &self.executable,
+            &self.expected_sha256,
+            "resource evaluator",
+        )
+    }
+
+    #[cfg(not(unix))]
+    pub fn verify_identity(&self) -> Result<()> {
+        bail!("external resource evaluators require a Unix process host")
+    }
+
+    #[cfg(unix)]
     fn execute(&self, request: &ResourceWorkerRequest) -> Result<ResourceWorkerResponse> {
         let mut bytes = serde_json::to_vec(request)?;
         ensure!(
@@ -211,10 +235,18 @@ impl ExternalResourceEvaluator {
             "resource evaluator request exceeds {MAX_RESOURCE_MESSAGE_BYTES} bytes"
         );
         bytes.push(b'\n');
-        // Revalidate immediately before spawning. This also walks every path
-        // ancestor, so an executable reached through a symlink is rejected.
-        self.verify_identity()?;
-        let mut command = Command::new(&self.executable);
+        // Walk every path ancestor immediately before opening the executable,
+        // then hash that opened generation and execute a private
+        // materialization of its exact bytes. Replacing the configured path
+        // after this point cannot change the program selected for exec.
+        self.validate_path_identity()?;
+        let executable = PinnedExecutable::open(
+            &self.executable,
+            &self.expected_sha256,
+            "resource evaluator",
+            "resource-evaluator",
+        )?;
+        let mut command = executable.command();
         command
             .args(&self.arguments)
             .env_clear()
@@ -235,151 +267,73 @@ impl ExternalResourceEvaluator {
                 self.executable.display()
             )
         })?;
-        let mut child = ChildGuard::new(child);
-        let mut input = child
-            .child_mut()
-            .stdin
-            .take()
-            .context("resource evaluator stdin is unavailable")?;
-        let stdout = child
-            .child_mut()
-            .stdout
-            .take()
-            .context("resource evaluator stdout is unavailable")?;
-        let (write_tx, write_rx) = mpsc::sync_channel(1);
-        let writer = thread::spawn(move || {
-            let result = input.write_all(&bytes).and_then(|()| input.flush());
-            let _ = write_tx.send(result);
-        });
-        let (read_tx, read_rx) = mpsc::sync_channel(1);
-        let reader = thread::spawn(move || {
-            let _ = read_tx.send(read_resource_response(stdout));
-        });
-        let deadline = Instant::now() + self.timeout;
-        let mut write_finished = false;
+        let mut child = SupervisedProcess::new(
+            child,
+            executable.into_staged(),
+            "resource evaluator",
+            MAX_RESOURCE_MESSAGE_BYTES,
+        )?;
+        let deadline = Instant::now()
+            .checked_add(self.timeout)
+            .context("resource evaluator timeout exceeds the monotonic clock")?;
+        let mut written = 0_usize;
         let mut response = None;
-        let mut read_finished = false;
         loop {
-            if !write_finished {
-                match write_rx.try_recv() {
-                    Ok(Ok(())) => write_finished = true,
-                    Ok(Err(error)) => {
-                        child.terminate();
-                        let _ = writer.join();
-                        let _ = reader.join();
-                        return Err(error).context("writing resource evaluator request");
-                    }
-                    Err(mpsc::TryRecvError::Disconnected) => {
-                        child.terminate();
-                        let _ = writer.join();
-                        let _ = reader.join();
-                        bail!("resource evaluator request writer panicked");
-                    }
-                    Err(mpsc::TryRecvError::Empty) => {}
-                }
+            child.write_available(&bytes, &mut written)?;
+            if written == bytes.len() {
+                child.close_input();
             }
-            if !read_finished {
-                match read_rx.try_recv() {
-                    Ok(Err(error)) => {
-                        child.terminate();
-                        let _ = writer.join();
-                        let _ = reader.join();
-                        return Err(error);
-                    }
-                    Err(mpsc::TryRecvError::Disconnected) => {
-                        child.terminate();
-                        let _ = writer.join();
-                        let _ = reader.join();
-                        bail!("resource evaluator response reader panicked");
-                    }
-                    Ok(Ok(value)) => {
-                        response = Some(value);
-                        read_finished = true;
-                    }
-                    Err(mpsc::TryRecvError::Empty) => {}
-                }
-            }
-            let status = match child.try_wait() {
-                Ok(status) => status,
-                Err(error) => {
-                    child.terminate();
-                    let _ = writer.join();
-                    let _ = reader.join();
-                    return Err(error).context("waiting for resource evaluator");
-                }
-            };
-            if let Some(status) = status {
-                let _ = writer.join();
-                let _ = reader.join();
-                let response = match response {
-                    Some(response) => response,
-                    None => read_rx
-                        .recv()
-                        .context("resource evaluator response reader stopped")??,
-                };
+            drain_resource_output(&mut child, &mut response)?;
+            if let Some(status) = child.try_wait()? {
+                // Leader exit is a protocol boundary even if a descendant has
+                // escaped the worker group with setsid() and retained stdout.
+                // Drain every byte already committed by the leader, then close
+                // our nonblocking pipes instead of joining an EOF waiter.
+                child.terminate_process_group();
+                drain_resource_output(&mut child, &mut response)?;
+                child.finish_output_at_leader_exit()?;
+                ensure!(
+                    written == bytes.len(),
+                    "resource evaluator exited before consuming its complete request"
+                );
                 ensure!(
                     status.success(),
                     "resource evaluator exited with status {status}"
                 );
-                return Ok(response);
+                return response.context("resource evaluator exited before responding");
             }
             if Instant::now() >= deadline {
-                child.terminate();
-                let _ = writer.join();
-                let _ = reader.join();
                 bail!(
                     "resource evaluator exceeded its {:?} execution timeout",
                     self.timeout
                 );
             }
-            thread::sleep(Duration::from_millis(5));
+            child.wait_for_activity(written < bytes.len(), deadline)?;
         }
+    }
+
+    #[cfg(not(unix))]
+    fn execute(&self, _request: &ResourceWorkerRequest) -> Result<ResourceWorkerResponse> {
+        bail!("external resource evaluators require a Unix process host")
     }
 }
 
-struct ChildGuard {
-    child: Child,
-    reaped: bool,
-}
-
-impl ChildGuard {
-    fn new(child: Child) -> Self {
-        Self {
-            child,
-            reaped: false,
-        }
-    }
-
-    fn child_mut(&mut self) -> &mut Child {
-        &mut self.child
-    }
-
-    fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
-        let status = self.child.try_wait()?;
-        if status.is_some() {
-            self.reaped = true;
-        }
-        Ok(status)
-    }
-
-    fn terminate(&mut self) {
-        if !self.reaped {
-            #[cfg(unix)]
-            // The worker owns a fresh process group. Kill descendants too so
-            // none can retain stdout and strand the bounded reader thread.
-            unsafe {
-                libc::kill(-(self.child.id() as i32), libc::SIGKILL);
+#[cfg(unix)]
+fn drain_resource_output(
+    child: &mut SupervisedProcess,
+    response: &mut Option<ResourceWorkerResponse>,
+) -> Result<()> {
+    loop {
+        match child.read_line()? {
+            ProtocolRead::Line(line) => {
+                ensure!(
+                    response.is_none(),
+                    "resource evaluator emitted output after its response"
+                );
+                *response = Some(parse_resource_response(&line)?);
             }
-            let _ = self.child.kill();
-            let _ = self.child.wait();
-            self.reaped = true;
+            ProtocolRead::Pending | ProtocolRead::Eof => return Ok(()),
         }
-    }
-}
-
-impl Drop for ChildGuard {
-    fn drop(&mut self) {
-        self.terminate();
     }
 }
 
@@ -455,39 +409,23 @@ fn validate_real_path(path: &Path, kind: RealPathKind, label: &str) -> Result<Pa
     Ok(normalized)
 }
 
-fn stable_file_sha256(path: &Path, label: &str) -> Result<String> {
-    validate_real_path(path, RealPathKind::File, label)?;
-    let before = fs::symlink_metadata(path)?;
-    let file = File::open(path).with_context(|| format!("opening {label} {}", path.display()))?;
-    let opened = file.metadata()?;
-    ensure_same_file(&before, &opened, label)?;
-    let mut reader = BufReader::new(file);
-    let mut hasher = Sha256::new();
-    let mut buffer = [0_u8; 1024 * 1024];
-    loop {
-        let count = reader.read(&mut buffer)?;
-        if count == 0 {
-            break;
-        }
-        hasher.update(&buffer[..count]);
-    }
-    let after = fs::symlink_metadata(path)?;
-    ensure!(
-        after.file_type().is_file() && !after.file_type().is_symlink(),
-        "{label} became a symlink or non-file while hashing"
-    );
-    ensure_same_file(&after, &opened, label)?;
-    Ok(format!("sha256:{:x}", hasher.finalize()))
-}
-
-fn stable_file_bytes(path: &Path, label: &str) -> Result<Vec<u8>> {
+fn stable_file_bytes(path: &Path, maximum_bytes: u64, label: &str) -> Result<Vec<u8>> {
     validate_real_path(path, RealPathKind::File, label)?;
     let before = fs::symlink_metadata(path)?;
     let mut file =
         File::open(path).with_context(|| format!("opening {label} {}", path.display()))?;
     let opened = file.metadata()?;
     ensure_same_file(&before, &opened, label)?;
+    ensure!(
+        opened.len() <= maximum_bytes,
+        "{label} exceeds its {maximum_bytes}-byte limit"
+    );
+    let capacity = usize::try_from(opened.len())
+        .with_context(|| format!("{label} exceeds this process address space"))?;
     let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(capacity)
+        .with_context(|| format!("reserving bounded buffer for {label}"))?;
     file.read_to_end(&mut bytes)?;
     let after = fs::symlink_metadata(path)?;
     ensure!(
@@ -532,7 +470,7 @@ pub fn run_resource_benchmark(
     output_directory: &Path,
 ) -> Result<ResourceEvidencePublication> {
     policy.validate()?;
-    validate_raw_sha256(policy_sha256, "resource policy")?;
+    validate_sha256_hex(policy_sha256, "resource policy")?;
     ensure!(
         evaluator.expected_sha256() == policy.resource_evaluator_version,
         "pinned resource evaluator differs from acceptance policy"
@@ -549,7 +487,7 @@ pub fn run_resource_benchmark(
         evaluator.arguments().to_vec(),
         relative_roots,
     )?;
-    let request_sha256 = canonical_sha256(&semantic)?;
+    let request_sha256 = json_sha256_identity(&semantic)?;
     let request = ResourceWorkerRequest {
         version: RESOURCE_EXECUTION_PROTOCOL_VERSION,
         semantic: semantic.clone(),
@@ -560,14 +498,14 @@ pub fn run_resource_benchmark(
     let response = evaluator.execute(&request)?;
     validate_response_artifact_scope(&response, &vault, &semantic.artifact_roots)?;
 
-    let baseline_target_sha256 = canonical_sha256(&semantic.baseline)?;
-    let candidate_target_sha256 = canonical_sha256(&semantic.candidate)?;
+    let baseline_target_sha256 = json_sha256_identity(&semantic.baseline)?;
+    let candidate_target_sha256 = json_sha256_identity(&semantic.candidate)?;
     let mut comparison = ResourceComparison {
         version: RESOURCE_COMPARISON_VERSION,
         baseline_id: semantic.baseline.id.clone(),
         candidate_id: semantic.candidate.id.clone(),
         benchmark_run_sha256: semantic.selected_benchmark_run_sha256.clone(),
-        strongest_baseline_id,
+        strongest_baseline_id: strongest_baseline_id.clone(),
         measurement_evaluator_id: semantic.policy.evaluator_id.clone(),
         measurement_evaluator_version: evaluator.expected_sha256().to_owned(),
         wake_trials: response.wake_trials,
@@ -604,6 +542,7 @@ pub fn run_resource_benchmark(
         comparison_runs,
         policy,
         policy_sha256,
+        &strongest_baseline_id,
         &comparison,
         &target,
     )?;
@@ -616,10 +555,10 @@ pub fn run_resource_benchmark(
         comparison_runs,
         policy,
         policy_sha256,
+        &strongest_baseline_id,
         verified.comparison(),
         verified.path(),
     )?;
-    verified.verify_contents()?;
     Ok(ResourceEvidencePublication {
         path: target,
         sha256: digest,
@@ -631,11 +570,12 @@ pub(crate) fn validate_execution_receipt(
     comparison_runs: &[VerifiedBenchmarkRun],
     policy: &AcceptancePolicy,
     policy_sha256: &str,
+    strongest_baseline_id: &str,
     comparison: &ResourceComparison,
     source_path: &Path,
 ) -> Result<()> {
     policy.validate()?;
-    validate_raw_sha256(policy_sha256, "resource policy")?;
+    validate_sha256_hex(policy_sha256, "resource policy")?;
     ensure!(
         comparison
             .execution
@@ -647,24 +587,23 @@ pub(crate) fn validate_execution_receipt(
         comparison.execution.evaluator_sha256 == policy.resource_evaluator_version,
         "resource execution receipt names another evaluator"
     );
-    let strongest_baseline_id = verified_resource_benchmark_context(selected_run, comparison_runs)?;
     let semantic = semantic_request(
         selected_run,
         comparison_runs,
         policy,
         policy_sha256,
-        &strongest_baseline_id,
+        strongest_baseline_id,
         comparison.execution.evaluator_arguments.clone(),
         comparison.execution.approved_artifact_roots.clone(),
     )?;
     ensure!(
-        comparison.execution.request_sha256 == canonical_sha256(&semantic)?,
+        comparison.execution.request_sha256 == json_sha256_identity(&semantic)?,
         "resource execution request receipt does not match the verified experiment"
     );
     ensure!(
-        comparison.execution.baseline_target_sha256 == canonical_sha256(&semantic.baseline)?
+        comparison.execution.baseline_target_sha256 == json_sha256_identity(&semantic.baseline)?
             && comparison.execution.candidate_target_sha256
-                == canonical_sha256(&semantic.candidate)?,
+                == json_sha256_identity(&semantic.candidate)?,
         "resource execution receipt addresses different benchmark targets"
     );
     ensure!(
@@ -696,7 +635,7 @@ pub(crate) fn derive_execution_receipt(
     comparison: &ResourceComparison,
 ) -> Result<ResourceExecutionReceipt> {
     policy.validate()?;
-    validate_raw_sha256(policy_sha256, "resource policy")?;
+    validate_sha256_hex(policy_sha256, "resource policy")?;
     let strongest_baseline_id = verified_resource_benchmark_context(selected_run, comparison_runs)?;
     let semantic = semantic_request(
         selected_run,
@@ -710,10 +649,10 @@ pub(crate) fn derive_execution_receipt(
     Ok(ResourceExecutionReceipt {
         protocol_version: RESOURCE_EXECUTION_PROTOCOL_VERSION,
         evaluator_sha256: policy.resource_evaluator_version.clone(),
-        request_sha256: canonical_sha256(&semantic)?,
+        request_sha256: json_sha256_identity(&semantic)?,
         observations_sha256: comparison.observations_sha256()?,
-        baseline_target_sha256: canonical_sha256(&semantic.baseline)?,
-        candidate_target_sha256: canonical_sha256(&semantic.candidate)?,
+        baseline_target_sha256: json_sha256_identity(&semantic.baseline)?,
+        candidate_target_sha256: json_sha256_identity(&semantic.candidate)?,
         policy_sha256: policy_sha256.to_owned(),
         evaluator_arguments,
         approved_artifact_roots: artifact_roots,
@@ -901,6 +840,7 @@ fn validate_safe_relative(path: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn read_resource_response(stdout: impl Read) -> Result<ResourceWorkerResponse> {
     let mut reader = BufReader::new(stdout);
     let line =
@@ -909,8 +849,12 @@ fn read_resource_response(stdout: impl Read) -> Result<ResourceWorkerResponse> {
         read_bounded_line(&mut reader)?.is_none(),
         "resource evaluator emitted output after its response"
     );
-    let response: ResourceWorkerResponse = serde_json::from_slice(&line)
-        .context("resource evaluator emitted invalid protocol JSON")?;
+    parse_resource_response(&line)
+}
+
+fn parse_resource_response(line: &[u8]) -> Result<ResourceWorkerResponse> {
+    let response: ResourceWorkerResponse =
+        serde_json::from_slice(line).context("resource evaluator emitted invalid protocol JSON")?;
     ensure!(
         response.version == RESOURCE_EXECUTION_PROTOCOL_VERSION,
         "unsupported resource evaluator response version {}",
@@ -919,6 +863,7 @@ fn read_resource_response(stdout: impl Read) -> Result<ResourceWorkerResponse> {
     Ok(response)
 }
 
+#[cfg(test)]
 fn read_bounded_line(reader: &mut impl BufRead) -> Result<Option<Vec<u8>>> {
     let mut line = Vec::new();
     loop {
@@ -952,43 +897,9 @@ fn pretty_json_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
-fn canonical_sha256<T: Serialize>(value: &T) -> Result<String> {
-    Ok(format!(
-        "sha256:{:x}",
-        Sha256::digest(serde_json::to_vec(value)?)
-    ))
-}
-
-fn sha256_hex(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
-}
-
-fn validate_prefixed_sha256(value: &str, name: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .with_context(|| format!("{name} must use `sha256:<64 lowercase hex>`"))?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{name} must use `sha256:<64 lowercase hex>`"
-    );
-    Ok(())
-}
-
-fn validate_raw_sha256(value: &str, name: &str) -> Result<()> {
-    ensure!(
-        value.len() == 64
-            && value
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{name} must use 64 lowercase hexadecimal characters"
-    );
-    Ok(())
-}
-
 fn publish_immutable(path: &Path, bytes: &[u8]) -> Result<()> {
+    let expected_bytes =
+        u64::try_from(bytes.len()).context("resource evidence length exceeds u64")?;
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let verified_parent = validate_real_path(
         parent,
@@ -1006,7 +917,8 @@ fn publish_immutable(path: &Path, bytes: &[u8]) -> Result<()> {
                 "content-addressed resource evidence must be a regular non-symlink file"
             );
             ensure!(
-                stable_file_bytes(path, "content-addressed resource evidence")? == bytes,
+                stable_file_bytes(path, expected_bytes, "content-addressed resource evidence",)?
+                    == bytes,
                 "content-addressed resource evidence already exists with different bytes"
             );
             return Ok(());
@@ -1031,13 +943,15 @@ fn publish_immutable(path: &Path, bytes: &[u8]) -> Result<()> {
         match fs::hard_link(&temporary, path) {
             Ok(()) => {
                 ensure!(
-                    stable_file_bytes(path, "published resource evidence")? == bytes,
+                    stable_file_bytes(path, expected_bytes, "published resource evidence")?
+                        == bytes,
                     "published resource evidence changed during publication"
                 );
             }
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                 ensure!(
-                    stable_file_bytes(path, "concurrent resource evidence")? == bytes,
+                    stable_file_bytes(path, expected_bytes, "concurrent resource evidence")?
+                        == bytes,
                     "resource evidence publication race produced different bytes"
                 );
             }
@@ -1181,13 +1095,58 @@ mod tests {
         path
     }
 
+    #[cfg(unix)]
+    fn python_with_setsid() -> PathBuf {
+        [
+            "/usr/bin/python3",
+            "/usr/local/bin/python3",
+            "/opt/homebrew/bin/python3",
+        ]
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|path| path.is_file())
+        .expect("setsid worker tests require an absolute Python 3 interpreter")
+    }
+
+    #[cfg(unix)]
+    fn kill_detached_pid(path: &Path) {
+        for _ in 0..100 {
+            if let Ok(value) = fs::read_to_string(path)
+                && let Ok(pid) = value.trim().parse::<i32>()
+            {
+                // SAFETY: the test helper wrote its own positive process ID.
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                }
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("detached worker did not publish its pid");
+    }
+
+    #[test]
+    fn immutable_resource_comparison_rejects_oversized_existing_file_before_allocation() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().canonicalize().unwrap();
+        let path = root.join("oversized.json");
+        let file = File::create(&path).unwrap();
+        file.set_len(1_025).unwrap();
+        drop(file);
+
+        let error = stable_file_bytes(&path, 1_024, "resource fixture")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("1024-byte limit"), "{error}");
+    }
+
     #[test]
     fn evaluator_arguments_are_part_of_the_semantic_request_identity() {
         let first = request(vec!["--mode=a".into()]);
         let second = request(vec!["--mode=b".into()]);
         assert_ne!(
-            canonical_sha256(&first.semantic).unwrap(),
-            canonical_sha256(&second.semantic).unwrap()
+            json_sha256_identity(&first.semantic).unwrap(),
+            json_sha256_identity(&second.semantic).unwrap()
         );
     }
 
@@ -1205,6 +1164,22 @@ mod tests {
         assert!(error.contains("exceeds"), "{error}");
     }
 
+    #[test]
+    fn evaluator_rejects_a_timeout_outside_the_monotonic_clock_range() {
+        let evaluator = ExternalResourceEvaluator {
+            executable: PathBuf::from("unused-test-worker"),
+            arguments: Vec::new(),
+            expected_sha256: format!("sha256:{}", "0".repeat(64)),
+            timeout: DEFAULT_RESOURCE_EVALUATOR_TIMEOUT,
+        };
+
+        let error = evaluator
+            .with_timeout(Duration::MAX)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("monotonic clock"), "{error}");
+    }
+
     #[cfg(unix)]
     #[test]
     fn hanging_evaluator_is_killed_at_the_bound() {
@@ -1215,7 +1190,7 @@ mod tests {
             "hang.sh",
             "#!/bin/sh\nIFS= read -r request\n/bin/sleep 30\n",
         );
-        let digest = stable_file_sha256(&worker, "test worker").unwrap();
+        let digest = pinned_file_sha256(&worker).unwrap();
         let evaluator = ExternalResourceEvaluator::new(&worker, Vec::new(), digest)
             .unwrap()
             .with_timeout(Duration::from_millis(100))
@@ -1227,6 +1202,93 @@ mod tests {
             .to_string();
         assert!(error.contains("timeout"), "{error}");
         assert!(started.elapsed() < Duration::from_secs(3));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn timeout_is_bounded_when_setsid_descendant_retains_protocol_pipes() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().canonicalize().unwrap();
+        let detached_pid = root.join("detached.pid");
+        let worker = executable(
+            &root,
+            "setsid-timeout.sh",
+            concat!(
+                "#!/bin/sh\n",
+                "IFS= read -r request\n",
+                "test -n \"$request\"\n",
+                "\"$1\" -c 'import os,sys,time; os.setsid(); f=open(sys.argv[1],\"w\"); f.write(str(os.getpid())); f.flush(); os.fsync(f.fileno()); time.sleep(30)' \"$2\" &\n",
+                "while [ ! -s \"$2\" ]; do /bin/sleep 0.01; done\n",
+                "/bin/sleep 30\n"
+            ),
+        );
+        let digest = pinned_file_sha256(&worker).unwrap();
+        let evaluator = ExternalResourceEvaluator::new(
+            &worker,
+            vec![
+                python_with_setsid().into_os_string(),
+                detached_pid.clone().into_os_string(),
+            ],
+            digest,
+        )
+        .unwrap()
+        .with_timeout(Duration::from_secs(3))
+        .unwrap();
+
+        let started = Instant::now();
+        let result = evaluator.execute(&request(Vec::new()));
+        let elapsed = started.elapsed();
+        kill_detached_pid(&detached_pid);
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("timeout"), "{error}");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "setsid descendant delayed resource timeout for {elapsed:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn protocol_error_is_bounded_when_setsid_descendant_retains_stdout() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().canonicalize().unwrap();
+        let detached_pid = root.join("detached.pid");
+        let worker = executable(
+            &root,
+            "setsid-error.sh",
+            concat!(
+                "#!/bin/sh\n",
+                "IFS= read -r request\n",
+                "test -n \"$request\"\n",
+                "\"$1\" -c 'import os,sys,time; os.setsid(); f=open(sys.argv[1],\"w\"); f.write(str(os.getpid())); f.flush(); os.fsync(f.fileno()); time.sleep(30)' \"$2\" &\n",
+                "while [ ! -s \"$2\" ]; do /bin/sleep 0.01; done\n",
+                "printf '{not-json}\\n'\n",
+                "/bin/sleep 30\n"
+            ),
+        );
+        let digest = pinned_file_sha256(&worker).unwrap();
+        let evaluator = ExternalResourceEvaluator::new(
+            &worker,
+            vec![
+                python_with_setsid().into_os_string(),
+                detached_pid.clone().into_os_string(),
+            ],
+            digest,
+        )
+        .unwrap()
+        .with_timeout(Duration::from_secs(3))
+        .unwrap();
+
+        let started = Instant::now();
+        let result = evaluator.execute(&request(Vec::new()));
+        let elapsed = started.elapsed();
+        kill_detached_pid(&detached_pid);
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("invalid protocol JSON"), "{error}");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "setsid descendant delayed resource protocol error for {elapsed:?}"
+        );
     }
 
     #[cfg(unix)]
@@ -1246,13 +1308,93 @@ mod tests {
                 response_path.display()
             ),
         );
-        let digest = stable_file_sha256(&worker, "test worker").unwrap();
+        let digest = pinned_file_sha256(&worker).unwrap();
         let evaluator = ExternalResourceEvaluator::new(&worker, Vec::new(), digest).unwrap();
         let error = evaluator
             .execute(&request(Vec::new()))
             .unwrap_err()
             .to_string();
         assert!(error.contains("after its response"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_evaluator_cannot_leave_a_descendant_holding_protocol_pipes() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().canonicalize().unwrap();
+        let response_path = root.join("response.jsonl");
+        let mut response_bytes = serde_json::to_vec(&response()).unwrap();
+        response_bytes.push(b'\n');
+        fs::write(&response_path, response_bytes).unwrap();
+        let worker = executable(
+            &root,
+            "orphan.sh",
+            &format!(
+                "#!/bin/sh\nIFS= read -r request\n/bin/cat '{}'\n/bin/sleep 30 &\nexit 0\n",
+                response_path.display()
+            ),
+        );
+        let digest = pinned_file_sha256(&worker).unwrap();
+        let evaluator = ExternalResourceEvaluator::new(&worker, Vec::new(), digest)
+            .unwrap()
+            // Leave enough scheduling margin when all process-lifecycle tests
+            // execute concurrently; the elapsed-time assertion still catches
+            // a descendant retaining the pipe for its 30-second lifetime.
+            .with_timeout(Duration::from_secs(3))
+            .unwrap();
+
+        let started = Instant::now();
+        evaluator.execute(&request(Vec::new())).unwrap();
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn leader_exit_is_bounded_when_setsid_descendant_retains_stdout() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().canonicalize().unwrap();
+        let response_path = root.join("response.jsonl");
+        let detached_pid = root.join("detached.pid");
+        let mut response_bytes = serde_json::to_vec(&response()).unwrap();
+        response_bytes.push(b'\n');
+        fs::write(&response_path, response_bytes).unwrap();
+        let worker = executable(
+            &root,
+            "setsid-exit.sh",
+            &format!(
+                concat!(
+                    "#!/bin/sh\n",
+                    "IFS= read -r request\n",
+                    "test -n \"$request\"\n",
+                    "\"$1\" -c 'import os,sys,time; os.setsid(); f=open(sys.argv[1],\"w\"); f.write(str(os.getpid())); f.flush(); os.fsync(f.fileno()); time.sleep(30)' \"$2\" &\n",
+                    "while [ ! -s \"$2\" ]; do /bin/sleep 0.01; done\n",
+                    "/bin/cat '{}'\n"
+                ),
+                response_path.display()
+            ),
+        );
+        let digest = pinned_file_sha256(&worker).unwrap();
+        let evaluator = ExternalResourceEvaluator::new(
+            &worker,
+            vec![
+                python_with_setsid().into_os_string(),
+                detached_pid.clone().into_os_string(),
+            ],
+            digest,
+        )
+        .unwrap()
+        .with_timeout(Duration::from_secs(2))
+        .unwrap();
+
+        let started = Instant::now();
+        let result = evaluator.execute(&request(Vec::new()));
+        let elapsed = started.elapsed();
+        kill_detached_pid(&detached_pid);
+        result.unwrap();
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "setsid descendant delayed resource leader exit for {elapsed:?}"
+        );
     }
 
     #[cfg(unix)]
@@ -1265,7 +1407,7 @@ mod tests {
         let real = root.join("real");
         fs::create_dir(&real).unwrap();
         let worker = executable(&real, "worker.sh", "#!/bin/sh\nexit 0\n");
-        let digest = stable_file_sha256(&worker, "test worker").unwrap();
+        let digest = pinned_file_sha256(&worker).unwrap();
         let direct = root.join("worker-link");
         symlink(&worker, &direct).unwrap();
         assert!(ExternalResourceEvaluator::new(&direct, Vec::new(), &digest).is_err());

--- a/hermes-train/src/runtime.rs
+++ b/hermes-train/src/runtime.rs
@@ -11,9 +11,9 @@
 use anyhow::{Context, Result, bail, ensure};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 
-use crate::metrics::{MetricContext, MetricEvent};
+use crate::artifact_io::{sha256_identity, validate_sha256_identity};
+use crate::metrics::{MetricContext, MetricEvent, MetricPhaseKind};
 use crate::workflow::{PhaseClass, PhaseKind, PhaseV2, ResolvedWorkflow};
 
 /// Version of the serialized workflow-runtime state.
@@ -66,9 +66,9 @@ impl ImmutableModelCheckpoint {
         self.sha256 == other.sha256
     }
 
-    fn validate(&self) -> Result<()> {
+    pub(crate) fn validate(&self) -> Result<()> {
         ensure!(!self.uri.trim().is_empty(), "checkpoint URI is empty");
-        validate_sha256(&self.sha256, "checkpoint")
+        validate_sha256_identity(&self.sha256, "checkpoint digest")
     }
 }
 
@@ -99,24 +99,10 @@ impl ImmutableArtifact {
         &self.sha256
     }
 
-    fn validate(&self) -> Result<()> {
+    pub(crate) fn validate(&self) -> Result<()> {
         ensure!(!self.uri.trim().is_empty(), "artifact URI is empty");
-        validate_sha256(&self.sha256, "artifact")
+        validate_sha256_identity(&self.sha256, "artifact digest")
     }
-}
-
-fn validate_sha256(value: &str, subject: &str) -> Result<()> {
-    let digest = value.strip_prefix("sha256:").with_context(|| {
-        format!("{subject} digest must use the `sha256:<64 lowercase hex>` form")
-    })?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{subject} digest must use the `sha256:<64 lowercase hex>` form"
-    );
-    Ok(())
 }
 
 /// A completed executor result.  The variants encode the legal side effects
@@ -250,7 +236,7 @@ impl WorkflowRunState {
         }
         let state = Self {
             version: WORKFLOW_RUNTIME_STATE_VERSION,
-            workflow_signature: workflow_signature(workflow)?,
+            workflow_signature: workflow_signature_after_validation(workflow)?,
             current_checkpoint: initial_checkpoint.clone(),
             initial_checkpoint,
             next_phase: 0,
@@ -302,7 +288,7 @@ impl WorkflowRunState {
             self.version
         );
         ensure!(
-            self.workflow_signature == workflow_signature(workflow)?,
+            self.workflow_signature == workflow_signature_after_validation(workflow)?,
             "workflow-runtime checkpoint does not belong to this resolved workflow"
         );
         ensure!(
@@ -349,6 +335,12 @@ impl WorkflowRunState {
             self.current_checkpoint == expected_checkpoint,
             "workflow-runtime current checkpoint disagrees with its phase receipts"
         );
+        if self.next_phase < workflow.phases.len() {
+            validate_phase_input(
+                &workflow.phases[self.next_phase],
+                expected_checkpoint.as_ref(),
+            )?;
+        }
 
         match &self.active {
             Some(active) => {
@@ -388,8 +380,12 @@ impl WorkflowRunState {
 /// workflow, including changed phase order or parameters.
 pub fn workflow_signature(workflow: &ResolvedWorkflow) -> Result<String> {
     workflow.validate()?;
+    workflow_signature_after_validation(workflow)
+}
+
+fn workflow_signature_after_validation(workflow: &ResolvedWorkflow) -> Result<String> {
     let encoded = serde_json::to_vec(workflow)?;
-    Ok(format!("sha256:{:x}", Sha256::digest(encoded)))
+    Ok(sha256_identity(&encoded))
 }
 
 fn validate_product(
@@ -478,6 +474,18 @@ fn validate_product(
             class
         ),
     }
+}
+
+fn validate_phase_input(phase: &PhaseV2, input: Option<&ImmutableModelCheckpoint>) -> Result<()> {
+    if phase.kind != PhaseKind::Pretrain {
+        ensure!(
+            input.is_some(),
+            "workflow phase `{}` ({}) requires an input model checkpoint",
+            phase.name,
+            phase.kind.name()
+        );
+    }
+    Ok(())
 }
 
 /// Owned request passed to an executor.  Cloning a phase boundary avoids
@@ -691,6 +699,33 @@ impl<S: RuntimeCheckpoint + ?Sized> PhaseProgressSink for ProgressCheckpoint<'_,
     }
 
     fn metric(&mut self, context: MetricContext, event: MetricEvent) -> Result<()> {
+        let active = self
+            .state
+            .active
+            .as_ref()
+            .context("cannot emit a metric without an active phase")?;
+        let expected_index = u32::try_from(active.phase_index)
+            .context("active workflow phase index exceeds the metric schema")?;
+        ensure!(
+            context.phase.index == expected_index && context.phase.name == active.phase_name,
+            "executor metric phase identity does not match active workflow phase `{}`",
+            active.phase_name
+        );
+        let expected_kind = MetricPhaseKind::from(active.phase_kind);
+        let periodic_sleep_subphase = context.phase.kind == MetricPhaseKind::Sleep
+            && self.workflow.phases[active.phase_index]
+                .periodic_sleep
+                .is_some();
+        ensure!(
+            context.phase.kind == expected_kind || periodic_sleep_subphase,
+            "executor metric kind does not match active workflow phase `{}` ({})",
+            active.phase_name,
+            active.phase_kind.name()
+        );
+        if let Some(checkpoint_hash) = &context.checkpoint_hash {
+            validate_sha256_identity(checkpoint_hash, "metric checkpoint digest")?;
+        }
+        event.validate()?;
         self.checkpoint.append_metric(context, event)
     }
 }
@@ -743,6 +778,11 @@ fn commit_prepared<S: RuntimeCheckpoint + ?Sized>(
 /// the already-persisted product without invoking an executor again.  This is
 /// the critical interruption window for immutable sleep/quantization
 /// candidates and release publication.
+///
+/// After any error, discard the driver and reload it from its
+/// [`RuntimeCheckpoint`]. An executor may have successfully persisted progress
+/// before a later operation failed, while metrics emitted after that boundary
+/// must be truncated by the persistence implementation during resume.
 pub fn run_next_phase<C, S: RuntimeCheckpoint + ?Sized>(
     workflow: &ResolvedWorkflow,
     state: &mut WorkflowRunState,
@@ -884,7 +924,7 @@ mod tests {
     use crate::workflow::WorkflowV2;
 
     fn digest(label: &str) -> String {
-        format!("sha256:{:x}", Sha256::digest(label.as_bytes()))
+        sha256_identity(label.as_bytes())
     }
 
     fn checkpoint(label: &str) -> ImmutableModelCheckpoint {
@@ -1048,6 +1088,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingCheckpoint {
         boundaries: Vec<RuntimeBoundary>,
+        metrics: Vec<(MetricContext, MetricEvent)>,
         fail_commit_once: bool,
     }
 
@@ -1060,6 +1101,23 @@ mod tests {
             self.boundaries.push(boundary.clone());
             Ok(())
         }
+
+        fn append_metric(&mut self, context: MetricContext, event: MetricEvent) -> Result<()> {
+            self.metrics.push((context, event));
+            Ok(())
+        }
+    }
+
+    fn timing_event() -> MetricEvent {
+        MetricEvent::PhaseTiming(crate::metrics::PhaseTimingMetrics {
+            boundary: crate::metrics::PhaseBoundary::Progress,
+            elapsed_seconds: 0.0,
+            input_wait_seconds: 0.0,
+            forward_seconds: 0.0,
+            backward_seconds: 0.0,
+            optimizer_seconds: 0.0,
+            checkpoint_seconds: 0.0,
+        })
     }
 
     struct CompleteExecutor;
@@ -1170,6 +1228,150 @@ mod tests {
         assert!(error.contains("pretrain"), "{error}");
         assert_eq!(state, pristine);
         assert!(persistence.boundaries.is_empty());
+    }
+
+    #[test]
+    fn executor_metrics_are_bound_to_the_active_workflow_phase() {
+        let full = full_workflow();
+        let workflow = ResolvedWorkflow {
+            version: full.version,
+            name: Some("metric-binding".to_owned()),
+            phases: vec![full.phases[0].clone()],
+        };
+        let mut state = WorkflowRunState::new(&workflow, None).unwrap();
+        let mut registry = ExecutorRegistry::new();
+        registry
+            .register(
+                PhaseKind::Pretrain,
+                |request: &PhaseExecutionRequest,
+                 _: &mut (),
+                 progress: &mut dyn PhaseProgressSink| {
+                    progress.metric(
+                        MetricContext {
+                            global_step: 1,
+                            phase: crate::metrics::MetricPhase {
+                                index: u32::try_from(request.phase_index).unwrap(),
+                                name: request.phase.name.clone(),
+                                kind: request.phase.kind.into(),
+                            },
+                            checkpoint_hash: None,
+                        },
+                        timing_event(),
+                    )?;
+                    Ok(PhaseExecutionResult::Complete(
+                        PhaseProduct::ModelCandidate {
+                            checkpoint: checkpoint("metric-output"),
+                        },
+                    ))
+                },
+            )
+            .unwrap();
+        let mut persistence = RecordingCheckpoint::default();
+        run_next_phase(
+            &workflow,
+            &mut state,
+            &mut registry,
+            &mut (),
+            &mut persistence,
+        )
+        .unwrap();
+        assert_eq!(persistence.metrics.len(), 1);
+
+        let mut state = WorkflowRunState::new(&workflow, None).unwrap();
+        let mut registry = ExecutorRegistry::new();
+        registry
+            .register(
+                PhaseKind::Pretrain,
+                |request: &PhaseExecutionRequest,
+                 _: &mut (),
+                 progress: &mut dyn PhaseProgressSink| {
+                    progress.metric(
+                        MetricContext {
+                            global_step: 1,
+                            phase: crate::metrics::MetricPhase {
+                                index: u32::try_from(request.phase_index).unwrap(),
+                                name: request.phase.name.clone(),
+                                kind: MetricPhaseKind::Evaluation,
+                            },
+                            checkpoint_hash: None,
+                        },
+                        timing_event(),
+                    )?;
+                    unreachable!("invalid metric must stop the executor")
+                },
+            )
+            .unwrap();
+        let mut persistence = RecordingCheckpoint::default();
+        let error = run_next_phase(
+            &workflow,
+            &mut state,
+            &mut registry,
+            &mut (),
+            &mut persistence,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("metric kind"), "{error}");
+        assert!(persistence.metrics.is_empty());
+    }
+
+    #[test]
+    fn periodic_sleep_metrics_keep_the_outer_phase_identity() {
+        let full = full_workflow();
+        let mut phase = full.phases[0].clone();
+        let mut periodic_sleep = full.phases[6]
+            .sleep
+            .clone()
+            .expect("full workflow has a standalone sleep fixture");
+        periodic_sleep.standalone_trigger_clock = None;
+        phase.periodic_sleep = Some(periodic_sleep);
+        let workflow = ResolvedWorkflow {
+            version: full.version,
+            name: Some("periodic-sleep-metric-binding".to_owned()),
+            phases: vec![phase],
+        };
+        workflow.validate().unwrap();
+
+        let mut state = WorkflowRunState::new(&workflow, None).unwrap();
+        let mut registry = ExecutorRegistry::new();
+        registry
+            .register(
+                PhaseKind::Pretrain,
+                |request: &PhaseExecutionRequest,
+                 _: &mut (),
+                 progress: &mut dyn PhaseProgressSink| {
+                    progress.metric(
+                        MetricContext {
+                            global_step: 1,
+                            phase: crate::metrics::MetricPhase {
+                                index: u32::try_from(request.phase_index).unwrap(),
+                                name: request.phase.name.clone(),
+                                kind: MetricPhaseKind::Sleep,
+                            },
+                            checkpoint_hash: None,
+                        },
+                        timing_event(),
+                    )?;
+                    Ok(PhaseExecutionResult::Complete(
+                        PhaseProduct::ModelCandidate {
+                            checkpoint: checkpoint("periodic-sleep-metric-output"),
+                        },
+                    ))
+                },
+            )
+            .unwrap();
+        let mut persistence = RecordingCheckpoint::default();
+        run_next_phase(
+            &workflow,
+            &mut state,
+            &mut registry,
+            &mut (),
+            &mut persistence,
+        )
+        .unwrap();
+        assert_eq!(persistence.metrics.len(), 1);
+        assert_eq!(persistence.metrics[0].0.phase.name, workflow.phases[0].name);
+        assert_eq!(persistence.metrics[0].0.phase.kind, MetricPhaseKind::Sleep);
     }
 
     #[derive(Default)]
@@ -1287,6 +1489,34 @@ mod tests {
             Some(&checkpoint("resumed-output"))
         );
         assert!(state.is_complete(&workflow));
+    }
+
+    #[test]
+    fn only_pretrain_can_bootstrap_without_an_input_model() {
+        let complete = full_workflow();
+        let pretrain_only = ResolvedWorkflow {
+            version: complete.version,
+            name: Some("pretrain-only".to_owned()),
+            phases: vec![complete.phases[0].clone()],
+        };
+        WorkflowRunState::new(&pretrain_only, None).unwrap();
+
+        for phase in complete.phases.iter().skip(1) {
+            let workflow = ResolvedWorkflow {
+                version: complete.version,
+                name: Some(format!("{}-only", phase.kind.name())),
+                phases: vec![phase.clone()],
+            };
+            let error = WorkflowRunState::new(&workflow, None)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                error.contains("requires an input model checkpoint"),
+                "{} unexpectedly accepted no input: {error}",
+                phase.kind.name()
+            );
+            WorkflowRunState::new(&workflow, Some(checkpoint("input"))).unwrap();
+        }
     }
 
     #[test]

--- a/hermes-train/src/sleep.rs
+++ b/hermes-train/src/sleep.rs
@@ -8,25 +8,40 @@
 
 use std::collections::BTreeSet;
 
+#[cfg(test)]
+use std::cell::Cell;
+
 use anyhow::{Context, Result, bail, ensure};
 use burn::module::{ParamId, list_param_ids};
 use hermes_llm::{MemorySlotStatus, Transformer};
 use serde::{Deserialize, Serialize};
 
+use crate::artifact_io::validate_sha256_identity;
 use crate::metrics::{DreamSelectionMetrics, DreamTrialMetrics, MetricEvent};
 
-fn validate_content_hash(value: &str, subject: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .with_context(|| format!("{subject} must use sha256:<64 lowercase hex>"))?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "{subject} must use sha256:<64 lowercase hex>"
-    );
-    Ok(())
+pub const MAX_MEMORY_TIERS: usize = 16;
+pub const MAX_RESERVE_SLOTS_PER_TIER: usize = 4_096;
+pub const MAX_TOTAL_RESERVE_SLOTS: usize = 16_384;
+pub const MAX_SLEEP_RNG_STREAMS: usize = 1_024;
+const MAX_MEMORY_TIER_ID_BYTES: usize = 128;
+const MAX_CHECKPOINT_LOCATION_BYTES: usize = 16 * 1_024;
+const MAX_SLEEP_EVALUATOR_HASHES: usize = 32;
+const MAX_DREAM_CANDIDATE_ID_BYTES: usize = 1_024;
+const MAX_DREAM_GRADIENT_DIMENSIONS: usize = 4_096;
+
+#[cfg(test)]
+thread_local! {
+    static FULL_SCOPE_VALIDATIONS: Cell<u64> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_full_scope_validation_count() {
+    FULL_SCOPE_VALIDATIONS.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn full_scope_validation_count() -> u64 {
+    FULL_SCOPE_VALIDATIONS.with(Cell::get)
 }
 
 /// Unit used by a memory tier's update period.
@@ -69,14 +84,15 @@ pub struct SleepSchedule {
 impl SleepSchedule {
     pub fn validate(&self) -> Result<()> {
         ensure!(
-            self.tiers.len() >= 2,
-            "sleep requires at least two memory tiers"
+            (2..=MAX_MEMORY_TIERS).contains(&self.tiers.len()),
+            "sleep requires 2..={MAX_MEMORY_TIERS} memory tiers"
         );
         let mut ids = BTreeSet::new();
+        let mut total_reserve_slots = 0usize;
         for (index, tier) in self.tiers.iter().enumerate() {
             ensure!(
-                !tier.id.trim().is_empty(),
-                "memory tier {index} has an empty id"
+                !tier.id.trim().is_empty() && tier.id.len() <= MAX_MEMORY_TIER_ID_BYTES,
+                "memory tier {index} id must contain 1..={MAX_MEMORY_TIER_ID_BYTES} bytes"
             );
             ensure!(
                 ids.insert(tier.id.as_str()),
@@ -89,9 +105,16 @@ impl SleepSchedule {
                 tier.id
             );
             ensure!(
-                tier.reserve_slots > 0,
-                "memory tier `{}` reserve_slots must be positive",
+                (1..=MAX_RESERVE_SLOTS_PER_TIER).contains(&tier.reserve_slots),
+                "memory tier `{}` reserve_slots must be in 1..={MAX_RESERVE_SLOTS_PER_TIER}",
                 tier.id
+            );
+            total_reserve_slots = total_reserve_slots
+                .checked_add(tier.reserve_slots)
+                .context("sleep reserve-slot count overflow")?;
+            ensure!(
+                total_reserve_slots <= MAX_TOTAL_RESERVE_SLOTS,
+                "sleep schedule exceeds the {MAX_TOTAL_RESERVE_SLOTS}-slot total reserve limit"
             );
             if let Some(faster) = index.checked_sub(1).map(|i| &self.tiers[i]) {
                 ensure!(
@@ -275,6 +298,216 @@ pub struct SleepState {
 }
 
 const COMPLETED_TRANSACTION_TAIL: usize = 64;
+const ARTIFACT_MANIFEST_TAIL: usize = COMPLETED_TRANSACTION_TAIL + 1;
+
+fn referenced_artifact_manifests(
+    completed: &[ConsolidationTxn],
+    pending: Option<&ConsolidationTxn>,
+) -> Result<Vec<String>> {
+    let mut manifests = BTreeSet::new();
+    for manifest in completed
+        .iter()
+        .chain(pending)
+        .filter_map(|txn| txn.generated_manifest.as_ref())
+    {
+        validate_sha256_identity(manifest, "sleep artifact manifest")?;
+        manifests.insert(manifest.clone());
+    }
+    ensure!(
+        manifests.len() <= ARTIFACT_MANIFEST_TAIL,
+        "sleep artifact-manifest tail exceeds its bounded transaction history"
+    );
+    Ok(manifests.into_iter().collect())
+}
+
+fn validate_completed_transaction(
+    txn: &ConsolidationTxn,
+    tiers: &[MemoryTierState],
+    rng_counters: &[u64],
+) -> Result<()> {
+    ensure!(
+        txn.committed,
+        "completed sleep transaction is not committed"
+    );
+    ensure!(
+        txn.sender < tiers.len() && txn.receiver < tiers.len(),
+        "completed sleep transaction tier is out of range"
+    );
+    ensure!(
+        txn.trigger_clock > 0 && txn.trigger_clock <= tiers[txn.sender].last_update_clock,
+        "completed sleep transaction trigger is ahead of its sender update clock"
+    );
+    ensure!(
+        txn.terminal == (txn.sender + 1 == tiers.len())
+            && ((txn.terminal && txn.receiver == txn.sender)
+                || (!txn.terminal && txn.sender + 1 == txn.receiver)),
+        "completed sleep transaction has invalid tier topology"
+    );
+    ensure!(
+        txn.terminal || txn.receiver_slot < tiers[txn.receiver].slots.len(),
+        "completed sleep transaction receiver slot is out of range"
+    );
+    ensure!(
+        txn.sender_slots_to_reset
+            .iter()
+            .all(|slot| *slot < tiers[txn.sender].slots.len())
+            && txn
+                .sender_slots_to_reset
+                .windows(2)
+                .all(|pair| pair[0] < pair[1]),
+        "completed sleep transaction has an invalid sender reset plan"
+    );
+    ensure!(
+        !txn.teacher_checkpoint.trim().is_empty()
+            && txn.teacher_checkpoint.len() <= MAX_CHECKPOINT_LOCATION_BYTES
+            && !txn.student_checkpoint.trim().is_empty()
+            && txn.student_checkpoint.len() <= MAX_CHECKPOINT_LOCATION_BYTES,
+        "completed sleep transaction has invalid checkpoint locations"
+    );
+    for (hash, label) in [
+        (&txn.teacher_hash, "completed teacher hash"),
+        (&txn.student_hash, "completed student hash"),
+        (
+            &txn.prospective_update_hash,
+            "completed prospective-update hash",
+        ),
+    ] {
+        validate_sha256_identity(hash, label)?;
+    }
+    let candidate_checkpoint = txn
+        .candidate_checkpoint
+        .as_deref()
+        .context("completed sleep transaction has no candidate checkpoint")?;
+    ensure!(
+        !candidate_checkpoint.trim().is_empty()
+            && candidate_checkpoint.len() <= MAX_CHECKPOINT_LOCATION_BYTES,
+        "completed sleep transaction has an invalid candidate checkpoint"
+    );
+    validate_sha256_identity(
+        txn.candidate_hash
+            .as_deref()
+            .context("completed sleep transaction has no candidate hash")?,
+        "completed candidate hash",
+    )?;
+
+    let mut reservations = [
+        txn.knowledge_rng
+            .context("completed sleep transaction has no Knowledge Seeding RNG receipt")?,
+        txn.imitation_rng
+            .context("completed sleep transaction has no imitation RNG receipt")?,
+    ]
+    .into_iter()
+    .chain(txn.dream_generation_rng)
+    .chain(txn.dream_selection_rng)
+    .chain(txn.dream_trial_rngs.iter().map(|trial| trial.reservation))
+    .collect::<Vec<_>>();
+    for reservation in &reservations {
+        reservation.validate(rng_counters)?;
+    }
+    reservations.sort_unstable_by_key(|reservation| (reservation.stream, reservation.start));
+    ensure!(
+        reservations.windows(2).all(|pair| {
+            pair[0].stream != pair[1].stream || pair[0].start + pair[0].count <= pair[1].start
+        }),
+        "completed sleep transaction has overlapping RNG receipts"
+    );
+
+    ensure!(
+        txn.tensor_transaction_generation.is_some()
+            == txn.tensor_transaction_manifest_hash.is_some(),
+        "completed sleep tensor transaction identity is incomplete"
+    );
+    if let (Some(generation), Some(hash)) = (
+        &txn.tensor_transaction_generation,
+        &txn.tensor_transaction_manifest_hash,
+    ) {
+        let digest = generation
+            .strip_prefix("sha256-")
+            .context("completed tensor generation has an unsafe name")?;
+        validate_sha256_identity(&format!("sha256:{digest}"), "completed tensor generation")?;
+        validate_sha256_identity(hash, "completed tensor manifest hash")?;
+        ensure!(
+            hash.strip_prefix("sha256:") == Some(digest),
+            "completed tensor generation differs from its manifest"
+        );
+    }
+
+    let selected = txn
+        .dream_selected
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let trial_ids = txn
+        .dream_trials
+        .iter()
+        .map(|trial| trial.candidate_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let trial_rng_ids = txn
+        .dream_trial_rngs
+        .iter()
+        .map(|trial| trial.candidate_id.as_str())
+        .collect::<BTreeSet<_>>();
+    ensure!(
+        selected.len() == txn.dream_selected.len()
+            && selected
+                .iter()
+                .all(|id| { !id.trim().is_empty() && id.len() <= MAX_DREAM_CANDIDATE_ID_BYTES })
+            && trial_ids.len() == txn.dream_trials.len()
+            && trial_rng_ids.len() == txn.dream_trial_rngs.len(),
+        "completed sleep transaction has invalid dream candidate IDs"
+    );
+    for trial in &txn.dream_trials {
+        ensure!(
+            trial.candidate_id.len() <= MAX_DREAM_CANDIDATE_ID_BYTES
+                && trial.independent_task_improvement.is_finite(),
+            "completed dream trial has invalid evidence"
+        );
+        validate_sha256_identity(&trial.adapter_hash, "completed dream adapter hash")?;
+        validate_sha256_identity(&trial.evaluator_hash, "completed dream evaluator hash")?;
+    }
+    match &txn.generated_manifest {
+        Some(manifest) => {
+            validate_sha256_identity(manifest, "completed dream manifest")?;
+            validate_sha256_identity(
+                txn.dream_shared_checkpoint_hash
+                    .as_deref()
+                    .context("completed dream has no shared-checkpoint hash")?,
+                "completed dream shared-checkpoint hash",
+            )?;
+            let candidate_count = usize::try_from(
+                txn.dream_generation_rng
+                    .context("completed dream has no generation RNG receipt")?
+                    .count,
+            )
+            .context("completed dream candidate count exceeds usize")?;
+            ensure!(
+                txn.dream_selection_rng.is_some()
+                    && !selected.is_empty()
+                    && selected.len() <= candidate_count
+                    && trial_ids == selected
+                    && trial_rng_ids == selected,
+                "completed dream selection/trial evidence is incomplete"
+            );
+            validate_sha256_identity(
+                txn.dream_policy_receipt
+                    .as_deref()
+                    .context("completed dream has no ReSTEM policy receipt")?,
+                "completed ReSTEM policy receipt",
+            )?;
+        }
+        None => ensure!(
+            txn.dream_generation_rng.is_none()
+                && txn.dream_selection_rng.is_none()
+                && txn.dream_trial_rngs.is_empty()
+                && txn.dream_shared_checkpoint_hash.is_none()
+                && txn.dream_selected.is_empty()
+                && txn.dream_trials.is_empty()
+                && txn.dream_policy_receipt.is_none(),
+            "completed transaction contains partial Dreaming evidence"
+        ),
+    }
+    Ok(())
+}
 
 /// Content-addressed optimizer/accumulator snapshot for one memory tier.
 /// The tensors live in the normal candidate checkpoint store; this receipt is
@@ -299,7 +532,7 @@ impl TierOptimizerArtifact {
             !self.state_uri.trim().is_empty(),
             "tier optimizer artifact has an empty URI"
         );
-        validate_content_hash(&self.manifest_hash, "tier optimizer-state manifest hash")
+        validate_sha256_identity(&self.manifest_hash, "tier optimizer-state manifest hash")
             .context("invalid tier optimizer-state bundle")?;
         for (ids, label) in [
             (&self.optimizer_parameter_ids, "optimizer"),
@@ -311,6 +544,19 @@ impl TierOptimizerArtifact {
                 "tier {label} state repeats a parameter ID"
             );
         }
+        Ok(())
+    }
+
+    /// Bind the durable gradient receipt to its independently persisted
+    /// accumulation clock. Empty gradient bytes with a positive counter would
+    /// silently shorten the next tier update; gradients with a zero counter
+    /// would be divided by an invalid wake window.
+    pub fn validate_pending_steps(&self, accumulated_micro_steps: u64) -> Result<()> {
+        self.validate()?;
+        ensure!(
+            self.accumulator_parameter_ids.is_empty() == (accumulated_micro_steps == 0),
+            "tier optimizer accumulator receipt disagrees with its pending-step counter"
+        );
         Ok(())
     }
 }
@@ -405,6 +651,8 @@ impl MemoryOptimizerScopes {
     }
 
     pub fn validate(&self, model: &Transformer, schedule: &SleepSchedule) -> Result<()> {
+        #[cfg(test)]
+        FULL_SCOPE_VALIDATIONS.with(|count| count.set(count.get().saturating_add(1)));
         schedule.validate()?;
         ensure!(
             self.tiers.len() == schedule.tiers.len(),
@@ -449,6 +697,35 @@ impl MemoryOptimizerScopes {
                 scope.tier_id
             );
             ensure!(
+                scope.update_clock.is_multiple_of(configured.update_period),
+                "optimizer tier `{}` sender-update clock is off schedule",
+                scope.tier_id
+            );
+            if tier == 0 {
+                ensure!(
+                    scope.transfer_clock == 0 && scope.transfer_generation == 0,
+                    "fastest optimizer tier cannot contain a receiver-transfer receipt"
+                );
+            } else {
+                ensure!(
+                    scope
+                        .transfer_clock
+                        .is_multiple_of(schedule.tiers[tier - 1].update_period),
+                    "optimizer tier `{}` receiver-transfer clock is off schedule",
+                    scope.tier_id
+                );
+            }
+            ensure!(
+                scope.transfer_generation <= scope.generation,
+                "optimizer tier `{}` transfer generation exceeds its artifact generation",
+                scope.tier_id
+            );
+            ensure!(
+                scope.artifact.is_some() == (scope.generation > 0),
+                "optimizer tier `{}` artifact presence disagrees with its generation",
+                scope.tier_id
+            );
+            ensure!(
                 wake.is_disjoint(&observed),
                 "wake optimizer contains parameters from memory tier `{}`",
                 scope.tier_id
@@ -478,9 +755,21 @@ impl MemoryOptimizerScopes {
         schedule: &SleepSchedule,
         state: &SleepState,
     ) -> Result<()> {
-        self.validate(model, schedule)?;
-        validate_model_memory_state(schedule, state, &model.memory_slot_statuses())?;
         let statuses = model.memory_slot_statuses();
+        validate_model_memory_state(schedule, state, &statuses)?;
+        self.validate_active_state_after_model_validation(model, schedule, &statuses)
+    }
+
+    /// Validate optimizer ownership after the caller has already reconciled
+    /// the same model and `SleepState`. This avoids repeating the full bounded
+    /// transaction-history and slot-topology walk on every wake clock tick.
+    pub(crate) fn validate_active_state_after_model_validation(
+        &self,
+        model: &Transformer,
+        schedule: &SleepSchedule,
+        statuses: &[MemorySlotStatus],
+    ) -> Result<()> {
+        self.validate(model, schedule)?;
         for scope in &self.tiers {
             let Some(artifact) = &scope.artifact else {
                 continue;
@@ -506,12 +795,14 @@ impl MemoryOptimizerScopes {
                     scope.tier_id
                 );
             }
-            ensure!(
-                artifact.accumulator_parameter_ids.is_empty()
-                    == (scope.accumulated_micro_steps == 0),
-                "tier `{}` accumulator receipt disagrees with its micro-step counter",
-                scope.tier_id
-            );
+            artifact
+                .validate_pending_steps(scope.accumulated_micro_steps)
+                .with_context(|| {
+                    format!(
+                        "tier `{}` accumulator receipt disagrees with its micro-step counter",
+                        scope.tier_id
+                    )
+                })?;
         }
         Ok(())
     }
@@ -586,8 +877,8 @@ impl MemoryOptimizerScopes {
             .get(tier)
             .with_context(|| format!("optimizer tier {tier} is absent from schedule"))?;
         ensure!(
-            clock > 0,
-            "optimizer tier `{}` update clock is zero",
+            clock > 0 && clock.is_multiple_of(configured.update_period),
+            "optimizer tier `{}` update clock is zero or off schedule",
             configured.id
         );
         let scope = self
@@ -595,8 +886,8 @@ impl MemoryOptimizerScopes {
             .get_mut(tier)
             .with_context(|| format!("optimizer tier {tier} does not exist"))?;
         ensure!(
-            clock >= scope.update_clock,
-            "optimizer tier `{}` clock moved backwards",
+            clock > scope.update_clock,
+            "optimizer tier `{}` sender update was replayed or moved backwards",
             scope.tier_id
         );
         ensure!(
@@ -628,8 +919,8 @@ impl MemoryOptimizerScopes {
             .get_mut(tier)
             .with_context(|| format!("optimizer tier {tier} does not exist"))?;
         ensure!(
-            clock >= scope.transfer_clock,
-            "optimizer tier `{}` transfer clock moved backwards",
+            clock > scope.transfer_clock,
+            "optimizer tier `{}` receiver transfer was replayed or moved backwards",
             scope.tier_id
         );
         if scope.accumulated_micro_steps == 0 {
@@ -665,6 +956,10 @@ impl MemoryOptimizerScopes {
 impl SleepState {
     pub fn new(schedule: &SleepSchedule, rng_streams: usize) -> Result<Self> {
         schedule.validate()?;
+        ensure!(
+            (1..=MAX_SLEEP_RNG_STREAMS).contains(&rng_streams),
+            "sleep requires 1..={MAX_SLEEP_RNG_STREAMS} RNG streams"
+        );
         Ok(Self {
             cycle: 0,
             clock: 0,
@@ -701,14 +996,19 @@ impl SleepState {
     /// when the workflow is resolved.
     pub fn validate_resume(&self) -> Result<()> {
         ensure!(
-            self.tiers.len() >= 2,
-            "sleep checkpoint has fewer than two tiers"
+            (2..=MAX_MEMORY_TIERS).contains(&self.tiers.len()),
+            "sleep checkpoint must contain 2..={MAX_MEMORY_TIERS} tiers"
+        );
+        ensure!(
+            (1..=MAX_SLEEP_RNG_STREAMS).contains(&self.rng_counters.len()),
+            "sleep checkpoint must contain 1..={MAX_SLEEP_RNG_STREAMS} RNG streams"
         );
         let mut tier_ids = BTreeSet::new();
+        let mut total_reserve_slots = 0usize;
         for tier in &self.tiers {
             ensure!(
-                !tier.id.trim().is_empty(),
-                "sleep checkpoint has an empty tier id"
+                !tier.id.trim().is_empty() && tier.id.len() <= MAX_MEMORY_TIER_ID_BYTES,
+                "sleep checkpoint tier id must contain 1..={MAX_MEMORY_TIER_ID_BYTES} bytes"
             );
             ensure!(
                 tier_ids.insert(tier.id.as_str()),
@@ -716,9 +1016,16 @@ impl SleepState {
                 tier.id
             );
             ensure!(
-                !tier.slots.is_empty(),
-                "sleep tier `{}` has no reserve slots",
+                (1..=MAX_RESERVE_SLOTS_PER_TIER).contains(&tier.slots.len()),
+                "sleep tier `{}` must contain 1..={MAX_RESERVE_SLOTS_PER_TIER} reserve slots",
                 tier.id
+            );
+            total_reserve_slots = total_reserve_slots
+                .checked_add(tier.slots.len())
+                .context("sleep checkpoint reserve-slot count overflow")?;
+            ensure!(
+                total_reserve_slots <= MAX_TOTAL_RESERVE_SLOTS,
+                "sleep checkpoint exceeds the {MAX_TOTAL_RESERVE_SLOTS}-slot total reserve limit"
             );
             ensure!(
                 tier.last_update_clock <= tier.last_boundary_clock
@@ -760,13 +1067,14 @@ impl SleepState {
                     .all(|pair| pair[0] < pair[1]),
             "sleep checkpoint has an invalid due-boundary queue"
         );
+        ensure!(
+            self.evaluator_hashes.len() <= MAX_SLEEP_EVALUATOR_HASHES,
+            "sleep checkpoint exceeds the {MAX_SLEEP_EVALUATOR_HASHES}-evaluator limit"
+        );
         for hash in &self.evaluator_hashes {
-            validate_content_hash(hash, "sleep evaluator hash")?;
+            validate_sha256_identity(hash, "sleep evaluator hash")?;
         }
-        for manifest in &self.artifact_manifests {
-            validate_content_hash(manifest, "sleep artifact manifest")?;
-        }
-        validate_content_hash(&self.completed_chain_hash, "sleep completed-history hash")?;
+        validate_sha256_identity(&self.completed_chain_hash, "sleep completed-history hash")?;
         let expected_completed_tail =
             usize::try_from(self.completed_count.min(COMPLETED_TRANSACTION_TAIL as u64))
                 .context("sleep completed-transaction tail length exceeds usize")?;
@@ -787,6 +1095,17 @@ impl SleepState {
                         && txn.candidate_hash.is_some()),
             "sleep completed-transaction audit tail is invalid"
         );
+        for txn in &self.completed_transactions {
+            validate_completed_transaction(txn, &self.tiers, &self.rng_counters)?;
+        }
+        ensure!(
+            self.artifact_manifests
+                == referenced_artifact_manifests(
+                    &self.completed_transactions,
+                    self.pending.as_ref(),
+                )?,
+            "sleep artifact-manifest index differs from its bounded transaction history"
+        );
         match (self.phase, self.pending.as_ref()) {
             (SleepPhase::Wake, None) => {}
             (SleepPhase::Wake, Some(_)) => bail!("wake checkpoint has a pending sleep transaction"),
@@ -795,6 +1114,10 @@ impl SleepState {
                 ensure!(
                     txn.sender < self.tiers.len(),
                     "sleep transaction sender tier is out of range"
+                );
+                ensure!(
+                    txn.terminal == (txn.sender + 1 == self.tiers.len()),
+                    "sleep transaction terminal marker disagrees with its sender tier"
                 );
                 ensure!(
                     (txn.terminal && txn.receiver == txn.sender)
@@ -817,6 +1140,22 @@ impl SleepState {
                     self.due_clocks.first().copied() == Some(txn.trigger_clock) || txn.committed,
                     "sleep transaction trigger clock differs from due-boundary queue"
                 );
+                ensure!(
+                    txn.trigger_clock > 0 && txn.trigger_clock <= self.clock,
+                    "sleep transaction trigger clock is zero or ahead of the sleep clock"
+                );
+                if txn.committed {
+                    ensure!(
+                        self.tiers[txn.sender].last_update_clock == txn.trigger_clock
+                            && self.tiers[txn.sender].last_boundary_clock == txn.trigger_clock,
+                        "committed sleep transaction disagrees with its sender clocks"
+                    );
+                } else {
+                    ensure!(
+                        self.tiers[txn.sender].last_boundary_clock < txn.trigger_clock,
+                        "uncommitted sleep transaction does not own a future sender boundary"
+                    );
+                }
                 let expected_id = if txn.committed {
                     self.cycle
                 } else {
@@ -850,6 +1189,23 @@ impl SleepState {
                         .all(|pair| pair[0] < pair[1]),
                     "sleep sender reset slots are duplicated or unordered"
                 );
+                if !txn.committed {
+                    let active_sender_slots = self.tiers[txn.sender]
+                        .slots
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(slot, state)| state.active.then_some(slot))
+                        .collect::<Vec<_>>();
+                    ensure!(
+                        txn.sender_slots_to_reset == active_sender_slots,
+                        "sleep sender reset plan does not contain the exact active-slot set"
+                    );
+                } else {
+                    ensure!(
+                        self.tiers[txn.sender].slots.iter().all(|slot| !slot.active),
+                        "committed sleep sender retains an active reserve slot"
+                    );
+                }
                 ensure!(
                     txn.sender_slots_to_reset.iter().all(|slot| {
                         self.tiers[txn.sender].slots[*slot].active != txn.committed
@@ -864,12 +1220,14 @@ impl SleepState {
                 }
                 ensure!(
                     !txn.teacher_checkpoint.trim().is_empty()
-                        && !txn.student_checkpoint.trim().is_empty(),
+                        && txn.teacher_checkpoint.len() <= MAX_CHECKPOINT_LOCATION_BYTES
+                        && !txn.student_checkpoint.trim().is_empty()
+                        && txn.student_checkpoint.len() <= MAX_CHECKPOINT_LOCATION_BYTES,
                     "sleep transaction has incomplete checkpoint locations"
                 );
-                validate_content_hash(&txn.teacher_hash, "sleep teacher hash")?;
-                validate_content_hash(&txn.student_hash, "sleep student hash")?;
-                validate_content_hash(
+                validate_sha256_identity(&txn.teacher_hash, "sleep teacher hash")?;
+                validate_sha256_identity(&txn.student_hash, "sleep student hash")?;
+                validate_sha256_identity(
                     &txn.prospective_update_hash,
                     "sleep prospective-update hash",
                 )?;
@@ -889,6 +1247,7 @@ impl SleepState {
                 for trial_rng in &txn.dream_trial_rngs {
                     ensure!(
                         !trial_rng.candidate_id.trim().is_empty()
+                            && trial_rng.candidate_id.len() <= MAX_DREAM_CANDIDATE_ID_BYTES
                             && trial_rng_ids.insert(trial_rng.candidate_id.as_str()),
                         "sleep dream-trial RNG reservations have duplicate or empty IDs"
                     );
@@ -943,10 +1302,11 @@ impl SleepState {
                     (&txn.candidate_checkpoint, &txn.candidate_hash)
                 {
                     ensure!(
-                        !checkpoint.trim().is_empty(),
+                        !checkpoint.trim().is_empty()
+                            && checkpoint.len() <= MAX_CHECKPOINT_LOCATION_BYTES,
                         "sleep transaction candidate checkpoint is empty"
                     );
-                    validate_content_hash(hash, "sleep candidate hash")?;
+                    validate_sha256_identity(hash, "sleep candidate hash")?;
                 }
                 ensure!(
                     !txn.committed || txn.candidate_checkpoint.is_some(),
@@ -964,30 +1324,34 @@ impl SleepState {
                     let digest = generation
                         .strip_prefix("sha256-")
                         .context("sleep tensor generation has an unsafe name")?;
-                    validate_content_hash(&format!("sha256:{digest}"), "sleep tensor generation")?;
-                    validate_content_hash(hash, "sleep tensor manifest hash")?;
+                    validate_sha256_identity(
+                        &format!("sha256:{digest}"),
+                        "sleep tensor generation",
+                    )?;
+                    validate_sha256_identity(hash, "sleep tensor manifest hash")?;
                     ensure!(
                         hash.strip_prefix("sha256:") == Some(digest),
                         "sleep tensor generation does not match its manifest hash"
                     );
                 }
                 if let Some(manifest) = &txn.generated_manifest {
-                    validate_content_hash(manifest, "dream artifact manifest")?;
+                    validate_sha256_identity(manifest, "dream artifact manifest")?;
                 }
                 if let Some(hash) = &txn.dream_shared_checkpoint_hash {
-                    validate_content_hash(hash, "dream shared-checkpoint hash")?;
+                    validate_sha256_identity(hash, "dream shared-checkpoint hash")?;
                 }
                 for trial in &txn.dream_trials {
                     ensure!(
                         !trial.candidate_id.trim().is_empty()
+                            && trial.candidate_id.len() <= MAX_DREAM_CANDIDATE_ID_BYTES
                             && trial.independent_task_improvement.is_finite(),
                         "dream trial has an invalid candidate identity or score"
                     );
-                    validate_content_hash(&trial.adapter_hash, "dream adapter hash")?;
-                    validate_content_hash(&trial.evaluator_hash, "dream evaluator hash")?;
+                    validate_sha256_identity(&trial.adapter_hash, "dream adapter hash")?;
+                    validate_sha256_identity(&trial.evaluator_hash, "dream evaluator hash")?;
                 }
                 if let Some(receipt) = &txn.dream_policy_receipt {
-                    validate_content_hash(receipt, "dream policy receipt")?;
+                    validate_sha256_identity(receipt, "dream policy receipt")?;
                 }
                 let selected = txn
                     .dream_selected
@@ -996,7 +1360,9 @@ impl SleepState {
                     .collect::<BTreeSet<_>>();
                 ensure!(
                     selected.len() == txn.dream_selected.len()
-                        && selected.iter().all(|id| !id.trim().is_empty()),
+                        && selected.iter().all(|id| {
+                            !id.trim().is_empty() && id.len() <= MAX_DREAM_CANDIDATE_ID_BYTES
+                        }),
                     "dream selection contains an empty or duplicate candidate id"
                 );
                 let trial_ids = txn
@@ -1009,6 +1375,31 @@ impl SleepState {
                         && trial_ids.iter().all(|id| selected.contains(id)),
                     "dream trials are duplicated or absent from the selected candidates"
                 );
+                ensure!(
+                    trial_rng_ids.iter().all(|id| selected.contains(id)),
+                    "dream-trial RNG reservation is absent from the selected candidates"
+                );
+                match txn.dream_generation_rng {
+                    Some(reservation) => {
+                        let candidate_count = usize::try_from(reservation.count)
+                            .context("dream candidate count exceeds usize")?;
+                        ensure!(
+                            txn.dream_selected.len() <= candidate_count
+                                && txn.dream_trials.len() <= candidate_count
+                                && txn.dream_trial_rngs.len() <= candidate_count,
+                            "dream checkpoint evidence exceeds its generated-candidate count"
+                        );
+                    }
+                    None => ensure!(
+                        txn.generated_manifest.is_none()
+                            && txn.dream_selection_rng.is_none()
+                            && txn.dream_trial_rngs.is_empty()
+                            && txn.dream_selected.is_empty()
+                            && txn.dream_trials.is_empty()
+                            && txn.dream_policy_receipt.is_none(),
+                        "dream checkpoint contains evidence without a generation reservation"
+                    ),
+                }
                 let requires_commit = matches!(
                     self.phase,
                     SleepPhase::DreamGeneration
@@ -1092,6 +1483,68 @@ impl SleepState {
                     txn.generated_manifest.is_none() || txn.dream_shared_checkpoint_hash.is_some(),
                     "dream artifacts have no immutable shared-checkpoint identity"
                 );
+                let no_dream_evidence = txn.dream_generation_rng.is_none()
+                    && txn.dream_selection_rng.is_none()
+                    && txn.dream_trial_rngs.is_empty()
+                    && txn.generated_manifest.is_none()
+                    && txn.dream_shared_checkpoint_hash.is_none()
+                    && txn.dream_selected.is_empty()
+                    && txn.dream_trials.is_empty()
+                    && txn.dream_policy_receipt.is_none();
+                match self.phase {
+                    SleepPhase::ProspectiveUpdate => ensure!(
+                        txn.knowledge_rng.is_none()
+                            && txn.imitation_rng.is_none()
+                            && no_dream_evidence,
+                        "prospective-update checkpoint contains later-subphase evidence"
+                    ),
+                    SleepPhase::KnowledgeSeeding => ensure!(
+                        txn.imitation_rng.is_none() && no_dream_evidence,
+                        "Knowledge Seeding checkpoint contains later-subphase evidence"
+                    ),
+                    SleepPhase::Imitation
+                    | SleepPhase::RetentionValidation
+                    | SleepPhase::Commit => ensure!(
+                        no_dream_evidence,
+                        "pre-Dreaming checkpoint contains Dreaming evidence"
+                    ),
+                    SleepPhase::DreamGeneration => ensure!(
+                        txn.generated_manifest.is_none()
+                            && txn.dream_selection_rng.is_none()
+                            && txn.dream_trial_rngs.is_empty()
+                            && txn.dream_selected.is_empty()
+                            && txn.dream_trials.is_empty()
+                            && txn.dream_policy_receipt.is_none(),
+                        "Dream Generation checkpoint contains later-subphase evidence"
+                    ),
+                    SleepPhase::DreamRanking => ensure!(
+                        txn.dream_trial_rngs.is_empty()
+                            && txn.dream_selected.is_empty()
+                            && txn.dream_trials.is_empty()
+                            && txn.dream_policy_receipt.is_none(),
+                        "Dream Ranking checkpoint contains later-subphase evidence"
+                    ),
+                    SleepPhase::DreamTrials => ensure!(
+                        txn.dream_policy_receipt.is_none(),
+                        "Dream Trials checkpoint contains a premature ReSTEM receipt"
+                    ),
+                    SleepPhase::DreamPolicyUpdate => ensure!(
+                        txn.dream_policy_receipt.is_none()
+                            || (trial_ids == selected && trial_rng_ids == selected),
+                        "ReSTEM receipt precedes complete isolated-trial evidence"
+                    ),
+                    SleepPhase::Candidate => ensure!(
+                        no_dream_evidence
+                            || (txn.generated_manifest.is_some()
+                                && txn.dream_generation_rng.is_some()
+                                && txn.dream_selection_rng.is_some()
+                                && trial_ids == selected
+                                && trial_rng_ids == selected
+                                && txn.dream_policy_receipt.is_some()),
+                        "sleep candidate contains incomplete Dreaming evidence"
+                    ),
+                    SleepPhase::Wake => unreachable!("wake checkpoints cannot have a transaction"),
+                }
             }
         }
         Ok(())
@@ -1244,12 +1697,15 @@ impl SleepState {
             self.clock
         );
         ensure!(
-            !teacher_checkpoint.trim().is_empty() && !student_checkpoint.trim().is_empty(),
+            !teacher_checkpoint.trim().is_empty()
+                && teacher_checkpoint.len() <= MAX_CHECKPOINT_LOCATION_BYTES
+                && !student_checkpoint.trim().is_empty()
+                && student_checkpoint.len() <= MAX_CHECKPOINT_LOCATION_BYTES,
             "consolidation checkpoint locations must not be empty"
         );
-        validate_content_hash(&teacher_hash, "teacher hash")?;
-        validate_content_hash(&student_hash, "student hash")?;
-        validate_content_hash(&prospective_update_hash, "prospective-update hash")?;
+        validate_sha256_identity(&teacher_hash, "teacher hash")?;
+        validate_sha256_identity(&student_hash, "student hash")?;
+        validate_sha256_identity(&prospective_update_hash, "prospective-update hash")?;
         let terminal = sender + 1 == self.tiers.len();
         let receiver = if terminal { sender } else { sender + 1 };
         let receiver_slot = if terminal {
@@ -1365,6 +1821,10 @@ impl SleepState {
     }
 
     pub fn reserve_knowledge_rng(&mut self, stream: usize, count: u64) -> Result<RngReservation> {
+        ensure!(
+            self.pending.is_some() && self.phase == SleepPhase::KnowledgeSeeding,
+            "knowledge RNG reservation requires the Knowledge Seeding phase"
+        );
         if let Some(reservation) = self.pending.as_ref().and_then(|txn| txn.knowledge_rng) {
             ensure!(
                 reservation.stream == stream && reservation.count == count,
@@ -1381,6 +1841,10 @@ impl SleepState {
     }
 
     pub fn reserve_imitation_rng(&mut self, stream: usize, count: u64) -> Result<RngReservation> {
+        ensure!(
+            self.pending.is_some() && self.phase == SleepPhase::Imitation,
+            "imitation RNG reservation requires the imitation phase"
+        );
         if let Some(reservation) = self.pending.as_ref().and_then(|txn| txn.imitation_rng) {
             ensure!(
                 reservation.stream == stream && reservation.count == count,
@@ -1401,6 +1865,10 @@ impl SleepState {
         stream: usize,
         count: u64,
     ) -> Result<RngReservation> {
+        ensure!(
+            self.pending.is_some() && self.phase == SleepPhase::DreamGeneration,
+            "dream-generation RNG reservation requires the Dream Generation phase"
+        );
         if let Some(reservation) = self
             .pending
             .as_ref()
@@ -1421,6 +1889,10 @@ impl SleepState {
     }
 
     pub fn reserve_dream_selection_rng(&mut self, stream: usize) -> Result<RngReservation> {
+        ensure!(
+            self.pending.is_some() && self.phase == SleepPhase::DreamRanking,
+            "dream-selection RNG reservation requires the Dream Ranking phase"
+        );
         if let Some(reservation) = self
             .pending
             .as_ref()
@@ -1446,8 +1918,18 @@ impl SleepState {
         candidate_id: &str,
     ) -> Result<RngReservation> {
         ensure!(
-            !candidate_id.trim().is_empty(),
-            "dream candidate ID is empty"
+            !candidate_id.trim().is_empty() && candidate_id.len() <= MAX_DREAM_CANDIDATE_ID_BYTES,
+            "dream candidate ID is empty or too long"
+        );
+        ensure!(
+            self.pending.is_some() && self.phase == SleepPhase::DreamTrials,
+            "dream-trial RNG reservation requires the Dream Trials phase"
+        );
+        ensure!(
+            self.pending
+                .as_ref()
+                .is_some_and(|txn| txn.dream_selected.iter().any(|id| id == candidate_id)),
+            "dream-trial RNG reservation is not for a selected candidate"
         );
         if let Some(reservation) = self.pending.as_ref().and_then(|txn| {
             txn.dream_trial_rngs
@@ -1489,12 +1971,22 @@ impl SleepState {
             return Ok(());
         }
         ensure!(
+            txn.sender < self.tiers.len() && txn.receiver < self.tiers.len(),
+            "consolidation transaction tier is out of range"
+        );
+        ensure!(
+            txn.terminal == (txn.sender.checked_add(1) == Some(self.tiers.len()))
+                && ((txn.terminal && txn.receiver == txn.sender)
+                    || (!txn.terminal && txn.sender.checked_add(1) == Some(txn.receiver))),
+            "consolidation transaction has an invalid sender/receiver topology"
+        );
+        ensure!(
             txn.candidate_checkpoint
                 .as_ref()
                 .is_some_and(|uri| !uri.trim().is_empty()),
             "consolidation has no published candidate checkpoint"
         );
-        validate_content_hash(
+        validate_sha256_identity(
             txn.candidate_hash
                 .as_deref()
                 .context("consolidation has no published candidate hash")?,
@@ -1508,6 +2000,16 @@ impl SleepState {
             .tiers
             .get(txn.sender)
             .context("committed sender tier is out of range")?;
+        let active_sender_slots = sender_tier
+            .slots
+            .iter()
+            .enumerate()
+            .filter_map(|(slot, state)| state.active.then_some(slot))
+            .collect::<Vec<_>>();
+        ensure!(
+            txn.sender_slots_to_reset == active_sender_slots,
+            "consolidation sender reset plan does not contain the exact active-slot set"
+        );
         if !txn.terminal {
             let receiver_slot = self
                 .tiers
@@ -1567,10 +2069,10 @@ impl SleepState {
             "candidate identity can be recorded only in commit phase"
         );
         ensure!(
-            !checkpoint.trim().is_empty(),
+            !checkpoint.trim().is_empty() && checkpoint.len() <= MAX_CHECKPOINT_LOCATION_BYTES,
             "candidate checkpoint is empty"
         );
-        validate_content_hash(&hash, "published candidate hash")?;
+        validate_sha256_identity(&hash, "published candidate hash")?;
         let txn = self
             .pending
             .as_mut()
@@ -1590,13 +2092,27 @@ impl SleepState {
     }
 
     pub fn record_generated_manifest(&mut self, manifest: String) -> Result<()> {
-        validate_content_hash(&manifest, "generated manifest")?;
+        validate_sha256_identity(&manifest, "generated manifest")?;
+        ensure!(
+            self.phase == SleepPhase::DreamGeneration,
+            "generated manifest can be recorded only during dream generation"
+        );
         let txn = self
             .pending
-            .as_mut()
+            .as_ref()
             .ok_or_else(|| anyhow::anyhow!("no consolidation transaction"))?;
-        txn.generated_manifest = Some(manifest.clone());
-        self.artifact_manifests.push(manifest);
+        if let Some(existing) = &txn.generated_manifest {
+            ensure!(
+                existing == &manifest,
+                "generated manifest identity changed during retry"
+            );
+        }
+        let mut next_pending = txn.clone();
+        next_pending.generated_manifest = Some(manifest);
+        let next_manifests =
+            referenced_artifact_manifests(&self.completed_transactions, Some(&next_pending))?;
+        self.pending = Some(next_pending);
+        self.artifact_manifests = next_manifests;
         Ok(())
     }
 
@@ -1610,8 +2126,12 @@ impl SleepState {
         let digest = generation
             .strip_prefix("sha256-")
             .context("tensor transaction generation has an unsafe name")?;
-        validate_content_hash(&format!("sha256:{digest}"), "tensor transaction generation")?;
-        validate_content_hash(&manifest_hash, "tensor transaction manifest hash")?;
+        validate_sha256_identity(&format!("sha256:{digest}"), "tensor transaction generation")?;
+        validate_sha256_identity(&manifest_hash, "tensor transaction manifest hash")?;
+        ensure!(
+            manifest_hash.strip_prefix("sha256:") == Some(digest),
+            "tensor transaction generation does not match its manifest hash"
+        );
         let txn = self
             .pending
             .as_mut()
@@ -1630,26 +2150,46 @@ impl SleepState {
             self.pending.as_ref().is_some_and(|txn| txn.committed),
             "sleep candidate is not atomically committed"
         );
+        // Derive every fallible result before mutating the checkpoint. A
+        // counter overflow or serialization error must leave the committed
+        // Candidate retryable instead of dropping its pending transaction or
+        // advancing only part of the audit chain.
         let txn = self
             .pending
-            .take()
-            .expect("committed transaction checked above");
+            .as_ref()
+            .expect("committed transaction checked above")
+            .clone();
         let encoded = serde_json::to_vec(&txn)?;
+        let completed_count = self
+            .completed_count
+            .checked_add(1)
+            .context("sleep completed-transaction count overflow")?;
+        self.validate_resume()
+            .context("validating completed sleep candidate")?;
+        let encoded_len = u64::try_from(encoded.len())
+            .context("sleep completed-transaction encoding exceeds u64")?;
         let mut hash = sha2::Sha256::new();
         use sha2::Digest as _;
         hash.update(b"hermes-sleep-audit-chain-v1\0");
         hash.update(self.completed_chain_hash.as_bytes());
-        hash.update((encoded.len() as u64).to_le_bytes());
+        hash.update(encoded_len.to_le_bytes());
         hash.update(encoded);
-        self.completed_chain_hash = format!("sha256:{:x}", hash.finalize());
-        self.completed_count = self
-            .completed_count
-            .checked_add(1)
-            .context("sleep completed-transaction count overflow")?;
-        self.completed_transactions.push(txn.clone());
-        if self.completed_transactions.len() > COMPLETED_TRANSACTION_TAIL {
-            self.completed_transactions.remove(0);
+        let completed_chain_hash = format!("sha256:{:x}", hash.finalize());
+        let mut completed_transactions = self.completed_transactions.clone();
+        completed_transactions
+            .try_reserve(1)
+            .context("reserving sleep completed-transaction audit tail")?;
+        completed_transactions.push(txn.clone());
+        if completed_transactions.len() > COMPLETED_TRANSACTION_TAIL {
+            completed_transactions.remove(0);
         }
+        let artifact_manifests = referenced_artifact_manifests(&completed_transactions, None)?;
+
+        self.pending = None;
+        self.completed_chain_hash = completed_chain_hash;
+        self.completed_count = completed_count;
+        self.completed_transactions = completed_transactions;
+        self.artifact_manifests = artifact_manifests;
         self.phase = SleepPhase::Wake;
         Ok(txn)
     }
@@ -1826,6 +2366,12 @@ pub fn validate_model_memory_state(
 
 /// Backend contract for one atomic compute-consolidate-update transaction.
 pub trait ConsolidationBackend {
+    /// Number of independently sampled teacher/student rollouts consumed by
+    /// Knowledge Seeding. Persisting the exact range makes a retry reproduce
+    /// every sample instead of merely reseeding the first rollout.
+    fn knowledge_rng_count(&self) -> Result<u64>;
+    /// Number of group-relative continuations consumed by imitation/GRPO.
+    fn imitation_rng_count(&self) -> Result<u64>;
     fn compute_prospective_update(&mut self, txn: &ConsolidationTxn) -> Result<()>;
     fn stage_student(&mut self, txn: &ConsolidationTxn) -> Result<()>;
     fn knowledge_seed(&mut self, txn: &ConsolidationTxn) -> Result<()>;
@@ -1880,15 +2426,56 @@ pub struct KnowledgeSeedingConfig {
 }
 
 impl KnowledgeSeedingConfig {
+    /// Operational ceilings keep a malformed workflow from turning one sleep
+    /// boundary into an unbounded rollout or logits allocation. They are well
+    /// above the paper-reproduction recipe and may only be raised alongside
+    /// memory-profile evidence.
+    pub const MAX_CHUNK_TOKENS: usize = 16_384;
+    pub const MAX_ROLLOUTS: usize = 1_024;
+    pub const MAX_TOKEN_WORK: usize = Self::MAX_CHUNK_TOKENS * Self::MAX_ROLLOUTS;
+
+    pub fn rollout_count(&self) -> Result<usize> {
+        self.teacher_rollouts
+            .checked_add(self.detached_student_rollouts)
+            .context("knowledge-seeding rollout count overflow")
+    }
+
+    pub fn rollout_count_u64(&self) -> Result<u64> {
+        self.rollout_count()?
+            .try_into()
+            .context("knowledge-seeding rollout count exceeds u64")
+    }
+
     pub fn validate(&self) -> Result<()> {
         ensure!(
             self.chunk_tokens > 0,
             "knowledge-seeding chunk_tokens must be positive"
         );
         ensure!(
+            self.chunk_tokens <= Self::MAX_CHUNK_TOKENS,
+            "knowledge-seeding chunk_tokens exceeds the {}-token operational limit",
+            Self::MAX_CHUNK_TOKENS
+        );
+        ensure!(
             self.teacher_rollouts > 0 && self.detached_student_rollouts > 0,
             "knowledge seeding requires teacher and detached-student rollouts"
         );
+        let rollout_count = self.rollout_count()?;
+        ensure!(
+            rollout_count <= Self::MAX_ROLLOUTS,
+            "knowledge-seeding rollout count exceeds the {}-rollout operational limit",
+            Self::MAX_ROLLOUTS
+        );
+        let token_work = self
+            .chunk_tokens
+            .checked_mul(rollout_count)
+            .context("knowledge-seeding token work overflow")?;
+        ensure!(
+            token_work <= Self::MAX_TOKEN_WORK,
+            "knowledge-seeding token work exceeds the {}-token operational limit",
+            Self::MAX_TOKEN_WORK
+        );
+        u64::try_from(rollout_count).context("knowledge-seeding rollout count exceeds u64")?;
         ensure!(
             self.temperature.is_finite() && self.temperature > 0.0,
             "knowledge-seeding temperature must be positive"
@@ -1911,8 +2498,20 @@ pub struct ImitationConfig {
 }
 
 impl ImitationConfig {
+    /// The edit reward uses a threshold-banded dynamic program and GRPO holds
+    /// one group of rollouts together, so both axes need explicit ceilings.
+    pub const MAX_EDIT_DISTANCE: usize = 4_096;
+    pub const MAX_GRPO_GROUP_SIZE: usize = 256;
+    pub const MAX_DISTANCE_WORK: usize = Self::MAX_EDIT_DISTANCE * Self::MAX_GRPO_GROUP_SIZE;
+
+    pub fn group_size_u64(&self) -> Result<u64> {
+        self.grpo_group_size
+            .try_into()
+            .context("imitation GRPO group size exceeds u64")
+    }
+
     pub fn validate(&self) -> Result<()> {
-        validate_content_hash(&self.semantic_judge_hash, "imitation semantic-judge hash")?;
+        validate_sha256_identity(&self.semantic_judge_hash, "imitation semantic-judge hash")?;
         ensure!(
             self.semantic_weight.is_finite() && (0.0..=1.0).contains(&self.semantic_weight),
             "imitation semantic_weight must be in [0, 1]"
@@ -1921,6 +2520,26 @@ impl ImitationConfig {
             self.grpo_group_size >= 2,
             "imitation GRPO group must contain at least two samples"
         );
+        ensure!(
+            self.maximum_edit_distance <= Self::MAX_EDIT_DISTANCE,
+            "imitation maximum edit distance exceeds the {}-token operational limit",
+            Self::MAX_EDIT_DISTANCE
+        );
+        ensure!(
+            self.grpo_group_size <= Self::MAX_GRPO_GROUP_SIZE,
+            "imitation GRPO group size exceeds the {}-sample operational limit",
+            Self::MAX_GRPO_GROUP_SIZE
+        );
+        let distance_work = self
+            .maximum_edit_distance
+            .checked_mul(self.grpo_group_size)
+            .context("imitation edit-distance work overflow")?;
+        ensure!(
+            distance_work <= Self::MAX_DISTANCE_WORK,
+            "imitation edit-distance work exceeds the {}-cell operational limit",
+            Self::MAX_DISTANCE_WORK
+        );
+        u64::try_from(self.grpo_group_size).context("imitation GRPO group size exceeds u64")?;
         Ok(())
     }
 }
@@ -1941,6 +2560,15 @@ pub struct DreamingConfig {
 }
 
 impl DreamingConfig {
+    /// Dream candidates and isolated adapters are materialized by the built-in
+    /// backend. These ceilings make their maximum cardinality and rank an
+    /// explicit part of the trainer contract instead of inheriting `usize`.
+    pub const MAX_CANDIDATES: usize = 1_024;
+    pub const MAX_LORA_RANK: usize = 1_024;
+    pub const MAX_LORA_ALPHA: usize = 65_536;
+    pub const MAX_RESTEM_ITERATIONS: usize = 128;
+    pub const MAX_POLICY_WORK: usize = Self::MAX_CANDIDATES * Self::MAX_RESTEM_ITERATIONS;
+
     pub fn paper_reproduction() -> Self {
         Self {
             candidate_count: 64,
@@ -1961,29 +2589,72 @@ impl DreamingConfig {
             "dream candidate count must be positive"
         );
         ensure!(
-            self.retain_top + self.retain_random <= self.candidate_count,
+            self.candidate_count <= Self::MAX_CANDIDATES,
+            "dream candidate count exceeds the {}-candidate operational limit",
+            Self::MAX_CANDIDATES
+        );
+        let retained = self.retained_count()?;
+        ensure!(
+            retained <= self.candidate_count,
             "dream selection quotas exceed candidate count"
         );
         ensure!(
-            self.retain_top + self.retain_random > 0,
+            retained > 0,
             "dream selection must retain at least one candidate"
         );
+        for (value, label) in [
+            (self.candidate_count, "dream candidate count"),
+            (self.retain_top, "dream alignment quota"),
+            (self.retain_random, "dream diversity quota"),
+            (self.lora_rank, "dream LoRA rank"),
+        ] {
+            u32::try_from(value).with_context(|| format!("{label} exceeds metric schema"))?;
+        }
         ensure!(
             self.lora_rank > 0 && self.lora_alpha > 0,
             "dream LoRA geometry must be positive"
+        );
+        ensure!(
+            self.lora_rank <= Self::MAX_LORA_RANK,
+            "dream LoRA rank exceeds the {}-rank operational limit",
+            Self::MAX_LORA_RANK
+        );
+        ensure!(
+            self.lora_alpha <= Self::MAX_LORA_ALPHA,
+            "dream LoRA alpha exceeds the {} operational limit",
+            Self::MAX_LORA_ALPHA
         );
         ensure!(
             self.restem_iterations > 0,
             "ReSTEM iterations must be positive"
         );
         ensure!(
+            self.restem_iterations <= Self::MAX_RESTEM_ITERATIONS,
+            "ReSTEM iterations exceed the {}-iteration operational limit",
+            Self::MAX_RESTEM_ITERATIONS
+        );
+        let policy_work = retained
+            .checked_mul(self.restem_iterations)
+            .context("dream policy work overflow")?;
+        ensure!(
+            policy_work <= Self::MAX_POLICY_WORK,
+            "dream policy work exceeds the {}-trial operational limit",
+            Self::MAX_POLICY_WORK
+        );
+        ensure!(
             self.selector_version == "gradient-cosine-v1",
             "unsupported dream selector `{}`; this build implements only `gradient-cosine-v1`",
             self.selector_version
         );
-        validate_content_hash(&self.reference_set_hash, "dream reference-set hash")?;
-        validate_content_hash(&self.trial_evaluator_hash, "dream trial-evaluator hash")?;
+        validate_sha256_identity(&self.reference_set_hash, "dream reference-set hash")?;
+        validate_sha256_identity(&self.trial_evaluator_hash, "dream trial-evaluator hash")?;
         Ok(())
+    }
+
+    pub(crate) fn retained_count(&self) -> Result<usize> {
+        self.retain_top
+            .checked_add(self.retain_random)
+            .context("dream selection quota overflow")
     }
 }
 
@@ -2009,6 +2680,15 @@ pub struct DreamTrial {
 /// corpus handle: its only source is model-owned wake contexts. Trials must be
 /// isolated and the shared hash is checked around every trial.
 pub trait DreamingBackend {
+    /// Verify that the backend's shared model was loaded from this exact
+    /// committed checkpoint. The checkpoint artifact identity and the model
+    /// parameter fingerprint are deliberately separate: a serialized
+    /// checkpoint hash is not necessarily a hash of only its tensors.
+    fn verify_committed_candidate(&mut self, txn: &ConsolidationTxn) -> Result<()>;
+    /// Return the sealed full-parameter identity of the shared candidate.
+    /// Backends with interior mutability must recompute it; structurally
+    /// immutable backends may return an identity cached when they sealed the
+    /// candidate, avoiding a device-to-host model copy around every trial.
     fn shared_checkpoint_hash(&mut self) -> Result<String>;
     fn generate_from_wake_contexts(
         &mut self,
@@ -2063,10 +2743,18 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
     progress: &mut P,
 ) -> Result<Vec<DreamTrial>> {
     config.validate()?;
+    state
+        .validate_resume()
+        .context("validating Dreaming resume state")?;
     ensure!(
         state.pending.as_ref().is_some_and(|txn| txn.committed),
         "dreaming requires committed transaction metadata"
     );
+    ensure_committed_candidate_binding(
+        state.pending.as_ref().expect("transaction checked above"),
+        backend,
+        "binding Dreaming to the committed candidate",
+    )?;
     loop {
         let txn = state
             .pending
@@ -2074,8 +2762,11 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
             .ok_or_else(|| anyhow::anyhow!("dreaming has no transaction"))?;
         match state.phase {
             SleepPhase::Commit => {
-                let shared_hash = backend.shared_checkpoint_hash()?;
-                validate_content_hash(&shared_hash, "dream shared checkpoint hash")?;
+                let shared_hash = read_shared_checkpoint_hash(
+                    &txn,
+                    backend,
+                    "fingerprinting the committed candidate for Dreaming",
+                )?;
                 state
                     .pending
                     .as_mut()
@@ -2085,11 +2776,23 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
                 progress.persist(state)?;
             }
             SleepPhase::DreamGeneration => {
-                state.reserve_dream_generation_rng(0, config.candidate_count as u64)?;
+                state.reserve_dream_generation_rng(
+                    0,
+                    config
+                        .candidate_count
+                        .try_into()
+                        .context("dream candidate count exceeds RNG schema")?,
+                )?;
                 progress.persist(state)?;
                 let txn = state.pending.clone().expect("transaction checked above");
-                let (manifest, candidates) =
-                    backend.generate_from_wake_contexts(&txn, config.candidate_count, true)?;
+                let (manifest, candidates) = run_shared_checkpoint_operation(
+                    &txn,
+                    backend,
+                    "dream generation",
+                    |backend| {
+                        backend.generate_from_wake_contexts(&txn, config.candidate_count, true)
+                    },
+                )?;
                 validate_generated_dreams(&candidates, config.candidate_count)?;
                 state.record_generated_manifest(manifest)?;
                 state.transition(SleepPhase::DreamRanking)?;
@@ -2103,9 +2806,25 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
                     .generated_manifest
                     .as_deref()
                     .expect("validated dream manifest");
-                let candidates = backend.load_generated_dreams(&txn, manifest)?;
+                let candidates = run_shared_checkpoint_operation(
+                    &txn,
+                    backend,
+                    "loading generated dreams",
+                    |backend| backend.load_generated_dreams(&txn, manifest),
+                )?;
                 validate_generated_dreams(&candidates, config.candidate_count)?;
-                let reference = backend.reference_gradient(&txn, &config.reference_set_hash)?;
+                let reference = run_shared_checkpoint_operation(
+                    &txn,
+                    backend,
+                    "dream reference-gradient evaluation",
+                    |backend| backend.reference_gradient(&txn, &config.reference_set_hash),
+                )?;
+                ensure!(
+                    !reference.is_empty()
+                        && reference.len() <= MAX_DREAM_GRADIENT_DIMENSIONS
+                        && reference.iter().all(|value| value.is_finite()),
+                    "dream reference gradient is empty, non-finite, or exceeds the operational dimension limit"
+                );
                 let scores = candidates
                     .iter()
                     .map(|candidate| {
@@ -2124,12 +2843,7 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
                 for score in &mut scores {
                     score.diversity_key ^= salt;
                 }
-                state
-                    .pending
-                    .as_mut()
-                    .expect("transaction checked above")
-                    .dream_selected =
-                    select_dreams(&scores, config.retain_top, config.retain_random)?;
+                let selected = select_dreams(&scores, config.retain_top, config.retain_random)?;
                 let cosine_mean = scores
                     .iter()
                     .map(|score| f64::from(score.importance))
@@ -2143,14 +2857,31 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
                     transaction_id: format!("sleep-{}", txn.id),
                     selector_version: config.selector_version.clone(),
                     reference_set_hash: config.reference_set_hash.clone(),
-                    candidates_generated: config.candidate_count as u32,
-                    selected_by_alignment: config.retain_top as u32,
-                    selected_random: config.retain_random as u32,
-                    random_quota: config.retain_random as u32,
+                    candidates_generated: config
+                        .candidate_count
+                        .try_into()
+                        .context("dream candidate count exceeds metric schema")?,
+                    selected_by_alignment: config
+                        .retain_top
+                        .try_into()
+                        .context("dream alignment quota exceeds metric schema")?,
+                    selected_random: config
+                        .retain_random
+                        .try_into()
+                        .context("dream diversity quota exceeds metric schema")?,
+                    random_quota: config
+                        .retain_random
+                        .try_into()
+                        .context("dream diversity quota exceeds metric schema")?,
                     gradient_cosine_mean: cosine_mean,
                     gradient_cosine_max: cosine_max,
                     selected_manifest_hash: manifest.to_owned(),
                 }))?;
+                state
+                    .pending
+                    .as_mut()
+                    .expect("transaction checked above")
+                    .dream_selected = selected;
                 state.transition(SleepPhase::DreamTrials)?;
                 progress.persist(state)?;
             }
@@ -2159,7 +2890,12 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
                     .generated_manifest
                     .as_deref()
                     .expect("validated dream manifest");
-                let candidates = backend.load_generated_dreams(&txn, manifest)?;
+                let candidates = run_shared_checkpoint_operation(
+                    &txn,
+                    backend,
+                    "loading dreams for isolated trials",
+                    |backend| backend.load_generated_dreams(&txn, manifest),
+                )?;
                 validate_generated_dreams(&candidates, config.candidate_count)?;
                 let completed = txn
                     .dream_trials
@@ -2177,29 +2913,38 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
                     state.reserve_dream_trial_rng(0, id)?;
                     progress.persist(state)?;
                     let current_txn = state.pending.clone().expect("transaction checked above");
-                    let trial = backend.isolated_lora_trial(
+                    let trial = run_shared_checkpoint_operation(
                         &current_txn,
-                        candidate,
-                        config.lora_rank,
-                        config.lora_alpha,
+                        backend,
+                        &format!("isolated dream trial `{id}`"),
+                        |backend| {
+                            backend.isolated_lora_trial(
+                                &current_txn,
+                                candidate,
+                                config.lora_rank,
+                                config.lora_alpha,
+                            )
+                        },
                     )?;
                     ensure!(
                         trial.candidate_id == *id && trial.independent_task_improvement.is_finite(),
                         "dream trial `{id}` returned incomplete or invalid evidence"
                     );
-                    validate_content_hash(&trial.adapter_hash, "dream trial adapter hash")?;
-                    validate_content_hash(&trial.evaluator_hash, "dream trial evaluator hash")?;
+                    validate_sha256_identity(&trial.adapter_hash, "dream trial adapter hash")?;
+                    validate_sha256_identity(&trial.evaluator_hash, "dream trial evaluator hash")?;
                     ensure!(
                         trial.evaluator_hash == config.trial_evaluator_hash,
                         "dream trial `{id}` used an evaluator other than the frozen configured artifact"
                     );
-                    ensure_shared_checkpoint_unchanged(&current_txn, backend, id)?;
                     progress.metric(MetricEvent::DreamTrial(DreamTrialMetrics {
                         transaction_id: format!("sleep-{}", txn.id),
                         candidate_hash: candidate.artifact_hash.clone(),
                         adapter_hash: trial.adapter_hash.clone(),
                         evaluator_hash: trial.evaluator_hash.clone(),
-                        lora_rank: config.lora_rank as u32,
+                        lora_rank: config
+                            .lora_rank
+                            .try_into()
+                            .context("dream LoRA rank exceeds metric schema")?,
                         lora_alpha: config.lora_alpha as f64,
                         independent_task_delta: f64::from(trial.independent_task_improvement),
                         reward: f64::from(trial.independent_task_improvement),
@@ -2227,9 +2972,13 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
                     .cloned()
                     .collect::<Vec<_>>();
                 if txn.dream_policy_receipt.is_none() {
-                    let receipt =
-                        backend.restem_update(&txn, &accepted, config.restem_iterations)?;
-                    validate_content_hash(&receipt, "ReSTEM policy receipt")?;
+                    let receipt = run_shared_checkpoint_operation(
+                        &txn,
+                        backend,
+                        "ReSTEM policy update",
+                        |backend| backend.restem_update(&txn, &accepted, config.restem_iterations),
+                    )?;
+                    validate_sha256_identity(&receipt, "ReSTEM policy receipt")?;
                     state
                         .pending
                         .as_mut()
@@ -2237,12 +2986,15 @@ pub fn run_dreaming_with_progress<B: DreamingBackend, P: SleepProgressSink>(
                         .dream_policy_receipt = Some(receipt);
                     progress.persist(state)?;
                 }
-                let current_txn = state.pending.clone().expect("transaction checked above");
-                ensure_shared_checkpoint_unchanged(&current_txn, backend, "ReSTEM policy update")?;
                 state.transition(SleepPhase::Candidate)?;
                 progress.persist(state)?;
             }
             SleepPhase::Candidate => {
+                ensure_shared_checkpoint_unchanged(
+                    &txn,
+                    backend,
+                    "finalizing the dream candidate",
+                )?;
                 return Ok(txn
                     .dream_trials
                     .into_iter()
@@ -2261,12 +3013,30 @@ fn validate_generated_dreams(candidates: &[GeneratedDream], expected: usize) -> 
         candidates.len()
     );
     let mut ids = BTreeSet::new();
+    let mut dimensions = None;
+    let mut gradient_elements = 0usize;
     for candidate in candidates {
         ensure!(
-            !candidate.id.trim().is_empty() && !candidate.gradient.is_empty(),
+            !candidate.id.trim().is_empty()
+                && candidate.id.len() <= MAX_DREAM_CANDIDATE_ID_BYTES
+                && !candidate.gradient.is_empty()
+                && candidate.gradient.len() <= MAX_DREAM_GRADIENT_DIMENSIONS
+                && candidate.gradient.iter().all(|value| value.is_finite()),
             "generated dream has incomplete identity or gradient"
         );
-        validate_content_hash(&candidate.artifact_hash, "generated dream artifact hash")?;
+        ensure!(
+            dimensions.is_none_or(|expected| expected == candidate.gradient.len()),
+            "generated dreams use inconsistent gradient dimensions"
+        );
+        dimensions = Some(candidate.gradient.len());
+        gradient_elements = gradient_elements
+            .checked_add(candidate.gradient.len())
+            .context("generated-dream gradient element count overflow")?;
+        ensure!(
+            gradient_elements <= DreamingConfig::MAX_CANDIDATES * MAX_DREAM_GRADIENT_DIMENSIONS,
+            "generated-dream gradient work exceeds its operational limit"
+        );
+        validate_sha256_identity(&candidate.artifact_hash, "generated dream artifact hash")?;
         ensure!(
             ids.insert(candidate.id.as_str()),
             "duplicate dream candidate `{}`",
@@ -2285,21 +3055,121 @@ fn ensure_shared_checkpoint_unchanged<B: DreamingBackend>(
         .dream_shared_checkpoint_hash
         .as_deref()
         .context("dream transaction has no shared checkpoint hash")?;
-    let observed = backend.shared_checkpoint_hash()?;
-    validate_content_hash(&observed, "observed shared-checkpoint hash")?;
-    if observed != expected {
-        backend.restore_shared_candidate(txn).with_context(|| {
-            format!("{operation} mutated the shared checkpoint and restoration failed")
-        })?;
-        let restored = backend.shared_checkpoint_hash()?;
-        validate_content_hash(&restored, "restored shared-checkpoint hash")?;
-        ensure!(
-            restored == expected,
-            "{operation} mutated the shared checkpoint and restoration did not recover it"
-        );
-        bail!("{operation} mutated the shared checkpoint; immutable candidate was restored");
+    ensure_shared_checkpoint_hash(txn, backend, expected, operation)
+}
+
+fn ensure_committed_candidate_binding<B: DreamingBackend>(
+    txn: &ConsolidationTxn,
+    backend: &mut B,
+    operation: &str,
+) -> Result<()> {
+    let first_error = match backend.verify_committed_candidate(txn) {
+        Ok(()) => return Ok(()),
+        Err(error) => error,
+    };
+    backend.restore_shared_candidate(txn).with_context(|| {
+        format!("{operation} failed and restoration of the committed candidate also failed")
+    })?;
+    backend.verify_committed_candidate(txn).with_context(|| {
+        format!(
+            "{operation} failed ({first_error:#}); restoration did not recover the committed candidate"
+        )
+    })?;
+    bail!(
+        "{operation} did not start from the committed candidate; immutable candidate was restored"
+    )
+}
+
+fn read_shared_checkpoint_hash<B: DreamingBackend>(
+    txn: &ConsolidationTxn,
+    backend: &mut B,
+    operation: &str,
+) -> Result<String> {
+    let observation = backend.shared_checkpoint_hash().and_then(|observed| {
+        validate_sha256_identity(&observed, "shared-checkpoint hash")?;
+        Ok(observed)
+    });
+    match observation {
+        Ok(hash) => Ok(hash),
+        Err(error) => {
+            backend.restore_shared_candidate(txn).with_context(|| {
+                format!("{operation} failed and restoration of the committed candidate also failed")
+            })?;
+            backend
+                .verify_committed_candidate(txn)
+                .with_context(|| format!("verifying the restored candidate after {operation}"))?;
+            bail!("{operation} failed ({error:#}); immutable candidate was restored")
+        }
     }
-    Ok(())
+}
+
+fn ensure_shared_checkpoint_hash<B: DreamingBackend>(
+    txn: &ConsolidationTxn,
+    backend: &mut B,
+    expected: &str,
+    operation: &str,
+) -> Result<()> {
+    validate_sha256_identity(expected, "expected shared-checkpoint hash")?;
+    let observation = backend.shared_checkpoint_hash().and_then(|observed| {
+        validate_sha256_identity(&observed, "observed shared-checkpoint hash")?;
+        Ok(observed)
+    });
+    if observation
+        .as_ref()
+        .is_ok_and(|observed| observed == expected)
+    {
+        return Ok(());
+    }
+
+    // If an operation returned an error, malformed evidence, or even made the
+    // fingerprint temporarily unreadable, treat the shared candidate as
+    // suspect. Restoration is mandatory before the caller can retry.
+    backend.restore_shared_candidate(txn).with_context(|| {
+        format!(
+            "{operation} did not preserve a verifiable shared checkpoint and restoration failed"
+        )
+    })?;
+    let restored = backend
+        .shared_checkpoint_hash()
+        .with_context(|| format!("reading the shared checkpoint after restoring {operation}"))?;
+    validate_sha256_identity(&restored, "restored shared-checkpoint hash")?;
+    ensure!(
+        restored == expected,
+        "{operation} did not preserve the shared checkpoint and restoration recovered a different candidate"
+    );
+    match observation {
+        Ok(observed) => bail!(
+            "{operation} mutated the shared checkpoint from {expected} to {observed}; immutable candidate was restored"
+        ),
+        Err(error) => bail!(
+            "{operation} left the shared checkpoint unverifiable ({error:#}); immutable candidate was restored"
+        ),
+    }
+}
+
+/// Run one potentially fallible Dreaming backend operation behind the shared
+/// candidate boundary. The postcondition is checked regardless of whether the
+/// operation succeeds; a backend error can never bypass restoration.
+fn run_shared_checkpoint_operation<B, T>(
+    txn: &ConsolidationTxn,
+    backend: &mut B,
+    operation: &str,
+    action: impl FnOnce(&mut B) -> Result<T>,
+) -> Result<T>
+where
+    B: DreamingBackend,
+{
+    ensure_shared_checkpoint_unchanged(txn, backend, &format!("before {operation}"))?;
+    let result = action(backend);
+    let integrity = ensure_shared_checkpoint_unchanged(txn, backend, operation);
+    match (result, integrity) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error).with_context(|| format!("{operation} failed")),
+        (Ok(_), Err(integrity_error)) => Err(integrity_error),
+        (Err(error), Err(integrity_error)) => bail!(
+            "{operation} failed: {error:#}; shared-candidate recovery also reported: {integrity_error:#}"
+        ),
+    }
 }
 
 /// Execute the non-dreaming half of sleep with rollback on every failure.
@@ -2315,6 +3185,9 @@ pub fn run_consolidation_with_progress<B: ConsolidationBackend, P: SleepProgress
     backend: &mut B,
     progress: &mut P,
 ) -> Result<bool> {
+    state
+        .validate_resume()
+        .context("validating consolidation resume state")?;
     progress.persist(state)?;
     let txn = state
         .pending
@@ -2329,7 +3202,7 @@ pub fn run_consolidation_with_progress<B: ConsolidationBackend, P: SleepProgress
                 progress.persist(state)?;
             }
             SleepPhase::KnowledgeSeeding => {
-                state.reserve_knowledge_rng(0, 1)?;
+                state.reserve_knowledge_rng(0, backend.knowledge_rng_count()?)?;
                 progress.persist(state)?;
                 let current_txn = state.pending.clone().expect("transaction checked above");
                 backend.knowledge_seed(&current_txn)?;
@@ -2337,7 +3210,7 @@ pub fn run_consolidation_with_progress<B: ConsolidationBackend, P: SleepProgress
                 progress.persist(state)?;
             }
             SleepPhase::Imitation => {
-                state.reserve_imitation_rng(0, 1)?;
+                state.reserve_imitation_rng(0, backend.imitation_rng_count()?)?;
                 progress.persist(state)?;
                 let current_txn = state.pending.clone().expect("transaction checked above");
                 backend.learn_to_imitate(&current_txn)?;
@@ -2377,8 +3250,10 @@ pub fn run_consolidation_with_progress<B: ConsolidationBackend, P: SleepProgress
         Ok(true) => Ok(true),
         Ok(false) => {
             backend.restore_teacher(&txn)?;
-            state.rollback()?;
-            progress.persist(state)?;
+            let mut restored = state.clone();
+            restored.rollback()?;
+            progress.persist(&restored)?;
+            *state = restored;
             Ok(false)
         }
         Err(error) => {
@@ -2391,15 +3266,17 @@ pub fn run_consolidation_with_progress<B: ConsolidationBackend, P: SleepProgress
                     "consolidation committed in memory but durable state publication failed; retry persistence without rolling back",
                 ));
             }
-            let restore = backend.restore_teacher(&txn);
-            state.rollback()?;
-            let persist = progress.persist(state);
-            if let Err(restore_error) = restore {
+            if let Err(restore_error) = backend.restore_teacher(&txn) {
                 bail!(
                     "consolidation failed: {error:#}; teacher restore also failed: {restore_error:#}"
                 );
             }
-            persist.context("failed to persist restored consolidation rollback")?;
+            let mut restored = state.clone();
+            restored.rollback()?;
+            progress
+                .persist(&restored)
+                .context("failed to persist restored consolidation rollback")?;
+            *state = restored;
             Err(error)
         }
     }
@@ -2492,8 +3369,11 @@ pub fn select_dreams(
     top: usize,
     random: usize,
 ) -> Result<Vec<String>> {
+    let retained = top
+        .checked_add(random)
+        .context("dream selection quota overflow")?;
     ensure!(
-        top + random <= candidates.len(),
+        retained <= candidates.len(),
         "dream selection exceeds candidate count"
     );
     ensure!(
@@ -2507,7 +3387,10 @@ pub fn select_dreams(
         .map(|candidate| candidate.id.as_str())
         .collect::<BTreeSet<_>>();
     ensure!(
-        unique_ids.len() == candidates.len() && unique_ids.iter().all(|id| !id.trim().is_empty()),
+        unique_ids.len() == candidates.len()
+            && unique_ids
+                .iter()
+                .all(|id| { !id.trim().is_empty() && id.len() <= MAX_DREAM_CANDIDATE_ID_BYTES }),
         "dream candidates must have unique, non-empty IDs"
     );
     let mut ranked = candidates.to_vec();
@@ -2616,6 +3499,72 @@ mod tests {
     }
 
     #[test]
+    fn sleep_topology_and_rng_state_are_operationally_bounded() {
+        let bounded_tiers = |count: usize, reserve_slots: usize| SleepSchedule {
+            clock: UpdateClock::OptimizerSteps,
+            terminal_consolidation: TerminalConsolidation::DistillIntoBaseV1,
+            tiers: (0..count)
+                .map(|index| MemoryTierSchedule {
+                    id: format!("tier-{index}"),
+                    update_period: 1_u64 << index,
+                    reserve_slots,
+                })
+                .collect(),
+        };
+
+        assert!(bounded_tiers(MAX_MEMORY_TIERS + 1, 2).validate().is_err());
+        assert!(
+            bounded_tiers(2, MAX_RESERVE_SLOTS_PER_TIER + 1)
+                .validate()
+                .is_err()
+        );
+        assert!(
+            bounded_tiers(5, MAX_RESERVE_SLOTS_PER_TIER)
+                .validate()
+                .is_err()
+        );
+
+        let schedule = schedule();
+        assert!(SleepState::new(&schedule, 0).is_err());
+        assert!(SleepState::new(&schedule, MAX_SLEEP_RNG_STREAMS + 1).is_err());
+        let mut state = SleepState::new(&schedule, 1).unwrap();
+        state.rng_counters.resize(MAX_SLEEP_RNG_STREAMS + 1, 0);
+        assert!(state.validate_resume().is_err());
+    }
+
+    #[test]
+    fn rng_reservations_without_a_transaction_are_failure_atomic() {
+        let mut state = SleepState::new(&schedule(), 1).unwrap();
+        let initial = state.clone();
+
+        assert!(state.reserve_knowledge_rng(0, 1).is_err());
+        assert_eq!(state, initial);
+        assert!(state.reserve_imitation_rng(0, 1).is_err());
+        assert_eq!(state, initial);
+        assert!(state.reserve_dream_generation_rng(0, 1).is_err());
+        assert_eq!(state, initial);
+        assert!(state.reserve_dream_selection_rng(0).is_err());
+        assert_eq!(state, initial);
+        assert!(state.reserve_dream_trial_rng(0, "candidate").is_err());
+        assert_eq!(state, initial);
+    }
+
+    #[test]
+    fn rng_reservations_in_the_wrong_subphase_are_failure_atomic() {
+        let mut state = begun_state();
+        let prospective = state.clone();
+        assert!(state.reserve_knowledge_rng(0, 1).is_err());
+        assert_eq!(state, prospective);
+
+        state.transition(SleepPhase::KnowledgeSeeding).unwrap();
+        let knowledge = state.clone();
+        assert!(state.reserve_imitation_rng(0, 1).is_err());
+        assert_eq!(state, knowledge);
+        assert!(state.reserve_dream_generation_rng(0, 1).is_err());
+        assert_eq!(state, knowledge);
+    }
+
+    #[test]
     fn resume_rejects_multiple_unconsumed_boundaries_for_one_sender() {
         let mut state = SleepState::new(&schedule(), 1).unwrap();
         state.clock = 4;
@@ -2655,6 +3604,20 @@ mod tests {
     }
 
     #[test]
+    fn tensor_generation_is_bound_to_its_manifest_without_partial_mutation() {
+        let mut state = begun_state();
+        let before = state.clone();
+
+        let error = state
+            .record_tensor_transaction(format!("sha256-{}", "1".repeat(64)), test_hash('2'))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("does not match"), "{error}");
+        assert_eq!(state, before);
+    }
+
+    #[test]
     fn resume_rejects_transaction_clock_mask_and_dream_drift() {
         let mut wrong_clock = begun_state();
         wrong_clock.pending.as_mut().unwrap().trigger_clock += 1;
@@ -2663,6 +3626,18 @@ mod tests {
         let mut wrong_receiver_mask = begun_state();
         wrong_receiver_mask.tiers[1].slots[0].active = true;
         assert!(wrong_receiver_mask.validate_resume().is_err());
+
+        let mut wrong_committed_clock = committed_state();
+        wrong_committed_clock
+            .pending
+            .as_mut()
+            .unwrap()
+            .trigger_clock = 1;
+        let error = wrong_committed_clock
+            .validate_resume()
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("sender clocks"), "{error}");
 
         let mut duplicate_selection = committed_state();
         duplicate_selection
@@ -2685,6 +3660,83 @@ mod tests {
             .transition(SleepPhase::DreamTrials)
             .unwrap();
         assert!(duplicate_selection.validate_resume().is_err());
+    }
+
+    #[test]
+    fn resume_rejects_forged_terminal_topology_and_incomplete_reset_plan() {
+        let mut forged_terminal = begun_state();
+        let pending = forged_terminal.pending.as_mut().unwrap();
+        pending.terminal = true;
+        pending.receiver = pending.sender;
+        let error = forged_terminal.validate_resume().unwrap_err().to_string();
+        assert!(error.contains("terminal marker"), "{error}");
+
+        let schedule = schedule();
+        let mut omitted_slot = SleepState::new(&schedule, 1).unwrap();
+        omitted_slot.tiers[0].slots[1].active = true;
+        omitted_slot.advance_clock(&schedule, 2).unwrap();
+        omitted_slot
+            .begin(
+                0,
+                "teacher/reset-plan".into(),
+                test_hash('a'),
+                "student/reset-plan".into(),
+                test_hash('b'),
+                test_hash('c'),
+            )
+            .unwrap();
+        assert_eq!(
+            omitted_slot.pending.as_ref().unwrap().sender_slots_to_reset,
+            vec![1]
+        );
+        omitted_slot
+            .pending
+            .as_mut()
+            .unwrap()
+            .sender_slots_to_reset
+            .clear();
+        let error = omitted_slot.validate_resume().unwrap_err().to_string();
+        assert!(error.contains("exact active-slot set"), "{error}");
+
+        let mut committed_omission = SleepState::new(&schedule, 1).unwrap();
+        committed_omission.tiers[0].slots[1].active = true;
+        committed_omission.advance_clock(&schedule, 2).unwrap();
+        committed_omission
+            .begin(
+                0,
+                "teacher/committed-reset-plan".into(),
+                test_hash('a'),
+                "student/committed-reset-plan".into(),
+                test_hash('b'),
+                test_hash('c'),
+            )
+            .unwrap();
+        committed_omission
+            .transition(SleepPhase::KnowledgeSeeding)
+            .unwrap();
+        committed_omission
+            .transition(SleepPhase::Imitation)
+            .unwrap();
+        committed_omission
+            .transition(SleepPhase::RetentionValidation)
+            .unwrap();
+        committed_omission.transition(SleepPhase::Commit).unwrap();
+        committed_omission
+            .record_committed_candidate("candidate/committed-reset-plan".into(), test_hash('d'))
+            .unwrap();
+        committed_omission.commit_consolidation().unwrap();
+        committed_omission.tiers[0].slots[1].active = true;
+        committed_omission
+            .pending
+            .as_mut()
+            .unwrap()
+            .sender_slots_to_reset
+            .clear();
+        let error = committed_omission
+            .validate_resume()
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("retains an active reserve slot"), "{error}");
     }
 
     #[test]
@@ -2715,7 +3767,9 @@ mod tests {
                     )
                     .unwrap();
                 state.transition(SleepPhase::KnowledgeSeeding).unwrap();
+                state.reserve_knowledge_rng(0, 1).unwrap();
                 state.transition(SleepPhase::Imitation).unwrap();
+                state.reserve_imitation_rng(0, 1).unwrap();
                 state.transition(SleepPhase::RetentionValidation).unwrap();
                 state.transition(SleepPhase::Commit).unwrap();
                 state
@@ -2898,9 +3952,20 @@ mod tests {
         calls: Vec<&'static str>,
         retention: bool,
         fail_seed: bool,
+        fail_restore: bool,
+        knowledge_samples: u64,
+        imitation_samples: u64,
     }
 
     impl ConsolidationBackend for MockBackend {
+        fn knowledge_rng_count(&self) -> Result<u64> {
+            Ok(self.knowledge_samples.max(1))
+        }
+
+        fn imitation_rng_count(&self) -> Result<u64> {
+            Ok(self.imitation_samples.max(1))
+        }
+
         fn compute_prospective_update(&mut self, _: &ConsolidationTxn) -> Result<()> {
             self.calls.push("compute");
             Ok(())
@@ -2931,6 +3996,7 @@ mod tests {
         }
         fn restore_teacher(&mut self, _: &ConsolidationTxn) -> Result<()> {
             self.calls.push("restore");
+            ensure!(!self.fail_restore, "restore failure");
             Ok(())
         }
     }
@@ -2972,6 +4038,23 @@ mod tests {
             before
         );
         assert!(state.due_senders.is_empty());
+    }
+
+    #[test]
+    fn generic_consolidation_reserves_every_backend_sample() {
+        let mut state = begun_state();
+        let mut backend = MockBackend {
+            retention: true,
+            knowledge_samples: 5,
+            imitation_samples: 7,
+            ..Default::default()
+        };
+
+        assert!(run_consolidation(&mut state, &mut backend).unwrap());
+        let txn = state.pending.unwrap();
+        assert_eq!(txn.knowledge_rng.unwrap().count, 5);
+        assert_eq!(txn.imitation_rng.unwrap().count, 7);
+        assert_eq!(state.rng_counters, vec![12]);
     }
 
     #[test]
@@ -3078,6 +4161,43 @@ mod tests {
     }
 
     #[test]
+    fn commit_rejects_an_incomplete_sender_reset_plan_without_mutation() {
+        let schedule = schedule();
+        let mut state = SleepState::new(&schedule, 1).unwrap();
+        state.tiers[0].slots[0].active = true;
+        state.advance_clock(&schedule, 2).unwrap();
+        state
+            .begin(
+                0,
+                "teacher/incomplete-reset".into(),
+                test_hash('a'),
+                "student/incomplete-reset".into(),
+                test_hash('b'),
+                test_hash('c'),
+            )
+            .unwrap();
+        state
+            .pending
+            .as_mut()
+            .unwrap()
+            .sender_slots_to_reset
+            .clear();
+        state.transition(SleepPhase::KnowledgeSeeding).unwrap();
+        state.transition(SleepPhase::Imitation).unwrap();
+        state.transition(SleepPhase::RetentionValidation).unwrap();
+        state.transition(SleepPhase::Commit).unwrap();
+        state
+            .record_committed_candidate("candidate/incomplete-reset".into(), test_hash('d'))
+            .unwrap();
+        let before = state.clone();
+
+        let error = state.commit_consolidation().unwrap_err().to_string();
+
+        assert!(error.contains("exact active-slot set"), "{error}");
+        assert_eq!(state, before);
+    }
+
+    #[test]
     fn resume_rejects_completed_receipts_that_can_alias_attempt_ids() {
         let mut finished = committed_state();
         finished.transition(SleepPhase::Candidate).unwrap();
@@ -3110,6 +4230,110 @@ mod tests {
     }
 
     #[test]
+    fn resume_revalidates_the_bounded_completed_transaction_evidence() {
+        let mut finished = committed_state();
+        finished.transition(SleepPhase::Candidate).unwrap();
+        finished.finish_candidate().unwrap();
+
+        let mut forged_hash = finished.clone();
+        forged_hash.completed_transactions[0].candidate_hash = Some("sha256:not-a-hash".into());
+        let error = forged_hash.validate_resume().unwrap_err().to_string();
+        assert!(error.contains("completed candidate hash"), "{error}");
+
+        let mut partial_dream = finished;
+        let start = partial_dream.rng_counters[0];
+        partial_dream.rng_counters[0] += 1;
+        partial_dream.completed_transactions[0].dream_generation_rng = Some(RngReservation {
+            stream: 0,
+            start,
+            count: 1,
+        });
+        let error = partial_dream.validate_resume().unwrap_err().to_string();
+        assert!(error.contains("partial Dreaming evidence"), "{error}");
+    }
+
+    #[test]
+    fn finish_candidate_overflow_is_failure_atomic() {
+        let mut state = committed_state();
+        state.transition(SleepPhase::Candidate).unwrap();
+        state.completed_count = u64::MAX;
+        let before = state.clone();
+
+        let error = state.finish_candidate().unwrap_err().to_string();
+
+        assert!(error.contains("count overflow"), "{error}");
+        assert_eq!(state, before);
+    }
+
+    #[test]
+    fn completed_candidate_prunes_the_manifest_index_with_the_audit_tail() {
+        let mut state = committed_state();
+        state.transition(SleepPhase::Candidate).unwrap();
+        let rng_start = state.rng_counters[0];
+        state.rng_counters[0] += 3;
+        let pending = state.pending.as_mut().unwrap();
+        pending.dream_generation_rng = Some(RngReservation {
+            stream: 0,
+            start: rng_start,
+            count: 1,
+        });
+        pending.dream_selection_rng = Some(RngReservation {
+            stream: 0,
+            start: rng_start + 1,
+            count: 1,
+        });
+        pending.dream_trial_rngs = vec![DreamTrialRng {
+            candidate_id: "dream".into(),
+            reservation: RngReservation {
+                stream: 0,
+                start: rng_start + 2,
+                count: 1,
+            },
+        }];
+        pending.dream_shared_checkpoint_hash = Some(test_hash('8'));
+        pending.dream_selected = vec!["dream".into()];
+        pending.dream_trials = vec![DreamTrial {
+            candidate_id: "dream".into(),
+            adapter_hash: test_hash('9'),
+            evaluator_hash: test_hash('6'),
+            independent_task_improvement: 0.1,
+        }];
+        pending.dream_policy_receipt = Some(test_hash('5'));
+        let template = state.pending.as_ref().unwrap().clone();
+        state.completed_transactions = (1..=COMPLETED_TRANSACTION_TAIL)
+            .map(|id| {
+                let mut txn = template.clone();
+                txn.id = id as u64;
+                txn.generated_manifest = Some(format!("sha256:{:064x}", id));
+                txn
+            })
+            .collect();
+        state.completed_count = COMPLETED_TRANSACTION_TAIL as u64;
+        state.cycle = ARTIFACT_MANIFEST_TAIL as u64;
+        let pending = state.pending.as_mut().unwrap();
+        pending.id = state.cycle;
+        pending.generated_manifest = Some(format!("sha256:{:064x}", ARTIFACT_MANIFEST_TAIL));
+        state.artifact_manifests =
+            referenced_artifact_manifests(&state.completed_transactions, state.pending.as_ref())
+                .unwrap();
+        assert_eq!(state.artifact_manifests.len(), ARTIFACT_MANIFEST_TAIL);
+
+        state.finish_candidate().unwrap();
+
+        assert_eq!(
+            state.completed_transactions.len(),
+            COMPLETED_TRANSACTION_TAIL
+        );
+        assert_eq!(state.artifact_manifests.len(), COMPLETED_TRANSACTION_TAIL);
+        assert!(
+            !state
+                .artifact_manifests
+                .contains(&format!("sha256:{:064x}", 1))
+        );
+        state.validate_resume().unwrap();
+    }
+
+    #[test]
     fn failed_consolidation_restores_teacher() {
         let mut state = begun_state();
         let mut backend = MockBackend {
@@ -3120,6 +4344,84 @@ mod tests {
         assert!(run_consolidation(&mut state, &mut backend).is_err());
         assert_eq!(backend.calls, vec!["compute", "stage", "seed", "restore"]);
         assert_eq!(state.phase, SleepPhase::Wake);
+    }
+
+    #[test]
+    fn failed_teacher_restore_never_publishes_rollback_metadata() {
+        #[derive(Default)]
+        struct RecordingProgress(Vec<SleepState>);
+
+        impl SleepProgressSink for RecordingProgress {
+            fn persist(&mut self, state: &SleepState) -> Result<()> {
+                self.0.push(state.clone());
+                Ok(())
+            }
+        }
+
+        let mut state = begun_state();
+        let mut backend = MockBackend {
+            fail_seed: true,
+            fail_restore: true,
+            ..Default::default()
+        };
+        let mut progress = RecordingProgress::default();
+        let error = run_consolidation_with_progress(&mut state, &mut backend, &mut progress)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("teacher restore also failed"), "{error}");
+        assert_eq!(state.phase, SleepPhase::KnowledgeSeeding);
+        assert!(state.pending.is_some());
+        assert!(
+            progress
+                .0
+                .iter()
+                .all(|snapshot| snapshot.phase != SleepPhase::Wake && snapshot.pending.is_some()),
+            "a rollback cursor was published despite failed teacher restoration"
+        );
+    }
+
+    #[test]
+    fn failed_rollback_persistence_leaves_the_caller_pending() {
+        #[derive(Default)]
+        struct RejectRollbackProgress(Vec<SleepState>);
+
+        impl SleepProgressSink for RejectRollbackProgress {
+            fn persist(&mut self, state: &SleepState) -> Result<()> {
+                if state.phase == SleepPhase::Wake {
+                    bail!("injected rollback persistence failure");
+                }
+                self.0.push(state.clone());
+                Ok(())
+            }
+        }
+
+        for mut backend in [
+            MockBackend::default(),
+            MockBackend {
+                fail_seed: true,
+                ..Default::default()
+            },
+        ] {
+            let mut state = begun_state();
+            let mut progress = RejectRollbackProgress::default();
+            let error = format!(
+                "{:#}",
+                run_consolidation_with_progress(&mut state, &mut backend, &mut progress)
+                    .unwrap_err()
+            );
+
+            assert!(error.contains("rollback persistence failure"), "{error}");
+            assert_ne!(state.phase, SleepPhase::Wake);
+            assert!(state.pending.is_some());
+            assert!(
+                progress
+                    .0
+                    .iter()
+                    .all(|snapshot| snapshot.phase != SleepPhase::Wake),
+                "a failed rollback publication escaped into durable progress"
+            );
+        }
     }
 
     #[test]
@@ -3197,7 +4499,9 @@ mod tests {
                 )
                 .unwrap();
             state.transition(SleepPhase::KnowledgeSeeding).unwrap();
+            state.reserve_knowledge_rng(0, 1).unwrap();
             state.transition(SleepPhase::Imitation).unwrap();
+            state.reserve_imitation_rng(0, 1).unwrap();
             state.transition(SleepPhase::RetentionValidation).unwrap();
             state.transition(SleepPhase::Commit).unwrap();
             state
@@ -3354,6 +4658,130 @@ mod tests {
             },
         ];
         assert!(select_dreams(&duplicated, 1, 1).is_err());
+        assert!(select_dreams(&[], usize::MAX, 1).is_err());
+
+        let mut overflow = dreaming_config();
+        overflow.retain_top = usize::MAX;
+        overflow.retain_random = 1;
+        assert!(overflow.validate().is_err());
+
+        let mut rollout_overflow = KnowledgeSeedingConfig {
+            chunk_tokens: 1,
+            teacher_rollouts: usize::MAX,
+            detached_student_rollouts: 1,
+            temperature: 1.0,
+            forward_kl_weight: 1.0,
+        };
+        assert!(rollout_overflow.validate().is_err());
+        rollout_overflow.detached_student_rollouts = 0;
+        assert!(rollout_overflow.validate().is_err());
+    }
+
+    #[test]
+    fn generated_dream_validation_rejects_unbounded_or_nonfinite_gradients() {
+        let candidate = |gradient| GeneratedDream {
+            id: "candidate".into(),
+            artifact_hash: test_hash('d'),
+            gradient,
+            diversity_key: 0,
+        };
+
+        assert!(validate_generated_dreams(&[candidate(vec![f32::NAN])], 1).is_err());
+        assert!(
+            validate_generated_dreams(
+                &[candidate(vec![0.0; MAX_DREAM_GRADIENT_DIMENSIONS + 1])],
+                1,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn sleep_configuration_accepts_boundaries_and_rejects_unbounded_work() {
+        let knowledge_boundary = KnowledgeSeedingConfig {
+            chunk_tokens: KnowledgeSeedingConfig::MAX_CHUNK_TOKENS,
+            teacher_rollouts: KnowledgeSeedingConfig::MAX_ROLLOUTS - 1,
+            detached_student_rollouts: 1,
+            temperature: 1.0,
+            forward_kl_weight: 1.0,
+        };
+        knowledge_boundary.validate().unwrap();
+
+        let mut invalid_knowledge = knowledge_boundary.clone();
+        invalid_knowledge.chunk_tokens = KnowledgeSeedingConfig::MAX_CHUNK_TOKENS + 1;
+        let error = invalid_knowledge.validate().unwrap_err();
+        assert!(format!("{error:#}").contains("chunk_tokens"), "{error:#}");
+        invalid_knowledge = knowledge_boundary.clone();
+        invalid_knowledge.teacher_rollouts = KnowledgeSeedingConfig::MAX_ROLLOUTS;
+        let error = invalid_knowledge.validate().unwrap_err();
+        assert!(format!("{error:#}").contains("rollout count"), "{error:#}");
+
+        let imitation_boundary = ImitationConfig {
+            semantic_judge_hash: test_hash('a'),
+            semantic_weight: 0.5,
+            maximum_edit_distance: ImitationConfig::MAX_EDIT_DISTANCE,
+            grpo_group_size: ImitationConfig::MAX_GRPO_GROUP_SIZE,
+        };
+        imitation_boundary.validate().unwrap();
+
+        let mut invalid_imitation = imitation_boundary.clone();
+        invalid_imitation.maximum_edit_distance = ImitationConfig::MAX_EDIT_DISTANCE + 1;
+        let error = invalid_imitation.validate().unwrap_err();
+        assert!(format!("{error:#}").contains("edit distance"), "{error:#}");
+        invalid_imitation = imitation_boundary.clone();
+        invalid_imitation.grpo_group_size = ImitationConfig::MAX_GRPO_GROUP_SIZE + 1;
+        let error = invalid_imitation.validate().unwrap_err();
+        assert!(format!("{error:#}").contains("group size"), "{error:#}");
+
+        let dreaming_boundary = DreamingConfig {
+            candidate_count: DreamingConfig::MAX_CANDIDATES,
+            retain_top: DreamingConfig::MAX_CANDIDATES,
+            retain_random: 0,
+            lora_rank: DreamingConfig::MAX_LORA_RANK,
+            lora_alpha: DreamingConfig::MAX_LORA_ALPHA,
+            restem_iterations: DreamingConfig::MAX_RESTEM_ITERATIONS,
+            selector_version: "gradient-cosine-v1".into(),
+            reference_set_hash: test_hash('b'),
+            trial_evaluator_hash: test_hash('c'),
+        };
+        dreaming_boundary.validate().unwrap();
+
+        for (mut invalid, expected) in [
+            (
+                DreamingConfig {
+                    candidate_count: DreamingConfig::MAX_CANDIDATES + 1,
+                    ..dreaming_boundary.clone()
+                },
+                "candidate count",
+            ),
+            (
+                DreamingConfig {
+                    lora_rank: DreamingConfig::MAX_LORA_RANK + 1,
+                    ..dreaming_boundary.clone()
+                },
+                "LoRA rank",
+            ),
+            (
+                DreamingConfig {
+                    lora_alpha: DreamingConfig::MAX_LORA_ALPHA + 1,
+                    ..dreaming_boundary.clone()
+                },
+                "LoRA alpha",
+            ),
+            (
+                DreamingConfig {
+                    restem_iterations: DreamingConfig::MAX_RESTEM_ITERATIONS + 1,
+                    ..dreaming_boundary.clone()
+                },
+                "ReSTEM iterations",
+            ),
+        ] {
+            // Keep quotas structurally valid when testing the candidate cap so
+            // the operational ceiling is the first rejected condition.
+            invalid.retain_top = invalid.retain_top.min(invalid.candidate_count);
+            let error = invalid.validate().unwrap_err();
+            assert!(format!("{error:#}").contains(expected), "{error:#}");
+        }
     }
 
     #[test]
@@ -3363,19 +4791,33 @@ mod tests {
         assert!(values[2] > values[1] && values[1] > values[0]);
     }
 
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum DreamFailure {
+        Generation,
+        Load,
+        Reference,
+        Trial,
+        Policy,
+    }
+
     #[derive(Default)]
     struct MockDreamBackend {
+        committed_hash: String,
         shared_hash: String,
         generation_calls: usize,
         load_calls: usize,
         trial_calls: Vec<String>,
         restem_calls: usize,
+        restores: usize,
         all_rejected: bool,
+        fail_once: Option<DreamFailure>,
+        invalid_trial: bool,
     }
 
     impl MockDreamBackend {
         fn new() -> Self {
             Self {
+                committed_hash: test_hash('d'),
                 shared_hash: test_hash('d'),
                 ..Self::default()
             }
@@ -3386,6 +4828,22 @@ mod tests {
                 all_rejected: true,
                 ..Self::new()
             }
+        }
+
+        fn failing(operation: DreamFailure) -> Self {
+            Self {
+                fail_once: Some(operation),
+                ..Self::new()
+            }
+        }
+
+        fn fail_if_requested(&mut self, operation: DreamFailure) -> Result<()> {
+            if self.fail_once == Some(operation) {
+                self.fail_once = None;
+                self.shared_hash = test_hash('e');
+                bail!("injected {operation:?} failure after shared-candidate mutation");
+            }
+            Ok(())
         }
 
         fn dreams() -> Vec<GeneratedDream> {
@@ -3422,6 +4880,18 @@ mod tests {
     }
 
     impl DreamingBackend for MockDreamBackend {
+        fn verify_committed_candidate(&mut self, txn: &ConsolidationTxn) -> Result<()> {
+            ensure!(
+                txn.candidate_hash.as_ref() == Some(&self.committed_hash),
+                "dream backend is bound to another committed checkpoint"
+            );
+            ensure!(
+                self.shared_hash == test_hash('d'),
+                "dream backend shared parameters differ from its immutable candidate"
+            );
+            Ok(())
+        }
+
         fn shared_checkpoint_hash(&mut self) -> Result<String> {
             Ok(self.shared_hash.clone())
         }
@@ -3434,6 +4904,7 @@ mod tests {
         ) -> Result<(String, Vec<GeneratedDream>)> {
             ensure!(random_extra_expert, "dream exploration was not enabled");
             ensure!(candidate_count == 3, "unexpected candidate count");
+            self.fail_if_requested(DreamFailure::Generation)?;
             self.generation_calls += 1;
             Ok((test_hash('7'), Self::dreams()))
         }
@@ -3444,6 +4915,7 @@ mod tests {
             manifest: &str,
         ) -> Result<Vec<GeneratedDream>> {
             ensure!(manifest == test_hash('7'), "wrong dream manifest");
+            self.fail_if_requested(DreamFailure::Load)?;
             self.load_calls += 1;
             Ok(Self::dreams())
         }
@@ -3454,6 +4926,7 @@ mod tests {
             reference_set_hash: &str,
         ) -> Result<Vec<f32>> {
             ensure!(reference_set_hash == test_hash('8'), "wrong reference set");
+            self.fail_if_requested(DreamFailure::Reference)?;
             Ok(vec![1.0, 0.0])
         }
 
@@ -3465,10 +4938,14 @@ mod tests {
             alpha: usize,
         ) -> Result<DreamTrial> {
             ensure!(rank == 64 && alpha == 128, "wrong LoRA recipe");
+            self.fail_if_requested(DreamFailure::Trial)?;
             self.trial_calls.push(candidate.id.clone());
             let mut trial = Self::trial(&candidate.id);
             if self.all_rejected {
                 trial.independent_task_improvement = -0.1;
+            }
+            if self.invalid_trial {
+                trial.candidate_id = "wrong-candidate".into();
             }
             Ok(trial)
         }
@@ -3480,6 +4957,7 @@ mod tests {
             iterations: usize,
         ) -> Result<String> {
             ensure!(iterations == 1, "wrong ReSTEM iterations");
+            self.fail_if_requested(DreamFailure::Policy)?;
             if self.all_rejected {
                 ensure!(accepted.is_empty(), "all-rejected run accepted a dream");
             } else {
@@ -3494,6 +4972,7 @@ mod tests {
 
         fn restore_shared_candidate(&mut self, _: &ConsolidationTxn) -> Result<()> {
             self.shared_hash = test_hash('d');
+            self.restores += 1;
             Ok(())
         }
     }
@@ -3580,6 +5059,51 @@ mod tests {
     }
 
     #[test]
+    fn dreaming_repairs_but_never_adopts_a_wrong_shared_candidate() {
+        let mut wrongly_bound_state = committed_state();
+        let wrongly_bound_before = wrongly_bound_state.clone();
+        let mut wrongly_bound = MockDreamBackend::new();
+        wrongly_bound.committed_hash = test_hash('e');
+        let error = run_dreaming(
+            &mut wrongly_bound_state,
+            &dreaming_config(),
+            &mut wrongly_bound,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("did not recover the committed candidate"),
+            "{error}"
+        );
+        assert_eq!(wrongly_bound_state, wrongly_bound_before);
+
+        let mut state = committed_state();
+        let before = state.clone();
+        let mut backend = MockDreamBackend::new();
+        backend.shared_hash = test_hash('e');
+
+        let error = run_dreaming(&mut state, &dreaming_config(), &mut backend)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("committed candidate"), "{error}");
+        assert_eq!(state, before);
+        assert_eq!(backend.shared_hash, test_hash('d'));
+        assert_eq!(backend.restores, 1);
+
+        run_dreaming(&mut state, &dreaming_config(), &mut backend).unwrap();
+        assert_eq!(state.phase, SleepPhase::Candidate);
+
+        backend.shared_hash = test_hash('e');
+        let before = state.clone();
+        let error = run_dreaming(&mut state, &dreaming_config(), &mut backend)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("committed candidate"), "{error}");
+        assert_eq!(state, before);
+        assert_eq!(backend.shared_hash, test_hash('d'));
+    }
+
+    #[test]
     fn dreaming_finishes_when_every_isolated_trial_is_rejected() {
         let mut state = committed_state();
         let mut backend = MockDreamBackend::all_rejected();
@@ -3595,6 +5119,51 @@ mod tests {
                 .dream_policy_receipt
                 .is_some()
         );
+    }
+
+    #[test]
+    fn dreaming_backend_errors_always_restore_the_shared_candidate_before_retry() {
+        for operation in [
+            DreamFailure::Generation,
+            DreamFailure::Load,
+            DreamFailure::Reference,
+            DreamFailure::Trial,
+            DreamFailure::Policy,
+        ] {
+            let mut state = committed_state();
+            let mut backend = MockDreamBackend::failing(operation);
+            let error = run_dreaming(&mut state, &dreaming_config(), &mut backend)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("shared"), "{operation:?}: {error}");
+            assert_eq!(backend.shared_hash, test_hash('d'), "{operation:?}");
+            assert_eq!(backend.restores, 1, "{operation:?}");
+            assert!(state.pending.is_some(), "{operation:?}");
+
+            let accepted = run_dreaming(&mut state, &dreaming_config(), &mut backend).unwrap();
+            assert_eq!(accepted.len(), 1, "{operation:?}");
+            assert_eq!(state.phase, SleepPhase::Candidate, "{operation:?}");
+        }
+    }
+
+    #[test]
+    fn invalid_dream_evidence_fails_without_changing_the_shared_candidate() {
+        let mut state = committed_state();
+        let mut backend = MockDreamBackend {
+            invalid_trial: true,
+            ..MockDreamBackend::new()
+        };
+        let error = run_dreaming(&mut state, &dreaming_config(), &mut backend)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("incomplete or invalid evidence"), "{error}");
+        assert_eq!(backend.shared_hash, test_hash('d'));
+        assert_eq!(backend.restores, 0);
+        assert_eq!(state.phase, SleepPhase::DreamTrials);
+
+        backend.invalid_trial = false;
+        let accepted = run_dreaming(&mut state, &dreaming_config(), &mut backend).unwrap();
+        assert_eq!(accepted.len(), 1);
     }
 
     #[test]
@@ -3632,5 +5201,43 @@ mod tests {
                 .count(),
             2
         );
+    }
+
+    #[test]
+    fn failed_selection_metric_leaves_a_resumable_ranking_cursor() {
+        struct RejectSelectionMetric;
+
+        impl SleepProgressSink for RejectSelectionMetric {
+            fn persist(&mut self, _: &SleepState) -> Result<()> {
+                Ok(())
+            }
+
+            fn metric(&mut self, event: MetricEvent) -> Result<()> {
+                if matches!(event, MetricEvent::DreamSelection(_)) {
+                    bail!("injected dream-selection metric failure");
+                }
+                Ok(())
+            }
+        }
+
+        let mut state = committed_state();
+        let mut backend = MockDreamBackend::new();
+        let error = run_dreaming_with_progress(
+            &mut state,
+            &dreaming_config(),
+            &mut backend,
+            &mut RejectSelectionMetric,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("metric failure"), "{error}");
+        assert_eq!(state.phase, SleepPhase::DreamRanking);
+        assert!(state.pending.as_ref().unwrap().dream_selected.is_empty());
+        state.validate_resume().unwrap();
+
+        let accepted = run_dreaming(&mut state, &dreaming_config(), &mut backend).unwrap();
+        assert_eq!(accepted.len(), 1);
+        assert_eq!(state.phase, SleepPhase::Candidate);
     }
 }

--- a/hermes-train/src/task.rs
+++ b/hermes-train/src/task.rs
@@ -5,10 +5,10 @@
 //! algorithm, RL algorithm, or model implementation; those choices belong to
 //! workflow phases and their executors.
 
-use std::collections::BTreeMap;
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
 
-use anyhow::{Context, Result, ensure};
-use serde::de::DeserializeOwned;
+use anyhow::{Context, Result, bail, ensure};
 use serde::{Deserialize, Serialize};
 
 fn default_temperature() -> f64 {
@@ -38,6 +38,18 @@ fn default_query_prefix() -> String {
 fn default_document_prefix() -> String {
     "Represent this document for retrieval:\n".to_owned()
 }
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+/// Includes the positive document. Wake retrieval materializes every document
+/// as one fixed-length token sequence before shuffling, so this also provides
+/// a finite geometry contract to WorkflowV2.
+const MAX_RETRIEVAL_REPRESENTATION_DOCUMENTS: usize = 32;
+/// Ranking is dispatched to a dedicated executor and can use larger lists,
+/// but a single bounded JSONL row must still not create an unbounded example.
+const MAX_RETRIEVAL_RANKING_DOCUMENTS: usize = 1_024;
 
 /// The model-facing operation required by a task.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -94,8 +106,79 @@ pub struct TaskContract {
     pub metrics: &'static [TaskMetric],
 }
 
+/// Text whose tokenization boundaries are part of the task contract.
+///
+/// Executors must tokenize each segment independently and concatenate the
+/// resulting token IDs. Tokenizing [`Self::render`] as one string is not
+/// equivalent for boundary-sensitive tokenizers such as BPE. At most one
+/// segment may be truncated; fixed prompt text must remain intact.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SegmentedText {
+    /// Ordered strings whose independently encoded token IDs are concatenated.
+    pub segments: Vec<String>,
+    /// The only segment an executor may shorten to meet its sequence limit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncatable_segment: Option<usize>,
+    /// Whether truncation must retain at least one token from that segment.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub truncatable_segment_required: bool,
+}
+
+impl SegmentedText {
+    fn prefixed(prefix: &str, text: String) -> Self {
+        Self {
+            segments: vec![prefix.to_owned(), text],
+            truncatable_segment: Some(1),
+            truncatable_segment_required: true,
+        }
+    }
+
+    /// Validate structural invariants before an externally supplied example is
+    /// dispatched to a model executor.
+    pub fn validate(&self) -> Result<()> {
+        ensure!(
+            !self.segments.is_empty(),
+            "segmented text must not be empty"
+        );
+        if let Some(index) = self.truncatable_segment {
+            ensure!(
+                index < self.segments.len(),
+                "truncatable segment {index} is outside {} segments",
+                self.segments.len()
+            );
+            if self.truncatable_segment_required {
+                ensure!(
+                    !self.segments[index].is_empty(),
+                    "required truncatable segment {index} must not be empty"
+                );
+            }
+        } else {
+            ensure!(
+                !self.truncatable_segment_required,
+                "a required truncatable segment needs an index"
+            );
+        }
+        Ok(())
+    }
+
+    /// Rendered text for inspection, logging, or APIs that consume text. Model
+    /// execution must preserve the segment boundaries documented above.
+    pub fn render(&self) -> String {
+        let capacity = self
+            .segments
+            .iter()
+            .fold(0usize, |total, segment| total.saturating_add(segment.len()));
+        let mut rendered = String::with_capacity(capacity);
+        for segment in &self.segments {
+            rendered.push_str(segment);
+        }
+        rendered
+    }
+}
+
 /// Backend-neutral example produced from one validated task record. Executors
-/// tokenize these strings and apply the accompanying [`LossSpec`] instead of
+/// tokenize these inputs and apply the accompanying [`LossSpec`] instead of
 /// hard-coding storage-field names in trainer core.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
@@ -104,17 +187,17 @@ pub enum TaskExample {
         text: String,
     },
     SupervisedGeneration {
-        prompt: String,
+        prompt: SegmentedText,
         target: String,
     },
     RetrievalRepresentation {
-        query: String,
-        documents: Vec<String>,
+        query: SegmentedText,
+        documents: Vec<SegmentedText>,
         positive_index: usize,
     },
     RetrievalRanking {
-        query: String,
-        documents: Vec<String>,
+        query: SegmentedText,
+        documents: Vec<SegmentedText>,
         relevance: Vec<f64>,
     },
     PairwisePreference {
@@ -208,7 +291,65 @@ pub enum TaskConfig {
     },
 }
 
+/// Canonical rendering of a supervised-generation record.
+///
+/// The source is kept separate from the fixed prompt text so an executor can
+/// truncate long documents, questions, or optional inputs without truncating
+/// the instruction, response marker, or target. All built-in executors must
+/// consume these segments instead of rebuilding task prompts independently.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SupervisedPromptSegments<'a> {
+    pub prefix: Cow<'a, str>,
+    pub source: Cow<'a, str>,
+    pub suffix: Cow<'a, str>,
+    pub target: Cow<'a, str>,
+    pub source_required: bool,
+}
+
+impl SupervisedPromptSegments<'_> {
+    pub fn prompt(&self) -> String {
+        let mut prompt = String::with_capacity(
+            self.prefix
+                .len()
+                .saturating_add(self.source.len())
+                .saturating_add(self.suffix.len()),
+        );
+        prompt.push_str(&self.prefix);
+        prompt.push_str(&self.source);
+        prompt.push_str(&self.suffix);
+        prompt
+    }
+
+    fn into_example(self) -> TaskExample {
+        let prompt = SegmentedText {
+            segments: vec![
+                self.prefix.into_owned(),
+                self.source.into_owned(),
+                self.suffix.into_owned(),
+            ],
+            truncatable_segment: Some(1),
+            truncatable_segment_required: self.source_required,
+        };
+        debug_assert!(prompt.validate().is_ok());
+        TaskExample::SupervisedGeneration {
+            prompt,
+            target: self.target.into_owned(),
+        }
+    }
+}
+
 impl TaskConfig {
+    /// Conservative upper bound on fixed-length model sequences retained for
+    /// one example by the built-in wake data path. Workflow validation uses it
+    /// for batch and shuffle-memory geometry instead of assuming one sequence
+    /// for a contrastive retrieval example.
+    pub fn maximum_model_sequences_per_example(&self) -> usize {
+        match self {
+            Self::RetrievalRepresentation { .. } => 1 + MAX_RETRIEVAL_REPRESENTATION_DOCUMENTS,
+            _ => 1,
+        }
+    }
+
     pub fn retrieval_layer(&self) -> Option<usize> {
         match self {
             Self::RetrievalRepresentation { layer, .. } | Self::RetrievalRanking { layer, .. } => {
@@ -223,6 +364,113 @@ impl TaskConfig {
             Self::RetrievalRepresentation { temperature, .. }
             | Self::RetrievalRanking { temperature, .. } => Some(*temperature),
             _ => None,
+        }
+    }
+
+    /// Parse and render one record for a built-in supervised-generation task.
+    /// The returned segmentation is the single prompt contract shared by wake
+    /// training and post-training executors.
+    pub fn construct_supervised_prompt<'a>(
+        &self,
+        record: &'a serde_json::Value,
+    ) -> Result<SupervisedPromptSegments<'a>> {
+        self.validate()?;
+        self.construct_supervised_prompt_after_validation(record)
+    }
+
+    fn construct_supervised_prompt_after_validation<'a>(
+        &self,
+        record: &'a serde_json::Value,
+    ) -> Result<SupervisedPromptSegments<'a>> {
+        match self {
+            Self::Summarization { instruction } => {
+                let record = parse_record::<SummarizationRecord>(record)?;
+                record.validate()?;
+                Ok(SupervisedPromptSegments {
+                    prefix: format!("{instruction}\n\nDocument:\n").into(),
+                    source: record.document,
+                    suffix: "\n\nSummary:\n".into(),
+                    target: record.summary,
+                    source_required: true,
+                })
+            }
+            Self::RetrievalPlanning { instruction } => {
+                let record = parse_record::<RetrievalPlanningRecord>(record)?;
+                record.validate()?;
+                let (prefix, source, suffix, source_required) = match record.context {
+                    Some(context) => (
+                        Cow::Owned(format!(
+                            "{instruction}\n\nRequest:\n{}\n\nContext:\n",
+                            record.request
+                        )),
+                        context,
+                        Cow::Borrowed("\nPlan:\n"),
+                        true,
+                    ),
+                    None => (
+                        Cow::Owned(format!("{instruction}\n\nRequest:\n{}\n", record.request)),
+                        Cow::Borrowed(""),
+                        Cow::Borrowed("Plan:\n"),
+                        false,
+                    ),
+                };
+                Ok(SupervisedPromptSegments {
+                    prefix,
+                    source,
+                    suffix,
+                    target: record.plan,
+                    source_required,
+                })
+            }
+            Self::InstructionTuning { instruction } => {
+                let record = parse_record::<InstructionTuningRecord>(record)?;
+                record.validate()?;
+                let mut prefix = String::new();
+                if let Some(system) = record.system {
+                    prefix.push_str("System:\n");
+                    prefix.push_str(&system);
+                    prefix.push_str("\n\n");
+                }
+                prefix.push_str(instruction);
+                prefix.push_str("\n\nInstruction:\n");
+                prefix.push_str(&record.instruction);
+                let (source, source_required) = match record.input {
+                    Some(input) => {
+                        prefix.push_str("\n\nInput:\n");
+                        (input, true)
+                    }
+                    None => (Cow::Borrowed(""), false),
+                };
+                Ok(SupervisedPromptSegments {
+                    prefix: prefix.into(),
+                    source,
+                    suffix: "\n\nResponse:\n".into(),
+                    target: record.response,
+                    source_required,
+                })
+            }
+            Self::QaReasoning {
+                instruction,
+                require_reasoning,
+            } => {
+                let record = parse_record::<QaReasoningRecord>(record)?;
+                record.validate(*require_reasoning)?;
+                let target = match record.reasoning {
+                    Some(reasoning) => Cow::Owned(format!(
+                        "Reasoning:\n{reasoning}\n\nAnswer:\n{}",
+                        record.answer
+                    )),
+                    None => record.answer,
+                };
+                Ok(SupervisedPromptSegments {
+                    prefix: format!("{instruction}\n\nQuestion:\n").into(),
+                    source: record.question,
+                    suffix: "\n\nResponse:\n".into(),
+                    target,
+                    source_required: true,
+                })
+            }
+            _ => bail!("task `{}` is not a supervised-generation task", self.name()),
         }
     }
 }
@@ -298,10 +546,16 @@ impl TaskAdapter for TaskConfig {
                 loss_mask: LossMaskPolicy::TargetTokensOnly,
                 metrics: &[TaskMetric::Loss],
             },
-            Self::QaReasoning { .. } => TaskContract {
+            Self::QaReasoning {
+                require_reasoning, ..
+            } => TaskContract {
                 execution: TaskExecution::SupervisedGeneration,
                 data_format: TaskDataFormat::Jsonl,
-                required_fields: &["question", "answer"],
+                required_fields: if *require_reasoning {
+                    &["question", "answer", "reasoning"]
+                } else {
+                    &["question", "answer"]
+                },
                 input_fields: &["question"],
                 target_fields: &["reasoning", "answer"],
                 loss_mask: LossMaskPolicy::TargetTokensOnly,
@@ -386,17 +640,12 @@ impl TaskAdapter for TaskConfig {
                 record.validate()?;
                 Ok(TaskExample::Autoregressive { text: record.text })
             }
-            Self::Summarization { instruction } => {
-                let record = parse_record::<SummarizationRecord>(record)?;
-                record.validate()?;
-                Ok(TaskExample::SupervisedGeneration {
-                    prompt: format!(
-                        "{instruction}\n\nDocument:\n{}\n\nSummary:\n",
-                        record.document
-                    ),
-                    target: record.summary,
-                })
-            }
+            Self::Summarization { .. }
+            | Self::RetrievalPlanning { .. }
+            | Self::InstructionTuning { .. }
+            | Self::QaReasoning { .. } => Ok(self
+                .construct_supervised_prompt_after_validation(record)?
+                .into_example()),
             Self::RetrievalRepresentation {
                 query_prefix,
                 document_prefix,
@@ -405,15 +654,15 @@ impl TaskAdapter for TaskConfig {
                 let record = parse_record::<RetrievalRepresentationRecord>(record)?;
                 record.validate()?;
                 let mut documents = Vec::with_capacity(record.negatives.len() + 1);
-                documents.push(format!("{document_prefix}{}", record.positive));
+                documents.push(SegmentedText::prefixed(document_prefix, record.positive));
                 documents.extend(
                     record
                         .negatives
                         .into_iter()
-                        .map(|document| format!("{document_prefix}{document}")),
+                        .map(|document| SegmentedText::prefixed(document_prefix, document)),
                 );
                 Ok(TaskExample::RetrievalRepresentation {
-                    query: format!("{query_prefix}{}", record.query),
+                    query: SegmentedText::prefixed(query_prefix, record.query),
                     documents,
                     positive_index: 0,
                 })
@@ -425,75 +674,16 @@ impl TaskAdapter for TaskConfig {
             } => {
                 let record = parse_record::<RetrievalRankingRecord>(record)?;
                 record.validate()?;
+                let mut documents = Vec::with_capacity(record.documents.len());
+                let mut relevance = Vec::with_capacity(record.documents.len());
+                for document in record.documents {
+                    documents.push(SegmentedText::prefixed(document_prefix, document.document));
+                    relevance.push(document.relevance);
+                }
                 Ok(TaskExample::RetrievalRanking {
-                    query: format!("{query_prefix}{}", record.query),
-                    documents: record
-                        .documents
-                        .iter()
-                        .map(|document| format!("{document_prefix}{}", document.document))
-                        .collect(),
-                    relevance: record
-                        .documents
-                        .into_iter()
-                        .map(|document| document.relevance)
-                        .collect(),
-                })
-            }
-            Self::RetrievalPlanning { instruction } => {
-                let record = parse_record::<RetrievalPlanningRecord>(record)?;
-                record.validate()?;
-                let prompt = match record.context {
-                    Some(context) => format!(
-                        "{instruction}\n\nRequest:\n{}\n\nContext:\n{context}\nPlan:\n",
-                        record.request
-                    ),
-                    None => format!("{instruction}\n\nRequest:\n{}\nPlan:\n", record.request),
-                };
-                Ok(TaskExample::SupervisedGeneration {
-                    prompt,
-                    target: record.plan,
-                })
-            }
-            Self::InstructionTuning { instruction } => {
-                let record = parse_record::<InstructionTuningRecord>(record)?;
-                record.validate()?;
-                let mut prompt = String::new();
-                if let Some(system) = record.system {
-                    prompt.push_str("System:\n");
-                    prompt.push_str(&system);
-                    prompt.push_str("\n\n");
-                }
-                prompt.push_str(instruction);
-                prompt.push_str("\n\nInstruction:\n");
-                prompt.push_str(&record.instruction);
-                if let Some(input) = record.input {
-                    prompt.push_str("\n\nInput:\n");
-                    prompt.push_str(&input);
-                }
-                prompt.push_str("\n\nResponse:\n");
-                Ok(TaskExample::SupervisedGeneration {
-                    prompt,
-                    target: record.response,
-                })
-            }
-            Self::QaReasoning {
-                instruction,
-                require_reasoning,
-            } => {
-                let record = parse_record::<QaReasoningRecord>(record)?;
-                record.validate(*require_reasoning)?;
-                let target = match record.reasoning {
-                    Some(reasoning) => {
-                        format!("Reasoning:\n{reasoning}\n\nAnswer:\n{}", record.answer)
-                    }
-                    None => record.answer,
-                };
-                Ok(TaskExample::SupervisedGeneration {
-                    prompt: format!(
-                        "{instruction}\n\nQuestion:\n{}\n\nResponse:\n",
-                        record.question
-                    ),
-                    target,
+                    query: SegmentedText::prefixed(query_prefix, record.query),
+                    documents,
+                    relevance,
                 })
             }
             Self::PairwisePreference {} => {
@@ -554,8 +744,8 @@ impl TaskAdapter for TaskConfig {
     }
 }
 
-fn parse_record<T: DeserializeOwned>(value: &serde_json::Value) -> Result<T> {
-    serde_json::from_value(value.clone()).context("record does not match the task schema")
+fn parse_record<'de, T: Deserialize<'de>>(value: &'de serde_json::Value) -> Result<T> {
+    T::deserialize(value).context("record does not match the task schema")
 }
 
 fn ensure_nonempty(value: &str, field: &str) -> Result<()> {
@@ -597,12 +787,14 @@ impl CausalLmRecord {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct SummarizationRecord {
-    pub document: String,
-    pub summary: String,
+pub struct SummarizationRecord<'a> {
+    #[serde(borrow)]
+    pub document: Cow<'a, str>,
+    #[serde(borrow)]
+    pub summary: Cow<'a, str>,
 }
 
-impl SummarizationRecord {
+impl SummarizationRecord<'_> {
     fn validate(&self) -> Result<()> {
         ensure_nonempty(&self.document, "document")?;
         ensure_nonempty(&self.summary, "summary")
@@ -621,9 +813,19 @@ impl RetrievalRepresentationRecord {
     fn validate(&self) -> Result<()> {
         ensure_nonempty(&self.query, "query")?;
         ensure_nonempty(&self.positive, "positive")?;
+        let mut documents = BTreeSet::from([self.positive.as_str()]);
         for (index, negative) in self.negatives.iter().enumerate() {
             ensure_nonempty(negative, &format!("negatives[{index}]"))?;
+            ensure!(
+                documents.insert(negative),
+                "`negatives[{index}]` duplicates the positive or another negative document"
+            );
         }
+        ensure!(
+            self.negatives.len() < MAX_RETRIEVAL_REPRESENTATION_DOCUMENTS,
+            "retrieval representation has {} documents; at most {MAX_RETRIEVAL_REPRESENTATION_DOCUMENTS} including the positive are supported",
+            self.negatives.len().saturating_add(1)
+        );
         Ok(())
     }
 }
@@ -647,35 +849,48 @@ impl RetrievalRankingRecord {
             self.documents.len() >= 2,
             "`documents` must contain at least two candidates"
         );
-        let mut positive = false;
-        let mut non_positive = false;
+        ensure!(
+            self.documents.len() <= MAX_RETRIEVAL_RANKING_DOCUMENTS,
+            "`documents` exceeds the {MAX_RETRIEVAL_RANKING_DOCUMENTS}-candidate limit"
+        );
+        let mut first_relevance = None;
+        let mut distinct_relevance = false;
+        let mut documents = BTreeSet::new();
         for (index, document) in self.documents.iter().enumerate() {
             ensure_nonempty(&document.document, &format!("documents[{index}].document"))?;
             ensure!(
-                document.relevance.is_finite(),
-                "`documents[{index}].relevance` must be finite"
+                documents.insert(document.document.as_str()),
+                "`documents[{index}].document` duplicates another ranking candidate"
             );
-            positive |= document.relevance > 0.0;
-            non_positive |= document.relevance <= 0.0;
+            ensure!(
+                document.relevance.is_finite() && document.relevance >= 0.0,
+                "`documents[{index}].relevance` must be finite and non-negative"
+            );
+            match first_relevance {
+                Some(first) => distinct_relevance |= document.relevance != first,
+                None => first_relevance = Some(document.relevance),
+            }
         }
-        ensure!(positive, "`documents` must contain a positive candidate");
         ensure!(
-            non_positive,
-            "`documents` must contain a non-positive candidate"
+            distinct_relevance,
+            "`documents` must contain at least two distinct relevance grades"
         );
         Ok(())
     }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct RetrievalPlanningRecord {
-    pub request: String,
+pub struct RetrievalPlanningRecord<'a> {
+    #[serde(borrow)]
+    pub request: Cow<'a, str>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub context: Option<String>,
-    pub plan: String,
+    #[serde(borrow)]
+    pub context: Option<Cow<'a, str>>,
+    #[serde(borrow)]
+    pub plan: Cow<'a, str>,
 }
 
-impl RetrievalPlanningRecord {
+impl RetrievalPlanningRecord<'_> {
     fn validate(&self) -> Result<()> {
         ensure_nonempty(&self.request, "request")?;
         ensure_optional_nonempty(self.context.as_deref(), "context")?;
@@ -684,16 +899,20 @@ impl RetrievalPlanningRecord {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct InstructionTuningRecord {
+pub struct InstructionTuningRecord<'a> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub system: Option<String>,
-    pub instruction: String,
+    #[serde(borrow)]
+    pub system: Option<Cow<'a, str>>,
+    #[serde(borrow)]
+    pub instruction: Cow<'a, str>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub input: Option<String>,
-    pub response: String,
+    #[serde(borrow)]
+    pub input: Option<Cow<'a, str>>,
+    #[serde(borrow)]
+    pub response: Cow<'a, str>,
 }
 
-impl InstructionTuningRecord {
+impl InstructionTuningRecord<'_> {
     fn validate(&self) -> Result<()> {
         ensure_optional_nonempty(self.system.as_deref(), "system")?;
         ensure_nonempty(&self.instruction, "instruction")?;
@@ -703,14 +922,17 @@ impl InstructionTuningRecord {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct QaReasoningRecord {
-    pub question: String,
-    pub answer: String,
+pub struct QaReasoningRecord<'a> {
+    #[serde(borrow)]
+    pub question: Cow<'a, str>,
+    #[serde(borrow)]
+    pub answer: Cow<'a, str>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reasoning: Option<String>,
+    #[serde(borrow)]
+    pub reasoning: Option<Cow<'a, str>>,
 }
 
-impl QaReasoningRecord {
+impl QaReasoningRecord<'_> {
     fn validate(&self, require_reasoning: bool) -> Result<()> {
         ensure_nonempty(&self.question, "question")?;
         ensure_nonempty(&self.answer, "answer")?;
@@ -799,6 +1021,46 @@ mod tests {
     }
 
     #[test]
+    fn qa_contract_exposes_configured_reasoning_requirement() {
+        let optional = config(json!({"type": "qa_reasoning"}));
+        assert_eq!(optional.contract().required_fields, ["question", "answer"]);
+
+        let required = config(json!({
+            "type": "qa_reasoning",
+            "require_reasoning": true
+        }));
+        assert_eq!(
+            required.contract().required_fields,
+            ["question", "answer", "reasoning"]
+        );
+    }
+
+    #[test]
+    fn supervised_prompt_segments_borrow_large_record_fields() {
+        let task = config(json!({"type": "summarization"}));
+        let record = json!({
+            "document": "a document large enough that copying it is undesirable",
+            "summary": "short summary"
+        });
+        let document = record["document"].as_str().unwrap();
+        let summary = record["summary"].as_str().unwrap();
+        let segments = task.construct_supervised_prompt(&record).unwrap();
+        assert!(matches!(&segments.source, Cow::Borrowed(_)));
+        assert!(matches!(&segments.target, Cow::Borrowed(_)));
+        assert_eq!(segments.source.as_ptr(), document.as_ptr());
+        assert_eq!(segments.target.as_ptr(), summary.as_ptr());
+
+        let reasoning = config(json!({
+            "type": "qa_reasoning",
+            "require_reasoning": true
+        }));
+        let record = json!({"question": "why?", "reasoning": "because", "answer": "therefore"});
+        let segments = reasoning.construct_supervised_prompt(&record).unwrap();
+        assert!(matches!(&segments.source, Cow::Borrowed(_)));
+        assert!(matches!(&segments.target, Cow::Owned(_)));
+    }
+
+    #[test]
     fn shipped_task_schemas_accept_valid_records() {
         let cases = [
             (
@@ -818,8 +1080,8 @@ mod tests {
                 json!({
                     "query": "q",
                     "documents": [
-                        {"document": "relevant", "relevance": 1.0},
-                        {"document": "irrelevant", "relevance": 0.0}
+                        {"document": "best", "relevance": 3.0},
+                        {"document": "also relevant", "relevance": 1.0}
                     ]
                 }),
             ),
@@ -855,18 +1117,53 @@ mod tests {
 
     #[test]
     fn record_validation_rejects_semantically_useless_examples() {
+        let representation = config(json!({"type": "retrieval_representation"}));
+        let error = representation
+            .validate_record(&json!({
+                "query": "q",
+                "positive": "same document",
+                "negatives": ["same document"]
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("duplicates the positive"), "{error}");
+
         let ranking = config(json!({"type": "retrieval_ranking"}));
         let error = ranking
             .validate_record(&json!({
                 "query": "q",
                 "documents": [
                     {"document": "a", "relevance": 1.0},
-                    {"document": "b", "relevance": 2.0}
+                    {"document": "b", "relevance": 1.0}
                 ]
             }))
             .unwrap_err()
             .to_string();
-        assert!(error.contains("non-positive candidate"), "{error}");
+        assert!(error.contains("distinct relevance grades"), "{error}");
+
+        let error = ranking
+            .validate_record(&json!({
+                "query": "q",
+                "documents": [
+                    {"document": "same document", "relevance": 1.0},
+                    {"document": "same document", "relevance": 0.0}
+                ]
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("duplicates another ranking"), "{error}");
+
+        let error = ranking
+            .validate_record(&json!({
+                "query": "q",
+                "documents": [
+                    {"document": "a", "relevance": 1.0},
+                    {"document": "b", "relevance": -1.0}
+                ]
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("non-negative"), "{error}");
 
         let preference = config(json!({"type": "pairwise_preference"}));
         let error = preference
@@ -881,6 +1178,47 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("reasoning"), "{error}");
+    }
+
+    #[test]
+    fn retrieval_records_bound_per_example_candidate_materialization() {
+        let representation = config(json!({"type": "retrieval_representation"}));
+        let accepted_negatives = (0..MAX_RETRIEVAL_REPRESENTATION_DOCUMENTS - 1)
+            .map(|index| format!("negative-{index}"))
+            .collect::<Vec<_>>();
+        representation
+            .validate_record(&json!({
+                "query": "q",
+                "positive": "p",
+                "negatives": accepted_negatives
+            }))
+            .unwrap();
+        let excessive_negatives = (0..MAX_RETRIEVAL_REPRESENTATION_DOCUMENTS)
+            .map(|index| format!("negative-{index}"))
+            .collect::<Vec<_>>();
+        let error = representation
+            .validate_record(&json!({
+                "query": "q",
+                "positive": "p",
+                "negatives": excessive_negatives
+            }))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("including the positive"), "{error}");
+        assert_eq!(
+            representation.maximum_model_sequences_per_example(),
+            MAX_RETRIEVAL_REPRESENTATION_DOCUMENTS + 1
+        );
+
+        let ranking = config(json!({"type": "retrieval_ranking"}));
+        let documents = (0..=MAX_RETRIEVAL_RANKING_DOCUMENTS)
+            .map(|index| json!({"document": format!("document-{index}"), "relevance": index}))
+            .collect::<Vec<_>>();
+        let error = ranking
+            .validate_record(&json!({"query": "q", "documents": documents}))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("candidate limit"), "{error}");
     }
 
     #[test]
@@ -917,7 +1255,9 @@ mod tests {
         let TaskExample::SupervisedGeneration { prompt, target } = example else {
             panic!("expected supervised-generation example")
         };
-        assert!(prompt.contains("Question:\nWhy?"));
+        assert!(prompt.render().contains("Question:\nWhy?"));
+        assert_eq!(prompt.truncatable_segment, Some(1));
+        assert!(prompt.truncatable_segment_required);
         assert_eq!(target, "Reasoning:\nBecause.\n\nAnswer:\nTherefore.");
         assert_eq!(
             reasoning.loss_spec(),
@@ -926,6 +1266,33 @@ mod tests {
             }
         );
         assert!(reasoning.reward_spec().is_none());
+
+        let retrieval = config(json!({
+            "type": "retrieval_representation",
+            "query_prefix": "query:",
+            "document_prefix": "document:"
+        }));
+        let example = retrieval
+            .construct_example(&json!({
+                "query": "needle",
+                "positive": "haystack",
+                "negatives": ["other"]
+            }))
+            .unwrap();
+        let TaskExample::RetrievalRepresentation {
+            query, documents, ..
+        } = example
+        else {
+            panic!("expected retrieval-representation example")
+        };
+        assert_eq!(query.segments, ["query:", "needle"]);
+        assert_eq!(documents[0].segments, ["document:", "haystack"]);
+        assert_eq!(documents[1].segments, ["document:", "other"]);
+        assert_eq!(query.render(), "query:needle");
+        query.validate().unwrap();
+        for document in documents {
+            document.validate().unwrap();
+        }
 
         let rl = config(json!({
             "type": "verifiable_rl",

--- a/hermes-train/src/tensor_sleep.rs
+++ b/hermes-train/src/tensor_sleep.rs
@@ -9,21 +9,32 @@
 //! implemented here rather than delegated to callbacks.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(test)]
+use std::fs::OpenOptions;
+#[cfg(test)]
+use std::io::Write;
 
 use anyhow::{Context, Result, bail, ensure};
 use burn::module::{AutodiffModule, Module, ModuleMapper, ModuleVisitor, Param, ParamId};
 use burn::tensor::activation::{log_softmax, softmax};
-use burn::tensor::{Bool, Device, Int, Tensor, TensorData};
+use burn::tensor::{Bool, Bytes, Device, Int, Tensor, TensorData};
 use burn_optim::{AdamWConfig, GradientsParams, ModuleOptimizer};
-use hermes_llm::{MemoryRouting, ModelDef, Transformer, load_safetensors, save_safetensors};
+use hermes_llm::{MemoryRouting, ModelDef, Transformer, load_safetensors_bytes, save_safetensors};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::optimizer_artifact::save_canonical_module_optimizer;
+use crate::artifact_io::{
+    AuthenticatedDirectorySnapshot, ensure_directory, ensure_real_directory, ensure_regular_file,
+    hash_regular_file as hash_file, read_regular_bounded, sha256_identity, sync_directory,
+    sync_regular_file, validate_sha256_identity, write_new_synced,
+};
+use crate::optimizer_artifact::{
+    canonical_module_optimizer_bytes, save_canonical_module_optimizer,
+};
 use crate::sleep::{
     CommittedCandidate, ConsolidationBackend, ConsolidationTxn, DreamTrial, DreamingBackend,
     GeneratedDream, ImitationConfig, KnowledgeSeedingConfig, RngReservation, SleepProgressSink,
@@ -32,6 +43,19 @@ use crate::sleep::{
 
 const KNOWLEDGE_DEVICE_RNG_DOMAIN: u64 = 0x6b6e_6f77_6c65_6467;
 const IMITATION_DEVICE_RNG_DOMAIN: u64 = 0x696d_6974_6174_696f;
+
+// These limits apply at the algorithm-neutral tensor boundary as well as in
+// the first-party rollout adapters. An injected adapter is still untrusted
+// operational input: without aggregate ceilings it could turn one sleep
+// transaction into billions of model tokens or edit-distance cells.
+const MAX_TENSOR_ROLLOUT_BATCH_ROWS: usize = 4_096;
+const MAX_TENSOR_FORWARD_TOKENS: usize = 65_536;
+const MAX_TENSOR_SUBPHASE_TOKENS: usize = 16 * 1024 * 1024;
+const MAX_TENSOR_ROLLOUT_BATCHES: usize = 4_096;
+pub(crate) const MAX_TENSOR_IMITATION_GROUPS: usize = 256;
+const MAX_TENSOR_EDIT_DISTANCE_CELLS: usize = 64 * 1024 * 1024;
+const MAX_TENSOR_GRPO_PADDED_TOKENS: usize = 1024 * 1024;
+const FINGERPRINT_CHUNK_VALUES: usize = 4_096;
 
 fn tensor_subphase_seed(txn: &ConsolidationTxn, reservation: RngReservation, domain: u64) -> u64 {
     let mut value = domain
@@ -56,7 +80,7 @@ pub struct ImmutableTransformerCheckpoint {
 impl ImmutableTransformerCheckpoint {
     pub fn validate(&self) -> Result<()> {
         ensure!(!self.uri.trim().is_empty(), "checkpoint URI is empty");
-        validate_sha256(&self.sha256)
+        validate_sha256_identity(&self.sha256, "checkpoint identity")
     }
 }
 
@@ -125,17 +149,14 @@ pub trait ProspectiveTransformerUpdate {
     ) -> Result<()>;
 }
 
-#[derive(Default)]
-struct ParameterFingerprintVisitor {
+struct ParameterFingerprintVisitor<'a> {
+    included: &'a BTreeSet<u64>,
     values: BTreeMap<u64, [u8; 32]>,
     failure: Option<String>,
 }
 
-impl ParameterFingerprintVisitor {
-    fn record(&mut self, id: ParamId, kind: u8, shape: &[usize], bytes: &[u8]) {
-        if self.failure.is_some() {
-            return;
-        }
+impl ParameterFingerprintVisitor<'_> {
+    fn hasher(&self, kind: u8, shape: &[usize]) -> Sha256 {
         let mut hash = Sha256::new();
         hash.update(b"hermes-parameter-fingerprint-v1\0");
         hash.update([kind]);
@@ -143,7 +164,13 @@ impl ParameterFingerprintVisitor {
         for dimension in shape {
             hash.update((*dimension as u64).to_le_bytes());
         }
-        hash.update(bytes);
+        hash
+    }
+
+    fn record(&mut self, id: ParamId, hash: Sha256) {
+        if self.failure.is_some() {
+            return;
+        }
         let digest: [u8; 32] = hash.finalize().into();
         if self.values.insert(id.val(), digest).is_some() {
             self.failure = Some(format!("model repeats parameter ID {}", id.val()));
@@ -151,63 +178,92 @@ impl ParameterFingerprintVisitor {
     }
 }
 
-impl ModuleVisitor for ParameterFingerprintVisitor {
+impl ModuleVisitor for ParameterFingerprintVisitor<'_> {
     fn visit_float<const D: usize>(&mut self, parameter: &Param<Tensor<D>>) {
+        if !self.included.contains(&parameter.id.val()) {
+            return;
+        }
         match parameter.val().into_data().convert::<f32>().to_vec::<f32>() {
             Ok(values) => {
-                let bytes = values
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect::<Vec<_>>();
-                self.record(parameter.id, b'f', &parameter.shape().dims::<D>(), &bytes);
+                let mut hash = self.hasher(b'f', &parameter.shape().dims::<D>());
+                let mut bytes =
+                    Vec::with_capacity(FINGERPRINT_CHUNK_VALUES * std::mem::size_of::<f32>());
+                for chunk in values.chunks(FINGERPRINT_CHUNK_VALUES) {
+                    bytes.clear();
+                    bytes.extend(chunk.iter().flat_map(|value| value.to_le_bytes()));
+                    hash.update(&bytes);
+                }
+                self.record(parameter.id, hash);
             }
             Err(error) => self.failure = Some(error.to_string()),
         }
     }
 
     fn visit_int<const D: usize>(&mut self, parameter: &Param<Tensor<D, Int>>) {
+        if !self.included.contains(&parameter.id.val()) {
+            return;
+        }
         match parameter.val().into_data().to_vec::<i64>() {
             Ok(values) => {
-                let bytes = values
-                    .iter()
-                    .flat_map(|value| value.to_le_bytes())
-                    .collect::<Vec<_>>();
-                self.record(parameter.id, b'i', &parameter.shape().dims::<D>(), &bytes);
+                let mut hash = self.hasher(b'i', &parameter.shape().dims::<D>());
+                let mut bytes =
+                    Vec::with_capacity(FINGERPRINT_CHUNK_VALUES * std::mem::size_of::<i64>());
+                for chunk in values.chunks(FINGERPRINT_CHUNK_VALUES) {
+                    bytes.clear();
+                    bytes.extend(chunk.iter().flat_map(|value| value.to_le_bytes()));
+                    hash.update(&bytes);
+                }
+                self.record(parameter.id, hash);
             }
             Err(error) => self.failure = Some(error.to_string()),
         }
     }
 
     fn visit_bool<const D: usize>(&mut self, parameter: &Param<Tensor<D, Bool>>) {
+        if !self.included.contains(&parameter.id.val()) {
+            return;
+        }
         match parameter.val().into_data().to_vec::<bool>() {
             Ok(values) => {
-                let values = values.into_iter().map(u8::from).collect::<Vec<_>>();
-                self.record(parameter.id, b'b', &parameter.shape().dims::<D>(), &values);
+                let mut hash = self.hasher(b'b', &parameter.shape().dims::<D>());
+                let mut bytes = Vec::with_capacity(FINGERPRINT_CHUNK_VALUES);
+                for chunk in values.chunks(FINGERPRINT_CHUNK_VALUES) {
+                    bytes.clear();
+                    bytes.extend(chunk.iter().copied().map(u8::from));
+                    hash.update(&bytes);
+                }
+                self.record(parameter.id, hash);
             }
             Err(error) => self.failure = Some(error.to_string()),
         }
     }
 }
 
-fn parameter_fingerprints(model: &Transformer) -> Result<BTreeMap<u64, [u8; 32]>> {
-    let mut visitor = ParameterFingerprintVisitor::default();
+fn parameter_fingerprints(
+    model: &Transformer,
+    included: &BTreeSet<u64>,
+) -> Result<BTreeMap<u64, [u8; 32]>> {
+    let mut visitor = ParameterFingerprintVisitor {
+        included,
+        values: BTreeMap::new(),
+        failure: None,
+    };
     model.visit(&mut visitor);
     if let Some(error) = visitor.failure {
         bail!("fingerprinting prospective update parameters: {error}");
     }
-    ensure!(!visitor.values.is_empty(), "model exposes no parameters");
+    ensure!(
+        visitor.values.keys().copied().eq(included.iter().copied()),
+        "prospective update fingerprint scope contains a parameter absent from the model"
+    );
     Ok(visitor.values)
 }
 
-/// Canonical scope and identity check for a prospective sender update. Only
-/// the sender tier's base plus currently active reserve slots may change.
-/// Dormant slots, slower/faster tiers, embeddings, mixers, and heads are
-/// immutable at this boundary.
-pub fn prospective_update_hash(
+fn prospective_update_scope(
     teacher: &Transformer,
     student: &Transformer,
     sender: usize,
-) -> Result<String> {
+) -> Result<(BTreeSet<u64>, BTreeSet<u64>)> {
     ensure!(
         serde_json::to_vec(teacher.config())? == serde_json::to_vec(student.config())?,
         "prospective student changed model topology"
@@ -230,6 +286,23 @@ pub fn prospective_update_hash(
                 }),
         "prospective student changed memory masks, generations, or topology"
     );
+    let teacher_parameter_ids = burn::module::list_param_ids(teacher);
+    let teacher_parameters = teacher_parameter_ids
+        .iter()
+        .map(|id| id.val())
+        .collect::<BTreeSet<_>>();
+    let student_parameter_ids = burn::module::list_param_ids(student);
+    let student_parameters = student_parameter_ids
+        .iter()
+        .map(|id| id.val())
+        .collect::<BTreeSet<_>>();
+    ensure!(
+        !teacher_parameters.is_empty()
+            && teacher_parameters.len() == teacher_parameter_ids.len()
+            && student_parameters.len() == student_parameter_ids.len()
+            && teacher_parameters == student_parameters,
+        "prospective student parameter IDs differ from teacher"
+    );
     let mut eligible = teacher
         .memory_tier_base_parameter_ids_all_layers(sender)?
         .into_iter()
@@ -245,38 +318,86 @@ pub fn prospective_update_hash(
         !eligible.is_empty(),
         "sender update has no eligible parameters"
     );
-
-    let teacher = parameter_fingerprints(teacher)?;
-    let student = parameter_fingerprints(student)?;
     ensure!(
-        teacher.keys().eq(student.keys()),
-        "prospective student parameter IDs differ from teacher"
+        eligible.is_subset(&teacher_parameters),
+        "sender update scope contains a parameter absent from the model"
     );
-    let changed = teacher
-        .iter()
-        .filter_map(|(id, before)| {
-            let after = student.get(id).expect("parameter key sets checked");
-            (before != after).then_some((*id, *before, *after))
-        })
-        .collect::<Vec<_>>();
-    ensure!(!changed.is_empty(), "prospective sender update is empty");
-    let escaped = changed
-        .iter()
-        .filter_map(|(id, _, _)| (!eligible.contains(id)).then_some(*id))
-        .collect::<Vec<_>>();
+    Ok((eligible, teacher_parameters))
+}
+
+fn prospective_update_hash_inner(
+    teacher: &Transformer,
+    student: &Transformer,
+    sender: usize,
+    validate_outside_scope: bool,
+) -> Result<String> {
+    let (eligible, all_parameters) = prospective_update_scope(teacher, student, sender)?;
+    if validate_outside_scope {
+        let outside = all_parameters
+            .difference(&eligible)
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let teacher_outside = parameter_fingerprints(teacher, &outside)?;
+        let student_outside = parameter_fingerprints(student, &outside)?;
+        let escaped = teacher_outside
+            .iter()
+            .filter_map(|(id, before)| (student_outside.get(id) != Some(before)).then_some(*id))
+            .collect::<Vec<_>>();
+        ensure!(
+            escaped.is_empty(),
+            "prospective update escaped sender tier {sender}: parameter IDs {escaped:?}"
+        );
+    }
+
+    // The hot-path identity contains only tensors which the independently
+    // scoped sender optimizer is allowed to mutate. In particular, this avoids
+    // copying embeddings, mixers, heads, and every other memory tier back to
+    // the host merely to derive one due-tier receipt.
+    let teacher_eligible = parameter_fingerprints(teacher, &eligible)?;
+    let student_eligible = parameter_fingerprints(student, &eligible)?;
     ensure!(
-        escaped.is_empty(),
-        "prospective update escaped sender tier {sender}: parameter IDs {escaped:?}"
+        teacher_eligible
+            .iter()
+            .any(|(id, before)| student_eligible.get(id) != Some(before)),
+        "prospective sender update is empty"
     );
     let mut hash = Sha256::new();
-    hash.update(b"hermes-prospective-update-v1\0");
+    hash.update(b"hermes-prospective-update-v2\0");
     hash.update((sender as u64).to_le_bytes());
-    for (id, before, after) in changed {
+    hash.update((eligible.len() as u64).to_le_bytes());
+    for (id, before) in teacher_eligible {
+        let after = student_eligible
+            .get(&id)
+            .expect("eligible parameter sets checked");
         hash.update(id.to_le_bytes());
         hash.update(before);
         hash.update(after);
     }
     Ok(format!("sha256:{:x}", hash.finalize()))
+}
+
+/// Bind the exact sender tier's base plus currently active reserve slots.
+/// The wake hot path constructs its student with an independently scoped
+/// optimizer, so hashing unrelated model tensors here would add a full-model
+/// device-to-host synchronization to every due update.
+pub fn prospective_update_hash(
+    teacher: &Transformer,
+    student: &Transformer,
+    sender: usize,
+) -> Result<String> {
+    prospective_update_hash_inner(teacher, student, sender, false)
+}
+
+/// Validate full-model parity outside the sender scope and return the same
+/// sender-only identity. This expensive check belongs at a consolidation
+/// transaction boundary, where updates may come from an injected adapter, not
+/// on ordinary wake-only optimizer updates.
+fn prospective_update_hash_at_boundary(
+    teacher: &Transformer,
+    student: &Transformer,
+    sender: usize,
+) -> Result<String> {
+    prospective_update_hash_inner(teacher, student, sender, true)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -297,6 +418,14 @@ impl TokenRolloutBatch {
             "rollout shape [{batch}, {sequence}] disagrees with {} tokens",
             token_ids.len()
         );
+        ensure!(
+            batch <= MAX_TENSOR_ROLLOUT_BATCH_ROWS,
+            "rollout batch exceeds the {MAX_TENSOR_ROLLOUT_BATCH_ROWS}-row operational limit"
+        );
+        ensure!(
+            token_ids.len() <= MAX_TENSOR_FORWARD_TOKENS,
+            "rollout batch exceeds the {MAX_TENSOR_FORWARD_TOKENS}-token operational limit"
+        );
         Ok(Self {
             batch,
             sequence,
@@ -306,13 +435,27 @@ impl TokenRolloutBatch {
 
     fn validate_for(&self, model: &Transformer) -> Result<()> {
         ensure!(
+            self.batch > 0
+                && self.sequence > 0
+                && self.batch.checked_mul(self.sequence) == Some(self.token_ids.len()),
+            "rollout dimensions no longer match its token storage"
+        );
+        ensure!(
+            self.batch <= MAX_TENSOR_ROLLOUT_BATCH_ROWS,
+            "rollout batch exceeds the {MAX_TENSOR_ROLLOUT_BATCH_ROWS}-row operational limit"
+        );
+        ensure!(
+            self.token_ids.len() <= MAX_TENSOR_FORWARD_TOKENS,
+            "rollout batch exceeds the {MAX_TENSOR_FORWARD_TOKENS}-token operational limit"
+        );
+        ensure!(
             self.sequence <= model.config().max_seq_len,
             "rollout exceeds model sequence limit"
         );
         ensure!(
             self.token_ids
                 .iter()
-                .all(|id| *id >= 0 && (*id as usize) < model.config().vocab_size),
+                .all(|id| usize::try_from(*id).is_ok_and(|id| id < model.config().vocab_size)),
             "rollout contains an out-of-vocabulary token"
         );
         Ok(())
@@ -324,6 +467,31 @@ impl TokenRolloutBatch {
             device,
         )
     }
+}
+
+fn validate_rollout_batches(
+    batches: &[TokenRolloutBatch],
+    model: &Transformer,
+    label: &str,
+) -> Result<u64> {
+    ensure!(
+        batches.len() <= MAX_TENSOR_ROLLOUT_BATCHES,
+        "{label} returned more than {MAX_TENSOR_ROLLOUT_BATCHES} rollout batches"
+    );
+    let mut total_tokens = 0_usize;
+    for batch in batches {
+        batch.validate_for(model)?;
+        total_tokens = total_tokens
+            .checked_add(batch.token_ids.len())
+            .with_context(|| format!("{label} token count overflow"))?;
+        ensure!(
+            total_tokens <= MAX_TENSOR_SUBPHASE_TOKENS,
+            "{label} exceeds the {MAX_TENSOR_SUBPHASE_TOKENS}-token subphase limit"
+        );
+    }
+    total_tokens
+        .try_into()
+        .with_context(|| format!("{label} token count exceeds u64"))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -426,9 +594,15 @@ impl TensorConsolidationConfig {
     pub fn validate(&self) -> Result<()> {
         self.knowledge.validate()?;
         self.imitation.validate()?;
-        validate_sha256(&self.imitation.semantic_judge_hash)?;
-        validate_sha256(&self.retention.evaluator_hash)?;
-        validate_sha256(&self.retention.suite_hash)?;
+        validate_sha256_identity(
+            &self.imitation.semantic_judge_hash,
+            "semantic judge identity",
+        )?;
+        validate_sha256_identity(
+            &self.retention.evaluator_hash,
+            "retention evaluator identity",
+        )?;
+        validate_sha256_identity(&self.retention.suite_hash, "retention suite identity")?;
         ensure!(
             self.retention.max_anchor_forward_kl.is_finite()
                 && self.retention.max_anchor_forward_kl >= 0.0,
@@ -531,7 +705,25 @@ const TENSOR_TXN_STUDENT: &str = "student.safetensors";
 const TENSOR_TXN_OPTIMIZER: &str = "receiver-optimizer.bpk";
 const TENSOR_TXN_UPDATE_PRE: &str = "sender-update-pre.bin";
 const TENSOR_TXN_UPDATE_STAGED: &str = "sender-update-staged.bin";
+const MAX_TENSOR_TXN_MANIFEST_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_TENSOR_TXN_METADATA_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_TENSOR_TXN_MEMBER_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+const TENSOR_TXN_SCHEMA: [&str; 7] = [
+    TENSOR_TXN_MANIFEST,
+    TENSOR_TXN_METADATA,
+    TENSOR_TXN_OPTIMIZER,
+    TENSOR_TXN_STUDENT,
+    TENSOR_TXN_TEACHER,
+    TENSOR_TXN_UPDATE_PRE,
+    TENSOR_TXN_UPDATE_STAGED,
+];
 static TENSOR_TXN_STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TensorLoadStage {
+    AfterCapture,
+    AfterStagedLoad,
+}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -619,7 +811,7 @@ impl TensorTransactionStore {
                 && !recovered.staged_update_state.as_bytes().is_empty(),
             "tensor snapshot is missing prospective-update state"
         );
-        validate_sha256(&recovered.student.update_sha256)?;
+        validate_sha256_identity(&recovered.student.update_sha256, "student update identity")?;
         ensure!(
             recovered.teacher.uri == txn.teacher_checkpoint
                 && recovered.teacher.sha256 == txn.teacher_hash,
@@ -670,15 +862,15 @@ impl TensorTransactionStore {
         let update_pre_path = staging.join(TENSOR_TXN_UPDATE_PRE);
         let update_staged_path = staging.join(TENSOR_TXN_UPDATE_STAGED);
         save_safetensors(&recovered.teacher.model.clone().valid(), &teacher_path)?;
-        sync_regular_file(&teacher_path)?;
+        sync_regular_file(&teacher_path, "tensor transaction teacher")?;
         save_safetensors(
             &recovered.student.checkpoint.model.clone().valid(),
             &student_path,
         )?;
-        sync_regular_file(&student_path)?;
+        sync_regular_file(&student_path, "tensor transaction student")?;
         save_canonical_module_optimizer(&recovered.receiver_optimizer, &optimizer_path)
             .context("saving receiver optimizer state")?;
-        sync_regular_file(&optimizer_path)?;
+        sync_regular_file(&optimizer_path, "tensor transaction optimizer")?;
         write_new_synced(&update_pre_path, recovered.pre_update_state.as_bytes())?;
         write_new_synced(
             &update_staged_path,
@@ -722,7 +914,7 @@ impl TensorTransactionStore {
             files,
         };
         let manifest_bytes = serde_json::to_vec_pretty(&manifest)?;
-        let manifest_sha256 = sha256_bytes(&manifest_bytes);
+        let manifest_sha256 = sha256_identity(&manifest_bytes);
         write_new_synced(&staging.join(TENSOR_TXN_MANIFEST), &manifest_bytes)?;
         sync_directory(&staging)?;
 
@@ -764,14 +956,17 @@ impl TensorTransactionStore {
         device: &Device,
         optimizer: ModuleOptimizer,
     ) -> Result<RecoveredTensorTransaction> {
-        ensure_existing_directory(&self.root, "tensor transaction root")?;
-        ensure_existing_directory(
+        ensure_real_directory(&self.root, "tensor transaction root")?;
+        ensure_real_directory(
             &self.root.join("generations"),
             "tensor transaction generations",
         )?;
         let pointer_path = self.root.join(TENSOR_TXN_POINTER);
-        ensure_regular_file(&pointer_path, "tensor transaction pointer")?;
-        let pointer: TensorTransactionPointer = serde_json::from_slice(&fs::read(&pointer_path)?)?;
+        let pointer: TensorTransactionPointer = serde_json::from_slice(&read_regular_bounded(
+            &pointer_path,
+            MAX_TENSOR_TXN_MANIFEST_BYTES,
+            "tensor transaction pointer",
+        )?)?;
         self.load_pointer(txn, config, device, optimizer, &pointer)
     }
 
@@ -808,8 +1003,20 @@ impl TensorTransactionStore {
         optimizer: ModuleOptimizer,
         pointer: &TensorTransactionPointer,
     ) -> Result<RecoveredTensorTransaction> {
-        ensure_existing_directory(&self.root, "tensor transaction root")?;
-        ensure_existing_directory(
+        self.load_pointer_inner(txn, config, device, optimizer, pointer, |_, _| Ok(()))
+    }
+
+    fn load_pointer_inner(
+        &self,
+        txn: &ConsolidationTxn,
+        config: &ModelDef,
+        device: &Device,
+        optimizer: ModuleOptimizer,
+        pointer: &TensorTransactionPointer,
+        mut stage_hook: impl FnMut(TensorLoadStage, &Path) -> Result<()>,
+    ) -> Result<RecoveredTensorTransaction> {
+        ensure_real_directory(&self.root, "tensor transaction root")?;
+        ensure_real_directory(
             &self.root.join("generations"),
             "tensor transaction generations",
         )?;
@@ -821,10 +1028,12 @@ impl TensorTransactionStore {
             pointer.txn_id == txn.id,
             "tensor transaction pointer belongs to another txn"
         );
-        validate_sha256(&pointer.manifest_sha256)?;
+        validate_sha256_identity(&pointer.manifest_sha256, "tensor manifest identity")?;
         validate_generation_identity(&pointer.generation, &pointer.manifest_sha256)?;
-        let generation = self.root.join("generations").join(&pointer.generation);
-        let metadata = verify_generation(&generation, txn.id, &pointer.manifest_sha256)?;
+        let generation_path = self.root.join("generations").join(&pointer.generation);
+        let (metadata, mut generation) =
+            capture_verified_generation(&generation_path, txn.id, &pointer.manifest_sha256)?;
+        stage_hook(TensorLoadStage::AfterCapture, &generation_path)?;
         ensure!(
             metadata.teacher_uri == txn.teacher_checkpoint
                 && metadata.teacher_sha256 == txn.teacher_hash,
@@ -839,17 +1048,38 @@ impl TensorTransactionStore {
 
         let mut teacher = Transformer::new(config, device)?;
         restore_parameter_ids(&mut teacher, &metadata.teacher_parameter_ids)?;
-        load_safetensors(&mut teacher, generation.join(TENSOR_TXN_TEACHER))?;
+        load_safetensors_bytes(
+            &mut teacher,
+            generation.take(TENSOR_TXN_TEACHER, MAX_TENSOR_TXN_MEMBER_BYTES)?,
+            "authenticated tensor-sleep teacher",
+        )?;
         let mut student = Transformer::new(config, device)?;
         restore_parameter_ids(&mut student, &metadata.student_parameter_ids)?;
-        load_safetensors(&mut student, generation.join(TENSOR_TXN_STUDENT))?;
+        load_safetensors_bytes(
+            &mut student,
+            generation.take(TENSOR_TXN_STUDENT, MAX_TENSOR_TXN_MEMBER_BYTES)?,
+            "authenticated tensor-sleep student",
+        )?;
+        let optimizer_bytes = generation.take(TENSOR_TXN_OPTIMIZER, MAX_TENSOR_TXN_MEMBER_BYTES)?;
+        let optimizer_bytes_len = optimizer_bytes.len();
+        let optimizer_sha256 = sha256_identity(&optimizer_bytes);
         let optimizer = optimizer
-            .load(generation.join(TENSOR_TXN_OPTIMIZER))
-            .context("loading receiver optimizer state")?;
-        let pre_update_state =
-            ProspectiveUpdateSnapshot::new(fs::read(generation.join(TENSOR_TXN_UPDATE_PRE))?)?;
-        let staged_update_state =
-            ProspectiveUpdateSnapshot::new(fs::read(generation.join(TENSOR_TXN_UPDATE_STAGED))?)?;
+            .from_bytes(Bytes::from_bytes_vec(optimizer_bytes))
+            .context("loading authenticated receiver optimizer state")?;
+        let canonical_optimizer = canonical_module_optimizer_bytes(&optimizer)?.to_vec();
+        ensure!(
+            canonical_optimizer.len() == optimizer_bytes_len
+                && sha256_identity(&canonical_optimizer) == optimizer_sha256,
+            "receiver optimizer bytes are non-canonical or failed exact restore"
+        );
+        let pre_update_state = ProspectiveUpdateSnapshot::new(
+            generation.take(TENSOR_TXN_UPDATE_PRE, MAX_TENSOR_TXN_MEMBER_BYTES)?,
+        )?;
+        let staged_update_state = ProspectiveUpdateSnapshot::new(
+            generation.take(TENSOR_TXN_UPDATE_STAGED, MAX_TENSOR_TXN_MEMBER_BYTES)?,
+        )?;
+        stage_hook(TensorLoadStage::AfterStagedLoad, &generation_path)?;
+        generation.ensure_still_published()?;
         Ok(RecoveredTensorTransaction {
             txn_id: txn.id,
             teacher: ImmutableTransformerCheckpoint {
@@ -873,81 +1103,6 @@ impl TensorTransactionStore {
             diagnostics: metadata.diagnostics,
         })
     }
-}
-
-fn ensure_directory(path: &Path, label: &str) -> Result<()> {
-    fs::create_dir_all(path).with_context(|| format!("creating {label} {}", path.display()))?;
-    let metadata = fs::symlink_metadata(path)?;
-    ensure!(
-        metadata.is_dir() && !metadata.file_type().is_symlink(),
-        "{label} is not a real directory"
-    );
-    Ok(())
-}
-
-fn ensure_existing_directory(path: &Path, label: &str) -> Result<()> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("{label} {} is missing", path.display()))?;
-    ensure!(
-        metadata.is_dir() && !metadata.file_type().is_symlink(),
-        "{label} is not a real directory"
-    );
-    Ok(())
-}
-
-fn ensure_regular_file(path: &Path, label: &str) -> Result<()> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("{label} {} is missing", path.display()))?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "{label} is not a regular non-symlink file"
-    );
-    Ok(())
-}
-
-fn sync_regular_file(path: &Path) -> Result<()> {
-    ensure_regular_file(path, "tensor transaction file")?;
-    File::open(path)?.sync_all()?;
-    Ok(())
-}
-
-fn sync_directory(path: &Path) -> Result<()> {
-    File::open(path)?.sync_all()?;
-    Ok(())
-}
-
-fn write_new_synced(path: &Path, bytes: &[u8]) -> Result<()> {
-    let mut file = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)
-        .with_context(|| format!("creating immutable file {}", path.display()))?;
-    file.write_all(bytes)?;
-    file.sync_all()?;
-    Ok(())
-}
-
-fn hash_file(path: &Path) -> Result<(u64, String)> {
-    ensure_regular_file(path, "tensor transaction artifact")?;
-    let mut file = File::open(path)?;
-    let mut hash = Sha256::new();
-    let mut bytes = 0_u64;
-    let mut buffer = [0_u8; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        bytes = bytes
-            .checked_add(read as u64)
-            .context("tensor transaction artifact length overflow")?;
-        hash.update(&buffer[..read]);
-    }
-    Ok((bytes, format!("sha256:{:x}", hash.finalize())))
-}
-
-fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("sha256:{:x}", Sha256::digest(bytes))
 }
 
 fn transaction_file(root: &Path, name: &str) -> Result<TensorTransactionFile> {
@@ -975,12 +1130,12 @@ fn validate_generation_name(name: &str) -> Result<()> {
     let digest = name
         .strip_prefix("sha256-")
         .context("tensor generation must use sha256-<64 lowercase hex>")?;
-    validate_sha256(&format!("sha256:{digest}"))
+    validate_sha256_identity(&format!("sha256:{digest}"), "tensor generation identity")
 }
 
 fn validate_generation_identity(name: &str, manifest_sha256: &str) -> Result<()> {
     validate_generation_name(name)?;
-    validate_sha256(manifest_sha256)?;
+    validate_sha256_identity(manifest_sha256, "tensor manifest identity")?;
     let generation_digest = name
         .strip_prefix("sha256-")
         .expect("validated tensor generation has a prefix");
@@ -994,58 +1149,26 @@ fn validate_generation_identity(name: &str, manifest_sha256: &str) -> Result<()>
     Ok(())
 }
 
-fn verify_generation(
+fn capture_verified_generation(
     generation: &Path,
     txn_id: u64,
     expected_manifest_hash: &str,
-) -> Result<TensorTransactionMetadata> {
-    let metadata = fs::symlink_metadata(generation)
-        .with_context(|| format!("tensor generation {} is missing", generation.display()))?;
+) -> Result<(TensorTransactionMetadata, AuthenticatedDirectorySnapshot)> {
+    let mut captured = AuthenticatedDirectorySnapshot::capture(
+        generation,
+        &TENSOR_TXN_SCHEMA,
+        "tensor transaction generation",
+    )?;
+    let manifest_bytes =
+        captured.read_bounded(TENSOR_TXN_MANIFEST, MAX_TENSOR_TXN_MANIFEST_BYTES)?;
     ensure!(
-        metadata.is_dir() && !metadata.file_type().is_symlink(),
-        "tensor generation is not a real directory"
-    );
-    let manifest_path = generation.join(TENSOR_TXN_MANIFEST);
-    ensure_regular_file(&manifest_path, "tensor transaction manifest")?;
-    let manifest_bytes = fs::read(&manifest_path)?;
-    ensure!(
-        sha256_bytes(&manifest_bytes) == expected_manifest_hash,
+        sha256_identity(&manifest_bytes) == expected_manifest_hash,
         "tensor transaction manifest hash mismatch"
     );
     let manifest: TensorTransactionManifest = serde_json::from_slice(&manifest_bytes)?;
     ensure!(
         manifest.version == TENSOR_TXN_MANIFEST_VERSION && manifest.txn_id == txn_id,
         "tensor transaction manifest identity/version mismatch"
-    );
-    let expected_names = [
-        TENSOR_TXN_MANIFEST,
-        TENSOR_TXN_METADATA,
-        TENSOR_TXN_OPTIMIZER,
-        TENSOR_TXN_STUDENT,
-        TENSOR_TXN_TEACHER,
-        TENSOR_TXN_UPDATE_PRE,
-        TENSOR_TXN_UPDATE_STAGED,
-    ]
-    .into_iter()
-    .map(str::to_owned)
-    .collect::<BTreeSet<_>>();
-    let mut observed_names = BTreeSet::new();
-    for entry in fs::read_dir(generation)? {
-        let entry = entry?;
-        let name = entry
-            .file_name()
-            .into_string()
-            .map_err(|_| anyhow::anyhow!("tensor generation contains non-UTF-8 name"))?;
-        let entry_metadata = fs::symlink_metadata(entry.path())?;
-        ensure!(
-            entry_metadata.is_file() && !entry_metadata.file_type().is_symlink(),
-            "tensor generation contains a non-file or symlink"
-        );
-        observed_names.insert(name);
-    }
-    ensure!(
-        observed_names == expected_names,
-        "tensor generation file set differs from its fixed schema"
     );
     ensure!(
         manifest.files.len() == 6
@@ -1068,24 +1191,27 @@ fn verify_generation(
             ),
             "tensor transaction manifest contains an unsafe path"
         );
-        validate_sha256(&file.sha256)?;
-        let (bytes, hash) = hash_file(&generation.join(&file.path))?;
+        validate_sha256_identity(&file.sha256, "tensor manifest member identity")?;
         ensure!(
-            bytes == file.bytes && hash == file.sha256,
-            "tensor transaction artifact `{}` failed authentication",
+            file.bytes <= MAX_TENSOR_TXN_MEMBER_BYTES,
+            "tensor transaction artifact `{}` exceeds the per-member size limit",
             file.path
         );
+        captured.verify(&file.path, file.bytes, &file.sha256)?;
     }
-    let transaction_path = generation.join(TENSOR_TXN_METADATA);
-    let transaction: TensorTransactionMetadata =
-        serde_json::from_slice(&fs::read(&transaction_path)?)?;
+    let metadata_bytes =
+        captured.read_bounded(TENSOR_TXN_METADATA, MAX_TENSOR_TXN_METADATA_BYTES)?;
+    let transaction: TensorTransactionMetadata = serde_json::from_slice(&metadata_bytes)?;
     ensure!(
         transaction.version == TENSOR_TXN_STORE_VERSION && transaction.txn_id == txn_id,
         "tensor transaction metadata identity/version mismatch"
     );
-    validate_sha256(&transaction.teacher_sha256)?;
-    validate_sha256(&transaction.student_sha256)?;
-    validate_sha256(&transaction.prospective_update_sha256)?;
+    validate_sha256_identity(&transaction.teacher_sha256, "teacher identity")?;
+    validate_sha256_identity(&transaction.student_sha256, "student identity")?;
+    validate_sha256_identity(
+        &transaction.prospective_update_sha256,
+        "prospective update identity",
+    )?;
     ensure!(
         !transaction.teacher_uri.trim().is_empty() && !transaction.student_uri.trim().is_empty(),
         "stored tensor transaction has an empty checkpoint URI"
@@ -1101,7 +1227,18 @@ fn verify_generation(
         transaction.retention_result,
         &transaction.diagnostics,
     )?;
-    Ok(transaction)
+    Ok((transaction, captured))
+}
+
+fn verify_generation(
+    generation: &Path,
+    txn_id: u64,
+    expected_manifest_hash: &str,
+) -> Result<TensorTransactionMetadata> {
+    let (metadata, captured) =
+        capture_verified_generation(generation, txn_id, expected_manifest_hash)?;
+    captured.ensure_still_published()?;
+    Ok(metadata)
 }
 
 fn publish_pointer(root: &Path, pointer: &TensorTransactionPointer) -> Result<()> {
@@ -1263,12 +1400,20 @@ impl ModuleMapper for RestoreParameterIds<'_> {
 /// optimizer snapshots therefore pin this companion identity vector.
 pub fn restore_parameter_ids(model: &mut Transformer, ids: &[u64]) -> Result<()> {
     ensure!(
+        ids.iter().copied().collect::<BTreeSet<_>>().len() == ids.len(),
+        "tensor transaction repeats a stored parameter ID"
+    );
+    ensure!(
         ids.len() == burn::module::list_param_ids(model).len(),
         "tensor transaction parameter-ID topology differs from model"
     );
     let mut mapper = RestoreParameterIds { ids: ids.iter() };
     *model = model.clone().map(&mut mapper);
     ensure!(mapper.ids.next().is_none(), "too many stored parameter IDs");
+    ensure!(
+        parameter_ids(model) == ids,
+        "tensor transaction failed to restore its exact parameter-ID ordering"
+    );
     Ok(())
 }
 
@@ -1434,7 +1579,7 @@ where
             &recovered.diagnostics,
         )?;
         let statuses = recovered.student.checkpoint.model.memory_slot_statuses();
-        self.receiver_ids = if txn.terminal {
+        let receiver_ids = if txn.terminal {
             recovered
                 .student
                 .checkpoint
@@ -1454,7 +1599,7 @@ where
                 .flat_map(|s| s.parameter_ids.clone())
                 .collect()
         };
-        self.reclaimed_sender_ids = statuses
+        let reclaimed_sender_ids: Vec<ParamId> = statuses
             .iter()
             .filter(|status| {
                 status.tier == txn.sender
@@ -1464,7 +1609,7 @@ where
             .flat_map(|status| status.parameter_ids.clone())
             .collect();
         ensure!(
-            txn.sender_slots_to_reset.is_empty() || !self.reclaimed_sender_ids.is_empty(),
+            txn.sender_slots_to_reset.is_empty() || !reclaimed_sender_ids.is_empty(),
             "recovered student has not reclaimed its planned sender slots"
         );
         // Restore the wake-side optimizer/accumulator only after all tensor
@@ -1478,6 +1623,8 @@ where
         self.pre_update_state = Some(recovered.pre_update_state);
         self.staged_update_state = Some(recovered.staged_update_state);
         self.receiver_optimizer = recovered.receiver_optimizer;
+        self.receiver_ids = receiver_ids;
+        self.reclaimed_sender_ids = reclaimed_sender_ids;
         self.stages = recovered.completed;
         self.retention = recovered.retention_result;
         self.diagnostics = recovered.diagnostics;
@@ -1618,14 +1765,16 @@ where
             &group.candidates,
             max_tokens,
             &self.device,
-        )?;
+        )?
+        .detach();
         let reference_log_probs = padded_group_log_probabilities(
             &teacher,
             &group.prefix,
             &group.candidates,
             max_tokens,
             &self.device,
-        )?;
+        )?
+        .detach();
         let active_mask = Tensor::<2>::from_data(
             TensorData::new(
                 group
@@ -1714,6 +1863,14 @@ where
     E: RetentionEvaluator,
     P: AtomicCandidatePublisher,
 {
+    fn knowledge_rng_count(&self) -> Result<u64> {
+        self.config.knowledge.rollout_count_u64()
+    }
+
+    fn imitation_rng_count(&self) -> Result<u64> {
+        self.config.imitation.group_size_u64()
+    }
+
     fn compute_prospective_update(&mut self, txn: &ConsolidationTxn) -> Result<()> {
         if self.stages.contains(&TensorStage::Prospective) {
             return Ok(());
@@ -1738,10 +1895,13 @@ where
         let staged = (|| {
             let student = self.updates.stage(txn, &teacher.model)?;
             student.checkpoint.validate()?;
-            validate_sha256(&student.update_sha256)?;
-            let derived_update =
-                prospective_update_hash(&teacher.model, &student.checkpoint.model, txn.sender)
-                    .context("validating prospective sender update scope")?;
+            validate_sha256_identity(&student.update_sha256, "student update identity")?;
+            let derived_update = prospective_update_hash_at_boundary(
+                &teacher.model,
+                &student.checkpoint.model,
+                txn.sender,
+            )
+            .context("validating prospective sender update scope")?;
             ensure!(
                 student.checkpoint.uri == txn.student_checkpoint
                     && student.checkpoint.sha256 == txn.student_hash,
@@ -1844,6 +2004,7 @@ where
             KNOWLEDGE_DEVICE_RNG_DOMAIN,
         ));
         let result = (|| {
+            let mut rollout_tokens = 0_u64;
             for (owner, count) in [
                 (
                     RolloutOwner::Teacher,
@@ -1865,6 +2026,17 @@ where
                     batches.len() == count,
                     "rollout source returned {} {owner:?} batches, expected {count}",
                     batches.len()
+                );
+                rollout_tokens = rollout_tokens
+                    .checked_add(validate_rollout_batches(
+                        &batches,
+                        &model,
+                        "knowledge rollout source",
+                    )?)
+                    .context("knowledge rollout token count overflow")?;
+                ensure!(
+                    rollout_tokens <= MAX_TENSOR_SUBPHASE_TOKENS as u64,
+                    "knowledge rollouts exceed the {MAX_TENSOR_SUBPHASE_TOKENS}-token subphase limit"
                 );
                 for batch in &batches {
                     self.optimize_kl(txn, batch)?;
@@ -1907,6 +2079,12 @@ where
             self.config.imitation.grpo_group_size,
         )?;
         ensure!(!groups.is_empty(), "imitation source returned no groups");
+        validate_imitation_groups(
+            &groups,
+            &student_snapshot,
+            self.config.imitation.grpo_group_size,
+            self.config.imitation.maximum_edit_distance,
+        )?;
         let old_student = self.student.clone();
         let old_optimizer = self.receiver_optimizer.clone();
         let old_diagnostics = self.diagnostics;
@@ -1939,6 +2117,7 @@ where
             !anchors.is_empty(),
             "retention evaluator returned no anchors"
         );
+        validate_rollout_batches(&anchors, &teacher, "retention anchor evaluator")?;
         let mut anchor_kl = 0.0;
         for batch in &anchors {
             anchor_kl += forward_kl_value(
@@ -2115,12 +2294,7 @@ where
                 persist_tensor_boundary(state, backend, store, progress)?;
             }
             crate::sleep::SleepPhase::KnowledgeSeeding => {
-                state.reserve_knowledge_rng(
-                    0,
-                    (backend.config.knowledge.teacher_rollouts
-                        + backend.config.knowledge.detached_student_rollouts)
-                        as u64,
-                )?;
+                state.reserve_knowledge_rng(0, backend.config.knowledge.rollout_count_u64()?)?;
                 progress.persist(state)?;
                 let current_txn = state.pending.clone().expect("transaction checked above");
                 backend.knowledge_seed(&current_txn)?;
@@ -2128,7 +2302,7 @@ where
                 persist_tensor_boundary(state, backend, store, progress)?;
             }
             crate::sleep::SleepPhase::Imitation => {
-                state.reserve_imitation_rng(0, backend.config.imitation.grpo_group_size as u64)?;
+                state.reserve_imitation_rng(0, backend.config.imitation.group_size_u64()?)?;
                 progress.persist(state)?;
                 let current_txn = state.pending.clone().expect("transaction checked above");
                 backend.learn_to_imitate(&current_txn)?;
@@ -2168,8 +2342,10 @@ where
         Ok(true) => Ok(true),
         Ok(false) => {
             backend.restore_teacher(&txn)?;
-            state.rollback()?;
-            progress.persist(state)?;
+            let mut restored = state.clone();
+            restored.rollback()?;
+            progress.persist(&restored)?;
+            *state = restored;
             Ok(false)
         }
         Err(error) => {
@@ -2182,15 +2358,17 @@ where
                     "tensor consolidation committed but state publication failed; retry persistence",
                 ));
             }
-            let restore = backend.restore_teacher(&txn);
-            state.rollback()?;
-            let persist = progress.persist(state);
-            if let Err(restore_error) = restore {
+            if let Err(restore_error) = backend.restore_teacher(&txn) {
                 bail!(
                     "tensor consolidation failed: {error:#}; teacher restore failed: {restore_error:#}"
                 );
             }
-            persist.context("persisting tensor consolidation rollback")?;
+            let mut restored = state.clone();
+            restored.rollback()?;
+            progress
+                .persist(&restored)
+                .context("persisting tensor consolidation rollback")?;
+            *state = restored;
             Err(error)
         }
     }
@@ -2267,8 +2445,8 @@ fn forward_kl_tensor(
     let teacher_projector = teacher.prepare_selected_logits(input.clone(), positions.clone());
     let student_projector = student.prepare_selected_logits(input, positions);
     let mut total: Option<Tensor<1>> = None;
-    let mut teacher_entropy = 0.0_f32;
-    let mut student_entropy = 0.0_f32;
+    let mut teacher_entropy: Option<Tensor<1>> = None;
+    let mut student_entropy: Option<Tensor<1>> = None;
     for start in (0..count).step_by(chunk_tokens) {
         let end = (start + chunk_tokens).min(count);
         let chunk_weight = (end - start) as f32 / count as f32;
@@ -2282,33 +2460,49 @@ fn forward_kl_tensor(
             .sum_dim(1)
             .mean()
             .neg()
-            .into_data()
-            .convert::<f32>()
-            .to_vec::<f32>()
-            .context("reading teacher entropy metric")?[0];
+            .mul_scalar(chunk_weight);
         let student_entropy_chunk = (student_probability * student_log.clone().detach())
             .sum_dim(1)
             .mean()
             .neg()
-            .into_data()
-            .convert::<f32>()
-            .to_vec::<f32>()
-            .context("reading student entropy metric")?[0];
-        teacher_entropy += teacher_entropy_chunk * chunk_weight;
-        student_entropy += student_entropy_chunk * chunk_weight;
+            .mul_scalar(chunk_weight);
+        teacher_entropy = Some(match teacher_entropy {
+            Some(sum) => sum + teacher_entropy_chunk,
+            None => teacher_entropy_chunk,
+        });
+        student_entropy = Some(match student_entropy {
+            Some(sum) => sum + student_entropy_chunk,
+            None => student_entropy_chunk,
+        });
         let loss = (teacher_probability * (teacher_log - student_log))
             .sum_dim(1)
             .mean()
             .mul_scalar(temperature * temperature * chunk_weight);
-        total = Some(total.map_or(loss.clone(), |sum| sum + loss));
+        total = Some(match total {
+            Some(sum) => sum + loss,
+            None => loss,
+        });
     }
     let total = total.context("empty KL rollout")?;
-    let value = total
-        .clone()
-        .into_data()
-        .convert::<f32>()
-        .to_vec::<f32>()
-        .context("reading KL scalar")?[0];
+    // Keep chunk metrics on the accelerator and synchronize exactly once.
+    // Reading two entropy scalars inside every chunk otherwise serializes the
+    // projection loop and creates visible GPU idle gaps during consolidation.
+    let metrics = Tensor::cat(
+        vec![
+            total.clone().detach(),
+            teacher_entropy.context("empty teacher entropy")?,
+            student_entropy.context("empty student entropy")?,
+        ],
+        0,
+    )
+    .into_data()
+    .convert::<f32>()
+    .to_vec::<f32>()
+    .context("reading KL and entropy metrics")?;
+    ensure!(metrics.len() == 3, "KL metric tensor has invalid shape");
+    let value = metrics[0];
+    let teacher_entropy = metrics[1];
+    let student_entropy = metrics[2];
     ensure!(
         value.is_finite() && value >= -1e-5,
         "invalid forward KL {value}"
@@ -2331,51 +2525,115 @@ fn forward_kl_tensor(
     ))
 }
 
-fn continuation_token_log_probabilities(
+fn equal_length_continuation_log_probabilities(
     model: &Transformer,
     prefix: &[i64],
-    continuation: &[i64],
+    candidates: &[Vec<i64>],
+    candidate_indices: &[usize],
     device: &Device,
-) -> Result<Tensor<1>> {
+) -> Result<Tensor<2>> {
     ensure!(
-        !prefix.is_empty() && !continuation.is_empty(),
-        "imitation prefix/continuation is empty"
+        !prefix.is_empty() && !candidate_indices.is_empty(),
+        "imitation prefix/candidate bucket is empty"
     );
-    let mut full = prefix.to_vec();
-    full.extend_from_slice(continuation);
+    let continuation_len = candidates[candidate_indices[0]].len();
+    ensure!(continuation_len > 0, "imitation continuation is empty");
     ensure!(
-        full.len() - 1 <= model.config().max_seq_len,
+        candidate_indices
+            .iter()
+            .all(|index| candidates[*index].len() == continuation_len),
+        "imitation length bucket contains mixed continuation lengths"
+    );
+    let input_len = prefix
+        .len()
+        .checked_add(continuation_len)
+        .and_then(|length| length.checked_sub(1))
+        .context("imitation sequence length overflow")?;
+    ensure!(
+        input_len <= model.config().max_seq_len,
         "imitation sequence exceeds model limit"
     );
     ensure!(
-        full.iter()
-            .all(|id| *id >= 0 && (*id as usize) < model.config().vocab_size),
+        prefix
+            .iter()
+            .chain(
+                candidate_indices
+                    .iter()
+                    .flat_map(|index| candidates[*index].iter()),
+            )
+            .all(|id| usize::try_from(*id).is_ok_and(|id| id < model.config().vocab_size)),
         "imitation token is outside vocabulary"
     );
-    let input_len = full.len() - 1;
-    let start = prefix.len() - 1;
+
+    let input_capacity = candidate_indices
+        .len()
+        .checked_mul(input_len)
+        .context("imitation input size overflow")?;
+    let output_capacity = candidate_indices
+        .len()
+        .checked_mul(continuation_len)
+        .context("imitation target size overflow")?;
+    let mut input_ids = Vec::with_capacity(input_capacity);
+    let mut positions = Vec::with_capacity(output_capacity);
+    let mut targets = Vec::with_capacity(output_capacity);
+    for (row, candidate_index) in candidate_indices.iter().copied().enumerate() {
+        let candidate = &candidates[candidate_index];
+        input_ids.extend_from_slice(prefix);
+        input_ids.extend_from_slice(&candidate[..continuation_len - 1]);
+        let row_start = row
+            .checked_mul(input_len)
+            .and_then(|offset| offset.checked_add(prefix.len() - 1))
+            .context("imitation position overflow")?;
+        for position in row_start..row_start + continuation_len {
+            positions.push(
+                i64::try_from(position).context("imitation position exceeds tensor index range")?,
+            );
+        }
+        targets.extend_from_slice(candidate);
+    }
+    ensure!(
+        input_ids.len() == input_capacity
+            && positions.len() == output_capacity
+            && targets.len() == output_capacity,
+        "imitation batch construction produced an invalid shape"
+    );
     let input = Tensor::<2, Int>::from_data(
-        TensorData::new(full[..input_len].to_vec(), [1, input_len]),
+        TensorData::new(input_ids, [candidate_indices.len(), input_len]),
         device,
     );
-    let positions = Tensor::<1, Int>::from_data(
-        TensorData::new(
-            (start..start + continuation.len())
-                .map(|value| value as i64)
-                .collect(),
-            [continuation.len()],
-        ),
-        device,
-    );
-    let targets = Tensor::<1, Int>::from_data(
-        TensorData::new(continuation.to_vec(), [continuation.len()]),
-        device,
-    );
+    let positions =
+        Tensor::<1, Int>::from_data(TensorData::new(positions, [output_capacity]), device);
+    let targets = Tensor::<1, Int>::from_data(TensorData::new(targets, [output_capacity]), device);
     Ok(
         log_softmax(model.forward_selected_logits(input, positions), 1)
             .gather(1, targets.unsqueeze_dim(1))
-            .reshape([continuation.len()]),
+            .reshape([candidate_indices.len(), continuation_len]),
     )
+}
+
+fn candidate_length_buckets(
+    candidates: &[Vec<i64>],
+    max_tokens: usize,
+) -> Result<BTreeMap<usize, Vec<usize>>> {
+    let mut buckets = BTreeMap::<usize, Vec<usize>>::new();
+    for (index, candidate) in candidates.iter().enumerate() {
+        ensure!(!candidate.is_empty(), "GRPO candidate is empty");
+        ensure!(
+            candidate.len() <= max_tokens,
+            "GRPO candidate exceeds padded token width"
+        );
+        buckets.entry(candidate.len()).or_default().push(index);
+    }
+    Ok(buckets)
+}
+
+fn grpo_rows_per_forward(prefix_len: usize, continuation_len: usize) -> Result<usize> {
+    let input_len = prefix_len
+        .checked_add(continuation_len)
+        .and_then(|length| length.checked_sub(1))
+        .context("imitation sequence length overflow")?;
+    ensure!(input_len > 0, "imitation model input is empty");
+    Ok((MAX_TENSOR_FORWARD_TOKENS / input_len).max(1))
 }
 
 fn padded_group_log_probabilities(
@@ -2387,28 +2645,42 @@ fn padded_group_log_probabilities(
 ) -> Result<Tensor<2>> {
     ensure!(!candidates.is_empty(), "GRPO candidate group is empty");
     ensure!(max_tokens > 0, "GRPO candidates have no tokens");
-    let rows = candidates
-        .iter()
-        .map(|candidate| {
-            ensure!(
-                candidate.len() <= max_tokens,
-                "GRPO candidate exceeds padded token width"
-            );
-            let log_probabilities =
-                continuation_token_log_probabilities(model, prefix, candidate, device)?;
-            let padded = if candidate.len() < max_tokens {
-                Tensor::cat(
-                    vec![
-                        log_probabilities,
-                        Tensor::<1>::zeros([max_tokens - candidate.len()], device),
-                    ],
-                    0,
-                )
-            } else {
-                log_probabilities
-            };
-            Ok(padded.unsqueeze_dim::<2>(0))
-        })
+    let buckets = candidate_length_buckets(candidates, max_tokens)?;
+    let mut rows = (0..candidates.len())
+        .map(|_| None)
+        .collect::<Vec<Option<Tensor<2>>>>();
+    for (continuation_len, candidate_indices) in buckets {
+        let rows_per_forward = grpo_rows_per_forward(prefix.len(), continuation_len)?;
+        for candidate_chunk in candidate_indices.chunks(rows_per_forward) {
+            let bucket = equal_length_continuation_log_probabilities(
+                model,
+                prefix,
+                candidates,
+                candidate_chunk,
+                device,
+            )?;
+            for (bucket_row, candidate_index) in candidate_chunk.iter().copied().enumerate() {
+                let row = bucket
+                    .clone()
+                    .slice([bucket_row..bucket_row + 1, 0..continuation_len]);
+                let padded = if continuation_len < max_tokens {
+                    Tensor::cat(
+                        vec![
+                            row,
+                            Tensor::<2>::zeros([1, max_tokens - continuation_len], device),
+                        ],
+                        1,
+                    )
+                } else {
+                    row
+                };
+                rows[candidate_index] = Some(padded);
+            }
+        }
+    }
+    let rows = rows
+        .into_iter()
+        .map(|row| row.context("GRPO candidate row was not constructed"))
         .collect::<Result<Vec<_>>>()?;
     Ok(Tensor::cat(rows, 0))
 }
@@ -2423,39 +2695,187 @@ fn validate_group(group: &ImitationGroup, model: &Transformer, size: usize) -> R
         "GRPO group has {} candidates, expected {size}",
         group.candidates.len()
     );
+    let valid_token = |token: &i64| {
+        *token >= 0 && usize::try_from(*token).is_ok_and(|id| id < model.config().vocab_size)
+    };
     ensure!(
-        group
+        group.prefix.iter().all(valid_token)
+            && group.teacher_continuation.iter().all(valid_token)
+            && group.candidates.iter().flatten().all(valid_token),
+        "imitation group contains an out-of-vocabulary token"
+    );
+    let teacher_sequence = group
+        .prefix
+        .len()
+        .checked_add(group.teacher_continuation.len())
+        .and_then(|length| length.checked_sub(1))
+        .context("imitation teacher sequence length overflow")?;
+    ensure!(
+        teacher_sequence <= model.config().max_seq_len,
+        "imitation teacher sequence exceeds model limit"
+    );
+    for candidate in &group.candidates {
+        ensure!(!candidate.is_empty(), "imitation candidate is empty");
+        let sequence = group
+            .prefix
+            .len()
+            .checked_add(candidate.len())
+            .and_then(|length| length.checked_sub(1))
+            .context("imitation candidate sequence length overflow")?;
+        ensure!(
+            sequence <= model.config().max_seq_len,
+            "imitation candidate sequence exceeds model limit"
+        );
+    }
+    Ok(())
+}
+
+fn validate_imitation_groups(
+    groups: &[ImitationGroup],
+    model: &Transformer,
+    group_size: usize,
+    maximum_edit_distance: usize,
+) -> Result<()> {
+    ensure!(
+        groups.len() <= MAX_TENSOR_IMITATION_GROUPS,
+        "imitation source returned more than {MAX_TENSOR_IMITATION_GROUPS} groups"
+    );
+    let mut model_token_evaluations = 0_usize;
+    let mut edit_distance_cells = 0_usize;
+    for group in groups {
+        validate_group(group, model, group_size)?;
+        let max_candidate_tokens = group
             .candidates
             .iter()
-            .all(|candidate| !candidate.is_empty()
-                && group.prefix.len() + candidate.len() - 1 <= model.config().max_seq_len),
-        "invalid imitation candidate"
-    );
+            .map(Vec::len)
+            .max()
+            .context("imitation group has no candidates")?;
+        let padded_tokens = max_candidate_tokens
+            .checked_mul(group.candidates.len())
+            .context("imitation padded tensor size overflow")?;
+        ensure!(
+            padded_tokens <= MAX_TENSOR_GRPO_PADDED_TOKENS,
+            "imitation group exceeds the {MAX_TENSOR_GRPO_PADDED_TOKENS}-element padded tensor limit"
+        );
+        let mut group_tokens = 0_usize;
+        for candidate in &group.candidates {
+            let sequence = group
+                .prefix
+                .len()
+                .checked_add(candidate.len())
+                .and_then(|length| length.checked_sub(1))
+                .context("imitation candidate sequence length overflow")?;
+            group_tokens = group_tokens
+                .checked_add(sequence)
+                .context("imitation group model-token work overflow")?;
+            ensure!(
+                group_tokens <= MAX_TENSOR_FORWARD_TOKENS,
+                "imitation group exceeds the {MAX_TENSOR_FORWARD_TOKENS}-token activation limit"
+            );
+            // Current policy, frozen behavior policy, and teacher reference
+            // each evaluate the same causal rows.
+            model_token_evaluations = model_token_evaluations
+                .checked_add(
+                    sequence
+                        .checked_mul(3)
+                        .context("imitation model-token work overflow")?,
+                )
+                .context("imitation model-token work overflow")?;
+            ensure!(
+                model_token_evaluations <= MAX_TENSOR_SUBPHASE_TOKENS,
+                "imitation exceeds the {MAX_TENSOR_SUBPHASE_TOKENS}-token model-work limit"
+            );
+
+            if group.teacher_continuation.len().abs_diff(candidate.len()) <= maximum_edit_distance {
+                let longest = group.teacher_continuation.len().max(candidate.len());
+                let band = maximum_edit_distance.min(longest);
+                let row_width = band
+                    .checked_mul(2)
+                    .and_then(|width| width.checked_add(1))
+                    .context("imitation edit-distance work overflow")?;
+                edit_distance_cells = edit_distance_cells
+                    .checked_add(
+                        longest
+                            .checked_mul(row_width)
+                            .context("imitation edit-distance work overflow")?,
+                    )
+                    .context("imitation edit-distance work overflow")?;
+                ensure!(
+                    edit_distance_cells <= MAX_TENSOR_EDIT_DISTANCE_CELLS,
+                    "imitation exceeds the {MAX_TENSOR_EDIT_DISTANCE_CELLS}-cell edit-distance limit"
+                );
+            }
+        }
+    }
     Ok(())
 }
 
 pub fn thresholded_edit_reward(reference: &[i64], candidate: &[i64], maximum: usize) -> f32 {
-    let distance = levenshtein(reference, candidate);
-    if distance > maximum {
+    let Some(distance) = thresholded_levenshtein(reference, candidate, maximum) else {
         return 0.0;
-    }
+    };
     1.0 - distance as f32 / reference.len().max(candidate.len()).max(1) as f32
 }
 
-fn levenshtein(left: &[i64], right: &[i64]) -> usize {
-    let mut previous = (0..=right.len()).collect::<Vec<_>>();
-    let mut current = vec![0; right.len() + 1];
+/// Return the exact edit distance when it is at most `maximum`.
+///
+/// Imitation only assigns a reward inside that threshold, so visiting the
+/// rest of the dynamic-programming matrix wastes quadratic CPU time between
+/// accelerator updates. The diagonal band is exact for every accepted result
+/// and reduces the usual `O(left * right)` work to
+/// `O(max(left, right) * maximum)` for the normal small-threshold recipe.
+fn thresholded_levenshtein(left: &[i64], right: &[i64], maximum: usize) -> Option<usize> {
+    if left.len().abs_diff(right.len()) > maximum {
+        return None;
+    }
+    if left.is_empty() {
+        return (right.len() <= maximum).then_some(right.len());
+    }
+    if right.is_empty() {
+        return (left.len() <= maximum).then_some(left.len());
+    }
+
+    // Distance is symmetric. Keeping the shorter sequence on the horizontal
+    // axis bounds scratch memory without changing the diagonal-band proof.
+    let (left, right) = if right.len() <= left.len() {
+        (left, right)
+    } else {
+        (right, left)
+    };
+    let band = maximum.min(left.len().max(right.len()));
+    let beyond = band + 1;
+    let mut previous = vec![beyond; right.len() + 1];
+    for (column, value) in previous.iter_mut().enumerate().take(band + 1) {
+        *value = column;
+    }
+    let mut current = vec![beyond; right.len() + 1];
     for (left_index, left_token) in left.iter().enumerate() {
-        current[0] = left_index + 1;
-        for (right_index, right_token) in right.iter().enumerate() {
-            current[right_index + 1] = (previous[right_index]
-                + usize::from(left_token != right_token))
-            .min(previous[right_index + 1] + 1)
-            .min(current[right_index] + 1);
+        let row = left_index + 1;
+        let first_column = row.saturating_sub(band).max(1);
+        let last_column = row.saturating_add(band).min(right.len());
+        if first_column > last_column {
+            return None;
+        }
+        // Only the diagonal band is read on the next row. Reset its two
+        // sentinels rather than filling the whole sequence-width buffer; a
+        // full fill here silently turns the advertised banded algorithm back
+        // into O(left * right) CPU work.
+        current[0] = if row <= band { row } else { beyond };
+        if first_column > 1 {
+            current[first_column - 1] = beyond;
+        }
+        for column in first_column..=last_column {
+            current[column] = (previous[column - 1]
+                + usize::from(left_token != &right[column - 1]))
+            .min(previous[column].saturating_add(1))
+            .min(current[column - 1].saturating_add(1));
+        }
+        if last_column < right.len() {
+            current[last_column + 1] = beyond;
         }
         std::mem::swap(&mut previous, &mut current);
     }
-    previous[right.len()]
+    (previous[right.len()] <= maximum).then_some(previous[right.len()])
 }
 
 pub fn normalized_group_advantages(rewards: &[f32]) -> Vec<f32> {
@@ -2470,20 +2890,6 @@ pub fn normalized_group_advantages(rewards: &[f32]) -> Vec<f32> {
         / rewards.len() as f32;
     let scale = (variance + 1e-6).sqrt();
     rewards.iter().map(|value| (value - mean) / scale).collect()
-}
-
-fn validate_sha256(value: &str) -> Result<()> {
-    let Some(hex) = value.strip_prefix("sha256:") else {
-        bail!("identity must start with sha256:");
-    };
-    ensure!(
-        hex.len() == 64
-            && hex
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "identity must be sha256 plus 64 lowercase hex digits"
-    );
-    Ok(())
 }
 
 /// A deterministic parameter/state digest used to verify that a publisher
@@ -2510,8 +2916,12 @@ pub(crate) fn model_parameter_hash(model: &Transformer) -> Result<String> {
             self.shape(b'f', parameter.shape().dims::<D>());
             match parameter.val().into_data().convert::<f32>().to_vec::<f32>() {
                 Ok(values) => {
-                    for value in values {
-                        self.hash.update(value.to_bits().to_le_bytes());
+                    let mut bytes =
+                        Vec::with_capacity(FINGERPRINT_CHUNK_VALUES * std::mem::size_of::<f32>());
+                    for chunk in values.chunks(FINGERPRINT_CHUNK_VALUES) {
+                        bytes.clear();
+                        bytes.extend(chunk.iter().flat_map(|value| value.to_bits().to_le_bytes()));
+                        self.hash.update(&bytes);
                     }
                 }
                 Err(error) => self.failure = Some(error.to_string()),
@@ -2522,8 +2932,12 @@ pub(crate) fn model_parameter_hash(model: &Transformer) -> Result<String> {
             self.shape(b'i', parameter.shape().dims::<D>());
             match parameter.val().into_data().to_vec::<i64>() {
                 Ok(values) => {
-                    for value in values {
-                        self.hash.update(value.to_le_bytes());
+                    let mut bytes =
+                        Vec::with_capacity(FINGERPRINT_CHUNK_VALUES * std::mem::size_of::<i64>());
+                    for chunk in values.chunks(FINGERPRINT_CHUNK_VALUES) {
+                        bytes.clear();
+                        bytes.extend(chunk.iter().flat_map(|value| value.to_le_bytes()));
+                        self.hash.update(&bytes);
                     }
                 }
                 Err(error) => self.failure = Some(error.to_string()),
@@ -2534,8 +2948,11 @@ pub(crate) fn model_parameter_hash(model: &Transformer) -> Result<String> {
             self.shape(b'b', parameter.shape().dims::<D>());
             match parameter.val().into_data().to_vec::<bool>() {
                 Ok(values) => {
-                    for value in values {
-                        self.hash.update([u8::from(value)]);
+                    let mut bytes = Vec::with_capacity(FINGERPRINT_CHUNK_VALUES);
+                    for chunk in values.chunks(FINGERPRINT_CHUNK_VALUES) {
+                        bytes.clear();
+                        bytes.extend(chunk.iter().copied().map(u8::from));
+                        self.hash.update(&bytes);
                     }
                 }
                 Err(error) => self.failure = Some(error.to_string()),
@@ -2605,6 +3022,8 @@ pub trait TransformerDreamOps {
 pub struct TensorDreamBackend<O> {
     shared: Transformer,
     immutable_shared: Transformer,
+    immutable_shared_hash: String,
+    bound_candidate_checkpoint: Option<(String, String)>,
     device: Device,
     operations: O,
 }
@@ -2617,12 +3036,35 @@ impl<O: TransformerDreamOps> TensorDreamBackend<O> {
         operations: O,
     ) -> Result<Self> {
         probe.validate_for(&shared)?;
+        let immutable_shared_hash = model_parameter_hash(&shared)?;
         Ok(Self {
             immutable_shared: shared.clone(),
             shared,
+            immutable_shared_hash,
+            bound_candidate_checkpoint: None,
             device,
             operations,
         })
+    }
+    /// Bind the in-memory immutable model to the artifact identity recorded by
+    /// the committed consolidation. This is separate from the parameter hash:
+    /// checkpoint formats may authenticate metadata in addition to tensors.
+    pub fn bind_candidate_checkpoint(&mut self, uri: &str, sha256: &str) -> Result<()> {
+        ensure!(
+            !uri.trim().is_empty(),
+            "dream candidate checkpoint URI is empty"
+        );
+        validate_sha256_identity(sha256, "published checkpoint identity")?;
+        let identity = (uri.to_owned(), sha256.to_owned());
+        if let Some(bound) = &self.bound_candidate_checkpoint {
+            ensure!(
+                bound == &identity,
+                "dream backend cannot be rebound to another candidate checkpoint"
+            );
+        } else {
+            self.bound_candidate_checkpoint = Some(identity);
+        }
+        Ok(())
     }
     pub fn shared_model(&self) -> &Transformer {
         &self.shared
@@ -2631,15 +3073,32 @@ impl<O: TransformerDreamOps> TensorDreamBackend<O> {
         &self.operations
     }
     fn fingerprint(&self) -> Result<String> {
-        // A probe-logit digest can miss changes to dormant reserve slots or
-        // parameters that do not affect that particular input. Dream trials
-        // must preserve the entire immutable candidate, including checkpoint
-        // state that is intentionally excluded from active routing.
-        model_parameter_hash(&self.shared)
+        // The shared model is never exposed mutably. Generation, reference
+        // evaluation, and policy updates receive `&Transformer`; LoRA trials
+        // receive an independently forked model. Cache the full parameter
+        // identity once instead of copying and hashing hundreds of millions
+        // of parameters around every trial.
+        Ok(self.immutable_shared_hash.clone())
     }
 }
 
 impl<O: TransformerDreamOps> DreamingBackend for TensorDreamBackend<O> {
+    fn verify_committed_candidate(&mut self, txn: &ConsolidationTxn) -> Result<()> {
+        let checkpoint = txn
+            .candidate_checkpoint
+            .as_ref()
+            .context("committed transaction has no candidate checkpoint")?;
+        let sha256 = txn
+            .candidate_hash
+            .as_ref()
+            .context("committed transaction has no candidate hash")?;
+        ensure!(
+            self.bound_candidate_checkpoint.as_ref() == Some(&(checkpoint.clone(), sha256.clone())),
+            "dream backend is not bound to the committed candidate checkpoint"
+        );
+        Ok(())
+    }
+
     fn shared_checkpoint_hash(&mut self) -> Result<String> {
         self.fingerprint()
     }
@@ -2660,9 +3119,9 @@ impl<O: TransformerDreamOps> DreamingBackend for TensorDreamBackend<O> {
             count,
             MemoryRouting::Dream { seed: txn.id },
         )?;
-        validate_sha256(&manifest)?;
+        validate_sha256_identity(&manifest, "dream manifest identity")?;
         for dream in &dreams {
-            validate_sha256(&dream.artifact_hash)?;
+            validate_sha256_identity(&dream.artifact_hash, "dream artifact identity")?;
         }
         Ok((manifest, dreams))
     }
@@ -2672,10 +3131,10 @@ impl<O: TransformerDreamOps> DreamingBackend for TensorDreamBackend<O> {
         txn: &ConsolidationTxn,
         manifest: &str,
     ) -> Result<Vec<GeneratedDream>> {
-        validate_sha256(manifest)?;
+        validate_sha256_identity(manifest, "dream manifest identity")?;
         let dreams = self.operations.load(txn, manifest)?;
         for dream in &dreams {
-            validate_sha256(&dream.artifact_hash)?;
+            validate_sha256_identity(&dream.artifact_hash, "dream artifact identity")?;
         }
         Ok(dreams)
     }
@@ -2685,7 +3144,7 @@ impl<O: TransformerDreamOps> DreamingBackend for TensorDreamBackend<O> {
         txn: &ConsolidationTxn,
         reference_hash: &str,
     ) -> Result<Vec<f32>> {
-        validate_sha256(reference_hash)?;
+        validate_sha256_identity(reference_hash, "dream reference identity")?;
         self.operations
             .reference_gradient(txn, &self.shared, reference_hash)
     }
@@ -2698,12 +3157,12 @@ impl<O: TransformerDreamOps> DreamingBackend for TensorDreamBackend<O> {
         alpha: usize,
     ) -> Result<DreamTrial> {
         let isolated = self.shared.clone().fork(&self.device);
-        validate_sha256(&candidate.artifact_hash)?;
+        validate_sha256_identity(&candidate.artifact_hash, "dream candidate identity")?;
         let trial = self
             .operations
             .isolated_lora_trial(txn, isolated, candidate, rank, alpha)?;
-        validate_sha256(&trial.adapter_hash)?;
-        validate_sha256(&trial.evaluator_hash)?;
+        validate_sha256_identity(&trial.adapter_hash, "dream adapter identity")?;
+        validate_sha256_identity(&trial.evaluator_hash, "dream evaluator identity")?;
         Ok(trial)
     }
 
@@ -2862,6 +3321,7 @@ mod tests {
     struct Update {
         device: Device,
         cleared: usize,
+        fail_restore: bool,
     }
     impl ProspectiveTransformerUpdate for Update {
         fn snapshot_state(&mut self, _: &ConsolidationTxn) -> Result<ProspectiveUpdateSnapshot> {
@@ -2873,6 +3333,7 @@ mod tests {
             _: &ConsolidationTxn,
             snapshot: &ProspectiveUpdateSnapshot,
         ) -> Result<()> {
+            ensure!(!self.fail_restore, "injected update-state restore failure");
             let bytes: [u8; std::mem::size_of::<usize>()] = snapshot
                 .as_bytes()
                 .try_into()
@@ -2933,6 +3394,30 @@ mod tests {
                 teacher_continuation: vec![3, 4],
                 candidates,
             }])
+        }
+    }
+
+    struct FailingKnowledgeRollouts;
+
+    impl ConsolidationRollouts for FailingKnowledgeRollouts {
+        fn knowledge_rollouts(
+            &mut self,
+            _: &ConsolidationTxn,
+            _: RolloutOwner,
+            _: &Transformer,
+            _: usize,
+        ) -> Result<Vec<TokenRolloutBatch>> {
+            bail!("injected knowledge-rollout failure")
+        }
+
+        fn imitation_groups(
+            &mut self,
+            _: &ConsolidationTxn,
+            _: &Transformer,
+            _: &Transformer,
+            _: usize,
+        ) -> Result<Vec<ImitationGroup>> {
+            bail!("imitation must not run after the injected knowledge failure")
         }
     }
 
@@ -3062,6 +3547,7 @@ mod tests {
             Update {
                 device: device.clone(),
                 cleared: 0,
+                fail_restore: false,
             },
             Rollouts(batch.clone()),
             Judge,
@@ -3155,6 +3641,106 @@ mod tests {
     }
 
     #[test]
+    fn durable_rollback_persist_failure_leaves_the_caller_pending() {
+        #[derive(Default)]
+        struct RejectRollbackSink(Vec<SleepState>);
+
+        impl SleepProgressSink for RejectRollbackSink {
+            fn persist(&mut self, state: &SleepState) -> Result<()> {
+                if state.phase == crate::sleep::SleepPhase::Wake {
+                    bail!("injected durable rollback persistence failure");
+                }
+                self.0.push(state.clone());
+                Ok(())
+            }
+        }
+
+        let device = Device::ndarray().autodiff();
+        device.seed(12);
+        let mut model = Transformer::new(&tiny_config(), &device).unwrap();
+        let (mut state, _) = begin(&mut model, &device);
+        let mut backend = backend(model, &device, true);
+        let directory = tempfile::tempdir().unwrap();
+        let store = TensorTransactionStore::new(directory.path());
+        let mut sink = RejectRollbackSink::default();
+
+        let error =
+            execute_tensor_consolidation_durable(&mut state, &mut backend, &store, &mut sink)
+                .unwrap_err()
+                .to_string();
+
+        assert!(error.contains("rollback persistence failure"), "{error}");
+        assert_eq!(state.phase, crate::sleep::SleepPhase::RetentionValidation);
+        assert!(state.pending.is_some());
+        assert!(
+            sink.0
+                .iter()
+                .all(|snapshot| snapshot.phase != crate::sleep::SleepPhase::Wake),
+            "a failed tensor rollback publication escaped into durable progress"
+        );
+    }
+
+    #[test]
+    fn durable_restore_failure_never_publishes_rollback_metadata() {
+        #[derive(Default)]
+        struct RecordingSink(Vec<SleepState>);
+
+        impl SleepProgressSink for RecordingSink {
+            fn persist(&mut self, state: &SleepState) -> Result<()> {
+                self.0.push(state.clone());
+                Ok(())
+            }
+        }
+
+        let device = Device::ndarray().autodiff();
+        device.seed(14);
+        let mut model = Transformer::new(&tiny_config(), &device).unwrap();
+        let (mut state, _) = begin(&mut model, &device);
+        let batch = TokenRolloutBatch::new(1, 4, vec![1, 2, 3, 4]).unwrap();
+        let mut backend = TensorConsolidationBackend::new(
+            ImmutableTransformerCheckpoint {
+                uri: "teacher.bpk".into(),
+                sha256: hash('a'),
+                model,
+            },
+            device.clone(),
+            config(),
+            Update {
+                device,
+                cleared: 0,
+                fail_restore: true,
+            },
+            FailingKnowledgeRollouts,
+            Judge,
+            Evaluator {
+                batch,
+                reject: false,
+                calls: 0,
+            },
+            Publisher::default(),
+        )
+        .unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let store = TensorTransactionStore::new(directory.path());
+        let mut sink = RecordingSink::default();
+
+        let error =
+            execute_tensor_consolidation_durable(&mut state, &mut backend, &store, &mut sink)
+                .unwrap_err()
+                .to_string();
+
+        assert!(error.contains("teacher restore failed"), "{error}");
+        assert_eq!(state.phase, crate::sleep::SleepPhase::KnowledgeSeeding);
+        assert!(state.pending.is_some());
+        assert!(
+            sink.0
+                .iter()
+                .all(|snapshot| snapshot.phase != crate::sleep::SleepPhase::Wake),
+            "a tensor rollback cursor was published despite failed restoration"
+        );
+    }
+
+    #[test]
     fn exact_receiver_optimizer_snapshot_resumes_from_imitation_boundary() {
         let device = Device::ndarray().autodiff();
         device.seed(13);
@@ -3181,7 +3767,7 @@ mod tests {
         let pointer = store
             .publish(&txn, &first.snapshot_inflight(&txn).unwrap())
             .unwrap();
-        validate_sha256(&pointer.manifest_sha256).unwrap();
+        validate_sha256_identity(&pointer.manifest_sha256, "tensor manifest identity").unwrap();
         state
             .record_tensor_transaction(pointer.generation.clone(), pointer.manifest_sha256.clone())
             .unwrap();
@@ -3209,6 +3795,45 @@ mod tests {
         assert!(execute_tensor_consolidation(&mut state, &mut resumed, &mut sink).unwrap());
         assert_eq!(resumed.diagnostics().knowledge_updates, 2);
         assert_eq!(resumed.diagnostics().imitation_updates, 1);
+    }
+
+    #[test]
+    fn failed_inflight_restore_does_not_partially_install_tensor_topology() {
+        let device = Device::ndarray().autodiff();
+        device.seed(41);
+        let mut model = Transformer::new(&tiny_config(), &device).unwrap();
+        let (_, txn) = begin(&mut model, &device);
+        let mut staged = backend(model.clone(), &device, false);
+        staged.compute_prospective_update(&txn).unwrap();
+        staged.stage_student(&txn).unwrap();
+        let recovered = staged.snapshot_inflight(&txn).unwrap();
+
+        let mut resumed = backend(model, &device, false);
+        resumed.updates.fail_restore = true;
+        let live_before = model_parameter_hash(&resumed.live.model).unwrap();
+        let error = resumed
+            .restore_inflight(&txn, recovered)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            error.contains("prospective sender optimizer state"),
+            "{error}"
+        );
+        assert!(resumed.teacher.is_none());
+        assert!(resumed.student.is_none());
+        assert!(resumed.pre_update_state.is_none());
+        assert!(resumed.staged_update_state.is_none());
+        assert!(resumed.receiver_ids.is_empty());
+        assert!(resumed.reclaimed_sender_ids.is_empty());
+        assert!(resumed.stages.is_empty());
+        assert_eq!(resumed.retention, None);
+        assert_eq!(resumed.diagnostics, TensorSleepDiagnostics::default());
+        assert_eq!(resumed.updates.cleared, 0);
+        assert_eq!(
+            model_parameter_hash(&resumed.live.model).unwrap(),
+            live_before
+        );
     }
 
     #[test]
@@ -3264,6 +3889,135 @@ mod tests {
                     .is_err()
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tensor_generation_load_is_aba_safe_and_rejects_persistent_replacement() {
+        let device = Device::ndarray().autodiff();
+        device.seed(31);
+        let mut model = Transformer::new(&tiny_config(), &device).unwrap();
+        let (_, txn) = begin(&mut model, &device);
+        let expected_teacher = model_parameter_hash(&model).unwrap();
+        let mut backend = backend(model, &device, false);
+        backend.compute_prospective_update(&txn).unwrap();
+        backend.stage_student(&txn).unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        let store = TensorTransactionStore::new(directory.path());
+        let pointer = store
+            .publish(&txn, &backend.snapshot_inflight(&txn).unwrap())
+            .unwrap();
+        let generation = directory
+            .path()
+            .join("generations")
+            .join(&pointer.generation);
+        let held = directory.path().join("held-tensor-generation");
+
+        let recovered = store
+            .load_pointer_inner(
+                &txn,
+                &tiny_config(),
+                &device,
+                AdamWConfig::new().with_weight_decay(0.0).init(),
+                &pointer,
+                |stage, path| {
+                    match stage {
+                        TensorLoadStage::AfterCapture => {
+                            fs::rename(path, &held)?;
+                            fs::create_dir(path)?;
+                        }
+                        TensorLoadStage::AfterStagedLoad => {
+                            fs::remove_dir(path)?;
+                            fs::rename(&held, path)?;
+                        }
+                    }
+                    Ok(())
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            model_parameter_hash(&recovered.teacher.model).unwrap(),
+            expected_teacher,
+            "an A->B->A pathname swap changed the loaded teacher"
+        );
+
+        let held = directory.path().join("held-persistent-tensor-generation");
+        let persistent = store.load_pointer_inner(
+            &txn,
+            &tiny_config(),
+            &device,
+            AdamWConfig::new().with_weight_decay(0.0).init(),
+            &pointer,
+            |stage, path| {
+                if stage == TensorLoadStage::AfterCapture {
+                    fs::rename(path, &held)?;
+                    fs::create_dir(path)?;
+                }
+                Ok(())
+            },
+        );
+        let error = match persistent {
+            Ok(_) => panic!("persistent tensor generation replacement was accepted"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("changed during authenticated load"),
+            "{error}"
+        );
+        fs::remove_dir(&generation).unwrap();
+        fs::rename(held, &generation).unwrap();
+
+        let student = generation.join(TENSOR_TXN_STUDENT);
+        let held_student = directory.path().join("held-student.safetensors");
+        let replacement = store.load_pointer_inner(
+            &txn,
+            &tiny_config(),
+            &device,
+            AdamWConfig::new().with_weight_decay(0.0).init(),
+            &pointer,
+            |stage, _| {
+                if stage == TensorLoadStage::AfterCapture {
+                    fs::rename(&student, &held_student)?;
+                    fs::write(&student, b"persistent replacement")?;
+                }
+                Ok(())
+            },
+        );
+        let error = match replacement {
+            Ok(_) => panic!("persistent tensor child replacement was accepted"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("file `student.safetensors` changed"),
+            "{error}"
+        );
+        fs::remove_file(&student).unwrap();
+        fs::rename(held_student, &student).unwrap();
+
+        let mutation = store.load_pointer_inner(
+            &txn,
+            &tiny_config(),
+            &device,
+            AdamWConfig::new().with_weight_decay(0.0).init(),
+            &pointer,
+            |stage, _| {
+                if stage == TensorLoadStage::AfterCapture {
+                    OpenOptions::new()
+                        .append(true)
+                        .open(&student)?
+                        .write_all(b"persistent mutation")?;
+                }
+                Ok(())
+            },
+        );
+        let error = match mutation {
+            Ok(_) => panic!("persistent in-place tensor mutation was accepted"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            error.contains("file `student.safetensors` changed"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -3358,7 +4112,11 @@ mod tests {
             live,
             device.clone(),
             config(),
-            Update { device, cleared: 0 },
+            Update {
+                device,
+                cleared: 0,
+                fail_restore: false,
+            },
             Rollouts(batch.clone()),
             Judge,
             Evaluator {
@@ -3398,6 +4156,48 @@ mod tests {
     }
 
     #[test]
+    fn threshold_banded_edit_distance_matches_full_dynamic_programming() {
+        fn full_distance(left: &[i64], right: &[i64]) -> usize {
+            let mut previous = (0..=right.len()).collect::<Vec<_>>();
+            let mut current = vec![0; right.len() + 1];
+            for (left_index, left_token) in left.iter().enumerate() {
+                current[0] = left_index + 1;
+                for (right_index, right_token) in right.iter().enumerate() {
+                    current[right_index + 1] = (previous[right_index]
+                        + usize::from(left_token != right_token))
+                    .min(previous[right_index + 1] + 1)
+                    .min(current[right_index] + 1);
+                }
+                std::mem::swap(&mut previous, &mut current);
+            }
+            previous[right.len()]
+        }
+
+        for left_len in 0..=5 {
+            for right_len in 0..=5 {
+                for left_bits in 0..(1usize << left_len) {
+                    let left = (0..left_len)
+                        .map(|bit| i64::from(((left_bits >> bit) & 1) != 0))
+                        .collect::<Vec<_>>();
+                    for right_bits in 0..(1usize << right_len) {
+                        let right = (0..right_len)
+                            .map(|bit| i64::from(((right_bits >> bit) & 1) != 0))
+                            .collect::<Vec<_>>();
+                        let exact = full_distance(&left, &right);
+                        for maximum in 0..=6 {
+                            assert_eq!(
+                                thresholded_levenshtein(&left, &right, maximum),
+                                (exact <= maximum).then_some(exact),
+                                "left={left:?} right={right:?} maximum={maximum}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn chunked_forward_kl_matches_an_unchunked_batch() {
         let device = Device::ndarray().autodiff();
         device.seed(37);
@@ -3415,6 +4215,79 @@ mod tests {
     }
 
     #[test]
+    fn grpo_log_probabilities_batch_equal_length_candidates_without_reordering() {
+        let device = Device::ndarray().autodiff();
+        device.seed(43);
+        let model = Transformer::new(&tiny_config(), &device).unwrap();
+        let prefix = vec![1, 2];
+        let candidates = vec![vec![3, 4], vec![5], vec![6, 7]];
+        let buckets = candidate_length_buckets(&candidates, 2).unwrap();
+        assert_eq!(buckets.len(), 2);
+        assert_eq!(buckets.get(&2), Some(&vec![0, 2]));
+
+        let grouped = padded_group_log_probabilities(&model, &prefix, &candidates, 2, &device)
+            .unwrap()
+            .into_data()
+            .convert::<f32>()
+            .to_vec::<f32>()
+            .unwrap();
+        let mut singleton = Vec::new();
+        for candidate in &candidates {
+            singleton.extend(
+                padded_group_log_probabilities(
+                    &model,
+                    &prefix,
+                    std::slice::from_ref(candidate),
+                    2,
+                    &device,
+                )
+                .unwrap()
+                .into_data()
+                .convert::<f32>()
+                .to_vec::<f32>()
+                .unwrap(),
+            );
+        }
+        assert_eq!(grouped.len(), singleton.len());
+        for (batched, separate) in grouped.iter().zip(&singleton) {
+            assert!(
+                (batched - separate).abs() < 1e-5,
+                "batched log probability {batched} differs from {separate}"
+            );
+        }
+    }
+
+    #[test]
+    fn injected_sleep_rollout_work_is_bounded_before_tensor_execution() {
+        let device = Device::ndarray().autodiff();
+        let model = Transformer::new(&tiny_config(), &device).unwrap();
+        let oversized_batch = TokenRolloutBatch {
+            batch: MAX_TENSOR_ROLLOUT_BATCH_ROWS + 1,
+            sequence: 1,
+            token_ids: vec![1; MAX_TENSOR_ROLLOUT_BATCH_ROWS + 1],
+        };
+        assert!(oversized_batch.validate_for(&model).is_err());
+
+        let group = ImitationGroup {
+            prefix: vec![1, 2],
+            teacher_continuation: vec![3, 4],
+            candidates: vec![vec![3, 4], vec![5, 6]],
+        };
+        let groups = vec![group; MAX_TENSOR_IMITATION_GROUPS + 1];
+        let error = validate_imitation_groups(&groups, &model, 2, 2)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("more than"), "{error}");
+
+        let batch = TokenRolloutBatch::new(1, 1, vec![1]).unwrap();
+        let batches = vec![batch; MAX_TENSOR_ROLLOUT_BATCHES + 1];
+        let error = validate_rollout_batches(&batches, &model, "hostile source")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("rollout batches"), "{error}");
+    }
+
+    #[test]
     fn prospective_update_rejects_parameters_outside_sender_tier() {
         let device = Device::ndarray().autodiff();
         let mut teacher = Transformer::new(&tiny_config(), &device).unwrap();
@@ -3429,7 +4302,7 @@ mod tests {
                 .with_weight_decay(0.0)
                 .init()
                 .step(1e-2.into(), student, selected);
-        let error = prospective_update_hash(&teacher, &student, 0)
+        let error = prospective_update_hash_at_boundary(&teacher, &student, 0)
             .unwrap_err()
             .to_string();
         assert!(error.contains("escaped sender tier"), "{error}");
@@ -3541,6 +4414,13 @@ mod tests {
             },
         )
         .unwrap();
+        let committed = state.pending.as_ref().unwrap();
+        dreams
+            .bind_candidate_checkpoint(
+                committed.candidate_checkpoint.as_ref().unwrap(),
+                committed.candidate_hash.as_ref().unwrap(),
+            )
+            .unwrap();
         let before = dreams.shared_checkpoint_hash().unwrap();
         let config = DreamingConfig {
             candidate_count: 2,
@@ -3564,7 +4444,7 @@ mod tests {
     }
 
     #[test]
-    fn dream_checkpoint_identity_covers_dormant_reserve_state() {
+    fn model_parameter_identity_covers_dormant_reserve_state() {
         let device = Device::ndarray().autodiff();
         device.seed(31);
         let model = Transformer::new(&tiny_config(), &device).unwrap();
@@ -3580,7 +4460,7 @@ mod tests {
             },
         )
         .unwrap();
-        let checkpoint_before = dreams.shared_checkpoint_hash().unwrap();
+        let checkpoint_before = model_parameter_hash(dreams.shared_model()).unwrap();
 
         // Reclaiming a slot leaves it dormant, so ordinary logits return to
         // their original value while its generation/stored tensors differ.
@@ -3593,6 +4473,26 @@ mod tests {
             model_probe_hash(dreams.shared_model(), &probe, &device).unwrap(),
             probe_before
         );
-        assert_ne!(dreams.shared_checkpoint_hash().unwrap(), checkpoint_before);
+        assert_ne!(
+            model_parameter_hash(dreams.shared_model()).unwrap(),
+            checkpoint_before
+        );
+    }
+
+    #[test]
+    fn parameter_id_restore_rejects_aliasing_without_mutating_the_model() {
+        let device = Device::ndarray().autodiff();
+        let mut model = Transformer::new(&tiny_config(), &device).unwrap();
+        let original = parameter_ids(&model);
+        assert!(original.len() >= 2);
+        let mut aliased = original.clone();
+        aliased[1] = aliased[0];
+
+        let error = restore_parameter_ids(&mut model, &aliased)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("repeats a stored parameter ID"), "{error}");
+        assert_eq!(parameter_ids(&model), original);
     }
 }

--- a/hermes-train/src/tier_optimizer.rs
+++ b/hermes-train/src/tier_optimizer.rs
@@ -7,21 +7,29 @@
 //! and publishes content-addressed optimizer/candidate generations.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
+
+#[cfg(test)]
+use std::fs::OpenOptions;
+#[cfg(test)]
+use std::io::Write;
 
 use anyhow::{Context, Result, bail, ensure};
 use burn::module::{AutodiffModule, Module, ModuleVisitor, Param, ParamId, list_param_ids};
 use burn::tensor::{Device, Gradients, Tensor, TensorData};
 use burn_optim::{AdamWConfig, GradientsParams, ModuleOptimizer};
 use burn_pack::{Bytes, Reader, Tensor as PackedTensor, Writer};
-use hermes_llm::{ModelDef, Transformer, load_safetensors, save_safetensors};
+use hermes_llm::{ModelDef, Transformer, load_safetensors_bytes, save_safetensors};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
+use crate::artifact_io::{
+    AuthenticatedDirectorySnapshot, atomic_write_new, ensure_directory, ensure_real_directory,
+    hash_regular_file as hash_file, read_regular_bounded, sha256_identity, sync_directory,
+    sync_regular_file, write_new_synced,
+};
 use crate::native_sleep::{
     PlannedConsolidation, TierOptimizerCommit, TierOptimizerCommitRole, TierOptimizerPublisher,
 };
@@ -42,7 +50,18 @@ const GRADIENT_FILE: &str = "gradients.bpk";
 const STATE_FILE: &str = "state.json";
 const MANIFEST_FILE: &str = "manifest.json";
 const WEIGHTS_FILE: &str = "weights.safetensors";
+const MAX_TIER_BUNDLE_MANIFEST_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_TIER_BUNDLE_STATE_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_TIER_BUNDLE_MEMBER_BYTES: u64 = 16 * 1024 * 1024 * 1024;
+const MAX_TIER_SNAPSHOT_HEADER_BYTES: usize = 64 * 1024 * 1024;
+const TIER_BUNDLE_SCHEMA: [&str; 4] = [MANIFEST_FILE, OPTIMIZER_FILE, GRADIENT_FILE, STATE_FILE];
 static STAGING_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TierBundleLoadStage {
+    AfterCapture,
+    AfterStagedLoad,
+}
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -144,6 +163,8 @@ struct BankInner {
 #[derive(Clone)]
 pub struct TierOptimizerBank {
     inner: Arc<Mutex<BankInner>>,
+    #[cfg(test)]
+    snapshot_serializations: Arc<AtomicU64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -151,6 +172,24 @@ pub struct TierAccumulationReport {
     pub wake_gradient_tensors: usize,
     pub tier_gradient_tensors: Vec<usize>,
     pub accumulated_micro_steps: Vec<u64>,
+}
+
+/// One directly applied due tier update in the `wake_only` sleep ablation.
+/// The independently scoped optimizer can touch only this tier; the receipt
+/// binds the exact eligible before/after tensors and unchanged reserve state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WakeOnlyTierUpdate {
+    pub tier: usize,
+    pub tier_id: String,
+    pub trigger_clock: u64,
+    pub accumulated_optimizer_steps: u64,
+    pub prospective_update_sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WakeOnlyTierUpdateReport {
+    pub trigger_clock: u64,
+    pub updates: Vec<WakeOnlyTierUpdate>,
 }
 
 /// One backward pass partitioned into the ordinary wake scope and one gradient
@@ -206,6 +245,8 @@ impl TierOptimizerBank {
                 staged: None,
                 cached_candidate: None,
             })),
+            #[cfg(test)]
+            snapshot_serializations: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -277,8 +318,10 @@ impl TierOptimizerBank {
         })
     }
 
-    /// Commit one or more already-averaged and already-clipped optimizer-step
-    /// gradients to the independently-clocked tier accumulators.  The operation
+    /// Commit one already-averaged and already-clipped optimizer-step gradient
+    /// set to the independently-clocked tier accumulators. Checkpoint v2 binds
+    /// one accumulator generation to every optimizer step, so callers must not
+    /// coalesce multiple optimizer steps into one state mutation. The operation
     /// validates every tier before changing any of them.
     pub fn commit_tier_gradients(
         &self,
@@ -287,8 +330,8 @@ impl TierOptimizerBank {
         optimizer_steps: u64,
     ) -> Result<TierAccumulationReport> {
         ensure!(
-            optimizer_steps > 0,
-            "optimizer-step increment must be positive"
+            optimizer_steps == 1,
+            "tier optimizer checkpoints require exactly one optimizer step per accumulation commit"
         );
         let mut inner = self.lock()?;
         validate_model_topology(&inner, model)?;
@@ -378,7 +421,7 @@ impl TierOptimizerBank {
 
     pub fn snapshot_bytes(&self) -> Result<Vec<u8>> {
         let inner = self.lock()?;
-        snapshot_inner(&inner)
+        self.serialize_snapshot(&inner)
     }
 
     /// Restore only after fully decoding, authenticating, and reconstructing
@@ -390,16 +433,15 @@ impl TierOptimizerBank {
         Ok(())
     }
 
-    fn snapshot_with_layout(&self) -> Result<(Vec<u8>, Transformer)> {
-        let inner = self.lock()?;
-        Ok((snapshot_inner(&inner)?, inner.model_layout.clone()))
+    fn serialize_snapshot(&self, inner: &BankInner) -> Result<Vec<u8>> {
+        #[cfg(test)]
+        self.snapshot_serializations.fetch_add(1, Ordering::Relaxed);
+        snapshot_inner(inner)
     }
 
-    fn restore_with_layout(&self, bytes: &[u8], model_layout: &Transformer) -> Result<()> {
-        let mut inner = self.lock()?;
-        let restored = restore_inner(&inner, bytes, model_layout)?;
-        *inner = restored;
-        Ok(())
+    #[cfg(test)]
+    fn snapshot_serialization_count(&self) -> u64 {
+        self.snapshot_serializations.load(Ordering::Relaxed)
     }
 
     pub fn tier_clocks(&self) -> Result<Vec<(u64, u64, u64)>> {
@@ -417,31 +459,162 @@ impl TierOptimizerBank {
             .collect())
     }
 
+    /// Apply every tier whose configured boundary is due, fastest-to-slowest,
+    /// without any consolidation, receiver transfer, reserve activation/reset,
+    /// or Dreaming. This is deliberately schedule-bound: it is the exact
+    /// `wake_only` ablation, not ordinary every-step AdamW over all tiers.
+    ///
+    /// The operation is atomic with respect to the bank. Every tier applies
+    /// the same averaged prospective base update used by sleep staging, while
+    /// the returned model is mutated only through the returned value.
+    pub fn apply_wake_only_due_updates(
+        &self,
+        model: &Transformer,
+        trigger_clock: u64,
+    ) -> Result<(Transformer, WakeOnlyTierUpdateReport)> {
+        ensure!(trigger_clock > 0, "wake_only update clock must be positive");
+        // Most wake steps are not tier boundaries. Inspect the immutable
+        // schedule before taking the rollback snapshot: snapshotting canonical
+        // optimizer/gradient bytes synchronizes every accumulator to the host.
+        // There is no state to roll back when no tier is due.
+        let mut inner = self.lock()?;
+        validate_model_topology(&inner, model)?;
+        ensure!(
+            inner.staged.is_none(),
+            "cannot apply wake_only tier updates while a sleep update is staged"
+        );
+        if !inner
+            .update_periods
+            .iter()
+            .any(|period| trigger_clock.is_multiple_of(*period))
+        {
+            inner.model_layout = model.clone();
+            inner.cached_candidate = None;
+            return Ok((
+                model.clone(),
+                WakeOnlyTierUpdateReport {
+                    trigger_clock,
+                    updates: Vec::new(),
+                },
+            ));
+        }
+        // Keep the bank lock across snapshot, mutation, and rollback. The bank
+        // is cloneable and may be shared by checkpointing/control code; a
+        // second caller must never commit between our rollback point and a
+        // failed update and then have that successful work silently undone.
+        let before_layout = inner.model_layout.clone();
+        let before = self.serialize_snapshot(&inner)?;
+        let result = (|| -> Result<(Transformer, WakeOnlyTierUpdateReport)> {
+            let due = inner
+                .update_periods
+                .iter()
+                .enumerate()
+                .filter_map(|(tier, period)| trigger_clock.is_multiple_of(*period).then_some(tier))
+                .collect::<Vec<_>>();
+            let learning_rate = inner.config.learning_rate;
+            let mut updated_model = model.clone();
+            let mut updates = Vec::with_capacity(due.len());
+            for sender in due {
+                let before_tier = updated_model.clone();
+                let tier = &mut inner.tiers[sender];
+                ensure!(
+                    trigger_clock > tier.update_clock,
+                    "wake_only tier {sender} update clock did not advance"
+                );
+                ensure!(
+                    tier.accumulated_micro_steps > 0 && !tier.accumulator.is_empty(),
+                    "wake_only tier {sender} has no accumulated wake gradients at its due boundary"
+                );
+                let active_ids = active_tier_parameter_ids(&updated_model, sender)?;
+                let active = active_ids
+                    .iter()
+                    .map(|id| id.val())
+                    .collect::<BTreeSet<_>>();
+                let accumulator_ids =
+                    gradient_parameter_ids(&updated_model, &tier.accumulator, &tier.parameter_ids)?;
+                ensure!(
+                    accumulator_ids.iter().all(|id| active.contains(id)),
+                    "wake_only tier {sender} accumulator contains a dormant parameter"
+                );
+                let accumulated_optimizer_steps = tier.accumulated_micro_steps;
+                let mut gradients = std::mem::take(&mut tier.accumulator);
+                average_gradients(
+                    &updated_model,
+                    &mut gradients,
+                    &active_ids,
+                    accumulated_optimizer_steps,
+                )?;
+                let mut optimizer = tier.optimizer.clone();
+                let candidate =
+                    optimizer.step(learning_rate.into(), updated_model.clone(), gradients);
+                let prospective_update_sha256 =
+                    prospective_update_hash(&before_tier, &candidate, sender)?;
+                tier.optimizer = optimizer;
+                tier.accumulated_micro_steps = 0;
+                tier.update_clock = trigger_clock;
+                tier.generation = tier
+                    .generation
+                    .checked_add(1)
+                    .context("wake_only tier optimizer generation overflow")?;
+                tier.artifact = None;
+                updates.push(WakeOnlyTierUpdate {
+                    tier: sender,
+                    tier_id: tier.tier_id.clone(),
+                    trigger_clock,
+                    accumulated_optimizer_steps,
+                    prospective_update_sha256,
+                });
+                updated_model = candidate;
+            }
+            inner.model_layout = updated_model.clone();
+            inner.cached_candidate = None;
+            Ok((
+                updated_model,
+                WakeOnlyTierUpdateReport {
+                    trigger_clock,
+                    updates,
+                },
+            ))
+        })();
+        match result {
+            Ok(updated) => Ok(updated),
+            Err(error) => {
+                *inner = restore_inner(&inner, &before, &before_layout)
+                    .context("restoring tier optimizer bank after failed wake_only update")?;
+                Err(error)
+            }
+        }
+    }
+
     /// Return checkpoint-v2 scopes only when every non-empty tier state has a
     /// matching immutable bundle. Call `publish_checkpoint_scopes` on the
     /// durable publisher after wake accumulation and before persisting a cursor.
     pub fn scopes(&self) -> Result<MemoryOptimizerScopes> {
         let inner = self.lock()?;
-        let mut scopes = inner.scopes.clone();
-        for (scope, tier) in scopes.tiers.iter_mut().zip(&inner.tiers) {
-            ensure!(
-                tier.artifact.is_some()
-                    || (tier.accumulated_micro_steps == 0
-                        && tier.update_clock == 0
-                        && tier.transfer_clock == 0
-                        && tier.generation == 0),
-                "tier `{}` has mutable state without an immutable optimizer bundle",
-                tier.tier_id
-            );
-            scope.update_clock = tier.update_clock;
-            scope.transfer_clock = tier.transfer_clock;
-            scope.accumulated_micro_steps = tier.accumulated_micro_steps;
-            scope.generation = tier.generation;
-            scope.transfer_generation = tier.transfer_generation;
-            scope.artifact = tier.artifact.clone();
-        }
-        Ok(scopes)
+        scopes_from_inner(&inner)
     }
+}
+
+fn scopes_from_inner(inner: &BankInner) -> Result<MemoryOptimizerScopes> {
+    let mut scopes = inner.scopes.clone();
+    for (scope, tier) in scopes.tiers.iter_mut().zip(&inner.tiers) {
+        ensure!(
+            tier.artifact.is_some()
+                || (tier.accumulated_micro_steps == 0
+                    && tier.update_clock == 0
+                    && tier.transfer_clock == 0
+                    && tier.generation == 0),
+            "tier `{}` has mutable state without an immutable optimizer bundle",
+            tier.tier_id
+        );
+        scope.update_clock = tier.update_clock;
+        scope.transfer_clock = tier.transfer_clock;
+        scope.accumulated_micro_steps = tier.accumulated_micro_steps;
+        scope.generation = tier.generation;
+        scope.transfer_generation = tier.transfer_generation;
+        scope.artifact = tier.artifact.clone();
+    }
+    Ok(scopes)
 }
 
 fn optimizer_topology_hash(
@@ -468,7 +641,7 @@ fn optimizer_topology_hash(
             })
             .collect(),
     })?;
-    Ok(sha256_bytes(&bytes))
+    Ok(sha256_identity(&bytes))
 }
 
 fn validate_model_topology(inner: &BankInner, model: &Transformer) -> Result<()> {
@@ -497,14 +670,7 @@ fn validate_model_topology(inner: &BankInner, model: &Transformer) -> Result<()>
 }
 
 fn active_tier_parameter_ids(model: &Transformer, tier: usize) -> Result<Vec<ParamId>> {
-    let mut ids = model.memory_tier_base_parameter_ids_all_layers(tier)?;
-    ids.extend(
-        model
-            .memory_slot_statuses()
-            .into_iter()
-            .filter(|status| status.tier == tier && status.active)
-            .flat_map(|status| status.parameter_ids),
-    );
+    let ids = model.memory_tier_active_parameter_ids_all_layers(tier)?;
     let unique = ids.iter().map(|id| id.val()).collect::<BTreeSet<_>>();
     ensure!(
         unique.len() == ids.len(),
@@ -514,12 +680,7 @@ fn active_tier_parameter_ids(model: &Transformer, tier: usize) -> Result<Vec<Par
 }
 
 fn dormant_parameter_ids(model: &Transformer) -> Vec<ParamId> {
-    model
-        .memory_slot_statuses()
-        .into_iter()
-        .filter(|status| !status.active)
-        .flat_map(|status| status.parameter_ids)
-        .collect()
+    model.dormant_memory_parameter_ids()
 }
 
 struct GradientAccumulatorVisitor<'a> {
@@ -647,9 +808,9 @@ fn snapshot_inner(inner: &BankInner) -> Result<Vec<u8>> {
             transfer_generation: tier.transfer_generation,
             artifact: tier.artifact.clone(),
             optimizer_bytes: optimizer.len() as u64,
-            optimizer_sha256: sha256_bytes(&optimizer),
+            optimizer_sha256: sha256_identity(&optimizer),
             gradient_bytes: gradients.len() as u64,
-            gradient_sha256: sha256_bytes(&gradients),
+            gradient_sha256: sha256_identity(&gradients),
         });
         chunks.push((optimizer, gradients));
     }
@@ -695,6 +856,10 @@ fn restore_inner(
             .expect("fixed slice"),
     ))
     .context("tier snapshot header does not fit this platform")?;
+    ensure!(
+        header_len <= MAX_TIER_SNAPSHOT_HEADER_BYTES,
+        "tier optimizer snapshot header exceeds the {MAX_TIER_SNAPSHOT_HEADER_BYTES}-byte limit"
+    );
     let header_start = SNAPSHOT_MAGIC.len() + 8;
     let header_end = header_start
         .checked_add(header_len)
@@ -735,6 +900,12 @@ fn restore_inner(
             .context("optimizer snapshot does not fit this platform")?;
         let gradient_len = usize::try_from(saved.gradient_bytes)
             .context("gradient snapshot does not fit this platform")?;
+        ensure!(
+            saved.optimizer_bytes <= MAX_TIER_BUNDLE_MEMBER_BYTES
+                && saved.gradient_bytes <= MAX_TIER_BUNDLE_MEMBER_BYTES,
+            "tier {} snapshot payload exceeds the per-member size limit",
+            saved.tier
+        );
         let optimizer_end = offset
             .checked_add(optimizer_len)
             .context("optimizer snapshot length overflow")?;
@@ -748,8 +919,8 @@ fn restore_inner(
         let optimizer_bytes = &bytes[offset..optimizer_end];
         let gradient_bytes = &bytes[optimizer_end..gradient_end];
         ensure!(
-            sha256_bytes(optimizer_bytes) == saved.optimizer_sha256
-                && sha256_bytes(gradient_bytes) == saved.gradient_sha256,
+            sha256_identity(optimizer_bytes) == saved.optimizer_sha256
+                && sha256_identity(gradient_bytes) == saved.gradient_sha256,
             "tier {} snapshot payload hash mismatch",
             saved.tier
         );
@@ -944,10 +1115,6 @@ fn restore_gradients(
     Ok((gradients, ids))
 }
 
-fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("sha256:{:x}", Sha256::digest(bytes))
-}
-
 struct GradientScaleVisitor<'a> {
     allowed: &'a BTreeSet<u64>,
     gradients: &'a mut GradientsParams,
@@ -1014,9 +1181,21 @@ impl ProspectiveTierUpdate {
         teacher: &ImmutableTransformerCheckpoint,
     ) -> Result<PlannedConsolidation> {
         teacher.validate()?;
-        let (before, before_layout) = self.bank.snapshot_with_layout()?;
-        let staged = self.stage_sender(txn_id, sender, trigger_clock, teacher);
-        let restored = self.bank.restore_with_layout(&before, &before_layout);
+        let teacher_model = load_local_checkpoint(&teacher.model, &teacher.uri, &teacher.sha256)?;
+        let mut inner = self.bank.lock()?;
+        let before_layout = inner.model_layout.clone();
+        let before = self.bank.serialize_snapshot(&inner)?;
+        let staged = stage_sender_locked(
+            &self.root,
+            &mut inner,
+            txn_id,
+            sender,
+            trigger_clock,
+            &teacher_model,
+        );
+        let restored = restore_inner(&inner, &before, &before_layout).map(|restored| {
+            *inner = restored;
+        });
         match (staged, restored) {
             (Ok(candidate), Ok(())) => Ok(PlannedConsolidation {
                 student_checkpoint: candidate.checkpoint.uri,
@@ -1043,101 +1222,117 @@ impl ProspectiveTierUpdate {
         teacher.validate()?;
         let teacher_model = load_local_checkpoint(&teacher.model, &teacher.uri, &teacher.sha256)?;
         let mut inner = self.bank.lock()?;
-        validate_model_topology(&inner, &teacher_model)?;
-        if let Some(staged) = &inner.staged {
-            ensure!(
-                staged.txn_id == txn_id
-                    && staged.sender == sender
-                    && staged.trigger_clock == trigger_clock,
-                "another prospective tier update is already staged"
-            );
-            let model = match &inner.cached_candidate {
-                Some(model) => model.clone(),
-                None => load_local_checkpoint(
-                    &teacher_model,
-                    &staged.student_uri,
-                    &staged.student_sha256,
-                )?,
-            };
-            return Ok(ProspectiveTransformerCandidate {
-                checkpoint: ImmutableTransformerCheckpoint {
-                    uri: staged.student_uri.clone(),
-                    sha256: staged.student_sha256.clone(),
-                    model,
-                },
-                update_sha256: staged.update_sha256.clone(),
-            });
-        }
-        let learning_rate = inner.config.learning_rate;
-        let update_period = *inner
-            .update_periods
-            .get(sender)
-            .with_context(|| format!("sender optimizer tier {sender} does not exist"))?;
-        ensure!(
-            trigger_clock.is_multiple_of(update_period),
-            "sender tier {sender} update is off its configured boundary"
-        );
-        let tier = inner
-            .tiers
-            .get_mut(sender)
-            .with_context(|| format!("sender optimizer tier {sender} does not exist"))?;
-        ensure!(
-            tier.accumulated_micro_steps > 0 && !tier.accumulator.is_empty(),
-            "sender tier {sender} has no accumulated wake gradients"
-        );
-        ensure!(
-            trigger_clock > tier.update_clock,
-            "sender tier {sender} update clock did not advance"
-        );
-        let active_ids = active_tier_parameter_ids(&teacher_model, sender)?;
-        let active_set = active_ids
-            .iter()
-            .map(|id| id.val())
-            .collect::<BTreeSet<_>>();
-        let (accumulator_bytes, accumulator_ids) =
-            canonical_gradients(&teacher_model, &tier.accumulator, &tier.parameter_ids)?;
-        let _ = accumulator_bytes;
-        ensure!(
-            accumulator_ids.iter().all(|id| active_set.contains(id)),
-            "sender tier accumulator contains a dormant parameter"
-        );
-
-        let mut gradients = std::mem::take(&mut tier.accumulator);
-        average_gradients(
-            &teacher_model,
-            &mut gradients,
-            &active_ids,
-            tier.accumulated_micro_steps,
-        )?;
-        let mut optimizer = tier.optimizer.clone();
-        let candidate_model =
-            optimizer.step(learning_rate.into(), teacher_model.clone(), gradients);
-        let update_sha256 = prospective_update_hash(&teacher_model, &candidate_model, sender)?;
-        let (student_uri, student_sha256) =
-            publish_immutable_model(&self.root, txn_id, &candidate_model)?;
-        tier.optimizer = optimizer;
-        tier.accumulated_micro_steps = 0;
-        tier.artifact = None;
-        let staged = StagedUpdateMeta {
+        stage_sender_locked(
+            &self.root,
+            &mut inner,
             txn_id,
             sender,
             trigger_clock,
-            student_uri: student_uri.clone(),
-            student_sha256: student_sha256.clone(),
-            update_sha256: update_sha256.clone(),
-            cleared_parameter_ids: Vec::new(),
-        };
-        inner.staged = Some(staged);
-        inner.cached_candidate = Some(candidate_model.clone());
-        Ok(ProspectiveTransformerCandidate {
-            checkpoint: ImmutableTransformerCheckpoint {
-                uri: student_uri,
-                sha256: student_sha256,
-                model: candidate_model,
-            },
-            update_sha256,
-        })
+            &teacher_model,
+        )
     }
+}
+
+fn stage_sender_locked(
+    root: &Path,
+    inner: &mut BankInner,
+    txn_id: u64,
+    sender: usize,
+    trigger_clock: u64,
+    teacher_model: &Transformer,
+) -> Result<ProspectiveTransformerCandidate> {
+    validate_model_topology(inner, teacher_model)?;
+    if let Some(staged) = &inner.staged {
+        ensure!(
+            staged.txn_id == txn_id
+                && staged.sender == sender
+                && staged.trigger_clock == trigger_clock,
+            "another prospective tier update is already staged"
+        );
+        let model = match &inner.cached_candidate {
+            Some(model) => model.clone(),
+            None => {
+                load_local_checkpoint(teacher_model, &staged.student_uri, &staged.student_sha256)?
+            }
+        };
+        return Ok(ProspectiveTransformerCandidate {
+            checkpoint: ImmutableTransformerCheckpoint {
+                uri: staged.student_uri.clone(),
+                sha256: staged.student_sha256.clone(),
+                model,
+            },
+            update_sha256: staged.update_sha256.clone(),
+        });
+    }
+    let learning_rate = inner.config.learning_rate;
+    let update_period = *inner
+        .update_periods
+        .get(sender)
+        .with_context(|| format!("sender optimizer tier {sender} does not exist"))?;
+    ensure!(
+        trigger_clock.is_multiple_of(update_period),
+        "sender tier {sender} update is off its configured boundary"
+    );
+    let tier = inner
+        .tiers
+        .get_mut(sender)
+        .with_context(|| format!("sender optimizer tier {sender} does not exist"))?;
+    ensure!(
+        tier.accumulated_micro_steps > 0 && !tier.accumulator.is_empty(),
+        "sender tier {sender} has no accumulated wake gradients"
+    );
+    ensure!(
+        trigger_clock > tier.update_clock,
+        "sender tier {sender} update clock did not advance"
+    );
+    let active_ids = active_tier_parameter_ids(teacher_model, sender)?;
+    let active_set = active_ids
+        .iter()
+        .map(|id| id.val())
+        .collect::<BTreeSet<_>>();
+    // This is an execution-time scope check, not a checkpoint write. Reuse
+    // the parameter-only visitor so consolidation does not serialize every
+    // gradient (and synchronize it back to the host) merely to inspect IDs.
+    let accumulator_ids =
+        gradient_parameter_ids(teacher_model, &tier.accumulator, &tier.parameter_ids)?;
+    ensure!(
+        accumulator_ids.iter().all(|id| active_set.contains(id)),
+        "sender tier accumulator contains a dormant parameter"
+    );
+
+    let mut gradients = std::mem::take(&mut tier.accumulator);
+    average_gradients(
+        teacher_model,
+        &mut gradients,
+        &active_ids,
+        tier.accumulated_micro_steps,
+    )?;
+    let mut optimizer = tier.optimizer.clone();
+    let candidate_model = optimizer.step(learning_rate.into(), teacher_model.clone(), gradients);
+    let update_sha256 = prospective_update_hash(teacher_model, &candidate_model, sender)?;
+    let (student_uri, student_sha256) = publish_immutable_model(root, txn_id, &candidate_model)?;
+    tier.optimizer = optimizer;
+    tier.accumulated_micro_steps = 0;
+    tier.artifact = None;
+    let staged = StagedUpdateMeta {
+        txn_id,
+        sender,
+        trigger_clock,
+        student_uri: student_uri.clone(),
+        student_sha256: student_sha256.clone(),
+        update_sha256: update_sha256.clone(),
+        cleared_parameter_ids: Vec::new(),
+    };
+    inner.staged = Some(staged);
+    inner.cached_candidate = Some(candidate_model.clone());
+    Ok(ProspectiveTransformerCandidate {
+        checkpoint: ImmutableTransformerCheckpoint {
+            uri: student_uri,
+            sha256: student_sha256,
+            model: candidate_model,
+        },
+        update_sha256,
+    })
 }
 
 impl ProspectiveTransformerUpdate for ProspectiveTierUpdate {
@@ -1217,13 +1412,24 @@ impl ProspectiveTransformerUpdate for ProspectiveTierUpdate {
 }
 
 fn load_local_checkpoint(template: &Transformer, uri: &str, sha256: &str) -> Result<Transformer> {
+    load_local_checkpoint_inner(template, uri, sha256, |_| Ok(()))
+}
+
+fn load_local_checkpoint_inner(
+    template: &Transformer,
+    uri: &str,
+    sha256: &str,
+    stage_hook: impl FnOnce(&Path) -> Result<()>,
+) -> Result<Transformer> {
     let path = Path::new(uri);
+    let bytes = read_regular_bounded(path, MAX_TIER_BUNDLE_MEMBER_BYTES, "prospective checkpoint")?;
     ensure!(
-        hash_file(path)?.1 == sha256,
+        sha256_identity(&bytes) == sha256,
         "prospective checkpoint hash changed"
     );
+    stage_hook(path)?;
     let mut model = template.clone();
-    load_safetensors(&mut model, path)?;
+    load_safetensors_bytes(&mut model, bytes, "authenticated prospective checkpoint")?;
     Ok(model)
 }
 
@@ -1234,22 +1440,23 @@ fn filter_optimizer(
 ) -> Result<ModuleOptimizer> {
     let bytes = canonical_optimizer(optimizer)?;
     let reader = Reader::from_bytes(Bytes::from_bytes_vec(bytes))?;
+    let scalars = reader.scalars().clone();
+    let metadata = reader.metadata().clone();
     let mut tensors = reader.into_tensors()?;
     tensors.retain(|tensor| tensor.param_id.is_none_or(|id| !removed.contains(&id)));
-    let reader = Reader::from_bytes(canonical_module_optimizer_bytes(optimizer)?)?;
     let mut writer = Writer::new(tensors);
-    for (key, value) in reader.scalars() {
-        if key_parameter_id(key).is_none_or(|id| !removed.contains(&id)) {
-            writer = writer.with_scalar(key, *value);
+    for (key, value) in scalars {
+        if key_parameter_id(&key).is_none_or(|id| !removed.contains(&id)) {
+            writer = writer.with_scalar(&key, value);
         }
     }
-    for (key, value) in reader.metadata() {
+    for (key, value) in metadata {
         if key
             .parse::<u64>()
             .ok()
             .is_none_or(|id| !removed.contains(&id))
         {
-            writer = writer.with_metadata(key, value);
+            writer = writer.with_metadata(&key, &value);
         }
     }
     let filtered = writer.into_bytes()?;
@@ -1300,7 +1507,11 @@ impl AtomicCandidatePublisher for AtomicSafetensorsCandidatePublisher {
             .join("transactions")
             .join(format!("txn-{}.json", txn.id));
         if receipt_path.exists() {
-            let receipt: CandidateReceipt = serde_json::from_slice(&read_regular(&receipt_path)?)?;
+            let receipt: CandidateReceipt = serde_json::from_slice(&read_regular_bounded(
+                &receipt_path,
+                MAX_TIER_BUNDLE_MANIFEST_BYTES,
+                "candidate receipt",
+            )?)?;
             ensure!(
                 receipt.version == CANDIDATE_STORE_VERSION && receipt.txn_id == txn.id,
                 "candidate receipt belongs to another transaction"
@@ -1448,7 +1659,7 @@ impl DurableTierOptimizerPublisher {
         model: &Transformer,
     ) -> Result<()> {
         let mut inner = self.bank.lock()?;
-        let before = snapshot_inner(&inner)?;
+        let before = self.bank.serialize_snapshot(&inner)?;
         let before_layout = inner.model_layout.clone();
         let result = (|| -> Result<()> {
             ensure!(
@@ -1528,22 +1739,19 @@ impl DurableTierOptimizerPublisher {
     /// return the exact checkpoint-v2 scope view. No clock is advanced by a
     /// checkpoint-only publication.
     pub fn publish_checkpoint_scopes(&self) -> Result<MemoryOptimizerScopes> {
-        let (before, before_layout) = self.bank.snapshot_with_layout()?;
-        let result = (|| -> Result<()> {
-            let mut inner = self.bank.lock()?;
-            for tier in 0..inner.tiers.len() {
-                let artifact = publish_tier_bundle(&self.root, &inner, tier)?;
-                inner.tiers[tier].artifact = Some(artifact);
-            }
-            Ok(())
-        })();
-        if let Err(error) = result {
-            self.bank
-                .restore_with_layout(&before, &before_layout)
-                .context("restoring tier optimizer bank after checkpoint publication failure")?;
-            return Err(error);
+        let mut inner = self.bank.lock()?;
+        // Publication itself is read-only. Stage every immutable receipt first
+        // and update the in-memory references only after all filesystem work
+        // succeeds. This makes failure atomic without serializing and then
+        // deserializing the complete optimizer/gradient bank on every wake
+        // checkpoint.
+        let artifacts = (0..inner.tiers.len())
+            .map(|tier| publish_tier_bundle(&self.root, &inner, tier))
+            .collect::<Result<Vec<_>>>()?;
+        for (tier, artifact) in inner.tiers.iter_mut().zip(artifacts) {
+            tier.artifact = Some(artifact);
         }
-        self.bank.scopes()
+        scopes_from_inner(&inner)
     }
 
     fn receipt_path(&self, txn_id: u64) -> PathBuf {
@@ -1569,19 +1777,27 @@ impl DurableTierOptimizerPublisher {
         let mut recorded = txn.clone();
         recorded.tensor_transaction_generation = Some(pointer.generation.clone());
         recorded.tensor_transaction_manifest_hash = Some(pointer.manifest_sha256.clone());
-        let committed_model = {
+        let optimizer = {
             let inner = self.bank.lock()?;
-            load_committed_tensor_model(
-                &self.tensor_store,
-                &recorded,
-                &self.model_config,
-                &self.device,
-                inner.config.optimizer(),
-            )?
+            inner.config.optimizer()
         };
-        let (before, before_layout) = self.bank.snapshot_with_layout()?;
+        let committed_model = load_committed_tensor_model(
+            &self.tensor_store,
+            &recorded,
+            &self.model_config,
+            &self.device,
+            optimizer,
+        )?;
+
+        // Keep the ownership lock from the rollback snapshot through the
+        // complete receipt application. Releasing it between those points
+        // would let another clone commit work which a later failure here could
+        // silently erase by restoring a stale snapshot.
+        let mut inner = self.bank.lock()?;
+        ensure_transaction_tiers_exist(&inner, txn)?;
+        let before_layout = inner.model_layout.clone();
+        let before = self.bank.serialize_snapshot(&inner)?;
         let result = (|| -> Result<()> {
-            let mut inner = self.bank.lock()?;
             inner.model_layout = committed_model;
             for commit in &receipt.commits {
                 let restored_tier = restore_tier_bundle(&self.root, &mut inner, &commit.artifact)?;
@@ -1609,8 +1825,7 @@ impl DurableTierOptimizerPublisher {
             Ok(())
         })();
         if let Err(error) = result {
-            self.bank
-                .restore_with_layout(&before, &before_layout)
+            *inner = restore_inner(&inner, &before, &before_layout)
                 .context("restoring tier optimizer bank after invalid durable receipt")?;
             return Err(error);
         }
@@ -1652,6 +1867,24 @@ fn validate_optimizer_receipt_commits(
     Ok(())
 }
 
+fn ensure_transaction_tiers_exist(inner: &BankInner, txn: &ConsolidationTxn) -> Result<()> {
+    ensure!(
+        txn.sender < inner.tiers.len(),
+        "consolidation sender tier {} is outside optimizer bank with {} tiers",
+        txn.sender,
+        inner.tiers.len()
+    );
+    if !txn.terminal {
+        ensure!(
+            txn.receiver < inner.tiers.len() && txn.receiver != txn.sender,
+            "consolidation receiver tier {} is absent or aliases sender tier {}",
+            txn.receiver,
+            txn.sender
+        );
+    }
+    Ok(())
+}
+
 impl TierOptimizerPublisher for DurableTierOptimizerPublisher {
     fn publish(
         &mut self,
@@ -1665,8 +1898,11 @@ impl TierOptimizerPublisher for DurableTierOptimizerPublisher {
         );
         let receipt_path = self.receipt_path(txn.id);
         if receipt_path.exists() {
-            let receipt: OptimizerTxnReceipt =
-                serde_json::from_slice(&read_regular(&receipt_path)?)?;
+            let receipt: OptimizerTxnReceipt = serde_json::from_slice(&read_regular_bounded(
+                &receipt_path,
+                MAX_TIER_BUNDLE_MANIFEST_BYTES,
+                "optimizer transaction receipt",
+            )?)?;
             return self.apply_receipt(txn, pointer, &receipt);
         }
 
@@ -1685,9 +1921,26 @@ impl TierOptimizerPublisher for DurableTierOptimizerPublisher {
                 .receiver_optimizer
         };
 
-        let (before, before_layout) = self.bank.snapshot_with_layout()?;
+        // The bank is shared by cloned publishers and wake accumulation.
+        // Serialize all mutable work from the rollback point onward so a
+        // failed transaction can restore only its own changes.
+        let mut inner = self.bank.lock()?;
+        if receipt_path.exists() {
+            // Another clone may have published while this caller loaded the
+            // detached tensor transaction. Drop the guard before the normal
+            // idempotent receipt path acquires it again.
+            drop(inner);
+            let receipt: OptimizerTxnReceipt = serde_json::from_slice(&read_regular_bounded(
+                &receipt_path,
+                MAX_TIER_BUNDLE_MANIFEST_BYTES,
+                "optimizer transaction receipt",
+            )?)?;
+            return self.apply_receipt(txn, pointer, &receipt);
+        }
+        ensure_transaction_tiers_exist(&inner, txn)?;
+        let before_layout = inner.model_layout.clone();
+        let before = self.bank.serialize_snapshot(&inner)?;
         let result = (|| {
-            let mut inner = self.bank.lock()?;
             let staged = inner
                 .staged
                 .as_ref()
@@ -1849,12 +2102,14 @@ impl TierOptimizerPublisher for DurableTierOptimizerPublisher {
             inner.cached_candidate = None;
             Ok(commits)
         })();
-        if result.is_err() {
-            self.bank
-                .restore_with_layout(&before, &before_layout)
-                .context("restoring tier optimizer bank after failed artifact transaction")?;
+        match result {
+            Ok(commits) => Ok(commits),
+            Err(error) => {
+                *inner = restore_inner(&inner, &before, &before_layout)
+                    .context("restoring tier optimizer bank after failed artifact transaction")?;
+                Err(error)
+            }
         }
-        result
     }
 }
 
@@ -2006,7 +2261,7 @@ fn publish_tier_bundle(
         files,
     };
     let manifest_bytes = serde_json::to_vec_pretty(&manifest)?;
-    let manifest_hash = sha256_bytes(&manifest_bytes);
+    let manifest_hash = sha256_identity(&manifest_bytes);
     write_new_synced(&staging.join(MANIFEST_FILE), &manifest_bytes)?;
     sync_directory(&staging)?;
     let generation = format!(
@@ -2034,20 +2289,45 @@ fn restore_tier_bundle(
     inner: &mut BankInner,
     artifact: &TierOptimizerArtifact,
 ) -> Result<usize> {
+    restore_tier_bundle_inner(root, inner, artifact, |_, _| Ok(()))
+}
+
+fn restore_tier_bundle_inner(
+    root: &Path,
+    inner: &mut BankInner,
+    artifact: &TierOptimizerArtifact,
+    mut stage_hook: impl FnMut(TierBundleLoadStage, &Path) -> Result<()>,
+) -> Result<usize> {
     artifact.validate()?;
     let manifest_path = Path::new(&artifact.state_uri);
+    let generations = root.join("generations");
     ensure!(
-        manifest_path.starts_with(root.join("generations"))
-            && manifest_path.file_name().and_then(|name| name.to_str()) == Some(MANIFEST_FILE),
+        manifest_path.file_name().and_then(|name| name.to_str()) == Some(MANIFEST_FILE),
         "tier optimizer artifact escapes configured store"
     );
     let generation = manifest_path
         .parent()
         .context("tier artifact has no generation")?;
-    ensure_real_directory(generation, "tier optimizer generation")?;
-    let manifest = verify_tier_bundle(generation, &artifact.manifest_hash)?;
-    let state: TierBundleState =
-        serde_json::from_slice(&read_regular(&generation.join(STATE_FILE))?)?;
+    ensure!(
+        generation.parent() == Some(generations.as_path()),
+        "tier optimizer artifact escapes configured store"
+    );
+    let expected_generation = format!(
+        "sha256-{}",
+        artifact
+            .manifest_hash
+            .strip_prefix("sha256:")
+            .context("tier optimizer manifest hash is malformed")?
+    );
+    ensure!(
+        generation.file_name().and_then(|name| name.to_str()) == Some(expected_generation.as_str()),
+        "tier optimizer generation name differs from its manifest hash"
+    );
+    let (manifest, mut captured) =
+        capture_verified_tier_bundle(generation, &artifact.manifest_hash)?;
+    stage_hook(TierBundleLoadStage::AfterCapture, generation)?;
+    let state_bytes = captured.read_bounded(STATE_FILE, MAX_TIER_BUNDLE_STATE_BYTES)?;
+    let state: TierBundleState = serde_json::from_slice(&state_bytes)?;
     ensure!(
         state.version == TIER_BUNDLE_VERSION
             && state.tier == manifest.tier
@@ -2057,9 +2337,10 @@ fn restore_tier_bundle(
             && state.accumulator_parameter_ids == artifact.accumulator_parameter_ids,
         "tier optimizer bundle metadata differs from receipt"
     );
+    artifact.validate_pending_steps(state.accumulated_micro_steps)?;
     let tier = inner
         .tiers
-        .get_mut(state.tier)
+        .get(state.tier)
         .context("tier optimizer bundle references absent tier")?;
     ensure!(
         tier.tier_id == state.tier_id,
@@ -2075,15 +2356,27 @@ fn restore_tier_bundle(
                 .all(|id| active.contains(id)),
         "tier optimizer bundle contains dormant or omits active parameter scope"
     );
-    let optimizer_bytes = read_regular(&generation.join(OPTIMIZER_FILE))?;
-    let gradient_bytes = read_regular(&generation.join(GRADIENT_FILE))?;
+    let optimizer_bytes = captured.take(OPTIMIZER_FILE, MAX_TIER_BUNDLE_MEMBER_BYTES)?;
     let optimizer = optimizer_from_bytes(&inner.config, &optimizer_bytes)?;
+    drop(optimizer_bytes);
+    let gradient_bytes = captured.take(GRADIENT_FILE, MAX_TIER_BUNDLE_MEMBER_BYTES)?;
     let (accumulator, ids) =
         restore_gradients(&inner.model_layout, &gradient_bytes, &tier.parameter_ids)?;
+    drop(gradient_bytes);
     ensure!(
         ids == state.accumulator_parameter_ids,
         "tier gradient receipt changed"
     );
+    ensure!(
+        accumulator.is_empty() == (state.accumulated_micro_steps == 0),
+        "restored tier gradients disagree with the pending-step counter"
+    );
+    stage_hook(TierBundleLoadStage::AfterStagedLoad, generation)?;
+    captured.ensure_still_published()?;
+    let tier = inner
+        .tiers
+        .get_mut(state.tier)
+        .context("tier optimizer bundle references absent tier")?;
     tier.optimizer = optimizer;
     tier.accumulator = accumulator;
     tier.accumulated_micro_steps = state.accumulated_micro_steps;
@@ -2096,10 +2389,23 @@ fn restore_tier_bundle(
 }
 
 fn verify_tier_bundle(generation: &Path, expected_hash: &str) -> Result<TierBundleManifest> {
-    ensure_real_directory(generation, "tier optimizer generation")?;
-    let manifest_bytes = read_regular(&generation.join(MANIFEST_FILE))?;
+    let (manifest, captured) = capture_verified_tier_bundle(generation, expected_hash)?;
+    captured.ensure_still_published()?;
+    Ok(manifest)
+}
+
+fn capture_verified_tier_bundle(
+    generation: &Path,
+    expected_hash: &str,
+) -> Result<(TierBundleManifest, AuthenticatedDirectorySnapshot)> {
+    let mut captured = AuthenticatedDirectorySnapshot::capture(
+        generation,
+        &TIER_BUNDLE_SCHEMA,
+        "tier optimizer generation",
+    )?;
+    let manifest_bytes = captured.read_bounded(MANIFEST_FILE, MAX_TIER_BUNDLE_MANIFEST_BYTES)?;
     ensure!(
-        sha256_bytes(&manifest_bytes) == expected_hash,
+        sha256_identity(&manifest_bytes) == expected_hash,
         "tier manifest hash mismatch"
     );
     let manifest: TierBundleManifest = serde_json::from_slice(&manifest_bytes)?;
@@ -2120,14 +2426,14 @@ fn verify_tier_bundle(generation: &Path, expected_hash: &str) -> Result<TierBund
         "tier bundle does not contain the exact required file set"
     );
     for file in &manifest.files {
-        let path = generation.join(&file.path);
-        let (bytes, hash) = hash_file(&path)?;
         ensure!(
-            bytes == file.bytes && hash == file.sha256,
-            "tier bundle file changed"
+            file.bytes <= MAX_TIER_BUNDLE_MEMBER_BYTES,
+            "tier bundle file `{}` exceeds the per-member size limit",
+            file.path
         );
+        captured.verify(&file.path, file.bytes, &file.sha256)?;
     }
-    Ok(manifest)
+    Ok((manifest, captured))
 }
 
 fn bundle_file(root: &Path, name: &str) -> Result<BundleFile> {
@@ -2149,109 +2455,6 @@ impl Drop for StagingDirectory {
     }
 }
 
-fn ensure_directory(path: &Path, label: &str) -> Result<()> {
-    fs::create_dir_all(path).with_context(|| format!("creating {label} {}", path.display()))?;
-    ensure_real_directory(path, label)
-}
-
-fn ensure_real_directory(path: &Path, label: &str) -> Result<()> {
-    let metadata = fs::symlink_metadata(path)?;
-    ensure!(
-        metadata.is_dir() && !metadata.file_type().is_symlink(),
-        "{label} {} is not a real directory",
-        path.display()
-    );
-    Ok(())
-}
-
-fn read_regular(path: &Path) -> Result<Vec<u8>> {
-    let metadata = fs::symlink_metadata(path)
-        .with_context(|| format!("reading artifact metadata {}", path.display()))?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "artifact {} is not a regular non-symlink file",
-        path.display()
-    );
-    fs::read(path).with_context(|| format!("reading artifact {}", path.display()))
-}
-
-fn write_new_synced(path: &Path, bytes: &[u8]) -> Result<()> {
-    let mut file = OpenOptions::new()
-        .create_new(true)
-        .write(true)
-        .open(path)
-        .with_context(|| format!("creating immutable file {}", path.display()))?;
-    file.write_all(bytes)?;
-    file.sync_all()?;
-    Ok(())
-}
-
-fn atomic_write_new(path: &Path, bytes: &[u8]) -> Result<()> {
-    let parent = path.parent().context("atomic artifact has no parent")?;
-    ensure_directory(parent, "atomic artifact parent")?;
-    if path.exists() {
-        ensure!(
-            read_regular(path)? == bytes,
-            "immutable artifact already exists with different bytes"
-        );
-        return Ok(());
-    }
-    let name = path
-        .file_name()
-        .context("atomic artifact has no file name")?
-        .to_string_lossy();
-    let temporary = parent.join(format!(
-        ".{name}.staging-{}-{}",
-        std::process::id(),
-        STAGING_SEQUENCE.fetch_add(1, Ordering::Relaxed)
-    ));
-    write_new_synced(&temporary, bytes)?;
-    match fs::hard_link(&temporary, path) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            ensure!(
-                read_regular(path)? == bytes,
-                "concurrent immutable publication differs"
-            );
-        }
-        Err(error) => {
-            let _ = fs::remove_file(&temporary);
-            return Err(error).context("atomically linking immutable artifact");
-        }
-    }
-    fs::remove_file(&temporary)?;
-    sync_directory(parent)
-}
-
-fn sync_directory(path: &Path) -> Result<()> {
-    File::open(path)?.sync_all()?;
-    Ok(())
-}
-
-fn hash_file(path: &Path) -> Result<(u64, String)> {
-    let metadata = fs::symlink_metadata(path)?;
-    ensure!(
-        metadata.is_file() && !metadata.file_type().is_symlink(),
-        "hashed artifact {} is not a regular file",
-        path.display()
-    );
-    let mut file = File::open(path)?;
-    let mut hasher = Sha256::new();
-    let mut buffer = [0_u8; 1024 * 1024];
-    let mut bytes = 0_u64;
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-        bytes = bytes
-            .checked_add(read as u64)
-            .context("artifact byte count overflow")?;
-    }
-    Ok((bytes, format!("sha256:{:x}", hasher.finalize())))
-}
-
 fn publish_immutable_model(
     root: &Path,
     txn_id: u64,
@@ -2269,7 +2472,7 @@ fn publish_immutable_model(
     let _guard = StagingDirectory(staging.clone());
     let weights = staging.join(WEIGHTS_FILE);
     save_safetensors(&model.clone().valid(), &weights)?;
-    OpenOptions::new().read(true).open(&weights)?.sync_all()?;
+    sync_regular_file(&weights, "model generation weights")?;
     let (_, sha256) = hash_file(&weights)?;
     sync_directory(&staging)?;
     let generation = format!(
@@ -2397,6 +2600,21 @@ mod tests {
         assert_eq!(bank.tier_clocks().unwrap(), vec![(0, 0, 0), (0, 0, 0)]);
     }
 
+    #[test]
+    fn accumulation_cannot_coalesce_checkpoint_generations() {
+        let (_, _, model) = model();
+        let bank =
+            TierOptimizerBank::new(&model, &schedule(), TierOptimizerConfig::default()).unwrap();
+        let before = bank.snapshot_bytes().unwrap();
+
+        let error = bank
+            .commit_tier_gradients(&model, Vec::new(), 2)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("exactly one optimizer step"), "{error}");
+        assert_eq!(bank.snapshot_bytes().unwrap(), before);
+    }
+
     fn teacher_checkpoint(root: &Path, model: &Transformer) -> ImmutableTransformerCheckpoint {
         let path = root.join("teacher.safetensors");
         save_safetensors(&model.clone().valid(), &path).unwrap();
@@ -2465,7 +2683,10 @@ mod tests {
             device,
         )
         .unwrap();
+        let clocks_before_publication = restored.tier_clocks().unwrap();
         let scopes = publisher.publish_checkpoint_scopes().unwrap();
+        assert_eq!(restored.tier_clocks().unwrap(), clocks_before_publication);
+        assert_eq!(publisher.publish_checkpoint_scopes().unwrap(), scopes);
         let dormant = dormant_parameter_ids(&model)
             .into_iter()
             .map(|id| id.val())
@@ -2486,6 +2707,265 @@ mod tests {
             format!("sha256:{}", "0".repeat(64));
         assert!(publisher.restore_scopes(&corrupted, &model).is_err());
         assert_eq!(before_failed_restore, restored.snapshot_bytes().unwrap());
+    }
+
+    #[test]
+    fn snapshot_restore_rejects_an_oversized_header_before_parsing() {
+        let (_, _, model) = model();
+        let bank =
+            TierOptimizerBank::new(&model, &schedule(), TierOptimizerConfig::default()).unwrap();
+        let before = bank.snapshot_bytes().unwrap();
+        let mut hostile = Vec::from(SNAPSHOT_MAGIC.as_slice());
+        hostile.extend_from_slice(
+            &u64::try_from(MAX_TIER_SNAPSHOT_HEADER_BYTES + 1)
+                .unwrap()
+                .to_le_bytes(),
+        );
+
+        let error = bank.restore_bytes(&hostile).unwrap_err().to_string();
+        assert!(error.contains("snapshot header exceeds"), "{error}");
+        assert_eq!(bank.snapshot_bytes().unwrap(), before);
+    }
+
+    #[test]
+    fn wake_only_non_boundary_does_not_serialize_optimizer_state() {
+        let (_, device, model) = model();
+        let mut delayed = schedule();
+        delayed.tiers[0].update_period = 2;
+        delayed.tiers[1].update_period = 4;
+        let bank =
+            TierOptimizerBank::new(&model, &delayed, TierOptimizerConfig::default()).unwrap();
+        accumulate(&bank, &model, &device);
+        let serializations_before = bank.snapshot_serialization_count();
+        let clocks_before = bank.tier_clocks().unwrap();
+
+        let (unchanged, report) = bank.apply_wake_only_due_updates(&model, 1).unwrap();
+
+        assert!(report.updates.is_empty());
+        assert_eq!(bank.snapshot_serialization_count(), serializations_before);
+        assert_eq!(bank.tier_clocks().unwrap(), clocks_before);
+        assert_eq!(
+            crate::tensor_sleep::model_parameter_hash(&unchanged).unwrap(),
+            crate::tensor_sleep::model_parameter_hash(&model).unwrap()
+        );
+    }
+
+    #[test]
+    fn wake_only_failure_after_an_earlier_due_tier_rolls_back_the_complete_bank() {
+        let (_, device, model) = model();
+        let bank =
+            TierOptimizerBank::new(&model, &schedule(), TierOptimizerConfig::default()).unwrap();
+        accumulate(&bank, &model, &device);
+        {
+            let mut inner = bank.lock().unwrap();
+            inner.tiers[1].generation = u64::MAX;
+        }
+        let before = bank.snapshot_bytes().unwrap();
+        let clocks_before = bank.tier_clocks().unwrap();
+
+        let error = bank.apply_wake_only_due_updates(&model, 2).unwrap_err();
+
+        assert!(
+            error.to_string().contains("generation overflow"),
+            "{error:#}"
+        );
+        assert_eq!(bank.snapshot_bytes().unwrap(), before);
+        assert_eq!(bank.tier_clocks().unwrap(), clocks_before);
+    }
+
+    #[test]
+    fn wake_only_updates_due_tiers_and_resumes_pending_accumulation_exactly() {
+        let (config, device, model) = model();
+        let schedule = schedule();
+        let optimizer = TierOptimizerConfig::default();
+        let source = TierOptimizerBank::new(&model, &schedule, optimizer.clone()).unwrap();
+        let initial_slots = model.memory_slot_statuses();
+        let initial_hash = crate::tensor_sleep::model_parameter_hash(&model).unwrap();
+
+        accumulate(&source, &model, &device);
+        let (after_one, first) = source.apply_wake_only_due_updates(&model, 1).unwrap();
+        assert_eq!(first.updates.len(), 1);
+        assert_eq!(first.updates[0].tier, 0);
+        assert_eq!(first.updates[0].accumulated_optimizer_steps, 1);
+        assert_ne!(
+            crate::tensor_sleep::model_parameter_hash(&after_one).unwrap(),
+            initial_hash,
+            "the due fast tier did not update model parameters"
+        );
+        assert_eq!(after_one.memory_slot_statuses(), initial_slots);
+        assert_eq!(source.tier_clocks().unwrap(), vec![(1, 0, 0), (0, 0, 1)]);
+
+        let directory = TempDir::new().unwrap();
+        let root = directory.path().join("wake-only-optimizers");
+        let publisher = DurableTierOptimizerPublisher::new(
+            source.clone(),
+            &root,
+            TensorTransactionStore::new(directory.path().join("unused-tensors")),
+            config.clone(),
+            device.clone(),
+        )
+        .unwrap();
+        let scopes = publisher.publish_checkpoint_scopes().unwrap();
+        assert_eq!(scopes.tiers[1].accumulated_micro_steps, 1);
+        let checkpoint_snapshot = source.snapshot_bytes().unwrap();
+
+        let resumed = TierOptimizerBank::new(&after_one, &schedule, optimizer).unwrap();
+        let resumed_publisher = DurableTierOptimizerPublisher::new(
+            resumed.clone(),
+            &root,
+            TensorTransactionStore::new(directory.path().join("unused-tensors")),
+            config,
+            device.clone(),
+        )
+        .unwrap();
+        resumed_publisher
+            .restore_scopes(&scopes, &after_one)
+            .unwrap();
+        assert_eq!(
+            resumed.snapshot_bytes().unwrap(),
+            checkpoint_snapshot,
+            "wake_only optimizer moments, clocks, or pending gradients changed on resume"
+        );
+
+        accumulate(&source, &after_one, &device);
+        accumulate(&resumed, &after_one, &device);
+        let (source_after_two, source_report) =
+            source.apply_wake_only_due_updates(&after_one, 2).unwrap();
+        let (resumed_after_two, resumed_report) =
+            resumed.apply_wake_only_due_updates(&after_one, 2).unwrap();
+        assert_eq!(source_report, resumed_report);
+        assert_eq!(
+            source_report
+                .updates
+                .iter()
+                .map(|update| (update.tier, update.accumulated_optimizer_steps))
+                .collect::<Vec<_>>(),
+            vec![(0, 1), (1, 2)],
+            "coincident boundaries must update fastest-to-slowest and retain the slow pending window"
+        );
+        assert_eq!(
+            crate::tensor_sleep::model_parameter_hash(&source_after_two).unwrap(),
+            crate::tensor_sleep::model_parameter_hash(&resumed_after_two).unwrap(),
+            "resumed wake_only update produced different parameters"
+        );
+        assert_eq!(
+            source.snapshot_bytes().unwrap(),
+            resumed.snapshot_bytes().unwrap()
+        );
+        assert_eq!(source.tier_clocks().unwrap(), vec![(2, 0, 0), (2, 0, 0)]);
+        assert_eq!(source_after_two.memory_slot_statuses(), initial_slots);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tier_bundle_load_is_aba_safe_and_rejects_persistent_replacement() {
+        let (config, device, model) = model();
+        let directory = TempDir::new().unwrap();
+        let root = directory.path().join("optimizers");
+        let source =
+            TierOptimizerBank::new(&model, &schedule(), TierOptimizerConfig::default()).unwrap();
+        accumulate(&source, &model, &device);
+        let publisher = DurableTierOptimizerPublisher::new(
+            source.clone(),
+            root.clone(),
+            TensorTransactionStore::new(directory.path().join("tensor")),
+            config,
+            device,
+        )
+        .unwrap();
+        let scopes = publisher.publish_checkpoint_scopes().unwrap();
+        let artifact = scopes.tiers[0].artifact.as_ref().unwrap().clone();
+        let generation = Path::new(&artifact.state_uri).parent().unwrap().to_owned();
+        let held = root.join("held-tier-generation");
+
+        let restored =
+            TierOptimizerBank::new(&model, &schedule(), TierOptimizerConfig::default()).unwrap();
+        {
+            let mut inner = restored.lock().unwrap();
+            restore_tier_bundle_inner(&root, &mut inner, &artifact, |stage, path| {
+                match stage {
+                    TierBundleLoadStage::AfterCapture => {
+                        fs::rename(path, &held)?;
+                        fs::create_dir(path)?;
+                    }
+                    TierBundleLoadStage::AfterStagedLoad => {
+                        fs::remove_dir(path)?;
+                        fs::rename(&held, path)?;
+                    }
+                }
+                Ok(())
+            })
+            .unwrap();
+        }
+        assert_eq!(
+            restored.tier_clocks().unwrap()[0],
+            source.tier_clocks().unwrap()[0],
+            "an A->B->A pathname swap changed the restored tier state"
+        );
+
+        let persistent =
+            TierOptimizerBank::new(&model, &schedule(), TierOptimizerConfig::default()).unwrap();
+        let before = persistent.snapshot_bytes().unwrap();
+        let held = root.join("held-persistent-tier-generation");
+        let result = {
+            let mut inner = persistent.lock().unwrap();
+            restore_tier_bundle_inner(&root, &mut inner, &artifact, |stage, path| {
+                if stage == TierBundleLoadStage::AfterCapture {
+                    fs::rename(path, &held)?;
+                    fs::create_dir(path)?;
+                }
+                Ok(())
+            })
+        };
+        let error = result.unwrap_err().to_string();
+        assert!(
+            error.contains("changed during authenticated load"),
+            "{error}"
+        );
+        assert_eq!(persistent.snapshot_bytes().unwrap(), before);
+        fs::remove_dir(&generation).unwrap();
+        fs::rename(held, &generation).unwrap();
+
+        let state_path = generation.join(STATE_FILE);
+        let held_state = root.join("held-tier-state.json");
+        let replacement =
+            TierOptimizerBank::new(&model, &schedule(), TierOptimizerConfig::default()).unwrap();
+        let before = replacement.snapshot_bytes().unwrap();
+        let result = {
+            let mut inner = replacement.lock().unwrap();
+            restore_tier_bundle_inner(&root, &mut inner, &artifact, |stage, _| {
+                if stage == TierBundleLoadStage::AfterCapture {
+                    fs::rename(&state_path, &held_state)?;
+                    fs::write(&state_path, b"persistent replacement")?;
+                }
+                Ok(())
+            })
+        };
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("file `state.json` changed"), "{error}");
+        assert_eq!(replacement.snapshot_bytes().unwrap(), before);
+        fs::remove_file(&state_path).unwrap();
+        fs::rename(held_state, state_path).unwrap();
+
+        let optimizer_path = generation.join(OPTIMIZER_FILE);
+        let mutated =
+            TierOptimizerBank::new(&model, &schedule(), TierOptimizerConfig::default()).unwrap();
+        let before = mutated.snapshot_bytes().unwrap();
+        let result = {
+            let mut inner = mutated.lock().unwrap();
+            restore_tier_bundle_inner(&root, &mut inner, &artifact, |stage, _| {
+                if stage == TierBundleLoadStage::AfterCapture {
+                    OpenOptions::new()
+                        .append(true)
+                        .open(&optimizer_path)?
+                        .write_all(b"persistent mutation")?;
+                }
+                Ok(())
+            })
+        };
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("file `optimizer.bpk` changed"), "{error}");
+        assert_eq!(mutated.snapshot_bytes().unwrap(), before);
     }
 
     #[test]
@@ -2529,6 +3009,64 @@ mod tests {
             .unwrap();
         assert_eq!(first.uri, second.uri);
         assert_eq!(first.sha256, second.sha256);
+    }
+
+    #[test]
+    fn failed_prospective_preview_restores_a_consumed_sender_accumulator() {
+        let (_, device, model) = model();
+        let directory = TempDir::new().unwrap();
+        let bank =
+            TierOptimizerBank::new(&model, &schedule(), TierOptimizerConfig::default()).unwrap();
+        accumulate(&bank, &model, &device);
+        let teacher = teacher_checkpoint(directory.path(), &model);
+        let root = directory.path().join("prospective-failure");
+        let mut update = ProspectiveTierUpdate::new(bank.clone(), &root).unwrap();
+        // Staging consumes the sender accumulator before publishing its
+        // immutable candidate. Force that publication to fail after the
+        // consume point and require byte-exact in-memory rollback.
+        fs::write(root.join("model-generations"), b"not a directory").unwrap();
+        let before = bank.snapshot_bytes().unwrap();
+
+        assert!(update.prepare_consolidation(1, 0, 1, &teacher).is_err());
+        assert_eq!(bank.snapshot_bytes().unwrap(), before);
+        assert_eq!(bank.tier_clocks().unwrap(), vec![(0, 0, 1), (0, 0, 1)]);
+    }
+
+    #[test]
+    fn prospective_checkpoint_load_uses_the_authenticated_bytes_after_path_replacement() {
+        let (config, device, model) = model();
+        let directory = TempDir::new().unwrap();
+        let checkpoint = directory.path().join("prospective.safetensors");
+        let held = directory.path().join("held-prospective.safetensors");
+        let replacement = directory.path().join("replacement.safetensors");
+        save_safetensors(&model.clone().valid(), &checkpoint).unwrap();
+        let expected_sha256 = hash_file(&checkpoint).unwrap().1;
+        let expected_parameters = crate::tensor_sleep::model_parameter_hash(&model).unwrap();
+
+        device.seed(97);
+        let other = Transformer::new(&config, &device).unwrap();
+        assert_ne!(
+            crate::tensor_sleep::model_parameter_hash(&other).unwrap(),
+            expected_parameters
+        );
+        save_safetensors(&other.valid(), &replacement).unwrap();
+
+        let loaded = load_local_checkpoint_inner(
+            &model,
+            checkpoint.to_str().unwrap(),
+            &expected_sha256,
+            |path| {
+                fs::rename(path, &held)?;
+                fs::rename(&replacement, path)?;
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            crate::tensor_sleep::model_parameter_hash(&loaded).unwrap(),
+            expected_parameters,
+            "prospective checkpoint loader reopened a replaced pathname"
+        );
     }
 
     fn run_tier_bundle_crash_scenario(sender_active: bool) {

--- a/hermes-train/src/trainer.rs
+++ b/hermes-train/src/trainer.rs
@@ -1,12 +1,31 @@
 //! Objective-aware streaming optimization loop.
 
 use super::*;
+use std::collections::VecDeque;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 
 const TRAINER_LOCK_FILE: &str = ".trainer.lock";
+const MAX_PREFETCHED_SAMPLES: usize = 4_096;
+
+fn training_prefetch_capacity(batch_size: usize) -> Result<usize> {
+    ensure!(batch_size > 0, "training batch size must be positive");
+    Ok(batch_size.saturating_mul(2).min(MAX_PREFETCHED_SAMPLES))
+}
+
+fn push_bounded_wake_context(
+    contexts: &mut VecDeque<Vec<i64>>,
+    context: Vec<i64>,
+    maximum_records: usize,
+) {
+    debug_assert!(maximum_records > 0);
+    if contexts.len() == maximum_records {
+        contexts.pop_front();
+    }
+    contexts.push_back(context);
+}
 
 /// Process-lifetime ownership of one mutable training output root.
 ///
@@ -183,20 +202,26 @@ impl hermes_train::native_sleep::NativeSleepProgressSink for TrainerSleepProgres
         checkpoint: &hermes_train::native_sleep::NativeSleepCheckpoint,
     ) -> Result<()> {
         let mut checkpoint_model = self.model_template.clone();
-        load_safetensors(
+        let checkpoint_path = Path::new(&checkpoint.live_checkpoint.uri);
+        let checkpoint_bytes =
+            read_pinned_checkpoint_bytes(checkpoint_path, &checkpoint.live_checkpoint.sha256)?;
+        hermes_llm::load_safetensors_bytes(
             &mut checkpoint_model,
-            Path::new(&checkpoint.live_checkpoint.uri),
+            checkpoint_bytes,
+            &format!("sleep checkpoint {}", checkpoint_path.display()),
         )?;
-        self.state.sleep = Some(checkpoint.clone());
-        self.state.metric_records = self.metrics.state().records;
+        let mut staged_state = self.state.clone();
+        staged_state.sleep = Some(checkpoint.clone());
+        staged_state.metric_records = self.metrics.state().records;
         let _ = save_training_checkpoint_with_evidence(
             &checkpoint_model,
             self.adamw,
             self.muon,
-            self.state,
+            &staged_state,
             self.metrics,
             self.output,
         )?;
+        *self.state = staged_state;
         Ok(())
     }
 
@@ -220,12 +245,87 @@ struct PeriodicTrainingRuntime {
     config_sha256: String,
 }
 
+/// Schedule-matched no-sleep ablation runtime. Tier optimizers and pending
+/// accumulators are identical in shape and cadence to periodic sleep, while
+/// due base updates commit directly and reserve state is never mutated.
+struct WakeOnlyMemoryRuntime {
+    config: MemoryUpdateMode,
+    bank: TierOptimizerBank,
+    publisher: DurableTierOptimizerPublisher,
+}
+
+impl WakeOnlyMemoryRuntime {
+    fn load(
+        workflow: &ResolvedWakePlan,
+        model: &Transformer,
+        output: &Path,
+        device: &hermes_llm::Device,
+    ) -> Result<Option<Self>> {
+        let Some(config) = workflow
+            .phases
+            .first()
+            .and_then(|phase| phase.memory_update_mode.clone())
+        else {
+            return Ok(None);
+        };
+        let bank =
+            TierOptimizerBank::new(model, config.schedule(), config.tier_optimizer().clone())?;
+        let output = fs::canonicalize(output)
+            .with_context(|| format!("canonicalizing training output {}", output.display()))?;
+        let publisher = DurableTierOptimizerPublisher::new(
+            bank.clone(),
+            output.join("wake-only-tier-optimizers"),
+            TensorTransactionStore::new(output.join("wake-only-tensor-transactions")),
+            model.config().clone(),
+            device.clone(),
+        )?;
+        Ok(Some(Self {
+            config,
+            bank,
+            publisher,
+        }))
+    }
+
+    fn restore(&self, state: &TrainingState, model: &Transformer) -> Result<()> {
+        let TrainingMemoryUpdateState::WakeOnly {
+            config,
+            optimizer_scopes,
+        } = &state.memory_update
+        else {
+            bail!("wake_only runtime cannot restore a checkpoint from another memory mode")
+        };
+        ensure!(
+            config == &self.config,
+            "wake_only checkpoint configuration differs from the workflow"
+        );
+        self.publisher.restore_scopes(optimizer_scopes, model)
+    }
+
+    fn checkpoint(&self, state: &mut TrainingState) -> Result<()> {
+        state.memory_update = TrainingMemoryUpdateState::WakeOnly {
+            config: self.config.clone(),
+            optimizer_scopes: self.publisher.publish_checkpoint_scopes()?,
+        };
+        Ok(())
+    }
+}
+
 /// Fake-quantized parameter leaves shared by the microbatches that contribute
 /// to one master-weight update. A window must never cross an optimizer step.
 struct StagedQuantizationWindow {
     format: UltraQuantFormat,
     model: Transformer,
     tensor_count: u64,
+}
+
+fn quantization_state_format(format: Option<UltraQuantFormat>) -> String {
+    match format {
+        None => "full_precision",
+        Some(UltraQuantFormat::BinaryG128) => "binary_g128",
+        Some(UltraQuantFormat::TernaryG128) => "ternary_g128",
+        Some(UltraQuantFormat::TernaryEntropyG128) => "ternary_entropy_g128",
+    }
+    .to_owned()
 }
 
 enum PrefetchedSample {
@@ -439,6 +539,32 @@ fn preflight_resumed_sleep_runtime(
     validate_sleep_runtime_artifact(&state.artifacts, &canonical, sha256)
 }
 
+pub(super) fn preflight_resumed_memory_mode(
+    workflow: &ResolvedWakePlan,
+    state: &TrainingState,
+) -> Result<()> {
+    let periodic = workflow
+        .phases
+        .first()
+        .and_then(|phase| phase.periodic_sleep.as_ref());
+    let wake_only = workflow
+        .phases
+        .first()
+        .and_then(|phase| phase.memory_update_mode.as_ref());
+    match (&state.memory_update, periodic, wake_only) {
+        (TrainingMemoryUpdateState::Ordinary, None, None)
+        | (TrainingMemoryUpdateState::PeriodicSleep, Some(_), None) => Ok(()),
+        (TrainingMemoryUpdateState::WakeOnly { config, .. }, None, Some(expected)) => {
+            ensure!(
+                config == expected,
+                "wake_only checkpoint configuration differs from the exact workflow"
+            );
+            Ok(())
+        }
+        _ => bail!("checkpoint memory update mode differs from the exact workflow"),
+    }
+}
+
 fn validate_periodic_runtime_binding(
     factory: &BuiltinSleepPhaseContextFactory,
     sleep: &hermes_train::workflow::InModelSleepConfig,
@@ -490,9 +616,12 @@ fn advance_and_drain_periodic_sleep(
         hermes_train::sleep::UpdateClock::OptimizerSteps => state.global_step as u64,
         hermes_train::sleep::UpdateClock::ModelTokens => state.tokens_seen as u64,
     };
+    // Keep the last durable cursor installed until a newly persisted cursor
+    // replaces it. Driver construction and boundary binding are fallible; a
+    // failed attempt must not erase resumable state from the live trainer.
     let mut cursor = state
         .sleep
-        .take()
+        .clone()
         .context("periodic training has no native sleep cursor")?;
     let continuing = cursor.sleep.pending.is_some() || cursor.sleep.next_due_sender().is_some();
     if !continuing {
@@ -601,12 +730,17 @@ fn publish_quantization_phase_candidate(
         state.global_step,
         stable_cache_id(&phase.name)
     );
-    let publication = publish_qat_candidate(
-        model,
-        &output.join("quantized-candidates"),
-        &key,
-        &plan.recipe,
-    )?;
+    let candidate_store = output.join("quantized-candidates");
+    let publication = match expected_source_checkpoint_sha256 {
+        Some(source_sha256) => publish_qat_candidate_from_authenticated_source(
+            model,
+            &candidate_store,
+            &key,
+            &plan.recipe,
+            source_sha256,
+        )?,
+        None => publish_qat_candidate(model, &candidate_store, &key, &plan.recipe)?,
+    };
     if let Some(expected) = expected_source_checkpoint_sha256 {
         ensure!(
             publication.weights_sha256 == expected,
@@ -623,10 +757,11 @@ fn publish_quantization_phase_candidate(
         .quantization
         .as_mut()
         .context("quantization phase has no checkpoint quantization state")?;
-    quantization.format = format!("{:?}", plan.recipe.format).to_ascii_lowercase();
+    quantization.format = quantization_state_format(Some(plan.recipe.format));
     quantization.fake_quant_active = false;
     quantization.calibration_step = state.global_step as u64;
     quantization.manifest = Some(manifest.clone());
+    quantization.candidate_weights_sha256 = Some(publication.weights_sha256.clone());
     if !state.artifacts.iter().any(|artifact| {
         artifact.kind == "hquant_candidate"
             && artifact.hash == publication.candidate_manifest_sha256
@@ -707,7 +842,7 @@ fn bind_post_sleep_quantization_source(
         .context("memory-model QAT phase has no periodic_sleep")?;
     let mut cursor = state
         .sleep
-        .take()
+        .clone()
         .context("memory-model QAT phase has no native sleep cursor")?;
     ensure!(
         cursor.sleep.pending.is_none() && cursor.sleep.next_due_sender().is_none(),
@@ -729,6 +864,7 @@ fn publish_completed_quantization_candidate_if_pending(
     metrics: &mut MetricWriter,
     output: &Path,
     periodic_runtime: Option<&PeriodicTrainingRuntime>,
+    authenticated_model_sha256: Option<&str>,
 ) -> Result<bool> {
     let Some(plan) = &phase.quantization else {
         return Ok(false);
@@ -742,7 +878,16 @@ fn publish_completed_quantization_candidate_if_pending(
     {
         return Ok(false);
     }
-    let source = bind_post_sleep_quantization_source(periodic_runtime, phase, state, model)?;
+    let sleep_source = bind_post_sleep_quantization_source(periodic_runtime, phase, state, model)?;
+    if let (Some(sleep_source), Some(checkpoint_source)) =
+        (sleep_source.as_deref(), authenticated_model_sha256)
+    {
+        ensure!(
+            sleep_source == checkpoint_source,
+            "post-sleep QAT source differs from the authenticated trainer checkpoint"
+        );
+    }
+    let source = sleep_source.as_deref().or(authenticated_model_sha256);
     publish_quantization_phase_candidate(
         model,
         plan,
@@ -751,7 +896,7 @@ fn publish_completed_quantization_candidate_if_pending(
         state,
         metrics,
         output,
-        source.as_deref(),
+        source,
     )?;
     Ok(true)
 }
@@ -760,30 +905,8 @@ fn verify_resumed_quantization_candidate(
     state: &TrainingState,
     phase: &super::wake::ResolvedWakePhase,
     planned_steps: usize,
-    model: &Transformer,
+    resumed_weights_sha256: &str,
 ) -> Result<()> {
-    for artifact in state
-        .artifacts
-        .iter()
-        .filter(|artifact| artifact.kind == "hquant_candidate")
-    {
-        let manifest = Path::new(&artifact.manifest);
-        ensure!(
-            manifest
-                .file_name()
-                .is_some_and(|name| name == "candidate.json"),
-            "HQUANT artifact does not name candidate.json"
-        );
-        let candidate_root = manifest
-            .parent()
-            .context("HQUANT artifact manifest has no candidate root")?;
-        let publication = open_qat_candidate(candidate_root)?;
-        ensure!(
-            publication.candidate_manifest_path == manifest
-                && publication.candidate_manifest_sha256 == artifact.hash,
-            "HQUANT artifact receipt differs from its validated candidate"
-        );
-    }
     let Some(plan) = &phase.quantization else {
         ensure!(
             state.quantization.is_none(),
@@ -795,6 +918,45 @@ fn verify_resumed_quantization_candidate(
         .quantization
         .as_ref()
         .context("quantization resume has no typed state")?;
+    let state_step = u64::try_from(state.global_step)
+        .context("quantization checkpoint global step exceeds u64")?;
+    let forward_step = if state.steps_in_phase == 0 {
+        state_step
+    } else {
+        state_step
+            .checked_sub(1)
+            .context("quantization checkpoint has phase steps but no global step")?
+    };
+    let candidate_published = quantization.manifest.is_some();
+    ensure!(
+        candidate_published == quantization.candidate_weights_sha256.is_some(),
+        "quantization candidate manifest and source identity must appear together"
+    );
+    let expected_format = if candidate_published {
+        Some(plan.recipe.format)
+    } else {
+        plan.format_at(forward_step)
+    };
+    ensure!(
+        quantization.format == quantization_state_format(expected_format)
+            && quantization.fake_quant_active
+                == (!candidate_published && expected_format.is_some()),
+        "quantization resume format differs from the configured optimizer-step schedule"
+    );
+    ensure!(
+        quantization.calibration_step == state_step,
+        "quantization resume calibration clock differs from the trainer global step"
+    );
+    let expected_teacher = match &plan.training {
+        WorkflowQuantizationTraining::Qat { .. } => None,
+        WorkflowQuantizationTraining::Distillation { teacher_sha256, .. } => {
+            Some(teacher_sha256.as_str())
+        }
+    };
+    ensure!(
+        quantization.teacher_hash.as_deref() == expected_teacher,
+        "quantization resume teacher identity differs from the workflow"
+    );
     if state.steps_in_phase < planned_steps {
         ensure!(
             quantization.manifest.is_none(),
@@ -829,25 +991,33 @@ fn verify_resumed_quantization_candidate(
     let candidate = manifest
         .parent()
         .context("quantization candidate manifest has no parent")?;
-    let root = candidate
-        .parent()
-        .context("quantization candidate has no store root")?;
-    let key = candidate
-        .file_name()
-        .and_then(|name| name.to_str())
-        .context("quantization candidate key is not UTF-8")?;
-    let publication = publish_qat_candidate(model, root, key, &plan.recipe)?;
+    let mut artifacts = state.artifacts.iter().filter(|artifact| {
+        artifact.kind == "hquant_candidate" && artifact.manifest == manifest.to_string_lossy()
+    });
+    let artifact = artifacts
+        .next()
+        .context("completed quantization phase has no candidate artifact receipt")?;
+    ensure!(
+        artifacts.next().is_none(),
+        "completed quantization phase repeats its candidate artifact receipt"
+    );
+    let publication = open_qat_candidate_addressed(candidate, &artifact.hash)?;
     ensure!(
         publication.candidate_manifest_path == manifest,
-        "quantization candidate retry resolved to another path"
+        "quantization candidate resolved to another path"
     );
-    let artifact = state
-        .artifacts
-        .iter()
-        .find(|artifact| {
-            artifact.kind == "hquant_candidate" && artifact.manifest == manifest.to_string_lossy()
-        })
-        .context("completed quantization phase has no candidate artifact receipt")?;
+    ensure!(
+        publication.recipe == plan.recipe,
+        "quantization candidate recipe differs from the workflow"
+    );
+    ensure!(
+        publication.weights_sha256 == resumed_weights_sha256,
+        "quantization candidate weights differ from the authenticated resume checkpoint"
+    );
+    ensure!(
+        quantization.candidate_weights_sha256.as_deref() == Some(resumed_weights_sha256),
+        "quantization candidate source identity differs from the authenticated resume checkpoint"
+    );
     ensure!(
         artifact.manifest == manifest.to_string_lossy()
             && artifact.hash == publication.candidate_manifest_sha256,
@@ -879,10 +1049,25 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
         device.seed(args.seed);
         Some((output_lock, device))
     };
-    let data_manifests = workflow
+    let mut data_binding_cache = HashMap::new();
+    let data_bindings = workflow
         .phases
         .iter()
-        .map(|phase| phase_data_identity(&phase.data, &tokenizer, &tokenizer_hash))
+        .map(|phase| {
+            bind_phase_data(
+                &phase.data,
+                &tokenizer,
+                &tokenizer_hash,
+                &mut data_binding_cache,
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let data_manifests = data_bindings
+        .iter()
+        .map(|binding| {
+            binding.ensure_still_published()?;
+            Ok(binding.signature_identity().to_owned())
+        })
         .collect::<Result<Vec<_>>>()?;
     let initial_checkpoint_sha256 = args.checkpoint.as_deref().map(file_sha256).transpose()?;
     let signature = run_signature(
@@ -892,6 +1077,9 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
         &data_manifests,
         initial_checkpoint_sha256.clone(),
     )?;
+    for binding in &data_bindings {
+        binding.ensure_still_published()?;
+    }
     if args.print_run_signature {
         println!("{signature}");
         return Ok(());
@@ -907,7 +1095,8 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             token_cache_path(&token_cache_root, data, &phase.data, &tokenizer_hash)
         })
         .collect::<Result<Vec<_>>>()?;
-    let (phase_plan, total_steps) = plan_training(&workflow, &tokenizer, &token_cache_paths)?;
+    let (phase_plan, total_steps) =
+        plan_training(&workflow, &tokenizer, &token_cache_paths, &data_bindings)?;
     ensure!(
         total_steps > 0,
         "training has zero complete optimizer steps"
@@ -916,11 +1105,16 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
     let metrics_path = args.output.join("metrics.jsonl");
     let mut initial_model = Transformer::new(&config, &device)?;
     if let Some(path) = &args.checkpoint {
-        load_safetensors(&mut initial_model, path)?;
-        ensure!(
-            Some(file_sha256(path)?) == initial_checkpoint_sha256,
-            "initial checkpoint changed after its run signature was computed"
-        );
+        let expected = initial_checkpoint_sha256
+            .as_deref()
+            .expect("checkpoint hash was computed for a configured checkpoint");
+        let bytes = read_pinned_checkpoint_bytes(path, expected)
+            .context("initial checkpoint changed after its run signature was computed")?;
+        hermes_llm::load_safetensors_bytes(
+            &mut initial_model,
+            bytes,
+            &format!("initial checkpoint {}", path.display()),
+        )?;
     }
     let mut muon_parameter_ids = initial_model.muon_parameter_ids();
     ensure!(
@@ -934,8 +1128,8 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
         .with_epsilon(1e-8)
         .with_weight_decay(args.weight_decay)
         .init();
-    let resume_state = if args.resume {
-        let (optimizer, state) = load_training_state(
+    let (resume_state, resume_weights_sha256) = if args.resume {
+        let (optimizer, state, weights_sha256) = load_training_state(
             &mut initial_model,
             adamw_optimizer,
             &mut muon_optimizer,
@@ -988,11 +1182,12 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             "checkpoint has no cumulative token count and cannot safely resume"
         );
         validate_wake_rng_state(&state, args.seed)?;
-        Some(state)
+        (Some(state), Some(weights_sha256))
     } else {
-        None
+        (None, None)
     };
     if let Some(state) = &resume_state {
+        preflight_resumed_memory_mode(&workflow, state)?;
         // Authenticate the exact runtime identity before constructing its
         // factory. Factory construction validates/creates configured stores,
         // so a mismatched resume must fail before that first side effect.
@@ -1001,14 +1196,25 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             state,
             &workflow.phases[state.phase],
             phase_plan[state.phase].steps,
-            &initial_model,
+            resume_weights_sha256
+                .as_deref()
+                .expect("resume checkpoint has an authenticated weights identity"),
         )?;
     }
     let periodic_runtime =
         PeriodicTrainingRuntime::load(&args, &workflow, &signature, &initial_model, &device)?;
-    if let Some(runtime) = &periodic_runtime {
-        let wake_ids = runtime
-            .bank
+    let wake_only_runtime =
+        WakeOnlyMemoryRuntime::load(&workflow, &initial_model, &args.output, &device)?;
+    ensure!(
+        periodic_runtime.is_none() || wake_only_runtime.is_none(),
+        "one training run cannot combine periodic_sleep and wake_only runtimes"
+    );
+    let tier_bank = periodic_runtime
+        .as_ref()
+        .map(|runtime| &runtime.bank)
+        .or_else(|| wake_only_runtime.as_ref().map(|runtime| &runtime.bank));
+    if let Some(bank) = tier_bank {
+        let wake_ids = bank
             .scopes()?
             .wake_parameter_ids
             .into_iter()
@@ -1023,7 +1229,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             "ordinary wake scope has no hidden matrix parameters for Muon"
         );
         muon_optimizer.set_parameter_ids(muon_parameter_ids.clone());
-        if let Some(state) = &resume_state {
+        if let (Some(runtime), Some(state)) = (&periodic_runtime, &resume_state) {
             let checkpoint = state
                 .sleep
                 .as_ref()
@@ -1036,12 +1242,16 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                 runtime.restore_bank(checkpoint, &initial_model, sleep)?;
             }
         }
+        if let (Some(runtime), Some(state)) = (&wake_only_runtime, &resume_state) {
+            runtime.restore(state, &initial_model)?;
+        }
     } else {
         ensure!(
-            resume_state
-                .as_ref()
-                .is_none_or(|state| state.sleep.is_none()),
-            "ordinary-model checkpoint unexpectedly contains native sleep state"
+            resume_state.as_ref().is_none_or(|state| {
+                state.sleep.is_none()
+                    && matches!(state.memory_update, TrainingMemoryUpdateState::Ordinary)
+            }),
+            "ordinary-model checkpoint unexpectedly contains memory-training state"
         );
     }
     if let Some(state) = &resume_state {
@@ -1074,10 +1284,9 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
 
     let mut muon_accumulator = GradientsAccumulator::new();
     let mut adamw_accumulator = GradientsAccumulator::new();
-    let mut tier_accumulators = periodic_runtime
-        .as_ref()
-        .map(|runtime| {
-            runtime.bank.scopes().map(|scopes| {
+    let mut tier_accumulators = tier_bank
+        .map(|bank| {
+            bank.scopes().map(|scopes| {
                 (0..scopes.tiers.len())
                     .map(|_| GradientsAccumulator::new())
                     .collect::<Vec<_>>()
@@ -1096,7 +1305,13 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
     let mut router_loss_sum: Option<Tensor<1>> = None;
     let mut distillation_loss_sum: Option<Tensor<1>> = None;
     let mut retrieval_correct_sum: Option<Tensor<1>> = None;
-    let mut step_wake_contexts = Vec::<Vec<i64>>::new();
+    let wake_context_limits = periodic_runtime.as_ref().map(|runtime| {
+        (
+            runtime.factory.config().max_wake_context_records,
+            runtime.factory.config().rollouts.max_context_tokens,
+        )
+    });
+    let mut step_wake_contexts = VecDeque::<Vec<i64>>::new();
     let mut step_stats = BatchStats::default();
     let mut optimizer_step_started = Instant::now();
     let mut step_input_wait_seconds = 0.0f64;
@@ -1123,6 +1338,16 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             gradient_accumulator: None,
             update_clock: 0,
         }],
+        memory_update: if periodic_runtime.is_some() {
+            TrainingMemoryUpdateState::PeriodicSleep
+        } else if let Some(runtime) = &wake_only_runtime {
+            TrainingMemoryUpdateState::WakeOnly {
+                config: runtime.config.clone(),
+                optimizer_scopes: runtime.bank.scopes()?,
+            }
+        } else {
+            TrainingMemoryUpdateState::Ordinary
+        },
         sleep: None,
         artifacts: Vec::new(),
         evaluator_hashes: Vec::new(),
@@ -1209,7 +1434,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                 phase: MetricPhase {
                     index: phase_index as u32,
                     name: phase.name.clone(),
-                    kind: metric_phase_kind(phase.phase_kind),
+                    kind: phase.phase_kind.into(),
                 },
                 checkpoint_hash: None,
             };
@@ -1235,8 +1460,12 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             &mut metrics,
             &args.output,
             periodic_runtime.as_ref(),
+            resume_weights_sha256.as_deref(),
         )? {
             training_state.metric_records = metrics.state().records;
+            if let Some(runtime) = &wake_only_runtime {
+                runtime.checkpoint(&mut training_state)?;
+            }
             let publication = save_training_checkpoint_with_evidence(
                 model.as_ref().unwrap(),
                 &adamw_optimizer,
@@ -1314,6 +1543,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             }
             let artifacts = training_state.artifacts.clone();
             let evaluator_hashes = training_state.evaluator_hashes.clone();
+            let memory_update = training_state.memory_update.clone();
             training_state = TrainingState {
                 version: TRAINING_STATE_VERSION,
                 global_step: step,
@@ -1335,6 +1565,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                     gradient_accumulator: None,
                     update_clock: step as u64,
                 }],
+                memory_update,
                 sleep: native_sleep,
                 artifacts,
                 evaluator_hashes,
@@ -1351,17 +1582,14 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                 quantization: phase.quantization.as_ref().map(|plan| {
                     let format = plan.format_at(step as u64);
                     QuantizationTrainingState {
-                        format: format.map_or_else(
-                            || "full_precision".to_owned(),
-                            |format| format!("{format:?}").to_ascii_lowercase(),
-                        ),
+                        format: quantization_state_format(format),
                         fake_quant_active: format.is_some(),
                         calibration_step: step as u64,
                         manifest: None,
+                        candidate_weights_sha256: None,
                         teacher_hash: quantization_teacher
                             .as_ref()
                             .map(|teacher| teacher.sha256.clone()),
-                        transaction: None,
                     }
                 }),
             };
@@ -1378,12 +1606,9 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             let tokenizer_ref = &tokenizer;
             let objective = phase.objective.clone();
             let token_cache_path = token_cache_paths[phase_index].clone();
+            let data_binding = &data_bindings[phase_index];
             std::thread::scope(|threads| -> Result<()> {
-                let prefetch_capacity = phase
-                    .batch_size
-                    .checked_mul(phase.gradient_accumulation)
-                    .and_then(|capacity| capacity.checked_mul(2))
-                    .context("training prefetch capacity overflows usize")?;
+                let prefetch_capacity = training_prefetch_capacity(phase.batch_size)?;
                 let (sender, receiver) = std::sync::mpsc::sync_channel(prefetch_capacity);
                 let reader = threads.spawn(move || -> Result<()> {
                     let mut visited = 0usize;
@@ -1403,6 +1628,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                             shuffle_buffer: phase.shuffle_buffer,
                             seed: shuffle_seed,
                             token_cache: Some(&token_cache_path),
+                            data_binding,
                         },
                         |sample| {
                             visited = visited
@@ -1466,12 +1692,16 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                     }
 
                     let transfer_started = Instant::now();
-                    if phase.periodic_sleep.is_some() {
-                        step_wake_contexts.extend(batch.iter().map(|sample| {
+                    if let Some((max_records, max_context_tokens)) = wake_context_limits {
+                        for sample in &batch {
                             let tokens = sample.wake_context_tokens();
-                            let keep = tokens.len().min(config.max_seq_len);
-                            tokens[tokens.len() - keep..].to_vec()
-                        }));
+                            let keep = tokens.len().min(config.max_seq_len).min(max_context_tokens);
+                            push_bounded_wake_context(
+                                &mut step_wake_contexts,
+                                tokens[tokens.len() - keep..].to_vec(),
+                                max_records,
+                            );
+                        }
                     }
                     let training_batch = make_batch(&batch, phase.sequence_length, &device)?;
                     step_host_to_device_seconds += transfer_started.elapsed().as_secs_f64();
@@ -1483,6 +1713,11 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         .checked_add(1)
                         .context("model RNG counter overflows u64")?;
                     let current = model.as_ref().unwrap();
+                    // QAT reconstruction is accelerator work too. Start the
+                    // busy interval before building the once-per-window
+                    // fake-quantized leaves so utilization metrics do not
+                    // misclassify that cost as host/input idle time.
+                    let accelerator_started = Instant::now();
                     let quantization_format = phase
                         .quantization
                         .as_ref()
@@ -1516,21 +1751,46 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                     let forward_model = quantized_window
                         .as_ref()
                         .map_or(current, |window| &window.model);
-                    let accelerator_started = Instant::now();
-                    let distillation_loss = quantization_teacher
+                    let teacher_logits = quantization_teacher
                         .as_ref()
                         .map(|teacher| {
-                            quantization_forward_kl(
-                                forward_model,
+                            quantization_teacher_logits(
                                 &teacher.model,
                                 &training_batch,
                                 &phase.objective,
-                                teacher.temperature,
                             )
                         })
                         .transpose()?;
-                    let (task_loss, router_loss, batch_stats, retrieval_correct) =
-                        objective_loss(forward_model, training_batch, &phase.objective)?;
+                    let ObjectiveForward {
+                        loss: task_loss,
+                        router_loss,
+                        stats: batch_stats,
+                        retrieval_correct,
+                        distillation_logits,
+                    } = objective_loss(
+                        forward_model,
+                        training_batch,
+                        &phase.objective,
+                        quantization_teacher.is_some(),
+                    )?;
+                    let distillation_loss = match (
+                        teacher_logits,
+                        distillation_logits,
+                        quantization_teacher.as_ref(),
+                    ) {
+                        (Some(teacher_logits), Some(student_logits), Some(teacher)) => {
+                            Some(forward_kl_distillation_tensor(
+                                teacher_logits,
+                                student_logits,
+                                teacher.temperature,
+                                true,
+                            )?)
+                        }
+                        (None, None, None) => None,
+                        _ => unreachable!(
+                            "teacher and student distillation outputs must be produced together"
+                        ),
+                    };
                     let detached_loss = task_loss.clone().detach();
                     accumulate_tensor(&mut loss_sum, detached_loss);
                     if let Some(router_loss) = &router_loss {
@@ -1558,7 +1818,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         (Some(_), None) => unreachable!("distillation loss requires teacher"),
                     };
                     let gradient_accumulation_scale = phase.gradient_accumulation as f64;
-                    let backward_loss = if periodic_runtime.is_some() {
+                    let backward_loss = if tier_bank.is_some() {
                         // Tier optimizers average their independently retained
                         // raw microbatch gradients at the sender boundary.
                         optimized_loss.mul_scalar(phase.loss_weight)
@@ -1573,10 +1833,9 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         forward_model,
                         &muon_parameter_ids,
                     );
-                    let mut adamw_grads = match &periodic_runtime {
-                        Some(runtime) => {
-                            let partitioned =
-                                runtime.bank.partition_gradients(current, &mut grads)?;
+                    let mut adamw_grads = match tier_bank {
+                        Some(bank) => {
+                            let partitioned = bank.partition_gradients(current, &mut grads)?;
                             ensure!(
                                 partitioned.tiers.len() == tier_accumulators.len(),
                                 "memory-tier gradient partition changed during wake training"
@@ -1590,7 +1849,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         }
                         None => GradientsParams::from_module(&mut grads, forward_model),
                     };
-                    if periodic_runtime.is_some() {
+                    if tier_bank.is_some() {
                         let scale = 1.0 / phase.gradient_accumulation as f32;
                         scale_gradients(current, &mut muon_grads, scale);
                         scale_gradients(current, &mut adamw_grads, scale);
@@ -1648,7 +1907,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                             .iter_mut()
                             .map(GradientsAccumulator::grads)
                             .collect::<Vec<_>>();
-                        if periodic_runtime.is_some() {
+                        if tier_bank.is_some() {
                             let scale = 1.0 / phase.gradient_accumulation as f32;
                             for gradients in &mut tier_grads {
                                 scale_gradients(current, gradients, scale);
@@ -1678,8 +1937,8 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                                 step + 1
                             );
                         }
-                        if let Some(runtime) = &periodic_runtime {
-                            runtime.bank.commit_tier_gradients(current, tier_grads, 1)?;
+                        if let Some(bank) = tier_bank {
+                            bank.commit_tier_gradients(current, tier_grads, 1)?;
                         } else {
                             ensure!(
                                 tier_grads.is_empty(),
@@ -1689,6 +1948,26 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         let current = model.take().unwrap();
                         let current = muon_optimizer.step(muon_lr, current, muon_grads)?;
                         model = Some(adamw_optimizer.step(lr.into(), current, adamw_grads));
+                        let next_step = step
+                            .checked_add(1)
+                            .context("global optimizer-step count overflows usize")?;
+                        let wake_only_updates = if let Some(runtime) = &wake_only_runtime {
+                            let current = model.take().expect("training model is present");
+                            let (updated, report) = runtime
+                                .bank
+                                .apply_wake_only_due_updates(&current, next_step as u64)?;
+                            debug_assert!(
+                                report
+                                    .updates
+                                    .windows(2)
+                                    .all(|pair| pair[0].tier < pair[1].tier),
+                                "wake_only updates must run fastest-to-slowest"
+                            );
+                            model = Some(updated);
+                            report.updates
+                        } else {
+                            Vec::new()
+                        };
                         let step_quantized_tensors = quantized_window
                             .as_ref()
                             .map_or(0, |window| window.tensor_count);
@@ -1696,7 +1975,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         // staged QAT leaf across optimizer-step boundaries.
                         quantized_window = None;
                         step_accelerator_seconds += accelerator_started.elapsed().as_secs_f64();
-                        step += 1;
+                        step = next_step;
                         steps_in_phase = steps_in_phase
                             .checked_add(1)
                             .context("phase optimizer-step count overflows usize")?;
@@ -1707,6 +1986,15 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         training_state.steps_in_phase = steps_in_phase;
                         training_state.tokens_seen = tokens_seen;
                         training_state.optimizer_states[0].update_clock = step as u64;
+                        let max_wake_context_records =
+                            wake_context_limits.map_or(0, |(records, _)| records);
+                        let retained_existing =
+                            max_wake_context_records.saturating_sub(step_wake_contexts.len());
+                        if training_state.wake_context_buffer.len() > retained_existing {
+                            let discard =
+                                training_state.wake_context_buffer.len() - retained_existing;
+                            training_state.wake_context_buffer.drain(..discard);
+                        }
                         for (ordinal, token_ids) in step_wake_contexts.drain(..).enumerate() {
                             training_state.wake_context_buffer.push(
                                 hermes_train::builtin_sleep_adapters::WakeContextRecord {
@@ -1716,24 +2004,15 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                                 },
                             );
                         }
-                        let max_wake_context_records =
-                            periodic_runtime.as_ref().map_or(0, |runtime| {
-                                runtime.factory.config().max_wake_context_records
-                            });
-                        if training_state.wake_context_buffer.len() > max_wake_context_records {
-                            let discard =
-                                training_state.wake_context_buffer.len() - max_wake_context_records;
-                            training_state.wake_context_buffer.drain(..discard);
-                        }
+                        debug_assert!(
+                            training_state.wake_context_buffer.len() <= max_wake_context_records
+                        );
                         if let Some(quantization) = &mut training_state.quantization {
                             let format = phase
                                 .quantization
                                 .as_ref()
                                 .and_then(|plan| plan.format_at((step - 1) as u64));
-                            quantization.format = format.map_or_else(
-                                || "full_precision".to_owned(),
-                                |format| format!("{format:?}").to_ascii_lowercase(),
-                            );
+                            quantization.format = quantization_state_format(format);
                             quantization.fake_quant_active = format.is_some();
                             quantization.calibration_step = step as u64;
                         }
@@ -1753,7 +2032,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                             phase: MetricPhase {
                                 index: phase_index as u32,
                                 name: phase.name.clone(),
-                                kind: metric_phase_kind(phase.phase_kind),
+                                kind: phase.phase_kind.into(),
                             },
                             checkpoint_hash: None,
                         };
@@ -1782,6 +2061,19 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                                 retrieval_candidates: step_stats.retrieval_candidates as u64,
                             }),
                         )?;
+                        if let Some(runtime) = &wake_only_runtime {
+                            append_wake_only_tier_metrics(
+                                &mut metrics,
+                                &context,
+                                runtime.config.schedule(),
+                                &wake_only_updates,
+                            )?;
+                        } else {
+                            ensure!(
+                                wake_only_updates.is_empty(),
+                                "ordinary training produced wake_only update evidence"
+                            );
+                        }
                         if let Some(plan) = &phase.quantization {
                             let active_format = plan.format_at((step - 1) as u64);
                             metrics.append(
@@ -1864,6 +2156,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                                 &mut metrics,
                                 &args.output,
                                 periodic_runtime.as_ref(),
+                                None,
                             )?;
                         }
                         if args.checkpoint_every > 0 && step % args.checkpoint_every == 0 {
@@ -1872,7 +2165,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                             {
                                 let mut cursor = training_state
                                     .sleep
-                                    .take()
+                                    .clone()
                                     .context("periodic checkpoint has no sleep cursor")?;
                                 let _ = runtime.checkpoint_wake(
                                     &mut cursor,
@@ -1880,6 +2173,9 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                                     sleep,
                                 )?;
                                 training_state.sleep = Some(cursor);
+                            }
+                            if let Some(runtime) = &wake_only_runtime {
+                                runtime.checkpoint(&mut training_state)?;
                             }
                             let publication = save_training_checkpoint_with_evidence(
                                 model.as_ref().unwrap(),
@@ -1960,7 +2256,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
         if let (Some(runtime), Some(sleep)) = (&periodic_runtime, phase.periodic_sleep.as_ref()) {
             let mut cursor = training_state
                 .sleep
-                .take()
+                .clone()
                 .context("periodic phase boundary has no sleep cursor")?;
             let _ = runtime.checkpoint_wake(&mut cursor, model.as_ref().unwrap(), sleep)?;
             training_state.sleep = Some(cursor);
@@ -1970,12 +2266,15 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             phase: MetricPhase {
                 index: phase_index as u32,
                 name: phase.name.clone(),
-                kind: metric_phase_kind(phase.phase_kind),
+                kind: phase.phase_kind.into(),
             },
             checkpoint_hash: None,
         };
         drain_device_sampler(&mut device_sampler, &mut metrics, &context)?;
         training_state.metric_records = metrics.state().records;
+        if let Some(runtime) = &wake_only_runtime {
+            runtime.checkpoint(&mut training_state)?;
+        }
         let publication = save_training_checkpoint_with_evidence(
             model.as_ref().unwrap(),
             &adamw_optimizer,
@@ -2002,7 +2301,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             .expect("validated memory workflow has periodic sleep");
         let mut cursor = training_state
             .sleep
-            .take()
+            .clone()
             .context("periodic final checkpoint has no sleep cursor")?;
         let _ = runtime.checkpoint_wake(&mut cursor, model.as_ref().unwrap(), sleep)?;
         training_state.sleep = Some(cursor);
@@ -2014,12 +2313,15 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
         phase: MetricPhase {
             index: final_phase_index as u32,
             name: final_phase.name.clone(),
-            kind: metric_phase_kind(final_phase.phase_kind),
+            kind: final_phase.phase_kind.into(),
         },
         checkpoint_hash: None,
     };
     shutdown_device_sampler(&mut device_sampler, &mut metrics, &final_context)?;
     training_state.metric_records = metrics.state().records;
+    if let Some(runtime) = &wake_only_runtime {
+        runtime.checkpoint(&mut training_state)?;
+    }
     let publication = save_training_checkpoint_with_evidence(
         model.as_ref().unwrap(),
         &adamw_optimizer,
@@ -2045,6 +2347,362 @@ fn print_checkpoint_publication(label: &str, publication: &CheckpointPublication
 #[cfg(test)]
 mod tests {
     use super::*;
+    use burn::tensor::Int;
+
+    #[test]
+    fn training_prefetch_is_two_batches_but_never_scales_with_accumulation() {
+        assert_eq!(training_prefetch_capacity(1).unwrap(), 2);
+        assert_eq!(training_prefetch_capacity(64).unwrap(), 128);
+        assert_eq!(training_prefetch_capacity(usize::MAX).unwrap(), 4_096);
+        assert!(training_prefetch_capacity(0).is_err());
+    }
+
+    #[test]
+    fn wake_context_collection_is_bounded_while_a_step_is_accumulating() {
+        let mut contexts = VecDeque::new();
+        for token in 0..10 {
+            push_bounded_wake_context(&mut contexts, vec![token], 3);
+        }
+        assert_eq!(
+            contexts.into_iter().collect::<Vec<_>>(),
+            vec![vec![7], vec![8], vec![9]]
+        );
+    }
+
+    #[test]
+    fn quantization_checkpoint_formats_use_workflow_names() {
+        assert_eq!(quantization_state_format(None), "full_precision");
+        assert_eq!(
+            quantization_state_format(Some(UltraQuantFormat::BinaryG128)),
+            "binary_g128"
+        );
+        assert_eq!(
+            quantization_state_format(Some(UltraQuantFormat::TernaryG128)),
+            "ternary_g128"
+        );
+        assert_eq!(
+            quantization_state_format(Some(UltraQuantFormat::TernaryEntropyG128)),
+            "ternary_entropy_g128"
+        );
+    }
+
+    #[test]
+    fn pinned_checkpoint_reader_authenticates_exact_regular_bytes() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("checkpoint.safetensors");
+        let bytes = b"authenticated checkpoint fixture";
+        fs::write(&path, bytes).unwrap();
+        let expected = format!("sha256:{:x}", Sha256::digest(bytes));
+        assert_eq!(
+            read_pinned_checkpoint_bytes(&path, &expected).unwrap(),
+            bytes
+        );
+        let error = read_pinned_checkpoint_bytes(&path, &format!("sha256:{}", "0".repeat(64)))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("hash mismatch"), "{error}");
+
+        let mut mutated = bytes.to_vec();
+        mutated[0] ^= 1;
+        let error = read_pinned_checkpoint_bytes_after_open(&path, &expected, || {
+            fs::write(&path, &mutated).context("mutating opened checkpoint fixture")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(
+            error.contains("changed while it was read") || error.contains("hash mismatch"),
+            "{error}"
+        );
+        fs::write(&path, bytes).unwrap();
+
+        let mut grown = bytes.to_vec();
+        grown.push(b'!');
+        let error = read_pinned_checkpoint_bytes_after_open(&path, &expected, || {
+            fs::write(&path, &grown).context("growing opened checkpoint fixture")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("changed while it was read"), "{error}");
+        fs::write(&path, bytes).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+
+            let link = directory.path().join("linked.safetensors");
+            symlink(&path, &link).unwrap();
+            let error = read_pinned_checkpoint_bytes(&link, &expected)
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("non-symlink"), "{error}");
+
+            let replacement = directory.path().join("replacement.safetensors");
+            let parked = directory.path().join("parked.safetensors");
+            fs::write(&replacement, bytes).unwrap();
+            let error = read_pinned_checkpoint_bytes_after_open(&path, &expected, || {
+                fs::rename(&path, &parked)?;
+                fs::rename(&replacement, &path)?;
+                Ok(())
+            })
+            .unwrap_err()
+            .to_string();
+            assert!(error.contains("publication changed"), "{error}");
+        }
+    }
+
+    fn qat_replay_model() -> ModelDef {
+        hermes_llm::parse_mal(
+            r#"
+            ffn base {
+                hidden_dim: 16
+                activation: swiglu
+                dropout: 0.0
+                bias: false
+            }
+            model qat-replay {
+                vocab_size: 32 max_seq_len: 8 hidden_size: 8 num_layers: 2
+                block: {
+                    attention: {
+                        num_heads: 2 num_kv_heads: 1 head_dim: 4
+                        position_encoding: none dropout: 0.0
+                    }
+                    ffn: base
+                    dropout: 0.0
+                }
+                embeddings { tie_weights: false dropout: 0.0 }
+            }
+            "#,
+        )
+        .unwrap()
+    }
+
+    fn apply_qat_window(
+        mut model: Transformer,
+        muon: &mut BatchedMuon,
+        adamw: &mut AdamWOptimizer,
+        device: &Device,
+        rng_counters: &[u64],
+    ) -> Transformer {
+        assert!(!rng_counters.is_empty());
+        let muon_ids = model.muon_parameter_ids();
+        let (staged, _) =
+            fake_quantized_transformer(&model, UltraQuantFormat::BinaryG128, true, true).unwrap();
+        let mut muon_accumulator = GradientsAccumulator::new();
+        let mut adamw_accumulator = GradientsAccumulator::new();
+        for &counter in rng_counters {
+            let first = 1 + i64::try_from(counter % 8).unwrap();
+            let input =
+                Tensor::<2, Int>::from_data([[first, first + 1, first + 2, first + 3]], device);
+            let target =
+                Tensor::<2, Int>::from_data([[first + 1, first + 2, first + 3, first + 4]], device);
+            let mut gradients = staged
+                .forward_loss(input, target)
+                .div_scalar(rng_counters.len() as f64)
+                .backward();
+            let muon_gradients = GradientsParams::from_params(&mut gradients, &staged, &muon_ids);
+            let adamw_gradients = GradientsParams::from_module(&mut gradients, &staged);
+            muon_accumulator.accumulate(&model, muon_gradients);
+            adamw_accumulator.accumulate(&model, adamw_gradients);
+        }
+        let mut muon_gradients = muon_accumulator.grads();
+        let mut adamw_gradients = adamw_accumulator.grads();
+        gradient_norm_and_clip(
+            &model,
+            &mut muon_gradients,
+            &mut adamw_gradients,
+            &mut [],
+            1.0,
+        )
+        .unwrap();
+        model = muon.step(2e-2, model, muon_gradients).unwrap();
+        adamw.step(1e-3.into(), model, adamw_gradients)
+    }
+
+    fn restore_qat_boundary(
+        config: &ModelDef,
+        device: &Device,
+        output: &Path,
+    ) -> (Transformer, BatchedMuon, AdamWOptimizer, TrainingState) {
+        let mut model = Transformer::new(config, device).unwrap();
+        let mut muon = BatchedMuon::new(model.muon_parameter_ids());
+        let adamw = AdamWConfig::new()
+            .with_beta_2(0.95)
+            .with_epsilon(1e-8)
+            .with_weight_decay(0.0)
+            .init();
+        let (adamw, state, _) =
+            load_training_state(&mut model, adamw, &mut muon, output, device).unwrap();
+        (model, muon, adamw, state)
+    }
+
+    #[test]
+    fn interrupted_qat_window_replays_exactly_from_atomic_trainer_checkpoint() {
+        let config = qat_replay_model();
+        let device = Device::ndarray().autodiff();
+        let mut model = Transformer::new(&config, &device).unwrap();
+        let mut muon = BatchedMuon::new(model.muon_parameter_ids());
+        let mut adamw = AdamWConfig::new()
+            .with_beta_2(0.95)
+            .with_epsilon(1e-8)
+            .with_weight_decay(0.0)
+            .init();
+        model = apply_qat_window(model, &mut muon, &mut adamw, &device, &[0, 1]);
+
+        let directory = tempfile::tempdir().unwrap();
+        let mut metrics =
+            MetricWriter::create(directory.path().join("metrics.jsonl"), "qat-replay").unwrap();
+        metrics
+            .append_at(
+                MetricContext {
+                    global_step: 1,
+                    phase: MetricPhase {
+                        index: 0,
+                        name: "qat".into(),
+                        kind: MetricPhaseKind::Quantization,
+                    },
+                    checkpoint_hash: None,
+                },
+                MetricEvent::Throughput(ThroughputMetrics {
+                    optimizer_steps: 1,
+                    compute_tokens: 8,
+                    supervised_tokens: 8,
+                    examples: 2,
+                    elapsed_seconds: 1.0,
+                    tokens_per_second: 8.0,
+                    examples_per_second: 2.0,
+                    input_wait_seconds: 0.0,
+                    host_to_device_seconds: 0.0,
+                    gpu_busy_seconds: 1.0,
+                }),
+                1,
+            )
+            .unwrap();
+        let state = TrainingState {
+            version: TRAINING_STATE_VERSION,
+            global_step: 1,
+            phase: 0,
+            phase_id: "qat".into(),
+            phase_kind: "quantization".into(),
+            epoch: 0,
+            records_in_phase: 2,
+            steps_in_phase: 1,
+            tokens_seen: 8,
+            metric_records: 1,
+            workflow_signature: format!("sha256:{}", "a".repeat(64)),
+            data_manifest_hash: Some(format!("sha256:{}", "b".repeat(64))),
+            parameter_ids: parameter_ids(&model),
+            optimizer_states: vec![OptimizerStateRef {
+                scope: "wake".into(),
+                adamw: "adamw-state.bpk".into(),
+                muon: "muon-state.bpk".into(),
+                gradient_accumulator: None,
+                update_clock: 1,
+            }],
+            memory_update: TrainingMemoryUpdateState::Ordinary,
+            sleep: None,
+            artifacts: Vec::new(),
+            evaluator_hashes: Vec::new(),
+            rng_streams: vec![
+                RngStreamState {
+                    name: DATA_RNG_STREAM.into(),
+                    seed: 19,
+                    counter: 2,
+                },
+                RngStreamState {
+                    name: MODEL_RNG_STREAM.into(),
+                    seed: 97,
+                    counter: 2,
+                },
+            ],
+            wake_context_buffer: Vec::new(),
+            quantization: Some(QuantizationTrainingState {
+                format: "binary_g128".into(),
+                fake_quant_active: true,
+                calibration_step: 1,
+                manifest: None,
+                candidate_weights_sha256: None,
+                teacher_hash: None,
+            }),
+        };
+        save_training_checkpoint_with_evidence(
+            &model,
+            &adamw,
+            &muon,
+            &state,
+            &mut metrics,
+            directory.path(),
+        )
+        .unwrap();
+        let durable_pointer = fs::read(directory.path().join("current.json")).unwrap();
+
+        let (reference_model, mut reference_muon, mut reference_adamw, reference_state) =
+            restore_qat_boundary(&config, &device, directory.path());
+        let reference = apply_qat_window(
+            reference_model,
+            &mut reference_muon,
+            &mut reference_adamw,
+            &device,
+            &[2, 3],
+        );
+
+        // This update is intentionally never published. Dropping the process-
+        // local model and optimizers represents an interruption anywhere in the
+        // accumulation/update window before the next immutable checkpoint.
+        let (interrupted_model, mut interrupted_muon, mut interrupted_adamw, interrupted_state) =
+            restore_qat_boundary(&config, &device, directory.path());
+        let interrupted = apply_qat_window(
+            interrupted_model,
+            &mut interrupted_muon,
+            &mut interrupted_adamw,
+            &device,
+            &[2],
+        );
+        drop((interrupted, interrupted_muon, interrupted_adamw));
+        assert_eq!(
+            fs::read(directory.path().join("current.json")).unwrap(),
+            durable_pointer,
+            "an in-memory QAT window must not advance the durable generation"
+        );
+        assert_eq!(interrupted_state.rng_streams, reference_state.rng_streams);
+
+        let (replayed_model, mut replayed_muon, mut replayed_adamw, replayed_state) =
+            restore_qat_boundary(&config, &device, directory.path());
+        assert_eq!(replayed_state.rng_streams, reference_state.rng_streams);
+        let replayed = apply_qat_window(
+            replayed_model,
+            &mut replayed_muon,
+            &mut replayed_adamw,
+            &device,
+            &[2, 3],
+        );
+
+        let artifacts = tempfile::tempdir().unwrap();
+        let reference_weights = artifacts.path().join("reference.safetensors");
+        let replayed_weights = artifacts.path().join("replayed.safetensors");
+        let reference_muon_path = artifacts.path().join("reference-muon.bpk");
+        let replayed_muon_path = artifacts.path().join("replayed-muon.bpk");
+        save_safetensors(&reference.valid(), &reference_weights).unwrap();
+        save_safetensors(&replayed.valid(), &replayed_weights).unwrap();
+        reference_muon.save(&reference_muon_path).unwrap();
+        replayed_muon.save(&replayed_muon_path).unwrap();
+        assert_eq!(
+            fs::read(reference_weights).unwrap(),
+            fs::read(replayed_weights).unwrap(),
+            "replayed QAT master weights differ"
+        );
+        assert_eq!(
+            fs::read(reference_muon_path).unwrap(),
+            fs::read(replayed_muon_path).unwrap(),
+            "replayed QAT Muon state differs"
+        );
+        assert_eq!(
+            &*hermes_train::optimizer_artifact::canonical_module_optimizer_bytes(&reference_adamw,)
+                .unwrap(),
+            &*hermes_train::optimizer_artifact::canonical_module_optimizer_bytes(&replayed_adamw)
+                .unwrap(),
+            "replayed QAT AdamW state differs"
+        );
+    }
 
     #[test]
     fn resume_cursor_filter_preserves_exact_shuffled_suffix() {
@@ -2267,6 +2925,7 @@ mod tests {
                 gradient_accumulator: None,
                 update_clock: 1,
             }],
+            memory_update: TrainingMemoryUpdateState::PeriodicSleep,
             sleep: Some(cursor),
             artifacts: Vec::new(),
             evaluator_hashes: Vec::new(),
@@ -2285,11 +2944,11 @@ mod tests {
             wake_context_buffer: Vec::new(),
             quantization: Some(QuantizationTrainingState {
                 format: "binary_g128".into(),
-                fake_quant_active: false,
+                fake_quant_active: true,
                 calibration_step: 1,
                 manifest: None,
+                candidate_weights_sha256: None,
                 teacher_hash: None,
-                transaction: None,
             }),
         };
         let metrics_path = directory.path().join("metrics.jsonl");
@@ -2351,9 +3010,54 @@ mod tests {
         assert_ne!(publication.weights_sha256, pre_sleep.sha256);
         let sealed = fs::read(&manifest).unwrap();
 
-        // Resume authentication reopens the same stable key with the same
-        // post-sleep model; it neither republishes nor changes any bytes.
-        verify_resumed_quantization_candidate(&state, phase, 1, &post_sleep_model).unwrap();
+        // Historical candidates are not execution inputs for this resume. A
+        // missing old archive must not trigger multi-gigabyte validation or
+        // prevent the current, independently authenticated candidate from
+        // resuming.
+        state.artifacts.push(ArtifactRef {
+            kind: "hquant_candidate".into(),
+            manifest: directory
+                .path()
+                .join("quantized-candidates/historical/candidate.json")
+                .to_string_lossy()
+                .into_owned(),
+            hash: format!("sha256:{}", "4".repeat(64)),
+        });
+
+        // Resume authentication reopens the same stable key using the sealed
+        // checkpoint weights identity; it neither serializes the mutable model
+        // nor republishes or changes any candidate bytes.
+        verify_resumed_quantization_candidate(&state, phase, 1, &post_sleep.sha256).unwrap();
+        let corruptions: [fn(&mut QuantizationTrainingState); 5] = [
+            |quantization: &mut QuantizationTrainingState| {
+                quantization.format = "full_precision".into();
+            },
+            |quantization: &mut QuantizationTrainingState| {
+                quantization.fake_quant_active = true;
+            },
+            |quantization: &mut QuantizationTrainingState| {
+                quantization.calibration_step = 0;
+            },
+            |quantization: &mut QuantizationTrainingState| {
+                quantization.teacher_hash = Some(format!("sha256:{}", "3".repeat(64)));
+            },
+            |quantization: &mut QuantizationTrainingState| {
+                quantization.candidate_weights_sha256 = Some(format!("sha256:{}", "5".repeat(64)));
+            },
+        ];
+        for mutate in corruptions {
+            let mut corrupted = state.clone();
+            mutate(corrupted.quantization.as_mut().unwrap());
+            assert!(
+                verify_resumed_quantization_candidate(&corrupted, phase, 1, &post_sleep.sha256,)
+                    .is_err(),
+                "resume accepted quantization state that differs from its workflow clock"
+            );
+        }
+        assert!(
+            verify_resumed_quantization_candidate(&state, phase, 1, &pre_sleep.sha256).is_err(),
+            "resume accepted a candidate from different authenticated checkpoint weights"
+        );
         assert_eq!(fs::read(&manifest).unwrap(), sealed);
         assert_eq!(
             open_qat_candidate(manifest.parent().unwrap())

--- a/hermes-train/src/wake.rs
+++ b/hermes-train/src/wake.rs
@@ -6,98 +6,23 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, bail};
+use anyhow::{Result, bail, ensure};
 use hermes_train::quantization::WorkflowQuantizationPlan;
 use hermes_train::task::{TaskAdapter, TaskConfig};
 use hermes_train::workflow::{
-    InModelSleepConfig, PhaseKind, ResolvedWorkflow as WorkflowV2,
+    InModelSleepConfig, MemoryUpdateMode, PhaseKind, ResolvedWorkflow as WorkflowV2,
     load_workflow as load_workflow_v2,
 };
 use serde::Serialize;
 
-#[derive(Clone, Debug, Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub(crate) enum ObjectiveConfig {
-    CausalLm,
-    Summarization {
-        instruction: String,
-    },
-    RetrievalPlanning {
-        instruction: String,
-    },
-    InstructionTuning {
-        instruction: String,
-    },
-    QaReasoning {
-        instruction: String,
-        require_reasoning: bool,
-    },
-    ContrastiveRetrieval {
-        temperature: f64,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        layer: Option<usize>,
-        query_prefix: String,
-        document_prefix: String,
-    },
-}
-
-impl ObjectiveConfig {
-    pub(crate) fn name(&self) -> &'static str {
-        match self {
-            Self::CausalLm => "causal_lm",
-            Self::Summarization { .. } => "summarization",
-            Self::RetrievalPlanning { .. } => "retrieval_planning",
-            Self::InstructionTuning { .. } => "instruction_tuning",
-            Self::QaReasoning { .. } => "qa_reasoning",
-            Self::ContrastiveRetrieval { .. } => "retrieval_representation",
-        }
-    }
-
-    pub(crate) fn retrieval_layer(&self) -> Option<usize> {
-        match self {
-            Self::ContrastiveRetrieval { layer, .. } => *layer,
-            _ => None,
-        }
-    }
-
-    pub(crate) fn temperature(&self) -> Option<f64> {
-        match self {
-            Self::ContrastiveRetrieval { temperature, .. } => Some(*temperature),
-            _ => None,
-        }
-    }
-}
-
-fn project_task(phase_name: &str, task: &TaskConfig) -> Result<ObjectiveConfig> {
+fn project_task(phase_name: &str, task: &TaskConfig) -> Result<TaskConfig> {
     match task {
-        TaskConfig::CausalLm {} => Ok(ObjectiveConfig::CausalLm),
-        TaskConfig::Summarization { instruction } => Ok(ObjectiveConfig::Summarization {
-            instruction: instruction.clone(),
-        }),
-        TaskConfig::RetrievalPlanning { instruction } => Ok(ObjectiveConfig::RetrievalPlanning {
-            instruction: instruction.clone(),
-        }),
-        TaskConfig::InstructionTuning { instruction } => Ok(ObjectiveConfig::InstructionTuning {
-            instruction: instruction.clone(),
-        }),
-        TaskConfig::QaReasoning {
-            instruction,
-            require_reasoning,
-        } => Ok(ObjectiveConfig::QaReasoning {
-            instruction: instruction.clone(),
-            require_reasoning: *require_reasoning,
-        }),
-        TaskConfig::RetrievalRepresentation {
-            temperature,
-            layer,
-            query_prefix,
-            document_prefix,
-        } => Ok(ObjectiveConfig::ContrastiveRetrieval {
-            temperature: *temperature,
-            layer: *layer,
-            query_prefix: query_prefix.clone(),
-            document_prefix: document_prefix.clone(),
-        }),
+        TaskConfig::CausalLm {}
+        | TaskConfig::Summarization { .. }
+        | TaskConfig::RetrievalPlanning { .. }
+        | TaskConfig::InstructionTuning { .. }
+        | TaskConfig::QaReasoning { .. }
+        | TaskConfig::RetrievalRepresentation { .. } => Ok(task.clone()),
         task => bail!(
             "workflow phase `{phase_name}` task `{}` is not executable by the wake trainer; dispatch it through its WorkflowV2 task executor",
             task.name()
@@ -110,7 +35,9 @@ pub(crate) struct ResolvedWakePhase {
     pub(crate) name: String,
     pub(crate) phase_kind: PhaseKind,
     pub(crate) data: PathBuf,
-    pub(crate) objective: ObjectiveConfig,
+    /// Exact WorkflowV2 task contract consumed by data construction and loss
+    /// dispatch. Keeping this type intact avoids a second wake-only schema.
+    pub(crate) objective: TaskConfig,
     pub(crate) sequence_length: usize,
     pub(crate) batch_size: usize,
     pub(crate) gradient_accumulation: usize,
@@ -123,6 +50,8 @@ pub(crate) struct ResolvedWakePhase {
     pub(crate) quantization: Option<WorkflowQuantizationPlan>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) periodic_sleep: Option<InModelSleepConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) memory_update_mode: Option<MemoryUpdateMode>,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -147,6 +76,11 @@ fn project_wake_workflow(workflow: WorkflowV2) -> Result<ResolvedWakePlan> {
                 phase.kind.name()
             );
         }
+        ensure!(
+            phase.parameters.is_empty(),
+            "workflow phase `{}` contains raw parameters that the wake trainer does not consume; use typed WorkflowV2 fields or a registered phase executor",
+            phase.name
+        );
         let task = phase
             .task
             .as_ref()
@@ -184,6 +118,7 @@ fn project_wake_workflow(workflow: WorkflowV2) -> Result<ResolvedWakePlan> {
             learning_rate_scale,
             quantization,
             periodic_sleep: phase.periodic_sleep,
+            memory_update_mode: phase.memory_update_mode,
         });
     }
     Ok(ResolvedWakePlan {
@@ -321,5 +256,33 @@ mod tests {
         .unwrap();
         let error = format!("{:#}", load_wake_plan(&path).unwrap_err());
         assert!(error.contains("sequnce_length"), "{error}");
+    }
+
+    #[test]
+    fn wake_projection_rejects_raw_parameters_instead_of_dropping_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("workflow.json");
+        fs::write(
+            &path,
+            r#"{
+                "version": 2,
+                "phases": [{
+                    "name": "custom-causal",
+                    "type": "pretrain",
+                    "data": "tokens.jsonl",
+                    "task": {"type": "causal_lm"},
+                    "sequence_length": 128,
+                    "batch_size": 4,
+                    "gradient_accumulation": 1,
+                    "steps": 1,
+                    "parameters": {"unconsumed_learning_rule": "v1"}
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let error = load_wake_plan(&path).unwrap_err().to_string();
+        assert!(error.contains("raw parameters"), "{error}");
+        assert!(error.contains("does not consume"), "{error}");
     }
 }

--- a/hermes-train/src/worker.rs
+++ b/hermes-train/src/worker.rs
@@ -7,18 +7,34 @@
 
 use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+#[cfg(test)]
+use std::thread;
+use std::time::{Duration, Instant};
 
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+
+#[cfg(not(unix))]
+use anyhow::bail;
 use anyhow::{Context, Result, ensure};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::metrics::{
-    MetricContext, MetricEvent, MetricLogState, MetricPhase, MetricPhaseKind, MetricWriter,
-};
+use crate::artifact_io::{read_regular_bounded, validate_sha256_identity};
+#[cfg(test)]
+use crate::metrics::MetricPhaseKind;
+use crate::metrics::{MetricContext, MetricEvent, MetricLogState, MetricPhase, MetricWriter};
+use crate::pinned_executable::file_sha256 as hash_file_sha256;
+#[cfg(unix)]
+use crate::pinned_executable::{PinnedExecutable, StagedExecutable};
+#[cfg(unix)]
+use crate::protocol_process::{ProtocolRead, SupervisedProcess};
 use crate::runtime::{
     ImmutableModelCheckpoint, PhaseExecutionRequest, PhaseExecutionResult, PhaseExecutor,
     PhaseProduct, PhaseProgressSink, RuntimeBoundary, RuntimeCheckpoint, WorkflowRunState,
@@ -27,7 +43,13 @@ use crate::workflow::ResolvedWorkflow;
 
 pub const PHASE_WORKER_PROTOCOL_VERSION: u32 = 2;
 pub const RUNTIME_CHECKPOINT_FILE_VERSION: u32 = 2;
+const PHASE_WORKER_EXECUTION_CONTRACT_VERSION: u32 = 1;
 const MAX_WORKER_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
+const MAX_RUNTIME_CHECKPOINT_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_PHASE_WORKER_ARGUMENTS: usize = 128;
+const MAX_PHASE_WORKER_ARGUMENT_BYTES: usize = 4 * 1024;
+const MAX_PHASE_WORKER_TOTAL_ARGUMENT_BYTES: usize = 64 * 1024;
+const DEFAULT_PHASE_WORKER_TIMEOUT: Duration = Duration::from_secs(3_600);
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -67,6 +89,7 @@ pub struct ExternalPhaseExecutor {
     executable: PathBuf,
     arguments: Vec<OsString>,
     expected_sha256: String,
+    timeout: Duration,
 }
 
 impl ExternalPhaseExecutor {
@@ -79,32 +102,136 @@ impl ExternalPhaseExecutor {
             executable: executable.into(),
             arguments,
             expected_sha256: expected_sha256.into(),
+            timeout: DEFAULT_PHASE_WORKER_TIMEOUT,
         };
+        validate_worker_arguments(&executor.arguments)?;
         executor.verify_identity()?;
         Ok(executor)
+    }
+
+    /// Set the hard wall-clock bound for one phase-worker invocation. Timeout
+    /// always terminates and reaps the worker's complete process group.
+    pub fn with_timeout(mut self, timeout: Duration) -> Result<Self> {
+        ensure!(!timeout.is_zero(), "phase worker timeout must be positive");
+        checked_worker_deadline(timeout)?;
+        self.timeout = timeout;
+        Ok(self)
     }
 
     pub fn expected_sha256(&self) -> &str {
         &self.expected_sha256
     }
 
-    pub fn verify_identity(&self) -> Result<()> {
-        validate_sha256(&self.expected_sha256)?;
-        let metadata = fs::symlink_metadata(&self.executable).with_context(|| {
-            format!("phase worker {} is unavailable", self.executable.display())
-        })?;
-        ensure!(
-            metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-            "phase worker {} must be a regular non-symlink file",
-            self.executable.display()
+    /// Stable identity of all executable semantics owned by this adapter.
+    /// Runtime checkpoints bind this value, while worker requests continue to
+    /// carry the raw executable content hash expected by protocol v2.
+    pub fn execution_identity(&self) -> String {
+        let mut hasher = Sha256::new();
+        hash_execution_part(&mut hasher, b"hermes-external-phase-executor");
+        hash_execution_part(&mut hasher, &PHASE_WORKER_PROTOCOL_VERSION.to_le_bytes());
+        hash_execution_part(
+            &mut hasher,
+            &PHASE_WORKER_EXECUTION_CONTRACT_VERSION.to_le_bytes(),
         );
-        ensure!(
-            file_sha256(&self.executable)? == self.expected_sha256,
-            "phase worker {} does not match its pinned SHA-256",
-            self.executable.display()
-        );
-        Ok(())
+        hash_execution_part(&mut hasher, b"empty-environment");
+        hash_execution_part(&mut hasher, b"working-directory:/");
+        hash_execution_part(&mut hasher, self.expected_sha256.as_bytes());
+        hash_execution_part(&mut hasher, &self.timeout.as_nanos().to_le_bytes());
+        hash_execution_part(&mut hasher, &(self.arguments.len() as u64).to_le_bytes());
+        for argument in &self.arguments {
+            #[cfg(unix)]
+            hash_execution_part(&mut hasher, argument.as_os_str().as_bytes());
+            #[cfg(not(unix))]
+            {
+                let text = argument.to_string_lossy();
+                hash_execution_part(&mut hasher, text.as_bytes());
+            }
+        }
+        format!("sha256:{:x}", hasher.finalize())
     }
+
+    pub fn verify_identity(&self) -> Result<()> {
+        validate_sha256_identity(&self.expected_sha256, "phase worker identity")?;
+        validate_worker_arguments(&self.arguments)?;
+        #[cfg(unix)]
+        {
+            PinnedExecutable::verify(&self.executable, &self.expected_sha256, "phase worker")
+        }
+        #[cfg(not(unix))]
+        {
+            let metadata = fs::symlink_metadata(&self.executable).with_context(|| {
+                format!("phase worker {} is unavailable", self.executable.display())
+            })?;
+            ensure!(
+                metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+                "phase worker {} must be a regular non-symlink file",
+                self.executable.display()
+            );
+            ensure!(
+                file_sha256(&self.executable)? == self.expected_sha256,
+                "phase worker {} does not match its pinned SHA-256",
+                self.executable.display()
+            );
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    fn pinned_command(&self) -> Result<(Command, StagedExecutable)> {
+        let executable = PinnedExecutable::open(
+            &self.executable,
+            &self.expected_sha256,
+            "phase worker",
+            "phase-worker",
+        )?;
+        let mut command = executable.command();
+        command
+            .args(&self.arguments)
+            .env_clear()
+            .current_dir("/")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .process_group(0);
+        Ok((command, executable.into_staged()))
+    }
+}
+
+fn validate_worker_arguments(arguments: &[OsString]) -> Result<()> {
+    ensure!(
+        arguments.len() <= MAX_PHASE_WORKER_ARGUMENTS,
+        "phase worker has more than {MAX_PHASE_WORKER_ARGUMENTS} arguments"
+    );
+    let mut total = 0usize;
+    for (index, argument) in arguments.iter().enumerate() {
+        #[cfg(unix)]
+        let bytes = argument.as_os_str().as_bytes();
+        #[cfg(not(unix))]
+        let encoded = argument.to_string_lossy();
+        #[cfg(not(unix))]
+        let bytes = encoded.as_bytes();
+        ensure!(
+            bytes.len() <= MAX_PHASE_WORKER_ARGUMENT_BYTES,
+            "phase worker argument {index} exceeds {MAX_PHASE_WORKER_ARGUMENT_BYTES} bytes"
+        );
+        ensure!(
+            !bytes.contains(&0),
+            "phase worker argument {index} contains a NUL byte"
+        );
+        total = total
+            .checked_add(bytes.len())
+            .context("phase worker argument bytes overflow usize")?;
+    }
+    ensure!(
+        total <= MAX_PHASE_WORKER_TOTAL_ARGUMENT_BYTES,
+        "phase worker arguments exceed {MAX_PHASE_WORKER_TOTAL_ARGUMENT_BYTES} total bytes"
+    );
+    Ok(())
+}
+
+fn hash_execution_part(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value);
 }
 
 impl<C> PhaseExecutor<C> for ExternalPhaseExecutor {
@@ -114,138 +241,165 @@ impl<C> PhaseExecutor<C> for ExternalPhaseExecutor {
         _: &mut C,
         progress: &mut dyn PhaseProgressSink,
     ) -> Result<PhaseExecutionResult> {
-        // Re-hash immediately before every spawn so a worker cannot change
-        // between workflow initialization and a later resumed phase.
-        self.verify_identity()?;
-        let mut child = Command::new(&self.executable)
-            .args(&self.arguments)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .spawn()
-            .with_context(|| {
+        #[cfg(not(unix))]
+        {
+            let _ = (request, progress);
+            bail!("external phase workers require a Unix process host");
+        }
+        #[cfg(unix)]
+        {
+            // Open and hash one exact file generation immediately before every
+            // spawn. Unix executes a private materialization of those opened bytes,
+            // closing the path-replacement window between verification and exec.
+            let wire_request = PhaseWorkerRequest {
+                version: PHASE_WORKER_PROTOCOL_VERSION,
+                executor_sha256: self.expected_sha256.clone(),
+                phase_index: request.phase_index,
+                phase: request.phase.clone(),
+                input_checkpoint: request.input_checkpoint.clone(),
+                resume_state: request.resume_state.clone(),
+            };
+            let mut encoded_request = serde_json::to_vec(&wire_request)?;
+            ensure!(
+                encoded_request.len() < MAX_WORKER_MESSAGE_BYTES,
+                "phase worker request is larger than {MAX_WORKER_MESSAGE_BYTES} bytes"
+            );
+            encoded_request.push(b'\n');
+            let deadline = checked_worker_deadline(self.timeout)?;
+            let (mut command, staged_executable) = self.pinned_command()?;
+            let child = command.spawn().with_context(|| {
                 format!("failed to start phase worker {}", self.executable.display())
             })?;
-        let wire_request = PhaseWorkerRequest {
-            version: PHASE_WORKER_PROTOCOL_VERSION,
-            executor_sha256: self.expected_sha256.clone(),
-            phase_index: request.phase_index,
-            phase: request.phase.clone(),
-            input_checkpoint: request.input_checkpoint.clone(),
-            resume_state: request.resume_state.clone(),
-        };
-        {
-            let mut stdin = child
-                .stdin
-                .take()
-                .context("phase worker stdin is unavailable")?;
-            serde_json::to_writer(&mut stdin, &wire_request)?;
-            stdin.write_all(b"\n")?;
-            stdin.flush()?;
-        }
-
-        let stdout = child
-            .stdout
-            .take()
-            .context("phase worker stdout is unavailable")?;
-        let mut reader = BufReader::new(stdout);
-        let mut terminal = None;
-        while let Some(line) = read_worker_message(&mut reader)? {
-            if line.iter().all(u8::is_ascii_whitespace) {
-                continue;
+            let mut child = SupervisedProcess::new(
+                child,
+                staged_executable,
+                "phase worker",
+                MAX_WORKER_MESSAGE_BYTES,
+            )?;
+            let mut written = 0_usize;
+            let mut terminal = None;
+            loop {
+                child.write_available(&encoded_request, &mut written)?;
+                if written == encoded_request.len() {
+                    child.close_input();
+                }
+                drain_phase_output(
+                    &mut child,
+                    request,
+                    progress,
+                    &mut terminal,
+                    deadline,
+                    self.timeout,
+                )?;
+                if let Some(status) = child.try_wait()? {
+                    // Do not wait for pipe EOF after leader exit. An unauthorized
+                    // setsid() descendant can retain stdout outside the process
+                    // group; every byte the leader committed is already readable.
+                    child.terminate_process_group();
+                    drain_phase_output(
+                        &mut child,
+                        request,
+                        progress,
+                        &mut terminal,
+                        deadline,
+                        self.timeout,
+                    )?;
+                    child.finish_output_at_leader_exit()?;
+                    ensure!(
+                        written == encoded_request.len(),
+                        "phase worker exited before consuming its complete request"
+                    );
+                    ensure!(status.success(), "phase worker exited with status {status}");
+                    return terminal.context("phase worker exited without a terminal message");
+                }
+                ensure_worker_before_deadline(deadline, self.timeout)?;
+                child.wait_for_activity(written < encoded_request.len(), deadline)?;
             }
-            ensure!(
-                terminal.is_none(),
-                "phase worker emitted data after a terminal message"
-            );
-            let message: PhaseWorkerMessage = serde_json::from_slice(&line)
-                .context("phase worker emitted invalid protocol JSON")?;
-            match message {
-                PhaseWorkerMessage::Metric {
-                    global_step,
-                    checkpoint_hash,
-                    event,
-                } => {
-                    if let Some(hash) = &checkpoint_hash {
-                        validate_sha256(hash).context(
+        }
+    }
+}
+
+#[cfg(unix)]
+fn drain_phase_output(
+    child: &mut SupervisedProcess,
+    request: &PhaseExecutionRequest,
+    progress: &mut dyn PhaseProgressSink,
+    terminal: &mut Option<PhaseExecutionResult>,
+    deadline: Instant,
+    timeout: Duration,
+) -> Result<()> {
+    loop {
+        ensure_worker_before_deadline(deadline, timeout)?;
+        let ProtocolRead::Line(line) = child.read_line()? else {
+            return Ok(());
+        };
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        ensure!(
+            terminal.is_none(),
+            "phase worker emitted data after a terminal message"
+        );
+        let message: PhaseWorkerMessage =
+            serde_json::from_slice(&line).context("phase worker emitted invalid protocol JSON")?;
+        match message {
+            PhaseWorkerMessage::Metric {
+                global_step,
+                checkpoint_hash,
+                event,
+            } => {
+                if let Some(hash) = &checkpoint_hash {
+                    validate_sha256_identity(hash, "phase worker metric checkpoint identity")
+                        .context(
                             "phase worker metric checkpoint_hash is not a canonical SHA-256",
                         )?;
-                    }
-                    event
-                        .validate()
-                        .context("phase worker emitted an invalid typed metric")?;
-                    progress.metric(
-                        MetricContext {
-                            global_step,
-                            phase: metric_phase(&request.phase, request.phase_index)?,
-                            checkpoint_hash,
-                        },
-                        event,
-                    )?;
                 }
-                PhaseWorkerMessage::Progress { resume_state } => {
-                    progress.checkpoint(resume_state)?;
-                }
-                PhaseWorkerMessage::Yielded { resume_state } => {
-                    terminal = Some(PhaseExecutionResult::Yielded { resume_state });
-                }
-                PhaseWorkerMessage::Complete { product } => {
-                    terminal = Some(PhaseExecutionResult::Complete(product));
-                }
+                event
+                    .validate()
+                    .context("phase worker emitted an invalid typed metric")?;
+                progress.metric(
+                    MetricContext {
+                        global_step,
+                        phase: metric_phase(&request.phase, request.phase_index)?,
+                        checkpoint_hash,
+                    },
+                    event,
+                )?;
+            }
+            PhaseWorkerMessage::Progress { resume_state } => {
+                progress.checkpoint(resume_state)?;
+            }
+            PhaseWorkerMessage::Yielded { resume_state } => {
+                *terminal = Some(PhaseExecutionResult::Yielded { resume_state });
+            }
+            PhaseWorkerMessage::Complete { product } => {
+                *terminal = Some(PhaseExecutionResult::Complete(product));
             }
         }
-        let status = child.wait()?;
-        ensure!(status.success(), "phase worker exited with status {status}");
-        terminal.context("phase worker exited without a terminal message")
     }
+}
+
+fn checked_worker_deadline(timeout: Duration) -> Result<Instant> {
+    Instant::now()
+        .checked_add(timeout)
+        .context("phase worker timeout is too large for the monotonic clock")
+}
+
+fn ensure_worker_before_deadline(deadline: Instant, timeout: Duration) -> Result<()> {
+    ensure!(
+        Instant::now() < deadline,
+        "phase worker exceeded its {timeout:?} wall timeout"
+    );
+    Ok(())
 }
 
 fn metric_phase(phase: &crate::workflow::PhaseV2, phase_index: usize) -> Result<MetricPhase> {
     let index = u32::try_from(phase_index).context("workflow phase index exceeds u32")?;
-    let kind = match phase.kind {
-        crate::workflow::PhaseKind::Pretrain => MetricPhaseKind::Pretrain,
-        crate::workflow::PhaseKind::ContinuedPretrain => MetricPhaseKind::ContinuedPretrain,
-        crate::workflow::PhaseKind::Sft => MetricPhaseKind::Sft,
-        crate::workflow::PhaseKind::Preference => MetricPhaseKind::Preference,
-        crate::workflow::PhaseKind::Rl => MetricPhaseKind::Rl,
-        crate::workflow::PhaseKind::Distillation => MetricPhaseKind::Distillation,
-        crate::workflow::PhaseKind::Sleep => MetricPhaseKind::Sleep,
-        crate::workflow::PhaseKind::Quantization => MetricPhaseKind::Quantization,
-        crate::workflow::PhaseKind::Evaluation => MetricPhaseKind::Evaluation,
-        crate::workflow::PhaseKind::Promotion => MetricPhaseKind::Promotion,
-    };
     Ok(MetricPhase {
         index,
         name: phase.name.clone(),
-        kind,
+        kind: phase.kind.into(),
     })
-}
-
-fn read_worker_message(reader: &mut impl BufRead) -> Result<Option<Vec<u8>>> {
-    let mut line = Vec::new();
-    loop {
-        let available = reader.fill_buf()?;
-        if available.is_empty() {
-            ensure!(
-                line.is_empty(),
-                "phase worker emitted an unterminated JSONL message"
-            );
-            return Ok(None);
-        }
-        let take = available
-            .iter()
-            .position(|byte| *byte == b'\n')
-            .map_or(available.len(), |position| position + 1);
-        ensure!(
-            line.len() + take <= MAX_WORKER_MESSAGE_BYTES,
-            "phase worker emitted a JSONL message larger than {MAX_WORKER_MESSAGE_BYTES} bytes"
-        );
-        line.extend_from_slice(&available[..take]);
-        reader.consume(take);
-        if line.ends_with(b"\n") {
-            return Ok(Some(line));
-        }
-    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -291,7 +445,7 @@ impl AtomicRuntimeCheckpoint {
             !checkpoint.path.as_os_str().is_empty(),
             "workflow-runtime checkpoint path is empty"
         );
-        validate_sha256(&checkpoint.executor_sha256)?;
+        validate_sha256_identity(&checkpoint.executor_sha256, "runtime executor identity")?;
         Ok(checkpoint)
     }
 
@@ -335,9 +489,14 @@ impl AtomicRuntimeCheckpoint {
         self.publish(None, state)
     }
 
-    pub fn load(&mut self, workflow: &ResolvedWorkflow) -> Result<WorkflowRunState> {
+    fn read_saved(&self) -> Result<RuntimeCheckpointFile> {
         ensure_regular_non_symlink(&self.path, "workflow-runtime checkpoint")?;
-        let bytes = fs::read(&self.path).with_context(|| {
+        let bytes = read_regular_bounded(
+            &self.path,
+            MAX_RUNTIME_CHECKPOINT_BYTES,
+            "workflow-runtime checkpoint",
+        )
+        .with_context(|| {
             format!(
                 "failed to read workflow-runtime checkpoint {}",
                 self.path.display()
@@ -349,6 +508,10 @@ impl AtomicRuntimeCheckpoint {
                 self.path.display()
             )
         })?;
+        Ok(saved)
+    }
+
+    fn validate_execution_identity(&self, saved: &RuntimeCheckpointFile) -> Result<()> {
         ensure!(
             saved.version == RUNTIME_CHECKPOINT_FILE_VERSION,
             "unsupported workflow-runtime checkpoint-file version {}",
@@ -356,8 +519,22 @@ impl AtomicRuntimeCheckpoint {
         );
         ensure!(
             saved.executor_sha256 == self.executor_sha256,
-            "workflow-runtime checkpoint was produced by a different phase worker"
+            "workflow-runtime checkpoint was produced by a different execution dispatch"
         );
+        Ok(())
+    }
+
+    /// Read-only preflight for adapter-backed resume. Callers can reject a
+    /// replacement native runtime before constructing it or truncating the
+    /// metric journal to the checkpoint's committed prefix.
+    pub fn verify_execution_identity(&self) -> Result<()> {
+        let saved = self.read_saved()?;
+        self.validate_execution_identity(&saved)
+    }
+
+    pub fn load(&mut self, workflow: &ResolvedWorkflow) -> Result<WorkflowRunState> {
+        let saved = self.read_saved()?;
+        self.validate_execution_identity(&saved)?;
         saved.state.validate(workflow)?;
         self.resume_metrics(saved.metrics.as_ref())?;
         Ok(saved.state)
@@ -540,44 +717,94 @@ fn ensure_path_absent(path: &Path, label: &str) -> Result<()> {
 }
 
 pub fn file_sha256(path: &Path) -> Result<String> {
-    let mut input = BufReader::new(
-        File::open(path).with_context(|| format!("failed to hash {}", path.display()))?,
-    );
-    let mut hasher = Sha256::new();
-    let mut buffer = [0u8; 1024 * 1024];
-    loop {
-        use std::io::Read as _;
-        let read = input.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        hasher.update(&buffer[..read]);
-    }
-    Ok(format!("sha256:{:x}", hasher.finalize()))
-}
-
-fn validate_sha256(value: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .context("SHA-256 identity must start with `sha256:`")?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "SHA-256 identity must contain 64 lowercase hexadecimal digits"
-    );
-    Ok(())
+    hash_file_sha256(path)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io::Cursor;
-
     use super::*;
     use crate::metrics::{MetricEvent, PhaseBoundary, PhaseTimingMetrics, validate_metric_log};
     use crate::runtime::{ExecutorRegistry, RuntimeStatus, run_until_yield_or_complete};
-    use crate::workflow::{WorkflowV2, load_workflow};
+    use crate::workflow::{ResolvedWorkflow, WorkflowV2, load_workflow};
+
+    struct NoopProgress;
+
+    impl PhaseProgressSink for NoopProgress {
+        fn checkpoint(&mut self, _: Value) -> Result<()> {
+            Ok(())
+        }
+
+        fn metric(&mut self, _: MetricContext, _: MetricEvent) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn one_phase_workflow(directory: &Path) -> ResolvedWorkflow {
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [{
+                "name": "pretrain",
+                "type": "pretrain",
+                "task": {"type": "causal_lm"},
+                "data": "data.jsonl",
+                "sequence_length": 8,
+                "batch_size": 1,
+                "gradient_accumulation": 1,
+                "steps": 1
+            }]
+        }))
+        .unwrap();
+        workflow.resolve(&directory.join("workflow.json")).unwrap()
+    }
+
+    fn phase_request(workflow: &ResolvedWorkflow) -> PhaseExecutionRequest {
+        PhaseExecutionRequest {
+            phase_index: 0,
+            phase: workflow.phases[0].clone(),
+            input_checkpoint: None,
+            resume_state: None,
+        }
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::write(path, contents).unwrap();
+        let mut permissions = fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(path, permissions).unwrap();
+    }
+
+    #[cfg(unix)]
+    fn python_with_setsid() -> PathBuf {
+        [
+            "/usr/bin/python3",
+            "/usr/local/bin/python3",
+            "/opt/homebrew/bin/python3",
+        ]
+        .into_iter()
+        .map(PathBuf::from)
+        .find(|path| path.is_file())
+        .expect("setsid worker tests require an absolute Python 3 interpreter")
+    }
+
+    #[cfg(unix)]
+    fn kill_detached_pid(path: &Path) {
+        for _ in 0..100 {
+            if let Ok(value) = fs::read_to_string(path)
+                && let Ok(pid) = value.trim().parse::<i32>()
+            {
+                // SAFETY: the test helper wrote its own positive process ID.
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                }
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("detached worker did not publish its pid");
+    }
 
     fn timing_event() -> MetricEvent {
         MetricEvent::PhaseTiming(PhaseTimingMetrics {
@@ -859,6 +1086,401 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn protocol_failure_terminates_the_worker_process_group() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::Duration;
+
+        let directory = tempfile::tempdir().unwrap();
+        let workflow_path = directory.path().join("workflow.json");
+        fs::write(
+            &workflow_path,
+            r#"{
+                "version": 2,
+                "phases": [{
+                    "name": "pretrain",
+                    "type": "pretrain",
+                    "task": {"type": "causal_lm"},
+                    "data": "data.jsonl",
+                    "sequence_length": 8,
+                    "batch_size": 1,
+                    "gradient_accumulation": 1,
+                    "steps": 1
+                }]
+            }"#,
+        )
+        .unwrap();
+        let workflow = load_workflow(&workflow_path).unwrap();
+        let worker_path = directory.path().join("worker.sh");
+        fs::write(
+            &worker_path,
+            concat!(
+                "#!/bin/sh\n",
+                "echo '{not-json'\n",
+                "sleep 1\n",
+                "echo leaked > \"$1\"\n"
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&worker_path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&worker_path, permissions).unwrap();
+        let leaked_side_effect = directory.path().join("leaked-side-effect");
+        let worker_hash = file_sha256(&worker_path).unwrap();
+        let mut registry = ExecutorRegistry::new();
+        registry
+            .register(
+                crate::workflow::PhaseKind::Pretrain,
+                ExternalPhaseExecutor::new(
+                    &worker_path,
+                    vec![leaked_side_effect.clone().into_os_string()],
+                    &worker_hash,
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        let state_path = directory.path().join("runtime.json");
+        let mut sink = AtomicRuntimeCheckpoint::new(&state_path, &worker_hash).unwrap();
+        let mut state = WorkflowRunState::new(&workflow, None).unwrap();
+        sink.initialize(&state).unwrap();
+
+        let error =
+            run_until_yield_or_complete(&workflow, &mut state, &mut registry, &mut (), &mut sink)
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("invalid protocol JSON"), "{error}");
+        std::thread::sleep(Duration::from_millis(1_200));
+        assert!(
+            !leaked_side_effect.exists(),
+            "failed worker continued mutating state after its protocol error"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wall_timeout_terminates_worker_and_descendants() {
+        let directory = tempfile::tempdir().unwrap();
+        let workflow = one_phase_workflow(directory.path());
+        let worker_path = directory.path().join("worker.sh");
+        let leaked_side_effect = directory.path().join("leaked-side-effect");
+        write_executable(
+            &worker_path,
+            concat!(
+                "#!/bin/sh\n",
+                "IFS= read -r request\n",
+                "test -n \"$request\"\n",
+                "(sleep 1; echo leaked > \"$1\") &\n",
+                "sleep 30\n"
+            ),
+        );
+        let worker_hash = file_sha256(&worker_path).unwrap();
+        let mut executor = ExternalPhaseExecutor::new(
+            &worker_path,
+            vec![leaked_side_effect.clone().into_os_string()],
+            &worker_hash,
+        )
+        .unwrap()
+        .with_timeout(Duration::from_millis(150))
+        .unwrap();
+        let start = Instant::now();
+        let error = executor
+            .execute(&phase_request(&workflow), &mut (), &mut NoopProgress)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("wall timeout"), "{error}");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "phase timeout did not return promptly"
+        );
+        thread::sleep(Duration::from_millis(1_100));
+        assert!(
+            !leaked_side_effect.exists(),
+            "timed-out worker descendant remained able to mutate state"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wall_timeout_is_bounded_when_setsid_descendant_retains_protocol_pipes() {
+        let directory = tempfile::tempdir().unwrap();
+        let workflow = one_phase_workflow(directory.path());
+        let worker_path = directory.path().join("setsid-timeout.sh");
+        let detached_pid = directory.path().join("detached.pid");
+        write_executable(
+            &worker_path,
+            concat!(
+                "#!/bin/sh\n",
+                "IFS= read -r request\n",
+                "test -n \"$request\"\n",
+                "\"$1\" -c 'import os,sys,time; os.setsid(); f=open(sys.argv[1],\"w\"); f.write(str(os.getpid())); f.flush(); os.fsync(f.fileno()); time.sleep(30)' \"$2\" &\n",
+                "while [ ! -s \"$2\" ]; do /bin/sleep 0.01; done\n",
+                "/bin/sleep 30\n"
+            ),
+        );
+        let worker_hash = file_sha256(&worker_path).unwrap();
+        let mut executor = ExternalPhaseExecutor::new(
+            &worker_path,
+            vec![
+                python_with_setsid().into_os_string(),
+                detached_pid.clone().into_os_string(),
+            ],
+            &worker_hash,
+        )
+        .unwrap()
+        .with_timeout(Duration::from_secs(3))
+        .unwrap();
+
+        let started = Instant::now();
+        let result = executor.execute(&phase_request(&workflow), &mut (), &mut NoopProgress);
+        let elapsed = started.elapsed();
+        kill_detached_pid(&detached_pid);
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("wall timeout"), "{error}");
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "setsid descendant delayed phase timeout for {elapsed:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn protocol_error_is_bounded_when_setsid_descendant_retains_stdout() {
+        let directory = tempfile::tempdir().unwrap();
+        let workflow = one_phase_workflow(directory.path());
+        let worker_path = directory.path().join("setsid-error.sh");
+        let detached_pid = directory.path().join("detached.pid");
+        write_executable(
+            &worker_path,
+            concat!(
+                "#!/bin/sh\n",
+                "IFS= read -r request\n",
+                "test -n \"$request\"\n",
+                "\"$1\" -c 'import os,sys,time; os.setsid(); f=open(sys.argv[1],\"w\"); f.write(str(os.getpid())); f.flush(); os.fsync(f.fileno()); time.sleep(30)' \"$2\" &\n",
+                "while [ ! -s \"$2\" ]; do /bin/sleep 0.01; done\n",
+                "printf '{not-json}\\n'\n",
+                "/bin/sleep 30\n"
+            ),
+        );
+        let worker_hash = file_sha256(&worker_path).unwrap();
+        let mut executor = ExternalPhaseExecutor::new(
+            &worker_path,
+            vec![
+                python_with_setsid().into_os_string(),
+                detached_pid.clone().into_os_string(),
+            ],
+            &worker_hash,
+        )
+        .unwrap()
+        .with_timeout(Duration::from_secs(3))
+        .unwrap();
+
+        let started = Instant::now();
+        let result = executor.execute(&phase_request(&workflow), &mut (), &mut NoopProgress);
+        let elapsed = started.elapsed();
+        kill_detached_pid(&detached_pid);
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("invalid protocol JSON"), "{error}");
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "setsid descendant delayed phase protocol error for {elapsed:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_worker_does_not_wait_for_descendant_holding_stdout() {
+        let directory = tempfile::tempdir().unwrap();
+        let workflow = one_phase_workflow(directory.path());
+        let worker_path = directory.path().join("worker.sh");
+        write_executable(
+            &worker_path,
+            concat!(
+                "#!/bin/sh\n",
+                "IFS= read -r request\n",
+                "test -n \"$request\"\n",
+                "sleep 30 &\n",
+                "echo '{\"type\":\"complete\",\"product\":{\"type\":\"model_candidate\",\"checkpoint\":{\"uri\":\"checkpoint://candidate\",\"sha256\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}}}'\n"
+            ),
+        );
+        let worker_hash = file_sha256(&worker_path).unwrap();
+        let mut executor = ExternalPhaseExecutor::new(&worker_path, Vec::new(), &worker_hash)
+            .unwrap()
+            .with_timeout(Duration::from_secs(5))
+            .unwrap();
+        let start = Instant::now();
+        let result = executor
+            .execute(&phase_request(&workflow), &mut (), &mut NoopProgress)
+            .unwrap();
+        assert!(
+            matches!(result, PhaseExecutionResult::Complete(_)),
+            "worker did not return its terminal product"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(4),
+            "descendant-held stdout delayed worker completion"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn leader_exit_is_bounded_when_setsid_descendant_retains_stdout() {
+        let directory = tempfile::tempdir().unwrap();
+        let workflow = one_phase_workflow(directory.path());
+        let worker_path = directory.path().join("setsid-exit.sh");
+        let detached_pid = directory.path().join("detached.pid");
+        write_executable(
+            &worker_path,
+            concat!(
+                "#!/bin/sh\n",
+                "IFS= read -r request\n",
+                "test -n \"$request\"\n",
+                "\"$1\" -c 'import os,sys,time; os.setsid(); f=open(sys.argv[1],\"w\"); f.write(str(os.getpid())); f.flush(); os.fsync(f.fileno()); time.sleep(30)' \"$2\" &\n",
+                "while [ ! -s \"$2\" ]; do /bin/sleep 0.01; done\n",
+                "echo '{\"type\":\"complete\",\"product\":{\"type\":\"model_candidate\",\"checkpoint\":{\"uri\":\"checkpoint://candidate\",\"sha256\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}}}'\n"
+            ),
+        );
+        let worker_hash = file_sha256(&worker_path).unwrap();
+        let mut executor = ExternalPhaseExecutor::new(
+            &worker_path,
+            vec![
+                python_with_setsid().into_os_string(),
+                detached_pid.clone().into_os_string(),
+            ],
+            &worker_hash,
+        )
+        .unwrap()
+        .with_timeout(Duration::from_secs(2))
+        .unwrap();
+
+        let started = Instant::now();
+        let result = executor.execute(&phase_request(&workflow), &mut (), &mut NoopProgress);
+        let elapsed = started.elapsed();
+        kill_detached_pid(&detached_pid);
+        assert!(matches!(result.unwrap(), PhaseExecutionResult::Complete(_)));
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "setsid descendant delayed phase leader exit for {elapsed:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn execution_identity_binds_arguments_and_timeout() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker_path = directory.path().join("worker.sh");
+        write_executable(&worker_path, "#!/bin/sh\nexit 0\n");
+        let worker_hash = file_sha256(&worker_path).unwrap();
+        let baseline = ExternalPhaseExecutor::new(
+            &worker_path,
+            vec![OsString::from("argument")],
+            &worker_hash,
+        )
+        .unwrap();
+        let same = ExternalPhaseExecutor::new(
+            &worker_path,
+            vec![OsString::from("argument")],
+            &worker_hash,
+        )
+        .unwrap();
+        let changed_argument = ExternalPhaseExecutor::new(
+            &worker_path,
+            vec![OsString::from("different")],
+            &worker_hash,
+        )
+        .unwrap();
+        let changed_timeout = same.clone().with_timeout(Duration::from_secs(60)).unwrap();
+
+        assert_eq!(baseline.execution_identity(), same.execution_identity());
+        assert_ne!(
+            baseline.execution_identity(),
+            changed_argument.execution_identity()
+        );
+        assert_ne!(
+            baseline.execution_identity(),
+            changed_timeout.execution_identity()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worker_runs_with_empty_environment_and_root_working_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let workflow = one_phase_workflow(directory.path());
+        let worker_path = directory.path().join("worker.sh");
+        write_executable(
+            &worker_path,
+            concat!(
+                "#!/bin/sh\n",
+                "IFS= read -r request\n",
+                "test -n \"$request\"\n",
+                "test \"$PWD\" = /\n",
+                "test -z \"${HOME+x}\"\n",
+                "echo '{\"type\":\"complete\",\"product\":{\"type\":\"model_candidate\",\"checkpoint\":{\"uri\":\"checkpoint://candidate\",\"sha256\":\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"}}}'\n"
+            ),
+        );
+        let worker_hash = file_sha256(&worker_path).unwrap();
+        let mut executor = ExternalPhaseExecutor::new(&worker_path, Vec::new(), &worker_hash)
+            .unwrap()
+            .with_timeout(Duration::from_secs(2))
+            .unwrap();
+        assert!(
+            executor
+                .execute(&phase_request(&workflow), &mut (), &mut NoopProgress)
+                .is_ok()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pinned_phase_worker_generation_survives_path_replacement_before_spawn() {
+        let directory = tempfile::tempdir().unwrap();
+        let worker_path = directory.path().join("worker.sh");
+        write_executable(&worker_path, "#!/bin/sh\nprintf 'pinned\\n'\n");
+        let worker_hash = file_sha256(&worker_path).unwrap();
+        let executor = ExternalPhaseExecutor::new(&worker_path, Vec::new(), &worker_hash).unwrap();
+        let (mut command, staged) = executor.pinned_command().unwrap();
+
+        let replacement = directory.path().join("replacement.sh");
+        write_executable(&replacement, "#!/bin/sh\nprintf 'replacement\\n'\n");
+        fs::rename(&replacement, &worker_path).unwrap();
+
+        command.stderr(Stdio::piped());
+        let output = command.output().unwrap();
+        assert!(output.status.success());
+        assert_eq!(output.stdout, b"pinned\n");
+        drop(staged);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn phase_worker_arguments_are_canonical_and_bounded() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let worker_path = directory.path().join("worker.sh");
+        write_executable(&worker_path, "#!/bin/sh\nexit 0\n");
+        let worker_hash = file_sha256(&worker_path).unwrap();
+
+        let too_many = vec![OsString::from("x"); MAX_PHASE_WORKER_ARGUMENTS + 1];
+        let error = ExternalPhaseExecutor::new(&worker_path, too_many, &worker_hash)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("more than"), "{error}");
+
+        let oversized = OsString::from("x".repeat(MAX_PHASE_WORKER_ARGUMENT_BYTES + 1));
+        let error = ExternalPhaseExecutor::new(&worker_path, vec![oversized], &worker_hash)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("exceeds"), "{error}");
+
+        let nul = OsString::from_vec(b"a\0b".to_vec());
+        let error = ExternalPhaseExecutor::new(&worker_path, vec![nul], &worker_hash)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("NUL"), "{error}");
+    }
+
     #[test]
     fn checkpoint_rejects_a_different_worker_identity() {
         let directory = tempfile::tempdir().unwrap();
@@ -878,11 +1500,29 @@ mod tests {
         let second = format!("sha256:{:064x}", 2);
         let path = directory.path().join("runtime.json");
         let mut writer = AtomicRuntimeCheckpoint::new(&path, &first).unwrap();
+        let initial = ImmutableModelCheckpoint::new(
+            "checkpoint://promotion-input",
+            format!("sha256:{:064x}", 3),
+        )
+        .unwrap();
         writer
-            .initialize(&WorkflowRunState::new(&workflow, None).unwrap())
+            .initialize(&WorkflowRunState::new(&workflow, Some(initial)).unwrap())
             .unwrap();
         let mut reader = AtomicRuntimeCheckpoint::new(&path, &second).unwrap();
         assert!(reader.load(&workflow).is_err());
+    }
+
+    #[test]
+    fn runtime_checkpoint_read_is_bounded_before_json_allocation() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("runtime.json");
+        File::create(&path)
+            .unwrap()
+            .set_len(MAX_RUNTIME_CHECKPOINT_BYTES + 1)
+            .unwrap();
+        let checkpoint = AtomicRuntimeCheckpoint::new(&path, format!("sha256:{:064x}", 1)).unwrap();
+        let error = format!("{:#}", checkpoint.verify_execution_identity().unwrap_err());
+        assert!(error.contains("byte limit"), "{error}");
     }
 
     #[cfg(unix)]
@@ -903,21 +1543,5 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("regular non-symlink file"), "{error}");
-    }
-
-    #[test]
-    fn worker_protocol_rejects_unterminated_and_oversized_messages_without_unbounded_reads() {
-        let mut unterminated = Cursor::new(b"{}".to_vec());
-        assert!(read_worker_message(&mut unterminated).is_err());
-
-        let mut oversized = Cursor::new(vec![b'x'; MAX_WORKER_MESSAGE_BYTES + 1]);
-        assert!(read_worker_message(&mut oversized).is_err());
-
-        let mut valid = Cursor::new(b"{}\n".to_vec());
-        assert_eq!(
-            read_worker_message(&mut valid).unwrap(),
-            Some(b"{}\n".to_vec())
-        );
-        assert_eq!(read_worker_message(&mut valid).unwrap(), None);
     }
 }

--- a/hermes-train/src/workflow.rs
+++ b/hermes-train/src/workflow.rs
@@ -1,19 +1,35 @@
 //! Strict version-2 training workflow configuration.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
 use std::path::{Path, PathBuf};
+
+#[cfg(test)]
+use std::fs;
 
 use anyhow::{Context, Result, bail, ensure};
 use hermes_llm::ModelDef;
 use serde::{Deserialize, Serialize};
 
+use crate::artifact_io::{read_regular_bounded, validate_sha256_identity};
 use crate::posttrain::PostTrainingConfig;
 use crate::sleep::{DreamingConfig, ImitationConfig, KnowledgeSeedingConfig, SleepSchedule};
 use crate::task::{TaskAdapter, TaskConfig, TaskExecution};
 use crate::tensor_sleep::{RetentionGateConfig, TensorConsolidationConfig};
+use crate::tier_optimizer::TierOptimizerConfig;
 
 pub const WORKFLOW_VERSION: u32 = 2;
+const MAX_WORKFLOW_JSON_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_WORKFLOW_PHASES: usize = 4_096;
+const MAX_WORKFLOW_NAME_BYTES: usize = 1_024;
+const MAX_PHASE_NAME_BYTES: usize = 256;
+const MAX_PHASE_BATCH_SIZE: usize = 65_536;
+const MAX_PHASE_GRADIENT_ACCUMULATION: usize = 1_048_576;
+const MAX_PHASE_SHUFFLE_SAMPLES: usize = 262_144;
+const MAX_PHASE_BATCH_TOKENS: usize = 8 * 1024 * 1024;
+// The checked-in education curriculum intentionally shuffles 65,536 examples
+// at 4,096 tokens. This is a documented high-memory (~2 GiB for one raw i64
+// token vector per sample) production tradeoff, and forms the upper bound.
+const MAX_PHASE_SHUFFLE_TOKENS: usize = 256 * 1024 * 1024;
 
 fn default_one_f64() -> f64 {
     1.0
@@ -135,9 +151,9 @@ impl PromotionEvidenceRef {
             !self.path.as_os_str().is_empty(),
             "workflow phase `{phase_name}` promotion {label} path is empty"
         );
-        validate_sha256_label(&self.sha256).with_context(|| {
-            format!("workflow phase `{phase_name}` promotion {label} has an invalid hash")
-        })?;
+        validate_sha256_identity(&self.sha256, "workflow artifact identity").with_context(
+            || format!("workflow phase `{phase_name}` promotion {label} has an invalid hash"),
+        )?;
         ensure!(
             !self
                 .path
@@ -326,7 +342,11 @@ impl InModelSleepConfig {
                 && !self.candidate_directory.as_os_str().is_empty(),
             "sleep phase `{phase_name}` requires retention_suite and candidate_directory"
         );
-        validate_sha256_label(&self.retention_suite_sha256).with_context(|| {
+        validate_sha256_identity(
+            &self.retention_suite_sha256,
+            "sleep retention suite identity",
+        )
+        .with_context(|| {
             format!("sleep phase `{phase_name}` has an invalid retention-suite hash")
         })?;
         self.tensor_config().validate().with_context(|| {
@@ -385,11 +405,12 @@ impl QuantizationConfig {
                     !teacher_checkpoint.as_os_str().is_empty(),
                     "workflow phase `{phase_name}` quantization distillation requires teacher_checkpoint"
                 );
-                validate_sha256_label(teacher_sha256).with_context(|| {
-                    format!(
-                        "workflow phase `{phase_name}` has an invalid quantization teacher hash"
-                    )
-                })?;
+                validate_sha256_identity(teacher_sha256, "quantization teacher identity")
+                    .with_context(|| {
+                        format!(
+                            "workflow phase `{phase_name}` has an invalid quantization teacher hash"
+                        )
+                    })?;
                 ensure!(
                     temperature.is_finite() && *temperature > 0.0,
                     "workflow phase `{phase_name}` quantization temperature must be finite and positive"
@@ -414,18 +435,51 @@ impl QuantizationConfig {
     }
 }
 
-fn validate_sha256_label(value: &str) -> Result<()> {
-    let digest = value
-        .strip_prefix("sha256:")
-        .context("digest must use sha256:<64 lowercase hex>")?;
-    ensure!(
-        digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)),
-        "digest must use sha256:<64 lowercase hex>"
-    );
-    Ok(())
+/// Memory-tier update policy for optimizer-bearing workflow phases.
+///
+/// `wake_only` is the capacity- and cadence-matched sleep ablation. It keeps
+/// each tier's independent optimizer and configured update period, but applies
+/// due prospective base updates directly, fastest-to-slowest. It never runs
+/// consolidation, transfers or reclaims reserve slots, or generates dreams.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum MemoryUpdateMode {
+    WakeOnly {
+        schedule: SleepSchedule,
+        #[serde(default)]
+        tier_optimizer: TierOptimizerConfig,
+    },
+}
+
+impl MemoryUpdateMode {
+    pub fn schedule(&self) -> &SleepSchedule {
+        match self {
+            Self::WakeOnly { schedule, .. } => schedule,
+        }
+    }
+
+    pub fn tier_optimizer(&self) -> &TierOptimizerConfig {
+        match self {
+            Self::WakeOnly { tier_optimizer, .. } => tier_optimizer,
+        }
+    }
+
+    pub fn validate(&self, phase_name: &str) -> Result<()> {
+        match self {
+            Self::WakeOnly {
+                schedule,
+                tier_optimizer,
+            } => {
+                schedule.validate().with_context(|| {
+                    format!("invalid wake_only memory schedule in workflow phase `{phase_name}`")
+                })?;
+                tier_optimizer.validate().with_context(|| {
+                    format!("invalid wake_only tier optimizer in workflow phase `{phase_name}`")
+                })?;
+            }
+        }
+        Ok(())
+    }
 }
 
 /// Serialized phase definition. Algorithm-specific knobs are namespaced under
@@ -466,6 +520,10 @@ pub struct PhaseV2 {
     /// optimizer-step or model-token boundaries.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub periodic_sleep: Option<InModelSleepConfig>,
+    /// Explicit non-sleep update policy for memory tiers. Mutually exclusive
+    /// with `periodic_sleep`; ordinary models leave both fields absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_update_mode: Option<MemoryUpdateMode>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quantization: Option<QuantizationConfig>,
     /// Content-addressed inputs for the trainer-owned release gate. Unlike
@@ -496,10 +554,7 @@ impl PhaseV2 {
 
     fn validate(&self) -> Result<()> {
         let name = &self.name;
-        ensure!(
-            !name.trim().is_empty(),
-            "workflow phase name must not be empty"
-        );
+        validate_workflow_identifier(name, "workflow phase name", MAX_PHASE_NAME_BYTES)?;
         if let Some(task) = &self.task {
             task.validate()
                 .with_context(|| format!("invalid task in workflow phase `{name}`"))?;
@@ -509,7 +564,23 @@ impl PhaseV2 {
         validate_positive(self.batch_size, "batch_size", name)?;
         validate_positive(self.gradient_accumulation, "gradient_accumulation", name)?;
         validate_positive(self.epochs, "epochs", name)?;
+        validate_positive(self.shuffle_buffer, "shuffle_buffer", name)?;
         validate_positive(self.steps, "steps", name)?;
+        ensure!(
+            self.batch_size
+                .is_none_or(|value| value <= MAX_PHASE_BATCH_SIZE),
+            "workflow phase `{name}` batch_size exceeds the {MAX_PHASE_BATCH_SIZE}-sample limit"
+        );
+        ensure!(
+            self.gradient_accumulation
+                .is_none_or(|value| value <= MAX_PHASE_GRADIENT_ACCUMULATION),
+            "workflow phase `{name}` gradient_accumulation exceeds the {MAX_PHASE_GRADIENT_ACCUMULATION}-microbatch limit"
+        );
+        ensure!(
+            self.shuffle_buffer
+                .is_none_or(|value| value <= MAX_PHASE_SHUFFLE_SAMPLES),
+            "workflow phase `{name}` shuffle_buffer exceeds the {MAX_PHASE_SHUFFLE_SAMPLES}-sample limit"
+        );
         if let Some(loss_weight) = self.loss_weight {
             ensure!(
                 loss_weight.is_finite() && loss_weight > 0.0,
@@ -545,6 +616,29 @@ impl PhaseV2 {
                 self.batch_size.is_some(),
                 "workflow phase `{name}` ({}) requires batch_size",
                 self.kind.name()
+            );
+            let sequence_length = self.sequence_length.expect("required above");
+            let batch_size = self.batch_size.expect("required above");
+            let sequences_per_example = self
+                .task
+                .as_ref()
+                .expect("required above")
+                .maximum_model_sequences_per_example();
+            ensure!(
+                sequence_length
+                    .checked_mul(batch_size)
+                    .and_then(|tokens| tokens.checked_mul(sequences_per_example))
+                    .is_some_and(|tokens| tokens <= MAX_PHASE_BATCH_TOKENS),
+                "workflow phase `{name}` batch geometry exceeds the {MAX_PHASE_BATCH_TOKENS}-token materialization limit"
+            );
+            let shuffle_buffer = self.shuffle_buffer_or_default();
+            ensure!(
+                shuffle_buffer <= MAX_PHASE_SHUFFLE_SAMPLES
+                    && sequence_length
+                        .checked_mul(shuffle_buffer)
+                        .and_then(|tokens| tokens.checked_mul(sequences_per_example))
+                        .is_some_and(|tokens| tokens <= MAX_PHASE_SHUFFLE_TOKENS),
+                "workflow phase `{name}` shuffle geometry exceeds the {MAX_PHASE_SHUFFLE_TOKENS}-token buffer limit"
             );
         } else {
             ensure!(
@@ -599,6 +693,16 @@ impl PhaseV2 {
             PhaseKind::Sft => ensure!(
                 execution == Some(TaskExecution::SupervisedGeneration),
                 "workflow phase `{name}` (sft) requires a supervised-generation task"
+            ),
+            PhaseKind::Distillation => ensure!(
+                matches!(
+                    execution,
+                    Some(
+                        TaskExecution::AutoregressiveTokenPrediction
+                            | TaskExecution::SupervisedGeneration
+                    )
+                ),
+                "workflow phase `{name}` (distillation) requires an autoregressive or supervised-generation task"
             ),
             PhaseKind::Preference => ensure!(
                 execution == Some(TaskExecution::PairwisePreference),
@@ -718,6 +822,18 @@ impl PhaseV2 {
                 "workflow phase `{name}` periodic_sleep must not set standalone_trigger_clock"
             );
         }
+        if let Some(mode) = &self.memory_update_mode {
+            ensure!(
+                self.kind.uses_optimizer(),
+                "workflow phase `{name}` ({}) cannot set memory_update_mode",
+                self.kind.name()
+            );
+            ensure!(
+                self.periodic_sleep.is_none(),
+                "workflow phase `{name}` cannot combine memory_update_mode with periodic_sleep"
+            );
+            mode.validate(name)?;
+        }
         Ok(())
     }
 
@@ -753,6 +869,23 @@ fn validate_positive(value: Option<usize>, field: &str, phase_name: &str) -> Res
     Ok(())
 }
 
+fn validate_workflow_identifier(value: &str, label: &str, maximum_bytes: usize) -> Result<()> {
+    ensure!(!value.is_empty(), "{label} must not be empty");
+    ensure!(
+        value.trim() == value,
+        "{label} must not have leading or trailing whitespace"
+    );
+    ensure!(
+        !value.chars().any(char::is_control),
+        "{label} must not contain control characters"
+    );
+    ensure!(
+        value.len() <= maximum_bytes,
+        "{label} exceeds the {maximum_bytes}-byte limit"
+    );
+    Ok(())
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowV2 {
@@ -764,25 +897,7 @@ pub struct WorkflowV2 {
 
 impl WorkflowV2 {
     pub fn validate(&self) -> Result<()> {
-        ensure!(
-            self.version == WORKFLOW_VERSION,
-            "unsupported workflow version {}; this build supports version {WORKFLOW_VERSION}",
-            self.version
-        );
-        if let Some(name) = &self.name {
-            ensure!(!name.trim().is_empty(), "workflow name must not be empty");
-        }
-        ensure!(!self.phases.is_empty(), "workflow contains no phases");
-        let mut names = BTreeSet::new();
-        for phase in &self.phases {
-            ensure!(
-                names.insert(phase.name.clone()),
-                "duplicate workflow phase name `{}`",
-                phase.name
-            );
-            phase.validate()?;
-        }
-        Ok(())
+        validate_workflow_parts(self.version, self.name.as_deref(), &self.phases)
     }
 
     pub fn resolve(mut self, source: &Path) -> Result<ResolvedWorkflow> {
@@ -799,6 +914,33 @@ impl WorkflowV2 {
     }
 }
 
+fn validate_workflow_parts(version: u32, name: Option<&str>, phases: &[PhaseV2]) -> Result<()> {
+    ensure!(
+        version == WORKFLOW_VERSION,
+        "unsupported workflow version {}; this build supports version {WORKFLOW_VERSION}",
+        version
+    );
+    if let Some(name) = name {
+        validate_workflow_identifier(name, "workflow name", MAX_WORKFLOW_NAME_BYTES)?;
+    }
+    ensure!(!phases.is_empty(), "workflow contains no phases");
+    ensure!(
+        phases.len() <= MAX_WORKFLOW_PHASES,
+        "workflow contains {} phases, exceeding the {MAX_WORKFLOW_PHASES}-phase limit",
+        phases.len()
+    );
+    let mut names = BTreeSet::new();
+    for phase in phases {
+        ensure!(
+            names.insert(phase.name.as_str()),
+            "duplicate workflow phase name `{}`",
+            phase.name
+        );
+        phase.validate()?;
+    }
+    Ok(())
+}
+
 /// Fully validated workflow with file references resolved against its source.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -811,12 +953,7 @@ pub struct ResolvedWorkflow {
 
 impl ResolvedWorkflow {
     pub fn validate(&self) -> Result<()> {
-        WorkflowV2 {
-            version: self.version,
-            name: self.name.clone(),
-            phases: self.phases.clone(),
-        }
-        .validate()
+        validate_workflow_parts(self.version, self.name.as_deref(), &self.phases)
     }
 }
 
@@ -877,37 +1014,99 @@ pub fn validate_workflow_for_model(workflow: &ResolvedWorkflow, model: &ModelDef
         .collect::<Vec<_>>();
     if memory_layers == 0 {
         ensure!(
-            optimizer_phases
-                .iter()
-                .all(|phase| phase.periodic_sleep.is_none())
-                && standalone_sleep.is_empty(),
-            "in-model sleep requires a MAL model with an explicit memory hierarchy; no implicit topology upgrade is performed"
+            optimizer_phases.iter().all(|phase| {
+                phase.periodic_sleep.is_none() && phase.memory_update_mode.is_none()
+            }) && standalone_sleep.is_empty(),
+            "memory update modes and in-model sleep require a MAL model with an explicit memory hierarchy; no implicit topology upgrade is performed"
         );
         return Ok(());
     }
 
     if !optimizer_phases.is_empty() {
+        let periodic_count = optimizer_phases
+            .iter()
+            .filter(|phase| phase.periodic_sleep.is_some())
+            .count();
+        let wake_only_count = optimizer_phases
+            .iter()
+            .filter(|phase| phase.memory_update_mode.is_some())
+            .count();
         ensure!(
-            optimizer_phases
-                .iter()
-                .all(|phase| phase.periodic_sleep.is_some()),
-            "sleep-capable MAL models require identical periodic_sleep on every optimizer-bearing phase, including QAT"
+            periodic_count == optimizer_phases.len() || wake_only_count == optimizer_phases.len(),
+            "memory MAL models require one identical update policy on every optimizer-bearing phase: periodic_sleep or memory_update_mode wake_only, including QAT"
         );
-        let reference = optimizer_phases[0]
-            .periodic_sleep
-            .as_ref()
-            .expect("checked every optimizer phase has periodic sleep");
-        ensure!(
-            optimizer_phases
-                .iter()
-                .all(|phase| phase.periodic_sleep.as_ref() == Some(reference)),
-            "all optimizer-bearing phases in one memory-model workflow must use an identical periodic_sleep configuration"
-        );
-        validate_sleep_schedule_for_model(model, &reference.schedule, &optimizer_phases[0].name)?;
+        if periodic_count == optimizer_phases.len() {
+            let reference = optimizer_phases[0]
+                .periodic_sleep
+                .as_ref()
+                .expect("checked every optimizer phase has periodic sleep");
+            ensure!(
+                optimizer_phases
+                    .iter()
+                    .all(|phase| phase.periodic_sleep.as_ref() == Some(reference)),
+                "all optimizer-bearing phases in one memory-model workflow must use an identical periodic_sleep configuration"
+            );
+            validate_sleep_schedule_for_model(
+                model,
+                &reference.schedule,
+                &optimizer_phases[0].name,
+            )?;
+            validate_dreaming_topology(model, reference, &optimizer_phases[0].name)?;
+        } else {
+            ensure!(
+                standalone_sleep.is_empty(),
+                "memory_update_mode wake_only is a no-sleep ablation and cannot be combined with standalone sleep phases"
+            );
+            let reference = optimizer_phases[0]
+                .memory_update_mode
+                .as_ref()
+                .expect("checked every optimizer phase has a memory update mode");
+            ensure!(
+                optimizer_phases
+                    .iter()
+                    .all(|phase| phase.memory_update_mode.as_ref() == Some(reference)),
+                "all optimizer-bearing phases in one memory-model workflow must use an identical memory_update_mode configuration"
+            );
+            validate_sleep_schedule_for_model(
+                model,
+                reference.schedule(),
+                &optimizer_phases[0].name,
+            )?;
+        }
     }
     for (phase, sleep) in standalone_sleep {
         validate_sleep_schedule_for_model(model, &sleep.schedule, &phase.name)?;
+        validate_dreaming_topology(model, sleep, &phase.name)?;
     }
+    Ok(())
+}
+
+fn validate_dreaming_topology(
+    model: &ModelDef,
+    sleep: &InModelSleepConfig,
+    phase_name: &str,
+) -> Result<()> {
+    if sleep.dreaming.is_none() {
+        return Ok(());
+    }
+    let has_exploration_route = (0..model.num_layers).any(|layer| {
+        model
+            .block_for_layer(layer)
+            .memory
+            .as_ref()
+            .is_some_and(|memory| {
+                memory.tiers.iter().any(|tier| {
+                    tier.ffn
+                        .moe
+                        .as_ref()
+                        .is_some_and(|moe| moe.experts > moe.top_k)
+                })
+            })
+    });
+    ensure!(
+        has_exploration_route,
+        "workflow phase `{phase_name}` enables Dreaming, but the MAL memory hierarchy has no persistent FFN MoE with an expert outside ordinary top-k"
+    );
     Ok(())
 }
 
@@ -956,8 +1155,8 @@ pub fn validate_sleep_schedule_for_model(
 }
 
 pub fn load_workflow(path: &Path) -> Result<ResolvedWorkflow> {
-    let bytes =
-        fs::read(path).with_context(|| format!("failed to read workflow {}", path.display()))?;
+    let bytes = read_regular_bounded(path, MAX_WORKFLOW_JSON_BYTES, "workflow JSON")
+        .with_context(|| format!("failed to read workflow {}", path.display()))?;
     let value: serde_json::Value = serde_json::from_slice(&bytes)
         .with_context(|| format!("invalid workflow JSON in {}", path.display()))?;
     let version = value
@@ -1038,7 +1237,7 @@ mod tests {
                     "reference": {
                         "adapter": "hermes_checkpoint",
                         "artifact": "reference",
-                        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+                        "sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
                     }
                 });
                 phase
@@ -1057,7 +1256,7 @@ mod tests {
                     "reference": {
                         "adapter": "hermes_checkpoint",
                         "artifact": "reference",
-                        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+                        "sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
                     },
                     "sampling": {"max_new_tokens": 128}
                 });
@@ -1067,14 +1266,14 @@ mod tests {
                 let mut phase = training_phase(
                     "distill",
                     "distillation",
-                    serde_json::json!({"type": "causal_lm"}),
+                    serde_json::json!({"type": "instruction_tuning"}),
                 );
                 phase["post_training"] = serde_json::json!({
                     "algorithm": "forward_kl",
                     "teacher": {
                         "adapter": "hermes_checkpoint",
                         "artifact": "teacher",
-                        "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+                        "sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
                     }
                 });
                 phase
@@ -1209,13 +1408,106 @@ mod tests {
     }
 
     #[test]
+    fn education_workflow_fits_the_bounded_shuffle_budget() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("workflow.education.example.json");
+        load_workflow(&path)
+            .unwrap_or_else(|error| panic!("education workflow is invalid: {error:#}"));
+    }
+
+    #[test]
     fn incompatible_workflow_versions_are_rejected_without_fallback() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("workflow.json");
         fs::write(&path, r#"{"version":1,"stages":[]}"#).unwrap();
 
-        let error = load_workflow(&path).unwrap_err().to_string();
+        let error = load_workflow(&path).unwrap_err();
+        let error = format!("{error:#}");
         assert!(error.contains("unsupported workflow version 1"), "{error}");
+    }
+
+    #[test]
+    fn workflow_file_is_bounded_before_json_allocation() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("oversized-workflow.json");
+        let file = fs::File::create(&path).unwrap();
+        file.set_len(MAX_WORKFLOW_JSON_BYTES + 1).unwrap();
+        drop(file);
+
+        let error = load_workflow(&path).unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("byte limit"), "{error}");
+    }
+
+    #[test]
+    fn memory_sized_phase_geometry_is_bounded_without_limiting_steps() {
+        let phase = |field: &str, value: usize| {
+            let mut phase = training_phase(
+                "bounded",
+                "pretrain",
+                serde_json::json!({"type": "causal_lm"}),
+            );
+            phase[field] = serde_json::json!(value);
+            let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+                "version": 2,
+                "phases": [phase]
+            }))
+            .unwrap();
+            workflow.validate().unwrap_err().to_string()
+        };
+
+        assert!(phase("batch_size", MAX_PHASE_BATCH_SIZE + 1).contains("batch_size exceeds"));
+        assert!(
+            phase("gradient_accumulation", MAX_PHASE_GRADIENT_ACCUMULATION + 1)
+                .contains("gradient_accumulation exceeds")
+        );
+        assert!(
+            phase("shuffle_buffer", MAX_PHASE_SHUFFLE_SAMPLES + 1)
+                .contains("shuffle_buffer exceeds")
+        );
+
+        let mut enormous_batch = training_phase(
+            "token-budget",
+            "pretrain",
+            serde_json::json!({"type": "causal_lm"}),
+        );
+        enormous_batch["sequence_length"] = serde_json::json!(MAX_PHASE_BATCH_TOKENS);
+        enormous_batch["batch_size"] = serde_json::json!(2);
+        enormous_batch["shuffle_buffer"] = serde_json::json!(1);
+        enormous_batch["steps"] = serde_json::json!(usize::MAX);
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [enormous_batch]
+        }))
+        .unwrap();
+        let error = workflow.validate().unwrap_err().to_string();
+        assert!(error.contains("batch geometry"), "{error}");
+
+        let mut retrieval = training_phase(
+            "retrieval-memory",
+            "continued_pretrain",
+            serde_json::json!({"type": "retrieval_representation"}),
+        );
+        retrieval["sequence_length"] = serde_json::json!(4096);
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [retrieval]
+        }))
+        .unwrap();
+        let error = workflow.validate().unwrap_err().to_string();
+        assert!(error.contains("shuffle geometry"), "{error}");
+
+        let mut long_run = training_phase(
+            "long-run",
+            "pretrain",
+            serde_json::json!({"type": "causal_lm"}),
+        );
+        long_run["steps"] = serde_json::json!(usize::MAX);
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [long_run]
+        }))
+        .unwrap();
+        workflow.validate().unwrap();
     }
 
     #[test]
@@ -1247,6 +1539,63 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(unknown.contains("sequnce_length"), "{unknown}");
+
+        let mut zero_shuffle = training_phase(
+            "zero-shuffle",
+            "pretrain",
+            serde_json::json!({"type": "causal_lm"}),
+        );
+        zero_shuffle["shuffle_buffer"] = serde_json::json!(0);
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [zero_shuffle]
+        }))
+        .unwrap();
+        let error = workflow.validate().unwrap_err().to_string();
+        assert!(error.contains("shuffle_buffer must be positive"), "{error}");
+
+        for invalid_name in [" leading", "trailing ", "line\nbreak"] {
+            let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+                "version": 2,
+                "phases": [training_phase(
+                    invalid_name,
+                    "pretrain",
+                    serde_json::json!({"type": "causal_lm"})
+                )]
+            }))
+            .unwrap();
+            let error = workflow.validate().unwrap_err().to_string();
+            assert!(
+                error.contains("whitespace") || error.contains("control characters"),
+                "{error}"
+            );
+        }
+
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [training_phase(
+                &"x".repeat(MAX_PHASE_NAME_BYTES + 1),
+                "pretrain",
+                serde_json::json!({"type": "causal_lm"})
+            )]
+        }))
+        .unwrap();
+        let error = workflow.validate().unwrap_err().to_string();
+        assert!(error.contains("byte limit"), "{error}");
+
+        let valid_phase: PhaseV2 = serde_json::from_value(training_phase(
+            "bounded",
+            "pretrain",
+            serde_json::json!({"type": "causal_lm"}),
+        ))
+        .unwrap();
+        let workflow = WorkflowV2 {
+            version: WORKFLOW_VERSION,
+            name: None,
+            phases: vec![valid_phase; MAX_WORKFLOW_PHASES + 1],
+        };
+        let error = workflow.validate().unwrap_err().to_string();
+        assert!(error.contains("phase limit"), "{error}");
     }
 
     #[test]
@@ -1274,6 +1623,42 @@ mod tests {
         .unwrap();
         let error = rl.validate().unwrap_err().to_string();
         assert!(error.contains("verifiable-reward task"), "{error}");
+
+        let mut invalid_distillation = training_phase(
+            "distill-ranking",
+            "distillation",
+            serde_json::json!({"type": "retrieval_ranking"}),
+        );
+        invalid_distillation["post_training"] = serde_json::json!({
+            "algorithm": "forward_kl",
+            "teacher": {"adapter": "test", "revision": "teacher-v1"}
+        });
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [invalid_distillation]
+        }))
+        .unwrap();
+        let error = workflow.validate().unwrap_err().to_string();
+        assert!(
+            error.contains("autoregressive or supervised-generation"),
+            "{error}"
+        );
+
+        let mut supervised_distillation = training_phase(
+            "distill-instructions",
+            "distillation",
+            serde_json::json!({"type": "instruction_tuning"}),
+        );
+        supervised_distillation["post_training"] = serde_json::json!({
+            "algorithm": "forward_kl",
+            "teacher": {"adapter": "test", "revision": "teacher-v1"}
+        });
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [supervised_distillation]
+        }))
+        .unwrap();
+        workflow.validate().unwrap();
 
         let missing_config: WorkflowV2 = serde_json::from_value(serde_json::json!({
             "version": 2,
@@ -1382,5 +1767,233 @@ mod tests {
             panic!("expected distillation")
         };
         assert_eq!(teacher_checkpoint, &dir.path().join("teacher.safetensors"));
+    }
+
+    fn wake_only_workflow() -> ResolvedWorkflow {
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [{
+                "name": "wake",
+                "type": "pretrain",
+                "task": {"type": "causal_lm"},
+                "data": "wake.jsonl",
+                "sequence_length": 8,
+                "batch_size": 1,
+                "gradient_accumulation": 1,
+                "steps": 2,
+                "memory_update_mode": {
+                    "type": "wake_only",
+                    "schedule": {
+                        "clock": "optimizer_steps",
+                        "terminal_consolidation": "distill_into_base_v1",
+                        "tiers": [
+                            {"id": "fast", "update_period": 1, "reserve_slots": 1},
+                            {"id": "slow", "update_period": 2, "reserve_slots": 2}
+                        ]
+                    }
+                }
+            }]
+        }))
+        .unwrap();
+        workflow.resolve(Path::new("workflow.json")).unwrap()
+    }
+
+    fn memory_model(mixed: bool) -> ModelDef {
+        let topology = if mixed {
+            "block: sleeping pattern: [ordinary, sleeping]"
+        } else {
+            "block: sleeping"
+        };
+        hermes_llm::parse_mal(&format!(
+            r#"
+            ffn base {{ hidden_dim: 12 activation: swiglu dropout: 0.0 }}
+            memory cms {{
+                tier fast {{
+                    ffn: base
+                    reserve_experts {{ capacity: 1 rank: 3 top_k: 1 }}
+                }}
+                tier slow {{
+                    ffn: base residual_init: zero
+                    reserve_experts {{ capacity: 2 rank: 3 top_k: 1 }}
+                }}
+            }}
+            block ordinary {{
+                attention: {{ num_heads: 1 dropout: 0.0 position_encoding: none }}
+                ffn: base dropout: 0.0
+            }}
+            block sleeping {{
+                attention: {{ num_heads: 1 dropout: 0.0 position_encoding: none }}
+                memory: cms dropout: 0.0
+            }}
+            model memory-test {{
+                vocab_size: 16 max_seq_len: 8 hidden_size: 8 num_layers: 2
+                {topology}
+            }}
+            "#
+        ))
+        .unwrap()
+    }
+
+    fn dreaming_memory_model() -> ModelDef {
+        hermes_llm::parse_mal(
+            r#"
+            ffn dense { hidden_dim: 12 activation: swiglu dropout: 0.0 }
+            ffn routed {
+                hidden_dim: 12 activation: swiglu dropout: 0.0
+                moe { experts: 2 top_k: 1 }
+            }
+            memory cms {
+                tier fast {
+                    ffn: routed
+                    reserve_experts { capacity: 1 rank: 3 top_k: 1 }
+                }
+                tier slow {
+                    ffn: dense residual_init: zero
+                    reserve_experts { capacity: 2 rank: 3 top_k: 1 }
+                }
+            }
+            block sleeping {
+                attention: { num_heads: 1 dropout: 0.0 position_encoding: none }
+                memory: cms dropout: 0.0
+            }
+            model memory-test {
+                vocab_size: 16 max_seq_len: 8 hidden_size: 8 num_layers: 2
+                block: sleeping
+            }
+            "#,
+        )
+        .unwrap()
+    }
+
+    fn periodic_sleep_config(with_dreaming: bool) -> InModelSleepConfig {
+        let mut value = serde_json::json!({
+            "schedule": {
+                "clock": "optimizer_steps",
+                "terminal_consolidation": "distill_into_base_v1",
+                "tiers": [
+                    {"id": "fast", "update_period": 1, "reserve_slots": 1},
+                    {"id": "slow", "update_period": 2, "reserve_slots": 2}
+                ]
+            },
+            "knowledge_seeding": {
+                "chunk_tokens": 8,
+                "teacher_rollouts": 1,
+                "detached_student_rollouts": 1,
+                "temperature": 1.0,
+                "forward_kl_weight": 1.0
+            },
+            "imitation": {
+                "semantic_judge_hash": format!("sha256:{}", "0".repeat(64)),
+                "semantic_weight": 1.0,
+                "maximum_edit_distance": 8,
+                "grpo_group_size": 2
+            },
+            "retention_suite": "retention.json",
+            "retention_suite_sha256": format!("sha256:{}", "0".repeat(64)),
+            "retention": {
+                "evaluator_hash": format!("sha256:{}", "0".repeat(64)),
+                "suite_hash": format!("sha256:{}", "0".repeat(64)),
+                "max_anchor_forward_kl": 0.1,
+                "max_anchor_regression": 0.1,
+                "min_incorporation_gain": 0.0
+            },
+            "receiver_learning_rate": 0.0001,
+            "receiver_weight_decay": 0.0,
+            "grpo_clip_epsilon": 0.2,
+            "grpo_advantage_epsilon": 0.000001,
+            "grpo_kl_coefficient": 0.04,
+            "candidate_directory": "candidates"
+        });
+        if with_dreaming {
+            value["dreaming"] = serde_json::to_value(DreamingConfig::paper_reproduction()).unwrap();
+        }
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn dreaming_requires_a_persistent_memory_moe_exploration_route() {
+        let mut workflow = wake_only_workflow();
+        workflow.phases[0].memory_update_mode = None;
+        workflow.phases[0].periodic_sleep = Some(periodic_sleep_config(true));
+
+        let error = validate_workflow_for_model(&workflow, &memory_model(false))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("persistent FFN MoE"), "{error}");
+
+        validate_workflow_for_model(&workflow, &dreaming_memory_model()).unwrap();
+
+        workflow.phases[0].periodic_sleep = Some(periodic_sleep_config(false));
+        validate_workflow_for_model(&workflow, &memory_model(false)).unwrap();
+    }
+
+    #[test]
+    fn wake_only_is_an_explicit_uniform_memory_update_policy() {
+        let workflow = wake_only_workflow();
+        validate_workflow_for_model(&workflow, &memory_model(false)).unwrap();
+
+        let mut missing = workflow.clone();
+        let mut second = missing.phases[0].clone();
+        second.name = "missing-policy".into();
+        second.memory_update_mode = None;
+        missing.phases.push(second);
+        let error = validate_workflow_for_model(&missing, &memory_model(false))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("one identical update policy"), "{error}");
+
+        let mut combined = workflow.clone();
+        combined.phases[0].periodic_sleep = Some(
+            serde_json::from_value(serde_json::json!({
+                "schedule": {
+                    "clock": "optimizer_steps",
+                    "terminal_consolidation": "distill_into_base_v1",
+                    "tiers": [
+                        {"id": "fast", "update_period": 1, "reserve_slots": 1},
+                        {"id": "slow", "update_period": 2, "reserve_slots": 2}
+                    ]
+                },
+                "knowledge_seeding": {
+                    "chunk_tokens": 8,
+                    "teacher_rollouts": 1,
+                    "detached_student_rollouts": 1,
+                    "temperature": 1.0,
+                    "forward_kl_weight": 1.0
+                },
+                "imitation": {
+                    "semantic_judge_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                    "semantic_weight": 1.0,
+                    "maximum_edit_distance": 8,
+                    "grpo_group_size": 2
+                },
+                "retention_suite": "retention.json",
+                "retention_suite_sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                "retention": {
+                    "evaluator_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                    "suite_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                    "max_anchor_forward_kl": 0.1,
+                    "max_anchor_regression": 0.1,
+                    "min_incorporation_gain": 0.0
+                },
+                "receiver_learning_rate": 0.0001,
+                "receiver_weight_decay": 0.0,
+                "grpo_clip_epsilon": 0.2,
+                "grpo_advantage_epsilon": 0.000001,
+                "grpo_kl_coefficient": 0.04,
+                "candidate_directory": "candidates"
+            }))
+            .unwrap(),
+        );
+        let error = combined.validate().unwrap_err().to_string();
+        assert!(error.contains("cannot combine"), "{error}");
+    }
+
+    #[test]
+    fn mixed_memory_and_ordinary_layers_are_an_explicitly_unsupported_topology() {
+        let error = validate_workflow_for_model(&wake_only_workflow(), &memory_model(true))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("model mixes"), "{error}");
+        assert!(error.contains("every layer"), "{error}");
     }
 }

--- a/hermes-train/tests/trainer_lifecycle.rs
+++ b/hermes-train/tests/trainer_lifecycle.rs
@@ -498,7 +498,9 @@ fn cli_enforces_memory_and_periodic_runtime_pairing() {
     );
     assert!(
         diagnostic(&ordinary_periodic)
-            .contains("periodic_sleep requires a MAL model with an explicit memory hierarchy"),
+            .contains(
+                "periodic_sleep and memory_update_mode require a MAL model with an explicit memory hierarchy"
+            ),
         "{}",
         diagnostic(&ordinary_periodic)
     );

--- a/hermes-train/tests/wake_tier_step_support.rs
+++ b/hermes-train/tests/wake_tier_step_support.rs
@@ -1,0 +1,102 @@
+//! Executable tests for pure support code used by the harness-less benchmark.
+//!
+//! A `harness = false` target has no libtest entry point of its own. Including
+//! only its side-effect-free CLI and statistics modules here keeps their
+//! bounds and paired aggregation in the normal hermes-train test matrix.
+
+#[allow(dead_code)]
+#[path = "../benches/wake_tier_step/cli.rs"]
+mod cli;
+#[allow(dead_code)]
+#[path = "../benches/wake_tier_step/stats.rs"]
+mod stats;
+
+fn parse(values: &[&str]) -> anyhow::Result<cli::Args> {
+    cli::parse_args_from(values.iter().map(|value| (*value).to_owned()))
+}
+
+#[test]
+fn defaults_are_a_bounded_three_seed_pair() {
+    let args = parse(&[]).unwrap();
+    assert_eq!(args.seeds, vec![17, 23, 29]);
+    assert_eq!(args.update_periods, vec![2, 4]);
+    assert!(
+        args.update_periods
+            .iter()
+            .all(|period| !args.non_due_clock.is_multiple_of(*period))
+    );
+    assert!(
+        args.update_periods
+            .iter()
+            .any(|period| args.due_clock.is_multiple_of(*period))
+    );
+}
+
+#[test]
+fn rejects_unbounded_or_statistically_invalid_runs() {
+    assert!(parse(&["--iterations", "0"]).is_err());
+    assert!(parse(&["--iterations", "10001"]).is_err());
+    assert!(parse(&["--seeds", "1,2"]).is_err());
+    assert!(parse(&["--seeds", "1,1,2"]).is_err());
+    assert!(parse(&["--seeds", "1,3,2"]).is_err());
+    assert!(parse(&["--batch-size", "65536", "--sequence-length", "8192"]).is_err());
+    let too_many_samples = cli::Args {
+        seeds: (0..64_u64).collect(),
+        iterations: 10_000,
+        ..Default::default()
+    };
+    assert!(cli::validate(too_many_samples).is_err());
+}
+
+#[test]
+fn rejects_mislabelled_boundary_clocks() {
+    assert!(parse(&["--non-due-clock", "2"]).is_err());
+    assert!(parse(&["--due-clock", "3"]).is_err());
+    assert!(parse(&["--periods", "2"]).is_err());
+    assert!(parse(&["--periods", "0,4"]).is_err());
+}
+
+#[test]
+fn paired_summary_keeps_raw_samples_and_uses_per_seed_ratios() {
+    use stats::{ExecutionOrder, PairedSample, PairedTrial};
+
+    let trials = vec![
+        PairedTrial::new(
+            17,
+            vec![
+                PairedSample::new(0, ExecutionOrder::NonDueThenDue, 2.0, 4.0).unwrap(),
+                PairedSample::new(1, ExecutionOrder::DueThenNonDue, 4.0, 6.0).unwrap(),
+            ],
+        )
+        .unwrap(),
+        PairedTrial::new(
+            23,
+            vec![PairedSample::new(0, ExecutionOrder::DueThenNonDue, 5.0, 5.0).unwrap()],
+        )
+        .unwrap(),
+        PairedTrial::new(
+            29,
+            vec![PairedSample::new(0, ExecutionOrder::NonDueThenDue, 3.0, 9.0).unwrap()],
+        )
+        .unwrap(),
+    ];
+
+    let summary = stats::summarize(&trials).unwrap();
+
+    assert_eq!(summary.seed_count, 3);
+    assert_eq!(summary.sample_count, 4);
+    assert_eq!(summary.non_due_median_ms, 3.5);
+    assert_eq!(summary.due_median_ms, 5.5);
+    assert_eq!(summary.paired_ratio_median, 1.75);
+    assert_eq!(summary.median_of_seed_median_ratios, 1.75);
+    assert_eq!(summary.worst_seed_median_ratio, 3.0);
+    assert_eq!(trials[0].samples.len(), 2);
+}
+
+#[test]
+fn durations_must_be_finite_and_positive() {
+    use stats::{ExecutionOrder, PairedSample};
+
+    assert!(PairedSample::new(0, ExecutionOrder::NonDueThenDue, 0.0, 1.0).is_err());
+    assert!(PairedSample::new(0, ExecutionOrder::NonDueThenDue, 1.0, f64::NAN).is_err());
+}

--- a/hermes-train/workflow.education.example.json
+++ b/hermes-train/workflow.education.example.json
@@ -702,7 +702,7 @@
         "teacher": {
           "adapter": "hermes_checkpoint",
           "artifact": "teachers/instruction-teacher.json",
-          "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+          "sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
         },
         "temperature": 1.5,
         "scale_by_temperature_squared": true
@@ -787,7 +787,7 @@
         "reference": {
           "adapter": "hermes_checkpoint",
           "artifact": "references/sft-reference.json",
-          "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+          "sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
         },
         "beta": 0.1,
         "label_smoothing": 0.0,
@@ -880,7 +880,7 @@
         "reference": {
           "adapter": "hermes_checkpoint",
           "artifact": "references/dpo-reference.json",
-          "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+          "sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
         },
         "sampling": {
           "max_new_tokens": 512,


### PR DESCRIPTION
Lands the sleep/dreaming/QAT lifecycle, corpus pipeline, acceptance and
promotion gates, and the process-orchestration layer after review, together
with fixes for the defects that review surfaced.

Acceptance: the stable-anchor tolerance was widened by the standard deviation
of the submitted baselines, so evidence could choose its own tolerance. A
candidate consistently 0.15 worse than baselines spread 0.6/0.8/1.0 passed a
gate whose policy limit is 0.01. The tolerance is now policy-only; paired
noise is still covered by gating on the confidence bound rather than the mean.
Extreme-magnitude metrics keep failing closed through an explicit
representable-metrics check, and a single wake trial now reports that it
cannot form a confidence interval instead of an opaque overflow.

Process groups: both the protocol supervisor and the device sampler reaped the
leader before sending SIGKILL to its process group. Once a pid is freed the
kernel may recycle it, so the signal could reach an unrelated group. The
supervisor now peeks with waitid(WNOWAIT) so the zombie holds the pgid until
after the kill; the sampler takes its child handle so the raw group signal
fires exactly once.

Corpus pipeline, per the fail-loud rule: records the materializer omitted are
counted as unmaterialized_records and warned about instead of vanishing; a
configured metadata pointer that matches no hit now warns rather than silently
disabling every rule keyed on it; and max_consecutive_blank_lines applies
independently of normalize_newlines instead of being inert.

Benchmark targets resolve against the run file that declared them, on a clone
so the artifact stays byte-identical, rather than against the process working
directory. Reserve-slot initialization is salted by layer and tier, matching
the salting slot reclamation already applied - previously slot k held an
identical A matrix in every layer and tier.

Also fixes a pre-existing test fixture that built every ablation baseline from
identical zero weights, which the comparison validator correctly rejects as
reused checkpoints.

Verified: 1807 tests across 22 suites, workspace clippy with -D warnings, and
rustfmt.

## Verification

- `cargo test --workspace --lib --tests`: 1807 passed, 0 failed across 22 suites
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean

## Scope

Training framework only. Unrelated `hermes-tokenizer` edits and the untracked `hermes-web/dist-model-lab/` build output are deliberately excluded and remain in the working tree.

The live 300M MoE run is unaffected: it is on the 2026-07-31 deployed binary and was not restarted or reconfigured.