### PR TITLE
feat(tokenizer): port GigaToken 0.10.0 batch special-token registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Thumbs.db
 # Node.js
 node_modules/
 hermes-web/dist/
+hermes-web/dist-model-lab/
 hermes-model-lab/dist/
 
 # Python

--- a/hermes-tokenizer/UPSTREAM.md
+++ b/hermes-tokenizer/UPSTREAM.md
@@ -3,7 +3,20 @@
 The optimized byte-level BPE engine, pretoken cache, merge kernels, and fast
 pretokenizers under `src/bpe/` and `src/pretokenize/` were extracted from
 [`marcelroed/gigatoken`](https://github.com/marcelroed/gigatoken) commit
-`542367a3efed134883fb4f1140b49c04e6fad3a3` (version 0.9.0).
+`34a1599f0c0ae7d7cd0d1c530e6522320158b360` (version 0.10.0).
+
+The 0.10.0 refresh adds batch special-token registration so a loader rebuilds
+the Aho-Corasick matcher and cache overwrites once per batch rather than once
+per token. It also makes the supported pretokenizer scheme names a single
+source of truth.
+
+Upstream 0.10.0 also fixes raw `.tiktoken` loading: rank files do not contain
+their split regex or special-token definitions, so those values must be
+selected by the caller rather than guessed. Hermes deliberately does not load
+raw rank files. Its local `tokenizer.json` loader reads and validates the
+artifact's pretokenizer and added-token metadata, so the faulty upstream path
+was never reachable here; scheme-sensitive differential cases guard that
+contract.
 
 The extraction removes the Python bindings, CLI, file/data-source layer,
 tokenizer trainer, reference pretokenizers, network loading, and SentencePiece

--- a/hermes-tokenizer/src/bpe/tiktoken.rs
+++ b/hermes-tokenizer/src/bpe/tiktoken.rs
@@ -290,8 +290,10 @@ impl Tokenizer {
     /// Shared construction tail ([`Self::new`], [`Self::new_ranked`] and
     /// [`Self::from_ranks`]): derive `vocab_inv` and the pair-rank table
     /// from the finished merges/vocab, seed the pretoken cache, and
-    /// assemble the tokenizer with default pipeline settings (GPT-2
-    /// pretokenization, no added tokens, no NFC).
+    /// assemble the tokenizer with placeholder pipeline settings (GPT-2
+    /// pretokenization, no added tokens, no NFC) that every loader must
+    /// overwrite for its actual scheme. A raw rank table does not carry
+    /// its pretokenizer or special-token definitions.
     fn from_tables(
         merges: HashMap<(TokenId, TokenId), TokenId, rustc_hash::FxBuildHasher>,
         ranked_merges: Option<RankedMerges>,
@@ -832,33 +834,42 @@ impl Tokenizer {
     ///
     /// [`WorkerPool`]: crate::batch::WorkerPool
     pub fn add_special_token(&mut self, content: Vec<u8>, id: TokenId) {
-        let idx = id.0 as usize;
-        // Loader-phase mutation of the shared model tables: `make_mut`
-        // copies only when a fork holds the tables too (never during
-        // loading, where this is called).
-        let vocab = Arc::make_mut(&mut self.vocab);
-        if idx >= vocab.len() {
-            vocab.resize(idx + 1, Arc::from(Vec::new().as_slice()));
-        }
-        if vocab[idx].is_empty() {
-            vocab[idx] = content.clone().into();
-            // If `content` duplicates an already-present vocab byte
-            // string, `vocab_inv` switches to the new ID (unconditional
-            // overwrite). The short-cache overwrite that keeps a matching
-            // pretoken resolving to `vocab_inv`'s answer happens in
-            // `set_added_tokens` below, which re-derives every added-token
-            // cache overwrite from the updated `vocab_inv` — the same
-            // computation a fork's reseed + re-apply performs (see
-            // [`Self::fork_sized`]), so parent and forked workers agree.
-            Arc::make_mut(&mut self.vocab_inv).insert(vocab[idx].clone(), id);
-        }
+        self.add_special_tokens([(content, id)]);
+    }
+
+    /// Register a batch of special added tokens. All vocabulary entries are
+    /// written first, then [`Self::set_added_tokens`] rebuilds the matcher
+    /// and cache overwrites once instead of once per token.
+    pub fn add_special_tokens(&mut self, tokens: impl IntoIterator<Item = (Vec<u8>, TokenId)>) {
         let mut added = self.added_tokens.clone();
-        added.push(AddedTokenDef {
-            content: content.into(),
-            id,
-            lstrip: false,
-            rstrip: false,
-        });
+        for (content, id) in tokens {
+            let idx = id.0 as usize;
+            // Loader-phase mutation of the shared model tables: `make_mut`
+            // copies only when a fork holds the tables too (never during
+            // loading, where this is called).
+            let vocab = Arc::make_mut(&mut self.vocab);
+            if idx >= vocab.len() {
+                vocab.resize(idx + 1, Arc::from(Vec::new().as_slice()));
+            }
+            if vocab[idx].is_empty() {
+                vocab[idx] = content.clone().into();
+                // If `content` duplicates an already-present vocab byte
+                // string, `vocab_inv` switches to the new ID (unconditional
+                // overwrite). The short-cache overwrite that keeps a matching
+                // pretoken resolving to `vocab_inv`'s answer happens in
+                // `set_added_tokens` below, which re-derives every added-token
+                // cache overwrite from the updated `vocab_inv` — the same
+                // computation a fork's reseed + re-apply performs (see
+                // [`Self::fork_sized`]), so parent and forked workers agree.
+                Arc::make_mut(&mut self.vocab_inv).insert(vocab[idx].clone(), id);
+            }
+            added.push(AddedTokenDef {
+                content: content.into(),
+                id,
+                lstrip: false,
+                rstrip: false,
+            });
+        }
         self.set_added_tokens(added);
     }
 
@@ -1405,5 +1416,43 @@ impl Debug for Tokenizer {
             .field("pair_ranks", &self.pair_ranks.is_some())
             .field("byte_remapping", &self.byte_remapping.is_some())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_special_tokens_extend_vocab_and_match_atomically() {
+        let vocab = (0..=u8::MAX).map(|byte| vec![byte]).collect();
+        let mut tokenizer = Tokenizer::new(HashMap::default(), vocab, None);
+
+        tokenizer.add_special_tokens([
+            (b"<first>".to_vec(), TokenId(300)),
+            (b"<second>".to_vec(), TokenId(301)),
+        ]);
+        tokenizer.add_special_token(b"<third>".to_vec(), TokenId(302));
+
+        let mut ids = Vec::new();
+        tokenizer.encode_with_added_tokens_flat(b"x<first>y<second>z<third>", &mut ids);
+        assert_eq!(
+            ids,
+            vec![
+                u32::from(b'x'),
+                300,
+                u32::from(b'y'),
+                301,
+                u32::from(b'z'),
+                302,
+            ]
+        );
+        assert_eq!(tokenizer.vocab_size(), 303);
+        assert_eq!(
+            tokenizer
+                .decode(&[TokenId(300), TokenId(301), TokenId(302)])
+                .collect::<Vec<_>>(),
+            b"<first><second><third>"
+        );
     }
 }

--- a/hermes-tokenizer/src/lib.rs
+++ b/hermes-tokenizer/src/lib.rs
@@ -1,7 +1,7 @@
 //! Stable-Rust, byte-level BPE tokenization for Hermes.
 //!
 //! The optimized merge engine and pretokenizers are derived from GigaToken
-//! 0.9.0. The public wrapper is intentionally narrower: local or in-memory
+//! 0.10.0. The public wrapper is intentionally narrower: local or in-memory
 //! Hugging Face `tokenizer.json` artifacts, persistent per-thread caches,
 //! deterministic batch order, and the vocabulary operations required by
 //! Hermes training, inference, and visualization.
@@ -23,7 +23,7 @@ use crate::bpe::Tokenizer as BpeEngine;
 use crate::token::TokenId;
 
 /// GigaToken revision from which the optimized byte-level core was extracted.
-pub const UPSTREAM_GIGATOKEN_REVISION: &str = "542367a3efed134883fb4f1140b49c04e6fad3a3";
+pub const UPSTREAM_GIGATOKEN_REVISION: &str = "34a1599f0c0ae7d7cd0d1c530e6522320158b360";
 
 /// Thread-safe tokenizer with persistent single-document and Rayon-worker
 /// caches. Token IDs remain those of the source `tokenizer.json`.

--- a/hermes-tokenizer/src/pretokenize/options.rs
+++ b/hermes-tokenizer/src/pretokenize/options.rs
@@ -66,10 +66,24 @@ impl PretokenizerType {
         }
     }
 
+    /// Canonical names for every scheme, in variant order. Loader error
+    /// messages should derive their accepted values from this list.
+    pub const NAMES: [&'static str; 9] = [
+        "gpt2",
+        "gpt4",
+        "qwen2",
+        "qwen35",
+        "olmo3",
+        "deepseek_v3",
+        "o200k",
+        "nemotron",
+        "kimi",
+    ];
+
     /// The scheme named by a lowercase identifier, as used by loaders whose
     /// source format carries no split regex (e.g. tiktoken-rank repos, whose
     /// regex lives in remote code) and the Python bindings. Accepts each
-    /// variant's canonical name plus the common tiktoken aliases.
+    /// canonical name from [`Self::NAMES`] plus the common tiktoken aliases.
     pub fn from_name(name: &str) -> Option<Self> {
         Some(match name {
             "gpt2" | "r50k" => PretokenizerType::GPT2,

--- a/hermes-tokenizer/tests/parity.rs
+++ b/hermes-tokenizer/tests/parity.rs
@@ -193,6 +193,9 @@ fn current_checkpoint_tokenizer_matches_hugging_face_when_available() {
         "NFC café; NFD cafe\u{301}; emoji 🦀🚀".to_owned(),
         " \t  whitespace\n\n                        end".to_owned(),
         "literal <|endoftext|> and <|padding|>".to_owned(),
+        ".data (self _name".to_owned(),
+        "1234 123456789 CamelCaseWord".to_owned(),
+        "xé\u{301}y  \n  end".to_owned(),
     ];
     let alphabet = [
         'a', 'Z', '0', ' ', '\n', '\t', '.', ',', 'é', '\u{301}', 'Ж', '中', 'ع', '🦀',


### PR DESCRIPTION
Refreshes the extracted byte-level BPE engine from upstream [`34a1599`](https://github.com/marcelroed/gigatoken/commit/34a1599f0c0ae7d7cd0d1c530e6522320158b360) (0.10.0).

- **Batch special-token registration** — a loader now rebuilds the Aho-Corasick matcher and cache overwrites once per batch instead of once per token.
- **`PretokenizerType::NAMES`** makes the supported scheme names a single source of truth, so loader errors derive their accepted values rather than restating them.

## Deliberately not ported

Upstream also fixed raw `.tiktoken` rank-file loading, where the split regex and special tokens must be supplied by the caller because the rank file does not carry them. Hermes only loads `tokenizer.json`, reading and validating that artifact's pretokenizer and added-token metadata, so the faulty path was never reachable here. Scheme-sensitive differential cases guard that contract.

## Also

Ignores `hermes-web/dist-model-lab/` — stale Vite output from before Model Lab moved to its own package. Nothing in the repo references it, and the sibling `hermes-web/dist/` and `hermes-model-lab/dist/` are already ignored.

## Verification

8 `hermes-tokenizer` tests pass; `cargo clippy -p hermes-tokenizer --all-targets -- -D warnings` clean. Hugging Face parity cases unchanged, so existing checkpoints keep identical token IDs.