### PR TITLE
test(core): fix test_auto_merge_triggered racing its own baseline

### DIFF
--- a/hermes-core/src/index/tests/merge.rs
+++ b/hermes-core/src/index/tests/merge.rs
@@ -595,6 +595,11 @@ async fn test_large_scale_merge_correctness() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn test_auto_merge_triggered() {
     use crate::directories::MmapDirectory;
+
+    /// Each commit flushes at least one segment, so this is a deterministic
+    /// lower bound on how many segments the merge policy had to work with.
+    const COMMITS: usize = 12;
+
     let tmp_dir = tempfile::tempdir().unwrap();
     let dir = MmapDirectory::new(tmp_dir.path());
 
@@ -615,8 +620,8 @@ async fn test_auto_merge_triggered() {
         .await
         .unwrap();
 
-    // Create 12 segments with ~50 docs each (4x the aggressive threshold of 3)
-    for batch in 0..12 {
+    // Create COMMITS segments with ~50 docs each (4x the aggressive threshold of 3)
+    for batch in 0..COMMITS {
         for i in 0..50 {
             let mut doc = Document::new();
             doc.add_text(title, format!("document_{} batch_{} alpha bravo", i, batch));
@@ -632,27 +637,39 @@ async fn test_auto_merge_triggered() {
         writer.commit().await.unwrap();
     }
 
-    let pre_merge = writer.segment_manager.get_segment_ids().await.len();
-
+    // Deliberately do not sample a live segment count as the baseline. Auto-merge
+    // runs in the background during the commit loop above, so a count taken here
+    // may already be collapsed; comparing against it makes the assertion fail
+    // precisely when auto-merge worked well. `COMMITS` is the race-free baseline.
+    //
     // wait_for_merging_thread waits for the single in-flight merge. After it completes,
     // re-evaluate since segments accumulated while the merge was running.
     writer.wait_for_merging_thread().await;
     writer.maybe_merge().await;
     writer.wait_for_merging_thread().await;
 
-    // After commit + auto-merge, segment count should be reduced
     let index = Index::open(dir.clone(), config.clone()).await.unwrap();
     let segment_count = index.segment_readers().await.unwrap().len();
-    eprintln!(
-        "Segments: {} before merge, {} after auto-merge",
-        pre_merge, segment_count
+    eprintln!("Segments: {COMMITS} committed, {segment_count} after auto-merge");
+    assert!(
+        segment_count >= 1,
+        "auto-merge must leave the index readable, got {segment_count} segments"
     );
     assert!(
-        segment_count < pre_merge,
-        "Expected auto-merge to reduce segments from {}, got {}",
-        pre_merge,
-        segment_count
+        segment_count < COMMITS,
+        "expected auto-merge to collapse the {COMMITS} committed segments without force_merge, got {segment_count}"
     );
+
+    // Merging must be lossless: every document from every batch survives.
+    for batch in 0..COMMITS {
+        let query = format!("batch_{batch}");
+        let results = index.query(&query, 100).await.unwrap();
+        assert_eq!(
+            results.hits.len(),
+            50,
+            "batch {batch} lost documents during auto-merge"
+        );
+    }
 }
 
 /// Regression test: commit with dense vector fields + aggressive merge policy.


### PR DESCRIPTION
`index::tests::merge::test_auto_merge_triggered` failed post-merge on `main` at `c55a4f68` with:

```
Expected auto-merge to reduce segments from 4, got 4
```

## Why it was flaky

The test sampled a **live** segment count as `pre_merge` after its commit loop, then asserted the count strictly dropped. But auto-merge runs in the background *during* that loop, so the baseline was itself part of the race. In the failing run the merger had already collapsed 12 segments to 4 before the sample was taken, and 4 segments under an aggressive tiered policy can sit converged with no tier holding 3 similar-sized candidates — so nothing further could merge and the assertion became `4 < 4`.

The test therefore failed **precisely when auto-merge worked well**, which is the opposite of what it set out to verify.

## Fix

The baseline is now the commit count. Every commit flushes at least one segment, so `COMMITS` is a race-free lower bound, and a final count below it proves merging happened without `force_merge` — exactly what the doc comment claims to test.

The observed final count legitimately varies between **1 and 5** across runs. That is the nondeterminism the old baseline was sampling from.

## Also strengthened

The previous version only counted segments and never checked that data survived merging. It now asserts the index stays readable and that all 50 documents from each of the 12 batches remain findable, making it a losslessness guarantee rather than a pure count check.

## Verification

- **40 consecutive passes**, 15 of them under 12-way CPU saturation to skew background-merge timing
- Full `hermes-core` suite: 1051 passed
- `cargo clippy --package hermes-core --features native --all-targets -- -D warnings` and `cargo fmt` clean

Unrelated to the LLM/training work in #132–#134; this crate was untouched by those.