### PR TITLE
fix(train): repair --resume for ordinary models and fine-tuning runs; add SFT workflow

### DIFF
--- a/docs/training-objectives-and-curricula.md
+++ b/docs/training-objectives-and-curricula.md
@@ -215,6 +215,39 @@ task defaults. In-batch negatives make retrieval accuracy depend on the
 candidate-pool size, so a trailing batch that cannot be filled is dropped and
 counted in `dropped_samples`; token-weighted language losses score it exactly.
 
+### Supervised-generation objectives
+
+`--objective summarization`, `instruction_tuning`, `qa_reasoning`, and
+`retrieval_planning` score the four supervised-generation tasks on their own
+JSONL contracts (`document`/`summary`, `instruction`/`response` with optional
+`system` and `input`, `question`/`answer` with optional `reasoning`,
+`request`/`plan` with optional `context`). Each reports
+`supervised_generation.loss` and `.perplexity`: the token-weighted mean
+cross-entropy over **target positions only**. Prompt and EOS-padding positions
+never contribute, because the command reuses the trainer's masked-loss forward
+pass and the same task adapter framing, so the reported number is the training
+loss for that phase minus gradients — comparable straight across a train/eval
+boundary. `supervised_tokens` is therefore much smaller than `compute_tokens`,
+and `truncated_tokens` counts source text dropped to reserve room for the target.
+
+Prompt framing must match the training phase exactly, so the report echoes the
+complete task in its `task` block. `--instruction` overrides the built-in
+instruction for phases that set their own, and `--require-reasoning` mirrors
+`qa_reasoning`'s `require_reasoning`, which demands a `reasoning` field and
+supervises the `Reasoning:`/`Answer:` target framing. Retrieval-only flags are
+rejected on these objectives and vice versa. Because targets are never
+truncated and padding cannot reach earlier positions through causal attention,
+the reported loss is unchanged by `--batch-size` and by any
+`--sequence-length` long enough to hold the record; use the training phase's
+sequence length so truncation behaviour matches too.
+
+`--sequence-length` is where evaluation deliberately differs from training. A
+supervised record whose prompt framing, complete target, and EOS do not fit
+makes `train` abort — a run must not optimize a silently reduced dataset — but
+one over-long held-out record must not void a whole evaluation. `eval` skips it,
+counts it in `oversized_records` (per shard and in total), and warns on stderr
+and in `warnings`; it is excluded from every reported number.
+
 `--shuffle-buffer` (default `0`, source order) is the only setting `--seed`
 affects, and the JSON report deliberately excludes timing, so identical inputs
 produce a byte-identical report. Config, tokenizer, checkpoint, and every shard

--- a/hermes-train/src/data.rs
+++ b/hermes-train/src/data.rs
@@ -34,6 +34,7 @@ pub(crate) use batch::{
     BatchStats, EncodedText, LanguageBatch, RetrievalBatch, TrainingBatch, TrainingSample,
     make_batch,
 };
+pub(crate) use structured::OversizedRecordPolicy;
 use structured::visit_structured_samples;
 
 const TOKENIZE_BATCH: usize = 1_000;
@@ -1849,44 +1850,54 @@ fn visit_samples_in_order(
     path: &Path,
     objective: &TaskConfig,
     tokenizer: &Tokenizer,
-    seq_len: usize,
-    token_cache: Option<&Path>,
-    data_binding: &PhaseDataBinding,
+    config: SampleStreamConfig<'_>,
     mut visit: impl FnMut(TrainingSample) -> Result<bool>,
 ) -> Result<usize> {
-    ensure!(seq_len > 0, "sequence_length must be positive");
+    ensure!(config.seq_len > 0, "sequence_length must be positive");
     match objective {
-        TaskConfig::CausalLm {} => {
-            visit_causal_samples(path, tokenizer, seq_len, token_cache, data_binding, visit)
-        }
+        TaskConfig::CausalLm {} => visit_causal_samples(
+            path,
+            tokenizer,
+            config.seq_len,
+            config.token_cache,
+            config.data_binding,
+            visit,
+        ),
         _ => {
             ensure!(
-                data_binding.authenticated_corpus().is_none(),
+                config.data_binding.authenticated_corpus().is_none(),
                 "prepared corpus manifests are only valid for causal-LM phases"
             );
             let mut count = None;
-            data_binding.with_readers(path, |source_path, reader| {
-                count = Some(visit_structured_samples(
-                    source_path,
-                    reader,
-                    objective,
-                    tokenizer,
-                    seq_len,
-                    &mut visit,
-                )?);
-                Ok(true)
-            })?;
+            config
+                .data_binding
+                .with_readers(path, |source_path, reader| {
+                    count = Some(visit_structured_samples(
+                        source_path,
+                        reader,
+                        objective,
+                        tokenizer,
+                        config.seq_len,
+                        config.oversized,
+                        &mut visit,
+                    )?);
+                    Ok(true)
+                })?;
             count.context("direct structured phase data produced no reader")
         }
     }
 }
 
+#[derive(Clone, Copy)]
 pub(crate) struct SampleStreamConfig<'a> {
     pub(crate) seq_len: usize,
     pub(crate) shuffle_buffer: usize,
     pub(crate) seed: u64,
     pub(crate) token_cache: Option<&'a Path>,
     pub(crate) data_binding: &'a PhaseDataBinding,
+    /// Disposition of a supervised record that cannot be framed at `seq_len`.
+    /// Training aborts; forward-only evaluation skips and counts.
+    pub(crate) oversized: OversizedRecordPolicy<'a>,
 }
 
 pub(crate) fn visit_samples(
@@ -1897,33 +1908,17 @@ pub(crate) fn visit_samples(
     mut visit: impl FnMut(TrainingSample) -> Result<bool>,
 ) -> Result<usize> {
     if config.shuffle_buffer == 0 {
-        return visit_samples_in_order(
-            path,
-            objective,
-            tokenizer,
-            config.seq_len,
-            config.token_cache,
-            config.data_binding,
-            visit,
-        );
+        return visit_samples_in_order(path, objective, tokenizer, config, visit);
     }
 
     let mut shuffler = ShuffleBuffer::new(config.shuffle_buffer, config.seed);
     let mut keep_going = true;
-    let count = visit_samples_in_order(
-        path,
-        objective,
-        tokenizer,
-        config.seq_len,
-        config.token_cache,
-        config.data_binding,
-        |sample| {
-            if let Some(sample) = shuffler.push(sample) {
-                keep_going = visit(sample)?;
-            }
-            Ok(keep_going)
-        },
-    )?;
+    let count = visit_samples_in_order(path, objective, tokenizer, config, |sample| {
+        if let Some(sample) = shuffler.push(sample) {
+            keep_going = visit(sample)?;
+        }
+        Ok(keep_going)
+    })?;
 
     if keep_going {
         for sample in shuffler.finish() {
@@ -1947,9 +1942,16 @@ pub(crate) fn count_samples(
         path,
         objective,
         tokenizer,
-        seq_len,
-        token_cache,
-        data_binding,
+        SampleStreamConfig {
+            seq_len,
+            shuffle_buffer: 0,
+            seed: 0,
+            token_cache,
+            data_binding,
+            // Counting is what a training run will stream, so a record the
+            // trainer cannot frame must fail here too.
+            oversized: OversizedRecordPolicy::Abort,
+        },
         |_| Ok(true),
     )
 }
@@ -2159,6 +2161,7 @@ mod tests {
             &task,
             &tokenizer,
             64,
+            OversizedRecordPolicy::Abort,
             |_| Ok(true),
         )
         .unwrap_err();
@@ -3110,9 +3113,14 @@ mod tests {
                 &path,
                 &objective,
                 &tokenizer,
-                64,
-                None,
-                &binding,
+                SampleStreamConfig {
+                    seq_len: 64,
+                    shuffle_buffer: 0,
+                    seed: 0,
+                    token_cache: None,
+                    data_binding: &binding,
+                    oversized: OversizedRecordPolicy::Abort,
+                },
                 |sample| {
                     observed.push(sample);
                     Ok(true)

--- a/hermes-train/src/data/structured.rs
+++ b/hermes-train/src/data/structured.rs
@@ -1,5 +1,7 @@
 //! JSONL schemas and tokenization for task-aligned objectives.
 
+use std::cell::Cell;
+use std::fmt;
 use std::io::BufRead;
 use std::path::Path;
 
@@ -8,8 +10,77 @@ use hermes_llm::Tokenizer;
 use hermes_train::task::{
     SegmentedText, SupervisedPromptSegments, TaskAdapter, TaskConfig, TaskExample,
 };
+use tracing::warn;
 
 use super::{EncodedText, TrainingSample, is_jsonl, read_training_jsonl_record};
+
+/// A supervised-generation record whose prompt framing, complete target, and
+/// EOS cannot fit `sequence_length`. Targets are never truncated, so such a
+/// record has no valid encoding at this geometry.
+///
+/// It is a distinct error type rather than a plain message so that a caller can
+/// tell "this record does not fit" apart from "this record is malformed"
+/// without matching on strings. Training treats both as fatal; forward-only
+/// evaluation skips and counts only this one (see [`OversizedRecordPolicy`]).
+#[derive(Debug)]
+pub(crate) struct OversizedSupervisedRecord {
+    /// Tokens the un-truncatable framing needs: prefix, suffix, target, EOS,
+    /// and — when the task requires a source — one source token.
+    required_tokens: usize,
+    /// Tokens the geometry provides, which is `sequence_length + 1` because the
+    /// batch is shifted by one position.
+    capacity: usize,
+    sequence_length: usize,
+}
+
+impl fmt::Display for OversizedSupervisedRecord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "instruction, target marker, complete target, EOS, and any required source token need {} tokens but sequence_length {} provides {}; targets are never truncated",
+            self.required_tokens, self.sequence_length, self.capacity
+        )
+    }
+}
+
+impl std::error::Error for OversizedSupervisedRecord {}
+
+/// What to do with a record that [`OversizedSupervisedRecord`] rejects.
+///
+/// Training must abort: a phase that silently dropped part of its own dataset
+/// would report a loss over an unknown subset of it, and the geometry is the
+/// operator's to fix. Forward-only evaluation must not, because one over-long
+/// held-out record would otherwise make an entire evaluation fail; it skips the
+/// record and counts it so the drop is reported rather than silent.
+#[derive(Clone, Copy)]
+pub(crate) enum OversizedRecordPolicy<'a> {
+    Abort,
+    Skip(&'a Cell<usize>),
+}
+
+impl OversizedRecordPolicy<'_> {
+    /// Decide whether streaming may continue past `error`. Returns the error
+    /// unchanged unless it is an oversized record this policy absorbs.
+    fn absorb(&self, error: anyhow::Error) -> Result<()> {
+        let Self::Skip(skipped) = self else {
+            return Err(error);
+        };
+        if !error
+            .chain()
+            .any(|cause| cause.is::<OversizedSupervisedRecord>())
+        {
+            return Err(error);
+        }
+        warn!("skipping oversized record: {error:#}");
+        skipped.set(
+            skipped
+                .get()
+                .checked_add(1)
+                .context("oversized record count overflows usize")?,
+        );
+        Ok(())
+    }
+}
 
 fn supervised_prompt_segments<'a>(
     value: &'a serde_json::Value,
@@ -61,17 +132,22 @@ fn make_supervised_sample(
         .and_then(|tokens| tokens.checked_add(target.len()))
         .and_then(|tokens| tokens.checked_add(1))
         .context("supervised example token count overflows usize")?;
-    ensure!(
-        fixed_tokens <= capacity,
-        "instruction, target marker, complete target, and EOS require {fixed_tokens} tokens but sequence_length {seq_len} provides {capacity}; targets are never truncated"
-    );
-    let kept_source = source.len().min(capacity - fixed_tokens);
-    if source_required {
-        ensure!(
-            kept_source > 0,
-            "sequence_length {seq_len} leaves no token for the source after reserving the target"
-        );
+    // A record needs the whole framing plus, when the task requires a source,
+    // at least one source token. Both shortfalls mean the same thing — this
+    // record has no valid encoding at this geometry — so both raise the typed
+    // error an evaluation can skip and count.
+    let required_tokens = fixed_tokens
+        .checked_add(usize::from(source_required))
+        .context("supervised example token count overflows usize")?;
+    if required_tokens > capacity {
+        return Err(anyhow::Error::new(OversizedSupervisedRecord {
+            required_tokens,
+            capacity,
+            sequence_length: seq_len,
+        }));
     }
+    let kept_source = source.len().min(capacity - fixed_tokens);
+    debug_assert!(!source_required || kept_source > 0);
     let truncated_tokens = source.len() - kept_source;
     let prompt_len = prefix.len() + kept_source + suffix.len();
     ensure!(prompt_len > 0, "supervised prompt tokenized to empty");
@@ -235,6 +311,7 @@ pub(super) fn visit_structured_samples(
     objective: &TaskConfig,
     tokenizer: &Tokenizer,
     seq_len: usize,
+    oversized: OversizedRecordPolicy<'_>,
     mut visit: impl FnMut(TrainingSample) -> Result<bool>,
 ) -> Result<usize> {
     ensure!(
@@ -260,7 +337,14 @@ pub(super) fn visit_structured_samples(
         }
         let value: serde_json::Value = serde_json::from_str(line)
             .with_context(|| format!("invalid JSONL at {}:{line_number}", path.display()))?;
-        let sample = structured_sample(&value, objective, tokenizer, seq_len, path, line_number)?;
+        let sample =
+            match structured_sample(&value, objective, tokenizer, seq_len, path, line_number) {
+                Ok(sample) => sample,
+                Err(error) => {
+                    oversized.absorb(error)?;
+                    continue;
+                }
+            };
         count = count
             .checked_add(1)
             .context("structured sample count overflows usize")?;

--- a/hermes-train/src/eval.rs
+++ b/hermes-train/src/eval.rs
@@ -8,6 +8,7 @@
 //! but an explicit `--output` report is created. A live run therefore remains
 //! byte-for-byte resumable while it is being evaluated.
 
+use std::cell::Cell;
 use std::fs;
 use std::path::Path;
 use std::time::Instant;
@@ -21,8 +22,8 @@ use serde_json::json;
 use tracing::warn;
 
 use crate::data::{
-    BatchStats, PhaseDataBinding, SampleStreamConfig, TrainingBatch, TrainingSample, make_batch,
-    visit_samples,
+    BatchStats, OversizedRecordPolicy, PhaseDataBinding, SampleStreamConfig, TrainingBatch,
+    TrainingSample, make_batch, visit_samples,
 };
 use crate::{
     EvalArgs, EvalObjective, ObjectiveForward, add_batch_stats, file_sha256, load_config,
@@ -30,7 +31,11 @@ use crate::{
 };
 
 /// Report schema version. Increment when a field changes meaning.
-const EVAL_REPORT_VERSION: u32 = 1;
+///
+/// v2 added the four supervised-generation objectives: the `task` block that
+/// pins their prompt framing, the `supervised_generation` metrics block, and
+/// `oversized_records`.
+const EVAL_REPORT_VERSION: u32 = 2;
 
 /// File names the trainer publishes inside its own output root. Refusing them
 /// keeps a mistyped `--output` from overwriting a live run's state with a
@@ -82,10 +87,16 @@ struct EvalDataSource {
     /// signature input for the same data.
     identity: String,
     samples_read: usize,
+    /// Records this shard could not frame at `--sequence-length`; see
+    /// [`EvalReport::oversized_records`].
+    oversized_records: usize,
 }
 
-#[derive(Debug, Serialize)]
-struct CausalLmMetrics {
+/// Cross-entropy over the tokens an objective supervises, plus its perplexity.
+/// For `causal_lm` that is every packed token; for supervised generation it is
+/// the target positions only, exactly as the training loss weights them.
+#[derive(Clone, Copy, Debug, Serialize)]
+struct LanguageMetrics {
     loss: f64,
     perplexity: f64,
 }
@@ -113,6 +124,10 @@ struct CandidateCounts {
 struct EvalReport {
     version: u32,
     objective: &'static str,
+    /// The complete task configuration this evaluation framed its prompts with,
+    /// including instruction text. A post-training run must repeat it exactly
+    /// for the two numbers to be comparable.
+    task: TaskConfig,
     config: String,
     config_sha256: String,
     tokenizer: String,
@@ -133,6 +148,11 @@ struct EvalReport {
     truncated_tokens: usize,
     /// Samples read but not scored because they could not fill a batch.
     dropped_samples: usize,
+    /// Supervised records skipped because their prompt framing, complete
+    /// target, and EOS do not fit `--sequence-length`. Training aborts on these;
+    /// evaluation must not let one over-long held-out record void the whole run,
+    /// so it counts them here and warns instead.
+    oversized_records: usize,
     /// Every condition that degraded or adjusted this evaluation, in the order
     /// it was detected. Also written to stderr, because the CLI's default log
     /// filter would otherwise hide a `warn!` from an operator.
@@ -140,7 +160,11 @@ struct EvalReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     router_loss: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    causal_lm: Option<CausalLmMetrics>,
+    causal_lm: Option<LanguageMetrics>,
+    /// Target-only cross-entropy for `summarization`, `instruction_tuning`,
+    /// `qa_reasoning`, and `retrieval_planning`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    supervised_generation: Option<LanguageMetrics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     retrieval: Option<RetrievalMetrics>,
 }
@@ -291,7 +315,11 @@ impl<'a> Evaluation<'a> {
         Ok(())
     }
 
-    fn causal_lm_metrics(&self) -> Result<Option<CausalLmMetrics>> {
+    /// Token-weighted mean cross-entropy over the tokens this objective
+    /// supervises. `causal_lm` supervises every packed token; supervised
+    /// generation supervises target positions only, because the trainer's masked
+    /// loss — reused verbatim here — divides by exactly those positions.
+    fn language_metrics(&self) -> Result<Option<LanguageMetrics>> {
         let Some(loss) = self.language_loss.mean() else {
             return Ok(None);
         };
@@ -300,7 +328,7 @@ impl<'a> Evaluation<'a> {
             perplexity.is_finite(),
             "mean held-out loss {loss} overflows perplexity; check that --config and --checkpoint match"
         );
-        Ok(Some(CausalLmMetrics { loss, perplexity }))
+        Ok(Some(LanguageMetrics { loss, perplexity }))
     }
 
     fn retrieval_metrics(&self) -> Result<Option<RetrievalMetrics>> {
@@ -335,22 +363,30 @@ impl<'a> Evaluation<'a> {
 }
 
 impl EvalArgs {
-    /// Build the exact task configuration the trainer would use. Retrieval
-    /// defaults are deserialized rather than restated so query and document
-    /// prefixes stay identical to an unset workflow objective.
+    /// Build the exact task configuration the trainer would use. Task defaults
+    /// are deserialized rather than restated so retrieval prefixes and
+    /// supervised instructions stay identical to an unset workflow objective.
     fn objective_config(&self) -> Result<TaskConfig> {
+        if !matches!(self.objective, EvalObjective::ContrastiveRetrieval) {
+            ensure!(
+                self.retrieval_layer.is_none() && self.temperature.is_none(),
+                "--retrieval-layer and --temperature only apply to --objective contrastive_retrieval"
+            );
+        }
+        if !self.objective.is_supervised_generation() {
+            ensure!(
+                self.instruction.is_none(),
+                "--instruction only applies to a supervised-generation objective"
+            );
+        }
+        ensure!(
+            !self.require_reasoning || matches!(self.objective, EvalObjective::QaReasoning),
+            "--require-reasoning only applies to --objective qa_reasoning"
+        );
         let objective = match self.objective {
-            EvalObjective::CausalLm => {
-                ensure!(
-                    self.retrieval_layer.is_none() && self.temperature.is_none(),
-                    "--retrieval-layer and --temperature only apply to --objective contrastive_retrieval"
-                );
-                TaskConfig::CausalLm {}
-            }
+            EvalObjective::CausalLm => TaskConfig::CausalLm {},
             EvalObjective::ContrastiveRetrieval => {
-                let mut objective: TaskConfig =
-                    serde_json::from_value(json!({"type": "retrieval_representation"}))
-                        .context("built-in retrieval objective defaults are invalid")?;
+                let mut objective = task_defaults("retrieval_representation")?;
                 let TaskConfig::RetrievalRepresentation {
                     temperature, layer, ..
                 } = &mut objective
@@ -363,10 +399,48 @@ impl EvalArgs {
                 *layer = self.retrieval_layer;
                 objective
             }
+            EvalObjective::Summarization => self.supervised_config("summarization")?,
+            EvalObjective::InstructionTuning => self.supervised_config("instruction_tuning")?,
+            EvalObjective::RetrievalPlanning => self.supervised_config("retrieval_planning")?,
+            EvalObjective::QaReasoning => {
+                let mut objective = self.supervised_config("qa_reasoning")?;
+                let TaskConfig::QaReasoning {
+                    require_reasoning, ..
+                } = &mut objective
+                else {
+                    unreachable!("qa_reasoning deserialized to another task");
+                };
+                *require_reasoning = self.require_reasoning;
+                objective
+            }
         };
         objective.validate()?;
         Ok(objective)
     }
+
+    /// A supervised-generation task with the trainer's default instruction,
+    /// optionally overridden to match a training phase that set its own.
+    fn supervised_config(&self, name: &str) -> Result<TaskConfig> {
+        let mut objective = task_defaults(name)?;
+        if let Some(configured) = &self.instruction {
+            let instruction = match &mut objective {
+                TaskConfig::Summarization { instruction }
+                | TaskConfig::InstructionTuning { instruction }
+                | TaskConfig::RetrievalPlanning { instruction }
+                | TaskConfig::QaReasoning { instruction, .. } => instruction,
+                other => unreachable!("`{}` is not a supervised task", other.name()),
+            };
+            *instruction = configured.clone();
+        }
+        Ok(objective)
+    }
+}
+
+/// Deserialize a task by tag alone, so every field this command does not expose
+/// keeps the built-in default a workflow phase would get.
+fn task_defaults(name: &str) -> Result<TaskConfig> {
+    serde_json::from_value(json!({"type": name}))
+        .with_context(|| format!("built-in `{name}` task defaults are invalid"))
 }
 
 /// Report a degraded or adjusted condition to both the operator and the report.
@@ -471,6 +545,17 @@ pub(super) fn evaluate(args: EvalArgs) -> Result<()> {
         args.sequence_length,
         args.recall_k,
     );
+    // Training aborts when a supervised record's prompt, complete target, and
+    // EOS exceed `sequence_length`, because a phase must not optimize a silently
+    // reduced dataset. Evaluation deliberately differs: one over-long held-out
+    // record must not void an entire evaluation, so it is skipped, counted per
+    // shard and in total, and warned about.
+    let oversized_records = Cell::new(0usize);
+    let oversized = if args.objective.is_supervised_generation() {
+        OversizedRecordPolicy::Skip(&oversized_records)
+    } else {
+        OversizedRecordPolicy::Abort
+    };
     let mut samples: Vec<TrainingSample> = Vec::with_capacity(args.batch_size);
     let mut sources = Vec::with_capacity(args.data.len());
     let mut reached_max_batches = false;
@@ -478,6 +563,7 @@ pub(super) fn evaluate(args: EvalArgs) -> Result<()> {
         if reached_max_batches {
             break;
         }
+        let oversized_before = oversized_records.get();
         let binding = PhaseDataBinding::open(path)?;
         let samples_read = visit_samples(
             path,
@@ -491,6 +577,7 @@ pub(super) fn evaluate(args: EvalArgs) -> Result<()> {
                 // belong to a live run's output directory.
                 token_cache: None,
                 data_binding: &binding,
+                oversized,
             },
             |sample| {
                 samples.push(sample);
@@ -511,7 +598,18 @@ pub(super) fn evaluate(args: EvalArgs) -> Result<()> {
             path: path.display().to_string(),
             identity: binding.signature_identity().to_owned(),
             samples_read,
+            oversized_records: oversized_records.get() - oversized_before,
         });
+    }
+    let oversized_records = oversized_records.get();
+    if oversized_records > 0 {
+        warn_operator(
+            &mut warnings,
+            format!(
+                "skipped {oversized_records} held-out record(s) whose prompt, complete target, and EOS exceed --sequence-length {}; they are excluded from every reported number",
+                args.sequence_length
+            ),
+        );
     }
     let mut dropped_samples = 0;
     if !samples.is_empty() {
@@ -530,13 +628,17 @@ pub(super) fn evaluate(args: EvalArgs) -> Result<()> {
     }
     ensure!(
         evaluation.batches > 0,
-        "held-out data produced no complete batch of --batch-size {}; {dropped_samples} sample(s) were read",
-        args.batch_size
+        "held-out data produced no complete batch of --batch-size {}; {dropped_samples} sample(s) were read and {oversized_records} record(s) did not fit --sequence-length {}",
+        args.batch_size,
+        args.sequence_length
     );
 
+    let language = evaluation.language_metrics()?;
+    let supervised = args.objective.is_supervised_generation();
     let report = EvalReport {
         version: EVAL_REPORT_VERSION,
         objective: objective.name(),
+        task: objective.clone(),
         config: args.config.display().to_string(),
         config_sha256: file_sha256(&args.config)?,
         tokenizer: args.tokenizer.display().to_string(),
@@ -556,9 +658,11 @@ pub(super) fn evaluate(args: EvalArgs) -> Result<()> {
         supervised_tokens: evaluation.stats.supervised_tokens,
         truncated_tokens: evaluation.stats.truncated_tokens,
         dropped_samples,
+        oversized_records,
         warnings,
         router_loss: evaluation.router_loss.mean(),
-        causal_lm: evaluation.causal_lm_metrics()?,
+        causal_lm: language.filter(|_| !supervised),
+        supervised_generation: language.filter(|_| supervised),
         retrieval: evaluation.retrieval_metrics()?,
     };
     write_report(&report, args.output.as_deref())?;
@@ -610,9 +714,15 @@ fn print_summary(report: &EvalReport, elapsed_seconds: f64) {
         "dropped samples      {} (incomplete trailing batch)",
         report.dropped_samples
     );
-    if let Some(causal_lm) = &report.causal_lm {
-        println!("loss                 {:.6}", causal_lm.loss);
-        println!("perplexity           {:.4}", causal_lm.perplexity);
+    println!(
+        "oversized records    {} (target does not fit sequence_length)",
+        report.oversized_records
+    );
+    // Exactly one language block is ever populated: the objective decides
+    // whether the same token-weighted mean is a causal or a target-only loss.
+    if let Some(language) = report.causal_lm.or(report.supervised_generation) {
+        println!("loss                 {:.6}", language.loss);
+        println!("perplexity           {:.4}", language.perplexity);
     }
     if let Some(retrieval) = &report.retrieval {
         println!("loss                 {:.6}", retrieval.loss);
@@ -643,10 +753,13 @@ mod tests {
     use super::*;
     use crate::data::write_test_tokenizer;
 
+    /// `max_seq_len` must clear the supervised objectives' fixed prompt framing:
+    /// their built-in instructions plus target markers already occupy more than
+    /// the retrieval tests' 56 positions before any record text.
     const EVAL_MODEL: &str = r#"
 ffn base { hidden_dim: 12 activation: swiglu dropout: 0.0 }
 model tiny {
-    vocab_size: 257 max_seq_len: 64 hidden_size: 8 num_layers: 2
+    vocab_size: 257 max_seq_len: 256 hidden_size: 8 num_layers: 2
     block: {
         attention: { num_heads: 1 dropout: 0.0 position_encoding: none }
         ffn: base
@@ -704,8 +817,18 @@ model tiny {
             recall_k: 2,
             retrieval_layer: None,
             temperature: None,
+            instruction: None,
+            require_reasoning: false,
             output: Some(fixture.output.clone()),
         }
+    }
+
+    /// Supervised prompts carry a full instruction and target marker before any
+    /// record text, so they need a longer sequence than the retrieval fixtures.
+    fn supervised_args(fixture: &Fixture, objective: EvalObjective, batch_size: usize) -> EvalArgs {
+        let mut arguments = args(fixture, objective, batch_size);
+        arguments.sequence_length = SUPERVISED_SEQUENCE_LENGTH;
+        arguments
     }
 
     fn report(path: &Path) -> serde_json::Value {
@@ -736,6 +859,93 @@ model tiny {
                 )
             })
             .collect()
+    }
+
+    const SUPERVISED_SEQUENCE_LENGTH: usize = 192;
+
+    /// Summaries are a fixed 21 ASCII bytes wide for `rows <= 10`, and the test
+    /// tokenizer is a merge-free byte-level BPE, so the exact number of
+    /// supervised target tokens is known: 21 target tokens plus the EOS the
+    /// model must also predict.
+    const SUMMARY_TARGET_TOKENS: usize = "summary of document 0".len() + 1;
+
+    fn summarization_records(rows: usize) -> String {
+        assert!(rows <= 10, "summary width is only fixed for one digit");
+        (0..rows)
+            .map(|index| {
+                format!(
+                    "{{\"document\":\"held-out source prose about topic {index}, long enough that the document is truncated before the reserved target\",\"summary\":\"summary of document {index}\"}}\n"
+                )
+            })
+            .collect()
+    }
+
+    fn instruction_records(rows: usize) -> String {
+        (0..rows)
+            .map(|index| {
+                format!(
+                    "{{\"instruction\":\"translate line {index}\",\"input\":\"bonjour {index}\",\"response\":\"hello {index}\"}}\n"
+                )
+            })
+            .collect()
+    }
+
+    fn qa_records(rows: usize) -> String {
+        (0..rows)
+            .map(|index| {
+                format!(
+                    "{{\"question\":\"what is held-out fact {index}?\",\"answer\":\"held-out answer {index}\"}}\n"
+                )
+            })
+            .collect()
+    }
+
+    /// Answers grow one phrase per row, so per-record supervised token counts
+    /// differ and batch grouping cannot be invariant by accident.
+    fn variable_length_qa_records(rows: usize) -> String {
+        (0..rows)
+            .map(|index| {
+                let answer = vec!["answer"; index + 1].join(" ");
+                format!("{{\"question\":\"what is fact {index}?\",\"answer\":\"{answer}\"}}\n")
+            })
+            .collect()
+    }
+
+    /// Planning records deliberately omit `context`, exactly as the production
+    /// held-out shard does, so the optional-source branch is the one evaluated.
+    fn planning_records(rows: usize) -> String {
+        (0..rows)
+            .map(|index| {
+                format!(
+                    "{{\"request\":\"find document {index}\",\"plan\":\"search {index}, then read it\"}}\n"
+                )
+            })
+            .collect()
+    }
+
+    fn supervised_fixtures() -> Vec<(EvalObjective, &'static str, Fixture)> {
+        vec![
+            (
+                EvalObjective::Summarization,
+                "summarization",
+                fixture(&summarization_records(9)),
+            ),
+            (
+                EvalObjective::InstructionTuning,
+                "instruction_tuning",
+                fixture(&instruction_records(9)),
+            ),
+            (
+                EvalObjective::QaReasoning,
+                "qa_reasoning",
+                fixture(&qa_records(9)),
+            ),
+            (
+                EvalObjective::RetrievalPlanning,
+                "retrieval_planning",
+                fixture(&planning_records(9)),
+            ),
+        ]
     }
 
     #[test]
@@ -836,6 +1046,239 @@ model tiny {
             (grouped_loss - single_loss).abs() < 1e-3,
             "token-weighted means diverged across batch groupings: {grouped_loss} vs {single_loss}"
         );
+    }
+
+    /// Every supervised-generation objective reports the same quantity the
+    /// trainer optimizes for it: a token-weighted mean cross-entropy over target
+    /// positions only. Prompt and padding positions must never contribute, which
+    /// is why the exactly known target-token count is asserted for one objective
+    /// and `supervised_tokens` must stay far below `compute_tokens` for all.
+    #[test]
+    fn eval_supervised_objectives_report_finite_target_only_loss_and_are_deterministic() {
+        for (objective, name, fixture) in supervised_fixtures() {
+            evaluate(supervised_args(&fixture, objective, 3)).unwrap();
+            let first = fs::read(&fixture.output).unwrap();
+            let parsed = report(&fixture.output);
+            let loss = finite(&parsed, "/supervised_generation/loss");
+            let perplexity = finite(&parsed, "/supervised_generation/perplexity");
+            assert!(loss > 0.0, "{name}: {parsed}");
+            assert!(
+                (perplexity - loss.exp()).abs() < 1e-9,
+                "{name}: perplexity {perplexity} does not match loss {loss}"
+            );
+            assert_eq!(parsed["objective"], name, "{parsed}");
+            assert_eq!(parsed["task"]["type"], name, "{parsed}");
+            assert!(parsed["causal_lm"].is_null(), "{name}: {parsed}");
+            assert!(parsed["retrieval"].is_null(), "{name}: {parsed}");
+            assert_eq!(parsed["examples"], 9, "{name}: {parsed}");
+            assert_eq!(parsed["batches"], 3, "{name}: {parsed}");
+            assert_eq!(parsed["dropped_samples"], 0, "{name}: {parsed}");
+            assert_eq!(parsed["oversized_records"], 0, "{name}: {parsed}");
+            let supervised = parsed["supervised_tokens"].as_u64().unwrap();
+            let compute = parsed["compute_tokens"].as_u64().unwrap();
+            assert_eq!(compute, 9 * SUPERVISED_SEQUENCE_LENGTH as u64, "{parsed}");
+            assert!(
+                supervised > 0 && supervised * 4 < compute,
+                "{name}: {supervised} supervised of {compute} computed tokens is not target-only"
+            );
+            if matches!(objective, EvalObjective::Summarization) {
+                // Nine fixed-width summaries plus the EOS after each: the loss
+                // denominator is exactly the target, never the truncated source.
+                assert_eq!(supervised, 9 * SUMMARY_TARGET_TOKENS as u64, "{parsed}");
+                assert!(
+                    parsed["truncated_tokens"].as_u64().unwrap() > 0,
+                    "sources long enough to truncate must be counted: {parsed}"
+                );
+            }
+
+            // The report carries no timing or environment noise, so the same
+            // seed must reproduce it byte for byte.
+            evaluate(supervised_args(&fixture, objective, 3)).unwrap();
+            assert_eq!(first, fs::read(&fixture.output).unwrap(), "{name}");
+        }
+    }
+
+    /// The same held-out target tokens must produce the same mean however they
+    /// are grouped into batches. Targets here differ in length, so an unweighted
+    /// average of per-batch means could not hold this property.
+    #[test]
+    fn eval_qa_reasoning_loss_is_token_weighted_across_unequal_batch_groupings() {
+        const BATCH: u64 = 4;
+
+        let fixture = fixture(&variable_length_qa_records(7));
+        let mut single = supervised_args(&fixture, EvalObjective::QaReasoning, 1);
+        single.output = Some(fixture.output.with_file_name("single.json"));
+        evaluate(single).unwrap();
+        let single = report(&fixture.output.with_file_name("single.json"));
+        let samples = single["examples"].as_u64().unwrap();
+        assert_eq!(samples, 7, "{single}");
+        assert_eq!(single["batches"].as_u64().unwrap(), samples, "{single}");
+
+        let mut grouped = supervised_args(&fixture, EvalObjective::QaReasoning, BATCH as usize);
+        grouped.output = Some(fixture.output.with_file_name("grouped.json"));
+        evaluate(grouped).unwrap();
+        let grouped = report(&fixture.output.with_file_name("grouped.json"));
+        // The short trailing batch is scored, not dropped: target-only losses
+        // are token weighted and can absorb it exactly.
+        assert_eq!(grouped["batches"], 2, "{grouped}");
+        assert_eq!(grouped["examples"].as_u64().unwrap(), samples, "{grouped}");
+        assert_eq!(grouped["dropped_samples"], 0, "{grouped}");
+        assert_eq!(single["supervised_tokens"], grouped["supervised_tokens"]);
+
+        let single_loss = finite(&single, "/supervised_generation/loss");
+        let grouped_loss = finite(&grouped, "/supervised_generation/loss");
+        assert!(
+            (grouped_loss - single_loss).abs() < 1e-3,
+            "token-weighted means diverged across batch groupings: {grouped_loss} vs {single_loss}"
+        );
+    }
+
+    /// Training must abort when a supervised target cannot fit the geometry,
+    /// because a run must not optimize a silently reduced dataset. Evaluation
+    /// must not: one over-long held-out record cannot be allowed to void an
+    /// entire evaluation. It is skipped, counted, and warned about instead.
+    #[test]
+    fn eval_skips_and_counts_oversized_supervised_records_that_training_rejects() {
+        let mut records = summarization_records(6);
+        records.push_str(&format!(
+            "{{\"document\":\"short source\",\"summary\":\"{}\"}}\n",
+            "an over-long held-out summary ".repeat(10)
+        ));
+        let fixture = fixture(&records);
+
+        evaluate(supervised_args(&fixture, EvalObjective::Summarization, 3)).unwrap();
+        let parsed = report(&fixture.output);
+        assert_eq!(parsed["oversized_records"], 1, "{parsed}");
+        assert_eq!(parsed["data"][0]["oversized_records"], 1, "{parsed}");
+        assert_eq!(parsed["data"][0]["samples_read"], 6, "{parsed}");
+        // The other six records are scored exactly as if the shard had only
+        // ever contained them.
+        assert_eq!(parsed["examples"], 6, "{parsed}");
+        assert_eq!(
+            parsed["supervised_tokens"].as_u64().unwrap(),
+            6 * SUMMARY_TARGET_TOKENS as u64,
+            "{parsed}"
+        );
+        finite(&parsed, "/supervised_generation/loss");
+        let warnings = parsed["warnings"].as_array().unwrap();
+        assert_eq!(warnings.len(), 1, "{parsed}");
+        assert!(
+            warnings[0]
+                .as_str()
+                .unwrap()
+                .contains("skipped 1 held-out record"),
+            "{parsed}"
+        );
+
+        // The trainer's own streaming path over the same shard still refuses it.
+        let tokenizer = Tokenizer::from_file(&fixture.tokenizer).unwrap();
+        let binding = PhaseDataBinding::open(&fixture.data).unwrap();
+        let error = format!(
+            "{:#}",
+            crate::data::count_samples(
+                &fixture.data,
+                &TaskConfig::Summarization {
+                    instruction: "Summarize the document faithfully and concisely.".to_owned(),
+                },
+                &tokenizer,
+                SUPERVISED_SEQUENCE_LENGTH,
+                None,
+                &binding,
+            )
+            .unwrap_err()
+        );
+        assert!(error.contains("targets are never truncated"), "{error}");
+    }
+
+    #[test]
+    fn eval_rejects_retrieval_flags_on_supervised_objectives() {
+        let fixture = fixture(&qa_records(4));
+        for objective in [
+            EvalObjective::Summarization,
+            EvalObjective::InstructionTuning,
+            EvalObjective::QaReasoning,
+            EvalObjective::RetrievalPlanning,
+        ] {
+            let mut temperature = supervised_args(&fixture, objective, 2);
+            temperature.temperature = Some(0.1);
+            let error = format!("{:#}", evaluate(temperature).unwrap_err());
+            assert!(error.contains("contrastive_retrieval"), "{error}");
+
+            let mut layer = supervised_args(&fixture, objective, 2);
+            layer.retrieval_layer = Some(1);
+            let error = format!("{:#}", evaluate(layer).unwrap_err());
+            assert!(error.contains("contrastive_retrieval"), "{error}");
+        }
+    }
+
+    #[test]
+    fn eval_rejects_supervised_prompt_flags_on_other_objectives() {
+        let fixture = fixture(&causal_records(4));
+        for objective in [EvalObjective::CausalLm, EvalObjective::ContrastiveRetrieval] {
+            let mut instruction = args(&fixture, objective, 2);
+            instruction.instruction = Some("Summarize.".to_owned());
+            let error = format!("{:#}", evaluate(instruction).unwrap_err());
+            assert!(error.contains("supervised-generation"), "{error}");
+        }
+
+        // `require_reasoning` changes the qa_reasoning target framing only.
+        let mut reasoning = supervised_args(&fixture, EvalObjective::Summarization, 2);
+        reasoning.require_reasoning = true;
+        let error = format!("{:#}", evaluate(reasoning).unwrap_err());
+        assert!(error.contains("qa_reasoning"), "{error}");
+    }
+
+    /// A held-out number is only comparable with a training loss if the prompt
+    /// framing matches, so the exact task — instruction text included — is part
+    /// of the report a post-training run has to reproduce.
+    #[test]
+    fn eval_records_the_task_that_framed_supervised_prompts() {
+        let fixture = fixture(&qa_records(6));
+        let mut arguments = supervised_args(&fixture, EvalObjective::QaReasoning, 3);
+        arguments.instruction = Some("Answer from the passages.".to_owned());
+        evaluate(arguments).unwrap();
+        let parsed = report(&fixture.output);
+        assert_eq!(parsed["version"], 2, "{parsed}");
+        assert_eq!(parsed["task"]["type"], "qa_reasoning", "{parsed}");
+        assert_eq!(
+            parsed["task"]["instruction"], "Answer from the passages.",
+            "{parsed}"
+        );
+        assert_eq!(parsed["task"]["require_reasoning"], false, "{parsed}");
+    }
+
+    /// A reasoning trace is part of the supervised target, not of the prompt, so
+    /// the scored tokens must cover the whole `Reasoning:`/`Answer:` framing.
+    /// `--require-reasoning` additionally refuses a shard without traces, rather
+    /// than quietly scoring a different target than the training phase did.
+    #[test]
+    fn eval_qa_reasoning_supervises_the_reasoning_trace_and_requires_it_when_asked() {
+        const FRAMED_TARGET: &str = "Reasoning:\nrecall fact 0\n\nAnswer:\nanswer 0";
+
+        let records: String = (0..6)
+            .map(|index| {
+                format!(
+                    "{{\"question\":\"fact {index}?\",\"reasoning\":\"recall fact {index}\",\"answer\":\"answer {index}\"}}\n"
+                )
+            })
+            .collect();
+        let traced = fixture(&records);
+        let mut arguments = supervised_args(&traced, EvalObjective::QaReasoning, 3);
+        arguments.require_reasoning = true;
+        evaluate(arguments).unwrap();
+        let parsed = report(&traced.output);
+        assert_eq!(parsed["task"]["require_reasoning"], true, "{parsed}");
+        assert_eq!(
+            parsed["supervised_tokens"].as_u64().unwrap(),
+            6 * (FRAMED_TARGET.len() + 1) as u64,
+            "{parsed}"
+        );
+
+        let bare = fixture(&qa_records(6));
+        let mut arguments = supervised_args(&bare, EvalObjective::QaReasoning, 3);
+        arguments.require_reasoning = true;
+        let error = format!("{:#}", evaluate(arguments).unwrap_err());
+        assert!(error.contains("`reasoning` is required"), "{error}");
     }
 
     #[test]

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -3037,9 +3037,17 @@ mod tests {
     fn training_decreases_loss_and_checkpoint_roundtrips() {
         let mut config = small_hybrid();
         for block in config.pattern.as_mut().unwrap() {
-            block.dropout = 0.1;
-            block.attention.dropout = 0.1;
-            block.ffn.dropout = 0.1;
+            // Deliberately zero, and do not "restore" this to a live rate. The
+            // dropout masks are drawn from the backend's *global* device RNG,
+            // which every concurrently running test that builds a model also
+            // draws from. With dropout enabled the in-process model and the
+            // checkpoint-restored model see different masks on their shared
+            // training step, and the round-trip comparison below fails
+            // nondeterministically. Nothing here asserts dropout behaviour, and
+            // the final comparison runs under `.valid()` with dropout disabled.
+            block.dropout = 0.0;
+            block.attention.dropout = 0.0;
+            block.ffn.dropout = 0.0;
         }
         let device = hermes_llm::default_device().autodiff();
         device.seed(41);

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -179,8 +179,10 @@ struct TrainArgs {
     /// Physical NVIDIA index, GPU UUID, or PCI bus ID passed to nvidia-smi.
     #[arg(long, default_value = "0")]
     gpu_physical_device: String,
-    /// Safetensors checkpoint to fine-tune from.
-    #[arg(long, conflicts_with = "resume")]
+    /// Safetensors checkpoint to fine-tune from. Its exact identity is part of
+    /// the run signature, so `--resume` must repeat the same value; the resumed
+    /// weights themselves always come from --output, never from this file.
+    #[arg(long)]
     checkpoint: Option<PathBuf>,
     /// Resume weights, optimizer state, schedule, and corpus position from --output.
     #[arg(long)]

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -83,8 +83,8 @@ use checkpoint::{
 #[cfg(test)]
 use data::TrainingSample;
 use data::{
-    BatchStats, PhaseDataBinding, SampleStreamConfig, TrainingBatch, count_samples,
-    indexed_causal_sample_count, make_batch, visit_samples,
+    BatchStats, OversizedRecordPolicy, PhaseDataBinding, SampleStreamConfig, TrainingBatch,
+    count_samples, indexed_causal_sample_count, make_batch, visit_samples,
 };
 use muon::BatchedMuon;
 use wake::{ResolvedWakePlan, load_wake_plan};
@@ -205,12 +205,35 @@ struct TrainArgs {
 /// Held-out objectives supported by the forward-only `eval` command. These are
 /// the objectives the wake trainer can optimize end to end, so their reported
 /// numbers are directly comparable with training-time metrics.
-#[derive(Clone, Copy, Debug, ValueEnum)]
+#[derive(Clone, Copy, Debug, PartialEq, ValueEnum)]
 enum EvalObjective {
     #[value(name = "causal_lm")]
     CausalLm,
     #[value(name = "contrastive_retrieval")]
     ContrastiveRetrieval,
+    #[value(name = "summarization")]
+    Summarization,
+    #[value(name = "instruction_tuning")]
+    InstructionTuning,
+    #[value(name = "qa_reasoning")]
+    QaReasoning,
+    #[value(name = "retrieval_planning")]
+    RetrievalPlanning,
+}
+
+impl EvalObjective {
+    /// Supervised-generation objectives score only their target tokens, so they
+    /// share one report block, one prompt-framing contract, and the
+    /// oversized-record policy that a prompt-plus-target geometry needs.
+    fn is_supervised_generation(self) -> bool {
+        matches!(
+            self,
+            Self::Summarization
+                | Self::InstructionTuning
+                | Self::QaReasoning
+                | Self::RetrievalPlanning
+        )
+    }
 }
 
 #[derive(clap::Args)]
@@ -252,6 +275,17 @@ struct EvalArgs {
     /// default, exactly as an unset workflow objective would.
     #[arg(long)]
     temperature: Option<f64>,
+    /// Instruction text for a supervised-generation objective. It is part of
+    /// every prompt, so it must match the training phase's `task.instruction`
+    /// for the reported loss to be comparable. Omitted uses the same built-in
+    /// default an unset workflow objective would.
+    #[arg(long)]
+    instruction: Option<String>,
+    /// `qa_reasoning` only: require a `reasoning` field and supervise the
+    /// `Reasoning:`/`Answer:` target framing, exactly as the training phase's
+    /// `require_reasoning` does.
+    #[arg(long)]
+    require_reasoning: bool,
     /// JSON report path. The human-readable summary is always printed.
     #[arg(short = 'o', long)]
     output: Option<PathBuf>,

--- a/hermes-train/src/trainer.rs
+++ b/hermes-train/src/trainer.rs
@@ -1644,6 +1644,11 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                             seed: shuffle_seed,
                             token_cache: Some(&token_cache_path),
                             data_binding,
+                            // A supervised record this phase cannot frame is a
+                            // geometry bug the operator must fix: training over
+                            // a silently reduced dataset would report a loss
+                            // over an unknown subset of it.
+                            oversized: OversizedRecordPolicy::Abort,
                         },
                         |sample| {
                             visited = visited

--- a/hermes-train/src/trainer.rs
+++ b/hermes-train/src/trainer.rs
@@ -1137,6 +1137,16 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
             &device,
         )?;
         adamw_optimizer = optimizer;
+        // The resume load restores the checkpoint's parameter IDs into the
+        // model, so the selection captured from the freshly constructed model
+        // above no longer identifies its matrices. Re-derive it from the model
+        // that will actually be differentiated; a stale selection extracts zero
+        // Muon gradients and fails the first resumed optimizer step.
+        muon_parameter_ids = initial_model.muon_parameter_ids();
+        ensure!(
+            !muon_parameter_ids.is_empty(),
+            "restored model has no hidden matrix parameters for Muon"
+        );
         ensure!(
             state.global_step <= total_steps,
             "checkpoint step {} exceeds requested total {total_steps}",
@@ -1170,7 +1180,12 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
         );
         ensure!(
             state.workflow_signature == signature,
-            "checkpoint workflow or training configuration differs from this invocation"
+            "checkpoint workflow or training configuration differs from this invocation{}",
+            if args.checkpoint.is_none() {
+                "; a run started from `--checkpoint` must repeat the same `--checkpoint` when resuming, because the initial checkpoint identity is part of the run signature"
+            } else {
+                ""
+            }
         );
         ensure!(
             state.data_manifest_hash.as_ref() == Some(&data_manifests[state.phase]),

--- a/hermes-train/tests/trainer_lifecycle.rs
+++ b/hermes-train/tests/trainer_lifecycle.rs
@@ -685,6 +685,170 @@ fn qat_cli_publishes_a_sealed_candidate_and_resume_authenticates_it() {
     );
 }
 
+fn read_training_state(output: &Path) -> Value {
+    let pointer: Value =
+        serde_json::from_slice(&fs::read(output.join("current.json")).unwrap()).unwrap();
+    let generation = pointer["generation"]
+        .as_str()
+        .expect("durable checkpoint pointer names a generation");
+    let state = output
+        .join("generations")
+        .join(generation)
+        .join("training-state.json");
+    serde_json::from_slice(&fs::read(state).unwrap()).unwrap()
+}
+
+/// A preempted ordinary (non-memory) wake run must resume and keep optimizing.
+///
+/// `load_training_state` restores the checkpoint's parameter IDs into the
+/// model, so any Muon matrix selection captured before that load is stale.
+/// `GradientsParams::from_params` then extracts nothing under the stale IDs and
+/// the first resumed optimizer step used to fail with
+/// `Muon gradient is missing for parameter ...`, which made `--resume`
+/// unusable for every model without a memory hierarchy.
+#[test]
+fn preempted_wake_run_resumes_and_keeps_optimizing() {
+    const TOTAL_STEPS: usize = 12;
+    let temporary = TempDir::new().unwrap();
+    let (model, tokenizer, _) = write_common_inputs(temporary.path(), ORDINARY_MODEL);
+    let data = temporary.path().join("stream.jsonl");
+    let mut rows = String::new();
+    for row in 0..48_i64 {
+        let first = row % 200 + 1;
+        let tokens = (first..first + 12)
+            .map(|token| token.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        rows.push_str(&format!("{{\"tokens\":[{tokens}]}}\n"));
+    }
+    fs::write(&data, rows).unwrap();
+    let workflow = temporary.path().join("wake.json");
+    fs::write(
+        &workflow,
+        serde_json::to_vec_pretty(&json!({
+            "version": 2,
+            "phases": [{
+                "name": "wake",
+                "type": "continued_pretrain",
+                "task": {"type": "causal_lm"},
+                "data": data,
+                "sequence_length": 4,
+                "batch_size": 1,
+                "gradient_accumulation": 1,
+                "epochs": 1,
+                "shuffle_buffer": 1,
+                "steps": TOTAL_STEPS
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let output = temporary.path().join("run");
+
+    // Preempt the run as soon as it has published one resumable generation.
+    let mut child = Command::new(binary())
+        .arg("train")
+        .arg("--config")
+        .arg(&model)
+        .arg("--tokenizer")
+        .arg(&tokenizer)
+        .arg("--workflow")
+        .arg(&workflow)
+        .arg("--output")
+        .arg(&output)
+        .args(["--warmup-steps", "0", "--checkpoint-every", "1"])
+        .spawn()
+        .expect("launching hermes-train");
+    let pointer = output.join("current.json");
+    for _ in 0..600 {
+        if pointer.is_file() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    child.kill().expect("preempting the trainer");
+    child.wait().expect("reaping the preempted trainer");
+    assert!(
+        pointer.is_file(),
+        "the trainer published no resumable generation to preempt"
+    );
+
+    let preempted = read_training_state(&output)["global_step"]
+        .as_u64()
+        .expect("checkpoint records a global step");
+    assert!(preempted >= 1, "preempted before the first optimizer step");
+    assert!(
+        preempted < TOTAL_STEPS as u64,
+        "the phase finished before it could be preempted, so this test would not resume mid-phase"
+    );
+
+    let resumed = run_train(&model, &tokenizer, &workflow, &output, &["--resume"]);
+    assert!(resumed.status.success(), "{}", diagnostic(&resumed));
+    assert_eq!(
+        read_training_state(&output)["global_step"].as_u64(),
+        Some(TOTAL_STEPS as u64),
+        "the resumed run did not finish the planned optimizer steps"
+    );
+}
+
+/// A fine-tuning run started from `--checkpoint` must stay resumable. The
+/// initial checkpoint's identity is part of the run signature, so the resumed
+/// invocation has to repeat it; omitting it must fail with an actionable
+/// message instead of an unexplained configuration mismatch.
+#[test]
+fn finetune_from_checkpoint_resumes_only_with_the_same_initial_checkpoint() {
+    let temporary = TempDir::new().unwrap();
+    let (model, tokenizer, data) = write_common_inputs(temporary.path(), ORDINARY_MODEL);
+    let workflow = temporary.path().join("wake.json");
+    fs::write(
+        &workflow,
+        serde_json::to_vec_pretty(&wake_workflow(&data, None)).unwrap(),
+    )
+    .unwrap();
+
+    // Publish a base checkpoint with an ordinary run, then fine-tune from it.
+    let base_output = temporary.path().join("base");
+    let base = run_train(&model, &tokenizer, &workflow, &base_output, &[]);
+    assert!(base.status.success(), "{}", diagnostic(&base));
+    let pointer: Value =
+        serde_json::from_slice(&fs::read(base_output.join("current.json")).unwrap()).unwrap();
+    let initial = base_output
+        .join("generations")
+        .join(pointer["generation"].as_str().unwrap())
+        .join("weights.safetensors");
+    assert!(initial.is_file());
+
+    let output = temporary.path().join("finetune");
+    let first = run_train(
+        &model,
+        &tokenizer,
+        &workflow,
+        &output,
+        &["--checkpoint", initial.to_str().unwrap()],
+    );
+    assert!(first.status.success(), "{}", diagnostic(&first));
+
+    // Resuming without the initial checkpoint cannot reconstruct the run
+    // signature, and says exactly what is missing.
+    let bare = run_train(&model, &tokenizer, &workflow, &output, &["--resume"]);
+    assert!(!bare.status.success(), "{}", diagnostic(&bare));
+    let error = String::from_utf8_lossy(&bare.stderr);
+    assert!(
+        error.contains("must repeat the same `--checkpoint`"),
+        "{error}"
+    );
+
+    // Repeating it resumes the fine-tune idempotently.
+    let resumed = run_train(
+        &model,
+        &tokenizer,
+        &workflow,
+        &output,
+        &["--resume", "--checkpoint", initial.to_str().unwrap()],
+    );
+    assert!(resumed.status.success(), "{}", diagnostic(&resumed));
+}
+
 fn memory_schedule() -> SleepSchedule {
     SleepSchedule {
         clock: UpdateClock::OptimizerSteps,

--- a/hermes-train/workflow.sft.example.json
+++ b/hermes-train/workflow.sft.example.json
@@ -34,19 +34,19 @@
       "learning_rate_scale": 0.5
     },
     {
-      "name": "sft-2-instruction-tuning-seq8192",
+      "name": "sft-2-instruction-tuning-seq2048",
       "type": "sft",
       "task": {
         "type": "instruction_tuning",
         "instruction": "Follow the instruction and provide the requested response."
       },
-      "data": "/data/sft-mixture/v1-20260804/train-instruction.jsonl.zst",
-      "sequence_length": 8192,
-      "batch_size": 2,
-      "gradient_accumulation": 16,
+      "data": "/data/sft-mixture/v2-20260804/train-instruction.jsonl.zst",
+      "sequence_length": 2048,
+      "batch_size": 8,
+      "gradient_accumulation": 4,
       "epochs": 1,
       "shuffle_buffer": 2048,
-      "steps": 1000,
+      "steps": 4000,
       "loss_weight": 1.0,
       "learning_rate_scale": 1.0
     },
@@ -83,20 +83,20 @@
       "learning_rate_scale": 1.0
     },
     {
-      "name": "sft-4-qa-reasoning-rag-seq4096",
+      "name": "sft-4-qa-reasoning-rag-seq2048",
       "type": "sft",
       "task": {
         "type": "qa_reasoning",
         "instruction": "Solve the problem carefully and provide the final answer.",
         "require_reasoning": false
       },
-      "data": "/data/rag-task-data/v1-20260804/train-qa.jsonl.zst",
-      "sequence_length": 4096,
-      "batch_size": 4,
-      "gradient_accumulation": 8,
+      "data": "/data/rag-tasks/v2-20260804/train-qa.jsonl.zst",
+      "sequence_length": 2048,
+      "batch_size": 8,
+      "gradient_accumulation": 4,
       "epochs": 1,
       "shuffle_buffer": 4096,
-      "steps": 900,
+      "steps": 1800,
       "loss_weight": 1.0,
       "learning_rate_scale": 1.0
     },
@@ -121,7 +121,7 @@
         "type": "retrieval_planning",
         "instruction": "Create a concise retrieval plan as an ordered action trace."
       },
-      "data": "/data/rag-task-data/v1-20260804/train-planning.jsonl.zst",
+      "data": "/data/rag-tasks/v2-20260804/train-planning.jsonl.zst",
       "sequence_length": 1024,
       "batch_size": 16,
       "gradient_accumulation": 2,

--- a/hermes-train/workflow.sft.example.json
+++ b/hermes-train/workflow.sft.example.json
@@ -1,0 +1,149 @@
+{
+  "version": 2,
+  "name": "retriever-300m-moe-sft-v1-20260804",
+  "phases": [
+    {
+      "name": "sft-1-summarization-seq4096",
+      "type": "sft",
+      "task": {
+        "type": "summarization",
+        "instruction": "Summarize the document faithfully and concisely."
+      },
+      "data": "/data/summarization-pairs/v1-20260803/train.jsonl.zst",
+      "sequence_length": 4096,
+      "batch_size": 4,
+      "gradient_accumulation": 8,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 1500,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    },
+    {
+      "name": "replay-1-language-foundations-seq512",
+      "type": "continued_pretrain",
+      "task": { "type": "causal_lm" },
+      "data": "/opt/hermes-run/moe-300m-v5-optimized-20260731/data/01-language-foundations-causal.jsonl.zst",
+      "sequence_length": 512,
+      "batch_size": 32,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 32768,
+      "steps": 1100,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    },
+    {
+      "name": "sft-2-instruction-tuning-seq8192",
+      "type": "sft",
+      "task": {
+        "type": "instruction_tuning",
+        "instruction": "Follow the instruction and provide the requested response."
+      },
+      "data": "/data/sft-mixture/v1-20260804/train-instruction.jsonl.zst",
+      "sequence_length": 8192,
+      "batch_size": 2,
+      "gradient_accumulation": 16,
+      "epochs": 1,
+      "shuffle_buffer": 2048,
+      "steps": 1000,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    },
+    {
+      "name": "replay-2-school-fundamentals-seq1024",
+      "type": "continued_pretrain",
+      "task": { "type": "causal_lm" },
+      "data": "/opt/hermes-run/moe-300m-v5-optimized-20260731/data/02-school-fundamentals-causal.jsonl.zst",
+      "sequence_length": 1024,
+      "batch_size": 16,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 16384,
+      "steps": 1100,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    },
+    {
+      "name": "sft-3-qa-reasoning-mixture-seq4096",
+      "type": "sft",
+      "task": {
+        "type": "qa_reasoning",
+        "instruction": "Solve the problem carefully and provide the final answer.",
+        "require_reasoning": false
+      },
+      "data": "/data/sft-mixture/v1-20260804/train-qa.jsonl.zst",
+      "sequence_length": 4096,
+      "batch_size": 4,
+      "gradient_accumulation": 8,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 700,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    },
+    {
+      "name": "sft-4-qa-reasoning-rag-seq4096",
+      "type": "sft",
+      "task": {
+        "type": "qa_reasoning",
+        "instruction": "Solve the problem carefully and provide the final answer.",
+        "require_reasoning": false
+      },
+      "data": "/data/rag-task-data/v1-20260804/train-qa.jsonl.zst",
+      "sequence_length": 4096,
+      "batch_size": 4,
+      "gradient_accumulation": 8,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 900,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    },
+    {
+      "name": "replay-3-university-core-seq2048",
+      "type": "continued_pretrain",
+      "task": { "type": "causal_lm" },
+      "data": "/opt/hermes-run/moe-300m-v5-optimized-20260731/data/03-university-core-causal.jsonl.zst",
+      "sequence_length": 2048,
+      "batch_size": 8,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 8192,
+      "steps": 1100,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    },
+    {
+      "name": "sft-5-retrieval-planning-seq1024",
+      "type": "sft",
+      "task": {
+        "type": "retrieval_planning",
+        "instruction": "Create a concise retrieval plan as an ordered action trace."
+      },
+      "data": "/data/rag-task-data/v1-20260804/train-planning.jsonl.zst",
+      "sequence_length": 1024,
+      "batch_size": 16,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 16384,
+      "steps": 900,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    },
+    {
+      "name": "replay-4-advanced-scholarship-seq4096",
+      "type": "continued_pretrain",
+      "task": { "type": "causal_lm" },
+      "data": "/opt/hermes-run/moe-300m-v5-optimized-20260731/data/04-advanced-scholarship-causal.jsonl.zst",
+      "sequence_length": 4096,
+      "batch_size": 4,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 1100,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    }
+  ]
+}


### PR DESCRIPTION
Found by feeding the newly built SFT corpora through the trainer for the first time. **Both are regressions on `main`** — the binary currently deployed on the training VM predates them and resumes correctly, verified by inspecting the deployed source. The live spot-instance run is therefore not at risk.

## Bug 1 — `--resume` broken for every model without a memory hierarchy

Muon parameter selection is captured from the freshly built model, but `load_training_state` then calls `restore_parameter_ids`, replacing the model's ParamIds with the checkpoint's. Only the memory-hierarchy branch re-derived the selection afterwards. A resumed ordinary run therefore extracted Muon gradients under stale IDs, got **zero** of them, and died on the first optimizer step:

```
Error: Muon gradient is missing for parameter ncl9iea6vbuo0
```

Reproduces with plain `causal_lm` on the repo's own ordinary test model — it would have hit the 300M SFT run on its first preemption. Existing tests missed it because they recompute IDs from the current model, and the QAT resume test resumes an already-*complete* run that takes no further steps.

## Bug 2 — a run started from `--checkpoint` could not be resumed at all

`--checkpoint` was `conflicts_with = "resume"`, yet the initial checkpoint's SHA-256 is part of the run signature. A resumed invocation computed a signature with `initial_checkpoint: None` and failed with an unactionable `checkpoint workflow or training configuration differs from this invocation`. Since SFT starts from the pretrained checkpoint, **the entire SFT run would have been unresumable.** The flags may now be combined (weights still load from `--output`; the path only supplies identity), and the mismatch message names what differs.

## Also: `workflow.sft.example.json`

A validated 9-phase post-training workflow over the three new corpora (202k summarization pairs, 307k instruction/QA mixture, 126k RAG-task records): 842M compute tokens, 9,400 steps, every microbatch exactly 16,384 tokens to match the pretraining envelope.

**Foundation replay has no framework primitive** — WorkflowV2 phases take exactly one data path, so replay is expressed as four interleaved `continued_pretrain` phases (17.1% of tokens) at each pretraining stage's *own* geometry, making their loss directly comparable to the live metrics stream.

## Tests

Two new end-to-end regressions that fail before the fix: `preempted_wake_run_resumes_and_keeps_optimizing` (SIGKILL mid-run, resume, keep optimizing) and `finetune_from_checkpoint_resumes_only_with_the_same_initial_checkpoint`.

585 tests pass; `clippy -D warnings` and `fmt` clean.