### PR TITLE
fix(train): add retrieval replay to SFT workflow; repair broken replay paths

### DIFF
--- a/hermes-train/workflow.sft.example.json
+++ b/hermes-train/workflow.sft.example.json
@@ -20,10 +20,30 @@
       "learning_rate_scale": 1.0
     },
     {
+      "name": "replay-retrieval-language-foundations-seq512",
+      "type": "continued_pretrain",
+      "task": {
+        "type": "retrieval_representation",
+        "temperature": 0.05,
+        "layer": 24
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/01-language-foundations-retrieval.jsonl.zst",
+      "sequence_length": 512,
+      "batch_size": 8,
+      "gradient_accumulation": 4,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 1200,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    },
+    {
       "name": "replay-1-language-foundations-seq512",
       "type": "continued_pretrain",
-      "task": { "type": "causal_lm" },
-      "data": "/opt/hermes-run/moe-300m-v5-optimized-20260731/data/01-language-foundations-causal.jsonl.zst",
+      "task": {
+        "type": "causal_lm"
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/01-language-foundations-causal.jsonl.zst",
       "sequence_length": 512,
       "batch_size": 32,
       "gradient_accumulation": 2,
@@ -51,10 +71,30 @@
       "learning_rate_scale": 1.0
     },
     {
+      "name": "replay-retrieval-school-fundamentals-seq512",
+      "type": "continued_pretrain",
+      "task": {
+        "type": "retrieval_representation",
+        "temperature": 0.05,
+        "layer": 24
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/02-school-fundamentals-retrieval.jsonl.zst",
+      "sequence_length": 512,
+      "batch_size": 8,
+      "gradient_accumulation": 4,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 1200,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    },
+    {
       "name": "replay-2-school-fundamentals-seq1024",
       "type": "continued_pretrain",
-      "task": { "type": "causal_lm" },
-      "data": "/opt/hermes-run/moe-300m-v5-optimized-20260731/data/02-school-fundamentals-causal.jsonl.zst",
+      "task": {
+        "type": "causal_lm"
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/02-school-fundamentals-causal.jsonl.zst",
       "sequence_length": 1024,
       "batch_size": 16,
       "gradient_accumulation": 2,
@@ -83,6 +123,24 @@
       "learning_rate_scale": 1.0
     },
     {
+      "name": "replay-retrieval-university-core-seq768",
+      "type": "continued_pretrain",
+      "task": {
+        "type": "retrieval_representation",
+        "temperature": 0.05,
+        "layer": 24
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/03-university-core-retrieval.jsonl.zst",
+      "sequence_length": 768,
+      "batch_size": 8,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 1200,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    },
+    {
       "name": "sft-4-qa-reasoning-rag-seq2048",
       "type": "sft",
       "task": {
@@ -101,10 +159,30 @@
       "learning_rate_scale": 1.0
     },
     {
+      "name": "replay-retrieval-advanced-scholarship-seq1024",
+      "type": "continued_pretrain",
+      "task": {
+        "type": "retrieval_representation",
+        "temperature": 0.05,
+        "layer": 24
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/04-advanced-scholarship-retrieval.jsonl.zst",
+      "sequence_length": 1024,
+      "batch_size": 4,
+      "gradient_accumulation": 4,
+      "epochs": 1,
+      "shuffle_buffer": 2048,
+      "steps": 1200,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    },
+    {
       "name": "replay-3-university-core-seq2048",
       "type": "continued_pretrain",
-      "task": { "type": "causal_lm" },
-      "data": "/opt/hermes-run/moe-300m-v5-optimized-20260731/data/03-university-core-causal.jsonl.zst",
+      "task": {
+        "type": "causal_lm"
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/03-university-core-causal.jsonl.zst",
       "sequence_length": 2048,
       "batch_size": 8,
       "gradient_accumulation": 2,
@@ -134,8 +212,10 @@
     {
       "name": "replay-4-advanced-scholarship-seq4096",
       "type": "continued_pretrain",
-      "task": { "type": "causal_lm" },
-      "data": "/opt/hermes-run/moe-300m-v5-optimized-20260731/data/04-advanced-scholarship-causal.jsonl.zst",
+      "task": {
+        "type": "causal_lm"
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/04-advanced-scholarship-causal.jsonl.zst",
       "sequence_length": 4096,
       "batch_size": 4,
       "gradient_accumulation": 2,


### PR DESCRIPTION
Two problems with `workflow.sft.example.json` — one measured, one that would have failed the run at launch.

## Retrieval decays during causal-only training (measured)

Held-out retrieval top-1 across the current pretraining run:

| Split | 249k (peak) | 285.5k | 291.5k | 392k |
|---|---:|---:|---:|---:|
| School | 22.4% | 10.5% | 10.5% | **12.5%** |
| University | 31.9% | 24.7% | 23.1% | **17.2%** |
| Advanced | 42.5% | 34.4% | 28.8% | **21.3%** |

Advanced MRR 0.541 → 0.325 over ~143k causal-only steps. Recall@10 is now falling too (university 0.656 → 0.553), so the embedding is losing documents outright, not just ranking them worse. **Training loss cannot show any of this** — it only reflects the objective currently running.

SFT is five consecutive supervised-generation phases, so it would erode the retriever the same way. Four `retrieval_representation` replay phases are now interleaved after each SFT phase at layer 24 / temperature 0.05, each using its own pretraining stage's retrieval shard and geometry: **8.1% of tokens**, alongside the existing 15.7% causal foundation replay.

The dose is a starting point, not a derived optimum. Verify with `hermes-train eval --objective contrastive_retrieval` on all three held-out splits before and after SFT against the 249k peak, and raise it if retrieval still regresses.

## All four causal replay paths were broken

They pointed at `/opt/hermes-run/moe-300m-v5-optimized-20260731/data/`, which does not exist on the training host — the shards live under `/opt/hermes-run/moe-300m-v4/data/`. Every replay phase would have failed to open its data.

## Note on geometry

Retrieval phases are sized against the validator's worst case of 33 sequences per example (`MAX_RETRIEVAL_REPRESENTATION_DOCUMENTS`), not the 4 our data carries, so batch and shuffle bounds hold for any negatives count the schema permits.

Validates against `retriever_300m_moe.mal`: 13 phases, 18,100 steps, 915.9M compute tokens.