### PR TITLE
fix(train): let SFT retrieval replay run one epoch instead of a guessed step count

### DIFF
--- a/hermes-train/workflow.sft.example.json
+++ b/hermes-train/workflow.sft.example.json
@@ -33,7 +33,6 @@
       "gradient_accumulation": 4,
       "epochs": 1,
       "shuffle_buffer": 4096,
-      "steps": 1200,
       "loss_weight": 1.0,
       "learning_rate_scale": 0.5
     },
@@ -84,7 +83,6 @@
       "gradient_accumulation": 4,
       "epochs": 1,
       "shuffle_buffer": 4096,
-      "steps": 1200,
       "loss_weight": 1.0,
       "learning_rate_scale": 0.5
     },
@@ -136,7 +134,6 @@
       "gradient_accumulation": 2,
       "epochs": 1,
       "shuffle_buffer": 4096,
-      "steps": 1200,
       "loss_weight": 1.0,
       "learning_rate_scale": 0.5
     },
@@ -172,7 +169,6 @@
       "gradient_accumulation": 4,
       "epochs": 1,
       "shuffle_buffer": 2048,
-      "steps": 1200,
       "loss_weight": 1.0,
       "learning_rate_scale": 0.5
     },


### PR DESCRIPTION
Follow-up to #138, found by the live SFT run crashing.

## What happened

The four retrieval replay phases I added in #138 each requested **1,200 optimizer steps**. That number was invented rather than measured, and the smallest shard cannot supply it — the language-foundations retrieval split yields **46 steps** at seq 512 / batch 8 / accumulation 4.

The live run completed its summarization phase (1,500 steps, loss 3.12 → 2.30), entered retrieval replay, ran 19 healthy steps at 38k tok/s, then died:

```
workflow phase `replay-retrieval-language-foundations-seq512` requested
1200 optimizer steps, but its data and epochs produced 46
```

It then looped **34 times** under the supervisor — restore checkpoint 1500, run ~20 steps, die — for about four hours. The supervisor behaved correctly; it cannot distinguish a transient failure from a deterministic one.

**`validate-workflow` cannot catch this.** It validates configuration; the shortfall is only visible by reading the data.

## Fix

`steps` is optional in WorkflowV2, so the replay phases now run **one epoch** of whatever their shard actually holds.

The trade-off is real and worth stating: epoch-bounded phases force the trainer to enumerate each phase's data at startup to compute its length. Measured at **~6 minutes** for this workflow, with the GPU idle. The first run started training in seconds precisely because every phase had a hardcoded step count. I consider that a good trade — phases that adapt to the corpus beat phases that assert a size the corpus may not have — but if startup cost matters more than adaptability, the alternative is explicit per-shard step counts measured against real capacity.

## Cost

Changing the workflow changes the run signature, so the interrupted run's step-1500 checkpoint could not be resumed. It is preserved (`checkpoint-abandoned-1500` on the box, and the 17.6 GB GCS prefix moved aside rather than deleted) and the run restarted from the pretrained weights — about 1.6 hours of A100 time.

Verified: workflow validates locally and on the training host; the restarted run is training at 89% GPU.