### PR TITLE
feat(train): corrective SFT workflow — right-sized replay, v3 abstention data, generative final phase

### DIFF
--- a/hermes-train/workflow.sft-corrective.example.json
+++ b/hermes-train/workflow.sft-corrective.example.json
@@ -1,0 +1,179 @@
+{
+  "version": 2,
+  "name": "retriever-300m-moe-sft-v1-20260804",
+  "phases": [
+    {
+      "name": "sft-1-qa-rag-v3-seq2048",
+      "type": "sft",
+      "task": {
+        "type": "qa_reasoning",
+        "instruction": "Solve the problem carefully and provide the final answer.",
+        "require_reasoning": false
+      },
+      "data": "/opt/hermes-run/sft-data-v3/train-qa.jsonl.zst",
+      "sequence_length": 2048,
+      "batch_size": 8,
+      "gradient_accumulation": 4,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 1800,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    },
+    {
+      "name": "replay-retr-university-seq768",
+      "type": "continued_pretrain",
+      "task": {
+        "type": "retrieval_representation",
+        "temperature": 0.05,
+        "layer": 24
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/03-university-core-retrieval.jsonl.zst",
+      "sequence_length": 768,
+      "batch_size": 8,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5,
+      "steps": 150
+    },
+    {
+      "name": "sft-2-instruction-seq2048",
+      "type": "sft",
+      "task": {
+        "type": "instruction_tuning",
+        "instruction": "Follow the instruction and provide the requested response."
+      },
+      "data": "/data/sft-mixture/v2-20260804/train-instruction.jsonl.zst",
+      "sequence_length": 2048,
+      "batch_size": 8,
+      "gradient_accumulation": 4,
+      "epochs": 1,
+      "shuffle_buffer": 2048,
+      "steps": 1200,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    },
+    {
+      "name": "replay-causal-foundations-seq512",
+      "type": "continued_pretrain",
+      "task": {
+        "type": "causal_lm"
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/01-language-foundations-causal.jsonl.zst",
+      "sequence_length": 512,
+      "batch_size": 32,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 32768,
+      "steps": 400,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    },
+    {
+      "name": "sft-3-summarization-seq4096",
+      "type": "sft",
+      "task": {
+        "type": "summarization",
+        "instruction": "Summarize the document faithfully and concisely."
+      },
+      "data": "/data/summarization-pairs/v1-20260803/train.jsonl.zst",
+      "sequence_length": 4096,
+      "batch_size": 4,
+      "gradient_accumulation": 8,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 800,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    },
+    {
+      "name": "replay-retr-advanced-seq1024",
+      "type": "continued_pretrain",
+      "task": {
+        "type": "retrieval_representation",
+        "temperature": 0.05,
+        "layer": 24
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/04-advanced-scholarship-retrieval.jsonl.zst",
+      "sequence_length": 1024,
+      "batch_size": 4,
+      "gradient_accumulation": 4,
+      "epochs": 1,
+      "shuffle_buffer": 2048,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5,
+      "steps": 150
+    },
+    {
+      "name": "replay-causal-university-seq2048",
+      "type": "continued_pretrain",
+      "task": {
+        "type": "causal_lm"
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/03-university-core-causal.jsonl.zst",
+      "sequence_length": 2048,
+      "batch_size": 8,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 8192,
+      "steps": 400,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5
+    },
+    {
+      "name": "sft-4-qa-mixture-seq4096",
+      "type": "sft",
+      "task": {
+        "type": "qa_reasoning",
+        "instruction": "Solve the problem carefully and provide the final answer.",
+        "require_reasoning": false
+      },
+      "data": "/data/sft-mixture/v1-20260804/train-qa.jsonl.zst",
+      "sequence_length": 4096,
+      "batch_size": 4,
+      "gradient_accumulation": 8,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "steps": 600,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    },
+    {
+      "name": "replay-retr-school-seq512",
+      "type": "continued_pretrain",
+      "task": {
+        "type": "retrieval_representation",
+        "temperature": 0.05,
+        "layer": 24
+      },
+      "data": "/opt/hermes-run/moe-300m-v4/data/02-school-fundamentals-retrieval.jsonl.zst",
+      "sequence_length": 512,
+      "batch_size": 8,
+      "gradient_accumulation": 4,
+      "epochs": 1,
+      "shuffle_buffer": 4096,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 0.5,
+      "steps": 150
+    },
+    {
+      "name": "sft-5-planning-seq1024",
+      "type": "sft",
+      "task": {
+        "type": "retrieval_planning",
+        "instruction": "Create a concise retrieval plan as an ordered action trace."
+      },
+      "data": "/data/rag-tasks/v2-20260804/train-planning.jsonl.zst",
+      "sequence_length": 1024,
+      "batch_size": 16,
+      "gradient_accumulation": 2,
+      "epochs": 1,
+      "shuffle_buffer": 16384,
+      "steps": 900,
+      "loss_weight": 1.0,
+      "learning_rate_scale": 1.0
+    }
+  ]
+}


### PR DESCRIPTION
The first SFT run finished (26,824 steps). Held-out loss says it worked; generation says it did not. This workflow addresses why.

## What the first run produced

| Objective | Pre-SFT | Post-SFT |
|---|---:|---:|
| Planning | 47.0 | **3.78** |
| QA (RAG) | 138.1 | **8.49** |
| QA (mixture) | 39.0 | **6.71** |
| Instruction | 11.7 | **5.90** |
| Summarization | 23.2 | **16.2** |

Retrieval was **completely preserved** — 98.0 / 99.7 / 100.0% top-1, identical to pre-SFT — and causal *improved* (advanced ppl 121.6 → 81.5). The interleaved replay from #138 did its job exactly.

But free-running generation is degenerate on every objective: summarization copies sentence one and loops it, instruction emits numbered *questions*, planning echoes the request, grounded QA repeats the question instead of reading passage [1]. Teacher-forced perplexity rewards knowing the format given a correct prefix; autoregressive decoding compounds error into copying. Exposure bias, structurally invisible to loss.

## Three fixes, each measured

**Replay steps explicit and short.** Epoch-bounding (#140) fixed the crash but let phase 10 run **~10,900 steps** on the 1.3 GB advanced shard — 40% of the run — so **12,200 of the final 13,100 steps were replay**, and the run *ended* on replay. Measured repair time is **17 steps** (phase 8 hit loss <1e-4 after 17 of 2,449), so 150 is generous. Replay drops from 63% of compute to **7%**.

**RAG QA reads v3.** In v2 every unanswerable record shared one target string — 20,606 of 74,709 targets, 85× the next most frequent — and the mid-run checkpoint emitted it for *every* prompt, even with the answer verbatim in passage [1]. v3 uses 34 structurally varied paraphrases at a 10% share; most frequent target 27.6% → **0.48%**.

**Ends on a generative phase**, so the final gradients shape generation rather than retrieval.

## Shape

10 phases, 6,550 steps, 442.6M compute tokens — about a third of the first run. Starts from the first SFT checkpoint, which already carries the retriever and the improved language model. Validates against `retriever_300m_moe.mal`.

Retrieval replay is retained (150 steps × 3) because the first run proved it necessary — without it the retriever would erode, as it did during pretraining's causal-only stages (42.5% → 21.3% top-1).