### PR TITLE
fix(train): bound data-derived replay phases

### DIFF
--- a/hermes-train/README.md
+++ b/hermes-train/README.md
@@ -26,6 +26,14 @@ Validate and inspect resolved paths before a run:
 hermes-train validate-workflow --workflow hermes-train/workflow.example.json
 ```
 
+Optimization phases may use `steps` for an exact optimizer-step request, or
+omit it to consume their configured epochs. Use `max_steps` with the latter to
+cap a natural-epoch plan: the resolved length is
+`min(epoch_steps, max_steps)`. `steps` and `max_steps` are mutually exclusive.
+This distinction matters for replay shards: an exact request can overrun a
+small shard and fail, while an uncapped large shard can silently dominate the
+workflow. The SFT example uses `max_steps` for retrieval replay for that reason.
+
 For the complete education recipe, also bind validation to the exact
 sleep-capable MAL before creating any run state. This rejects missing sleep
 hooks, mixed memory/ordinary layers, and tier-name or reserve-capacity drift:

--- a/hermes-train/src/device_sampler.rs
+++ b/hermes-train/src/device_sampler.rs
@@ -753,7 +753,7 @@ mod tests {
         let program = directory.path().join("fake-nvidia-smi");
         executable(
             &program,
-            "#!/bin/sh\nprintf 'malformed\\n'\ni=0\nwhile [ \"$i\" -lt 64 ]; do\n  printf '3, 92, 2048, 40960, 255.5, 67\\n'\n  i=$((i + 1))\ndone\nsleep 30\n",
+            "#!/bin/sh\nprintf 'malformed\\n'\ni=0\nwhile [ \"$i\" -lt 64 ]; do\n  printf '3, 92, 2048, 40960, 255.5, 67\\n'\n  i=$((i + 1))\ndone\nexec sleep 30\n",
         );
         let mut config = NvidiaSmiSamplerConfig::new(Duration::from_millis(250), "3").unwrap();
         config.channel_capacity = 1;
@@ -765,11 +765,7 @@ mod tests {
             let drain = sampler.drain();
             if !drain.samples.is_empty()
                 && drain.diagnostics.iter().any(|diagnostic| {
-                    matches!(
-                        diagnostic,
-                        DeviceSamplerDiagnostic::InvalidSample(_)
-                            | DeviceSamplerDiagnostic::DroppedSamples(_)
-                    )
+                    matches!(diagnostic, DeviceSamplerDiagnostic::DroppedSamples(_))
                 })
             {
                 break drain;
@@ -780,8 +776,18 @@ mod tests {
             );
             thread::sleep(Duration::from_millis(10));
         };
-        assert_eq!(drain.samples.len(), 1);
-        assert_eq!(drain.samples[0].metrics.device_index, 3);
+        // The channel holds at most one queued sample, but the producer may
+        // refill it while `drain()` consumes it. Therefore one drain can
+        // legitimately observe more than the channel capacity. The dropped
+        // diagnostic above is the observable proof that overflow stayed
+        // bounded; an exact vector length would be a scheduler race.
+        assert!(!drain.samples.is_empty());
+        assert!(
+            drain
+                .samples
+                .iter()
+                .all(|sample| sample.metrics.device_index == 3)
+        );
         let stopped = Instant::now();
         drop(sampler);
         assert!(stopped.elapsed() < Duration::from_secs(2));

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -817,7 +817,24 @@ fn validate_model_wake_plan(config: &ModelDef, workflow: &ResolvedWakePlan) -> R
 #[derive(Clone, Copy)]
 struct PhasePlan {
     samples: Option<usize>,
+    natural_steps: Option<usize>,
     steps: usize,
+}
+
+fn select_phase_steps(
+    phase_name: &str,
+    samples: usize,
+    batch_size: usize,
+    gradient_accumulation: usize,
+    epochs: usize,
+    max_steps: Option<usize>,
+) -> Result<(usize, usize)> {
+    let steps_per_epoch = (samples / batch_size).div_euclid(gradient_accumulation);
+    let natural_steps = steps_per_epoch.checked_mul(epochs).with_context(|| {
+        format!("workflow phase `{phase_name}` optimizer-step count overflows usize")
+    })?;
+    let selected_steps = max_steps.map_or(natural_steps, |cap| natural_steps.min(cap));
+    Ok((natural_steps, selected_steps))
 }
 
 fn planned_sample_count(
@@ -863,8 +880,8 @@ fn plan_training(
     let mut total_steps = 0usize;
     let mut plan = Vec::with_capacity(workflow.phases.len());
     for (phase_index, phase) in workflow.phases.iter().enumerate() {
-        let (samples, steps) = match phase.steps {
-            Some(steps) => (None, steps),
+        let (samples, natural_steps, steps) = match phase.steps {
+            Some(steps) => (None, None, steps),
             None => {
                 let samples = planned_sample_count(
                     &phase.data,
@@ -874,16 +891,15 @@ fn plan_training(
                     &token_cache_paths[phase_index],
                     &data_bindings[phase_index],
                 )?;
-                let steps_per_epoch =
-                    (samples / phase.batch_size).div_euclid(phase.gradient_accumulation);
-                let optimizer_steps =
-                    steps_per_epoch.checked_mul(phase.epochs).with_context(|| {
-                        format!(
-                            "workflow phase `{}` optimizer-step count overflows usize",
-                            phase.name
-                        )
-                    })?;
-                (Some(samples), optimizer_steps)
+                let (natural_steps, selected_steps) = select_phase_steps(
+                    &phase.name,
+                    samples,
+                    phase.batch_size,
+                    phase.gradient_accumulation,
+                    phase.epochs,
+                    phase.max_steps,
+                )?;
+                (Some(samples), Some(natural_steps), selected_steps)
             }
         };
         ensure!(
@@ -908,7 +924,11 @@ fn plan_training(
         total_steps = total_steps
             .checked_add(steps)
             .ok_or_else(|| anyhow::anyhow!("workflow optimizer-step count overflows usize"))?;
-        plan.push(PhasePlan { samples, steps });
+        plan.push(PhasePlan {
+            samples,
+            natural_steps,
+            steps,
+        });
     }
     Ok((plan, total_steps))
 }
@@ -1876,6 +1896,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn natural_epoch_step_cap_never_overasks_or_runs_unbounded() {
+        // 1,600 samples / 8 per batch / 4-way accumulation = 50 steps.
+        assert_eq!(
+            select_phase_steps("retrieval", 1_600, 8, 4, 1, None).unwrap(),
+            (50, 50)
+        );
+        assert_eq!(
+            select_phase_steps("retrieval", 1_600, 8, 4, 1, Some(20)).unwrap(),
+            (50, 20)
+        );
+        // A cap larger than the data is not an exact request: the natural
+        // epoch wins, avoiding the deterministic short-shard crash that an
+        // exact `steps` value would cause.
+        assert_eq!(
+            select_phase_steps("retrieval", 1_600, 8, 4, 1, Some(200)).unwrap(),
+            (50, 50)
+        );
+    }
+
+    #[test]
     fn coincident_wake_only_updates_emit_ordered_committed_metrics() {
         let schedule: hermes_train::sleep::SleepSchedule =
             serde_json::from_value(serde_json::json!({
@@ -2094,6 +2134,7 @@ mod tests {
                 epochs: 1,
                 shuffle_buffer: 1,
                 steps: Some(1),
+                max_steps: None,
                 loss_weight: 1.0,
                 learning_rate_scale: 1.0,
                 quantization: Some(WorkflowQuantizationPlan {

--- a/hermes-train/src/trainer.rs
+++ b/hermes-train/src/trainer.rs
@@ -1498,13 +1498,19 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
         .iter()
         .zip(&phase_plan)
         .map(|(phase, plan)| {
+            let step_summary = match plan.natural_steps {
+                Some(natural) if natural > plan.steps => {
+                    format!("{}(capped_from={natural})", plan.steps)
+                }
+                _ => plan.steps.to_string(),
+            };
             format!(
                 "{}:{}:samples={}:steps={}",
                 phase.name,
                 phase.objective.name(),
                 plan.samples
                     .map_or_else(|| "streaming".to_owned(), |n| n.to_string()),
-                plan.steps,
+                step_summary,
             )
         })
         .collect::<Vec<_>>()
@@ -2213,9 +2219,7 @@ pub(super) fn train(args: TrainArgs) -> Result<()> {
                         step_input_wait_seconds = 0.0;
                         step_host_to_device_seconds = 0.0;
                         step_accelerator_seconds = 0.0;
-                        if step >= total_steps
-                            || phase.steps.is_some_and(|limit| steps_in_phase >= limit)
-                        {
+                        if step >= total_steps || steps_in_phase >= phase_plan[phase_index].steps {
                             phase_limit_reached = true;
                             break;
                         }

--- a/hermes-train/src/wake.rs
+++ b/hermes-train/src/wake.rs
@@ -44,6 +44,7 @@ pub(crate) struct ResolvedWakePhase {
     pub(crate) epochs: usize,
     pub(crate) shuffle_buffer: usize,
     pub(crate) steps: Option<usize>,
+    pub(crate) max_steps: Option<usize>,
     pub(crate) loss_weight: f64,
     pub(crate) learning_rate_scale: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -114,6 +115,7 @@ fn project_wake_workflow(workflow: WorkflowV2) -> Result<ResolvedWakePlan> {
             epochs,
             shuffle_buffer,
             steps: phase.steps,
+            max_steps: phase.max_steps,
             loss_weight,
             learning_rate_scale,
             quantization,
@@ -171,6 +173,7 @@ mod tests {
         assert_eq!(phase.epochs, 1);
         assert_eq!(phase.shuffle_buffer, 8192);
         assert_eq!(phase.steps, Some(10));
+        assert_eq!(phase.max_steps, None);
         assert_eq!(phase.learning_rate_scale, 0.25);
         assert_eq!(phase.objective.name(), "summarization");
     }

--- a/hermes-train/src/workflow.rs
+++ b/hermes-train/src/workflow.rs
@@ -487,6 +487,12 @@ pub struct PhaseV2 {
     pub shuffle_buffer: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub steps: Option<usize>,
+    /// Cap a data-derived epoch plan without asserting that the corpus can
+    /// supply exactly this many optimizer steps. Mutually exclusive with
+    /// `steps`: `steps` is an exact request, while `max_steps` is
+    /// `min(natural_epoch_steps, max_steps)`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_steps: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub loss_weight: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -547,6 +553,23 @@ impl PhaseV2 {
         validate_positive(self.epochs, "epochs", name)?;
         validate_positive(self.shuffle_buffer, "shuffle_buffer", name)?;
         validate_positive(self.steps, "steps", name)?;
+        validate_positive(self.max_steps, "max_steps", name)?;
+        ensure!(
+            self.steps.is_none() || self.max_steps.is_none(),
+            "workflow phase `{name}` cannot set both steps and max_steps"
+        );
+        ensure!(
+            self.max_steps.is_none()
+                || matches!(
+                    self.kind,
+                    PhaseKind::Pretrain
+                        | PhaseKind::ContinuedPretrain
+                        | PhaseKind::Sft
+                        | PhaseKind::Quantization
+                ),
+            "workflow phase `{name}` ({}) cannot set max_steps because its executor does not implement adaptive data-derived step caps",
+            self.kind.name()
+        );
         ensure!(
             self.batch_size
                 .is_none_or(|value| value <= MAX_PHASE_BATCH_SIZE),
@@ -661,6 +684,7 @@ impl PhaseV2 {
                         && self.epochs.is_none()
                         && self.shuffle_buffer.is_none()
                         && self.steps.is_none()
+                        && self.max_steps.is_none()
                         && self.loss_weight.is_none()
                         && self.learning_rate_scale.is_none(),
                     "workflow phase `{name}` ({}) must not set task execution or optimizer geometry",
@@ -1408,6 +1432,26 @@ mod tests {
     }
 
     #[test]
+    fn sft_retrieval_replay_is_adaptively_capped() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("workflow.sft.example.json");
+        let workflow = load_workflow(&path)
+            .unwrap_or_else(|error| panic!("SFT workflow is invalid: {error:#}"));
+        let retrieval = workflow
+            .phases
+            .iter()
+            .filter(|phase| {
+                matches!(
+                    phase.task.as_ref(),
+                    Some(TaskConfig::RetrievalRepresentation { .. })
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(retrieval.len(), 4);
+        assert!(retrieval.iter().all(|phase| phase.steps.is_none()));
+        assert!(retrieval.iter().all(|phase| phase.max_steps == Some(150)));
+    }
+
+    #[test]
     fn incompatible_workflow_versions_are_rejected_without_fallback() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("workflow.json");
@@ -1589,6 +1633,38 @@ mod tests {
         };
         let error = workflow.validate().unwrap_err().to_string();
         assert!(error.contains("phase limit"), "{error}");
+    }
+
+    #[test]
+    fn exact_steps_and_natural_epoch_cap_are_mutually_exclusive() {
+        let mut phase = training_phase(
+            "bounded-retrieval",
+            "continued_pretrain",
+            serde_json::json!({"type": "retrieval_representation"}),
+        );
+        phase["max_steps"] = serde_json::json!(5);
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [phase]
+        }))
+        .unwrap();
+        let error = workflow.validate().unwrap_err().to_string();
+        assert!(error.contains("both steps and max_steps"), "{error}");
+
+        let mut phase = training_phase(
+            "bounded-retrieval",
+            "continued_pretrain",
+            serde_json::json!({"type": "retrieval_representation"}),
+        );
+        phase.as_object_mut().unwrap().remove("steps");
+        phase["max_steps"] = serde_json::json!(0);
+        let workflow: WorkflowV2 = serde_json::from_value(serde_json::json!({
+            "version": 2,
+            "phases": [phase]
+        }))
+        .unwrap();
+        let error = workflow.validate().unwrap_err().to_string();
+        assert!(error.contains("max_steps must be positive"), "{error}");
     }
 
     #[test]

--- a/hermes-train/workflow.sft.example.json
+++ b/hermes-train/workflow.sft.example.json
@@ -33,6 +33,7 @@
       "gradient_accumulation": 4,
       "epochs": 1,
       "shuffle_buffer": 4096,
+      "max_steps": 150,
       "loss_weight": 1.0,
       "learning_rate_scale": 0.5
     },
@@ -83,6 +84,7 @@
       "gradient_accumulation": 4,
       "epochs": 1,
       "shuffle_buffer": 4096,
+      "max_steps": 150,
       "loss_weight": 1.0,
       "learning_rate_scale": 0.5
     },
@@ -134,6 +136,7 @@
       "gradient_accumulation": 2,
       "epochs": 1,
       "shuffle_buffer": 4096,
+      "max_steps": 150,
       "loss_weight": 1.0,
       "learning_rate_scale": 0.5
     },
@@ -169,6 +172,7 @@
       "gradient_accumulation": 4,
       "epochs": 1,
       "shuffle_buffer": 2048,
+      "max_steps": 150,
       "loss_weight": 1.0,
       "learning_rate_scale": 0.5
     },


### PR DESCRIPTION
## Summary

- add `max_steps` as an adaptive cap over data-derived epoch length
- use it for every retrieval replay phase in the checked-in SFT workflow
- report when a natural plan was capped and stop on the resolved plan
- remove a scheduler-dependent exact-count assertion from the device sampler test

## Why

The first SFT run exposed both sides of the existing `steps` contract: an exact 1,200-step request crashed on a shard that could supply only 46 steps, while removing `steps` let the advanced retrieval shard run roughly 9,500 pure-contrastive steps. The measured decay curve showed QA-RAG perplexity rising 4.54 -> 858.58 and EOS emission falling 0.708 -> 0 during that phase. `max_steps` resolves the intended plan as `min(natural_epoch_steps, cap)`, so small shards finish naturally and large shards cannot dominate the workflow.

## Verification

- 461 `hermes-train` library tests
- 142 `hermes-train` binary tests
- sampler test: 20 consecutive repetitions
- strict clippy (`-D warnings`)
- rustfmt and `git diff --check`
- all five checked-in workflows validate