### PR TITLE
feat(train): add generation and full-pool retrieval eval

### DIFF
--- a/docs/generation-eval.md
+++ b/docs/generation-eval.md
@@ -1,0 +1,101 @@
+# Generation evaluation
+
+## Why
+
+`hermes-train eval` measures teacher-forced cross-entropy: given a correct
+target prefix, how well the model predicts the next token. That is the right
+number for tracking training, and it is not a measure of whether the model can
+produce text.
+
+The 300M MoE run made the gap concrete. A corrective SFT pass improved held-out
+loss on four of five supervised objectives — grounded QA fell 17%, planning 19% —
+while free-running greedy decoding on the same objective still collapsed into
+repetition on 5 of 24 records. Earlier, the reverse happened: loss caught
+retrieval decay that generations hid entirely. **Perplexity and generation
+measure different things and both are required.** Neither alone is sufficient,
+and only one of them was automated.
+
+## What is measured
+
+For each held-out record, frame the prompt exactly as training frames it, decode
+greedily, and score the decode. Reported as means over scored records:
+
+| metric                                                            | meaning                                                                                                                             |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `repeated_trigram_rate`                                           | share of the decode's word trigrams taken by its most frequent one, excluding that trigram's first occurrence; zero for unique text |
+| `degenerate_fraction`                                             | share of decodes above a 0.10 repeated-trigram rate                                                                                 |
+| `target_containment`                                              | share whose lowercase alphanumeric word sequence contains the complete gold target word sequence                                    |
+| `source_overlap`                                                  | share of the decode's word 4-grams that also occur in the prompt source                                                             |
+| `stopped_at_eos`                                                  | share that ended by emitting EOS rather than exhausting `--max-new-tokens`                                                          |
+| `empty_fraction`, `mean_generated_tokens`, `mean_generated_words` | shape of the output                                                                                                                 |
+
+Two are deliberately reported without a verdict:
+
+- `source_overlap` is the goal for grounded QA (extract from the passage) and the
+  failure mode for summarization (copy sentence one). The task decides, not the
+  metric.
+- `target_containment` is a correctness _floor_, not accuracy. It counts exact
+  inclusion, so a correct answer phrased differently scores zero — the observed
+  "Yadkin County" for gold "Yadkin River" counts as a miss.
+
+`stopped_at_eos` low together with `repeated_trigram_rate` high is the signature
+of a model that cannot stop, which is the specific failure this project hit.
+
+## Correctness constraints
+
+**The decode prompt is the training prompt by construction.** Both come from
+`TaskConfig::construct_supervised_prompt` followed by
+`data::structured::frame_supervised`, one function with two consumers. Framing
+was previously inlined in `make_supervised_sample`; it was extracted so decoding
+could not drift from it.
+
+This is not a stylistic preference. A prompt assembled by hand — passages before
+the question, no instruction line, no `Response:` suffix — is out of distribution,
+and a continuation-pretrained model correctly continues it instead of answering.
+That produced a false "generation is still broken" conclusion on this project,
+reported twice, and an exposure-bias theory built on top of it. In the real
+format the same checkpoint answers correctly and stops.
+
+**The target's length is reserved, then decoding replaces it.** Training truncates
+the source to fit prompt + target + EOS inside `--sequence-length`. Decoding
+supplies the gold target too, purely so the same budget is reserved and the
+prompt is identical to the one the loss was measured against. The target is never
+shown to the model. Source-overlap is computed against only the retained source
+token range; text truncated out of the prompt cannot count as grounding.
+
+**Greedy by default.** `--temperature 0` is the default because it is
+reproducible and because degenerate copying is visible under it; sampling can
+mask a collapsed argmax, which is how one earlier failure stayed hidden. The seed
+is always explicit so a report is reproducible even when sampling is enabled.
+
+**Oversized records are skipped and counted**, matching `eval`: one over-long
+held-out record must not void an evaluation, but the drop is never silent.
+
+## Shape
+
+```
+hermes-train generate-eval \
+  --config <config.json> --tokenizer <tokenizer.json> --checkpoint <weights.safetensors> \
+  --data <shard.jsonl.zst> --objective qa_reasoning \
+  --sequence-length 2048 --max-new-tokens 60 --max-records 200 \
+  --samples samples.json -o report.json
+```
+
+`--samples` writes every prompt, decode, and gold target for review. Metrics
+summarize; reading decodes is what caught the failure metrics missed. When
+`--samples` is given, the decodes live only in that file — duplicating them into
+the metrics report would silently double a large artifact.
+
+Decoding is autoregressive and therefore far slower than `eval`'s single forward
+pass; `--max-records` exists to bound it, and what it excludes is reported.
+
+## Tests
+
+- The prompt tokens `frame_supervised` yields equal the training sample's tokens
+  up to the target, pinning the shared-framing guarantee.
+- `repeated_trigram_rate` and `source_overlap` on hand-computed inputs, including
+  the fully-degenerate and fully-unique ends.
+- Metrics are finite, in range, and deterministic under greedy decoding.
+- Oversized records are skipped, counted, and warned about.
+- `--samples` writes decodes to its own file and omits them from the report.
+- `--require-reasoning` is rejected for objectives other than `qa_reasoning`.

--- a/docs/retrieval-pool-eval.md
+++ b/docs/retrieval-pool-eval.md
@@ -1,0 +1,124 @@
+# Large-candidate-pool retrieval evaluation
+
+## Why
+
+`hermes-train eval --objective contrastive_retrieval` scores retrieval **in
+batch**: the candidate set for a query is whatever the other rows of the same
+batch contributed. At the geometry the 300M MoE run used — `--sequence-length
+1024 --batch-size 4`, one positive and two mined negatives per record — that is
+**12 candidates per query**.
+
+The metric saturated. Every checkpoint from step 457.5k onward reports
+`top1_accuracy 1.0, mrr 1.0, recall_at_k 1.0` on all three curriculum stages,
+before and after two rounds of SFT. A metric pinned at its ceiling cannot
+detect a regression, and retrieval is the capability this model exists to
+provide. Ranking one document above eleven in-batch peers says nothing about
+ranking it above thousands of plausible alternatives, which is the only
+question a search engine asks.
+
+This document specifies a second, harder measurement. It does not replace the
+in-batch number — that one stays comparable with training-time metrics, which
+is its purpose — it answers a different question.
+
+## What is measured
+
+Given retrieval shards, build one **global candidate pool** from every unique
+document they mention, keyed by `document_id` (positives and mined negatives
+alike; negatives in the current eval shards are other queries' positives, so
+each shard is already a closed ranking set). Embed the whole pool once, embed
+every query, and rank each query's own positive against the **entire pool**.
+
+Pool sizes available today, from `.context/heldout-eval/`:
+
+| shard                                    | queries | unique documents |
+| ---------------------------------------- | ------- | ---------------- |
+| `02-school-fundamentals-eval-retrieval`  | 156     | 156              |
+| `03-university-core-eval-retrieval`      | 641     | 641              |
+| `04-advanced-scholarship-eval-retrieval` | 2652    | 2652             |
+
+2652 candidates is 221× the current advanced-stage candidate set. Additional
+shards may be passed as pure distractors to grow the pool further without
+adding queries.
+
+Reported per run:
+
+- `top1_accuracy`, `mrr`, `recall@k` — same definitions as the in-batch eval,
+  so the two are directly comparable at differing pool sizes.
+- `ndcg_at_10` — with exactly one relevant document per query this is
+  `1/log2(rank+1)` when `rank <= 10` and `0` otherwise.
+- `ranks.mean`, `median`, `p90`, `p99`, `worst`, and `beyond_100` — the tail
+  shape that aggregate ratios and a maximum alone can hide. `beyond_100`
+  counts positives outside a plausible first-stage re-ranking window.
+- `pool.documents`, `pool.queries` — always emitted. If the pool is ever
+  subsampled the report must say by how much; a silently truncated pool would
+  read as a harder benchmark than it was.
+
+## Correctness constraints
+
+**Prefixes and truncation come from the task adapter, never from this
+command.** Retrieval text is framed by `TaskConfig::RetrievalRepresentation`'s
+`query_prefix` / `document_prefix` (defaults `"Represent this query for
+retrieval:\n"` and `"Represent this document for retrieval:\n"`) and encoded by
+`data::structured::encode_retrieval_text`, which owns EOS placement,
+`end_position`, and truncation of the document body. A prompt assembled by hand
+here would be out of distribution and would report a fake failure — this has
+already happened once on the `qa_reasoning` path.
+
+**A document id names one model-visible text.** Repeated `document_id`s collapse
+to one pool slot only when their adapter-framed, truncated tokens are equal. A
+collision carrying different visible text fails the run; keeping the first
+silently could score a later query against the wrong positive.
+
+**The read-out layer must match the training phase.** `--retrieval-layer` is
+validated against the model by `validate_retrieval_layer_for_model`, exactly as
+in `eval`. The 300M run trained retrieval at layer 24 with temperature 0.05;
+reading any other layer measures an untrained projection.
+
+**Ranking must not be optimistic on ties.** Scores use the same deterministic
+tie-break as first-index argmax: a candidate tied with the positive ranks ahead
+of it when its pool index is lower. Embeddings are L2-normalized by
+`forward_embeddings`, so the dot product is cosine similarity and temperature
+does not affect ordering.
+
+**Padding is asserted, not assumed, to be inert.** `encode_retrieval_text` pads
+to `--sequence-length` with EOS and records the true `end_position`. Reading the
+embedding at `end_position` under a causal model (both the attention and SSM
+blocks are causal) cannot depend on later positions, so shorter padding would
+be mathematically identical. v1 pads everything to `--sequence-length` anyway,
+matching training geometry exactly; a length-bucketing optimization may follow
+only with a test pinning bitwise-equal embeddings.
+
+## Shape
+
+New subcommand rather than a flag on `eval`, because the flow is two-pass
+(embed pool, then rank queries) where `eval` is single-pass streaming, and
+because it emits a different report schema:
+
+```
+hermes-train retrieval-pool-eval \
+  --config <config.json> --tokenizer <tokenizer.json> --checkpoint <weights.safetensors> \
+  --data <shard.jsonl.zst>... [--distractors <shard.jsonl.zst>...] \
+  --sequence-length 1024 --batch-size 16 \
+  --retrieval-layer 24 --recall-k 10 \
+  -o report.json
+```
+
+It inherits `eval`'s safety properties: forward-only, never `.autodiff()`, no
+token cache writes, and `RESERVED_OUTPUT_NAMES` refused for `--output` so a
+mistyped path cannot overwrite a live run's state.
+
+## Tests
+
+- Pool larger than one batch ranks correctly across the batch boundary — the
+  regression that a per-batch implementation would pass and this must not.
+- Metrics are finite, deterministic across two runs, and ordered
+  `top1 <= mrr <= 1` and `top1 <= recall@k <= 1`.
+- Rank-distribution percentiles distinguish one catastrophic outlier from a
+  systematically heavy tail even when both inputs have the same worst rank.
+- Prefixes in the emitted `task` block equal the adapter defaults, pinning that
+  they were not reconstructed locally.
+- A `--retrieval-layer` outside the model is rejected.
+- Duplicate `document_id`s across shards collapse to one pool entry, and a
+  query whose positive appears twice still resolves to its own document;
+  duplicate ids with different model-visible text are rejected.
+- Reported `pool.documents` equals the distinct ids actually embedded.

--- a/docs/training-objectives-and-curricula.md
+++ b/docs/training-objectives-and-curricula.md
@@ -215,6 +215,13 @@ task defaults. In-batch negatives make retrieval accuracy depend on the
 candidate-pool size, so a trailing batch that cannot be filled is dropped and
 counted in `dropped_samples`; token-weighted language losses score it exactly.
 
+For measurements that the streaming evaluator cannot make, use
+[`retrieval-pool-eval`](retrieval-pool-eval.md) to rank against one global
+candidate pool and [`generate-eval`](generation-eval.md) to score free-running
+decodes. The former exposes retrieval regressions after the in-batch metric
+saturates; the latter catches generation failures that teacher-forced loss can
+hide.
+
 ### Supervised-generation objectives
 
 `--objective summarization`, `instruction_tuning`, `qa_reasoning`, and

--- a/hermes-train/src/data.rs
+++ b/hermes-train/src/data.rs
@@ -34,8 +34,10 @@ pub(crate) use batch::{
     BatchStats, EncodedText, LanguageBatch, RetrievalBatch, TrainingBatch, TrainingSample,
     make_batch,
 };
-pub(crate) use structured::OversizedRecordPolicy;
 use structured::visit_structured_samples;
+pub(crate) use structured::{
+    OversizedRecordPolicy, OversizedSupervisedRecord, encode_retrieval_text, frame_supervised,
+};
 
 const TOKENIZE_BATCH: usize = 1_000;
 const TOKEN_CACHE_MAGIC: &[u8; 8] = b"HERTOK01";
@@ -138,7 +140,7 @@ impl PhaseDataBinding {
 
     /// Stream every source through authenticated handles. The final identity
     /// check deliberately runs even when the visitor errors or exits early.
-    fn with_readers(
+    pub(crate) fn with_readers(
         &self,
         path: &Path,
         mut visit: impl FnMut(&Path, &mut dyn BufRead) -> Result<bool>,

--- a/hermes-train/src/data/structured.rs
+++ b/hermes-train/src/data/structured.rs
@@ -105,7 +105,30 @@ fn encode_tokens(tokenizer: &Tokenizer, text: &str) -> Result<Vec<i64>> {
         .collect())
 }
 
-fn make_supervised_sample(
+/// One supervised record split into the tokens the model is prompted with and
+/// the tokens it is supervised to produce.
+///
+/// Training and free-running decoding both consume this, so a decode prompt is
+/// the training prompt by construction rather than by convention. Assembling a
+/// prompt independently would put it out of distribution and make a healthy
+/// model look broken — a mistake already made once by hand.
+pub(crate) struct SupervisedFraming {
+    pub(crate) prompt_tokens: Vec<i64>,
+    /// Token range inside `prompt_tokens` that came from the truncatable source.
+    /// Generation metrics use this rather than the original source so text the
+    /// model never saw cannot count as grounded overlap.
+    pub(crate) source_range: std::ops::Range<usize>,
+    pub(crate) target_tokens: Vec<i64>,
+    pub(crate) truncated_tokens: usize,
+}
+
+/// Tokenize and truncate one supervised record at `seq_len`.
+///
+/// The source is the only truncatable part, and the target's own length is
+/// reserved before truncating it. Decoding therefore has to supply the gold
+/// target too: reserving the same budget is what makes the generated prompt
+/// identical to the one the loss was measured against.
+pub(crate) fn frame_supervised(
     tokenizer: &Tokenizer,
     prefix: &str,
     source: &str,
@@ -113,7 +136,7 @@ fn make_supervised_sample(
     target: &str,
     seq_len: usize,
     source_required: bool,
-) -> Result<TrainingSample> {
+) -> Result<SupervisedFraming> {
     let prefix = encode_tokens(tokenizer, prefix)?;
     let source = encode_tokens(tokenizer, source)?;
     let suffix = encode_tokens(tokenizer, suffix)?;
@@ -149,27 +172,68 @@ fn make_supervised_sample(
     let kept_source = source.len().min(capacity - fixed_tokens);
     debug_assert!(!source_required || kept_source > 0);
     let truncated_tokens = source.len() - kept_source;
-    let prompt_len = prefix.len() + kept_source + suffix.len();
-    ensure!(prompt_len > 0, "supervised prompt tokenized to empty");
 
-    let mut tokens = Vec::with_capacity(capacity);
-    tokens.extend(prefix);
-    tokens.extend_from_slice(&source[..kept_source]);
-    tokens.extend(suffix);
-    tokens.extend(target.iter().copied());
-    tokens.push(i64::from(tokenizer.eos_token_id()));
-    tokens.resize(capacity, i64::from(tokenizer.eos_token_id()));
-
-    // Combined token `i` is target position `i - 1` in the shifted batch.
-    let loss_positions = (prompt_len - 1..prompt_len + target.len()).collect();
-    Ok(TrainingSample::Supervised {
-        tokens,
-        loss_positions,
+    let source_start = prefix.len();
+    let source_end = source_start + kept_source;
+    let mut prompt_tokens = Vec::with_capacity(prefix.len() + kept_source + suffix.len());
+    prompt_tokens.extend(prefix);
+    prompt_tokens.extend_from_slice(&source[..kept_source]);
+    prompt_tokens.extend(suffix);
+    ensure!(
+        !prompt_tokens.is_empty(),
+        "supervised prompt tokenized to empty"
+    );
+    Ok(SupervisedFraming {
+        prompt_tokens,
+        source_range: source_start..source_end,
+        target_tokens: target,
         truncated_tokens,
     })
 }
 
-fn encode_retrieval_text(
+fn make_supervised_sample(
+    tokenizer: &Tokenizer,
+    prefix: &str,
+    source: &str,
+    suffix: &str,
+    target: &str,
+    seq_len: usize,
+    source_required: bool,
+) -> Result<TrainingSample> {
+    let framing = frame_supervised(
+        tokenizer,
+        prefix,
+        source,
+        suffix,
+        target,
+        seq_len,
+        source_required,
+    )?;
+    let capacity = seq_len + 1;
+    let prompt_len = framing.prompt_tokens.len();
+    let target_len = framing.target_tokens.len();
+
+    let mut tokens = Vec::with_capacity(capacity);
+    tokens.extend(framing.prompt_tokens);
+    tokens.extend(framing.target_tokens);
+    tokens.push(i64::from(tokenizer.eos_token_id()));
+    tokens.resize(capacity, i64::from(tokenizer.eos_token_id()));
+
+    // Combined token `i` is target position `i - 1` in the shifted batch.
+    let loss_positions = (prompt_len - 1..prompt_len + target_len).collect();
+    Ok(TrainingSample::Supervised {
+        tokens,
+        loss_positions,
+        truncated_tokens: framing.truncated_tokens,
+    })
+}
+
+/// Frame one retrieval text exactly as retrieval training frames it: task
+/// prefix segments kept whole, the document body truncated to fit, EOS appended,
+/// and `end_position` pointing at that EOS. The pool evaluator shares this so a
+/// pool embedding is never computed from a differently framed prompt than the
+/// one the objective was trained on.
+pub(crate) fn encode_retrieval_text(
     tokenizer: &Tokenizer,
     text: &SegmentedText,
     seq_len: usize,
@@ -363,6 +427,50 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+    use crate::data::write_test_tokenizer;
+
+    /// The guarantee `generate-eval` rests on: the tokens a decode is prompted
+    /// with are exactly the training sample's tokens up to the target. Training
+    /// and decoding share [`frame_supervised`], and this pins that they cannot
+    /// drift apart — a hand-built prompt would be out of distribution and would
+    /// report a failure that is not there.
+    #[test]
+    fn the_decode_prompt_is_the_training_sample_prefix() {
+        let directory = tempfile::tempdir().unwrap();
+        let tokenizer = write_test_tokenizer(directory.path());
+        let seq_len = 96;
+        let (prefix, source, suffix, target) = (
+            "Follow the instruction.\n\nInstruction:\n",
+            "summarize this held-out source text",
+            "\n\nResponse:\n",
+            "a short response",
+        );
+        let framing =
+            frame_supervised(&tokenizer, prefix, source, suffix, target, seq_len, true).unwrap();
+        let TrainingSample::Supervised { tokens, .. } =
+            make_supervised_sample(&tokenizer, prefix, source, suffix, target, seq_len, true)
+                .unwrap()
+        else {
+            panic!("expected a supervised sample")
+        };
+        assert_eq!(
+            framing.prompt_tokens,
+            tokens[..framing.prompt_tokens.len()],
+            "decode prompt diverged from the training prompt prefix"
+        );
+        assert_eq!(
+            framing.target_tokens,
+            tokens[framing.prompt_tokens.len()
+                ..framing.prompt_tokens.len() + framing.target_tokens.len()],
+            "target tokens diverged from the training sample"
+        );
+        let encoded_source = encode_tokens(&tokenizer, source).unwrap();
+        assert_eq!(
+            &framing.prompt_tokens[framing.source_range.clone()],
+            &encoded_source[..framing.source_range.len()],
+            "visible source range does not identify the source inside the prompt"
+        );
+    }
 
     fn assert_supervised_contract(
         task: TaskConfig,

--- a/hermes-train/src/eval.rs
+++ b/hermes-train/src/eval.rs
@@ -34,8 +34,9 @@ use crate::{
 ///
 /// v2 added the four supervised-generation objectives: the `task` block that
 /// pins their prompt framing, the `supervised_generation` metrics block, and
-/// `oversized_records`.
-const EVAL_REPORT_VERSION: u32 = 2;
+/// `oversized_records`. v3 makes retrieval rank metrics use the same
+/// deterministic first-index tie-break as top-1 argmax.
+const EVAL_REPORT_VERSION: u32 = 3;
 
 /// File names the trainer publishes inside its own output root. Refusing them
 /// keeps a mistyped `--output` from overwriting a live run's state with a
@@ -78,6 +79,29 @@ impl WeightedMean {
     fn mean(&self) -> Option<f64> {
         (self.weight > 0.0).then(|| self.weighted_sum / self.weight)
     }
+}
+
+/// One-based rank under the same deterministic tie-break as an argmax that
+/// returns the lowest candidate index. A positive tied with an earlier
+/// candidate is therefore not awarded an optimistic rank of one.
+pub(super) fn rank_with_index_tiebreak(scores: &[f32], positive_index: usize) -> Result<usize> {
+    let positive = *scores.get(positive_index).with_context(|| {
+        format!(
+            "positive index {positive_index} is outside {} scores",
+            scores.len()
+        )
+    })?;
+    ensure!(
+        scores.iter().all(|score| score.is_finite()),
+        "retrieval scores contain a non-finite value"
+    );
+    Ok(1 + scores
+        .iter()
+        .enumerate()
+        .filter(|(index, score)| {
+            **score > positive || (**score == positive && *index < positive_index)
+        })
+        .count())
 }
 
 #[derive(Debug, Serialize)]
@@ -295,10 +319,7 @@ impl<'a> Evaluation<'a> {
                             format!("retrieval label {label} is outside {candidates} candidates")
                         })?;
                     let row = &scores[query * candidates..(query + 1) * candidates];
-                    let positive = row[label];
-                    // Count strictly better candidates so tied scores never
-                    // produce an optimistic rank of zero.
-                    let rank = 1 + row.iter().filter(|score| **score > positive).count();
+                    let rank = rank_with_index_tiebreak(row, label)?;
                     self.retrieval_reciprocal_rank.push(1.0 / rank as f64, 1)?;
                     self.retrieval_recall_at_k
                         .push(f64::from(u8::from(rank <= self.recall_k)), 1)?;
@@ -438,20 +459,20 @@ impl EvalArgs {
 
 /// Deserialize a task by tag alone, so every field this command does not expose
 /// keeps the built-in default a workflow phase would get.
-fn task_defaults(name: &str) -> Result<TaskConfig> {
+pub(super) fn task_defaults(name: &str) -> Result<TaskConfig> {
     serde_json::from_value(json!({"type": name}))
         .with_context(|| format!("built-in `{name}` task defaults are invalid"))
 }
 
 /// Report a degraded or adjusted condition to both the operator and the report.
 /// `tracing` alone is not enough here: the CLI's default filter hides warnings.
-fn warn_operator(warnings: &mut Vec<String>, message: String) {
+pub(super) fn warn_operator(warnings: &mut Vec<String>, message: String) {
     eprintln!("warning: {message}");
     warn!("{message}");
     warnings.push(message);
 }
 
-fn validate_report_path(output: &Path) -> Result<()> {
+pub(super) fn validate_report_path(output: &Path) -> Result<()> {
     ensure!(
         !output.is_dir(),
         "--output {} is a directory",
@@ -515,7 +536,8 @@ pub(super) fn evaluate(args: EvalArgs) -> Result<()> {
         args.sequence_length,
         config.max_seq_len
     );
-    if let Some(layer) = objective.retrieval_layer() {
+    if matches!(objective, TaskConfig::RetrievalRepresentation { .. }) {
+        let layer = objective.retrieval_layer().unwrap_or(config.num_layers);
         validate_retrieval_layer_for_model(layer, &config, "eval")?;
     }
 
@@ -752,6 +774,20 @@ mod tests {
 
     use super::*;
     use crate::data::write_test_tokenizer;
+
+    #[test]
+    fn retrieval_rank_uses_the_same_first_index_tiebreak_as_top1() {
+        let scores = [0.5, 1.0, 1.0, 0.25];
+        let device = hermes_llm::default_device();
+        let argmax = burn::tensor::Tensor::<1>::from_floats(scores, &device)
+            .argmax(0)
+            .into_scalar::<i64>();
+        assert_eq!(argmax, 1, "backend argmax tie-break changed");
+        assert_eq!(rank_with_index_tiebreak(&scores, 1).unwrap(), 1);
+        assert_eq!(rank_with_index_tiebreak(&scores, 2).unwrap(), 2);
+        assert!(rank_with_index_tiebreak(&scores, 4).is_err());
+        assert!(rank_with_index_tiebreak(&[0.5, f32::NAN], 0).is_err());
+    }
 
     /// `max_seq_len` must clear the supervised objectives' fixed prompt framing:
     /// their built-in instructions plus target markers already occupy more than
@@ -1238,7 +1274,7 @@ model tiny {
         arguments.instruction = Some("Answer from the passages.".to_owned());
         evaluate(arguments).unwrap();
         let parsed = report(&fixture.output);
-        assert_eq!(parsed["version"], 2, "{parsed}");
+        assert_eq!(parsed["version"], 3, "{parsed}");
         assert_eq!(parsed["task"]["type"], "qa_reasoning", "{parsed}");
         assert_eq!(
             parsed["task"]["instruction"], "Answer from the passages.",

--- a/hermes-train/src/generate_eval.rs
+++ b/hermes-train/src/generate_eval.rs
@@ -1,0 +1,842 @@
+//! Free-running generation evaluation of a published checkpoint.
+//!
+//! `eval` measures teacher-forced loss: given a correct target prefix, how well
+//! the model predicts the next token. That number can improve while autoregressive
+//! decoding collapses into copying, and on this project it did — the 300M run's
+//! grounded-QA perplexity fell 17% across a corrective SFT pass whose decodes
+//! were still degenerate. Perplexity and generation measure different things and
+//! both are required.
+//!
+//! Prompts come from [`TaskConfig::construct_supervised_prompt`] and
+//! [`frame_supervised`], the same pair training uses, so the decode prompt is the
+//! training prompt by construction. Hand-assembling one puts it out of
+//! distribution and reports a failure that is not there; that has already
+//! happened once, on `qa_reasoning`, and this command exists partly to make it
+//! impossible.
+//!
+//! Design: `docs/generation-eval.md`.
+
+use std::fs;
+use std::io::{BufRead, Read};
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{Context, Result, ensure};
+use hermes_llm::generate::SamplingConfig;
+use hermes_llm::{TextGenerator, Tokenizer, Transformer};
+use hermes_train::task::{TaskAdapter, TaskConfig};
+use serde::Serialize;
+
+use crate::data::{OversizedSupervisedRecord, PhaseDataBinding, frame_supervised};
+use crate::eval::{task_defaults, validate_report_path, warn_operator};
+use crate::{GenerateEvalArgs, file_sha256, load_config};
+
+/// Report schema version. Increment when a field changes meaning.
+const GENERATE_EVAL_REPORT_VERSION: u32 = 1;
+
+/// A generation whose most frequent word trigram occupies more than this share
+/// of all its trigrams is counted degenerate. Chosen because healthy short
+/// answers on this data sit near zero while the observed collapse
+/// ("Berlin, Berlin, Berlin, …") sits far above it.
+const DEGENERATE_TRIGRAM_RATE: f64 = 0.10;
+
+/// One malformed record must not make evaluation allocate an unbounded line.
+const MAX_RECORD_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Debug, Serialize)]
+struct GenerateDataSource {
+    path: String,
+    identity: String,
+    records_read: usize,
+    /// Records skipped because prompt, target, and EOS exceed
+    /// `--sequence-length`. Excluded from every reported number, exactly as
+    /// `eval` excludes them.
+    oversized_records: usize,
+}
+
+/// Decode-quality statistics. Every field is a mean over scored records, so a
+/// report is comparable across checkpoints only at the same `--max-new-tokens`
+/// and decoding settings, which the report pins.
+#[derive(Debug, Serialize)]
+struct GenerationMetrics {
+    /// Share of a generation's word trigrams taken by its single most frequent
+    /// one, averaged. Rises with repetition; zero when every trigram is unique.
+    repeated_trigram_rate: f64,
+    /// Share of generations above [`DEGENERATE_TRIGRAM_RATE`].
+    degenerate_fraction: f64,
+    /// Share whose lowercase alphanumeric word sequence contains the complete
+    /// gold target word sequence. A blunt correctness floor: it counts exact
+    /// inclusion only, so a right answer phrased differently scores zero.
+    target_containment: f64,
+    /// Share of a generation's word 4-grams that also occur in the prompt's
+    /// source text. Interpretation is task-dependent — extraction is the goal for
+    /// grounded QA and the failure mode for summarization — so this is reported
+    /// without a verdict.
+    source_overlap: f64,
+    empty_fraction: f64,
+    /// Share that ended by emitting EOS instead of hitting `--max-new-tokens`.
+    /// A low value alongside a high repeated-trigram rate is the signature of a
+    /// model that cannot stop.
+    stopped_at_eos: f64,
+    mean_generated_tokens: f64,
+    mean_generated_words: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct GenerationSample {
+    prompt: String,
+    generated: String,
+    target: String,
+    repeated_trigram_rate: f64,
+    contains_target: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct GenerateEvalReport {
+    version: u32,
+    objective: &'static str,
+    task: TaskConfig,
+    config: String,
+    config_sha256: String,
+    tokenizer: String,
+    tokenizer_sha256: String,
+    checkpoint: String,
+    checkpoint_sha256: String,
+    device: String,
+    sequence_length: usize,
+    max_new_tokens: usize,
+    temperature: f64,
+    top_k: Option<usize>,
+    repetition_penalty: f64,
+    seed: u64,
+    data: Vec<GenerateDataSource>,
+    scored_records: usize,
+    oversized_records: usize,
+    truncated_tokens: usize,
+    warnings: Vec<String>,
+    generation: GenerationMetrics,
+    /// Verbatim decodes, written only when `--samples` asks for them. Reviewing
+    /// these is what caught the degenerate decoding that perplexity hid.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    samples: Vec<GenerationSample>,
+}
+
+/// Lowercase alphanumeric words, the comparison basis for every text metric here.
+fn words(text: &str) -> Vec<String> {
+    text.split(|character: char| !character.is_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .map(str::to_lowercase)
+        .collect()
+}
+
+/// Share of `text`'s word trigrams taken by its most frequent trigram, excluding
+/// that trigram's first occurrence so unique text scores zero.
+fn repeated_trigram_rate(words: &[String]) -> f64 {
+    if words.len() < 5 {
+        return 0.0;
+    }
+    let mut counts = std::collections::HashMap::new();
+    let total = words.len() - 2;
+    for window in words.windows(3) {
+        *counts.entry(window).or_insert(0usize) += 1;
+    }
+    let most = counts.values().copied().max().unwrap_or(1);
+    (most - 1) as f64 / total as f64
+}
+
+/// Share of `generated`'s word 4-grams that also occur in `source`.
+fn source_overlap(generated: &[String], source: &[String]) -> f64 {
+    if generated.len() < 4 {
+        return 0.0;
+    }
+    let reference: std::collections::HashSet<&[String]> = source.windows(4).collect();
+    let windows = generated.windows(4);
+    let total = windows.len();
+    let shared = generated
+        .windows(4)
+        .filter(|window| reference.contains(*window))
+        .count();
+    shared as f64 / total as f64
+}
+
+fn contains_word_sequence(generated: &[String], target: &[String]) -> bool {
+    !target.is_empty()
+        && target.len() <= generated.len()
+        && generated
+            .windows(target.len())
+            .any(|window| window == target)
+}
+
+/// Running mean that reports zero records as absent rather than as zero.
+#[derive(Default)]
+struct Mean {
+    total: f64,
+    count: usize,
+}
+
+impl Mean {
+    fn push(&mut self, value: f64) {
+        self.total += value;
+        self.count += 1;
+    }
+
+    fn value(&self) -> f64 {
+        if self.count == 0 {
+            return 0.0;
+        }
+        self.total / self.count as f64
+    }
+}
+
+pub(super) fn evaluate(args: GenerateEvalArgs) -> Result<()> {
+    let started = Instant::now();
+    if let Some(output) = &args.output {
+        validate_report_path(output)?;
+    }
+    if let Some(samples) = &args.samples {
+        validate_report_path(samples)?;
+    }
+    if let (Some(output), Some(samples)) = (&args.output, &args.samples) {
+        ensure!(
+            output != samples,
+            "--output and --samples must name different files"
+        );
+    }
+    ensure!(
+        args.sequence_length > 0,
+        "--sequence-length must be positive"
+    );
+    ensure!(args.max_new_tokens > 0, "--max-new-tokens must be positive");
+
+    let mut objective = task_defaults(args.objective.task_name())?;
+    if let Some(configured) = &args.instruction {
+        let instruction = match &mut objective {
+            TaskConfig::Summarization { instruction }
+            | TaskConfig::InstructionTuning { instruction }
+            | TaskConfig::RetrievalPlanning { instruction }
+            | TaskConfig::QaReasoning { instruction, .. } => instruction,
+            other => unreachable!("`{}` is not a supervised task", other.name()),
+        };
+        *instruction = configured.clone();
+    }
+    if let TaskConfig::QaReasoning {
+        require_reasoning, ..
+    } = &mut objective
+    {
+        *require_reasoning = args.require_reasoning;
+    } else {
+        ensure!(
+            !args.require_reasoning,
+            "--require-reasoning only applies to --objective qa_reasoning"
+        );
+    }
+    objective.validate()?;
+
+    let mut warnings = Vec::new();
+    let tokenizer = Tokenizer::from_file(&args.tokenizer)?;
+    let mut config = load_config(&args.config)?;
+    if config.vocab_size != tokenizer.vocab_size() {
+        warn_operator(
+            &mut warnings,
+            format!(
+                "model config vocab_size {} differs from tokenizer vocab_size {}; decoding with the tokenizer vocabulary exactly as `train` does",
+                config.vocab_size,
+                tokenizer.vocab_size()
+            ),
+        );
+        config.vocab_size = tokenizer.vocab_size();
+    }
+    ensure!(
+        args.sequence_length <= config.max_seq_len,
+        "--sequence-length {} exceeds model max_seq_len {}",
+        args.sequence_length,
+        config.max_seq_len
+    );
+
+    let device = hermes_llm::default_device();
+    let mut model = Transformer::new(&config, &device)?;
+    hermes_llm::load_safetensors(&mut model, &args.checkpoint).with_context(|| {
+        format!(
+            "checkpoint {} does not match model configuration {}",
+            args.checkpoint.display(),
+            args.config.display()
+        )
+    })?;
+    let generator = TextGenerator::new(&model, &device);
+    let sampling = SamplingConfig {
+        max_new_tokens: args.max_new_tokens,
+        temperature: args.temperature,
+        top_k: args.top_k,
+        repetition_penalty: args.repetition_penalty,
+        eos_token: Some(tokenizer.eos_token_id()),
+        // Always explicit: an unseeded decode would make the report
+        // irreproducible, and greedy decoding ignores it anyway.
+        seed: Some(args.seed),
+    };
+
+    let mut repeated = Mean::default();
+    let mut degenerate = Mean::default();
+    let mut containment = Mean::default();
+    let mut overlap = Mean::default();
+    let mut empty = Mean::default();
+    let mut stopped = Mean::default();
+    let mut generated_tokens = Mean::default();
+    let mut generated_words = Mean::default();
+    let mut truncated_tokens = 0usize;
+    let mut scored_records = 0usize;
+    let mut samples = Vec::new();
+    let mut sources = Vec::with_capacity(args.data.len());
+
+    for path in &args.data {
+        let mut records_read = 0usize;
+        let mut oversized = 0usize;
+        let binding = PhaseDataBinding::open(path)?;
+        binding.with_readers(path, |source_path, reader| {
+            let mut line = String::new();
+            loop {
+                if args
+                    .max_records
+                    .is_some_and(|maximum| scored_records >= maximum)
+                {
+                    return Ok(false);
+                }
+                line.clear();
+                let read = Read::take(&mut *reader, MAX_RECORD_BYTES)
+                    .read_line(&mut line)
+                    .with_context(|| format!("cannot read {}", source_path.display()))?;
+                if read == 0 {
+                    break;
+                }
+                ensure!(
+                    line.ends_with('\n') || read < MAX_RECORD_BYTES as usize,
+                    "record {} in {} exceeds the {MAX_RECORD_BYTES}-byte limit",
+                    records_read + 1,
+                    source_path.display()
+                );
+                if line.trim().is_empty() {
+                    continue;
+                }
+                records_read += 1;
+                let value: serde_json::Value = serde_json::from_str(&line).with_context(|| {
+                    format!(
+                        "cannot parse {}:{records_read} as JSON",
+                        source_path.display()
+                    )
+                })?;
+                let segments =
+                    objective
+                        .construct_supervised_prompt(&value)
+                        .with_context(|| {
+                            format!("invalid record at {}:{records_read}", source_path.display())
+                        })?;
+                let framing = match frame_supervised(
+                    &tokenizer,
+                    &segments.prefix,
+                    &segments.source,
+                    &segments.suffix,
+                    &segments.target,
+                    args.sequence_length,
+                    segments.source_required,
+                ) {
+                    Ok(framing) => framing,
+                    // One over-long held-out record must not void the whole
+                    // evaluation; skip and count it, as `eval` does. The cause
+                    // chain is walked rather than the top-level error so added
+                    // context cannot hide the typed rejection.
+                    Err(error)
+                        if error
+                            .chain()
+                            .any(|cause| cause.is::<OversizedSupervisedRecord>()) =>
+                    {
+                        oversized += 1;
+                        continue;
+                    }
+                    Err(error) => {
+                        return Err(error).with_context(|| {
+                            format!("cannot frame {}:{records_read}", source_path.display())
+                        });
+                    }
+                };
+                truncated_tokens = truncated_tokens
+                    .checked_add(framing.truncated_tokens)
+                    .context("truncated-token count overflows usize")?;
+
+                let prompt_tokens: Vec<u32> = framing
+                    .prompt_tokens
+                    .iter()
+                    .map(|token| u32::try_from(*token).context("prompt token exceeds u32"))
+                    .collect::<Result<_>>()?;
+                let visible_source =
+                    tokenizer.decode(&prompt_tokens[framing.source_range.clone()], true)?;
+                let decoded = generator.generate(&prompt_tokens, &sampling)?;
+                let new_tokens = &decoded[prompt_tokens.len()..];
+                let ended_at_eos = new_tokens
+                    .last()
+                    .is_some_and(|token| *token == tokenizer.eos_token_id());
+                let new_tokens = if ended_at_eos {
+                    &new_tokens[..new_tokens.len() - 1]
+                } else {
+                    new_tokens
+                };
+                let text = tokenizer.decode(new_tokens, true)?;
+                let text = text.trim();
+
+                let generated = words(text);
+                let source = words(&visible_source);
+                let rate = repeated_trigram_rate(&generated);
+                let normalized_target = words(&segments.target);
+                let contains_target = contains_word_sequence(&generated, &normalized_target);
+
+                repeated.push(rate);
+                degenerate.push(f64::from(u8::from(rate > DEGENERATE_TRIGRAM_RATE)));
+                containment.push(f64::from(u8::from(contains_target)));
+                overlap.push(source_overlap(&generated, &source));
+                empty.push(f64::from(u8::from(text.is_empty())));
+                stopped.push(f64::from(u8::from(ended_at_eos)));
+                generated_tokens.push(new_tokens.len() as f64);
+                generated_words.push(generated.len() as f64);
+                scored_records += 1;
+
+                if args.samples.is_some() {
+                    samples.push(GenerationSample {
+                        prompt: tokenizer.decode(&prompt_tokens, true)?,
+                        generated: text.to_owned(),
+                        target: segments.target.to_string(),
+                        repeated_trigram_rate: rate,
+                        contains_target,
+                    });
+                }
+            }
+            Ok(true)
+        })?;
+        if oversized > 0 {
+            warn_operator(
+                &mut warnings,
+                format!(
+                    "skipped {oversized} record(s) in {} whose prompt, complete target, and EOS exceed --sequence-length {}",
+                    path.display(),
+                    args.sequence_length
+                ),
+            );
+        }
+        sources.push(GenerateDataSource {
+            path: path.display().to_string(),
+            identity: binding.signature_identity().to_owned(),
+            records_read,
+            oversized_records: oversized,
+        });
+    }
+    ensure!(
+        scored_records > 0,
+        "held-out data produced no scorable record"
+    );
+
+    let oversized_records = sources.iter().map(|source| source.oversized_records).sum();
+    let report = GenerateEvalReport {
+        version: GENERATE_EVAL_REPORT_VERSION,
+        objective: objective.name(),
+        task: objective.clone(),
+        config: args.config.display().to_string(),
+        config_sha256: file_sha256(&args.config)?,
+        tokenizer: args.tokenizer.display().to_string(),
+        tokenizer_sha256: file_sha256(&args.tokenizer)?,
+        checkpoint: args.checkpoint.display().to_string(),
+        checkpoint_sha256: file_sha256(&args.checkpoint)?,
+        device: format!("{device:?}"),
+        sequence_length: args.sequence_length,
+        max_new_tokens: args.max_new_tokens,
+        temperature: args.temperature,
+        top_k: args.top_k,
+        repetition_penalty: args.repetition_penalty,
+        seed: args.seed,
+        data: sources,
+        scored_records,
+        oversized_records,
+        truncated_tokens,
+        warnings,
+        generation: GenerationMetrics {
+            repeated_trigram_rate: repeated.value(),
+            degenerate_fraction: degenerate.value(),
+            target_containment: containment.value(),
+            source_overlap: overlap.value(),
+            empty_fraction: empty.value(),
+            stopped_at_eos: stopped.value(),
+            mean_generated_tokens: generated_tokens.value(),
+            mean_generated_words: generated_words.value(),
+        },
+        samples: if args.samples.is_some() {
+            std::mem::take(&mut samples)
+        } else {
+            Vec::new()
+        },
+    };
+    if let Some(path) = &args.samples {
+        write_json(&report.samples, path)?;
+    }
+    let mut published = report;
+    if args.samples.is_some() {
+        // The samples file owns the verbatim decodes; keeping them in the metrics
+        // report too would silently double a large artifact.
+        published.samples = Vec::new();
+    }
+    if let Some(path) = &args.output {
+        write_json(&published, path)?;
+    }
+    print_summary(&published, started.elapsed().as_secs_f64());
+    Ok(())
+}
+
+fn write_json<T: Serialize>(value: &T, output: &Path) -> Result<()> {
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("cannot create directory {}", parent.display()))?;
+    }
+    let mut encoded = serde_json::to_vec_pretty(value)?;
+    encoded.push(b'\n');
+    fs::write(output, encoded).with_context(|| format!("cannot write {}", output.display()))
+}
+
+fn print_summary(report: &GenerateEvalReport, elapsed_seconds: f64) {
+    println!("objective            {}", report.objective);
+    println!(
+        "checkpoint           {} ({})",
+        report.checkpoint, report.checkpoint_sha256
+    );
+    println!(
+        "decoding             {} new token(s), temperature {}, repetition_penalty {}, seed {}",
+        report.max_new_tokens, report.temperature, report.repetition_penalty, report.seed
+    );
+    println!(
+        "records              {} scored, {} oversized, {} truncated token(s)",
+        report.scored_records, report.oversized_records, report.truncated_tokens
+    );
+    let generation = &report.generation;
+    println!(
+        "repeated 3-grams     {:.4} mean, {:.4} degenerate (>{DEGENERATE_TRIGRAM_RATE})",
+        generation.repeated_trigram_rate, generation.degenerate_fraction
+    );
+    println!("target containment   {:.4}", generation.target_containment);
+    println!("source overlap       {:.4}", generation.source_overlap);
+    println!(
+        "stopped at eos       {:.4} ({:.1} token(s), {:.1} word(s) mean)",
+        generation.stopped_at_eos,
+        generation.mean_generated_tokens,
+        generation.mean_generated_words
+    );
+    if generation.empty_fraction > 0.0 {
+        println!("empty generations    {:.4}", generation.empty_fraction);
+    }
+    for warning in &report.warnings {
+        println!("warning              {warning}");
+    }
+    println!("elapsed              {elapsed_seconds:.2}s");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use hermes_llm::parse_mal;
+
+    use super::*;
+    use crate::GenerationObjective;
+    use crate::data::write_test_tokenizer;
+
+    const GENERATE_MODEL: &str = r#"
+ffn base { hidden_dim: 12 activation: swiglu dropout: 0.0 }
+model tiny {
+    vocab_size: 257 max_seq_len: 256 hidden_size: 8 num_layers: 2
+    block: {
+        attention: { num_heads: 1 dropout: 0.0 position_encoding: none }
+        ffn: base
+        dropout: 0.0
+    }
+}
+"#;
+
+    /// Wide enough for the supervised instruction, markers, and record text.
+    const GENERATE_SEQUENCE_LENGTH: usize = 192;
+
+    struct Fixture {
+        _directory: tempfile::TempDir,
+        root: PathBuf,
+        config: PathBuf,
+        tokenizer: PathBuf,
+        checkpoint: PathBuf,
+        data: PathBuf,
+        output: PathBuf,
+    }
+
+    fn fixture(records: &str) -> Fixture {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().to_owned();
+        let config = root.join("model.mal");
+        fs::write(&config, GENERATE_MODEL).unwrap();
+        write_test_tokenizer(&root);
+        let device = hermes_llm::default_device();
+        device.seed(7);
+        let model = Transformer::new(&parse_mal(GENERATE_MODEL).unwrap(), &device).unwrap();
+        let checkpoint = root.join("weights.safetensors");
+        hermes_llm::save_safetensors(&model, &checkpoint).unwrap();
+        let data = root.join("holdout.jsonl");
+        fs::write(&data, records).unwrap();
+        Fixture {
+            _directory: directory,
+            tokenizer: root.join("tokenizer.json"),
+            output: root.join("reports/generate.json"),
+            root,
+            config,
+            checkpoint,
+            data,
+        }
+    }
+
+    fn args(fixture: &Fixture, objective: GenerationObjective) -> GenerateEvalArgs {
+        GenerateEvalArgs {
+            config: fixture.config.clone(),
+            tokenizer: fixture.tokenizer.clone(),
+            checkpoint: fixture.checkpoint.clone(),
+            data: vec![fixture.data.clone()],
+            objective,
+            sequence_length: GENERATE_SEQUENCE_LENGTH,
+            max_new_tokens: 8,
+            temperature: 0.0,
+            top_k: None,
+            repetition_penalty: 1.0,
+            seed: 0,
+            max_records: None,
+            instruction: None,
+            require_reasoning: false,
+            samples: None,
+            output: Some(fixture.output.clone()),
+        }
+    }
+
+    fn qa_records(rows: usize) -> String {
+        (0..rows)
+            .map(|index| {
+                format!(
+                    "{{\"question\":\"question {index} about a topic\",\"answer\":\"answer {index}\"}}\n"
+                )
+            })
+            .collect()
+    }
+
+    fn report(path: &Path) -> serde_json::Value {
+        serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+    }
+
+    fn word_list(text: &str) -> Vec<String> {
+        words(text)
+    }
+
+    #[test]
+    fn repeated_trigram_rate_separates_unique_text_from_a_collapsed_loop() {
+        assert_eq!(
+            repeated_trigram_rate(&word_list("alpha beta gamma delta epsilon zeta")),
+            0.0,
+            "text with no repeated trigram must score zero"
+        );
+        // "berlin berlin berlin" repeats across a 7-word run: 5 trigrams, the
+        // most frequent occurring 3 times.
+        let looped = word_list("paris berlin berlin berlin berlin berlin berlin");
+        let rate = repeated_trigram_rate(&looped);
+        assert!(rate > 0.5, "collapsed loop scored {rate}");
+        // Too short to have a meaningful trigram profile.
+        assert_eq!(repeated_trigram_rate(&word_list("one two")), 0.0);
+    }
+
+    #[test]
+    fn source_overlap_counts_only_shared_four_grams() {
+        let source = word_list("the capital of france is paris on the river seine");
+        assert_eq!(
+            source_overlap(&word_list("the capital of france"), &source),
+            1.0,
+            "a verbatim quote must score one"
+        );
+        assert_eq!(
+            source_overlap(&word_list("entirely different words here now"), &source),
+            0.0
+        );
+        // Shorter than one 4-gram: nothing to compare.
+        assert_eq!(source_overlap(&word_list("paris"), &source), 0.0);
+    }
+
+    #[test]
+    fn target_containment_matches_words_not_substrings() {
+        let generated = word_list("Russia and Belarus are countries");
+        assert!(contains_word_sequence(&generated, &word_list("Belarus")));
+        assert!(!contains_word_sequence(&generated, &word_list("US")));
+        assert!(contains_word_sequence(
+            &generated,
+            &word_list("Russia and Belarus")
+        ));
+        assert!(!contains_word_sequence(&generated, &[]));
+    }
+
+    #[test]
+    fn generation_metrics_are_finite_in_range_and_deterministic() {
+        let fixture = fixture(&qa_records(4));
+        evaluate(args(&fixture, GenerationObjective::QaReasoning)).unwrap();
+        let first = report(&fixture.output);
+        evaluate(args(&fixture, GenerationObjective::QaReasoning)).unwrap();
+        assert_eq!(
+            first,
+            report(&fixture.output),
+            "greedy decoding is not reproducible"
+        );
+        assert_eq!(
+            first.pointer("/scored_records").unwrap().as_u64(),
+            Some(4),
+            "{first}"
+        );
+        for field in [
+            "repeated_trigram_rate",
+            "degenerate_fraction",
+            "target_containment",
+            "source_overlap",
+            "empty_fraction",
+            "stopped_at_eos",
+        ] {
+            let value = first
+                .pointer(&format!("/generation/{field}"))
+                .unwrap_or_else(|| panic!("no {field}: {first}"))
+                .as_f64()
+                .unwrap();
+            assert!(
+                value.is_finite() && (0.0..=1.0).contains(&value),
+                "{field} is {value}"
+            );
+        }
+    }
+
+    /// `--max-records` bounds an autoregressive pass without reading the rest of
+    /// the shard once the requested number of decodes exists.
+    #[test]
+    fn max_records_bounds_the_pass_and_reports_the_bound() {
+        let fixture = fixture(&qa_records(6));
+        let mut arguments = args(&fixture, GenerationObjective::QaReasoning);
+        arguments.max_records = Some(2);
+        evaluate(arguments).unwrap();
+        let parsed = report(&fixture.output);
+        assert_eq!(
+            parsed.pointer("/scored_records").unwrap().as_u64(),
+            Some(2),
+            "{parsed}"
+        );
+    }
+
+    /// Decodes belong in the samples file only. Serializing them into the metrics
+    /// report as well would silently double a large artifact.
+    #[test]
+    fn samples_are_written_to_their_own_file_and_omitted_from_the_report() {
+        let fixture = fixture(&qa_records(3));
+        let samples = fixture.root.join("samples.json");
+        let mut arguments = args(&fixture, GenerationObjective::QaReasoning);
+        arguments.samples = Some(samples.clone());
+        evaluate(arguments).unwrap();
+
+        let written = report(&samples);
+        let written = written.as_array().expect("samples file holds an array");
+        assert_eq!(written.len(), 3, "{written:?}");
+        assert!(
+            written[0]
+                .get("prompt")
+                .and_then(|p| p.as_str())
+                .is_some_and(|prompt| prompt.contains("Question:") && prompt.contains("Response:")),
+            "samples must record the adapter-framed prompt: {written:?}"
+        );
+        assert!(
+            report(&fixture.output).get("samples").is_none(),
+            "metrics report must not duplicate the decodes"
+        );
+    }
+
+    /// A record too long for the geometry must be skipped, counted, and warned
+    /// about rather than voiding the evaluation or vanishing.
+    #[test]
+    fn oversized_records_are_skipped_counted_and_warned() {
+        let long_question = "x".repeat(GENERATE_SEQUENCE_LENGTH * 4);
+        let records = format!(
+            "{{\"question\":\"short question\",\"answer\":\"answer\"}}\n\
+             {{\"question\":\"q\",\"answer\":\"{long_question}\"}}\n"
+        );
+        let fixture = fixture(&records);
+        evaluate(args(&fixture, GenerationObjective::QaReasoning)).unwrap();
+        let parsed = report(&fixture.output);
+        assert_eq!(
+            parsed.pointer("/oversized_records").unwrap().as_u64(),
+            Some(1),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/scored_records").unwrap().as_u64(),
+            Some(1),
+            "{parsed}"
+        );
+        let warnings = parsed.pointer("/warnings").unwrap().as_array().unwrap();
+        assert!(
+            warnings.iter().any(|warning| {
+                let warning = warning.as_str().unwrap_or_default();
+                warning.contains("skipped 1 record(s)") && warning.contains("--sequence-length")
+            }),
+            "the drop must name what was skipped and why: {parsed}"
+        );
+    }
+
+    #[test]
+    fn the_report_pins_the_prompt_framing_and_decoding_settings() {
+        let fixture = fixture(&qa_records(2));
+        let mut arguments = args(&fixture, GenerationObjective::QaReasoning);
+        arguments.instruction = Some("Answer from the passage only.".to_owned());
+        evaluate(arguments).unwrap();
+        let parsed = report(&fixture.output);
+        assert_eq!(
+            parsed.pointer("/task/instruction").unwrap().as_str(),
+            Some("Answer from the passage only."),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/temperature").unwrap().as_f64(),
+            Some(0.0),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/max_new_tokens").unwrap().as_u64(),
+            Some(8),
+            "{parsed}"
+        );
+    }
+
+    #[test]
+    fn require_reasoning_is_rejected_outside_qa_reasoning() {
+        let fixture = fixture(
+            "{\"document\":\"some held-out prose to summarize\",\"summary\":\"a summary\"}\n",
+        );
+        let mut arguments = args(&fixture, GenerationObjective::Summarization);
+        arguments.require_reasoning = true;
+        let error = evaluate(arguments).unwrap_err().to_string();
+        assert!(error.contains("qa_reasoning"), "{error}");
+    }
+
+    #[test]
+    fn a_report_path_naming_a_training_artifact_is_rejected() {
+        let fixture = fixture(&qa_records(2));
+        let mut arguments = args(&fixture, GenerationObjective::QaReasoning);
+        arguments.output = Some(fixture.root.join("current.json"));
+        let error = evaluate(arguments).unwrap_err().to_string();
+        assert!(error.contains("current.json"), "{error}");
+    }
+
+    #[test]
+    fn samples_cannot_overwrite_the_metrics_report() {
+        let fixture = fixture(&qa_records(2));
+        let mut arguments = args(&fixture, GenerationObjective::QaReasoning);
+        arguments.samples = arguments.output.clone();
+        let error = evaluate(arguments).unwrap_err().to_string();
+        assert!(error.contains("different files"), "{error}");
+    }
+}

--- a/hermes-train/src/main.rs
+++ b/hermes-train/src/main.rs
@@ -70,7 +70,9 @@ use sha2::{Digest, Sha256};
 mod checkpoint;
 mod data;
 mod eval;
+mod generate_eval;
 mod muon;
+mod retrieval_pool;
 mod trainer;
 mod wake;
 
@@ -110,6 +112,10 @@ enum Command {
     Train(TrainArgs),
     /// Score a checkpoint on held-out data with a forward-only pass.
     Eval(EvalArgs),
+    /// Rank retrieval queries against a full document pool, not their own batch.
+    RetrievalPoolEval(RetrievalPoolArgs),
+    /// Decode freely from a checkpoint and score the decodes, not the loss.
+    GenerateEval(GenerateEvalArgs),
     /// Validate and resolve a strict WorkflowV2 file.
     ValidateWorkflow(ValidateWorkflowArgs),
     /// Verify an exact-resume checkpoint with the trainer's strict schema.
@@ -286,6 +292,123 @@ struct EvalArgs {
     /// `require_reasoning` does.
     #[arg(long)]
     require_reasoning: bool,
+    /// JSON report path. The human-readable summary is always printed.
+    #[arg(short = 'o', long)]
+    output: Option<PathBuf>,
+}
+
+/// Supervised-generation tasks, the only ones that can be decoded from. Value
+/// names match `eval`'s so the two commands take the same `--objective` spelling.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum GenerationObjective {
+    #[value(name = "summarization")]
+    Summarization,
+    #[value(name = "instruction_tuning")]
+    InstructionTuning,
+    #[value(name = "qa_reasoning")]
+    QaReasoning,
+    #[value(name = "retrieval_planning")]
+    RetrievalPlanning,
+}
+
+impl GenerationObjective {
+    fn task_name(self) -> &'static str {
+        match self {
+            Self::Summarization => "summarization",
+            Self::InstructionTuning => "instruction_tuning",
+            Self::QaReasoning => "qa_reasoning",
+            Self::RetrievalPlanning => "retrieval_planning",
+        }
+    }
+}
+
+/// Decode freely from a checkpoint using the trainer's own prompt framing and
+/// score the decodes. See `docs/generation-eval.md`.
+#[derive(clap::Args)]
+struct GenerateEvalArgs {
+    /// MAL source or exported JSON model configuration.
+    #[arg(long)]
+    config: PathBuf,
+    #[arg(short = 't', long)]
+    tokenizer: PathBuf,
+    /// Safetensors weights to decode with. Loaded strictly against --config.
+    #[arg(long)]
+    checkpoint: PathBuf,
+    /// Held-out shard, repeatable. Requires .jsonl/.jsonl.zst.
+    #[arg(long = "data", required = true)]
+    data: Vec<PathBuf>,
+    #[arg(long, value_enum)]
+    objective: GenerationObjective,
+    /// Prompt budget. The gold target's length is reserved inside it, exactly as
+    /// training reserves it, so the decode prompt matches the trained prompt.
+    #[arg(long)]
+    sequence_length: usize,
+    #[arg(long, default_value_t = 60)]
+    max_new_tokens: usize,
+    /// `<= 0` selects greedy decoding, which is the reproducible default and the
+    /// setting under which degenerate copying is visible.
+    #[arg(long, default_value_t = 0.0)]
+    temperature: f64,
+    #[arg(long)]
+    top_k: Option<usize>,
+    #[arg(long, default_value_t = 1.0)]
+    repetition_penalty: f64,
+    #[arg(long, default_value_t = 0)]
+    seed: u64,
+    /// Stop after scoring this many records. Unset decodes every record, which is
+    /// slow: decoding is autoregressive.
+    #[arg(long)]
+    max_records: Option<usize>,
+    /// Instruction text. It is part of every prompt, so it must match the
+    /// training phase's `task.instruction` for decodes to be in distribution.
+    #[arg(long)]
+    instruction: Option<String>,
+    /// `qa_reasoning` only: supervise and expect the `Reasoning:`/`Answer:`
+    /// framing, exactly as the training phase's `require_reasoning` does.
+    #[arg(long)]
+    require_reasoning: bool,
+    /// Write every prompt, decode, and gold target here for review. Metrics
+    /// summarize; only reading decodes catches a new failure mode.
+    #[arg(long)]
+    samples: Option<PathBuf>,
+    /// JSON report path. The human-readable summary is always printed.
+    #[arg(short = 'o', long)]
+    output: Option<PathBuf>,
+}
+
+/// Rank each query's positive against a pool built from every distinct document
+/// the shards mention, instead of against its own batch. See
+/// `docs/retrieval-pool-eval.md`.
+#[derive(clap::Args)]
+struct RetrievalPoolArgs {
+    /// MAL source or exported JSON model configuration.
+    #[arg(long)]
+    config: PathBuf,
+    #[arg(short = 't', long)]
+    tokenizer: PathBuf,
+    /// Safetensors weights to score. Loaded strictly against --config.
+    #[arg(long)]
+    checkpoint: PathBuf,
+    /// Retrieval shard, repeatable. Contributes both queries and pool documents.
+    #[arg(long = "data", required = true)]
+    data: Vec<PathBuf>,
+    /// Extra shard whose documents enlarge the pool without contributing
+    /// queries. Use it to make ranking harder than the query set alone allows.
+    #[arg(long = "distractors")]
+    distractors: Vec<PathBuf>,
+    #[arg(long)]
+    sequence_length: usize,
+    /// Sequences embedded per forward pass. Unlike `eval`, this does not change
+    /// the candidate set: the pool is always every pooled document.
+    #[arg(long)]
+    batch_size: usize,
+    /// Rank cut-off for the reported recall.
+    #[arg(long, default_value_t = 10)]
+    recall_k: usize,
+    /// One-based retrieval read-out layer; omitted reads the final layer. Must
+    /// match the layer the retrieval training phase used.
+    #[arg(long)]
+    retrieval_layer: Option<usize>,
     /// JSON report path. The human-readable summary is always printed.
     #[arg(short = 'o', long)]
     output: Option<PathBuf>,
@@ -1877,6 +2000,8 @@ fn main() -> Result<()> {
     match Cli::parse().command {
         Command::Train(args) => trainer::train(args),
         Command::Eval(args) => eval::evaluate(args),
+        Command::RetrievalPoolEval(args) => retrieval_pool::evaluate(args),
+        Command::GenerateEval(args) => generate_eval::evaluate(args),
         Command::ValidateWorkflow(args) => validate_workflow_command(args),
         Command::VerifyCheckpoint(args) => verify_checkpoint_command(args),
         Command::PrepareCorpus(args) => prepare_corpus_command(args),
@@ -2205,6 +2330,45 @@ mod tests {
             sleep_runtime: None,
             sleep_runtime_sha256: None,
             print_run_signature: false,
+        }
+    }
+
+    /// `eval` and `generate-eval` are run back to back on the same objective, so
+    /// a reader must not have to remember that one spells it `qa_reasoning` and
+    /// the other `qa-reasoning`. Derived value names would kebab-case these.
+    #[test]
+    fn generate_eval_objectives_are_spelled_exactly_as_eval_spells_them() {
+        for objective in [
+            "summarization",
+            "instruction_tuning",
+            "qa_reasoning",
+            "retrieval_planning",
+        ] {
+            for command in ["eval", "generate-eval"] {
+                let mut arguments = vec![
+                    "hermes-train",
+                    command,
+                    "--config",
+                    "model.mal",
+                    "--tokenizer",
+                    "tokenizer.json",
+                    "--checkpoint",
+                    "weights.safetensors",
+                    "--data",
+                    "holdout.jsonl",
+                    "--objective",
+                    objective,
+                    "--sequence-length",
+                    "128",
+                ];
+                if command == "eval" {
+                    arguments.extend(["--batch-size", "2"]);
+                }
+                assert!(
+                    Cli::try_parse_from(arguments).is_ok(),
+                    "`{command} --objective {objective}` must parse"
+                );
+            }
         }
     }
 

--- a/hermes-train/src/retrieval_pool.rs
+++ b/hermes-train/src/retrieval_pool.rs
@@ -1,0 +1,1053 @@
+//! Full-pool retrieval evaluation of a published checkpoint.
+//!
+//! `eval --objective contrastive_retrieval` scores a query against the other
+//! rows of its own batch, so its candidate set is `batch_size` documents wide —
+//! twelve, at the geometry the 300M run used. That metric saturated at 1.000 and
+//! can no longer detect a regression. This command answers the question a search
+//! engine actually asks: embed every distinct document the shards mention into
+//! one pool, then rank each query's positive against the whole pool.
+//!
+//! Framing is delegated, never reconstructed. Prefixes come from
+//! [`TaskConfig::RetrievalRepresentation`] defaults and encoding from
+//! [`encode_retrieval_text`], so a pool embedding is computed from exactly the
+//! prompt retrieval training used. Like `eval`, this command is forward-only: the
+//! device is never `.autodiff()`, no token cache is written, and only an explicit
+//! `--output` report is created.
+//!
+//! Design: `docs/retrieval-pool-eval.md`.
+
+use std::collections::HashMap;
+use std::io::{BufRead, Read};
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{Context, Result, ensure};
+use burn::tensor::{Int, Tensor, TensorData};
+use hermes_llm::{Tokenizer, Transformer};
+use hermes_train::task::{TaskAdapter, TaskConfig, TaskExample};
+use hermes_train::workflow::validate_retrieval_layer_for_model;
+use serde::Serialize;
+
+use crate::data::{EncodedText, PhaseDataBinding, encode_retrieval_text};
+use crate::eval::{rank_with_index_tiebreak, task_defaults, validate_report_path, warn_operator};
+use crate::{RetrievalPoolArgs, file_sha256, load_config};
+
+/// Report schema version. Increment when a field changes meaning.
+///
+/// v2 replaced the flat `mean_rank`/`worst_rank` pair with a `ranks` block
+/// carrying median, p90, p99, and a count beyond rank 100, because a maximum
+/// alone cannot distinguish one pathological query from a systematically heavy
+/// tail. v3 uses the same deterministic first-index tie-break as top-1 argmax.
+const RETRIEVAL_POOL_REPORT_VERSION: u32 = 3;
+
+/// One malformed record must not make evaluation allocate an unbounded line.
+/// Matches the training pipeline's own per-record ceiling.
+const MAX_RECORD_BYTES: u64 = 64 * 1024 * 1024;
+
+#[derive(Debug, Serialize)]
+struct PoolDataSource {
+    path: String,
+    identity: String,
+    records_read: usize,
+    /// Queries this shard contributed. Zero for `--distractors` shards, which
+    /// enlarge the pool without being asked about.
+    queries: usize,
+    /// Documents this shard introduced that no earlier shard had already
+    /// contributed under the same `document_id`.
+    documents_added: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct PoolCounts {
+    /// Distinct `document_id`s embedded and ranked against.
+    documents: usize,
+    queries: usize,
+    /// Documents reached only because a `--distractors` shard supplied them.
+    from_distractors: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct PoolRetrievalMetrics {
+    top1_accuracy: f64,
+    mrr: f64,
+    recall_at_k: f64,
+    k: usize,
+    /// Discounted gain at rank 10. With exactly one relevant document per query
+    /// this is `1/log2(rank+1)` inside the cut-off and zero outside it.
+    ndcg_at_10: f64,
+    ranks: RankDistribution,
+}
+
+/// Where the positive actually landed, across queries.
+///
+/// The ratio metrics above absorb a handful of catastrophic ranks without
+/// moving: on the 2652-document advanced pool two checkpoints agreed to three
+/// decimals on top-1, MRR, recall@10, and nDCG while their worst ranks were 74
+/// and 710. A maximum alone is one query wide, so percentiles and an
+/// outside-the-first-page count are reported beside it to show whether a heavy
+/// tail is systematic or a single outlier.
+#[derive(Debug, Serialize)]
+struct RankDistribution {
+    mean: f64,
+    median: usize,
+    p90: usize,
+    p99: usize,
+    worst: usize,
+    /// Queries whose positive fell outside the first 100 candidates — beyond any
+    /// plausible re-ranking window, so effectively unretrieved.
+    beyond_100: usize,
+}
+
+impl RankDistribution {
+    /// `ranks` is consumed sorted ascending. Percentiles use the
+    /// nearest-rank convention, which needs no interpolation and always names an
+    /// observed rank.
+    fn from_sorted(ranks: &[usize]) -> Result<Self> {
+        ensure!(
+            !ranks.is_empty(),
+            "rank distribution needs at least one query"
+        );
+        let quantile = |fraction: f64| {
+            let position = (fraction * ranks.len() as f64).ceil() as usize;
+            ranks[position.saturating_sub(1).min(ranks.len() - 1)]
+        };
+        let rank_sum = ranks.iter().try_fold(0usize, |sum, rank| {
+            sum.checked_add(*rank)
+                .context("rank-distribution sum overflows usize")
+        })?;
+        Ok(Self {
+            mean: rank_sum as f64 / ranks.len() as f64,
+            median: quantile(0.5),
+            p90: quantile(0.9),
+            p99: quantile(0.99),
+            worst: *ranks.last().context("sorted ranks are non-empty")?,
+            beyond_100: ranks.iter().filter(|rank| **rank > 100).count(),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct RetrievalPoolReport {
+    version: u32,
+    objective: &'static str,
+    task: TaskConfig,
+    config: String,
+    config_sha256: String,
+    tokenizer: String,
+    tokenizer_sha256: String,
+    checkpoint: String,
+    checkpoint_sha256: String,
+    device: String,
+    sequence_length: usize,
+    batch_size: usize,
+    retrieval_layer: Option<usize>,
+    data: Vec<PoolDataSource>,
+    pool: PoolCounts,
+    /// Sequences embedded (pool documents plus queries) and their token cost.
+    embedded_sequences: usize,
+    compute_tokens: usize,
+    truncated_tokens: usize,
+    warnings: Vec<String>,
+    retrieval: PoolRetrievalMetrics,
+}
+
+struct PooledQuery {
+    encoded: EncodedText,
+    /// Index into the pool of this query's own positive document.
+    positive: usize,
+}
+
+/// Accumulates the deduplicated document pool and the query set.
+#[derive(Default)]
+struct PoolBuilder {
+    documents: Vec<EncodedText>,
+    /// `document_id` to pool index. Dedup lives here rather than beside the
+    /// encodings so the same document never occupies two pool slots, which would
+    /// let a query outrank a duplicate of its own positive.
+    index: HashMap<String, usize>,
+    queries: Vec<PooledQuery>,
+    truncated_tokens: usize,
+}
+
+impl PoolBuilder {
+    /// Insert a document under its id, returning its pool index and whether it
+    /// was new. A repeated id must carry the same model-visible text; silently
+    /// keeping the first would let a query be scored against the wrong positive.
+    fn intern(&mut self, id: &str, encoded: EncodedText) -> Result<(usize, bool)> {
+        if let Some(existing) = self.index.get(id) {
+            let prior = &self.documents[*existing];
+            ensure!(
+                prior.end_position == encoded.end_position && prior.tokens == encoded.tokens,
+                "document_id `{id}` maps to different model-visible text"
+            );
+            return Ok((*existing, false));
+        }
+        let position = self.documents.len();
+        self.documents.push(encoded);
+        self.index.insert(id.to_owned(), position);
+        Ok((position, true))
+    }
+}
+
+/// Read one retrieval record's ids and adapter-framed texts into the pool.
+///
+/// `collect_queries` is false for distractor shards: their documents enlarge the
+/// pool, but nothing is asked about them.
+fn absorb_record(
+    builder: &mut PoolBuilder,
+    objective: &TaskConfig,
+    tokenizer: &Tokenizer,
+    seq_len: usize,
+    value: &serde_json::Value,
+    collect_queries: bool,
+) -> Result<()> {
+    let TaskExample::RetrievalRepresentation {
+        query,
+        documents,
+        positive_index,
+    } = objective.construct_example(value)?
+    else {
+        unreachable!("retrieval-representation adapter returned another example type")
+    };
+    ensure!(
+        positive_index == 0,
+        "retrieval adapter placed the positive at index {positive_index}; this command assumes index 0"
+    );
+    let positive_id = value
+        .get("document_id")
+        .and_then(serde_json::Value::as_str)
+        .context("retrieval record has no string `document_id`; the pool is keyed by it")?;
+    let negative_ids = match value.get("negative_document_ids") {
+        Some(ids) => ids
+            .as_array()
+            .context("`negative_document_ids` is not an array")?
+            .iter()
+            .map(|id| {
+                id.as_str()
+                    .context("`negative_document_ids` contains a non-string id")
+            })
+            .collect::<Result<Vec<_>>>()?,
+        None => Vec::new(),
+    };
+    let negatives = documents.len() - 1;
+    ensure!(
+        negative_ids.len() == negatives,
+        "record has {negatives} negative document(s) but {} negative id(s); the pool cannot be keyed reliably",
+        negative_ids.len()
+    );
+
+    let mut positive_position = None;
+    for (offset, document) in documents.iter().enumerate() {
+        let id = if offset == 0 {
+            positive_id
+        } else {
+            negative_ids[offset - 1]
+        };
+        let (encoded, truncated) = encode_retrieval_text(tokenizer, document, seq_len)?;
+        let (position, inserted) = builder.intern(id, encoded)?;
+        if inserted {
+            builder.truncated_tokens = builder
+                .truncated_tokens
+                .checked_add(truncated)
+                .context("truncated-token count overflows usize")?;
+        }
+        if offset == 0 {
+            positive_position = Some(position);
+        }
+    }
+    let positive = match positive_position {
+        Some(position) => position,
+        // The positive was already pooled by an earlier record.
+        None => *builder
+            .index
+            .get(positive_id)
+            .context("interned positive document is missing from the pool index")?,
+    };
+
+    if collect_queries {
+        let (encoded, truncated) = encode_retrieval_text(tokenizer, &query, seq_len)?;
+        builder.truncated_tokens = builder
+            .truncated_tokens
+            .checked_add(truncated)
+            .context("truncated-token count overflows usize")?;
+        builder.queries.push(PooledQuery { encoded, positive });
+    }
+    Ok(())
+}
+
+/// Embed `texts` in `batch_size` chunks, returning a row-major `[texts, hidden]`
+/// matrix on the device.
+fn embed(
+    model: &Transformer,
+    texts: &[&EncodedText],
+    seq_len: usize,
+    batch_size: usize,
+    layer: Option<usize>,
+    device: &hermes_llm::Device,
+) -> Result<Tensor<2>> {
+    ensure!(!texts.is_empty(), "nothing to embed");
+    let mut chunks = Vec::with_capacity(texts.len().div_ceil(batch_size));
+    for chunk in texts.chunks(batch_size) {
+        let mut tokens = Vec::with_capacity(chunk.len() * seq_len);
+        let mut end_positions = Vec::with_capacity(chunk.len());
+        for (row, text) in chunk.iter().enumerate() {
+            ensure!(
+                text.tokens.len() == seq_len && text.end_position < seq_len,
+                "encoded retrieval text does not match sequence_length {seq_len}"
+            );
+            tokens.extend_from_slice(&text.tokens);
+            // `forward_embeddings` selects from the flattened [batch, sequence]
+            // hidden states, exactly as `make_batch` does for training.
+            end_positions.push(
+                i64::try_from(row * seq_len + text.end_position)
+                    .context("retrieval end position exceeds i64")?,
+            );
+        }
+        let input_ids: Tensor<2, Int> =
+            Tensor::from_data(TensorData::new(tokens, [chunk.len(), seq_len]), device);
+        let ends: Tensor<1, Int> =
+            Tensor::from_data(TensorData::new(end_positions, [chunk.len()]), device);
+        chunks.push(model.forward_embeddings(input_ids, ends, layer));
+    }
+    Ok(Tensor::cat(chunks, 0))
+}
+
+pub(super) fn evaluate(args: RetrievalPoolArgs) -> Result<()> {
+    let started = Instant::now();
+    if let Some(output) = &args.output {
+        validate_report_path(output)?;
+    }
+    ensure!(
+        args.sequence_length > 0,
+        "--sequence-length must be positive"
+    );
+    ensure!(args.batch_size > 0, "--batch-size must be positive");
+    ensure!(args.recall_k > 0, "--recall-k must be positive");
+
+    let mut objective = task_defaults("retrieval_representation")?;
+    let TaskConfig::RetrievalRepresentation { layer, .. } = &mut objective else {
+        unreachable!("retrieval_representation deserialized to another task");
+    };
+    *layer = args.retrieval_layer;
+
+    let mut warnings = Vec::new();
+    let tokenizer = Tokenizer::from_file(&args.tokenizer)?;
+    let mut config = load_config(&args.config)?;
+    if config.vocab_size != tokenizer.vocab_size() {
+        warn_operator(
+            &mut warnings,
+            format!(
+                "model config vocab_size {} differs from tokenizer vocab_size {}; evaluating with the tokenizer vocabulary exactly as `train` does",
+                config.vocab_size,
+                tokenizer.vocab_size()
+            ),
+        );
+        config.vocab_size = tokenizer.vocab_size();
+    }
+    ensure!(
+        args.sequence_length <= config.max_seq_len,
+        "--sequence-length {} exceeds model max_seq_len {}",
+        args.sequence_length,
+        config.max_seq_len
+    );
+    validate_retrieval_layer_for_model(
+        args.retrieval_layer.unwrap_or(config.num_layers),
+        &config,
+        "retrieval-pool-eval",
+    )?;
+
+    // Forward-only by construction, as in `eval`: never `.autodiff()`, never
+    // `prepare_inference()`d, so these numbers stay comparable with the
+    // in-batch retrieval metric and a live run remains resumable.
+    let device = hermes_llm::default_device();
+    let mut model = Transformer::new(&config, &device)?;
+    hermes_llm::load_safetensors(&mut model, &args.checkpoint).with_context(|| {
+        format!(
+            "checkpoint {} does not match model configuration {}",
+            args.checkpoint.display(),
+            args.config.display()
+        )
+    })?;
+
+    let mut builder = PoolBuilder::default();
+    let mut sources = Vec::with_capacity(args.data.len() + args.distractors.len());
+    // Query shards are read first so every document a query can be asked about
+    // is pooled before distractors enlarge the pool; `documents_from_queries`
+    // then separates the two contributions in the report.
+    let shards = args
+        .data
+        .iter()
+        .map(|path| (path, true))
+        .chain(args.distractors.iter().map(|path| (path, false)));
+    let mut documents_from_queries = 0;
+    for (path, collect_queries) in shards {
+        let documents_before = builder.documents.len();
+        let queries_before = builder.queries.len();
+        let mut records_read = 0usize;
+        let binding = PhaseDataBinding::open(path)?;
+        binding.with_readers(path, |source_path, reader| {
+            let mut line = String::new();
+            loop {
+                line.clear();
+                // Re-borrow per line so the byte ceiling applies to each record
+                // rather than to the whole shard. Spelled through `Read::take`
+                // because the method needs a sized `Self`, which the reborrowed
+                // reference is and the bare trait object is not.
+                let read = Read::take(&mut *reader, MAX_RECORD_BYTES)
+                    .read_line(&mut line)
+                    .with_context(|| format!("cannot read {}", source_path.display()))?;
+                if read == 0 {
+                    break;
+                }
+                ensure!(
+                    line.ends_with('\n') || read < MAX_RECORD_BYTES as usize,
+                    "record {} in {} exceeds the {MAX_RECORD_BYTES}-byte limit",
+                    records_read + 1,
+                    source_path.display()
+                );
+                if line.trim().is_empty() {
+                    continue;
+                }
+                records_read += 1;
+                let value: serde_json::Value = serde_json::from_str(&line).with_context(|| {
+                    format!(
+                        "cannot parse {}:{records_read} as JSON",
+                        source_path.display()
+                    )
+                })?;
+                absorb_record(
+                    &mut builder,
+                    &objective,
+                    &tokenizer,
+                    args.sequence_length,
+                    &value,
+                    collect_queries,
+                )
+                .with_context(|| format!("cannot pool {}:{records_read}", source_path.display()))?;
+            }
+            Ok(true)
+        })?;
+        if collect_queries {
+            documents_from_queries = builder.documents.len();
+        }
+        sources.push(PoolDataSource {
+            path: path.display().to_string(),
+            identity: binding.signature_identity().to_owned(),
+            records_read,
+            queries: builder.queries.len() - queries_before,
+            documents_added: builder.documents.len() - documents_before,
+        });
+    }
+    ensure!(
+        !builder.queries.is_empty(),
+        "--data produced no retrieval queries"
+    );
+    ensure!(
+        builder.documents.len() > 1,
+        "the candidate pool holds {} document(s); ranking needs at least two",
+        builder.documents.len()
+    );
+    if builder.documents.len() <= args.batch_size {
+        warn_operator(
+            &mut warnings,
+            format!(
+                "pool holds only {} document(s), no more than --batch-size {}; this is no harder than the in-batch `eval` metric",
+                builder.documents.len(),
+                args.batch_size
+            ),
+        );
+    }
+
+    let document_texts: Vec<&EncodedText> = builder.documents.iter().collect();
+    let pool = embed(
+        &model,
+        &document_texts,
+        args.sequence_length,
+        args.batch_size,
+        args.retrieval_layer,
+        &device,
+    )?;
+    // Embeddings are L2-normalized by `forward_embeddings`, so this dot product
+    // is cosine similarity and ranking is invariant to the loss temperature.
+    let pool = pool.transpose();
+
+    let mut reciprocal_rank = 0.0;
+    let mut top1 = 0usize;
+    let mut within_k = 0usize;
+    let mut ndcg = 0.0;
+    // Every rank is retained so the report can describe the tail, not just its
+    // maximum. One usize per query is negligible beside the embedding matrix.
+    let mut ranks = Vec::with_capacity(builder.queries.len());
+    let pool_size = builder.documents.len();
+    for chunk in builder.queries.chunks(args.batch_size) {
+        let texts: Vec<&EncodedText> = chunk.iter().map(|query| &query.encoded).collect();
+        let queries = embed(
+            &model,
+            &texts,
+            args.sequence_length,
+            args.batch_size,
+            args.retrieval_layer,
+            &device,
+        )?;
+        let scores = queries.matmul(pool.clone());
+        let [rows, candidates] = scores.dims();
+        ensure!(
+            rows == chunk.len() && candidates == pool_size,
+            "similarity matrix is {rows}x{candidates} for {} queries and {pool_size} documents",
+            chunk.len()
+        );
+        let scores = scores.into_data().convert::<f32>().to_vec::<f32>()?;
+        for (row, query) in chunk.iter().enumerate() {
+            let row = &scores[row * candidates..(row + 1) * candidates];
+            let rank = rank_with_index_tiebreak(row, query.positive)?;
+            reciprocal_rank += 1.0 / rank as f64;
+            top1 += usize::from(rank == 1);
+            within_k += usize::from(rank <= args.recall_k);
+            if rank <= 10 {
+                ndcg += 1.0 / ((rank + 1) as f64).log2();
+            }
+            ranks.push(rank);
+        }
+    }
+    ranks.sort_unstable();
+
+    let queries = builder.queries.len();
+    let sequences = pool_size
+        .checked_add(queries)
+        .context("embedded sequence count overflows usize")?;
+    let report = RetrievalPoolReport {
+        version: RETRIEVAL_POOL_REPORT_VERSION,
+        objective: objective.name(),
+        task: objective.clone(),
+        config: args.config.display().to_string(),
+        config_sha256: file_sha256(&args.config)?,
+        tokenizer: args.tokenizer.display().to_string(),
+        tokenizer_sha256: file_sha256(&args.tokenizer)?,
+        checkpoint: args.checkpoint.display().to_string(),
+        checkpoint_sha256: file_sha256(&args.checkpoint)?,
+        device: format!("{device:?}"),
+        sequence_length: args.sequence_length,
+        batch_size: args.batch_size,
+        retrieval_layer: args.retrieval_layer,
+        data: sources,
+        pool: PoolCounts {
+            documents: pool_size,
+            queries,
+            from_distractors: pool_size - documents_from_queries,
+        },
+        embedded_sequences: sequences,
+        compute_tokens: sequences
+            .checked_mul(args.sequence_length)
+            .context("compute-token count overflows usize")?,
+        truncated_tokens: builder.truncated_tokens,
+        warnings,
+        retrieval: PoolRetrievalMetrics {
+            top1_accuracy: top1 as f64 / queries as f64,
+            mrr: reciprocal_rank / queries as f64,
+            recall_at_k: within_k as f64 / queries as f64,
+            k: args.recall_k,
+            ndcg_at_10: ndcg / queries as f64,
+            ranks: RankDistribution::from_sorted(&ranks)?,
+        },
+    };
+    write_report(&report, args.output.as_deref())?;
+    print_summary(&report, started.elapsed().as_secs_f64());
+    Ok(())
+}
+
+fn write_report(report: &RetrievalPoolReport, output: Option<&Path>) -> Result<()> {
+    let Some(output) = output else {
+        return Ok(());
+    };
+    if let Some(parent) = output
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("cannot create report directory {}", parent.display()))?;
+    }
+    let mut encoded = serde_json::to_vec_pretty(report)?;
+    encoded.push(b'\n');
+    std::fs::write(output, encoded)
+        .with_context(|| format!("cannot write evaluation report {}", output.display()))
+}
+
+fn print_summary(report: &RetrievalPoolReport, elapsed_seconds: f64) {
+    println!("objective            {}", report.objective);
+    println!(
+        "checkpoint           {} ({})",
+        report.checkpoint, report.checkpoint_sha256
+    );
+    println!(
+        "pool                 {} document(s), {} quer(ies){}",
+        report.pool.documents,
+        report.pool.queries,
+        if report.pool.from_distractors > 0 {
+            format!(", {} from --distractors", report.pool.from_distractors)
+        } else {
+            String::new()
+        }
+    );
+    println!(
+        "embedded             {} sequence(s), {} compute token(s), {} truncated",
+        report.embedded_sequences, report.compute_tokens, report.truncated_tokens
+    );
+    let retrieval = &report.retrieval;
+    println!("top-1 accuracy       {:.6}", retrieval.top1_accuracy);
+    println!("mrr                  {:.6}", retrieval.mrr);
+    println!(
+        "{:<20} {:.6}",
+        format!("recall@{}", retrieval.k),
+        retrieval.recall_at_k
+    );
+    println!("ndcg@10              {:.6}", retrieval.ndcg_at_10);
+    let ranks = &retrieval.ranks;
+    println!(
+        "rank                 mean {:.2}, median {}, p90 {}, p99 {}, worst {} of {}",
+        ranks.mean, ranks.median, ranks.p90, ranks.p99, ranks.worst, report.pool.documents
+    );
+    println!(
+        "beyond rank 100      {} of {} quer(ies)",
+        ranks.beyond_100, report.pool.queries
+    );
+    for warning in &report.warnings {
+        println!("warning              {warning}");
+    }
+    println!("elapsed              {elapsed_seconds:.2}s");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use hermes_llm::parse_mal;
+
+    use super::*;
+    use crate::data::write_test_tokenizer;
+
+    const POOL_MODEL: &str = r#"
+ffn base { hidden_dim: 12 activation: swiglu dropout: 0.0 }
+model tiny {
+    vocab_size: 257 max_seq_len: 256 hidden_size: 8 num_layers: 2
+    block: {
+        attention: { num_heads: 1 dropout: 0.0 position_encoding: none }
+        ffn: base
+        dropout: 0.0
+    }
+}
+"#;
+
+    /// Wide enough for the retrieval task's fixed document prefix (38 bytes under
+    /// the merge-free byte-level test tokenizer), the record text, and EOS.
+    const POOL_SEQUENCE_LENGTH: usize = 56;
+
+    struct Fixture {
+        _directory: tempfile::TempDir,
+        root: PathBuf,
+        config: PathBuf,
+        tokenizer: PathBuf,
+        checkpoint: PathBuf,
+        data: PathBuf,
+        output: PathBuf,
+    }
+
+    fn fixture(records: &str) -> Fixture {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().to_owned();
+        let config = root.join("model.mal");
+        fs::write(&config, POOL_MODEL).unwrap();
+        write_test_tokenizer(&root);
+        let device = hermes_llm::default_device();
+        device.seed(7);
+        let model = Transformer::new(&parse_mal(POOL_MODEL).unwrap(), &device).unwrap();
+        let checkpoint = root.join("weights.safetensors");
+        hermes_llm::save_safetensors(&model, &checkpoint).unwrap();
+        let data = root.join("holdout.jsonl");
+        fs::write(&data, records).unwrap();
+        Fixture {
+            _directory: directory,
+            tokenizer: root.join("tokenizer.json"),
+            output: root.join("reports/pool.json"),
+            root,
+            config,
+            checkpoint,
+            data,
+        }
+    }
+
+    fn args(fixture: &Fixture, batch_size: usize) -> RetrievalPoolArgs {
+        RetrievalPoolArgs {
+            config: fixture.config.clone(),
+            tokenizer: fixture.tokenizer.clone(),
+            checkpoint: fixture.checkpoint.clone(),
+            data: vec![fixture.data.clone()],
+            distractors: Vec::new(),
+            sequence_length: POOL_SEQUENCE_LENGTH,
+            batch_size,
+            recall_k: 2,
+            retrieval_layer: None,
+            output: Some(fixture.output.clone()),
+        }
+    }
+
+    /// Each record owns a distinct positive and a distinct negative, so `rows`
+    /// records contribute exactly `2 * rows` pool documents.
+    fn records(rows: usize) -> String {
+        (0..rows)
+            .map(|index| {
+                format!(
+                    "{{\"query\":\"query {index}\",\"positive\":\"answer {index}\",\"document_id\":\"pos-{index}\",\"negatives\":[\"other {index}\"],\"negative_document_ids\":[\"neg-{index}\"]}}\n"
+                )
+            })
+            .collect()
+    }
+
+    fn report(path: &Path) -> serde_json::Value {
+        serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+    }
+
+    fn number(value: &serde_json::Value, pointer: &str) -> f64 {
+        let number = value
+            .pointer(pointer)
+            .unwrap_or_else(|| panic!("report has no {pointer}: {value}"))
+            .as_f64()
+            .unwrap_or_else(|| panic!("{pointer} is not a JSON number: {value}"));
+        assert!(number.is_finite(), "{pointer} is {number}");
+        number
+    }
+
+    /// The property that separates this command from `eval`: the candidate set is
+    /// the whole pool, so `--batch-size` changes only how many sequences are
+    /// embedded per forward pass and must not move any reported metric. A
+    /// per-batch implementation would score against `batch_size` candidates and
+    /// disagree here — and could never report a rank above `batch_size`.
+    #[test]
+    fn pool_metrics_are_invariant_to_batch_size() {
+        let fixture = fixture(&records(6));
+        let mut measured = Vec::new();
+        for batch_size in [2, 5, 12] {
+            evaluate(args(&fixture, batch_size)).unwrap();
+            let parsed = report(&fixture.output);
+            assert_eq!(
+                parsed.pointer("/pool/documents").unwrap().as_u64(),
+                Some(12),
+                "{parsed}"
+            );
+            assert_eq!(
+                parsed.pointer("/pool/queries").unwrap().as_u64(),
+                Some(6),
+                "{parsed}"
+            );
+            measured.push((
+                number(&parsed, "/retrieval/top1_accuracy"),
+                number(&parsed, "/retrieval/mrr"),
+                number(&parsed, "/retrieval/recall_at_k"),
+                number(&parsed, "/retrieval/ndcg_at_10"),
+                parsed
+                    .pointer("/retrieval/ranks/worst")
+                    .unwrap()
+                    .as_u64()
+                    .unwrap(),
+            ));
+        }
+        for other in &measured[1..] {
+            assert_eq!(measured[0].4, other.4, "worst rank moved with batch size");
+            for (first, second) in [
+                (measured[0].0, other.0),
+                (measured[0].1, other.1),
+                (measured[0].2, other.2),
+                (measured[0].3, other.3),
+            ] {
+                assert!(
+                    (first - second).abs() < 1e-9,
+                    "metric moved with batch size: {first} vs {second}"
+                );
+            }
+        }
+        // A rank above the smallest batch size proves candidates outside the
+        // query's own forward pass were ranked against it.
+        assert!(
+            measured[0].4 > 2,
+            "worst rank {} never left the smallest batch",
+            measured[0].4
+        );
+    }
+
+    #[test]
+    fn pool_metrics_are_finite_ordered_and_deterministic() {
+        let fixture = fixture(&records(6));
+        evaluate(args(&fixture, 4)).unwrap();
+        let first = report(&fixture.output);
+        evaluate(args(&fixture, 4)).unwrap();
+        assert_eq!(
+            first,
+            report(&fixture.output),
+            "report is not deterministic"
+        );
+
+        let top1 = number(&first, "/retrieval/top1_accuracy");
+        let mrr = number(&first, "/retrieval/mrr");
+        let recall = number(&first, "/retrieval/recall_at_k");
+        let ndcg = number(&first, "/retrieval/ndcg_at_10");
+        let mean_rank = number(&first, "/retrieval/ranks/mean");
+        for (name, value) in [
+            ("top1", top1),
+            ("mrr", mrr),
+            ("recall", recall),
+            ("ndcg", ndcg),
+        ] {
+            assert!((0.0..=1.0).contains(&value), "{name} is {value}");
+        }
+        assert!(mrr >= top1 - 1e-9, "mrr {mrr} below top-1 {top1}");
+        assert!(recall >= top1 - 1e-9, "recall {recall} below top-1 {top1}");
+        assert!(mean_rank >= 1.0, "mean rank {mean_rank} below one");
+        let worst = first
+            .pointer("/retrieval/ranks/worst")
+            .unwrap()
+            .as_u64()
+            .unwrap();
+        assert!((1..=12).contains(&worst), "worst rank {worst} outside pool");
+    }
+
+    /// The pool is keyed by `document_id`, so a document two records share must
+    /// occupy one slot. Two slots would let a query rank a duplicate of its own
+    /// positive above it and silently inflate every metric.
+    /// A maximum cannot tell one pathological query from a heavy tail, which is
+    /// why v2 reports percentiles beside it. Percentiles use nearest-rank, so
+    /// every reported value is a rank some query actually achieved.
+    #[test]
+    fn rank_distribution_describes_the_tail_not_just_its_maximum() {
+        // 100 queries: 99 at rank 1, one catastrophic. Ratio metrics would barely
+        // move; the distribution must show the max without implying a bad median.
+        let mut one_outlier = vec![1usize; 99];
+        one_outlier.push(710);
+        one_outlier.sort_unstable();
+        let outlier = RankDistribution::from_sorted(&one_outlier).unwrap();
+        assert_eq!(outlier.median, 1);
+        assert_eq!(outlier.p90, 1);
+        assert_eq!(outlier.worst, 710);
+        assert_eq!(outlier.beyond_100, 1);
+
+        // Same maximum, but the tail is systematic rather than a single query.
+        let mut heavy: Vec<usize> = (0..80).map(|_| 1).collect();
+        heavy.extend((0..20).map(|index| 300 + index));
+        heavy.sort_unstable();
+        let heavy = RankDistribution::from_sorted(&heavy).unwrap();
+        assert_eq!(heavy.median, 1);
+        assert!(
+            heavy.p90 >= 300,
+            "p90 must expose a 20% heavy tail: {heavy:?}"
+        );
+        assert_eq!(heavy.beyond_100, 20);
+        assert!(
+            heavy.mean > outlier.mean,
+            "a systematic tail must outweigh one outlier: {heavy:?} vs {outlier:?}"
+        );
+
+        // Degenerate input is rejected rather than reported as zero.
+        assert!(RankDistribution::from_sorted(&[]).is_err());
+
+        // A single query is representable: every percentile is that rank.
+        let single = RankDistribution::from_sorted(&[4]).unwrap();
+        assert_eq!(
+            (single.median, single.p90, single.p99, single.worst),
+            (4, 4, 4, 4)
+        );
+    }
+
+    #[test]
+    fn repeated_document_ids_collapse_to_one_pool_entry() {
+        let shared = (0..4)
+            .map(|index| {
+                format!(
+                    "{{\"query\":\"query {index}\",\"positive\":\"answer {index}\",\"document_id\":\"pos-{index}\",\"negatives\":[\"shared distractor\"],\"negative_document_ids\":[\"neg-shared\"]}}\n"
+                )
+            })
+            .collect::<String>();
+        let fixture = fixture(&shared);
+        evaluate(args(&fixture, 3)).unwrap();
+        let parsed = report(&fixture.output);
+        // Four positives plus one shared negative, not four negatives.
+        assert_eq!(
+            parsed.pointer("/pool/documents").unwrap().as_u64(),
+            Some(5),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/data/0/documents_added").unwrap().as_u64(),
+            Some(5),
+            "{parsed}"
+        );
+    }
+
+    #[test]
+    fn repeated_document_id_with_different_text_is_rejected() {
+        let conflicting = concat!(
+            "{\"query\":\"query a\",\"positive\":\"first visible text\",\"document_id\":\"shared\",\"negatives\":[\"other a\"],\"negative_document_ids\":[\"neg-a\"]}\n",
+            "{\"query\":\"query b\",\"positive\":\"different visible text\",\"document_id\":\"shared\",\"negatives\":[\"other b\"],\"negative_document_ids\":[\"neg-b\"]}\n",
+        );
+        let fixture = fixture(conflicting);
+        let error = format!("{:#}", evaluate(args(&fixture, 2)).unwrap_err());
+        assert!(error.contains("different model-visible text"), "{error}");
+    }
+
+    /// A query whose positive was already pooled as another record's negative
+    /// must still resolve to its own document rather than failing to find it.
+    #[test]
+    fn a_positive_already_pooled_as_a_negative_still_resolves() {
+        let overlapping = concat!(
+            "{\"query\":\"query a\",\"positive\":\"answer a\",\"document_id\":\"doc-a\",\"negatives\":[\"answer b\"],\"negative_document_ids\":[\"doc-b\"]}\n",
+            "{\"query\":\"query b\",\"positive\":\"answer b\",\"document_id\":\"doc-b\",\"negatives\":[\"answer a\"],\"negative_document_ids\":[\"doc-a\"]}\n",
+        );
+        let fixture = fixture(overlapping);
+        evaluate(args(&fixture, 2)).unwrap();
+        let parsed = report(&fixture.output);
+        assert_eq!(
+            parsed.pointer("/pool/documents").unwrap().as_u64(),
+            Some(2),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/pool/queries").unwrap().as_u64(),
+            Some(2),
+            "{parsed}"
+        );
+        // With two documents and two queries every rank is 1 or 2.
+        let worst = parsed
+            .pointer("/retrieval/ranks/worst")
+            .unwrap()
+            .as_u64()
+            .unwrap();
+        assert!(worst <= 2, "{parsed}");
+    }
+
+    /// Distractor shards must enlarge the candidate pool without being asked
+    /// about, and the report must attribute them separately.
+    #[test]
+    fn distractor_shards_add_documents_without_adding_queries() {
+        let fixture = fixture(&records(3));
+        let distractors = fixture.root.join("distractors.jsonl");
+        let extra = (10..14)
+            .map(|index| {
+                format!(
+                    "{{\"query\":\"query {index}\",\"positive\":\"answer {index}\",\"document_id\":\"pos-{index}\",\"negatives\":[\"other {index}\"],\"negative_document_ids\":[\"neg-{index}\"]}}\n"
+                )
+            })
+            .collect::<String>();
+        fs::write(&distractors, extra).unwrap();
+        let mut arguments = args(&fixture, 4);
+        arguments.distractors = vec![distractors];
+        evaluate(arguments).unwrap();
+        let parsed = report(&fixture.output);
+        assert_eq!(
+            parsed.pointer("/pool/queries").unwrap().as_u64(),
+            Some(3),
+            "{parsed}"
+        );
+        // Six from the query shard, eight from the distractor shard.
+        assert_eq!(
+            parsed.pointer("/pool/documents").unwrap().as_u64(),
+            Some(14),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/pool/from_distractors").unwrap().as_u64(),
+            Some(8),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/data/1/queries").unwrap().as_u64(),
+            Some(0),
+            "{parsed}"
+        );
+    }
+
+    /// Prefixes must come from the task adapter, not be rebuilt here: a prompt
+    /// assembled locally would be out of distribution and report a fake number.
+    #[test]
+    fn report_pins_the_adapter_prefixes_and_read_out_layer() {
+        let fixture = fixture(&records(4));
+        let mut arguments = args(&fixture, 4);
+        arguments.retrieval_layer = Some(2);
+        evaluate(arguments).unwrap();
+        let parsed = report(&fixture.output);
+        assert_eq!(
+            parsed.pointer("/task/query_prefix").unwrap().as_str(),
+            Some("Represent this query for retrieval:\n"),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/task/document_prefix").unwrap().as_str(),
+            Some("Represent this document for retrieval:\n"),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/task/layer").unwrap().as_u64(),
+            Some(2),
+            "{parsed}"
+        );
+        assert_eq!(
+            parsed.pointer("/retrieval_layer").unwrap().as_u64(),
+            Some(2),
+            "{parsed}"
+        );
+    }
+
+    #[test]
+    fn a_read_out_layer_outside_the_model_is_rejected() {
+        let fixture = fixture(&records(4));
+        let mut arguments = args(&fixture, 4);
+        arguments.retrieval_layer = Some(3);
+        let error = evaluate(arguments).unwrap_err().to_string();
+        assert!(error.contains("retrieval"), "{error}");
+    }
+
+    /// A record whose negatives and negative ids disagree cannot be keyed into
+    /// the pool, and must fail loudly rather than be silently dropped.
+    #[test]
+    fn mismatched_negative_ids_are_rejected() {
+        let fixture = fixture(
+            "{\"query\":\"q\",\"positive\":\"p\",\"document_id\":\"doc\",\"negatives\":[\"a\",\"b\"],\"negative_document_ids\":[\"only-one\"]}\n",
+        );
+        let error = format!("{:#}", evaluate(args(&fixture, 1)).unwrap_err());
+        assert!(error.contains("negative id"), "{error}");
+    }
+
+    /// A record with no `document_id` cannot be pooled: without it two distinct
+    /// documents could collapse or one could be duplicated.
+    #[test]
+    fn a_record_without_a_document_id_is_rejected() {
+        let fixture = fixture(
+            "{\"query\":\"q\",\"positive\":\"p\",\"negatives\":[\"a\"],\"negative_document_ids\":[\"n\"]}\n",
+        );
+        let error = format!("{:#}", evaluate(args(&fixture, 1)).unwrap_err());
+        assert!(error.contains("document_id"), "{error}");
+    }
+
+    /// A pool no larger than the batch is no harder than the in-batch metric this
+    /// command exists to replace, so it must say so rather than look like a
+    /// stronger result than it is.
+    #[test]
+    fn a_pool_no_larger_than_the_batch_warns() {
+        let fixture = fixture(&records(2));
+        evaluate(args(&fixture, 8)).unwrap();
+        let parsed = report(&fixture.output);
+        let warnings = parsed.pointer("/warnings").unwrap().as_array().unwrap();
+        assert!(
+            warnings
+                .iter()
+                .any(|warning| warning.as_str().unwrap_or_default().contains("in-batch")),
+            "{parsed}"
+        );
+    }
+
+    #[test]
+    fn a_report_path_naming_a_training_artifact_is_rejected() {
+        let fixture = fixture(&records(4));
+        let mut arguments = args(&fixture, 4);
+        arguments.output = Some(fixture.root.join("weights.safetensors"));
+        let error = evaluate(arguments).unwrap_err().to_string();
+        assert!(error.contains("weights.safetensors"), "{error}");
+    }
+}


### PR DESCRIPTION
## Summary

- add a full-pool retrieval evaluator with deterministic tie handling, rank-tail statistics, distractor shards, and duplicate-document validation
- add free-running generation evaluation that shares prompt framing with supervised training and reports EOS, repetition, containment, and source-overlap signals
- make retrieval rank semantics consistent in the existing evaluator and document both workflows

## Verification

- cargo test --workspace
- cargo fmt --all -- --check
- strict clippy via the repository pre-push hook
- real Metal checkpoint smoke test produced a schema-v3 156-document report; the complete three-checkpoint matrix is running separately