### PR TITLE
fix: widen stored field count and reject vector overflow

### DIFF
--- a/docs/document-store-v3.md
+++ b/docs/document-store-v3.md
@@ -1,0 +1,21 @@
+# Document store v3
+
+Document store v3 removes the `u16` ceiling on the number of stored
+field-values in one document. The count at the start of every serialized
+document is now a little-endian `u32`; the per-value field ID remains `u16`.
+Repeated values count separately.
+
+This is an intentionally incompatible format change. Readers accept only v3
+stores, so indexes containing v2 segments must be rebuilt before deployment.
+Raw block copying during merge remains safe because an old segment cannot be
+opened and admitted to a v3 merge.
+
+The wider count adds two uncompressed bytes per document. Vector ordinals
+remain `u16`, so an indexed vector field can contain 65,536 values, represented
+by ordinals `0..=65535`. Writers reject a document that exceeds that independent
+limit before it enters an indexing generation; this keeps one invalid document
+from poisoning the rest of a commit batch.
+
+The maximum decompressed document-store block size is 256 MiB (formerly 64
+MiB). A serialized document, including its four-byte block length prefix, must
+fit within that ceiling.

--- a/hermes-core/src/index/wasm_writer.rs
+++ b/hermes-core/src/index/wasm_writer.rs
@@ -21,7 +21,9 @@ use crate::directories::DirectoryWriter;
 use crate::dsl::{Document, Field, FieldType, FieldValue, Schema};
 use crate::error::Result;
 use crate::index::IndexMetadata;
-use crate::segment::{SegmentBuilder, SegmentBuilderConfig, SegmentId};
+use crate::segment::{
+    SegmentBuilder, SegmentBuilderConfig, SegmentId, validate_vector_value_counts,
+};
 use crate::tokenizer::BoxedTokenizer;
 
 use super::IndexConfig;
@@ -204,17 +206,16 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// native-only spill paths do not exist here); all of them are pure
     /// functions of (document, schema).
     fn validate_document(&self, doc: &Document) -> Result<()> {
-        let mut vector_values_per_field: FxHashMap<u32, u32> = FxHashMap::default();
-        let mut stored_count: usize = 0;
+        validate_vector_value_counts(doc, &self.schema)?;
+        let mut stored_count = 0usize;
 
         for (field, value) in doc.field_values() {
             let Some(entry) = self.schema.get_field_entry(*field) else {
                 continue;
             };
 
-            // Mirrors `write_document_to_store` / `serialize_document_into`
-            // limits: stored field ids and the stored-field count are u16 on
-            // the wire.
+            // Stored field IDs remain u16 on disk; only the number of stored
+            // field-values was widened to u32 in store v3.
             let stored_in_store = entry.stored
                 && !matches!(
                     value,
@@ -230,25 +231,10 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 }
             }
 
-            // Mirrors `SegmentBuilder::next_vector_ordinal`: vector ordinals
-            // are u16, so at most u16::MAX + 1 values per field per document.
-            let mut count_vector_value = |field_id: u32| -> Result<()> {
-                let count = vector_values_per_field.entry(field_id).or_insert(0);
-                *count += 1;
-                if *count > u16::MAX as u32 + 1 {
-                    return Err(crate::Error::Document(format!(
-                        "field {field_id} has more than {} vector values in one document",
-                        u16::MAX as usize + 1
-                    )));
-                }
-                Ok(())
-            };
-
             match (&entry.field_type, value) {
                 (FieldType::DenseVector, FieldValue::DenseVector(vec))
                     if entry.indexed || entry.stored =>
                 {
-                    count_vector_value(field.0)?;
                     let expected_dim = entry
                         .dense_vector_config
                         .as_ref()
@@ -272,7 +258,6 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 (FieldType::BinaryDenseVector, FieldValue::BinaryDenseVector(bytes))
                     if entry.indexed || entry.stored =>
                 {
-                    count_vector_value(field.0)?;
                     let dim_bits = entry
                         .binary_dense_vector_config
                         .as_ref()
@@ -300,7 +285,6 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
                 (FieldType::SparseVector, FieldValue::SparseVector(entries))
                     if entry.indexed || entry.fast =>
                 {
-                    count_vector_value(field.0)?;
                     if let Some((index, (_, weight))) = entries
                         .iter()
                         .enumerate()
@@ -315,10 +299,11 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             }
         }
 
-        if stored_count > u16::MAX as usize {
-            return Err(crate::Error::Document(
-                "too many stored fields in one document (max 65535)".to_string(),
-            ));
+        if u32::try_from(stored_count).is_err() {
+            return Err(crate::Error::Document(format!(
+                "too many stored field-values in one document (max {})",
+                u32::MAX
+            )));
         }
 
         Ok(())

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -44,7 +44,9 @@ use rustc_hash::FxHashMap;
 use crate::directories::DirectoryWriter;
 use crate::dsl::{Document, Field, Schema};
 use crate::error::{Error, Result};
-use crate::segment::{SegmentBuilder, SegmentBuilderConfig, SegmentId};
+use crate::segment::{
+    SegmentBuilder, SegmentBuilderConfig, SegmentId, validate_vector_value_counts,
+};
 use crate::tokenizer::BoxedTokenizer;
 
 use super::IndexConfig;
@@ -1195,6 +1197,10 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         if sender.is_closed() {
             return Err(Error::CommitInProgress);
         }
+        // Reject unencodable documents before they enter a worker queue. A
+        // worker discovers these limits only after mutating a segment builder,
+        // which invalidates every sibling document in the commit generation.
+        validate_vector_value_counts(&doc, &self.schema)?;
         let primary_key_index = self.primary_key_index.read();
         if let Some(ref pk_index) = *primary_key_index {
             pk_index.check_and_insert(&doc)?;

--- a/hermes-core/src/segment/builder/mod.rs
+++ b/hermes-core/src/segment/builder/mod.rs
@@ -129,6 +129,10 @@ const NEW_POS_TERM_OVERHEAD: usize =
 const MAX_POSITION_ELEMENT_ORDINAL: u32 = (1 << 12) - 1;
 const MAX_TOKEN_POSITION: u32 = (1 << 20) - 1;
 
+/// Vector ordinals are zero-based `u16`s, so all 65,536 ordinal values are
+/// available to one vector field in one document.
+pub(crate) const MAX_VECTOR_VALUES_PER_FIELD: usize = u16::MAX as usize + 1;
+
 /// Default BMP vocabulary size when `dims` is unset in the sparse vector
 /// config (SPLADE unigram vocabulary). Must match the build-time defaults in
 /// `builder/sparse.rs` and `merger/sparse.rs`.
@@ -162,6 +166,44 @@ fn field_value_type_name(value: &FieldValue) -> &'static str {
         FieldValue::Json(_) => "json",
         FieldValue::BinaryDenseVector(_) => "binary_dense_vector",
     }
+}
+
+/// Reject vector lists that cannot be represented by the ordinal wire format.
+///
+/// This validation is intentionally pure and runs before a document enters a
+/// native worker queue or mutates an inline/WASM segment builder. Otherwise a
+/// single oversized document is discovered only after sibling documents have
+/// been indexed, forcing the entire commit generation to be discarded.
+pub(crate) fn validate_vector_value_counts(doc: &Document, schema: &Schema) -> Result<()> {
+    let mut vector_values_per_field: FxHashMap<u32, usize> = FxHashMap::default();
+
+    for (field, value) in doc.field_values() {
+        let Some(entry) = schema.get_field_entry(*field) else {
+            continue;
+        };
+
+        let consumes_vector_ordinal = match (&entry.field_type, value) {
+            (FieldType::DenseVector, FieldValue::DenseVector(_))
+            | (FieldType::BinaryDenseVector, FieldValue::BinaryDenseVector(_)) => {
+                entry.indexed || entry.stored
+            }
+            (FieldType::SparseVector, FieldValue::SparseVector(_)) => entry.indexed || entry.fast,
+            _ => false,
+        };
+        if !consumes_vector_ordinal {
+            continue;
+        }
+
+        let count = vector_values_per_field.entry(field.0).or_insert(0);
+        *count += 1;
+        if *count > MAX_VECTOR_VALUES_PER_FIELD {
+            return Err(crate::Error::Document(format!(
+                "field '{}' (id {}) has more than {} vector values in one document",
+                entry.name, field.0, MAX_VECTOR_VALUES_PER_FIELD
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Segment builder with optimized memory usage
@@ -559,6 +601,8 @@ impl SegmentBuilder {
     ///   from the grid and silently filtered from queries — permanently
     ///   unsearchable.
     fn validate_document_against_schema(&self, doc: &Document) -> Result<()> {
+        validate_vector_value_counts(doc, &self.schema)?;
+
         for (field, value) in doc.field_values() {
             let Some(entry) = self.schema.get_field_entry(*field) else {
                 continue;

--- a/hermes-core/src/segment/builder/store.rs
+++ b/hermes-core/src/segment/builder/store.rs
@@ -165,7 +165,7 @@ pub(super) fn build_store_streaming_from_buffer(
     writer.write_u64::<LittleEndian>(0)?; // dict_offset
     writer.write_u32::<LittleEndian>(next_doc_id)?;
     writer.write_u32::<LittleEndian>(0)?; // has_dict = false
-    writer.write_u32::<LittleEndian>(2)?; // STORE_VERSION
+    writer.write_u32::<LittleEndian>(3)?; // STORE_VERSION
     writer.write_u32::<LittleEndian>(0x53544F52)?; // STORE_MAGIC
 
     if next_doc_id != expected_docs {

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -29,6 +29,8 @@ pub(crate) use builder::graph_bisection::{
     build_forward_index_from_blocks, build_forward_index_from_bmps, graph_bisection,
 };
 #[cfg(any(feature = "native", feature = "wasm"))]
+pub(crate) use builder::validate_vector_value_counts;
+#[cfg(any(feature = "native", feature = "wasm"))]
 pub use builder::{
     BpBudget, MemoryBreakdown, SegmentBuilder, SegmentBuilderConfig, SegmentBuilderStats,
 };

--- a/hermes-core/src/segment/store.rs
+++ b/hermes-core/src/segment/store.rs
@@ -34,7 +34,8 @@ use crate::directories::FileHandle;
 use crate::dsl::{Document, Schema};
 
 const STORE_MAGIC: u32 = 0x53544F52; // "STOR"
-const STORE_VERSION: u32 = 2; // Version 2 supports dictionaries
+/// Version 3 widens each document's stored field-value count from u16 to u32.
+const STORE_VERSION: u32 = 3;
 
 /// Block size for document store (16KB).
 /// Smaller blocks reduce read amplification for single-doc fetches at the
@@ -48,7 +49,7 @@ pub const DEFAULT_DICT_SIZE: usize = 4 * 1024;
 /// Hard safety bounds for individual on-disk store objects. Writers normally
 /// emit ~16 KiB blocks and 4 KiB dictionaries; these generous limits preserve
 /// unusually large stored documents while bounding corrupt compressed frames.
-const MAX_STORE_BLOCK_BYTES: usize = 64 * 1024 * 1024;
+const MAX_STORE_BLOCK_BYTES: usize = 256 * 1024 * 1024;
 const MAX_STORE_DICTIONARY_BYTES: u64 = 16 * 1024 * 1024;
 
 /// Default compression level for document store
@@ -88,7 +89,7 @@ fn write_store_index_and_footer(
 }
 
 /// Binary document format:
-///   num_fields: u16
+///   num_fields: u32
 ///   per field: field_id: u16, type_tag: u8, value data
 ///     0=Text:         len:u32 + utf8
 ///     1=U64:          u64 LE
@@ -133,10 +134,9 @@ pub fn serialize_document_into(
         .filter(|(field, value)| is_stored(field, value))
         .count();
 
-    buf.write_u16::<LittleEndian>(
-        u16::try_from(stored_count)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "too many stored fields"))?,
-    )?;
+    buf.write_u32::<LittleEndian>(u32::try_from(stored_count).map_err(|_| {
+        io::Error::new(io::ErrorKind::InvalidInput, "too many stored field-values")
+    })?)?;
 
     for (field, value) in doc.field_values().iter().filter(|(f, v)| is_stored(f, v)) {
         buf.write_u16::<LittleEndian>(u16::try_from(field.0).map_err(|_| {
@@ -1379,7 +1379,7 @@ fn deserialize_document_inner(
     use crate::dsl::Field;
 
     let mut reader = data;
-    let num_fields = reader.read_u16::<LittleEndian>()? as usize;
+    let num_fields = reader.read_u32::<LittleEndian>()? as usize;
     let mut doc = Document::new();
 
     for _ in 0..num_fields {
@@ -1891,12 +1891,17 @@ mod tests {
     }
 
     #[test]
+    fn document_store_block_limit_is_256_mib() {
+        assert_eq!(MAX_STORE_BLOCK_BYTES, 256 * 1024 * 1024);
+    }
+
+    #[test]
     fn document_deserializer_rejects_length_prefixed_slice_overrun() {
         let schema = Schema::builder().build();
-        let truncated_text = [1, 0, 0, 0, 0, 5, 0, 0, 0, b'x'];
+        let truncated_text = [1, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, b'x'];
         assert!(deserialize_document(&truncated_text, &schema).is_err());
 
-        let truncated_sparse = [1, 0, 0, 0, 5, 2, 0, 0, 0, 1, 0, 0, 0];
+        let truncated_sparse = [1, 0, 0, 0, 0, 0, 5, 2, 0, 0, 0, 1, 0, 0, 0];
         assert!(deserialize_document(&truncated_sparse, &schema).is_err());
     }
 

--- a/hermes-core/tests/index_writer_regressions.rs
+++ b/hermes-core/tests/index_writer_regressions.rs
@@ -12,6 +12,9 @@
 //! 4. A commit cancelled mid-flush (client disconnect drops the future)
 //!    leaves a detached waiter on the flush condvar; the retried commit must
 //!    still observe the flush completion instead of stalling to its deadline.
+//! 5. The v3 document store must encode more than 65,535 stored field-values,
+//!    while the independent u16 vector-ordinal limit is rejected before a
+//!    document enters an indexing generation.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -366,6 +369,92 @@ async fn test_retried_prepare_commit_survives_cancelled_commit_waiter() {
             .expect("retried prepare_commit must succeed");
     assert!(prepared.commit().await.unwrap());
     opener.await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// 5. stored-value counts and vector-ordinal limits are independent
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_store_v3_accepts_more_than_u16_stored_field_values() {
+    const VECTOR_COUNT: usize = u16::MAX as usize + 1;
+
+    let mut schema_builder = Schema::builder();
+    // Stored-only vectors do not consume vector ordinals. They isolate the
+    // document-store count from the separate indexed-vector limit.
+    let vectors = schema_builder.add_sparse_vector_field("vectors", false, true);
+    let title = schema_builder.add_text_field("title", true, true);
+    let directory = RamDirectory::new();
+    let mut writer = IndexWriter::create(
+        directory.clone(),
+        schema_builder.build(),
+        IndexConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    // 65,536 sparse values plus the title crosses the old u16 stored-value
+    // ceiling while remaining a valid document in store v3.
+    let mut document = Document::new();
+    document.add_text(title, "large document");
+    for _ in 0..VECTOR_COUNT {
+        document.add_sparse_vector(vectors, Vec::new());
+    }
+    writer.add_document(document).unwrap();
+    assert!(
+        writer.commit().await.unwrap(),
+        "the u32 stored-value count must commit"
+    );
+
+    drop(writer);
+    let index = Index::open(directory, IndexConfig::default())
+        .await
+        .unwrap();
+    let segment_id = index.segment_readers().await.unwrap()[0].meta().id;
+    let stored = index
+        .get_document(&hermes_core::query::DocAddress::new(segment_id, 0))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.get_all(vectors).count(), VECTOR_COUNT);
+    assert_eq!(
+        stored.get_first(title).and_then(|value| value.as_text()),
+        Some("large document")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_too_many_vector_values_is_rejected_before_queueing() {
+    let mut schema_builder = Schema::builder();
+    let vectors = schema_builder.add_sparse_vector_field("vectors", true, false);
+    let title = schema_builder.add_text_field("title", true, true);
+    let mut writer = IndexWriter::create(
+        RamDirectory::new(),
+        schema_builder.build(),
+        IndexConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    let mut oversized = Document::new();
+    for _ in 0..=(u16::MAX as usize + 1) {
+        oversized.add_sparse_vector(vectors, Vec::new());
+    }
+    let error = writer
+        .add_document(oversized)
+        .expect_err("ordinal overflow must be rejected before queueing");
+    assert!(
+        error.to_string().contains("more than 65536 vector values"),
+        "error must state the vector-value limit: {error}"
+    );
+
+    writer
+        .add_document(title_doc(title, "valid after rejection"))
+        .unwrap();
+    assert!(
+        writer.commit().await.unwrap(),
+        "a rejected document must not poison the commit generation"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- widen the per-document stored field-value count from u16 to u32 and bump the store format to v3
- raise the document-store block ceiling from 64 MiB to 256 MiB
- reject more than 65,536 indexed vectors per field before queueing so the commit generation remains usable

## Compatibility
- store v3 is intentionally incompatible with v2; existing indexes must be rebuilt
- vector ordinals remain u16

## Verification
- `cargo test -p hermes-core --lib` (1132 passed, 9 ignored)
- `cargo test -p hermes-core --test index_writer_regressions -- --nocapture` (8 passed)
- `cargo test -p hermes-core --no-default-features --features wasm --test wasm_writer_regressions -- --nocapture` (4 passed)
- `cargo clippy -p hermes-core --all-targets -- -D warnings`
- `cargo check -p hermes-core --no-default-features --features wasm`