### PR TITLE
feat(server,broker): make gRPC message caps, search limits, and query-shape guards startup-configurable

### DIFF
--- a/docs/broker.md
+++ b/docs/broker.md
@@ -80,8 +80,14 @@ Contract guarantees clients rely on:
   is `RESOURCE_EXHAUSTED` with the server's exact message, so client backoff
   logic cannot tell broker and backend apart. Only genuine unavailability
   surfaces as `UNAVAILABLE` (it trips client circuit breakers).
-- Transport limits and tuning mirror hermes-server exactly (search 4 MiB
-  decode / 64 MiB encode, index 256 MiB decode / 64 MiB encode, gzip+zstd).
+- Transport limits and tuning mirror hermes-server by default (search
+  4 MiB decode / 256 MiB encode, index 256 MiB decode / 64 MiB encode,
+  gzip+zstd). All six message caps are startup flags
+  (`--search-max-decode-mb`, `--search-max-encode-mb`,
+  `--index-max-decode-mb`, `--index-max-encode-mb`, plus
+  `--backend-max-decode-mb` / `--backend-max-encode-mb` for the
+  broker→backend channels); inconsistent combinations warn loudly at
+  startup.
 
 Pass-through responses are proto-equal, not always byte-equal: protobuf map
 fields (`SearchHit.fields`) may re-serialize entries in a different order.

--- a/hermes-broker/src/client.rs
+++ b/hermes-broker/src/client.rs
@@ -19,13 +19,6 @@ use tonic::transport::{Channel, Endpoint};
 use crate::proto::hermes::index_service_client::IndexServiceClient;
 use crate::proto::hermes::search_service_client::SearchServiceClient;
 
-/// Backends encode search/index responses up to 64 MiB (hermes-server
-/// SEARCH_MAX_ENCODE / INDEX_MAX_ENCODE).
-const BACKEND_MAX_DECODE: usize = 256 * 1024 * 1024;
-/// Backends accept index requests up to 256 MiB (INDEX_MAX_DECODE); the
-/// broker forwards whatever it accepted at its own edge.
-const BACKEND_MAX_ENCODE: usize = 256 * 1024 * 1024;
-
 /// Shaved off a propagated client deadline to cover broker overhead, so the
 /// backend gives up slightly before the client does and the client sees the
 /// backend's status rather than a broker-side race.
@@ -44,13 +37,26 @@ pub struct BackendChannels {
 pub struct ClientPool {
     channels: Mutex<HashMap<String, BackendChannels>>,
     backend_max_searches: usize,
+    /// Decoded-message cap on broker→backend channels (--backend-max-decode-mb);
+    /// must cover the backends' search/index encode caps.
+    backend_max_decode: usize,
+    /// Encoded-message cap on broker→backend channels (--backend-max-encode-mb);
+    /// must cover whatever the broker accepted at its own edge
+    /// (--index-max-decode-mb).
+    backend_max_encode: usize,
 }
 
 impl ClientPool {
-    pub fn new(backend_max_searches: usize) -> Self {
+    pub fn new(
+        backend_max_searches: usize,
+        backend_max_decode: usize,
+        backend_max_encode: usize,
+    ) -> Self {
         Self {
             channels: Mutex::new(HashMap::new()),
             backend_max_searches,
+            backend_max_decode,
+            backend_max_encode,
         }
     }
 
@@ -71,14 +77,14 @@ impl ClientPool {
                 .send_compressed(CompressionEncoding::Zstd)
                 .accept_compressed(CompressionEncoding::Zstd)
                 .accept_compressed(CompressionEncoding::Gzip)
-                .max_decoding_message_size(BACKEND_MAX_DECODE)
-                .max_encoding_message_size(BACKEND_MAX_ENCODE),
+                .max_decoding_message_size(self.backend_max_decode)
+                .max_encoding_message_size(self.backend_max_encode),
             index: IndexServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Zstd)
                 .accept_compressed(CompressionEncoding::Zstd)
                 .accept_compressed(CompressionEncoding::Gzip)
-                .max_decoding_message_size(BACKEND_MAX_DECODE)
-                .max_encoding_message_size(BACKEND_MAX_ENCODE),
+                .max_decoding_message_size(self.backend_max_decode)
+                .max_encoding_message_size(self.backend_max_encode),
             search_permits: Arc::new(Semaphore::new(self.backend_max_searches)),
         };
         self.channels

--- a/hermes-broker/src/main.rs
+++ b/hermes-broker/src/main.rs
@@ -129,6 +129,100 @@ struct Args {
     /// Maximum number of tokio worker threads (default: min(cpus, 16))
     #[arg(long)]
     worker_threads: Option<usize>,
+
+    /// Maximum decoded (received) gRPC message size in MiB for client-facing
+    /// SearchService requests. Mirror the hermes-server flag of the same name
+    /// so the broker stays transparent to clients.
+    #[arg(long, default_value = "4")]
+    search_max_decode_mb: usize,
+
+    /// Maximum encoded (sent) gRPC message size in MiB for client-facing
+    /// SearchService responses; must cover the backends'
+    /// --max-search-response-mb hydration budget.
+    #[arg(long, default_value = "256")]
+    search_max_encode_mb: usize,
+
+    /// Maximum decoded (received) gRPC message size in MiB for client-facing
+    /// IndexService requests (bounds one indexing batch).
+    #[arg(long, default_value = "256")]
+    index_max_decode_mb: usize,
+
+    /// Maximum encoded (sent) gRPC message size in MiB for client-facing
+    /// IndexService responses.
+    #[arg(long, default_value = "64")]
+    index_max_encode_mb: usize,
+
+    /// Maximum decoded message size in MiB on broker→backend channels; must
+    /// cover the backends' --search-max-encode-mb / --index-max-encode-mb.
+    #[arg(long, default_value = "256")]
+    backend_max_decode_mb: usize,
+
+    /// Maximum encoded message size in MiB on broker→backend channels; must
+    /// cover forwarded index batches (>= --index-max-decode-mb).
+    #[arg(long, default_value = "256")]
+    backend_max_encode_mb: usize,
+}
+
+/// gRPC message caps resolved from CLI flags. Inconsistent combinations that
+/// would strand traffic inside the broker are refused or warned about at
+/// startup, never discovered per-request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MessageCaps {
+    search_max_decode: usize,
+    search_max_encode: usize,
+    index_max_decode: usize,
+    index_max_encode: usize,
+    backend_max_decode: usize,
+    backend_max_encode: usize,
+}
+
+fn nonzero_mb_to_bytes(flag: &str, mb: usize) -> Result<usize> {
+    if mb == 0 {
+        return Err(anyhow::anyhow!("{flag} must be greater than zero"));
+    }
+    mb.checked_mul(1024 * 1024)
+        .ok_or_else(|| anyhow::anyhow!("{flag} is too large"))
+}
+
+fn resolve_message_caps(args: &Args) -> Result<MessageCaps> {
+    let caps = MessageCaps {
+        search_max_decode: nonzero_mb_to_bytes(
+            "--search-max-decode-mb",
+            args.search_max_decode_mb,
+        )?,
+        search_max_encode: nonzero_mb_to_bytes(
+            "--search-max-encode-mb",
+            args.search_max_encode_mb,
+        )?,
+        index_max_decode: nonzero_mb_to_bytes("--index-max-decode-mb", args.index_max_decode_mb)?,
+        index_max_encode: nonzero_mb_to_bytes("--index-max-encode-mb", args.index_max_encode_mb)?,
+        backend_max_decode: nonzero_mb_to_bytes(
+            "--backend-max-decode-mb",
+            args.backend_max_decode_mb,
+        )?,
+        backend_max_encode: nonzero_mb_to_bytes(
+            "--backend-max-encode-mb",
+            args.backend_max_encode_mb,
+        )?,
+    };
+    // Warnings, not errors: a fleet may intentionally run asymmetric caps
+    // (e.g. while rolling out a raise), but a silent mismatch strands
+    // responses inside the broker with a confusing per-request error.
+    if caps.search_max_encode < caps.backend_max_decode {
+        warn!(
+            "--search-max-encode-mb ({}) is below --backend-max-decode-mb ({}): backend \
+             search responses in between will fail to re-encode at the broker edge",
+            args.search_max_encode_mb, args.backend_max_decode_mb,
+        );
+    }
+    if caps.backend_max_encode < caps.index_max_decode {
+        warn!(
+            "--backend-max-encode-mb ({}) is below --index-max-decode-mb ({}): index \
+             batches in between are accepted from clients but cannot be forwarded",
+            args.backend_max_encode_mb, args.index_max_decode_mb,
+        );
+    }
+    Ok(caps)
 }
 
 fn main() -> Result<()> {
@@ -180,6 +274,7 @@ async fn async_main(args: Args) -> Result<()> {
     }
 
     let addr: SocketAddr = args.addr.parse()?;
+    let message_caps = resolve_message_caps(&args)?;
     if args.backend_max_searches == 0 {
         return Err(anyhow::anyhow!(
             "--backend-max-searches must be greater than zero"
@@ -273,7 +368,11 @@ async fn async_main(args: Args) -> Result<()> {
         }
     };
 
-    let pool = Arc::new(ClientPool::new(args.backend_max_searches));
+    let pool = Arc::new(ClientPool::new(
+        args.backend_max_searches,
+        message_caps.backend_max_decode,
+        message_caps.backend_max_encode,
+    ));
     let snapshot = Arc::new(ArcSwap::from_pointee(TopologySnapshot::default()));
     let (health_reporter, health_service) = tonic_health::server::health_reporter();
     health_reporter
@@ -339,12 +438,18 @@ async fn async_main(args: Args) -> Result<()> {
         None => info!("Broker-global search admission: per-backend caps only"),
     }
 
-    // Same limits and transport tuning as hermes-server so the broker is
-    // transparent to clients written against the server's envelope.
-    const SEARCH_MAX_DECODE: usize = 4 * 1024 * 1024; // 4 MB (queries are small)
-    const SEARCH_MAX_ENCODE: usize = 256 * 1024 * 1024; // 256 MB (must cover the backends' 192 MiB hydration budget)
-    const INDEX_MAX_DECODE: usize = 256 * 1024 * 1024; // 256 MB (batch indexing)
-    const INDEX_MAX_ENCODE: usize = 64 * 1024 * 1024; // 64 MB (responses are medium)
+    // Defaults mirror hermes-server so the broker is transparent to clients
+    // written against the server's envelope.
+    info!(
+        "gRPC message caps: search {}/{} MiB decode/encode, index {}/{} MiB decode/encode, \
+         backend channels {}/{} MiB decode/encode",
+        args.search_max_decode_mb,
+        args.search_max_encode_mb,
+        args.index_max_decode_mb,
+        args.index_max_encode_mb,
+        args.backend_max_decode_mb,
+        args.backend_max_encode_mb,
+    );
 
     let signal_flag = Arc::clone(&shutting_down);
     let signal_shutdown = shutdown_tx.clone();
@@ -363,16 +468,16 @@ async fn async_main(args: Args) -> Result<()> {
         .add_service(reflection_service)
         .add_service(
             SearchServiceServer::new(search_service)
-                .max_decoding_message_size(SEARCH_MAX_DECODE)
-                .max_encoding_message_size(SEARCH_MAX_ENCODE)
+                .max_decoding_message_size(message_caps.search_max_decode)
+                .max_encoding_message_size(message_caps.search_max_encode)
                 .accept_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Zstd)
                 .send_compressed(CompressionEncoding::Zstd),
         )
         .add_service(
             IndexServiceServer::new(index_service)
-                .max_decoding_message_size(INDEX_MAX_DECODE)
-                .max_encoding_message_size(INDEX_MAX_ENCODE)
+                .max_decoding_message_size(message_caps.index_max_decode)
+                .max_encoding_message_size(message_caps.index_max_encode)
                 .accept_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Zstd)
                 .send_compressed(CompressionEncoding::Zstd),
@@ -457,6 +562,38 @@ mod tests {
         assert_eq!(args.backend_max_searches, 16);
         assert_eq!(args.max_concurrent_searches, None);
         assert_eq!(args.placement_default, PlacementDefault::Single);
+
+        // Message caps default to the historical hard-coded envelope.
+        let caps = resolve_message_caps(&args).unwrap();
+        assert_eq!(
+            caps,
+            MessageCaps {
+                search_max_decode: 4 * 1024 * 1024,
+                search_max_encode: 256 * 1024 * 1024,
+                index_max_decode: 256 * 1024 * 1024,
+                index_max_encode: 64 * 1024 * 1024,
+                backend_max_decode: 256 * 1024 * 1024,
+                backend_max_encode: 256 * 1024 * 1024,
+            }
+        );
+    }
+
+    #[test]
+    fn message_cap_flags_override_and_reject_zero() {
+        let args = Args::try_parse_from([
+            "hermes-broker",
+            "--search-max-encode-mb",
+            "512",
+            "--backend-max-decode-mb",
+            "512",
+        ])
+        .unwrap();
+        let caps = resolve_message_caps(&args).unwrap();
+        assert_eq!(caps.search_max_encode, 512 * 1024 * 1024);
+        assert_eq!(caps.backend_max_decode, 512 * 1024 * 1024);
+
+        let zero = Args::try_parse_from(["hermes-broker", "--index-max-decode-mb", "0"]).unwrap();
+        assert!(resolve_message_caps(&zero).is_err());
     }
 
     #[test]

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -19,9 +19,7 @@ static TOKENIZER_REGISTRY: LazyLock<TokenizerRegistry> = LazyLock::new(Tokenizer
 use crate::proto;
 use crate::proto::field_value::Value;
 use crate::proto::query::Query as ProtoQueryType;
-
-const MAX_TEXT_QUERY_TOKENS: usize = 256;
-const MAX_SPARSE_TOKEN_DIMENSIONS: usize = 4_096;
+use crate::search_service::QueryShapeLimits;
 
 fn validate_token_expansion(kind: &str, count: usize, maximum: usize) -> Result<(), String> {
     if count > maximum {
@@ -61,6 +59,7 @@ pub fn convert_query(
     schema: &Schema,
     global_stats: Option<&LazyGlobalStats>,
     idf_cache_dir: Option<&std::path::Path>,
+    shape: &QueryShapeLimits,
 ) -> Result<Box<dyn Query>, String> {
     match &query.query {
         Some(ProtoQueryType::Term(term_query)) => {
@@ -89,7 +88,7 @@ pub fn convert_query(
                 .into_iter()
                 .map(|t| t.text)
                 .collect();
-            validate_token_expansion("TermQuery", tokens.len(), MAX_TEXT_QUERY_TOKENS)?;
+            validate_token_expansion("TermQuery", tokens.len(), shape.max_text_query_tokens)?;
             if tokens.is_empty() {
                 return Err(format!("No tokens in term '{}'", term_query.term));
             }
@@ -131,7 +130,7 @@ pub fn convert_query(
                 .into_iter()
                 .map(|t| t.text)
                 .collect();
-            validate_token_expansion("MatchQuery", tokens.len(), MAX_TEXT_QUERY_TOKENS)?;
+            validate_token_expansion("MatchQuery", tokens.len(), shape.max_text_query_tokens)?;
 
             if tokens.is_empty() {
                 return Err(format!(
@@ -153,7 +152,7 @@ pub fn convert_query(
             Ok(Box::new(query))
         }
         Some(ProtoQueryType::Boolean(bool_query)) => {
-            convert_boolean_query(bool_query, schema, global_stats, idf_cache_dir)
+            convert_boolean_query(bool_query, schema, global_stats, idf_cache_dir, shape)
         }
         Some(ProtoQueryType::Boost(boost_query)) => {
             if !boost_query.boost.is_finite() {
@@ -163,7 +162,7 @@ pub fn convert_query(
                 .query
                 .as_ref()
                 .ok_or_else(|| "Boost query requires inner query".to_string())?;
-            let inner_query = convert_query(inner, schema, global_stats, idf_cache_dir)?;
+            let inner_query = convert_query(inner, schema, global_stats, idf_cache_dir, shape)?;
             Ok(Box::new(BoostQuery {
                 inner: inner_query.into(),
                 boost: boost_query.boost,
@@ -249,7 +248,7 @@ pub fn convert_query(
                 validate_token_expansion(
                     "SparseVectorQuery.text",
                     token_counts.len(),
-                    MAX_SPARSE_TOKEN_DIMENSIONS,
+                    shape.max_sparse_token_dimensions,
                 )?;
 
                 // Convert (token_id, count) to (token_id, weight)
@@ -551,18 +550,19 @@ fn convert_boolean_query(
     schema: &Schema,
     global_stats: Option<&LazyGlobalStats>,
     idf_cache_dir: Option<&std::path::Path>,
+    shape: &QueryShapeLimits,
 ) -> Result<Box<dyn Query>, String> {
     let mut bq = BooleanQuery::new();
     for q in &bool_query.must {
-        let inner = convert_query(q, schema, global_stats, idf_cache_dir)?;
+        let inner = convert_query(q, schema, global_stats, idf_cache_dir, shape)?;
         bq.must.push(inner.into());
     }
     for q in &bool_query.should {
-        let inner = convert_query(q, schema, global_stats, idf_cache_dir)?;
+        let inner = convert_query(q, schema, global_stats, idf_cache_dir, shape)?;
         bq.should.push(inner.into());
     }
     for q in &bool_query.must_not {
-        let inner = convert_query(q, schema, global_stats, idf_cache_dir)?;
+        let inner = convert_query(q, schema, global_stats, idf_cache_dir, shape)?;
         bq.must_not.push(inner.into());
     }
     Ok(Box::new(bq))
@@ -1197,6 +1197,10 @@ pub fn convert_proto_to_document(
 mod tests {
     use super::*;
 
+    fn shape() -> QueryShapeLimits {
+        QueryShapeLimits::default()
+    }
+
     #[test]
     fn token_expansion_is_bounded_before_query_construction() {
         assert!(validate_token_expansion("test", 256, 256).is_ok());
@@ -1253,18 +1257,26 @@ mod tests {
     #[test]
     fn bmp_query_dimension_pruning_is_explicit_not_a_server_fallback() {
         let schema = bmp_sparse_test_schema();
-        let default_query = convert_query(&sparse_proto_query(0.0), &schema, None, None).unwrap();
+        let default_query =
+            convert_query(&sparse_proto_query(0.0), &schema, None, None, &shape()).unwrap();
         assert!(!default_query.to_string().contains("orig="));
 
-        let pruned_query = convert_query(&sparse_proto_query(0.33), &schema, None, None).unwrap();
+        let pruned_query =
+            convert_query(&sparse_proto_query(0.33), &schema, None, None, &shape()).unwrap();
         assert!(pruned_query.to_string().contains("orig=6"));
     }
 
     #[test]
     fn dense_query_uses_schema_nprobe_when_request_omits_it() {
         let schema = dense_test_schema(17);
-        let query =
-            convert_query(&dense_proto_query(vec![1.0, 2.0, 3.0]), &schema, None, None).unwrap();
+        let query = convert_query(
+            &dense_proto_query(vec![1.0, 2.0, 3.0]),
+            &schema,
+            None,
+            None,
+            &shape(),
+        )
+        .unwrap();
 
         assert!(query.to_string().contains("nprobe=17"));
     }
@@ -1272,8 +1284,14 @@ mod tests {
     #[test]
     fn server_conversion_uses_the_shared_candidate_budget() {
         let schema = dense_test_schema(17);
-        let query =
-            convert_query(&dense_proto_query(vec![1.0, 2.0, 3.0]), &schema, None, None).unwrap();
+        let query = convert_query(
+            &dense_proto_query(vec![1.0, 2.0, 3.0]),
+            &schema,
+            None,
+            None,
+            &shape(),
+        )
+        .unwrap();
 
         assert!(query.to_string().contains("rerank=1"));
     }
@@ -1290,7 +1308,7 @@ mod tests {
             vec![1.0, f32::NEG_INFINITY, 3.0],
         ] {
             assert!(
-                convert_query(&dense_proto_query(vector), &schema, None, None).is_err(),
+                convert_query(&dense_proto_query(vector), &schema, None, None, &shape()).is_err(),
                 "invalid vector should be rejected"
             );
         }
@@ -1304,14 +1322,14 @@ mod tests {
             unreachable!()
         };
         query.field = "title".to_string();
-        assert!(convert_query(&wrong_field, &schema, None, None).is_err());
+        assert!(convert_query(&wrong_field, &schema, None, None, &shape()).is_err());
 
         let mut proto = dense_proto_query(vec![1.0, 2.0, 3.0]);
         let Some(ProtoQueryType::DenseVector(query)) = proto.query.as_mut() else {
             unreachable!()
         };
         query.nprobe = MAX_DENSE_NPROBE as u32 + 1;
-        assert!(convert_query(&proto, &schema, None, None).is_err());
+        assert!(convert_query(&proto, &schema, None, None, &shape()).is_err());
     }
 
     #[test]
@@ -1330,8 +1348,8 @@ mod tests {
             })),
         };
 
-        assert!(convert_query(&match_all_prefix, &schema, None, None).is_err());
-        assert!(convert_query(&explicit_empty_prefix, &schema, None, None).is_err());
+        assert!(convert_query(&match_all_prefix, &schema, None, None, &shape()).is_err());
+        assert!(convert_query(&explicit_empty_prefix, &schema, None, None, &shape()).is_err());
     }
 
     #[test]
@@ -1347,9 +1365,9 @@ mod tests {
             )),
         };
 
-        assert!(convert_query(&query("binary", vec![0, 1]), &schema, None, None).is_ok());
-        assert!(convert_query(&query("binary", vec![0]), &schema, None, None).is_err());
-        assert!(convert_query(&query("title", vec![0, 1]), &schema, None, None).is_err());
+        assert!(convert_query(&query("binary", vec![0, 1]), &schema, None, None, &shape()).is_ok());
+        assert!(convert_query(&query("binary", vec![0]), &schema, None, None, &shape()).is_err());
+        assert!(convert_query(&query("title", vec![0, 1]), &schema, None, None, &shape()).is_err());
 
         let bad_document = [proto::FieldEntry {
             name: "binary".to_string(),
@@ -1372,27 +1390,53 @@ mod tests {
             })),
         };
 
-        assert!(convert_query(&query("sparse", vec![1], vec![1.0]), &schema, None, None).is_ok());
         assert!(
-            convert_query(&query("sparse", vec![1, 2], vec![1.0]), &schema, None, None).is_err()
+            convert_query(
+                &query("sparse", vec![1], vec![1.0]),
+                &schema,
+                None,
+                None,
+                &shape()
+            )
+            .is_ok()
+        );
+        assert!(
+            convert_query(
+                &query("sparse", vec![1, 2], vec![1.0]),
+                &schema,
+                None,
+                None,
+                &shape()
+            )
+            .is_err()
         );
         assert!(
             convert_query(
                 &query("sparse", vec![1], vec![f32::NAN]),
                 &schema,
                 None,
-                None
+                None,
+                &shape()
             )
             .is_err()
         );
-        assert!(convert_query(&query("title", vec![1], vec![1.0]), &schema, None, None).is_err());
+        assert!(
+            convert_query(
+                &query("title", vec![1], vec![1.0]),
+                &schema,
+                None,
+                None,
+                &shape()
+            )
+            .is_err()
+        );
 
         let mut invalid_factor = query("sparse", vec![1], vec![1.0]);
         let Some(ProtoQueryType::SparseVector(query)) = invalid_factor.query.as_mut() else {
             unreachable!()
         };
         query.heap_factor = f32::INFINITY;
-        assert!(convert_query(&invalid_factor, &schema, None, None).is_err());
+        assert!(convert_query(&invalid_factor, &schema, None, None, &shape()).is_err());
     }
 
     #[test]

--- a/hermes-server/src/main.rs
+++ b/hermes-server/src/main.rs
@@ -196,6 +196,244 @@ struct Args {
     /// Set to "off" to disable the exporter.
     #[arg(long, default_value = "0.0.0.0:9184")]
     metrics_addr: String,
+
+    /// Maximum decoded (received) gRPC message size in MiB for SearchService
+    /// requests. Queries are small; raise only for very large query vectors.
+    #[arg(long, default_value = "4")]
+    search_max_decode_mb: usize,
+
+    /// Maximum encoded (sent) gRPC message size in MiB for SearchService
+    /// responses. Must be at least --max-search-response-mb plus framing
+    /// headroom; a hermes-broker in front must mirror it in
+    /// --backend-max-decode-mb.
+    #[arg(long, default_value = "256")]
+    search_max_encode_mb: usize,
+
+    /// Maximum decoded (received) gRPC message size in MiB for IndexService
+    /// requests (bounds one indexing batch).
+    #[arg(long, default_value = "256")]
+    index_max_decode_mb: usize,
+
+    /// Maximum encoded (sent) gRPC message size in MiB for IndexService
+    /// responses.
+    #[arg(long, default_value = "64")]
+    index_max_encode_mb: usize,
+
+    /// Hydration budget in MiB for one search response: caps estimated
+    /// retained heap while the response is built and its encoded size.
+    /// Must not exceed --search-max-encode-mb; downstream broker/client
+    /// decode caps must stay above it.
+    #[arg(long, default_value = "192")]
+    max_search_response_mb: usize,
+
+    /// Results returned when SearchRequest.limit is 0
+    #[arg(long, default_value = "10")]
+    default_search_limit: usize,
+
+    /// Upper bound on SearchRequest.limit
+    #[arg(long, default_value = "10000")]
+    max_search_limit: usize,
+
+    /// Upper bound on SearchRequest.offset + limit (pagination window)
+    #[arg(long, default_value = "50000")]
+    max_search_window: usize,
+
+    /// Upper bound on the first-stage candidate pool
+    /// (SearchRequest.candidate_limit)
+    #[arg(long, default_value = "50000")]
+    max_candidate_limit: usize,
+
+    // Structural anti-DoS budgets for one decoded request. The transport's
+    // decode limit bounds wire bytes, not decoded object count or downstream
+    // expansion, so these are independent budgets.
+    /// Maximum query tree nesting depth
+    #[arg(long, default_value = "32")]
+    max_query_depth: usize,
+
+    /// Maximum query tree nodes per request
+    #[arg(long, default_value = "256")]
+    max_query_nodes: usize,
+
+    /// Maximum aggregate clauses across the query tree
+    #[arg(long, default_value = "512")]
+    max_query_clauses: usize,
+
+    /// Maximum clauses in a single BooleanQuery
+    #[arg(long, default_value = "128")]
+    max_boolean_clauses: usize,
+
+    /// Maximum aggregate query text bytes (terms, match text, field names)
+    #[arg(long, default_value = "65536")]
+    max_query_text_bytes: usize,
+
+    /// Maximum bytes in one field name
+    #[arg(long, default_value = "255")]
+    max_field_name_bytes: usize,
+
+    /// Maximum bytes in the index name
+    #[arg(long, default_value = "255")]
+    max_index_name_bytes: usize,
+
+    /// Maximum elements in one dense query/reranker vector
+    #[arg(long, default_value = "65536")]
+    max_dense_query_dims: usize,
+
+    /// Maximum entries in one sparse query vector
+    #[arg(long, default_value = "4096")]
+    max_sparse_query_dims: usize,
+
+    /// Maximum bytes in one binary query/reranker vector
+    #[arg(long, default_value = "262144")]
+    max_binary_query_bytes: usize,
+
+    /// Maximum aggregate query vector bytes per request
+    #[arg(long, default_value = "1048576")]
+    max_total_query_vector_bytes: usize,
+
+    /// Maximum names in SearchRequest.fields_to_load
+    #[arg(long, default_value = "64")]
+    max_fields_to_load: usize,
+
+    /// Maximum aggregate bytes across fields_to_load names
+    #[arg(long, default_value = "16384")]
+    max_fields_to_load_name_bytes: usize,
+
+    /// Maximum tokens a Term/Match query may expand to after tokenization
+    #[arg(long, default_value = "256")]
+    max_text_query_tokens: usize,
+
+    /// Maximum dimensions a SparseVectorQuery text may tokenize into
+    #[arg(long, default_value = "4096")]
+    max_sparse_token_dimensions: usize,
+}
+
+/// gRPC transport envelope and request-facing search limits resolved from CLI
+/// flags, cross-validated so an inconsistent configuration fails at startup
+/// instead of rejecting every oversized response at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ServiceLimits {
+    search_max_decode_bytes: usize,
+    search_max_encode_bytes: usize,
+    index_max_decode_bytes: usize,
+    index_max_encode_bytes: usize,
+    search: search_service::SearchLimits,
+}
+
+fn nonzero_mb_to_bytes(flag: &str, mb: usize) -> Result<usize> {
+    if mb == 0 {
+        return Err(anyhow::anyhow!("{flag} must be greater than zero"));
+    }
+    mb.checked_mul(1024 * 1024)
+        .ok_or_else(|| anyhow::anyhow!("{flag} is too large"))
+}
+
+fn nonzero(flag: &str, value: usize) -> Result<usize> {
+    if value == 0 {
+        return Err(anyhow::anyhow!("{flag} must be greater than zero"));
+    }
+    Ok(value)
+}
+
+fn resolve_query_shape_limits(args: &Args) -> Result<search_service::QueryShapeLimits> {
+    let shape = search_service::QueryShapeLimits {
+        max_query_depth: nonzero("--max-query-depth", args.max_query_depth)?,
+        max_query_nodes: nonzero("--max-query-nodes", args.max_query_nodes)?,
+        max_query_clauses: nonzero("--max-query-clauses", args.max_query_clauses)?,
+        max_boolean_clauses: nonzero("--max-boolean-clauses", args.max_boolean_clauses)?,
+        max_query_text_bytes: nonzero("--max-query-text-bytes", args.max_query_text_bytes)?,
+        max_field_name_bytes: nonzero("--max-field-name-bytes", args.max_field_name_bytes)?,
+        max_index_name_bytes: nonzero("--max-index-name-bytes", args.max_index_name_bytes)?,
+        max_dense_query_dims: nonzero("--max-dense-query-dims", args.max_dense_query_dims)?,
+        max_sparse_query_dims: nonzero("--max-sparse-query-dims", args.max_sparse_query_dims)?,
+        max_binary_query_bytes: nonzero("--max-binary-query-bytes", args.max_binary_query_bytes)?,
+        max_total_query_vector_bytes: nonzero(
+            "--max-total-query-vector-bytes",
+            args.max_total_query_vector_bytes,
+        )?,
+        max_fields_to_load: nonzero("--max-fields-to-load", args.max_fields_to_load)?,
+        max_fields_to_load_name_bytes: nonzero(
+            "--max-fields-to-load-name-bytes",
+            args.max_fields_to_load_name_bytes,
+        )?,
+        max_text_query_tokens: nonzero("--max-text-query-tokens", args.max_text_query_tokens)?,
+        max_sparse_token_dimensions: nonzero(
+            "--max-sparse-token-dimensions",
+            args.max_sparse_token_dimensions,
+        )?,
+    };
+    if shape.max_boolean_clauses > shape.max_query_clauses {
+        return Err(anyhow::anyhow!(
+            "--max-boolean-clauses ({}) must not exceed --max-query-clauses ({}): a single \
+             BooleanQuery could never reach its own cap",
+            shape.max_boolean_clauses,
+            shape.max_query_clauses,
+        ));
+    }
+    Ok(shape)
+}
+
+fn resolve_service_limits(args: &Args) -> Result<ServiceLimits> {
+    let search_max_decode_bytes =
+        nonzero_mb_to_bytes("--search-max-decode-mb", args.search_max_decode_mb)?;
+    let search_max_encode_bytes =
+        nonzero_mb_to_bytes("--search-max-encode-mb", args.search_max_encode_mb)?;
+    let index_max_decode_bytes =
+        nonzero_mb_to_bytes("--index-max-decode-mb", args.index_max_decode_mb)?;
+    let index_max_encode_bytes =
+        nonzero_mb_to_bytes("--index-max-encode-mb", args.index_max_encode_mb)?;
+    let max_search_response_bytes =
+        nonzero_mb_to_bytes("--max-search-response-mb", args.max_search_response_mb)?;
+
+    if search_max_encode_bytes < max_search_response_bytes {
+        return Err(anyhow::anyhow!(
+            "--search-max-encode-mb ({}) must be at least --max-search-response-mb ({}) \
+             or every response near the hydration budget fails to encode",
+            args.search_max_encode_mb,
+            args.max_search_response_mb,
+        ));
+    }
+    if args.default_search_limit == 0 {
+        return Err(anyhow::anyhow!(
+            "--default-search-limit must be greater than zero"
+        ));
+    }
+    if args.default_search_limit > args.max_search_limit {
+        return Err(anyhow::anyhow!(
+            "--default-search-limit ({}) must not exceed --max-search-limit ({})",
+            args.default_search_limit,
+            args.max_search_limit,
+        ));
+    }
+    if args.max_search_window < args.max_search_limit {
+        return Err(anyhow::anyhow!(
+            "--max-search-window ({}) must be at least --max-search-limit ({})",
+            args.max_search_window,
+            args.max_search_limit,
+        ));
+    }
+    if args.max_candidate_limit < args.max_search_window {
+        return Err(anyhow::anyhow!(
+            "--max-candidate-limit ({}) must be at least --max-search-window ({}) \
+             so every allowed page can fill its candidate pool",
+            args.max_candidate_limit,
+            args.max_search_window,
+        ));
+    }
+
+    Ok(ServiceLimits {
+        search_max_decode_bytes,
+        search_max_encode_bytes,
+        index_max_decode_bytes,
+        index_max_encode_bytes,
+        search: search_service::SearchLimits {
+            default_search_limit: args.default_search_limit,
+            max_search_limit: args.max_search_limit,
+            max_search_window: args.max_search_window,
+            max_candidate_limit: args.max_candidate_limit,
+            shape: resolve_query_shape_limits(args)?,
+            max_search_response_bytes,
+        },
+    })
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug)]
@@ -304,6 +542,8 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
     }
 
     let addr: SocketAddr = args.addr.parse()?;
+
+    let service_limits = resolve_service_limits(&args)?;
 
     let num_indexing_threads = args
         .indexing_threads
@@ -440,8 +680,11 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
         registry.doctor_all_indexes().await;
     }
 
-    let search_service =
-        search_service::SearchServiceImpl::new(Arc::clone(&registry), max_concurrent_searches);
+    let search_service = search_service::SearchServiceImpl::new(
+        Arc::clone(&registry),
+        max_concurrent_searches,
+        service_limits.search,
+    );
 
     let index_service = index_service::IndexServiceImpl {
         registry: Arc::clone(&registry),
@@ -510,11 +753,34 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
         );
     }
 
-    // Separate message size limits for search vs index services
-    const SEARCH_MAX_DECODE: usize = 4 * 1024 * 1024; // 4 MB (queries are small)
-    const SEARCH_MAX_ENCODE: usize = 256 * 1024 * 1024; // 256 MB (192 MiB hydration budget + framing headroom)
-    const INDEX_MAX_DECODE: usize = 256 * 1024 * 1024; // 256 MB (batch indexing)
-    const INDEX_MAX_ENCODE: usize = 64 * 1024 * 1024; // 64 MB (responses are medium)
+    info!(
+        "gRPC message caps: search {}/{} MiB decode/encode, index {}/{} MiB decode/encode",
+        args.search_max_decode_mb,
+        args.search_max_encode_mb,
+        args.index_max_decode_mb,
+        args.index_max_encode_mb,
+    );
+    info!(
+        "Search limits: default {}, max {}, window {}, candidates {}, response budget {} MiB",
+        args.default_search_limit,
+        args.max_search_limit,
+        args.max_search_window,
+        args.max_candidate_limit,
+        args.max_search_response_mb,
+    );
+    info!(
+        "Query shape budgets: depth {}, nodes {}, clauses {} (boolean {}), text {} B, \
+         vectors {} B total, fields_to_load {}, token expansion {} (sparse {})",
+        args.max_query_depth,
+        args.max_query_nodes,
+        args.max_query_clauses,
+        args.max_boolean_clauses,
+        args.max_query_text_bytes,
+        args.max_total_query_vector_bytes,
+        args.max_fields_to_load,
+        args.max_text_query_tokens,
+        args.max_sparse_token_dimensions,
+    );
 
     let signal_registry = Arc::clone(&registry);
     let signal_shutdown = shutdown_tx.clone();
@@ -532,16 +798,16 @@ async fn async_main(args: Args, worker_threads: usize) -> Result<()> {
         .concurrency_limit_per_connection(128)
         .add_service(
             SearchServiceServer::new(search_service)
-                .max_decoding_message_size(SEARCH_MAX_DECODE)
-                .max_encoding_message_size(SEARCH_MAX_ENCODE)
+                .max_decoding_message_size(service_limits.search_max_decode_bytes)
+                .max_encoding_message_size(service_limits.search_max_encode_bytes)
                 .accept_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Zstd)
                 .send_compressed(CompressionEncoding::Zstd),
         )
         .add_service(
             IndexServiceServer::new(index_service)
-                .max_decoding_message_size(INDEX_MAX_DECODE)
-                .max_encoding_message_size(INDEX_MAX_ENCODE)
+                .max_decoding_message_size(service_limits.index_max_decode_bytes)
+                .max_encoding_message_size(service_limits.index_max_encode_bytes)
                 .accept_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Zstd)
                 .send_compressed(CompressionEncoding::Zstd),
@@ -632,5 +898,112 @@ mod tests {
     fn zero_merge_bp_budget_is_unbudgeted() {
         assert_eq!(merge_bp_time_budget(0), None);
         assert_eq!(merge_bp_time_budget(600), Some(Duration::from_secs(600)));
+    }
+
+    #[test]
+    fn service_limit_defaults_match_historical_constants() {
+        let args = Args::try_parse_from(["hermes-server"]).unwrap();
+        let limits = resolve_service_limits(&args).unwrap();
+        assert_eq!(limits.search_max_decode_bytes, 4 * 1024 * 1024);
+        assert_eq!(limits.search_max_encode_bytes, 256 * 1024 * 1024);
+        assert_eq!(limits.index_max_decode_bytes, 256 * 1024 * 1024);
+        assert_eq!(limits.index_max_encode_bytes, 64 * 1024 * 1024);
+        assert_eq!(limits.search, search_service::SearchLimits::default());
+    }
+
+    #[test]
+    fn service_limit_flags_override_defaults() {
+        let args = Args::try_parse_from([
+            "hermes-server",
+            "--search-max-encode-mb",
+            "512",
+            "--max-search-response-mb",
+            "384",
+            "--max-search-limit",
+            "20000",
+            "--max-search-window",
+            "80000",
+            "--max-candidate-limit",
+            "80000",
+        ])
+        .unwrap();
+        let limits = resolve_service_limits(&args).unwrap();
+        assert_eq!(limits.search_max_encode_bytes, 512 * 1024 * 1024);
+        assert_eq!(limits.search.max_search_response_bytes, 384 * 1024 * 1024);
+        assert_eq!(limits.search.max_search_limit, 20_000);
+        assert_eq!(limits.search.max_search_window, 80_000);
+        assert_eq!(limits.search.max_candidate_limit, 80_000);
+    }
+
+    #[test]
+    fn query_shape_flags_override_defaults_and_reject_inconsistency() {
+        let args = Args::try_parse_from([
+            "hermes-server",
+            "--max-query-depth",
+            "8",
+            "--max-text-query-tokens",
+            "64",
+            "--max-sparse-token-dimensions",
+            "1024",
+        ])
+        .unwrap();
+        let shape = resolve_service_limits(&args).unwrap().search.shape;
+        assert_eq!(shape.max_query_depth, 8);
+        assert_eq!(shape.max_text_query_tokens, 64);
+        assert_eq!(shape.max_sparse_token_dimensions, 1024);
+
+        // Zero budgets are refused.
+        let zero = Args::try_parse_from(["hermes-server", "--max-query-nodes", "0"]).unwrap();
+        assert!(resolve_service_limits(&zero).is_err());
+
+        // A per-boolean cap above the aggregate clause budget is unreachable.
+        let unreachable = Args::try_parse_from([
+            "hermes-server",
+            "--max-boolean-clauses",
+            "1024",
+            "--max-query-clauses",
+            "512",
+        ])
+        .unwrap();
+        assert!(resolve_service_limits(&unreachable).is_err());
+    }
+
+    #[test]
+    fn inconsistent_service_limits_fail_at_startup() {
+        // Zero message caps are refused.
+        let zero = Args::try_parse_from(["hermes-server", "--search-max-decode-mb", "0"]).unwrap();
+        assert!(resolve_service_limits(&zero).is_err());
+
+        // Hydration budget above the transport encode cap is refused.
+        let over_encode = Args::try_parse_from([
+            "hermes-server",
+            "--search-max-encode-mb",
+            "128",
+            "--max-search-response-mb",
+            "192",
+        ])
+        .unwrap();
+        assert!(resolve_service_limits(&over_encode).is_err());
+
+        // Default limit above the maximum is refused.
+        let bad_default = Args::try_parse_from([
+            "hermes-server",
+            "--default-search-limit",
+            "100",
+            "--max-search-limit",
+            "50",
+        ])
+        .unwrap();
+        assert!(resolve_service_limits(&bad_default).is_err());
+
+        // Window below the maximum limit is refused.
+        let bad_window =
+            Args::try_parse_from(["hermes-server", "--max-search-window", "5000"]).unwrap();
+        assert!(resolve_service_limits(&bad_window).is_err());
+
+        // Candidate cap below the window is refused.
+        let bad_candidates =
+            Args::try_parse_from(["hermes-server", "--max-candidate-limit", "10000"]).unwrap();
+        assert!(resolve_service_limits(&bad_candidates).is_err());
     }
 }

--- a/hermes-server/src/search_service.rs
+++ b/hermes-server/src/search_service.rs
@@ -14,50 +14,136 @@ use crate::proto::search_service_server::SearchService;
 use crate::proto::*;
 use crate::registry::IndexRegistry;
 
-const DEFAULT_SEARCH_LIMIT: usize = 10;
-const MAX_SEARCH_LIMIT: usize = 10_000;
-const MAX_SEARCH_WINDOW: usize = 50_000;
-const MAX_CANDIDATE_LIMIT: usize = 50_000;
 const MAX_FUSION_SUB_QUERIES: usize = hermes_core::query::MAX_FUSION_SUB_QUERIES;
 const MAX_FUSION_CANDIDATE_SLOTS: usize = hermes_core::query::MAX_FUSION_CANDIDATE_SLOTS;
 
-// The transport's 4 MiB decode limit bounds wire bytes, not decoded object
-// count or downstream expansion. Empty protobuf messages and strings are only
-// a few bytes on the wire, so keep independent structural budgets here.
-const MAX_QUERY_DEPTH: usize = 32;
-const MAX_QUERY_NODES: usize = 256;
-const MAX_QUERY_CLAUSES: usize = 512;
-const MAX_BOOLEAN_CLAUSES: usize = 128;
-const MAX_QUERY_TEXT_BYTES: usize = 64 * 1024;
-const MAX_FIELD_NAME_BYTES: usize = 255;
-const MAX_INDEX_NAME_BYTES: usize = 255;
-const MAX_DENSE_QUERY_DIMS: usize = 65_536;
-const MAX_SPARSE_QUERY_DIMS: usize = 4_096;
-const MAX_BINARY_QUERY_BYTES: usize = 256 * 1024;
-const MAX_TOTAL_QUERY_VECTOR_BYTES: usize = 1024 * 1024;
-const MAX_FIELDS_TO_LOAD: usize = 64;
-const MAX_FIELDS_TO_LOAD_NAME_BYTES: usize = 16 * 1024;
-
-// Leave headroom below tonic's 256 MiB response limit for compression and
-// framing, and also cap estimated retained heap while the response is built.
-// 2026-08-22: raised 48 → 192 MiB — chunk-level binary reranking over a
-// book-heavy RAG pool legitimately hydrates >48 MiB (a few dozen books ×
-// thousands of 320-byte chunk vectors). Downstream caps that must stay
-// above this: hermes-server SEARCH_MAX_ENCODE (256 MiB), hermes-broker
-// BACKEND_MAX_DECODE / SEARCH_MAX_ENCODE (256 MiB), and the consumers'
-// hermes-client decode cap (200 MiB).
-const MAX_SEARCH_RESPONSE_BYTES: usize = 192 * 1024 * 1024;
 const UNKNOWN_INDEX_LABEL: &str = "unknown";
 
-#[derive(Default)]
-struct QueryShapeBudget {
+/// Structural anti-DoS budgets for one decoded request, set once at startup
+/// from the hermes-server CLI (flags of the same names). The transport's
+/// decode limit (`--search-max-decode-mb`) bounds wire bytes, not decoded
+/// object count or downstream expansion — empty protobuf messages and strings
+/// are only a few bytes on the wire — so these are independent budgets.
+/// `Default` preserves the historical hard-coded values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueryShapeLimits {
+    /// Maximum query tree nesting depth.
+    pub max_query_depth: usize,
+    /// Maximum query tree nodes per request.
+    pub max_query_nodes: usize,
+    /// Maximum aggregate clauses across the query tree.
+    pub max_query_clauses: usize,
+    /// Maximum clauses in a single BooleanQuery.
+    pub max_boolean_clauses: usize,
+    /// Maximum aggregate query text bytes (terms, match text, field names).
+    pub max_query_text_bytes: usize,
+    /// Maximum bytes in one field name.
+    pub max_field_name_bytes: usize,
+    /// Maximum bytes in the index name.
+    pub max_index_name_bytes: usize,
+    /// Maximum elements in one dense query/reranker vector.
+    pub max_dense_query_dims: usize,
+    /// Maximum entries in one sparse query vector.
+    pub max_sparse_query_dims: usize,
+    /// Maximum bytes in one binary query/reranker vector.
+    pub max_binary_query_bytes: usize,
+    /// Maximum aggregate query vector bytes per request.
+    pub max_total_query_vector_bytes: usize,
+    /// Maximum names in SearchRequest.fields_to_load.
+    pub max_fields_to_load: usize,
+    /// Maximum aggregate bytes across fields_to_load names.
+    pub max_fields_to_load_name_bytes: usize,
+    /// Maximum tokens a Term/Match query may expand to after tokenization.
+    pub max_text_query_tokens: usize,
+    /// Maximum dimensions a SparseVectorQuery text may tokenize into.
+    pub max_sparse_token_dimensions: usize,
+}
+
+impl Default for QueryShapeLimits {
+    fn default() -> Self {
+        Self {
+            max_query_depth: 32,
+            max_query_nodes: 256,
+            max_query_clauses: 512,
+            max_boolean_clauses: 128,
+            max_query_text_bytes: 64 * 1024,
+            max_field_name_bytes: 255,
+            max_index_name_bytes: 255,
+            max_dense_query_dims: 65_536,
+            max_sparse_query_dims: 4_096,
+            max_binary_query_bytes: 256 * 1024,
+            max_total_query_vector_bytes: 1024 * 1024,
+            max_fields_to_load: 64,
+            max_fields_to_load_name_bytes: 16 * 1024,
+            max_text_query_tokens: 256,
+            max_sparse_token_dimensions: 4_096,
+        }
+    }
+}
+
+/// Request-facing result and hydration limits, set once at startup from the
+/// hermes-server CLI (`--default-search-limit`, `--max-search-limit`,
+/// `--max-search-window`, `--max-candidate-limit`,
+/// `--max-search-response-mb`). `Default` preserves the historical
+/// hard-coded values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SearchLimits {
+    /// Results returned when `SearchRequest.limit` is 0.
+    pub default_search_limit: usize,
+    /// Upper bound on `SearchRequest.limit`.
+    pub max_search_limit: usize,
+    /// Upper bound on `SearchRequest.offset + limit`.
+    pub max_search_window: usize,
+    /// Upper bound on the first-stage candidate pool
+    /// (`SearchRequest.candidate_limit`).
+    pub max_candidate_limit: usize,
+    /// Structural anti-DoS budgets for the decoded query tree.
+    pub shape: QueryShapeLimits,
+    /// Hydration budget for one search response: caps both estimated retained
+    /// heap while the response is built and its encoded size. Must leave
+    /// headroom below the transport's encode limit (`--search-max-encode-mb`)
+    /// for compression and framing — startup validation enforces the ordering.
+    /// 2026-08-22: raised 48 → 192 MiB — chunk-level binary reranking over a
+    /// book-heavy RAG pool legitimately hydrates >48 MiB (a few dozen books ×
+    /// thousands of 320-byte chunk vectors). Downstream caps that must stay
+    /// above this: hermes-server `--search-max-encode-mb` (256 MiB),
+    /// hermes-broker `--backend-max-decode-mb` / `--search-max-encode-mb`
+    /// (256 MiB), and the consumers' hermes-client decode cap (200 MiB).
+    pub max_search_response_bytes: usize,
+}
+
+impl Default for SearchLimits {
+    fn default() -> Self {
+        Self {
+            default_search_limit: 10,
+            max_search_limit: 10_000,
+            max_search_window: 50_000,
+            max_candidate_limit: 50_000,
+            shape: QueryShapeLimits::default(),
+            max_search_response_bytes: 192 * 1024 * 1024,
+        }
+    }
+}
+
+struct QueryShapeBudget<'a> {
+    shape: &'a QueryShapeLimits,
     nodes: usize,
     clauses: usize,
     text_bytes: usize,
     vector_bytes: usize,
 }
 
-impl QueryShapeBudget {
+impl<'a> QueryShapeBudget<'a> {
+    fn new(shape: &'a QueryShapeLimits) -> Self {
+        Self {
+            shape,
+            nodes: 0,
+            clauses: 0,
+            text_bytes: 0,
+            vector_bytes: 0,
+        }
+    }
+
     fn add_limited(
         current: &mut usize,
         amount: usize,
@@ -77,27 +163,34 @@ impl QueryShapeBudget {
     }
 
     fn add_node(&mut self, depth: usize) -> Result<(), Status> {
-        if depth > MAX_QUERY_DEPTH {
+        if depth > self.shape.max_query_depth {
             return Err(Status::invalid_argument(format!(
-                "Query nesting depth must not exceed {MAX_QUERY_DEPTH}"
+                "Query nesting depth must not exceed {}",
+                self.shape.max_query_depth
             )));
         }
-        Self::add_limited(&mut self.nodes, 1, MAX_QUERY_NODES, "Query node count")
+        Self::add_limited(
+            &mut self.nodes,
+            1,
+            self.shape.max_query_nodes,
+            "Query node count",
+        )
     }
 
     fn add_clauses(&mut self, clauses: usize) -> Result<(), Status> {
         Self::add_limited(
             &mut self.clauses,
             clauses,
-            MAX_QUERY_CLAUSES,
+            self.shape.max_query_clauses,
             "Query clause count",
         )
     }
 
     fn add_field_name(&mut self, name: &str, description: &str) -> Result<(), Status> {
-        if name.len() > MAX_FIELD_NAME_BYTES {
+        if name.len() > self.shape.max_field_name_bytes {
             return Err(Status::invalid_argument(format!(
-                "{description} must not exceed {MAX_FIELD_NAME_BYTES} bytes"
+                "{description} must not exceed {} bytes",
+                self.shape.max_field_name_bytes
             )));
         }
         self.add_text(name.len())
@@ -107,7 +200,7 @@ impl QueryShapeBudget {
         Self::add_limited(
             &mut self.text_bytes,
             bytes,
-            MAX_QUERY_TEXT_BYTES,
+            self.shape.max_query_text_bytes,
             "Aggregate query text bytes",
         )
     }
@@ -130,7 +223,7 @@ impl QueryShapeBudget {
         Self::add_limited(
             &mut self.vector_bytes,
             bytes,
-            MAX_TOTAL_QUERY_VECTOR_BYTES,
+            self.shape.max_total_query_vector_bytes,
             "Aggregate query vector bytes",
         )
     }
@@ -138,37 +231,45 @@ impl QueryShapeBudget {
 
 /// Validate decoded request structure before acquiring scarce search capacity
 /// or recursively converting the protobuf query tree.
-fn validate_search_request_shape(req: &SearchRequest, root: &Query) -> Result<(), Status> {
-    if req.index_name.is_empty() || req.index_name.len() > MAX_INDEX_NAME_BYTES {
+fn validate_search_request_shape(
+    req: &SearchRequest,
+    root: &Query,
+    shape: &QueryShapeLimits,
+) -> Result<(), Status> {
+    if req.index_name.is_empty() || req.index_name.len() > shape.max_index_name_bytes {
         return Err(Status::invalid_argument(format!(
-            "SearchRequest.index_name must contain 1..={MAX_INDEX_NAME_BYTES} bytes"
+            "SearchRequest.index_name must contain 1..={} bytes",
+            shape.max_index_name_bytes
         )));
     }
-    if req.fields_to_load.len() > MAX_FIELDS_TO_LOAD {
+    if req.fields_to_load.len() > shape.max_fields_to_load {
         return Err(Status::invalid_argument(format!(
-            "SearchRequest.fields_to_load supports at most {MAX_FIELDS_TO_LOAD} names (got {})",
+            "SearchRequest.fields_to_load supports at most {} names (got {})",
+            shape.max_fields_to_load,
             req.fields_to_load.len()
         )));
     }
     let mut selected_name_bytes = 0usize;
     for (index, name) in req.fields_to_load.iter().enumerate() {
-        if name.len() > MAX_FIELD_NAME_BYTES {
+        if name.len() > shape.max_field_name_bytes {
             return Err(Status::invalid_argument(format!(
-                "SearchRequest.fields_to_load[{index}] must not exceed {MAX_FIELD_NAME_BYTES} bytes"
+                "SearchRequest.fields_to_load[{index}] must not exceed {} bytes",
+                shape.max_field_name_bytes
             )));
         }
         selected_name_bytes = selected_name_bytes
             .checked_add(name.len())
             .ok_or_else(|| Status::invalid_argument("Field selection byte count overflows"))?;
     }
-    if selected_name_bytes > MAX_FIELDS_TO_LOAD_NAME_BYTES {
+    if selected_name_bytes > shape.max_fields_to_load_name_bytes {
         return Err(Status::invalid_argument(format!(
             "SearchRequest.fields_to_load names must total at most \
-             {MAX_FIELDS_TO_LOAD_NAME_BYTES} bytes (got {selected_name_bytes})"
+             {} bytes (got {selected_name_bytes})",
+            shape.max_fields_to_load_name_bytes
         )));
     }
 
-    let mut budget = QueryShapeBudget::default();
+    let mut budget = QueryShapeBudget::new(shape);
     let mut stack = vec![(root, 1usize)];
     while let Some((query, depth)) = stack.pop() {
         budget.add_node(depth)?;
@@ -188,10 +289,11 @@ fn validate_search_request_shape(req: &SearchRequest, root: &Query) -> Result<()
                     .checked_add(boolean.should.len())
                     .and_then(|count| count.checked_add(boolean.must_not.len()))
                     .ok_or_else(|| Status::invalid_argument("Boolean clause count overflows"))?;
-                if clauses > MAX_BOOLEAN_CLAUSES {
+                if clauses > shape.max_boolean_clauses {
                     return Err(Status::invalid_argument(format!(
-                        "Each BooleanQuery supports at most {MAX_BOOLEAN_CLAUSES} clauses \
-                         (got {clauses})"
+                        "Each BooleanQuery supports at most {} clauses \
+                         (got {clauses})",
+                        shape.max_boolean_clauses
                     )));
                 }
                 budget.add_clauses(clauses)?;
@@ -219,13 +321,13 @@ fn validate_search_request_shape(req: &SearchRequest, root: &Query) -> Result<()
                     "SparseVectorQuery.indices",
                     sparse.indices.len(),
                     std::mem::size_of::<u32>(),
-                    MAX_SPARSE_QUERY_DIMS,
+                    shape.max_sparse_query_dims,
                 )?;
                 budget.add_vector(
                     "SparseVectorQuery.values",
                     sparse.values.len(),
                     std::mem::size_of::<f32>(),
-                    MAX_SPARSE_QUERY_DIMS,
+                    shape.max_sparse_query_dims,
                 )?;
             }
             query::Query::DenseVector(dense) => {
@@ -234,7 +336,7 @@ fn validate_search_request_shape(req: &SearchRequest, root: &Query) -> Result<()
                     "DenseVectorQuery.vector",
                     dense.vector.len(),
                     std::mem::size_of::<f32>(),
-                    MAX_DENSE_QUERY_DIMS,
+                    shape.max_dense_query_dims,
                 )?;
             }
             query::Query::Match(match_query) => {
@@ -254,7 +356,7 @@ fn validate_search_request_shape(req: &SearchRequest, root: &Query) -> Result<()
                     "BinaryDenseVectorQuery.vector",
                     binary.vector.len(),
                     1,
-                    MAX_BINARY_QUERY_BYTES,
+                    shape.max_binary_query_bytes,
                 )?;
             }
             query::Query::Fusion(fusion) => {
@@ -288,13 +390,13 @@ fn validate_search_request_shape(req: &SearchRequest, root: &Query) -> Result<()
             "Reranker.vector",
             reranker.vector.len(),
             std::mem::size_of::<f32>(),
-            MAX_DENSE_QUERY_DIMS,
+            shape.max_dense_query_dims,
         )?;
         budget.add_vector(
             "Reranker.binary_vector",
             reranker.binary_vector.len(),
             1,
-            MAX_BINARY_QUERY_BYTES,
+            shape.max_binary_query_bytes,
         )?;
     }
 
@@ -340,10 +442,6 @@ struct SearchResponseBudget {
 }
 
 impl SearchResponseBudget {
-    fn new() -> Self {
-        Self::with_maximum(MAX_SEARCH_RESPONSE_BYTES)
-    }
-
     fn with_maximum(maximum: usize) -> Self {
         Self {
             retained_bytes: 0,
@@ -489,30 +587,34 @@ fn try_acquire_search_permit(permits: &Arc<Semaphore>) -> Result<OwnedSemaphoreP
 
 /// Validate all request-controlled result and candidate depths before opening
 /// an index, constructing queries, or allocating candidate lists.
-fn validate_search_budget(req: &SearchRequest) -> Result<SearchBudget, Status> {
+fn validate_search_budget(
+    req: &SearchRequest,
+    limits: &SearchLimits,
+) -> Result<SearchBudget, Status> {
     let query = req
         .query
         .as_ref()
         .ok_or_else(|| Status::invalid_argument("Query is required"))?;
-    validate_search_request_shape(req, query)?;
+    validate_search_request_shape(req, query, &limits.shape)?;
     let final_limit = bounded_limit(
         "SearchRequest.limit",
         req.limit,
-        DEFAULT_SEARCH_LIMIT,
-        MAX_SEARCH_LIMIT,
+        limits.default_search_limit,
+        limits.max_search_limit,
     )?;
     let offset = req.offset as usize;
     let search_limit = offset
         .checked_add(final_limit)
         .ok_or_else(|| Status::invalid_argument("Search result window is too large"))?;
-    if search_limit > MAX_SEARCH_WINDOW {
+    if search_limit > limits.max_search_window {
         return Err(Status::invalid_argument(format!(
-            "SearchRequest.offset + limit must not exceed {MAX_SEARCH_WINDOW} \
-             (got {offset} + {final_limit} = {search_limit})"
+            "SearchRequest.offset + limit must not exceed {} \
+             (got {offset} + {final_limit} = {search_limit})",
+            limits.max_search_window
         )));
     }
     let max_candidate_limit =
-        hermes_core::query::max_candidate_limit(search_limit).min(MAX_CANDIDATE_LIMIT);
+        hermes_core::query::max_candidate_limit(search_limit).min(limits.max_candidate_limit);
     let candidate_limit = bounded_limit(
         "SearchRequest.candidate_limit",
         req.candidate_limit,
@@ -577,10 +679,15 @@ fn validate_search_budget(req: &SearchRequest) -> Result<SearchBudget, Status> {
 pub struct SearchServiceImpl {
     pub registry: Arc<IndexRegistry>,
     search_permits: Arc<Semaphore>,
+    limits: SearchLimits,
 }
 
 impl SearchServiceImpl {
-    pub fn new(registry: Arc<IndexRegistry>, max_concurrent_searches: usize) -> Self {
+    pub fn new(
+        registry: Arc<IndexRegistry>,
+        max_concurrent_searches: usize,
+        limits: SearchLimits,
+    ) -> Self {
         assert!(
             max_concurrent_searches > 0,
             "max_concurrent_searches must be greater than zero"
@@ -588,6 +695,7 @@ impl SearchServiceImpl {
         Self {
             registry,
             search_permits: Arc::new(Semaphore::new(max_concurrent_searches)),
+            limits,
         }
     }
 }
@@ -602,7 +710,7 @@ impl SearchService for SearchServiceImpl {
         let metric_index = std::sync::OnceLock::new();
         let t = std::time::Instant::now();
         let result = async {
-        let budget = validate_search_budget(&req)?;
+        let budget = validate_search_budget(&req, &self.limits)?;
 
         // Bound expensive pipelines across all HTTP/2 connections without an
         // unbounded waiter queue retaining decoded requests under overload.
@@ -670,6 +778,7 @@ impl SearchService for SearchServiceImpl {
                         searcher.schema(),
                         Some(searcher.global_stats()),
                         Some(index.directory().root()),
+                        &self.limits.shape,
                     )
                     .map_err(|e| {
                         Status::invalid_argument(format!("Invalid fusion sub-query: {}", e))
@@ -746,6 +855,7 @@ impl SearchService for SearchServiceImpl {
                     searcher.schema(),
                     Some(searcher.global_stats()),
                     Some(index.directory().root()),
+                    &self.limits.shape,
                 )
                 .map_err(|e| Status::invalid_argument(format!("Invalid query: {}", e)))?;
 
@@ -828,7 +938,8 @@ impl SearchService for SearchServiceImpl {
             }
         }
 
-        let mut response_budget = SearchResponseBudget::new();
+        let mut response_budget =
+            SearchResponseBudget::with_maximum(self.limits.max_search_response_bytes);
         let mut hits = Vec::with_capacity(results.len());
         for result in results {
             // Convert ordinal scores before hydration so their retained memory
@@ -1149,14 +1260,104 @@ mod tests {
         }
     }
 
+    fn limits() -> SearchLimits {
+        SearchLimits::default()
+    }
+
     #[test]
     fn search_budget_applies_defaults() {
-        let budget = validate_search_budget(&ordinary_request()).unwrap();
+        let budget = validate_search_budget(&ordinary_request(), &limits()).unwrap();
 
-        assert_eq!(budget.final_limit, DEFAULT_SEARCH_LIMIT);
+        assert_eq!(budget.final_limit, limits().default_search_limit);
         assert_eq!(budget.offset, 0);
-        assert_eq!(budget.search_limit, DEFAULT_SEARCH_LIMIT);
-        assert_eq!(budget.candidate_limit, DEFAULT_SEARCH_LIMIT);
+        assert_eq!(budget.search_limit, limits().default_search_limit);
+        assert_eq!(budget.candidate_limit, limits().default_search_limit);
+    }
+
+    #[test]
+    fn search_budget_honors_configured_limits() {
+        let tight = SearchLimits {
+            default_search_limit: 5,
+            max_search_limit: 20,
+            max_search_window: 30,
+            max_candidate_limit: 30,
+            ..SearchLimits::default()
+        };
+
+        let budget = validate_search_budget(&ordinary_request(), &tight).unwrap();
+        assert_eq!(budget.final_limit, 5);
+
+        let mut over_limit = ordinary_request();
+        over_limit.limit = 21;
+        assert_eq!(
+            validate_search_budget(&over_limit, &tight)
+                .unwrap_err()
+                .code(),
+            Code::InvalidArgument
+        );
+
+        let mut over_window = ordinary_request();
+        over_window.limit = 20;
+        over_window.offset = 11;
+        assert_eq!(
+            validate_search_budget(&over_window, &tight)
+                .unwrap_err()
+                .code(),
+            Code::InvalidArgument
+        );
+
+        let mut over_candidates = ordinary_request();
+        over_candidates.candidate_limit = 31;
+        assert_eq!(
+            validate_search_budget(&over_candidates, &tight)
+                .unwrap_err()
+                .code(),
+            Code::InvalidArgument
+        );
+    }
+
+    #[test]
+    fn query_shape_honors_configured_limits() {
+        let tight = SearchLimits {
+            shape: QueryShapeLimits {
+                max_query_depth: 2,
+                max_fields_to_load: 1,
+                ..QueryShapeLimits::default()
+            },
+            ..SearchLimits::default()
+        };
+
+        // Depth 3 (two boolean wrappers around the leaf) exceeds the
+        // configured depth of 2 but is fine under the defaults.
+        let mut nested = all_query();
+        for _ in 0..2 {
+            nested = Query {
+                query: Some(query::Query::Boolean(BooleanQuery {
+                    must: vec![nested],
+                    ..Default::default()
+                })),
+            };
+        }
+        let mut deep_req = ordinary_request();
+        deep_req.query = Some(nested);
+        assert_eq!(
+            validate_search_budget(&deep_req, &tight)
+                .unwrap_err()
+                .code(),
+            Code::InvalidArgument
+        );
+        assert!(validate_search_budget(&deep_req, &limits()).is_ok());
+
+        // Two selected fields exceed the configured cap of 1.
+        let mut wide_req = ordinary_request();
+        wide_req.fields_to_load = vec!["a".to_owned(), "b".to_owned()];
+        assert_eq!(
+            validate_search_budget(&wide_req, &tight)
+                .unwrap_err()
+                .code(),
+            Code::InvalidArgument
+        );
+        assert!(validate_search_budget(&wide_req, &limits()).is_ok());
     }
 
     #[test]
@@ -1164,13 +1365,13 @@ mod tests {
         let mut req = ordinary_request();
         req.index_name.clear();
         assert_eq!(
-            validate_search_budget(&req).unwrap_err().code(),
+            validate_search_budget(&req, &limits()).unwrap_err().code(),
             Code::InvalidArgument
         );
 
-        req.index_name = "x".repeat(MAX_INDEX_NAME_BYTES + 1);
+        req.index_name = "x".repeat(limits().shape.max_index_name_bytes + 1);
         assert_eq!(
-            validate_search_budget(&req).unwrap_err().code(),
+            validate_search_budget(&req, &limits()).unwrap_err().code(),
             Code::InvalidArgument
         );
     }
@@ -1178,9 +1379,9 @@ mod tests {
     #[test]
     fn search_budget_rejects_excessive_final_limit() {
         let mut req = ordinary_request();
-        req.limit = (MAX_SEARCH_LIMIT + 1) as u32;
+        req.limit = (limits().max_search_limit + 1) as u32;
 
-        let err = validate_search_budget(&req).unwrap_err();
+        let err = validate_search_budget(&req, &limits()).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
     }
 
@@ -1189,17 +1390,17 @@ mod tests {
         let mut req = ordinary_request();
         req.limit = 100;
         req.offset = 400;
-        let budget = validate_search_budget(&req).unwrap();
+        let budget = validate_search_budget(&req, &limits()).unwrap();
         assert_eq!(budget.final_limit, 100);
         assert_eq!(budget.offset, 400);
         assert_eq!(budget.search_limit, 500);
 
-        req.limit = DEFAULT_SEARCH_LIMIT as u32;
-        req.offset = (MAX_SEARCH_WINDOW - DEFAULT_SEARCH_LIMIT) as u32;
-        assert!(validate_search_budget(&req).is_ok());
+        req.limit = limits().default_search_limit as u32;
+        req.offset = (limits().max_search_window - limits().default_search_limit) as u32;
+        assert!(validate_search_budget(&req, &limits()).is_ok());
 
         req.offset += 1;
-        let err = validate_search_budget(&req).unwrap_err();
+        let err = validate_search_budget(&req, &limits()).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
     }
 
@@ -1208,32 +1409,32 @@ mod tests {
         let mut ordinary_default = ordinary_request();
         ordinary_default.limit = 300;
         assert_eq!(
-            validate_search_budget(&ordinary_default)
+            validate_search_budget(&ordinary_default, &limits())
                 .unwrap()
                 .candidate_limit,
             300
         );
 
         let mut default_req = ordinary_request();
-        default_req.limit = MAX_SEARCH_LIMIT as u32;
+        default_req.limit = limits().max_search_limit as u32;
         assert_eq!(
-            validate_search_budget(&default_req)
+            validate_search_budget(&default_req, &limits())
                 .unwrap()
                 .candidate_limit,
-            MAX_SEARCH_LIMIT
+            limits().max_search_limit
         );
 
         let mut excessive_req = ordinary_request();
         excessive_req.limit = 100;
         excessive_req.candidate_limit = 201;
-        let err = validate_search_budget(&excessive_req).unwrap_err();
+        let err = validate_search_budget(&excessive_req, &limits()).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
 
         let mut impossible_page = ordinary_request();
         impossible_page.limit = 10;
         impossible_page.offset = 1_000;
         impossible_page.candidate_limit = 100;
-        let err = validate_search_budget(&impossible_page).unwrap_err();
+        let err = validate_search_budget(&impossible_page, &limits()).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
     }
 
@@ -1242,7 +1443,7 @@ mod tests {
         let mut request = ordinary_request();
         request.limit = 100;
         request.candidate_limit = 100;
-        let budget = validate_search_budget(&request).unwrap();
+        let budget = validate_search_budget(&request, &limits()).unwrap();
         assert_eq!(budget.search_limit, 100);
         assert_eq!(budget.candidate_limit, 100);
     }
@@ -1264,7 +1465,7 @@ mod tests {
         let mut req = fusion_request(2, 201);
         req.limit = 100;
 
-        let err = validate_search_budget(&req).unwrap_err();
+        let err = validate_search_budget(&req, &limits()).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
     }
 
@@ -1274,7 +1475,7 @@ mod tests {
         req.limit = 100;
         req.reranker = Some(Reranker::default());
 
-        let budget = validate_search_budget(&req).unwrap();
+        let budget = validate_search_budget(&req, &limits()).unwrap();
         assert_eq!(budget.candidate_limit, 100);
     }
 
@@ -1282,23 +1483,26 @@ mod tests {
     fn fusion_budget_rejects_too_many_sub_queries_before_conversion() {
         let req = fusion_request(MAX_FUSION_SUB_QUERIES + 1, 50);
 
-        let err = validate_search_budget(&req).unwrap_err();
+        let err = validate_search_budget(&req, &limits()).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
     }
 
     #[test]
     fn fusion_budget_rejects_excessive_fetch_and_aggregate_work() {
-        let excessive_fetch = fusion_request(2, (MAX_CANDIDATE_LIMIT + 1) as u32);
+        let excessive_fetch = fusion_request(2, (limits().max_candidate_limit + 1) as u32);
         assert_eq!(
-            validate_search_budget(&excessive_fetch).unwrap_err().code(),
+            validate_search_budget(&excessive_fetch, &limits())
+                .unwrap_err()
+                .code(),
             Code::InvalidArgument
         );
 
-        let mut excessive_aggregate = fusion_request(5, MAX_CANDIDATE_LIMIT as u32);
-        excessive_aggregate.limit = MAX_SEARCH_LIMIT as u32;
-        excessive_aggregate.offset = (MAX_SEARCH_WINDOW - MAX_SEARCH_LIMIT) as u32;
+        let mut excessive_aggregate = fusion_request(5, limits().max_candidate_limit as u32);
+        excessive_aggregate.limit = limits().max_search_limit as u32;
+        excessive_aggregate.offset =
+            (limits().max_search_window - limits().max_search_limit) as u32;
         assert_eq!(
-            validate_search_budget(&excessive_aggregate)
+            validate_search_budget(&excessive_aggregate, &limits())
                 .unwrap_err()
                 .code(),
             Code::InvalidArgument
@@ -1308,11 +1512,11 @@ mod tests {
     #[test]
     fn fusion_default_candidate_pool_is_checked_and_capped() {
         let mut req = fusion_request(2, 0);
-        req.limit = MAX_SEARCH_LIMIT as u32;
+        req.limit = limits().max_search_limit as u32;
         req.reranker = Some(Reranker::default());
 
-        let budget = validate_search_budget(&req).unwrap();
-        assert_eq!(budget.candidate_limit, MAX_SEARCH_LIMIT);
+        let budget = validate_search_budget(&req, &limits()).unwrap();
+        assert_eq!(budget.candidate_limit, limits().max_search_limit);
     }
 
     #[test]
@@ -1326,7 +1530,7 @@ mod tests {
             };
             fusion.rrf_k = rrf_k;
             assert_eq!(
-                validate_search_budget(&req).unwrap_err().code(),
+                validate_search_budget(&req, &limits()).unwrap_err().code(),
                 Code::InvalidArgument
             );
         }
@@ -1340,7 +1544,7 @@ mod tests {
             };
             fusion.queries[0].weight = weight;
             assert_eq!(
-                validate_search_budget(&req).unwrap_err().code(),
+                validate_search_budget(&req, &limits()).unwrap_err().code(),
                 Code::InvalidArgument
             );
         }
@@ -1349,21 +1553,25 @@ mod tests {
     #[test]
     fn request_shape_rejects_field_and_boolean_amplification() {
         let mut too_many_fields = ordinary_request();
-        too_many_fields.fields_to_load = vec![String::new(); MAX_FIELDS_TO_LOAD + 1];
+        too_many_fields.fields_to_load = vec![String::new(); limits().shape.max_fields_to_load + 1];
         assert_eq!(
-            validate_search_budget(&too_many_fields).unwrap_err().code(),
+            validate_search_budget(&too_many_fields, &limits())
+                .unwrap_err()
+                .code(),
             Code::InvalidArgument
         );
 
         let mut too_many_clauses = ordinary_request();
         too_many_clauses.query = Some(Query {
             query: Some(query::Query::Boolean(BooleanQuery {
-                must: (0..=MAX_BOOLEAN_CLAUSES).map(|_| all_query()).collect(),
+                must: (0..=limits().shape.max_boolean_clauses)
+                    .map(|_| all_query())
+                    .collect(),
                 ..Default::default()
             })),
         });
         assert_eq!(
-            validate_search_budget(&too_many_clauses)
+            validate_search_budget(&too_many_clauses, &limits())
                 .unwrap_err()
                 .code(),
             Code::InvalidArgument
@@ -1373,7 +1581,7 @@ mod tests {
     #[test]
     fn request_shape_rejects_depth_node_text_and_vector_expansion() {
         let mut nested = all_query();
-        for _ in 0..MAX_QUERY_DEPTH {
+        for _ in 0..limits().shape.max_query_depth {
             nested = Query {
                 query: Some(query::Query::Boost(Box::new(BoostQuery {
                     query: Some(Box::new(nested)),
@@ -1384,13 +1592,15 @@ mod tests {
         let mut excessive_depth = ordinary_request();
         excessive_depth.query = Some(nested);
         assert_eq!(
-            validate_search_budget(&excessive_depth).unwrap_err().code(),
+            validate_search_budget(&excessive_depth, &limits())
+                .unwrap_err()
+                .code(),
             Code::InvalidArgument
         );
 
         // 1 root + 128 Boolean children + 128 leaves exceeds the node budget,
         // while each Boolean and the aggregate clause count remain legal.
-        let branches = (0..MAX_BOOLEAN_CLAUSES)
+        let branches = (0..limits().shape.max_boolean_clauses)
             .map(|_| Query {
                 query: Some(query::Query::Boolean(BooleanQuery {
                     must: vec![all_query()],
@@ -1406,7 +1616,9 @@ mod tests {
             })),
         });
         assert_eq!(
-            validate_search_budget(&excessive_nodes).unwrap_err().code(),
+            validate_search_budget(&excessive_nodes, &limits())
+                .unwrap_err()
+                .code(),
             Code::InvalidArgument
         );
 
@@ -1414,11 +1626,13 @@ mod tests {
         excessive_text.query = Some(Query {
             query: Some(query::Query::Match(MatchQuery {
                 field: "body".to_owned(),
-                text: "x".repeat(MAX_QUERY_TEXT_BYTES + 1),
+                text: "x".repeat(limits().shape.max_query_text_bytes + 1),
             })),
         });
         assert_eq!(
-            validate_search_budget(&excessive_text).unwrap_err().code(),
+            validate_search_budget(&excessive_text, &limits())
+                .unwrap_err()
+                .code(),
             Code::InvalidArgument
         );
 
@@ -1426,12 +1640,12 @@ mod tests {
         excessive_vector.query = Some(Query {
             query: Some(query::Query::DenseVector(DenseVectorQuery {
                 field: "embedding".to_owned(),
-                vector: vec![0.0; MAX_DENSE_QUERY_DIMS + 1],
+                vector: vec![0.0; limits().shape.max_dense_query_dims + 1],
                 ..Default::default()
             })),
         });
         assert_eq!(
-            validate_search_budget(&excessive_vector)
+            validate_search_budget(&excessive_vector, &limits())
                 .unwrap_err()
                 .code(),
             Code::InvalidArgument


### PR DESCRIPTION
All operational limit constants in hermes-server and hermes-broker are now CLI flags with defaults identical to the old hard-coded values:

- Transport message caps: --search-max-decode-mb/--search-max-encode-mb, --index-max-decode-mb/--index-max-encode-mb on both binaries, plus --backend-max-decode-mb/--backend-max-encode-mb for the broker's backend channels
- Search limits (SearchLimits): --max-search-response-mb hydration budget, --default-search-limit, --max-search-limit, --max-search-window, --max-candidate-limit
- Query-shape anti-DoS budgets (QueryShapeLimits, threaded through validation and convert_query): depth/nodes/clauses/boolean-clauses, text/field-name/index-name bytes, dense/sparse/binary vector dims and bytes, fields_to_load caps, and token-expansion caps (--max-text-query-tokens, --max-sparse-token-dimensions)

Inconsistent combinations fail loud at startup (zero budgets, hydration budget above the encode cap, boolean cap above the aggregate clause budget, etc.); broker cap mismatches warn. Regression tests pin that configured limits are honored and that defaults match the historical constants byte-for-byte.