### PR TITLE
BMP multi-segment correctness fixes + hermes-tool batch search

### DIFF
--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -929,8 +929,10 @@ impl<D: Directory + 'static> Searcher<D> {
         use futures::StreamExt;
         use futures::TryStreamExt;
         // Cross-segment top-k floor (see search_internal_sync). Concurrent
-        // segments share it via an atomic; ordering is best-effort.
-        let shared = crate::query::SharedThreshold::new();
+        // segments share it via an atomic; ordering is best-effort. The floor
+        // carries the query window so executors with clamped heaps (segments
+        // smaller than the window) can never publish an invalid floor.
+        let shared = crate::query::SharedThreshold::for_limit(fetch_limit);
         let lsp_plans = self.prepare_global_lsp(query, fetch_limit, false)?;
         let mut total_seen: u32 = 0;
         let mut merged = Vec::new();
@@ -1060,7 +1062,7 @@ impl<D: Directory + 'static> Searcher<D> {
         use rayon::prelude::*;
 
         let lsp_plans = self.prepare_global_lsp(query, fetch_limit, true)?;
-        let shared = crate::query::SharedThreshold::new();
+        let shared = crate::query::SharedThreshold::for_limit(fetch_limit);
         let run_segment = |segment_index: &usize| {
             let segment = &self.segments[*segment_index];
             let lsp_plan = lsp_plans[*segment_index].clone();

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3852,3 +3852,402 @@ async fn test_failed_reorder_leaves_no_orphan_files() {
         "orphan files must be gone"
     );
 }
+
+// ============================================================================
+// Regression tests: multi-segment BMP search dropped whole segments' results,
+// force merge did not converge to one segment, and BMP without configured
+// dims silently returned empty results (2026-08 CLI repro).
+// ============================================================================
+
+/// Helper: BMP config matching the CLI repro schema
+/// (`dims: 131072, max_weight: 5.0, bmp_block_size: 256`).
+fn repro_bmp_config() -> SparseVectorConfig {
+    SparseVectorConfig {
+        format: SparseFormat::Bmp,
+        weight_quantization: WeightQuantization::UInt8,
+        bmp_block_size: 256,
+        dims: Some(131_072),
+        max_weight: Some(5.0),
+        ..SparseVectorConfig::default()
+    }
+}
+
+fn repro_schema() -> (crate::dsl::Schema, crate::dsl::Field, crate::dsl::Field) {
+    let mut sb = SchemaBuilder::default();
+    let doc_id = sb.add_text_field("doc_id", true, true);
+    let emb = sb.add_sparse_vector_field_with_config("emb", true, true, repro_bmp_config());
+    (sb.build(), doc_id, emb)
+}
+
+async fn results_by_label(
+    searcher: &crate::index::Searcher<RamDirectory>,
+    doc_id: crate::dsl::Field,
+    results: &[crate::query::SearchResult],
+) -> Vec<(String, f32)> {
+    let mut labeled = Vec::with_capacity(results.len());
+    for result in results {
+        let doc = searcher
+            .doc(result.segment_id, result.doc_id)
+            .await
+            .unwrap()
+            .unwrap();
+        labeled.push((
+            doc.get_first(doc_id)
+                .unwrap()
+                .as_text()
+                .unwrap()
+                .to_string(),
+            result.score,
+        ));
+    }
+    labeled
+}
+
+/// A segment smaller than the query limit must never publish its own k-th
+/// score as a cross-segment floor: that floor is not the global k-th score
+/// and erased every lower-scoring segment's results (whole segments' hits
+/// vanished from multi-segment BMP searches).
+#[tokio::test]
+async fn test_bmp_multi_segment_search_returns_all_matching_docs() {
+    let (schema, doc_id, emb) = repro_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    // Segment 1 (largest — deterministic pilot): the two top-scoring docs.
+    for (label, weight) in [("a1", 2.0f32), ("a2", 1.5f32)] {
+        let mut doc = Document::new();
+        doc.add_text(doc_id, label);
+        doc.add_sparse_vector(emb, vec![(5, weight), (9000, weight)]);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    // Segment 2: one doc scoring below segment 1's k-th heap entry.
+    let mut doc_b = Document::new();
+    doc_b.add_text(doc_id, "b");
+    doc_b.add_sparse_vector(emb, vec![(5, 1.0)]);
+    writer.add_document(doc_b).unwrap();
+    writer.commit().await.unwrap();
+
+    // Segment 3: one doc scoring below both.
+    let mut doc_c = Document::new();
+    doc_c.add_text(doc_id, "c");
+    doc_c.add_sparse_vector(emb, vec![(9000, 0.5)]);
+    writer.add_document(doc_c).unwrap();
+    writer.commit().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert_eq!(index.segment_readers().await.unwrap().len(), 3);
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    let query = SparseVectorQuery::new(emb, vec![(5, 1.0), (9000, 1.0)]).with_lsp_gamma(0);
+    let results = searcher.search(&query, 10).await.unwrap();
+    let labeled = results_by_label(&searcher, doc_id, &results).await;
+    assert_eq!(
+        labeled
+            .iter()
+            .map(|(label, _)| label.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a1", "a2", "b", "c"],
+        "multi-segment BMP search must return matches from every segment, got {labeled:?}",
+    );
+    for ((_, score), expected) in labeled.iter().zip([4.0f32, 3.0, 1.0, 0.5]) {
+        assert!(
+            (score - expected).abs() < 0.05,
+            "score {score} diverged from expected {expected}: {labeled:?}",
+        );
+    }
+}
+
+/// The exact CLI repro: docs a/b/c in three one-doc segments. Every matching
+/// document must come back regardless of segment execution order.
+#[tokio::test]
+async fn test_bmp_multi_segment_search_one_doc_segments_cli_repro() {
+    let (schema, doc_id, emb) = repro_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    for (label, entries) in [
+        ("a", vec![(5u32, 1.5f32), (9000, 2.0), (130_000, 0.5)]),
+        ("b", vec![(5, 0.5), (77, 3.0)]),
+        ("c", vec![(9000, 2.5), (130_000, 1.0)]),
+    ] {
+        let mut doc = Document::new();
+        doc.add_text(doc_id, label);
+        doc.add_sparse_vector(emb, entries);
+        writer.add_document(doc).unwrap();
+        writer.commit().await.unwrap();
+    }
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert_eq!(index.segment_readers().await.unwrap().len(), 3);
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    let query = SparseVectorQuery::new(emb, vec![(5, 1.0), (9000, 1.0)]).with_lsp_gamma(0);
+    // Run repeatedly: the failure mode depended on segment completion order.
+    for round in 0..20 {
+        let results = searcher.search(&query, 5).await.unwrap();
+        let labeled = results_by_label(&searcher, doc_id, &results).await;
+        assert_eq!(
+            labeled
+                .iter()
+                .map(|(label, _)| label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "c", "b"],
+            "round {round}: BMP dropped a segment's results: {labeled:?}",
+        );
+        for ((_, score), expected) in labeled.iter().zip([3.51f32, 2.51, 0.51]) {
+            assert!(
+                (score - expected).abs() < 0.05,
+                "round {round}: score {score} diverged from expected {expected}",
+            );
+        }
+    }
+}
+
+/// Force merge must converge to a single segment (sources fit the format
+/// limit) and post-merge search must return the exact same documents.
+#[tokio::test]
+async fn test_bmp_force_merge_collapses_to_single_segment_and_search_is_correct() {
+    let (schema, doc_id, emb) = repro_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    for (label, entries) in [
+        ("a", vec![(5u32, 1.5f32), (9000, 2.0), (130_000, 0.5)]),
+        ("b", vec![(5, 0.5), (77, 3.0)]),
+        ("c", vec![(9000, 2.5), (130_000, 1.0)]),
+    ] {
+        let mut doc = Document::new();
+        doc.add_text(doc_id, label);
+        doc.add_sparse_vector(emb, entries);
+        writer.add_document(doc).unwrap();
+        writer.commit().await.unwrap();
+    }
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    assert_eq!(index.segment_readers().await.unwrap().len(), 3);
+    drop(index);
+
+    writer.force_merge().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    assert_eq!(
+        index.segment_readers().await.unwrap().len(),
+        1,
+        "force merge must end at exactly one segment",
+    );
+    assert_eq!(index.num_docs().await.unwrap(), 3);
+
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let query = SparseVectorQuery::new(emb, vec![(5, 1.0), (9000, 1.0)]).with_lsp_gamma(0);
+    let results = searcher.search(&query, 5).await.unwrap();
+    let labeled = results_by_label(&searcher, doc_id, &results).await;
+    assert_eq!(
+        labeled
+            .iter()
+            .map(|(label, _)| label.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a", "c", "b"],
+        "post-merge BMP search must return every matching doc: {labeled:?}",
+    );
+    for ((_, score), expected) in labeled.iter().zip([3.51f32, 2.51, 0.51]) {
+        assert!(
+            (score - expected).abs() < 0.05,
+            "post-merge score {score} diverged from expected {expected}",
+        );
+    }
+}
+
+/// Force merge must not stop above one segment because the background merge
+/// policy caps segment size: an explicit force merge packs up to the u32
+/// format limit (or fails loudly), never silently leaving extra segments.
+#[tokio::test]
+async fn test_bmp_force_merge_ignores_policy_segment_cap() {
+    let (schema, _doc_id, emb) = repro_schema();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        // Policy cap of 2 docs per segment would split 3 one-doc sources
+        // into 2 outputs if force merge honored it.
+        merge_policy: Box::new(crate::merge::TieredMergePolicy {
+            max_segment_docs: 2,
+            max_merged_docs: 2,
+            ..crate::merge::TieredMergePolicy::default()
+        }),
+        ..IndexConfig::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    for weight in [1.0f32, 2.0, 3.0] {
+        let mut doc = Document::new();
+        doc.add_sparse_vector(emb, vec![(5, weight)]);
+        writer.add_document(doc).unwrap();
+        writer.commit().await.unwrap();
+    }
+    writer.force_merge().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert_eq!(
+        index.segment_readers().await.unwrap().len(),
+        1,
+        "explicit force merge must converge to one segment despite the policy cap",
+    );
+}
+
+/// BMP without configured `dims`/`max_weight` must either work end-to-end or
+/// refuse loudly at commit time — never commit successfully and then return
+/// zero hits for every query.
+#[tokio::test]
+async fn test_bmp_without_dims_config_works_or_fails_loud() {
+    let mut sb = SchemaBuilder::default();
+    let doc_id = sb.add_text_field("doc_id", true, true);
+    let emb = sb.add_sparse_vector_field_with_config(
+        "emb",
+        true,
+        true,
+        SparseVectorConfig {
+            format: SparseFormat::Bmp,
+            weight_quantization: WeightQuantization::UInt8,
+            bmp_block_size: 256,
+            // No dims / max_weight configured.
+            ..SparseVectorConfig::default()
+        },
+    );
+    let schema = sb.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    for (label, entries) in [
+        ("a", vec![(5u32, 1.5f32), (9000, 2.0), (130_000, 0.5)]),
+        ("b", vec![(5, 0.5), (77, 3.0)]),
+        ("c", vec![(9000, 2.5), (130_000, 1.0)]),
+    ] {
+        let mut doc = Document::new();
+        doc.add_text(doc_id, label);
+        doc.add_sparse_vector(emb, entries);
+        writer.add_document(doc).unwrap();
+    }
+
+    let committed = writer.commit().await;
+    match committed {
+        Err(error) => {
+            // Loud refusal is acceptable; silence is not.
+            let message = format!("{error}");
+            assert!(
+                message.contains("dims"),
+                "load-time refusal must explain the dims capability mismatch: {message}",
+            );
+        }
+        Ok(_) => {
+            let index = Index::open(dir, config).await.unwrap();
+            let reader = index.reader().await.unwrap();
+            let searcher = reader.searcher().await.unwrap();
+            let query = SparseVectorQuery::new(emb, vec![(5, 1.0), (9000, 1.0)]).with_lsp_gamma(0);
+            let results = searcher.search(&query, 5).await.unwrap();
+            assert_eq!(
+                results.len(),
+                3,
+                "commit succeeded, so search must return every matching doc",
+            );
+        }
+    }
+}
+
+/// BMP segments must open through directories that only provide lazy (async)
+/// file handles. `FsDirectory` — used by `hermes-tool merge`/`commit` — is
+/// such a directory: every BMP segment open (and therefore every force merge)
+/// used to fail with "Synchronous read not available on lazy file handle".
+#[tokio::test]
+async fn test_bmp_force_merge_works_on_lazy_fs_directory() {
+    let (schema, doc_id, emb) = repro_schema();
+    let temp = tempfile::TempDir::new().unwrap();
+    let dir = crate::directories::FsDirectory::new(temp.path());
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    for (label, entries) in [
+        ("a", vec![(5u32, 1.5f32), (9000, 2.0), (130_000, 0.5)]),
+        ("b", vec![(5, 0.5), (77, 3.0)]),
+        ("c", vec![(9000, 2.5), (130_000, 1.0)]),
+    ] {
+        let mut doc = Document::new();
+        doc.add_text(doc_id, label);
+        doc.add_sparse_vector(emb, entries);
+        writer.add_document(doc).unwrap();
+        writer.commit().await.unwrap();
+    }
+
+    // Opening and searching BMP segments must work on a lazy directory.
+    let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+    assert_eq!(index.segment_readers().await.unwrap().len(), 3);
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let query = SparseVectorQuery::new(emb, vec![(5, 1.0), (9000, 1.0)]).with_lsp_gamma(0);
+    let results = searcher.search(&query, 5).await.unwrap();
+    assert_eq!(results.len(), 3, "pre-merge lazy-directory search");
+    drop(index);
+
+    writer.force_merge().await.unwrap();
+    drop(writer);
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert_eq!(
+        index.segment_readers().await.unwrap().len(),
+        1,
+        "force merge on a lazy directory must end at one segment",
+    );
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let results = searcher.search(&query, 5).await.unwrap();
+    let mut labels = Vec::new();
+    for result in &results {
+        let doc = searcher
+            .doc(result.segment_id, result.doc_id)
+            .await
+            .unwrap()
+            .unwrap();
+        labels.push(
+            doc.get_first(doc_id)
+                .unwrap()
+                .as_text()
+                .unwrap()
+                .to_string(),
+        );
+    }
+    assert_eq!(
+        labels,
+        vec!["a", "c", "b"],
+        "post-merge lazy-directory search"
+    );
+}

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -2534,11 +2534,14 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         }
     }
 
-    /// Force merge segments into compact, size-balanced groups, respecting
-    /// `max_segment_docs` from the merge policy.
+    /// Force merge all segments into one (packing up to the u32 document
+    /// format limit per output).
     ///
-    /// If the policy defines a max segment size, segments are merged in batches
-    /// that stay within that limit. Otherwise, all segments are merged into one.
+    /// An explicit force merge is a full compaction: unlike background
+    /// merges, it deliberately ignores the policy's `max_segment_docs` cap
+    /// (which exists to bound background BP/merge cost, not to keep an index
+    /// permanently split). Only the u32 doc-id format limit can force more
+    /// than one output, and that outcome is logged loudly.
     ///
     /// Each batch is registered in `active_operations` via an RAII guard to prevent
     /// `maybe_merge` from spawning a conflicting background merge.
@@ -2575,7 +2578,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         // wait for a release; those passes run for minutes, so poll slowly.
         const FORCE_MERGE_HELD_BACKOFF: std::time::Duration = std::time::Duration::from_secs(1);
 
-        let (_force_merge_activity, max_segment_docs) = {
+        let (_force_merge_activity, policy_segment_docs) = {
             let st = self.state.lock().await;
             // `maybe_merge` registers and publishes every task handle under
             // this same state lock. Raising the barrier here therefore makes
@@ -2661,13 +2664,31 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 .into_iter()
                 .filter(|(id, _)| !active_ids.contains(id))
                 .collect();
-            // Every segment format and doc map uses u32 document IDs. A policy
-            // with no explicit cap therefore means "up to the format limit",
-            // not an unrepresentable u64-sized output.
-            let max_docs = max_segment_docs
-                .map(u64::from)
-                .unwrap_or(u64::from(u32::MAX));
-            let next_group = plan_force_merge_groups(free_segments, max_docs)
+            // Every segment format and doc map uses u32 document IDs.
+            // An explicit force merge packs up to that format limit: the
+            // policy's `max_segment_docs` bounds *background* merge cost and
+            // must not silently leave a forced compaction above one segment
+            // (observed in prod: an 8.8M-doc index stuck at 2 segments under
+            // a 5M-doc policy cap).
+            let max_docs = u64::from(u32::MAX);
+            let planned_groups = plan_force_merge_groups(free_segments, max_docs);
+            if let Some(cap) = policy_segment_docs {
+                for group in planned_groups
+                    .iter()
+                    .filter(|group| group.segments.len() >= 2)
+                    .filter(|group| group.total_docs > u64::from(cap))
+                {
+                    log::warn!(
+                        "[force_merge] index={} output of {} docs intentionally exceeds the \
+                         background merge policy cap of {} docs (force merge compacts to the \
+                         u32 format limit)",
+                        self.schema.index_label(),
+                        group.total_docs,
+                        cap,
+                    );
+                }
+            }
+            let next_group = planned_groups
                 .into_iter()
                 .find(|group| group.segments.len() >= 2);
 
@@ -2683,7 +2704,22 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                         continue;
                     }
                     // Every remaining free segment is either already at the
-                    // size cap or cannot be paired without exceeding it.
+                    // u32 format limit or cannot be paired without exceeding
+                    // it. More than one leftover segment is an exceptional,
+                    // loudly-reported outcome — never a silent policy effect.
+                    let remaining = {
+                        let st = self.state.lock().await;
+                        st.metadata.segment_metas.len()
+                    };
+                    if remaining > 1 {
+                        log::warn!(
+                            "[force_merge] index={} finished with {} segments: combined \
+                             document count exceeds the u32 segment format limit, so a \
+                             single output is impossible",
+                            self.schema.index_label(),
+                            remaining,
+                        );
+                    }
                     // A reorder that was already running when foreground
                     // admission began may have published after the preceding
                     // callback. Reconcile external readers one final time so

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -214,6 +214,7 @@ fn bmp_threshold<'a>(
     options: &'a super::ScorerOptions,
     combiner: MultiValueCombiner,
     single_valued: bool,
+    heap_covers_limit: bool,
 ) -> super::bmp::BmpThreshold<'a> {
     if !single_valued && combiner != MultiValueCombiner::Max {
         return super::bmp::BmpThreshold::default();
@@ -221,7 +222,12 @@ fn bmp_threshold<'a>(
     super::bmp::BmpThreshold {
         initial: options.initial_threshold,
         shared: options.shared_threshold.as_ref(),
-        publish: single_valued,
+        // A full heap's k-th score is a valid cross-segment floor only when
+        // the heap is as deep as the requested result window. A segment with
+        // fewer documents than `limit` fills its (clamped) heap early; its
+        // k-th score says nothing about the global top-`limit` set and used
+        // to erase every lower-scoring segment's results.
+        publish: single_valued && heap_covers_limit,
     }
 }
 
@@ -333,7 +339,19 @@ fn build_sparse_bmp_results_inner(
         .lsp_gamma
         .unwrap_or_else(|| super::bmp::recommended_lsp_gamma(executor_limit));
     let field_label = reader.schema().get_field_name(field).unwrap_or("?");
-    let threshold = bmp_threshold(options, info.combiner, bmp.is_single_valued());
+    // The per-segment `limit` may already be clamped to the segment's doc
+    // count, so validate the heap depth against the *query* window carried by
+    // the shared floor, not against `limit`.
+    let heap_covers_floor = options
+        .shared_threshold
+        .as_ref()
+        .is_none_or(|shared| shared.covers(executor_limit));
+    let threshold = bmp_threshold(
+        options,
+        info.combiner,
+        bmp.is_single_valued(),
+        heap_covers_floor,
+    );
     let results = if let Some(predicate) = predicate {
         super::bmp::execute_bmp_filtered_with_threshold(
             bmp,
@@ -683,18 +701,38 @@ mod tests {
             lsp_plan: None,
         };
 
-        let single_sum = bmp_threshold(&options, MultiValueCombiner::Sum, true);
+        let single_sum = bmp_threshold(&options, MultiValueCombiner::Sum, true, true);
         assert_eq!(single_sum.initial, 5.0);
         assert!(single_sum.shared.is_some());
         assert!(single_sum.publish);
 
-        let multi_max = bmp_threshold(&options, MultiValueCombiner::Max, false);
+        let multi_max = bmp_threshold(&options, MultiValueCombiner::Max, false, true);
         assert!(multi_max.shared.is_some());
         assert!(!multi_max.publish);
 
-        let multi_sum = bmp_threshold(&options, MultiValueCombiner::Sum, false);
+        let multi_sum = bmp_threshold(&options, MultiValueCombiner::Sum, false, true);
         assert_eq!(multi_sum.initial, 0.0);
         assert!(multi_sum.shared.is_none());
         assert!(!multi_sum.publish);
+    }
+
+    /// A segment with fewer real docs than the requested window clamps its
+    /// heap below `limit`; its full-heap threshold must then stay private.
+    #[test]
+    fn bmp_threshold_from_a_clamped_heap_is_never_published() {
+        let shared = super::super::SharedThreshold::new();
+        let options = super::super::ScorerOptions {
+            collect_positions: false,
+            initial_threshold: 0.0,
+            shared_threshold: Some(shared),
+            lsp_plan: None,
+        };
+
+        let clamped = bmp_threshold(&options, MultiValueCombiner::Sum, true, false);
+        assert!(clamped.shared.is_some(), "reading a valid floor stays safe");
+        assert!(
+            !clamped.publish,
+            "a heap shallower than the result window must not publish a floor"
+        );
     }
 }

--- a/hermes-core/src/query/scoring.rs
+++ b/hermes-core/src/query/scoring.rs
@@ -292,20 +292,59 @@ impl ScoreCollector {
 /// any other segment with `v` can never drop a document that belongs in the
 /// final top-k. Completion order is arbitrary, so the floor is best-effort — it
 /// only changes how aggressively later segments prune, never correctness.
-#[derive(Clone, Debug, Default)]
-pub struct SharedThreshold(std::sync::Arc<std::sync::atomic::AtomicU32>);
+///
+/// The floor carries the query's result-window depth `k` (`for_limit`).
+/// Publishing from a heap shallower than `k` is invalid — a segment with
+/// fewer documents than the window fills its clamped heap early, and its
+/// heap threshold says nothing about the query-global k-th score. Executors
+/// must check `SharedThreshold::covers` before raising the floor with a
+/// full-heap threshold.
+#[derive(Clone, Debug)]
+pub struct SharedThreshold {
+    floor: std::sync::Arc<std::sync::atomic::AtomicU32>,
+    /// Result-window depth the floor is valid for. `usize::MAX` means the
+    /// depth is unknown; reading stays safe, publishing is disabled.
+    k: usize,
+}
+
+impl Default for SharedThreshold {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl SharedThreshold {
-    /// A fresh floor of 0.0 (no pruning seed).
+    /// A fresh floor of 0.0 (no pruning seed) with an unknown window depth.
+    /// Executors can read and manually raise it, but never publish their own
+    /// full-heap thresholds into it.
     pub fn new() -> Self {
-        // 0.0_f32.to_bits() == 0, matching AtomicU32::default().
-        Self(std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)))
+        Self::with_depth(usize::MAX)
+    }
+
+    /// A fresh floor valid for a query fetching `limit` results.
+    pub fn for_limit(limit: usize) -> Self {
+        Self::with_depth(limit)
+    }
+
+    fn with_depth(k: usize) -> Self {
+        Self {
+            // 0.0_f32.to_bits() == 0, matching AtomicU32::default().
+            floor: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            k,
+        }
+    }
+
+    /// True when a full heap of `heap_depth` distinct documents backs a valid
+    /// query-global floor for this threshold's result window.
+    #[inline]
+    pub(crate) fn covers(&self, heap_depth: usize) -> bool {
+        heap_depth >= self.k
     }
 
     /// Current floor.
     #[inline]
     pub fn get(&self) -> f32 {
-        f32::from_bits(self.0.load(std::sync::atomic::Ordering::Relaxed))
+        f32::from_bits(self.floor.load(std::sync::atomic::Ordering::Relaxed))
     }
 
     /// Raise the floor to `score` if it is strictly higher. Monotonic; a lower
@@ -320,9 +359,12 @@ impl SharedThreshold {
         }
         use std::sync::atomic::Ordering::Relaxed;
         let bits = score.to_bits();
-        let mut cur = self.0.load(Relaxed);
+        let mut cur = self.floor.load(Relaxed);
         while f32::from_bits(cur) < score {
-            match self.0.compare_exchange_weak(cur, bits, Relaxed, Relaxed) {
+            match self
+                .floor
+                .compare_exchange_weak(cur, bits, Relaxed, Relaxed)
+            {
                 Ok(_) => break,
                 Err(actual) => cur = actual,
             }

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -863,9 +863,21 @@ pub async fn load_sparse_file<D: Directory>(
             }
             payload_ranges.push((blob_offset, blob_end, field_id, dim_id));
 
+            // `BmpIndex::parse` slices the blob with zero-copy synchronous
+            // reads (mmap/RAM). Lazy directories (tokio-fs `FsDirectory`,
+            // HTTP) only support async range reads, so materialize the blob
+            // once here; parsing it through the sync path used to fail every
+            // BMP segment open — and with it every `hermes-tool merge` — with
+            // "Synchronous read not available on lazy file handle".
+            let (parse_handle, parse_offset) = if handle.is_sync() {
+                (handle.clone(), blob_offset)
+            } else {
+                let blob_bytes = handle.read_bytes_range(blob_offset..blob_end).await?;
+                (crate::directories::FileHandle::from_bytes(blob_bytes), 0u64)
+            };
             match BmpIndex::parse(
-                handle.clone(),
-                blob_offset,
+                parse_handle,
+                parse_offset,
                 blob_len,
                 total_docs,
                 total_vectors,

--- a/hermes-tool/src/index_ops.rs
+++ b/hermes-tool/src/index_ops.rs
@@ -252,9 +252,13 @@ pub async fn search_index(
     query_str: &str,
     limit: usize,
     offset: usize,
+    search_threads: Option<usize>,
 ) -> Result<()> {
-    let dir = FsDirectory::new(&index_path);
-    let config = IndexConfig::default();
+    let dir = hermes_core::MmapDirectory::new(&index_path);
+    let mut config = IndexConfig::default();
+    if let Some(threads) = search_threads {
+        config.num_threads = threads;
+    }
     let index = hermes_core::Index::open(dir, config).await?;
     let schema = index.schema().clone();
 
@@ -293,50 +297,86 @@ pub async fn search_index(
 }
 
 /// Run many queries against an index opened once, emitting one JSON line per
-/// query: `{"line": <1-based input line>, "total_hits": N, "hits": [{"score",
-/// "doc"}]}`. Output is flushed per query so a driving process can stream.
-pub async fn search_batch(index_path: PathBuf, queries_path: PathBuf, limit: usize) -> Result<()> {
+/// query in input order: `{"line": <1-based input line>, "total_hits": N,
+/// "hits": [{"score", "doc"}]}`. Queries execute `concurrency` at a time;
+/// output is flushed per chunk so a driving process can stream. Logs stay on
+/// stderr — stdout carries only result JSONL.
+pub async fn search_batch(
+    index_path: PathBuf,
+    queries_path: PathBuf,
+    limit: usize,
+    concurrency: usize,
+    search_threads: Option<usize>,
+) -> Result<()> {
     use std::io::Write;
+    use std::sync::Arc;
 
-    let dir = FsDirectory::new(&index_path);
-    let config = IndexConfig::default();
-    let index = hermes_core::Index::open(dir, config).await?;
-    let schema = index.schema().clone();
+    anyhow::ensure!(concurrency > 0, "--concurrency must be at least 1");
+    // Mmap (inline) handles: the BMP reader needs synchronous range reads,
+    // which lazy FsDirectory handles refuse; this matches hermes-server.
+    let dir = hermes_core::MmapDirectory::new(&index_path);
+    let mut config = IndexConfig::default();
+    if let Some(threads) = search_threads {
+        config.num_threads = threads;
+    }
+    let index = Arc::new(hermes_core::Index::open(dir, config).await?);
+    let schema = Arc::new(index.schema().clone());
 
     let file = File::open(&queries_path)
         .with_context(|| format!("Failed to open queries file: {:?}", queries_path))?;
+    let queries: Vec<(usize, String)> = BufReader::new(file)
+        .lines()
+        .enumerate()
+        .filter_map(|(line_no, line)| match line {
+            Ok(line) => {
+                let query = line.trim();
+                if query.is_empty() {
+                    None
+                } else {
+                    Some(Ok((line_no + 1, query.to_string())))
+                }
+            }
+            Err(e) => Some(Err(e)),
+        })
+        .collect::<std::result::Result<_, _>>()?;
+
     let stdout = io::stdout();
     let mut out = io::BufWriter::new(stdout.lock());
-    let mut queries = 0usize;
-    for (line_no, line) in BufReader::new(file).lines().enumerate() {
-        let line = line?;
-        let query_str = line.trim();
-        if query_str.is_empty() {
-            continue;
+    let mut done = 0usize;
+    for chunk in queries.chunks(concurrency) {
+        let mut handles = Vec::with_capacity(chunk.len());
+        for (line_no, query_str) in chunk.iter().cloned() {
+            let index = Arc::clone(&index);
+            let schema = Arc::clone(&schema);
+            handles.push(tokio::spawn(async move {
+                let response = index
+                    .query_offset(&query_str, limit, 0)
+                    .await
+                    .with_context(|| format!("Search failed for query on line {}", line_no))?;
+                let mut hits = Vec::with_capacity(response.hits.len());
+                for hit in &response.hits {
+                    let doc = match index.get_document(&hit.address).await? {
+                        Some(doc) => doc.to_json(&schema),
+                        None => serde_json::Value::Null,
+                    };
+                    hits.push(serde_json::json!({"score": hit.score, "doc": doc}));
+                }
+                anyhow::Ok(serde_json::json!({
+                    "line": line_no,
+                    "total_hits": response.total_hits,
+                    "hits": hits,
+                }))
+            }));
         }
-        let response = index
-            .query_offset(query_str, limit, 0)
-            .await
-            .with_context(|| format!("Search failed for query on line {}", line_no + 1))?;
-        let mut hits = Vec::with_capacity(response.hits.len());
-        for hit in &response.hits {
-            let doc = match index.get_document(&hit.address).await? {
-                Some(doc) => doc.to_json(&schema),
-                None => serde_json::Value::Null,
-            };
-            hits.push(serde_json::json!({"score": hit.score, "doc": doc}));
+        for handle in handles {
+            let row = handle.await??;
+            serde_json::to_writer(&mut out, &row)?;
+            out.write_all(b"\n")?;
         }
-        let row = serde_json::json!({
-            "line": line_no + 1,
-            "total_hits": response.total_hits,
-            "hits": hits,
-        });
-        serde_json::to_writer(&mut out, &row)?;
-        out.write_all(b"\n")?;
         out.flush()?;
-        queries += 1;
+        done += chunk.len();
     }
-    info!("Ran {} queries from {:?}", queries, queries_path);
+    info!("Ran {} queries from {:?}", done, queries_path);
     Ok(())
 }
 

--- a/hermes-tool/src/index_ops.rs
+++ b/hermes-tool/src/index_ops.rs
@@ -292,6 +292,54 @@ pub async fn search_index(
     Ok(())
 }
 
+/// Run many queries against an index opened once, emitting one JSON line per
+/// query: `{"line": <1-based input line>, "total_hits": N, "hits": [{"score",
+/// "doc"}]}`. Output is flushed per query so a driving process can stream.
+pub async fn search_batch(index_path: PathBuf, queries_path: PathBuf, limit: usize) -> Result<()> {
+    use std::io::Write;
+
+    let dir = FsDirectory::new(&index_path);
+    let config = IndexConfig::default();
+    let index = hermes_core::Index::open(dir, config).await?;
+    let schema = index.schema().clone();
+
+    let file = File::open(&queries_path)
+        .with_context(|| format!("Failed to open queries file: {:?}", queries_path))?;
+    let stdout = io::stdout();
+    let mut out = io::BufWriter::new(stdout.lock());
+    let mut queries = 0usize;
+    for (line_no, line) in BufReader::new(file).lines().enumerate() {
+        let line = line?;
+        let query_str = line.trim();
+        if query_str.is_empty() {
+            continue;
+        }
+        let response = index
+            .query_offset(query_str, limit, 0)
+            .await
+            .with_context(|| format!("Search failed for query on line {}", line_no + 1))?;
+        let mut hits = Vec::with_capacity(response.hits.len());
+        for hit in &response.hits {
+            let doc = match index.get_document(&hit.address).await? {
+                Some(doc) => doc.to_json(&schema),
+                None => serde_json::Value::Null,
+            };
+            hits.push(serde_json::json!({"score": hit.score, "doc": doc}));
+        }
+        let row = serde_json::json!({
+            "line": line_no + 1,
+            "total_hits": response.total_hits,
+            "hits": hits,
+        });
+        serde_json::to_writer(&mut out, &row)?;
+        out.write_all(b"\n")?;
+        out.flush()?;
+        queries += 1;
+    }
+    info!("Ran {} queries from {:?}", queries, queries_path);
+    Ok(())
+}
+
 pub async fn show_info(index_path: PathBuf) -> Result<()> {
     let dir = FsDirectory::new(&index_path);
     let config = IndexConfig::default();

--- a/hermes-tool/src/index_ops.rs
+++ b/hermes-tool/src/index_ops.rs
@@ -345,7 +345,9 @@ pub async fn search_batch(
     let mut done = 0usize;
     for chunk in queries.chunks(concurrency) {
         let mut handles = Vec::with_capacity(chunk.len());
-        for (line_no, query_str) in chunk.iter().cloned() {
+        for (line_no, query_str) in chunk {
+            let line_no = *line_no;
+            let query_str = query_str.clone();
             let index = Arc::clone(&index);
             let schema = Arc::clone(&schema);
             handles.push(tokio::spawn(async move {

--- a/hermes-tool/src/main.rs
+++ b/hermes-tool/src/main.rs
@@ -280,14 +280,24 @@ enum Commands {
         index: PathBuf,
 
         /// Query string (e.g. "rust", "title:rust", "rust AND search")
-        #[arg(short, long)]
-        query: String,
+        #[arg(
+            short,
+            long,
+            required_unless_present = "queries_file",
+            conflicts_with = "queries_file"
+        )]
+        query: Option<String>,
+
+        /// File with one query per line; the index is opened once and one
+        /// JSON result line is emitted per query
+        #[arg(long)]
+        queries_file: Option<PathBuf>,
 
         /// Number of results to return
         #[arg(short, long, default_value = "10")]
         limit: usize,
 
-        /// Offset for pagination
+        /// Offset for pagination (single --query only)
         #[arg(short, long, default_value = "0")]
         offset: usize,
     },
@@ -509,10 +519,17 @@ async fn main() -> Result<()> {
         Commands::Search {
             index,
             query,
+            queries_file,
             limit,
             offset,
         } => {
-            index_ops::search_index(index, &query, limit, offset).await?;
+            if let Some(queries_file) = queries_file {
+                anyhow::ensure!(offset == 0, "--offset is not supported with --queries-file");
+                index_ops::search_batch(index, queries_file, limit).await?;
+            } else {
+                let query = query.expect("clap enforces --query when --queries-file is absent");
+                index_ops::search_index(index, &query, limit, offset).await?;
+            }
         }
         Commands::Warmup { index, cache_size } => {
             index_ops::warmup_cache(index, cache_size).await?;

--- a/hermes-tool/src/main.rs
+++ b/hermes-tool/src/main.rs
@@ -293,6 +293,14 @@ enum Commands {
         #[arg(long)]
         queries_file: Option<PathBuf>,
 
+        /// Concurrent queries for --queries-file (default: CPU count)
+        #[arg(short = 'j', long)]
+        concurrency: Option<usize>,
+
+        /// Search pool threads (default: CPU count / 4)
+        #[arg(short = 't', long)]
+        search_threads: Option<usize>,
+
         /// Number of results to return
         #[arg(short, long, default_value = "10")]
         limit: usize,
@@ -441,6 +449,9 @@ async fn main() -> Result<()> {
             tracing_subscriber::EnvFilter::from_default_env()
                 .add_directive("hermes_tool=info".parse()?),
         )
+        // Logs go to stderr so machine-readable stdout (e.g. search
+        // --queries-file JSONL) stays clean.
+        .with_writer(std::io::stderr)
         .init();
 
     let cli = Cli::parse();
@@ -520,15 +531,27 @@ async fn main() -> Result<()> {
             index,
             query,
             queries_file,
+            concurrency,
+            search_threads,
             limit,
             offset,
         } => {
             if let Some(queries_file) = queries_file {
                 anyhow::ensure!(offset == 0, "--offset is not supported with --queries-file");
-                index_ops::search_batch(index, queries_file, limit).await?;
+                let concurrency = concurrency.unwrap_or_else(|| {
+                    std::thread::available_parallelism()
+                        .map(|n| n.get())
+                        .unwrap_or(8)
+                });
+                index_ops::search_batch(index, queries_file, limit, concurrency, search_threads)
+                    .await?;
             } else {
+                anyhow::ensure!(
+                    concurrency.is_none(),
+                    "--concurrency requires --queries-file"
+                );
                 let query = query.expect("clap enforces --query when --queries-file is absent");
-                index_ops::search_index(index, &query, limit, offset).await?;
+                index_ops::search_index(index, &query, limit, offset, search_threads).await?;
             }
         }
         Commands::Warmup { index, cache_size } => {


### PR DESCRIPTION
- fix(core): cross-segment SharedThreshold poisoning silently dropped whole segments' hits from multi-segment BMP queries; clamped heaps can no longer publish the global score floor (6 reproduce-first regression tests)
- fix(core): force merge on BMP indexes always failed on lazy FsDirectory handles; sparse loads now materialize the blob via one async read
- fix(core): explicit force merge no longer silently honors the background policy max_segment_docs cap (8.8M-doc indexes stayed at 2 segments); packs to the u32 format limit and warns loudly otherwise
- feat(tool): search --queries-file batch mode (index opened once, JSONL results, -j concurrent queries), --search-threads pool override, mmap-backed search directory (BMP indexes were unsearchable from the CLI), logs to stderr

Full hermes-core native suite green (1139 tests), clippy/fmt/doc clean. Verified end-to-end on an 8.84M-doc MS MARCO sparse index.