### PR TITLE
feat(core): chunked text fields with per-chunk BM25 and ordinals

### DIFF
--- a/docs/chunked-text-fields.md
+++ b/docs/chunked-text-fields.md
@@ -1,0 +1,131 @@
+# Chunked text fields: BM25 over passages with ordinals
+
+Status: design (2026-09-03), implemented.
+
+## Problem
+
+Sparse and dense vector fields are chunk-level: every value of a multi-valued
+field is one scoring unit, results carry per-ordinal scores, and hybrid
+fusion (`FusionQuery`) keys on `(segment, doc, ordinal)` so a chunk found by
+two verticals compounds. Text fields were document-level end to end:
+
+- postings store `(doc_id, tf)` with term frequencies **summed across all
+  values** of a multi-valued field, so a chunk never had its own BM25 score;
+- the only place an ordinal existed was the high 12 bits of an optional
+  position list, and text scorers exposed raw encoded token positions as
+  `ScoredPosition`s. Fusion turned every token occurrence into a pseudo-chunk
+  key that could never collide with a vector ordinal, and the response
+  serialiser leaked those encoded positions as `ordinal_scores`;
+- BM25 had no length normalisation: the engine used `tf` as the document
+  length proxy because no per-document field length was persisted;
+- Block-Max MaxScore was disabled whenever positions were requested — which
+  is the default server search path and every fusion sub-query — so
+  multi-term BM25 ran through the exhaustive `BooleanScorer`.
+
+## Design
+
+A text field declared `chunked` treats **every value as its own document for
+the purposes of the inverted index**. Postings, positions, IDF and average
+length are all computed over chunks; results are folded back to documents with
+per-ordinal scores exactly like sparse vectors.
+
+```
+field content: text<stem(by: languages, default: simple)> [indexed<chunked, token_position>]
+```
+
+### Virtual ids
+
+Each chunked field owns a segment-local, dense **virtual id** space. The
+`n`-th chunk value indexed for the field (across all documents, in indexing
+order) gets virtual id `n`; documents are added in doc-id order, so virtual
+ids are sorted by `(doc_id, ordinal)`. Term postings and position lists of a
+chunked field are keyed by virtual id and use the existing
+`BlockPostingList` / `PositionPostingList` formats unchanged. Token positions
+restart at 0 in every chunk, so a `PhraseQuery` can never match across a chunk
+boundary.
+
+A sidecar file `seg_<id>.chunks` maps virtual ids back:
+
+```text
+[magic "CHNK"][version u32 = 1][num_fields u32]
+TOC × num_fields: [field_id u32][num_chunks u32][total_tokens u64][data_offset u64]
+per field:        doc_ids u32 × n | ordinals u16 × n | lengths u16 × n
+```
+
+`lengths` is the token count of the chunk (saturating at 65 535) and gives
+BM25 its real length normalisation: `score = idf · tf · (k1 + 1) /
+(tf + k1 · (1 − b + b · len / avg_len))`. Non-chunked fields keep the historic
+`tf`-as-length approximation; upper bounds are unchanged (they already assume
+the shortest possible document).
+
+`FieldStats` of a chunked field count chunks: `doc_count` is the number of
+chunks and `total_tokens / doc_count` is the average chunk length. IDF uses
+the segment's chunk count as `N` and a posting's `doc_count` (number of
+chunks containing the term) as `df`.
+
+### Query execution
+
+Every query on a chunked field runs an executor over virtual ids, resolves
+each hit through the chunk map and combines per document:
+
+| query                                                            | path                                                                                                                                                 |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| multi-term OR (`MatchQuery`, Boolean SHOULD of terms, one field) | Block-Max MaxScore over chunk postings, over-fetched like sparse (`2 × limit`, capped by the chunk count), then `combine_ordinal_results` with `Max` |
+| single `TermQuery`                                               | same executor with one cursor                                                                                                                        |
+| `PhraseQuery`                                                    | positional `PhraseScorer` over virtual ids, drained, then combined with `Max`                                                                        |
+| `PrefixQuery`                                                    | rejected: prefix unions materialise doc-id sets and cannot be re-keyed cheaply                                                                       |
+
+The combined result is a `VectorTopKResultScorer`, so `matched_positions`
+carries `(ordinal, chunk score)` pairs, `SearchHit.ordinal_scores` holds true
+ordinals, and fusion keys line up with the sparse/dense ordinals of the same
+chunk when the client sends chunk texts in the same order as the vectors.
+Boolean composition with other clauses (filters, other fields) happens at the
+document level on the combined scorer, as it already does for sparse fields.
+
+Cross-segment threshold seeding is skipped for chunked MaxScore groups: the
+k-th _chunk_ score of a full heap is not a valid document-level floor after
+`Max` folding.
+
+### MaxScore and position collection
+
+`collect_positions` no longer disables text MaxScore wholesale. It stays
+disabled only for fields whose position mode tracks element ordinals
+(`positions` / `ordinal`), because those callers expect the raw encoded
+positions. Fields with no positions or `token_position` — phrase support
+only — take the MaxScore path and report no positions; a chunked field takes
+the MaxScore path and reports ordinals. Multi-term BM25 on the default server
+search path and inside every fusion sub-query is therefore pruned again.
+
+### Merges and reorder
+
+Postings and positions of a chunked field are stacked with a **per-field
+virtual-id offset** (the sum of the source segments' chunk counts) instead of
+the document offset; the term-dictionary key carries the field id, so the
+merger picks the offset per term. The `.chunks` sections are concatenated
+with the document offset added to `doc_ids`; ordinals and lengths are copied
+verbatim. BP reorder identity-copies `.chunks` like the other text files.
+
+### Schema rules (fail loudly)
+
+- `chunked` is valid only on text fields.
+- A chunked field may declare `token_position` (per-chunk phrases) or no
+  positions; `positions` and `ordinal` are rejected because the chunk is the
+  ordinal.
+- A chunked field is implicitly multi-valued (`multi`) so stored values
+  round-trip as arrays.
+
+## Wire and client impact
+
+No protocol change. `GetIndexInfo` renders `chunked` in the SDL so clients can
+detect the capability. `SearchHit.ordinal_scores` for chunked text fields are
+chunk ordinals; the existing per-token leak for positioned text fields is
+unchanged for `positions`/`ordinal` fields and gone for `token_position`
+fields (they now report no positions).
+
+## Not in scope
+
+- Highlighting / matched-token export.
+- Per-query combiner selection for text (fixed to `Max`; fusion works at
+  chunk granularity anyway).
+- Re-encoding existing indexes: a chunked field needs a rebuilt index
+  generation.

--- a/docs/dynamic-tokenizer-and-phrase.md
+++ b/docs/dynamic-tokenizer-and-phrase.md
@@ -86,6 +86,18 @@ The broker forwards `SearchRequest` opaquely but must be rebuilt against the
 new proto: a stale decoder drops the unknown oneof field and the server then
 rejects the request as having no query.
 
+## Performance notes (2026-09-03)
+
+Measured on an M-series laptop with a 1.1 MB English text (`tokenize_hinted`,
+release build, single thread): plain cleaning runs at ~340 MiB/s; adding the
+English Snowball stemmer brings it to ~55 MiB/s, and mixed Russian/English
+with `"ru,en"` to ~54 MiB/s. The stemmer itself (~120 ns per word) is the
+cost; the tokenizer around it now fetches the thread-local stemmers once per
+call instead of once per token and keeps a token's allocation when stemming
+leaves it unchanged (+8% over the first implementation). Query-time
+resolution of a `stem(...)` spec is cached per spec string in
+`TokenizerRegistry` (~1 µs per query for a five-word query).
+
 ## Not in scope
 
 - JSON (`SchemaFieldConfig`) schemas: the dynamic spec is SDL-only.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -161,6 +161,31 @@ field content: text<stem(by: languages, default: simple)> [indexed<token_positio
 
 See `docs/dynamic-tokenizer-and-phrase.md` for the design.
 
+### Chunked text fields
+
+A multi-valued text field declared `chunked` indexes **every value as its own
+BM25 unit**, the way sparse and dense vector fields treat every value as one
+vector:
+
+```
+field content: text<stem(by: languages, default: simple)> [indexed<chunked, token_position>]
+```
+
+- Postings, IDF and the average length are computed over chunks; BM25 uses
+  each chunk's real token count for length normalisation.
+- Hits report the matching chunks as `ordinal_scores` (ordinal `n` = the
+  `n`-th value sent for the field), so `FusionQuery` compounds a chunk found
+  by a text query and by a vector query when both fields receive their values
+  in the same chunk order, and clients can render the matching passage.
+- The document score is the best chunk (`Max`).
+- `token_position` keeps phrase queries per chunk; positions restart in every
+  value, so a phrase never matches across two chunks. `positions` and
+  `ordinal` are rejected on chunked fields (the chunk is the ordinal).
+- `chunked` implies `multi`; prefix (`term*`) queries are not supported on
+  chunked fields.
+
+See `docs/chunked-text-fields.md` for the design.
+
 ### Available Tokenizers
 
 | Name                      | Aliases      | Description                                        |

--- a/hermes-core/src/dsl/schema.rs
+++ b/hermes-core/src/dsl/schema.rs
@@ -75,6 +75,10 @@ pub struct FieldEntry {
     /// into the same blocks for better pruning effectiveness.
     #[serde(default)]
     pub reorder: bool,
+    /// Chunked text field: every value is its own BM25 scoring unit with a
+    /// per-chunk ordinal in results (`docs/chunked-text-fields.md`). Text only.
+    #[serde(default)]
+    pub chunked: bool,
 }
 
 impl FieldEntry {
@@ -1037,6 +1041,7 @@ impl SchemaBuilder {
             fast: false,
             primary_key: false,
             reorder: false,
+            chunked: false,
         });
         field
     }
@@ -1089,6 +1094,7 @@ impl SchemaBuilder {
             fast: false,
             primary_key: false,
             reorder: false,
+            chunked: false,
         });
         field
     }
@@ -1136,6 +1142,7 @@ impl SchemaBuilder {
             fast: false,
             primary_key: false,
             reorder: false,
+            chunked: false,
         });
         field
     }
@@ -1185,6 +1192,7 @@ impl SchemaBuilder {
             fast: false,
             primary_key: false,
             reorder: false,
+            chunked: false,
         });
         field
     }
@@ -1221,6 +1229,17 @@ impl SchemaBuilder {
     pub fn set_reorder(&mut self, field: Field, reorder: bool) {
         if let Some(entry) = self.fields.get_mut(field.0 as usize) {
             entry.reorder = reorder;
+        }
+    }
+
+    /// Mark a text field as chunked: each value is indexed as its own BM25
+    /// unit and results carry per-chunk ordinals. Implies `multi`.
+    pub fn set_chunked(&mut self, field: Field, chunked: bool) {
+        if let Some(entry) = self.fields.get_mut(field.0 as usize) {
+            entry.chunked = chunked;
+            if chunked {
+                entry.multi = true;
+            }
         }
     }
 

--- a/hermes-core/src/dsl/sdl/mod.rs
+++ b/hermes-core/src/dsl/sdl/mod.rs
@@ -84,6 +84,8 @@ pub struct FieldDef {
     pub primary: bool,
     /// Whether build-time document reordering (BP) is enabled for BMP fields
     pub reorder: bool,
+    /// Chunked text field (`indexed<chunked>`): each value is its own BM25 unit
+    pub chunked: bool,
 }
 
 /// Parsed index definition
@@ -169,6 +171,9 @@ impl IndexDef {
             }
             if field.reorder {
                 builder.set_reorder(f, true);
+            }
+            if field.chunked {
+                builder.set_chunked(f, true);
             }
             // Set positions: explicit > auto (ordinal for multi vectors)
             let positions = field.positions.or({
@@ -297,6 +302,8 @@ struct IndexConfig {
     max_weight: Option<f32>,
     // Position tracking mode for phrase queries
     positions: Option<super::schema::PositionMode>,
+    // Chunked text field: every value is its own BM25 unit
+    chunked: bool,
 }
 
 /// Parsed attributes from SDL field definition
@@ -618,6 +625,9 @@ fn parse_single_index_config_param(
                 _ => PositionMode::Full, // "positions" or any other value defaults to Full
             });
         }
+        Rule::chunked_kwarg => {
+            config.chunked = true;
+        }
         _ => {}
     }
 
@@ -826,8 +836,33 @@ fn parse_field_def(pair: pest::iterators::Pair<Rule>) -> Result<FieldDef> {
 
     // Merge index config into vector configs if both exist
     let mut positions = None;
+    let mut chunked = false;
     if let Some(idx_cfg) = index_config {
         positions = idx_cfg.positions;
+        chunked = idx_cfg.chunked;
+        if chunked {
+            if field_type != FieldType::Text {
+                return Err(Error::Schema(format!(
+                    "field '{name}': `chunked` requires a text field, got {field_type:?}"
+                )));
+            }
+            if let Some(mode) = positions
+                && mode != super::schema::PositionMode::TokenPosition
+            {
+                return Err(Error::Schema(format!(
+                    "field '{name}': a chunked text field may only declare `token_position` \
+                     (positions restart in every chunk and the chunk is the ordinal); \
+                     `{}` is not allowed",
+                    match mode {
+                        super::schema::PositionMode::Ordinal => "ordinal",
+                        super::schema::PositionMode::Full => "positions",
+                        super::schema::PositionMode::TokenPosition => unreachable!(),
+                    }
+                )));
+            }
+            // Stored values of a chunked field round-trip as an array.
+            multi = true;
+        }
         if let Some(ref mut bv_config) = binary_dense_vector_config {
             apply_index_config_to_binary_dense_vector(bv_config, idx_cfg)?;
         } else if let Some(ref mut dv_config) = dense_vector_config {
@@ -856,6 +891,7 @@ fn parse_field_def(pair: pest::iterators::Pair<Rule>) -> Result<FieldDef> {
         fast,
         primary,
         reorder,
+        chunked,
     })
 }
 
@@ -1660,6 +1696,57 @@ mod tests {
         // Default should be indexed and stored
         assert!(field.indexed);
         assert!(field.stored);
+    }
+
+    #[test]
+    fn chunked_text_field_parses_and_implies_multi() {
+        let sdl = r#"
+            index documents {
+                field languages: text<raw_ci> [fast]
+                field content: text<stem(by: languages, default: simple)> [indexed<chunked, token_position>]
+                field notes: text<simple> [indexed<chunked>, stored]
+            }
+        "#;
+        let index = parse_single_index(sdl).unwrap();
+        let content = &index.fields[1];
+        assert!(content.chunked);
+        assert!(content.multi, "chunked implies multi-valued storage");
+        assert_eq!(
+            content.positions,
+            Some(crate::dsl::PositionMode::TokenPosition)
+        );
+        let notes = &index.fields[2];
+        assert!(notes.chunked && notes.stored && notes.positions.is_none());
+
+        let schema = index.to_schema();
+        let entry = schema
+            .get_field_entry(schema.get_field("content").unwrap())
+            .unwrap();
+        assert!(entry.chunked && entry.multi);
+        assert!(
+            !schema
+                .get_field_entry(schema.get_field("languages").unwrap())
+                .unwrap()
+                .chunked
+        );
+    }
+
+    #[test]
+    fn chunked_rejects_non_text_and_ordinal_position_modes() {
+        let non_text = parse_sdl("index i { field n: u64 [indexed<chunked>] }").unwrap_err();
+        assert!(
+            non_text.to_string().contains("requires a text field"),
+            "{non_text}"
+        );
+
+        for mode in ["positions", "ordinal"] {
+            let sdl = format!("index i {{ field c: text<simple> [indexed<chunked, {mode}>] }}");
+            let error = parse_sdl(&sdl).unwrap_err();
+            assert!(
+                error.to_string().contains("token_position"),
+                "{mode}: {error}"
+            );
+        }
     }
 
     #[test]

--- a/hermes-core/src/dsl/sdl/sdl.pest
+++ b/hermes-core/src/dsl/sdl/sdl.pest
@@ -144,12 +144,15 @@ stored_with_config = { "stored" ~ "<" ~ "multi" ~ ">" }
 //   indexed<quantization: uint8, query<tokenizer: "model/name", weighting: idf>>  # with query config
 indexed_with_config = { "indexed" ~ "<" ~ index_config_params ~ ">" }
 index_config_params = { index_config_param ~ ("," ~ index_config_param)* }
-index_config_param = { index_type_kwarg | num_clusters_kwarg | target_vectors_kwarg | tree_levels_kwarg | nprobe_kwarg | routing_kwarg | quantization_kwarg | weight_threshold_kwarg | bmp_block_size_kwarg | bmp_grid_bits_kwarg | block_size_kwarg | pruning_kwarg | min_terms_kwarg | sparse_format_kwarg | sparse_dims_kwarg | sparse_max_weight_kwarg | doc_mass_kwarg | soar_kwarg | query_config_block | positions_kwarg | index_type_spec }
+index_config_param = { index_type_kwarg | num_clusters_kwarg | target_vectors_kwarg | tree_levels_kwarg | nprobe_kwarg | routing_kwarg | quantization_kwarg | weight_threshold_kwarg | bmp_block_size_kwarg | bmp_grid_bits_kwarg | block_size_kwarg | pruning_kwarg | min_terms_kwarg | sparse_format_kwarg | sparse_dims_kwarg | sparse_max_weight_kwarg | doc_mass_kwarg | soar_kwarg | query_config_block | positions_kwarg | chunked_kwarg | index_type_spec }
 // Position tracking modes:
 //   positions - full tracking (element ordinal + token position)
 //   ordinal - only element ordinal for multi-valued fields
 //   token_position - only token position within text for phrase queries
 positions_kwarg = { "positions" | "ordinal" | "token_position" }
+// Chunked text: every value of the field is its own BM25 scoring unit
+// (see docs/chunked-text-fields.md).
+chunked_kwarg = { "chunked" }
 index_type_kwarg = { "index" ~ ":" ~ index_type_spec }
 index_type_spec = { "flat" | "ivf_pq" | "ivf_tq" | "ivf" | "scann" | "tq" }
 num_clusters_kwarg = { "num_clusters" ~ ":" ~ num_clusters_spec }

--- a/hermes-core/src/index/tests/chunked.rs
+++ b/hermes-core/src/index/tests/chunked.rs
@@ -1,0 +1,386 @@
+//! Chunked text fields: every value of the field is its own BM25 unit and
+//! results carry per-chunk ordinals (`docs/chunked-text-fields.md`).
+
+use crate::directories::RamDirectory;
+use crate::dsl::{Document, Field, PositionMode, Schema, SchemaBuilder};
+use crate::index::{Index, IndexConfig, IndexWriter};
+use crate::query::{
+    BooleanQuery, FusionMethod, MultiValueCombiner, PhraseQuery, PrefixQuery, SearchResult,
+    SparseVectorQuery, TermQuery,
+};
+
+struct Fields {
+    schema: Schema,
+    content: Field,
+    kind: Field,
+    sparse: Field,
+}
+
+fn chunked_schema() -> Fields {
+    let mut sb = SchemaBuilder::default();
+    let languages = sb.add_text_field_with_tokenizer("languages", false, true, "raw_ci");
+    sb.set_fast(languages, true);
+    let kind = sb.add_text_field_with_tokenizer("kind", true, true, "raw_ci");
+    sb.set_fast(kind, true);
+    let content = sb.add_text_field_with_tokenizer(
+        "content",
+        true,
+        false,
+        "stem(by: languages, default: simple)",
+    );
+    sb.set_chunked(content, true);
+    sb.set_positions(content, PositionMode::TokenPosition);
+    let sparse = sb.add_sparse_vector_field("sparse", true, false);
+    Fields {
+        schema: sb.build(),
+        content,
+        kind,
+        sparse,
+    }
+}
+
+fn doc(fields: &Fields, kind: &str, chunks: &[&str]) -> Document {
+    let mut d = Document::new();
+    d.add_text(fields.kind, kind);
+    for chunk in chunks {
+        d.add_text(fields.content, *chunk);
+    }
+    d
+}
+
+/// Ordinals reported for a hit, ascending.
+fn ordinals(result: &SearchResult) -> Vec<u32> {
+    let mut ordinals: Vec<u32> = result
+        .positions
+        .iter()
+        .flat_map(|(_, scored)| scored.iter().map(|sp| sp.position))
+        .collect();
+    ordinals.sort_unstable();
+    ordinals
+}
+
+fn by_doc(results: &[SearchResult], doc_id: u32) -> &SearchResult {
+    results
+        .iter()
+        .find(|r| r.doc_id == doc_id)
+        .unwrap_or_else(|| panic!("doc {doc_id} missing from {results:?}"))
+}
+
+async fn open(dir: RamDirectory) -> Index<RamDirectory> {
+    Index::open(dir, IndexConfig::default()).await.unwrap()
+}
+
+#[tokio::test]
+async fn chunked_match_scores_chunks_and_reports_ordinals() {
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    writer
+        .add_document(doc(
+            &f,
+            "article",
+            &["alpha beta gamma", "delta epsilon", "zeta eta theta needle"],
+        ))
+        .unwrap();
+    writer
+        .add_document(doc(&f, "article", &["needle needle here", "other words"]))
+        .unwrap();
+    writer
+        .add_document(doc(&f, "article", &["nothing relevant", "still nothing"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    // Multi-term OR → chunked MaxScore. Every matching chunk is an ordinal.
+    let or_query = BooleanQuery::new()
+        .should(TermQuery::text(f.content, "needle"))
+        .should(TermQuery::text(f.content, "gamma"));
+    let (results, _) = searcher.search_with_positions(&or_query, 10).await.unwrap();
+    assert_eq!(results.len(), 2, "doc 2 has no matching chunk: {results:?}");
+    let doc0 = by_doc(&results, 0);
+    assert_eq!(
+        ordinals(doc0),
+        vec![0, 2],
+        "gamma in chunk 0, needle in chunk 2"
+    );
+    let doc1 = by_doc(&results, 1);
+    assert_eq!(ordinals(doc1), vec![0]);
+    // Document score is the best chunk, not the sum over chunks.
+    let chunk_score = |result: &SearchResult, ordinal: u32| {
+        result.positions[0]
+            .1
+            .iter()
+            .find(|sp| sp.position == ordinal)
+            .map(|sp| sp.score)
+            .unwrap()
+    };
+    let best_chunk = chunk_score(doc0, 0).max(chunk_score(doc0, 2));
+    assert!((doc0.score - best_chunk).abs() < 1e-6, "{doc0:?}");
+    // Each chunk is scored on its own: doc 1's tf=2 needle chunk outranks
+    // doc 0's single-occurrence needle chunk.
+    assert!(
+        chunk_score(doc1, 0) > chunk_score(doc0, 2),
+        "tf=2 short chunk must outrank a single occurrence: {results:?}"
+    );
+
+    // Single term → same ordinal reporting.
+    let term = TermQuery::text(f.content, "needle");
+    let (results, _) = searcher.search_with_positions(&term, 10).await.unwrap();
+    assert_eq!(ordinals(by_doc(&results, 0)), vec![2]);
+    assert_eq!(ordinals(by_doc(&results, 1)), vec![0]);
+
+    // The positions-free API yields the same documents and scores.
+    let (plain, _) = searcher.search_with_count(&term, 10).await.unwrap();
+    assert_eq!(plain.len(), 2);
+    assert!(plain.iter().all(|r| r.positions.is_empty()));
+    for hit in &plain {
+        assert_eq!(hit.score, by_doc(&results, hit.doc_id).score);
+    }
+}
+
+#[tokio::test]
+async fn chunked_phrase_never_crosses_a_chunk_boundary() {
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    // "brown" ends chunk 0 and "fox" starts chunk 1: adjacent in the document,
+    // never adjacent inside one chunk.
+    writer
+        .add_document(doc(&f, "article", &["quick brown", "fox jumps"]))
+        .unwrap();
+    writer
+        .add_document(doc(&f, "article", &["padding text", "quick brown fox"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    let phrase = |text: &str| {
+        PhraseQuery::new(
+            f.content,
+            text.split(' ').map(|t| t.as_bytes().to_vec()).collect(),
+        )
+    };
+    let (results, _) = searcher
+        .search_with_positions(&phrase("brown fox"), 10)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1, "{results:?}");
+    assert_eq!(results[0].doc_id, 1);
+    assert_eq!(ordinals(&results[0]), vec![1]);
+
+    let (results, _) = searcher
+        .search_with_positions(&phrase("quick brown"), 10)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(ordinals(by_doc(&results, 0)), vec![0]);
+    assert_eq!(ordinals(by_doc(&results, 1)), vec![1]);
+}
+
+#[tokio::test]
+async fn chunked_bm25_normalises_by_real_chunk_length() {
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    let long = format!("needle {}", "filler ".repeat(40));
+    writer.add_document(doc(&f, "article", &[&long])).unwrap();
+    writer
+        .add_document(doc(&f, "article", &["needle filler filler"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let (results, _) = searcher
+        .search_with_positions(&TermQuery::text(f.content, "needle"), 10)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(
+        by_doc(&results, 1).score > by_doc(&results, 0).score,
+        "same tf, shorter chunk must score higher: {results:?}"
+    );
+}
+
+#[tokio::test]
+async fn chunked_ordinals_survive_segment_merge() {
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    writer
+        .add_document(doc(&f, "article", &["first chunk", "second needle"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+    // Second segment: its virtual ids restart at 0 and must be re-based on merge.
+    writer
+        .add_document(doc(
+            &f,
+            "article",
+            &["another chunk", "more text", "final needle"],
+        ))
+        .unwrap();
+    writer
+        .add_document(doc(&f, "article", &["needle first"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+    writer.force_merge().await.unwrap();
+
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let (results, _) = searcher
+        .search_with_positions(&TermQuery::text(f.content, "needle"), 10)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 3, "{results:?}");
+    let segments: std::collections::HashSet<u128> = results.iter().map(|r| r.segment_id).collect();
+    assert_eq!(segments.len(), 1, "force_merge must leave one segment");
+    assert_eq!(ordinals(by_doc(&results, 0)), vec![1]);
+    assert_eq!(ordinals(by_doc(&results, 1)), vec![2]);
+    assert_eq!(ordinals(by_doc(&results, 2)), vec![0]);
+
+    // Phrases still resolve per chunk after the merge.
+    let phrase = PhraseQuery::new(f.content, vec![b"final".to_vec(), b"needle".to_vec()]);
+    let (results, _) = searcher.search_with_positions(&phrase, 10).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].doc_id, 1);
+    assert_eq!(ordinals(&results[0]), vec![2]);
+}
+
+#[tokio::test]
+async fn chunked_text_fuses_with_sparse_vectors_on_shared_ordinals() {
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    // Doc 0: text and vector agree on chunk 0.
+    let mut d = doc(&f, "article", &["needle words", "hay words"]);
+    d.add_sparse_vector(f.sparse, vec![(1, 1.0)]);
+    d.add_sparse_vector(f.sparse, vec![(2, 1.0)]);
+    writer.add_document(d).unwrap();
+    // Doc 1: text and vector agree on chunk 1.
+    let mut d = doc(&f, "article", &["hay words", "needle words"]);
+    d.add_sparse_vector(f.sparse, vec![(2, 1.0)]);
+    d.add_sparse_vector(f.sparse, vec![(1, 1.0)]);
+    writer.add_document(d).unwrap();
+    // Doc 2: text hits chunk 0 but the vector hits chunk 1 — no corroboration.
+    let mut d = doc(&f, "article", &["needle words", "hay words"]);
+    d.add_sparse_vector(f.sparse, vec![(2, 1.0)]);
+    d.add_sparse_vector(f.sparse, vec![(1, 1.0)]);
+    writer.add_document(d).unwrap();
+    writer.commit().await.unwrap();
+
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    let text = TermQuery::text(f.content, "needle");
+    let sparse = SparseVectorQuery::new(f.sparse, vec![(1, 1.0)]);
+    let fused = searcher
+        .search_fused(
+            &[(&text, 1.0), (&sparse, 1.0)],
+            10,
+            10,
+            FusionMethod::default(),
+            MultiValueCombiner::Max,
+        )
+        .await
+        .unwrap();
+    assert_eq!(fused.len(), 3, "{fused:?}");
+    let doc0 = by_doc(&fused, 0);
+    let doc1 = by_doc(&fused, 1);
+    let doc2 = by_doc(&fused, 2);
+    assert_eq!(ordinals(doc0), vec![0], "both verticals land on chunk 0");
+    assert_eq!(ordinals(doc1), vec![1], "both verticals land on chunk 1");
+    assert_eq!(
+        ordinals(doc2),
+        vec![0, 1],
+        "disagreeing verticals stay separate chunks"
+    );
+    assert!(
+        doc0.score > doc2.score && doc1.score > doc2.score,
+        "same-chunk corroboration must compound: {fused:?}"
+    );
+}
+
+#[tokio::test]
+async fn chunked_match_composes_with_document_filters() {
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    writer
+        .add_document(doc(&f, "article", &["hay", "needle here"]))
+        .unwrap();
+    writer
+        .add_document(doc(&f, "book", &["needle here", "hay"]))
+        .unwrap();
+    writer
+        .add_document(doc(&f, "article", &["hay only"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+
+    let query = BooleanQuery::new()
+        .must(TermQuery::text(f.kind, "book"))
+        .should(TermQuery::text(f.content, "needle"))
+        .should(TermQuery::text(f.content, "here"));
+    let (results, _) = searcher.search_with_positions(&query, 10).await.unwrap();
+    assert_eq!(results.len(), 1, "{results:?}");
+    assert_eq!(results[0].doc_id, 1);
+    assert_eq!(ordinals(&results[0]), vec![0]);
+
+    // Terms spread over different chunks all report their own ordinal.
+    let query = BooleanQuery::new()
+        .should(TermQuery::text(f.content, "needle"))
+        .should(TermQuery::text(f.content, "hay"));
+    let (results, _) = searcher.search_with_positions(&query, 10).await.unwrap();
+    assert_eq!(ordinals(by_doc(&results, 0)), vec![0, 1]);
+    assert_eq!(ordinals(by_doc(&results, 1)), vec![0, 1]);
+    assert_eq!(ordinals(by_doc(&results, 2)), vec![0]);
+}
+
+#[tokio::test]
+async fn chunked_field_rejects_prefix_queries_loudly() {
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    writer
+        .add_document(doc(&f, "article", &["needle here"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let error = searcher
+        .search_with_count(&PrefixQuery::text(f.content, "need"), 10)
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("chunked"),
+        "prefix on a chunked field must fail with an actionable message: {error}"
+    );
+}

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -1,6 +1,7 @@
 mod basic;
 mod bmp;
 mod boolean;
+mod chunked;
 mod merge;
 mod pin;
 mod primary_key;

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -9,8 +9,8 @@ use crate::{DocId, Score};
 use super::planner::{
     build_combined_bitset, build_sparse_bmp_results, build_sparse_bmp_results_filtered,
     build_sparse_maxscore_executor, chain_predicates, combine_sparse_results, compute_idf,
-    extract_all_sparse_infos, finish_text_maxscore, prepare_per_field_grouping,
-    prepare_text_maxscore,
+    extract_all_sparse_infos, finish_chunked_text_maxscore, finish_text_maxscore,
+    prepare_per_field_grouping, prepare_text_maxscore, text_maxscore_allowed,
 };
 use super::{CountFuture, EmptyScorer, GlobalStats, Query, Scorer, ScorerFuture};
 
@@ -201,9 +201,9 @@ macro_rules! boolean_plan {
         // ── 2. Pure OR → MaxScore optimisations ──────────────────────────
         if must.is_empty() && must_not.is_empty() && should.len() >= 2 {
             // 2a. Text MaxScore (single-field, all term queries)
-            if !scorer_options.collect_positions
-                && let Some((mut infos, text_field, avg_field_len, num_docs)) =
+            if let Some((mut infos, text_field, avg_field_len, num_docs)) =
                 prepare_text_maxscore(should, reader, global_stats)
+                && text_maxscore_allowed(reader, text_field, scorer_options.collect_positions)
             {
                 let mut posting_lists = Vec::with_capacity(infos.len());
                 for info in infos.drain(..) {
@@ -213,6 +213,10 @@ macro_rules! boolean_plan {
                         let idf = compute_idf(&pl, info.field, &info.term, num_docs, global_stats);
                         posting_lists.push((pl, idf));
                     }
+                }
+                // Chunked field: score chunks, fold to documents with ordinals.
+                if reader.is_chunked_field(text_field) {
+                    return finish_chunked_text_maxscore(posting_lists, limit, reader, text_field);
                 }
                 // Seed from the cross-segment floor: this path scores final
                 // per-doc BM25 into a top-`limit` heap, so a floor carried from
@@ -249,26 +253,38 @@ macro_rules! boolean_plan {
             }
 
             // 2c. Per-field text MaxScore (multi-field term grouping)
-            if !scorer_options.collect_positions
-                && let Some(grouping) =
-                    prepare_per_field_grouping(should, reader, limit, global_stats)
-            {
+            if let Some(grouping) = prepare_per_field_grouping(
+                should,
+                reader,
+                limit,
+                global_stats,
+                scorer_options.collect_positions,
+            ) {
                 let mut scorers: Vec<Box<dyn Scorer + '_>> = Vec::new();
                 // Query-local cross-group threshold seeding (see finish_text_maxscore)
                 let shared_threshold = std::cell::Cell::new(0.0f32);
                 for (field, avg_field_len, infos) in &grouping.multi_term_groups {
+                    // Chunked fields: IDF over chunks, not documents.
+                    let corpus_size = reader.text_corpus_size(*field);
                     let mut posting_lists = Vec::with_capacity(infos.len());
                     for info in infos {
                         if let Some(pl) = reader.$get_postings_fn(info.field, &info.term)
                             $(. $aw)* ?
                         {
                             let idf = compute_idf(
-                                &pl, *field, &info.term, grouping.num_docs, global_stats,
+                                &pl, *field, &info.term, corpus_size, global_stats,
                             );
                             posting_lists.push((pl, idf));
                         }
                     }
-                    if !posting_lists.is_empty() {
+                    if reader.is_chunked_field(*field) {
+                        scorers.push(finish_chunked_text_maxscore(
+                            posting_lists,
+                            grouping.per_field_limit,
+                            reader,
+                            *field,
+                        )?);
+                    } else if !posting_lists.is_empty() {
                         scorers.push(finish_text_maxscore(
                             posting_lists,
                             *avg_field_len,
@@ -291,10 +307,12 @@ macro_rules! boolean_plan {
         }
 
         // ── 3. Filter push-down (MUST + SHOULD) ─────────────────────────
-        if !scorer_options.collect_positions
-            && !should.is_empty()
-            && !must.is_empty()
-        {
+        //
+        // Position collection no longer disables this path: fast-field
+        // predicates carry no positions to lose and verifier scorers keep
+        // theirs. Only the posting-list bitset shortcut is skipped when
+        // positions are requested, because a bitset cannot report them.
+        if !should.is_empty() && !must.is_empty() {
             // Pre-check: is SHOULD all-sparse? This determines whether we can
             // use bitset fallback for MUST clauses that lack fast-field predicates.
             // For sparse SHOULD, the predicate is pushed into BMP/MaxScore traversal
@@ -303,6 +321,7 @@ macro_rules! boolean_plan {
             // don't match SHOULD), so those go to verifier → BooleanScorer.
             let should_is_sparse = scorer_options.lsp_plan.is_some()
                 || extract_all_sparse_infos(should).is_some();
+            let bitset_predicates_allowed = should_is_sparse && !scorer_options.collect_positions;
 
             // 3a. Compile MUST → predicates (O(1)) vs verifier scorers (seek)
             //
@@ -315,7 +334,7 @@ macro_rules! boolean_plan {
                 if let Some(pred) = q.as_doc_predicate(reader) {
                     log::debug!("BooleanQuery planner 3a: MUST clause → predicate ({})", q);
                     predicates.push(pred);
-                } else if should_is_sparse {
+                } else if bitset_predicates_allowed {
                     if let Some(bitset) = q.as_doc_bitset(reader) {
                         log::debug!("BooleanQuery planner 3a: MUST clause → bitset predicate ({})", q);
                         predicates.push(Box::new(move |doc_id| bitset.contains(doc_id)));
@@ -339,7 +358,7 @@ macro_rules! boolean_plan {
                     let negated: super::DocPredicate<'_> =
                         Box::new(move |doc_id| !pred(doc_id));
                     predicates.push(negated);
-                } else if should_is_sparse {
+                } else if bitset_predicates_allowed {
                     if let Some(bitset) = q.as_doc_bitset(reader) {
                         log::debug!("BooleanQuery planner 3a: MUST_NOT clause → bitset predicate ({})", q);
                         predicates.push(Box::new(move |doc_id| !bitset.contains(doc_id)));
@@ -886,9 +905,51 @@ impl Scorer for BooleanScorer<'_> {
         if all_positions.is_empty() {
             None
         } else {
-            Some(all_positions)
+            Some(merge_matched_positions(all_positions))
         }
     }
+}
+
+/// Coalesce the position lists that several clauses reported for one field.
+///
+/// Two term clauses on the same chunked field each report the chunk ordinal
+/// they matched; the union must present one entry per chunk whose score is
+/// the sum of the clause contributions (the chunk's BM25 score), not the same
+/// ordinal twice. Distinct positions are left untouched, so token positions of
+/// `positions`-mode fields keep their per-term scores.
+pub(super) fn merge_matched_positions(
+    positions: super::MatchedPositions,
+) -> super::MatchedPositions {
+    if positions.len() < 2 {
+        return positions;
+    }
+    let mut merged: super::MatchedPositions = Vec::with_capacity(positions.len());
+    for (field_id, scored) in positions {
+        match merged
+            .iter_mut()
+            .find(|(existing, _)| *existing == field_id)
+        {
+            Some((_, existing)) => existing.extend(scored),
+            None => merged.push((field_id, scored)),
+        }
+    }
+    for (_, scored) in &mut merged {
+        if scored.len() < 2 {
+            continue;
+        }
+        scored.sort_by_key(|sp| sp.position);
+        let mut write = 0usize;
+        for read in 1..scored.len() {
+            if scored[read].position == scored[write].position {
+                scored[write].score += scored[read].score;
+            } else {
+                write += 1;
+                scored[write] = scored[read];
+            }
+        }
+        scored.truncate(write + 1);
+    }
+    merged
 }
 
 #[cfg(test)]

--- a/hermes-core/src/query/global_stats.rs
+++ b/hermes-core/src/query/global_stats.rs
@@ -213,7 +213,8 @@ impl LazyGlobalStats {
 
         for segment in &self.segments {
             let avg_len = segment.avg_field_len(field);
-            let doc_count = segment.num_docs() as u64;
+            // Chunked fields average over chunks, not documents.
+            let doc_count = segment.text_corpus_size(field) as u64;
             if avg_len > 0.0 && doc_count > 0 {
                 weighted_sum += avg_len as f64 * doc_count as f64;
                 total_weight += doc_count;

--- a/hermes-core/src/query/phrase.rs
+++ b/hermes-core/src/query/phrase.rs
@@ -97,6 +97,49 @@ impl PhraseQuery {
     }
 }
 
+/// Phrase over a chunked field: match and score every chunk (posting ids are
+/// virtual chunk ids, positions restart per chunk so a phrase never spans two
+/// chunks), then fold the chunk hits into documents with per-ordinal scores.
+///
+/// The phrase is a conjunction, so draining the positional scorer costs one
+/// pass over the matching chunks only.
+fn build_chunked_phrase_scorer<'a>(
+    term_data: Vec<(BlockPostingList, PositionPostingList)>,
+    slop: u32,
+    reader: &SegmentReader,
+    field: Field,
+    limit: usize,
+) -> crate::Result<Box<dyn Scorer + 'a>> {
+    let Some(chunk_map) = reader.chunk_map(field) else {
+        return Err(crate::Error::Corruption(format!(
+            "chunked text field '{}' has postings but segment {:016x} carries no chunk map",
+            reader.schema().get_field_name(field).unwrap_or("?"),
+            reader.meta().id,
+        )));
+    };
+    let num_chunks = chunk_map.num_chunks() as f32;
+    let idf: f32 = term_data
+        .iter()
+        .map(|(p, _)| super::bm25_idf(p.doc_count() as f32, num_chunks))
+        .sum();
+    let (postings, positions): (Vec<_>, Vec<_>) = term_data.into_iter().unzip();
+    let mut scorer = PhraseScorer::new(postings, positions, slop, idf, chunk_map.avg_len())
+        .with_chunk_lengths(chunk_map.clone());
+
+    use super::docset::DocSet as _;
+    let mut raw: Vec<(u32, u16, f32)> = Vec::new();
+    while scorer.doc() != TERMINATED {
+        let (doc_id, ordinal) = chunk_map.resolve(scorer.doc());
+        raw.push((doc_id, ordinal, scorer.score()));
+        scorer.advance();
+    }
+    let combined =
+        crate::segment::combine_ordinal_results(raw, super::MultiValueCombiner::Max, limit.max(1));
+    Ok(Box::new(super::planner::VectorTopKResultScorer::new(
+        combined, field.0,
+    )) as Box<dyn Scorer + 'a>)
+}
+
 /// Build a PhraseScorer from already-fetched term data.
 fn build_phrase_scorer<'a>(
     term_data: Vec<(BlockPostingList, PositionPostingList)>,
@@ -186,6 +229,9 @@ impl Query for PhraseQuery {
                 }
             }
 
+            if reader.is_chunked_field(field) {
+                return build_chunked_phrase_scorer(term_data, slop, reader, field, limit);
+            }
             Ok(build_phrase_scorer(term_data, slop, reader, field))
         })
     }
@@ -237,6 +283,9 @@ impl Query for PhraseQuery {
             }
         }
 
+        if reader.is_chunked_field(self.field) {
+            return build_chunked_phrase_scorer(term_data, self.slop, reader, self.field, limit);
+        }
         Ok(build_phrase_scorer(
             term_data, self.slop, reader, self.field,
         ))
@@ -281,6 +330,9 @@ struct PhraseScorer {
     idf: f32,
     /// Average field length
     avg_field_len: f32,
+    /// Real per-chunk lengths for chunked fields (posting ids are virtual
+    /// chunk ids). `None` keeps the historic `tf`-as-length approximation.
+    chunk_lengths: Option<crate::segment::chunk_map::ChunkMap>,
     /// Reusable position buffers (one per term, avoids per-document allocation)
     position_bufs: Vec<Vec<u32>>,
 }
@@ -306,11 +358,18 @@ impl PhraseScorer {
             current_doc: 0,
             idf,
             avg_field_len,
+            chunk_lengths: None,
             position_bufs: (0..num_terms).map(|_| Vec::new()).collect(),
         };
 
         scorer.find_next_phrase_match();
         scorer
+    }
+
+    /// Score with each chunk's real length (chunked fields).
+    fn with_chunk_lengths(mut self, lengths: crate::segment::chunk_map::ChunkMap) -> Self {
+        self.chunk_lengths = Some(lengths);
+        self
     }
 
     /// Find next document where all terms appear as a phrase
@@ -467,7 +526,14 @@ impl Scorer for PhraseScorer {
             .map(|it| it.term_freq() as f32)
             .sum();
 
+        // Chunked fields know the real chunk length; other fields keep the
+        // `tf`-as-length approximation.
+        let doc_len = match &self.chunk_lengths {
+            Some(lengths) => lengths.length(self.current_doc) as f32,
+            None => tf,
+        };
+
         // Phrase matches get a boost since they're more precise
-        super::bm25_score(tf, self.idf, tf, self.avg_field_len) * 1.5
+        super::bm25_score(tf, self.idf, doc_len, self.avg_field_len) * 1.5
     }
 }

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -60,7 +60,8 @@ pub(super) fn prepare_text_maxscore(
     let avg_field_len = global_stats
         .map(|s| s.avg_field_len(field))
         .unwrap_or_else(|| reader.avg_field_len(field));
-    let num_docs = reader.num_docs() as f32;
+    // Chunked fields: IDF over chunks, not documents.
+    let num_docs = reader.text_corpus_size(field);
     Some((infos, field, avg_field_len, num_docs))
 }
 
@@ -99,6 +100,84 @@ pub(super) fn finish_text_maxscore<'a>(
     Ok(Box::new(TopKResultScorer::new(results)) as Box<dyn Scorer + 'a>)
 }
 
+/// Over-fetch factor for chunked text MaxScore: the executor ranks chunks and
+/// `Max` folding collapses a document's chunks into one hit, so fetch more
+/// raw chunks than documents requested (same budget as sparse vectors).
+const CHUNKED_TEXT_OVER_FETCH_FACTOR: f32 = 2.0;
+
+/// Whether the text MaxScore fast path may serve a field when the caller
+/// asked for positions.
+///
+/// Without positions it always may. With positions it may unless the field's
+/// position mode tracks element ordinals (`positions` / `ordinal`): those
+/// callers expect the raw encoded positions of every hit, which the top-k
+/// executor does not produce. Phrase-only (`token_position`) fields report no
+/// positions and chunked fields report chunk ordinals, both via MaxScore.
+pub(super) fn text_maxscore_allowed(
+    reader: &SegmentReader,
+    field: crate::Field,
+    collect_positions: bool,
+) -> bool {
+    if !collect_positions || reader.is_chunked_field(field) {
+        return true;
+    }
+    !reader
+        .schema()
+        .get_field_entry(field)
+        .and_then(|entry| entry.positions)
+        .is_some_and(|mode| mode.tracks_ordinal())
+}
+
+/// Run BM25 MaxScore over a chunked field and fold the chunk hits into
+/// documents with per-ordinal scores.
+///
+/// Posting ids are virtual chunk ids; every hit is resolved through the
+/// segment's chunk map, grouped by document with `Max`, and served by a
+/// `VectorTopKResultScorer` so `matched_positions` carries `(ordinal, chunk
+/// score)` pairs — the same shape sparse vectors produce. Cross-segment
+/// threshold seeding is deliberately not applied: the k-th chunk score of a
+/// full heap is not a document-level floor after `Max` folding.
+pub(crate) fn finish_chunked_text_maxscore<'a>(
+    posting_lists: Vec<(crate::structures::BlockPostingList, f32)>,
+    limit: usize,
+    reader: &SegmentReader,
+    field: crate::Field,
+) -> crate::Result<Box<dyn Scorer + 'a>> {
+    if posting_lists.is_empty() {
+        return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + 'a>);
+    }
+    let Some(chunk_map) = reader.chunk_map(field) else {
+        return Err(crate::Error::Corruption(format!(
+            "chunked text field '{}' has postings but segment {:016x} carries no chunk map",
+            reader.schema().get_field_name(field).unwrap_or("?"),
+            reader.meta().id,
+        )));
+    };
+    let executor_limit = bounded_sparse_executor_limit(limit, CHUNKED_TEXT_OVER_FETCH_FACTOR)
+        .min(chunk_map.num_chunks() as usize)
+        .max(1);
+    let executor = MaxScoreExecutor::text_chunked(
+        posting_lists,
+        chunk_map.avg_len(),
+        executor_limit,
+        chunk_map,
+    )
+    .with_metric_labels(
+        reader.schema().index_label(),
+        reader.schema().get_field_name(field).unwrap_or("?"),
+    );
+    let raw = executor.execute_sync()?;
+    let combined = crate::segment::combine_ordinal_results(
+        raw.into_iter().map(|hit| {
+            let (doc_id, ordinal) = chunk_map.resolve(hit.doc_id);
+            (doc_id, ordinal, hit.score)
+        }),
+        MultiValueCombiner::Max,
+        limit,
+    );
+    Ok(Box::new(VectorTopKResultScorer::new(combined, field.0)) as Box<dyn Scorer + 'a>)
+}
+
 // ── Per-field grouping ───────────────────────────────────────────────────
 
 /// Shared grouping result for per-field MaxScore.
@@ -109,7 +188,6 @@ pub(super) struct PerFieldGrouping {
     pub fallback_indices: Vec<usize>,
     /// Limit per field group (over-fetched to compensate for cross-field scoring)
     pub per_field_limit: usize,
-    pub num_docs: f32,
 }
 
 /// Group SHOULD clauses by field for per-field MaxScore.
@@ -119,13 +197,16 @@ pub(super) fn prepare_per_field_grouping(
     reader: &SegmentReader,
     limit: usize,
     global_stats: Option<&Arc<GlobalStats>>,
+    collect_positions: bool,
 ) -> Option<PerFieldGrouping> {
     let mut field_groups: rustc_hash::FxHashMap<crate::Field, Vec<(usize, TermQueryInfo)>> =
         rustc_hash::FxHashMap::default();
     let mut non_term_indices: Vec<usize> = Vec::new();
 
     for (i, q) in should.iter().enumerate() {
-        if let super::QueryDecomposition::TextTerm(info) = q.decompose() {
+        if let super::QueryDecomposition::TextTerm(info) = q.decompose()
+            && text_maxscore_allowed(reader, info.field, collect_positions)
+        {
             field_groups.entry(info.field).or_default().push((i, info));
         } else {
             non_term_indices.push(i);
@@ -137,7 +218,6 @@ pub(super) fn prepare_per_field_grouping(
     }
 
     let per_field_limit = super::max_candidate_limit(limit).min(reader.num_docs() as usize);
-    let num_docs = reader.num_docs() as f32;
 
     let mut multi_term_groups = Vec::new();
     let mut fallback_indices = non_term_indices;
@@ -159,7 +239,6 @@ pub(super) fn prepare_per_field_grouping(
         multi_term_groups,
         fallback_indices,
         per_field_limit,
-        num_docs,
     })
 }
 

--- a/hermes-core/src/query/prefix.rs
+++ b/hermes-core/src/query/prefix.rs
@@ -49,11 +49,25 @@ impl PrefixQuery {
     }
 }
 
+/// Prefix unions materialise document-id sets; postings of a chunked field
+/// are keyed by virtual chunk ids, so the union would filter the wrong
+/// documents. Fail loudly instead of silently mis-matching.
+fn reject_chunked(reader: &SegmentReader, field: Field) -> crate::Result<()> {
+    if reader.is_chunked_field(field) {
+        return Err(crate::Error::Query(format!(
+            "PrefixQuery is not supported on chunked text field '{}'; use a MatchQuery or PhraseQuery",
+            reader.schema().get_field_name(field).unwrap_or("?")
+        )));
+    }
+    Ok(())
+}
+
 impl Query for PrefixQuery {
     fn scorer<'a>(&self, reader: &'a SegmentReader, _limit: usize) -> ScorerFuture<'a> {
         let field = self.field;
         let prefix = self.prefix.clone();
         Box::pin(async move {
+            reject_chunked(reader, field)?;
             let postings = reader.get_prefix_postings(field, &prefix).await?;
             if postings.is_empty() {
                 return Ok(Box::new(EmptyScorer) as Box<dyn Scorer>);
@@ -72,6 +86,7 @@ impl Query for PrefixQuery {
         reader: &'a SegmentReader,
         _limit: usize,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        reject_chunked(reader, self.field)?;
         let postings = reader.get_prefix_postings_sync(self.field, &self.prefix)?;
         if postings.is_empty() {
             return Ok(Box::new(EmptyScorer) as Box<dyn Scorer>);
@@ -107,6 +122,9 @@ impl Query for PrefixQuery {
 
     #[cfg(feature = "sync")]
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<super::DocBitset> {
+        if reader.is_chunked_field(self.field) {
+            return None;
+        }
         let postings = reader
             .get_prefix_postings_sync(self.field, &self.prefix)
             .ok()?;

--- a/hermes-core/src/query/scoring.rs
+++ b/hermes-core/src/query/scoring.rs
@@ -446,6 +446,12 @@ enum CursorVariant<'a> {
         denom_tf_coeff: f32,
         /// Precomputed: BM25_K1 * (1.0 - BM25_B) — denominator constant
         denom_const: f32,
+        /// Precomputed: BM25_K1 * BM25_B / avg_len — per-token length
+        /// coefficient, used when `lengths` supplies real chunk lengths.
+        denom_len_coeff: f32,
+        /// Real per-posting lengths (chunked fields: posting ids are virtual
+        /// chunk ids). `None` keeps the historic `tf`-as-length approximation.
+        lengths: Option<&'a crate::segment::chunk_map::ChunkMap>,
         tfs: Vec<u32>,
         /// Deferred TF decode state: (block_offset, tf_start, count).
         /// Set when doc_ids are decoded but TFs/scores are not yet computed.
@@ -560,6 +566,26 @@ impl<'a> TermCursor<'a> {
         idf: f32,
         avg_field_len: f32,
     ) -> Self {
+        Self::text_with_lengths(posting_list, idf, avg_field_len, None)
+    }
+
+    /// Full-text BM25 cursor over a chunked field: posting ids are virtual
+    /// chunk ids and `lengths` supplies each chunk's real token count.
+    pub fn text_chunked(
+        posting_list: crate::structures::BlockPostingList,
+        idf: f32,
+        avg_chunk_len: f32,
+        lengths: &'a crate::segment::chunk_map::ChunkMap,
+    ) -> Self {
+        Self::text_with_lengths(posting_list, idf, avg_chunk_len, Some(lengths))
+    }
+
+    fn text_with_lengths(
+        posting_list: crate::structures::BlockPostingList,
+        idf: f32,
+        avg_field_len: f32,
+        lengths: Option<&'a crate::segment::chunk_map::ChunkMap>,
+    ) -> Self {
         let max_tf = posting_list.max_tf() as f32;
         let max_score = super::bm25_upper_bound(max_tf.max(1.0), idf);
         let num_blocks = posting_list.num_blocks();
@@ -583,6 +609,8 @@ impl<'a> TermCursor<'a> {
                 idf_times_k1_plus_1: idf * (super::BM25_K1 + 1.0),
                 denom_tf_coeff: 1.0 + super::BM25_K1 * (super::BM25_B / safe_avg),
                 denom_const: super::BM25_K1 * (1.0 - super::BM25_B),
+                denom_len_coeff: super::BM25_K1 * super::BM25_B / safe_avg,
+                lengths,
                 tfs: Vec::with_capacity(128),
                 deferred_tf: None,
             },
@@ -770,6 +798,8 @@ impl<'a> TermCursor<'a> {
             idf_times_k1_plus_1,
             denom_tf_coeff,
             denom_const,
+            denom_len_coeff,
+            lengths,
             tfs,
             deferred_tf,
             ..
@@ -780,13 +810,30 @@ impl<'a> TermCursor<'a> {
             let num_scale = *idf_times_k1_plus_1;
             let d_tf = *denom_tf_coeff;
             let d_const = *denom_const;
+            let d_len = *denom_len_coeff;
             self.scores.clear();
             self.scores.resize(count, 0.0);
-            for i in 0..count {
-                let tf = unsafe { *tfs.get_unchecked(i) } as f32;
-                let score = (num_scale * tf) / (d_tf * tf + d_const);
-                unsafe {
-                    *self.scores.get_unchecked_mut(i) = score;
+            match lengths {
+                // Chunked field: real BM25 length normalisation per chunk.
+                Some(map) => {
+                    for i in 0..count {
+                        let tf = unsafe { *tfs.get_unchecked(i) } as f32;
+                        let vid = unsafe { *self.doc_ids.get_unchecked(i) };
+                        let len = map.length(vid) as f32;
+                        let score = (num_scale * tf) / (tf + d_const + d_len * len);
+                        unsafe {
+                            *self.scores.get_unchecked_mut(i) = score;
+                        }
+                    }
+                }
+                None => {
+                    for i in 0..count {
+                        let tf = unsafe { *tfs.get_unchecked(i) } as f32;
+                        let score = (num_scale * tf) / (d_tf * tf + d_const);
+                        unsafe {
+                            *self.scores.get_unchecked_mut(i) = score;
+                        }
+                    }
                 }
             }
         }
@@ -1250,6 +1297,22 @@ impl<'a> MaxScoreExecutor<'a> {
         let cursors: Vec<TermCursor<'a>> = posting_lists
             .into_iter()
             .map(|(pl, idf)| TermCursor::text(pl, idf, avg_field_len))
+            .collect();
+        Self::new(cursors, k, 1.0)
+    }
+
+    /// Executor for BM25 over a chunked text field: posting ids are virtual
+    /// chunk ids, scored with each chunk's real length. Results carry the
+    /// virtual id in `doc_id`; the caller resolves it through `lengths`.
+    pub fn text_chunked(
+        posting_lists: Vec<(crate::structures::BlockPostingList, f32)>,
+        avg_chunk_len: f32,
+        k: usize,
+        lengths: &'a crate::segment::chunk_map::ChunkMap,
+    ) -> Self {
+        let cursors: Vec<TermCursor<'a>> = posting_lists
+            .into_iter()
+            .map(|(pl, idf)| TermCursor::text_chunked(pl, idf, avg_chunk_len, lengths))
             .collect();
         Self::new(cursors, k, 1.0)
     }

--- a/hermes-core/src/query/term.rs
+++ b/hermes-core/src/query/term.rs
@@ -102,13 +102,14 @@ fn compute_term_idf(
 //   $get_positions_fn – get_positions | get_positions_sync
 //   $($aw)*          – .await  (present for async, absent for sync)
 macro_rules! term_plan {
-    ($field:expr, $term:expr, $global_stats:expr, $reader:expr,
+    ($field:expr, $term:expr, $global_stats:expr, $reader:expr, $limit:expr,
      $load_positions:expr, $get_postings_fn:ident, $get_positions_fn:ident
      $(, $aw:tt)*) => {{
         let field: Field = $field;
         let term: &[u8] = $term;
         let global_stats: Option<&Arc<GlobalStats>> = $global_stats;
         let reader: &SegmentReader = $reader;
+        let limit: usize = $limit;
 
         // Non-indexed fields → fast-field-only path
         let is_indexed = reader.schema().get_field_entry(field).is_none_or(|e| e.indexed);
@@ -123,6 +124,18 @@ macro_rules! term_plan {
         let postings = reader.$get_postings_fn(field, term) $(. $aw)* ?;
 
         match postings {
+            // Chunked field: postings are keyed by virtual chunk id. Score the
+            // chunks, fold them back to documents and report the ordinals.
+            Some(posting_list) if reader.is_chunked_field(field) => {
+                let num_chunks = reader.text_corpus_size(field);
+                let idf = super::bm25_idf(posting_list.doc_count() as f32, num_chunks);
+                super::planner::finish_chunked_text_maxscore(
+                    vec![(posting_list, idf)],
+                    limit,
+                    reader,
+                    field,
+                )
+            }
             Some(posting_list) => {
                 let (idf, avg_field_len) =
                     compute_term_idf(&posting_list, field, reader, global_stats, term);
@@ -159,7 +172,7 @@ impl Query for TermQuery {
     fn scorer_with_options<'a>(
         &self,
         reader: &'a SegmentReader,
-        _limit: usize,
+        limit: usize,
         options: super::ScorerOptions,
     ) -> ScorerFuture<'a> {
         let field = self.field;
@@ -172,6 +185,7 @@ impl Query for TermQuery {
                 &term,
                 global_stats.as_ref(),
                 reader,
+                limit,
                 load_positions,
                 get_postings,
                 get_positions,
@@ -204,7 +218,7 @@ impl Query for TermQuery {
     fn scorer_sync_with_options<'a>(
         &self,
         reader: &'a SegmentReader,
-        _limit: usize,
+        limit: usize,
         options: super::ScorerOptions,
     ) -> crate::Result<Box<dyn Scorer + 'a>> {
         term_plan!(
@@ -212,6 +226,7 @@ impl Query for TermQuery {
             &self.term,
             self.global_stats.as_ref(),
             reader,
+            limit,
             options.collect_positions,
             get_postings_sync,
             get_positions_sync
@@ -232,6 +247,10 @@ impl Query for TermQuery {
 
     #[cfg(feature = "sync")]
     fn bitset_cardinality_estimate(&self, reader: &SegmentReader) -> Option<u64> {
+        // Chunked postings count chunks, not documents.
+        if reader.is_chunked_field(self.field) {
+            return None;
+        }
         // Exact: the posting list header carries the doc count.
         let pl = reader.get_postings_sync(self.field, &self.term).ok()??;
         Some(pl.doc_count() as u64)
@@ -239,6 +258,11 @@ impl Query for TermQuery {
 
     #[cfg(feature = "sync")]
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<super::DocBitset> {
+        // Chunked postings are keyed by virtual chunk ids, not document ids;
+        // a bitset over them would filter the wrong documents.
+        if reader.is_chunked_field(self.field) {
+            return None;
+        }
         // Build bitset from posting list: O(M) where M = matching doc count.
         // Much faster than O(N) fast-field scan for selective terms.
         let pl = reader.get_postings_sync(self.field, &self.term).ok()??;

--- a/hermes-core/src/segment/builder/mod.rs
+++ b/hermes-core/src/segment/builder/mod.rs
@@ -298,6 +298,10 @@ pub struct SegmentBuilder {
     /// Current element ordinal for multi-valued fields (reset per document)
     current_element_ordinal: FxHashMap<u32, u32>,
 
+    /// Virtual-id maps of chunked text fields: field -> (doc, ordinal, length)
+    /// per chunk. Postings of these fields are keyed by the virtual id.
+    chunk_maps: FxHashMap<u32, super::chunk_map::ChunkMapBuilder>,
+
     /// Whether the once-per-segment position-encoding saturation warning
     /// has already been emitted (see MAX_POSITION_ELEMENT_ORDINAL).
     position_saturation_warned: bool,
@@ -416,6 +420,7 @@ impl SegmentBuilder {
             store_buffer: Vec::with_capacity(STORE_BUFFER_SIZE),
             next_doc_id: 0,
             field_stats: FxHashMap::default(),
+            chunk_maps: FxHashMap::default(),
             doc_field_lengths: Vec::new(),
             num_indexed_fields,
             field_to_slot,
@@ -756,7 +761,45 @@ impl SegmentBuilder {
 
             match (&entry.field_type, value) {
                 (FieldType::Text, FieldValue::Text(text)) => {
-                    if entry.indexed {
+                    if entry.indexed && entry.chunked {
+                        // Chunked field: this value is its own scoring unit.
+                        // Postings and positions are keyed by the virtual id;
+                        // the chunk map resolves it back to (doc, ordinal).
+                        let field_id = field.0;
+                        let element_ordinal = self.next_element_ordinal(field_id);
+                        let ordinal = u16::try_from(element_ordinal).map_err(|_| {
+                            crate::Error::Document(format!(
+                                "chunked field {field_id} has more than {} chunk values in one document",
+                                u16::MAX as usize + 1
+                            ))
+                        })?;
+                        let hinted = self.resolve_tokenizer_hint(*field, &doc, element_ordinal);
+                        let vid = self
+                            .chunk_maps
+                            .get(&field.0)
+                            .map_or(0usize, |map| map.len());
+                        let vid = u32::try_from(vid).map_err(|_| {
+                            crate::Error::Document(format!(
+                                "chunked field {field_id} exceeds u32::MAX chunks in one segment"
+                            ))
+                        })?;
+                        // Positions restart at 0 in every chunk (ordinal 0 in
+                        // the encoded position; the schema forbids ordinal
+                        // tracking modes on chunked fields).
+                        let token_count = self.index_text_field(*field, vid, text, 0, hinted)?;
+                        self.chunk_maps.entry(field.0).or_default().push(
+                            doc_id,
+                            ordinal,
+                            token_count,
+                        )?;
+                        self.estimated_memory += 8;
+
+                        // Chunk statistics: `doc_count` counts chunks so
+                        // `avg_field_len` is the average chunk length.
+                        let stats = self.field_stats.entry(field.0).or_default();
+                        stats.total_tokens += token_count as u64;
+                        stats.doc_count += 1;
+                    } else if entry.indexed {
                         let element_ordinal = self.next_element_ordinal(field.0);
                         let hinted = self.resolve_tokenizer_hint(*field, &doc, element_ordinal);
                         let token_count =
@@ -1347,6 +1390,22 @@ impl SegmentBuilder {
         } else {
             FxHashMap::default()
         };
+
+        // Phase 1b: chunk maps of chunked text fields (small: 8 bytes per chunk).
+        let chunk_maps = std::mem::take(&mut self.chunk_maps);
+        {
+            let mut fields: Vec<(u32, &super::chunk_map::ChunkMapBuilder)> = chunk_maps
+                .iter()
+                .filter(|(_, map)| !map.is_empty())
+                .map(|(field_id, map)| (*field_id, map))
+                .collect();
+            if !fields.is_empty() {
+                fields.sort_by_key(|(field_id, _)| *field_id);
+                let mut writer = dir.streaming_writer(&files.chunks).await?;
+                super::chunk_map::write_chunk_maps(&mut *writer, &fields)?;
+                writer.finish()?;
+            }
+        }
 
         // Phase 2: 4-way parallel build — postings, store, dense vectors, sparse vectors
         // These are fully independent: different source data, different output files.

--- a/hermes-core/src/segment/chunk_map.rs
+++ b/hermes-core/src/segment/chunk_map.rs
@@ -1,0 +1,419 @@
+//! Virtual-id maps of chunked text fields (`seg_<id>.chunks`).
+//!
+//! A text field declared `chunked` indexes every value as its own scoring
+//! unit: term postings and positions are keyed by a dense, segment-local
+//! **virtual id** instead of the document id. This file maps each virtual id
+//! back to `(doc_id, ordinal)` and records the chunk's token count for BM25
+//! length normalisation. See `docs/chunked-text-fields.md`.
+//!
+//! ```text
+//! [magic "CHNK"][version u32 = 1][num_fields u32]
+//! TOC × num_fields: [field_id u32][num_chunks u32][total_tokens u64][data_offset u64]
+//! per field:        doc_ids u32 × n | ordinals u16 × n | lengths u16 × n
+//! ```
+//!
+//! Virtual ids are assigned in indexing order, and documents are indexed in
+//! doc-id order, so `doc_ids` is non-decreasing and `(doc_id, ordinal)` is
+//! strictly increasing. Merges concatenate sections and add the document
+//! offset to `doc_ids`; ordinals and lengths are copied verbatim.
+
+use std::io::{self, Write};
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use rustc_hash::FxHashMap;
+
+use crate::DocId;
+use crate::directories::OwnedBytes;
+
+const MAGIC: u32 = 0x4B4E_4843; // "CHNK"
+const VERSION: u32 = 1;
+const HEADER_SIZE: usize = 12;
+const TOC_ENTRY_SIZE: usize = 24;
+
+/// Token count stored per chunk; longer chunks saturate.
+pub const MAX_CHUNK_LENGTH: u32 = u16::MAX as u32;
+
+/// In-memory map of one chunked field while a segment is being built.
+#[derive(Debug, Default, Clone)]
+pub struct ChunkMapBuilder {
+    doc_ids: Vec<DocId>,
+    ordinals: Vec<u16>,
+    lengths: Vec<u16>,
+    total_tokens: u64,
+}
+
+impl ChunkMapBuilder {
+    /// Number of chunks so far (the next virtual id).
+    pub fn len(&self) -> usize {
+        self.doc_ids.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.doc_ids.is_empty()
+    }
+
+    /// Register the next chunk. Returns its virtual id.
+    pub fn push(&mut self, doc_id: DocId, ordinal: u16, token_count: u32) -> io::Result<u32> {
+        let vid = u32::try_from(self.doc_ids.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "chunked text field exceeds u32::MAX chunks in one segment",
+            )
+        })?;
+        self.doc_ids.push(doc_id);
+        self.ordinals.push(ordinal);
+        self.lengths.push(token_count.min(MAX_CHUNK_LENGTH) as u16);
+        self.total_tokens += u64::from(token_count);
+        Ok(vid)
+    }
+
+    /// Heap bytes held by this builder (memory-budget accounting).
+    pub fn estimated_bytes(&self) -> usize {
+        self.doc_ids.capacity() * 4 + self.ordinals.capacity() * 2 + self.lengths.capacity() * 2
+    }
+
+    fn section_bytes(&self) -> u64 {
+        self.doc_ids.len() as u64 * 8
+    }
+}
+
+/// Write every chunked field's map as one `.chunks` file.
+///
+/// `fields` must be sorted by field id and contain only non-empty builders.
+pub fn write_chunk_maps<W: Write + ?Sized>(
+    writer: &mut W,
+    fields: &[(u32, &ChunkMapBuilder)],
+) -> io::Result<u64> {
+    let mut offset = (HEADER_SIZE + TOC_ENTRY_SIZE * fields.len()) as u64;
+    writer.write_u32::<LittleEndian>(MAGIC)?;
+    writer.write_u32::<LittleEndian>(VERSION)?;
+    writer.write_u32::<LittleEndian>(fields.len() as u32)?;
+    for (field_id, map) in fields {
+        writer.write_u32::<LittleEndian>(*field_id)?;
+        writer.write_u32::<LittleEndian>(map.len() as u32)?;
+        writer.write_u64::<LittleEndian>(map.total_tokens)?;
+        writer.write_u64::<LittleEndian>(offset)?;
+        offset += map.section_bytes();
+    }
+    for (_, map) in fields {
+        for doc_id in &map.doc_ids {
+            writer.write_u32::<LittleEndian>(*doc_id)?;
+        }
+        for ordinal in &map.ordinals {
+            writer.write_u16::<LittleEndian>(*ordinal)?;
+        }
+        for length in &map.lengths {
+            writer.write_u16::<LittleEndian>(*length)?;
+        }
+    }
+    Ok(offset)
+}
+
+/// Read-only chunk map of one field, backed by the mapped `.chunks` file.
+#[derive(Debug, Clone)]
+pub struct ChunkMap {
+    doc_ids: OwnedBytes,
+    ordinals: OwnedBytes,
+    lengths: OwnedBytes,
+    num_chunks: u32,
+    total_tokens: u64,
+}
+
+impl ChunkMap {
+    /// Number of chunks (virtual ids) in this segment.
+    #[inline]
+    pub fn num_chunks(&self) -> u32 {
+        self.num_chunks
+    }
+
+    /// Sum of all chunk token counts.
+    pub fn total_tokens(&self) -> u64 {
+        self.total_tokens
+    }
+
+    /// Average chunk length in tokens (1.0 when empty).
+    pub fn avg_len(&self) -> f32 {
+        if self.num_chunks == 0 {
+            1.0
+        } else {
+            (self.total_tokens as f64 / f64::from(self.num_chunks)) as f32
+        }
+    }
+
+    /// Document owning virtual id `vid`.
+    #[inline]
+    pub fn doc_id(&self, vid: u32) -> DocId {
+        let at = vid as usize * 4;
+        let b = &self.doc_ids.as_slice()[at..at + 4];
+        u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+    }
+
+    /// Ordinal (value index within the document) of virtual id `vid`.
+    #[inline]
+    pub fn ordinal(&self, vid: u32) -> u16 {
+        let at = vid as usize * 2;
+        let b = &self.ordinals.as_slice()[at..at + 2];
+        u16::from_le_bytes([b[0], b[1]])
+    }
+
+    /// Token count of virtual id `vid` (saturated at `MAX_CHUNK_LENGTH`).
+    #[inline]
+    pub fn length(&self, vid: u32) -> u32 {
+        let at = vid as usize * 2;
+        let b = &self.lengths.as_slice()[at..at + 2];
+        u32::from(u16::from_le_bytes([b[0], b[1]]))
+    }
+
+    /// `(doc_id, ordinal)` of virtual id `vid`.
+    #[inline]
+    pub fn resolve(&self, vid: u32) -> (DocId, u16) {
+        (self.doc_id(vid), self.ordinal(vid))
+    }
+
+    /// Raw little-endian document-id column (merge copy).
+    pub(crate) fn doc_id_bytes(&self) -> &[u8] {
+        self.doc_ids.as_slice()
+    }
+
+    /// Raw little-endian ordinal column (merge copy).
+    pub(crate) fn ordinal_bytes(&self) -> &[u8] {
+        self.ordinals.as_slice()
+    }
+
+    /// Raw little-endian length column (merge copy).
+    pub(crate) fn length_bytes(&self) -> &[u8] {
+        self.lengths.as_slice()
+    }
+}
+
+/// Parse a `.chunks` file into per-field maps.
+pub fn read_chunk_maps(bytes: OwnedBytes) -> io::Result<FxHashMap<u32, ChunkMap>> {
+    let data = bytes.as_slice();
+    if data.len() < HEADER_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "chunk map file shorter than its header",
+        ));
+    }
+    let mut cursor = io::Cursor::new(data);
+    let magic = cursor.read_u32::<LittleEndian>()?;
+    if magic != MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("chunk map magic mismatch: {magic:#x}"),
+        ));
+    }
+    let version = cursor.read_u32::<LittleEndian>()?;
+    if version != VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported chunk map version {version} (expected {VERSION})"),
+        ));
+    }
+    let num_fields = cursor.read_u32::<LittleEndian>()? as usize;
+    if data.len() < HEADER_SIZE + TOC_ENTRY_SIZE * num_fields {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "chunk map table of contents truncated",
+        ));
+    }
+    let mut maps = FxHashMap::default();
+    for _ in 0..num_fields {
+        let field_id = cursor.read_u32::<LittleEndian>()?;
+        let num_chunks = cursor.read_u32::<LittleEndian>()?;
+        let total_tokens = cursor.read_u64::<LittleEndian>()?;
+        let offset = cursor.read_u64::<LittleEndian>()? as usize;
+        let n = num_chunks as usize;
+        let end = offset
+            .checked_add(n.checked_mul(8).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "chunk map size overflow")
+            })?)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "chunk map size overflow"))?;
+        if end > data.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("chunk map section of field {field_id} exceeds file length"),
+            ));
+        }
+        let doc_ids = bytes.slice(offset..offset + n * 4);
+        let ordinals = bytes.slice(offset + n * 4..offset + n * 6);
+        let lengths = bytes.slice(offset + n * 6..end);
+        maps.insert(
+            field_id,
+            ChunkMap {
+                doc_ids,
+                ordinals,
+                lengths,
+                num_chunks,
+                total_tokens,
+            },
+        );
+    }
+    Ok(maps)
+}
+
+/// One source section of a merged chunk map.
+pub struct ChunkMapSource<'a> {
+    pub map: &'a ChunkMap,
+    /// Added to every document id of the source.
+    pub doc_offset: u32,
+}
+
+/// Write the merged `.chunks` file: per field, the sources' sections are
+/// concatenated in order (virtual ids of a later source are offset by the
+/// chunk counts of the earlier ones, matching the posting merge).
+///
+/// `fields` must be sorted by field id; a field with zero total chunks is
+/// skipped.
+pub fn write_merged_chunk_maps<W: Write + ?Sized>(
+    writer: &mut W,
+    fields: &[(u32, Vec<ChunkMapSource<'_>>)],
+) -> io::Result<u64> {
+    let live: Vec<&(u32, Vec<ChunkMapSource<'_>>)> = fields
+        .iter()
+        .filter(|(_, sources)| sources.iter().any(|s| s.map.num_chunks() > 0))
+        .collect();
+    let mut offset = (HEADER_SIZE + TOC_ENTRY_SIZE * live.len()) as u64;
+    writer.write_u32::<LittleEndian>(MAGIC)?;
+    writer.write_u32::<LittleEndian>(VERSION)?;
+    writer.write_u32::<LittleEndian>(live.len() as u32)?;
+    for (field_id, sources) in &live {
+        let mut num_chunks = 0u64;
+        let mut total_tokens = 0u64;
+        for source in sources {
+            num_chunks += u64::from(source.map.num_chunks());
+            total_tokens += source.map.total_tokens();
+        }
+        let num_chunks = u32::try_from(num_chunks).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("chunked field {field_id} exceeds u32::MAX chunks after merge"),
+            )
+        })?;
+        writer.write_u32::<LittleEndian>(*field_id)?;
+        writer.write_u32::<LittleEndian>(num_chunks)?;
+        writer.write_u64::<LittleEndian>(total_tokens)?;
+        writer.write_u64::<LittleEndian>(offset)?;
+        offset += u64::from(num_chunks) * 8;
+    }
+    let mut patched: Vec<u8> = Vec::new();
+    for (_, sources) in &live {
+        for source in sources {
+            if source.doc_offset == 0 {
+                writer.write_all(source.map.doc_id_bytes())?;
+                continue;
+            }
+            patched.clear();
+            patched.reserve(source.map.doc_id_bytes().len());
+            for chunk in source.map.doc_id_bytes().chunks_exact(4) {
+                let doc = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                let remapped = doc.checked_add(source.doc_offset).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "document id overflow while merging chunk maps",
+                    )
+                })?;
+                patched.extend_from_slice(&remapped.to_le_bytes());
+            }
+            writer.write_all(&patched)?;
+        }
+        for source in sources {
+            writer.write_all(source.map.ordinal_bytes())?;
+        }
+        for source in sources {
+            writer.write_all(source.map.length_bytes())?;
+        }
+    }
+    Ok(offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build(entries: &[(u32, u16, u32)]) -> ChunkMapBuilder {
+        let mut builder = ChunkMapBuilder::default();
+        for &(doc, ord, len) in entries {
+            builder.push(doc, ord, len).unwrap();
+        }
+        builder
+    }
+
+    #[test]
+    fn round_trips_two_fields() {
+        let a = build(&[(0, 0, 10), (0, 1, 20), (3, 0, 70_000)]);
+        let b = build(&[(1, 0, 5)]);
+        let mut out = Vec::new();
+        write_chunk_maps(&mut out, &[(2, &a), (7, &b)]).unwrap();
+        let maps = read_chunk_maps(OwnedBytes::new(out)).unwrap();
+        let a = &maps[&2];
+        assert_eq!(a.num_chunks(), 3);
+        assert_eq!(a.resolve(0), (0, 0));
+        assert_eq!(a.resolve(1), (0, 1));
+        assert_eq!(a.resolve(2), (3, 0));
+        assert_eq!(a.length(1), 20);
+        assert_eq!(a.length(2), MAX_CHUNK_LENGTH, "lengths saturate at u16");
+        assert_eq!(a.total_tokens(), 70_030);
+        assert_eq!(maps[&7].resolve(0), (1, 0));
+        assert_eq!(maps[&7].avg_len(), 5.0);
+    }
+
+    #[test]
+    fn merged_maps_offset_doc_ids_and_keep_ordinals() {
+        let first = build(&[(0, 0, 10), (1, 0, 11), (1, 1, 12)]);
+        let second = build(&[(0, 0, 20), (0, 1, 21)]);
+        let mut raw_first = Vec::new();
+        write_chunk_maps(&mut raw_first, &[(4, &first)]).unwrap();
+        let mut raw_second = Vec::new();
+        write_chunk_maps(&mut raw_second, &[(4, &second)]).unwrap();
+        let first = read_chunk_maps(OwnedBytes::new(raw_first)).unwrap();
+        let second = read_chunk_maps(OwnedBytes::new(raw_second)).unwrap();
+
+        let mut merged = Vec::new();
+        write_merged_chunk_maps(
+            &mut merged,
+            &[(
+                4,
+                vec![
+                    ChunkMapSource {
+                        map: &first[&4],
+                        doc_offset: 0,
+                    },
+                    ChunkMapSource {
+                        map: &second[&4],
+                        doc_offset: 2,
+                    },
+                ],
+            )],
+        )
+        .unwrap();
+        let merged = read_chunk_maps(OwnedBytes::new(merged)).unwrap();
+        let map = &merged[&4];
+        assert_eq!(map.num_chunks(), 5);
+        assert_eq!(map.total_tokens(), 74);
+        assert_eq!(
+            (0..5).map(|v| map.resolve(v)).collect::<Vec<_>>(),
+            vec![(0, 0), (1, 0), (1, 1), (2, 0), (2, 1)]
+        );
+        assert_eq!(
+            (0..5).map(|v| map.length(v)).collect::<Vec<_>>(),
+            vec![10, 11, 12, 20, 21]
+        );
+    }
+
+    #[test]
+    fn rejects_foreign_or_truncated_files() {
+        assert!(read_chunk_maps(OwnedBytes::new(vec![0u8; 4])).is_err());
+        let mut bad_magic = Vec::new();
+        bad_magic.write_u32::<LittleEndian>(0xDEAD_BEEF).unwrap();
+        bad_magic.write_u32::<LittleEndian>(VERSION).unwrap();
+        bad_magic.write_u32::<LittleEndian>(0).unwrap();
+        assert!(read_chunk_maps(OwnedBytes::new(bad_magic)).is_err());
+
+        let a = build(&[(0, 0, 10)]);
+        let mut out = Vec::new();
+        write_chunk_maps(&mut out, &[(1, &a)]).unwrap();
+        out.truncate(out.len() - 1);
+        assert!(read_chunk_maps(OwnedBytes::new(out)).is_err());
+    }
+}

--- a/hermes-core/src/segment/merger/chunk_maps.rs
+++ b/hermes-core/src/segment/merger/chunk_maps.rs
@@ -1,0 +1,94 @@
+//! Merge of chunked-text virtual-id maps (`.chunks`).
+//!
+//! Virtual ids of a chunked field are segment-local and dense, so merged
+//! postings stack with per-field chunk-count offsets (see `chunk_offsets`)
+//! while the map itself is a plain section concatenation with the document
+//! offset added to `doc_ids`. Ordinals and lengths are copied verbatim.
+
+use rustc_hash::FxHashMap;
+
+use super::SegmentMerger;
+use crate::Result;
+use crate::directories::{Directory, DirectoryWriter};
+use crate::dsl::Schema;
+use crate::segment::chunk_map::{ChunkMapSource, write_merged_chunk_maps};
+use crate::segment::reader::SegmentReader;
+use crate::segment::types::SegmentFiles;
+
+/// Per chunked field, the virtual-id offset of every source segment: the sum
+/// of the chunk counts of the segments before it (same order as `doc_offsets`).
+pub(super) fn chunk_offsets(
+    schema: &Schema,
+    segments: &[SegmentReader],
+) -> Result<FxHashMap<u32, Vec<u32>>> {
+    let mut offsets: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    for (field, entry) in schema.fields() {
+        if !entry.chunked {
+            continue;
+        }
+        let mut acc = 0u32;
+        let mut per_segment = Vec::with_capacity(segments.len());
+        for segment in segments {
+            per_segment.push(acc);
+            acc = acc.checked_add(segment.num_chunks(field)).ok_or_else(|| {
+                crate::Error::Internal(format!(
+                    "chunked field '{}' exceeds u32::MAX chunks after merge",
+                    entry.name
+                ))
+            })?;
+        }
+        offsets.insert(field.0, per_segment);
+    }
+    Ok(offsets)
+}
+
+impl SegmentMerger {
+    /// Concatenate the sources' chunk maps into the output `.chunks` file.
+    /// Returns the bytes written (0 when no chunked field has data).
+    pub(super) async fn merge_chunk_maps<D: Directory + DirectoryWriter>(
+        &self,
+        dir: &D,
+        segments: &[SegmentReader],
+        files: &SegmentFiles,
+    ) -> Result<u64> {
+        let mut chunked_fields: Vec<u32> = self
+            .schema
+            .fields()
+            .filter(|(_, entry)| entry.chunked)
+            .map(|(field, _)| field.0)
+            .collect();
+        if chunked_fields.is_empty() || segments.iter().all(|s| !s.has_chunks_file()) {
+            return Ok(0);
+        }
+        chunked_fields.sort_unstable();
+
+        let doc_offs = super::doc_offsets(segments)?;
+        let mut fields: Vec<(u32, Vec<ChunkMapSource<'_>>)> = Vec::new();
+        for field_id in chunked_fields {
+            let mut sources = Vec::new();
+            for (segment, &doc_offset) in segments.iter().zip(doc_offs.iter()) {
+                if let Some(map) = segment.chunk_map(crate::dsl::Field(field_id)) {
+                    sources.push(ChunkMapSource { map, doc_offset });
+                }
+            }
+            if !sources.is_empty() {
+                fields.push((field_id, sources));
+            }
+        }
+        if fields.is_empty() {
+            return Ok(0);
+        }
+
+        self.ensure_not_cancelled()?;
+        let mut writer = dir.streaming_writer_cold(&files.chunks).await?;
+        let bytes = write_merged_chunk_maps(&mut *writer, &fields).map_err(crate::Error::Io)?;
+        writer.finish()?;
+        log::info!(
+            "[merge] index={} chunk maps done: {} fields, {}",
+            self.schema.index_label(),
+            fields.len(),
+            crate::format_bytes(bytes),
+        );
+        Ok(bytes)
+    }
+}

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -1,5 +1,6 @@
 //! Segment merger for combining multiple segments
 
+mod chunk_maps;
 mod dense;
 mod fast_fields;
 mod postings;
@@ -623,8 +624,10 @@ impl SegmentMerger {
 
         let fast_fut = async { self.merge_fast_fields(dir, segments, &files).await };
 
-        let (postings_result, store_result, fast_bytes) =
-            tokio::try_join!(postings_fut, store_fut, fast_fut)?;
+        let chunks_fut = async { self.merge_chunk_maps(dir, segments, &files).await };
+
+        let (postings_result, store_result, fast_bytes, _chunk_bytes) =
+            tokio::try_join!(postings_fut, store_fut, fast_fut, chunks_fut)?;
         self.ensure_not_cancelled()?;
 
         log::info!(

--- a/hermes-core/src/segment/merger/postings.rs
+++ b/hermes-core/src/segment/merger/postings.rs
@@ -13,6 +13,7 @@ use std::io::Write;
 
 use super::OffsetWriter;
 use super::SegmentMerger;
+use super::chunk_maps::chunk_offsets;
 use super::doc_offsets;
 use crate::Result;
 use crate::segment::reader::SegmentReader;
@@ -64,6 +65,16 @@ impl SegmentMerger {
         positions_out: &mut OffsetWriter,
     ) -> Result<usize> {
         let doc_offs = doc_offsets(segments)?;
+        // Chunked text fields key their postings by virtual chunk id, so their
+        // terms stack with the field's chunk-count offsets, not document offsets.
+        let chunk_offs = chunk_offsets(&self.schema, segments)?;
+        let offset_for = |key: &[u8], segment_idx: usize| -> u32 {
+            let field_id = u32::from_le_bytes([key[0], key[1], key[2], key[3]]);
+            match chunk_offs.get(&field_id) {
+                Some(offsets) => offsets[segment_idx],
+                None => doc_offs[segment_idx],
+            }
+        };
 
         // Parallel prefetch all term dict blocks
         let prefetch_start = std::time::Instant::now();
@@ -97,11 +108,12 @@ impl SegmentMerger {
         let mut heap: BinaryHeap<MergeEntry> = BinaryHeap::new();
         for (seg_idx, iter) in iterators.iter_mut().enumerate() {
             if let Some((key, term_info)) = iter.next().await.map_err(crate::Error::from)? {
+                let doc_offset = offset_for(&key, seg_idx);
                 heap.push(MergeEntry {
                     key,
                     term_info,
                     segment_idx: seg_idx,
-                    doc_offset: doc_offs[seg_idx],
+                    doc_offset,
                 });
             }
         }
@@ -130,11 +142,12 @@ impl SegmentMerger {
                 .await
                 .map_err(crate::Error::from)?
             {
+                let doc_offset = offset_for(&key, first.segment_idx);
                 heap.push(MergeEntry {
                     key,
                     term_info,
                     segment_idx: first.segment_idx,
-                    doc_offset: doc_offs[first.segment_idx],
+                    doc_offset,
                 });
             }
 
@@ -152,11 +165,12 @@ impl SegmentMerger {
                     .await
                     .map_err(crate::Error::from)?
                 {
+                    let doc_offset = offset_for(&key, entry.segment_idx);
                     heap.push(MergeEntry {
                         key,
                         term_info,
                         segment_idx: entry.segment_idx,
-                        doc_offset: doc_offs[entry.segment_idx],
+                        doc_offset,
                     });
                 }
             }

--- a/hermes-core/src/segment/mod.rs
+++ b/hermes-core/src/segment/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod bmp_adaptive;
 pub(crate) mod bmp_grid;
 #[cfg(any(feature = "native", feature = "wasm"))]
 mod builder;
+pub mod chunk_map;
 pub(crate) mod format;
 #[cfg(feature = "native")]
 mod merger;

--- a/hermes-core/src/segment/reader/loader.rs
+++ b/hermes-core/src/segment/reader/loader.rs
@@ -1049,6 +1049,34 @@ pub async fn open_positions_file<D: Directory>(
     }
 }
 
+/// Load the virtual-id maps of chunked text fields from `.chunks`.
+///
+/// Absent file = no chunk was indexed in this segment (the builder only
+/// writes the file when a chunked field received values).
+pub async fn load_chunk_maps_file<D: Directory>(
+    dir: &D,
+    files: &SegmentFiles,
+    schema: &Schema,
+) -> Result<FxHashMap<u32, crate::segment::chunk_map::ChunkMap>> {
+    if !schema.fields().any(|(_, entry)| entry.chunked) {
+        return Ok(FxHashMap::default());
+    }
+    let handle = match dir.open_read(&files.chunks).await {
+        Ok(handle) => handle,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(FxHashMap::default());
+        }
+        Err(error) => return Err(crate::Error::Io(error)),
+    };
+    let bytes = handle.read_bytes().await?;
+    crate::segment::chunk_map::read_chunk_maps(bytes).map_err(|error| {
+        crate::Error::Corruption(format!(
+            "chunk map file {} is unreadable: {error}",
+            files.chunks.display()
+        ))
+    })
+}
+
 /// Load fast-field columns from `.fast` file.
 /// Returns a map of field_id → FastFieldReader.
 pub async fn load_fast_fields_file<D: Directory>(

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -1593,6 +1593,8 @@ pub struct SegmentReader {
     positions_handle: Option<FileHandle>,
     /// Fast-field columnar readers per field_id
     fast_fields: FxHashMap<u32, crate::structures::fast_field::FastFieldReader>,
+    /// Virtual-id maps of chunked text fields per field_id
+    chunk_maps: FxHashMap<u32, super::chunk_map::ChunkMap>,
     /// Dense-vector hot-metadata pin accounting (see `segment::pin`).
     #[cfg(feature = "native")]
     dense_pin_report: crate::segment::pin::PinReport,
@@ -1683,6 +1685,9 @@ impl SegmentReader {
         // Load fast-field columns from .fast file
         let fast_fields = loader::load_fast_fields_file(dir, &files, &schema).await?;
 
+        // Load chunk maps of chunked text fields from .chunks file
+        let chunk_maps = loader::load_chunk_maps_file(dir, &files, &schema).await?;
+
         // Log segment loading stats
         {
             let mut parts = vec![format!(
@@ -1715,6 +1720,13 @@ impl SegmentReader {
             if !fast_fields.is_empty() {
                 parts.push(format!("fast: {} fields", fast_fields.len()));
             }
+            for (field_id, map) in &chunk_maps {
+                parts.push(format!(
+                    "chunked text field {}: {} chunks",
+                    field_id,
+                    map.num_chunks()
+                ));
+            }
             log::debug!("{}", parts.join(", "));
         }
 
@@ -1734,6 +1746,7 @@ impl SegmentReader {
             sparse_file_backed_bytes,
             positions_handle,
             fast_fields,
+            chunk_maps,
             #[cfg(feature = "native")]
             dense_pin_report: Default::default(),
             #[cfg(feature = "native")]
@@ -1930,6 +1943,47 @@ impl SegmentReader {
     /// Get all fast-field readers.
     pub fn fast_fields(&self) -> &FxHashMap<u32, crate::structures::fast_field::FastFieldReader> {
         &self.fast_fields
+    }
+
+    /// Virtual-id map of a chunked text field, when the field is chunked and
+    /// this segment indexed at least one chunk of it.
+    pub fn chunk_map(&self, field: Field) -> Option<&super::chunk_map::ChunkMap> {
+        self.chunk_maps.get(&field.0)
+    }
+
+    /// All chunk maps of this segment.
+    pub fn chunk_maps(&self) -> &FxHashMap<u32, super::chunk_map::ChunkMap> {
+        &self.chunk_maps
+    }
+
+    /// Whether `field` is declared chunked in the schema (its postings are
+    /// keyed by virtual chunk ids, never by document ids).
+    pub fn is_chunked_field(&self, field: Field) -> bool {
+        self.schema
+            .get_field_entry(field)
+            .is_some_and(|entry| entry.chunked)
+    }
+
+    /// Number of chunks a chunked field holds in this segment (0 when none).
+    pub fn num_chunks(&self, field: Field) -> u32 {
+        self.chunk_maps
+            .get(&field.0)
+            .map_or(0, |map| map.num_chunks())
+    }
+
+    /// BM25 corpus size for `field`: chunks for a chunked field, documents
+    /// otherwise.
+    pub fn text_corpus_size(&self, field: Field) -> f32 {
+        if self.is_chunked_field(field) {
+            self.num_chunks(field) as f32
+        } else {
+            self.meta.num_docs as f32
+        }
+    }
+
+    /// Whether this segment carries a `.chunks` file.
+    pub fn has_chunks_file(&self) -> bool {
+        !self.chunk_maps.is_empty()
     }
 
     /// Get term dictionary stats for debugging

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -983,6 +983,11 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
             &dst_files.positions,
             reader.has_positions_file(),
         ),
+        (
+            &src_files.chunks,
+            &dst_files.chunks,
+            reader.has_chunks_file(),
+        ),
         (&src_files.store, &dst_files.store, true),
         (
             &src_files.fast,
@@ -1082,6 +1087,11 @@ pub async fn rewrite_vector_segment<D: Directory + DirectoryWriter>(
             &src_files.positions,
             &dst_files.positions,
             reader.has_positions_file(),
+        ),
+        (
+            &src_files.chunks,
+            &dst_files.chunks,
+            reader.has_chunks_file(),
         ),
         (&src_files.store, &dst_files.store, true),
         (

--- a/hermes-core/src/segment/types.rs
+++ b/hermes-core/src/segment/types.rs
@@ -393,6 +393,8 @@ pub struct SegmentFiles {
     pub positions: PathBuf,
     /// Fast-field columnar storage for O(1) doc→value access
     pub fast: PathBuf,
+    /// Virtual-id → (doc, ordinal, length) maps of chunked text fields
+    pub chunks: PathBuf,
 }
 
 impl SegmentFiles {
@@ -407,6 +409,7 @@ impl SegmentFiles {
             sparse: PathBuf::from(format!("{}.sparse", prefix)),
             positions: PathBuf::from(format!("{}.pos", prefix)),
             fast: PathBuf::from(format!("{}.fast", prefix)),
+            chunks: PathBuf::from(format!("{}.chunks", prefix)),
         }
     }
 
@@ -432,7 +435,7 @@ impl SegmentFiles {
 
     /// Every permanent or temporary path owned by this segment ID.
     #[cfg(feature = "native")]
-    pub(crate) fn lifecycle_paths(&self) -> [PathBuf; 9] {
+    pub(crate) fn lifecycle_paths(&self) -> [PathBuf; 10] {
         [
             self.term_dict.clone(),
             self.postings.clone(),
@@ -443,6 +446,7 @@ impl SegmentFiles {
             self.sparse_skip_temp(),
             self.positions.clone(),
             self.fast.clone(),
+            self.chunks.clone(),
         ]
     }
 }

--- a/hermes-core/src/tokenizer/mod.rs
+++ b/hermes-core/src/tokenizer/mod.rs
@@ -573,14 +573,32 @@ thread_local! {
         std::cell::RefCell::new(HashMap::new());
 }
 
-/// Stem `word` with the cached Snowball stemmer for `language`.
-fn stem_cached(language: Language, word: &str) -> String {
+/// Stem an owned, already cleaned token, reusing its allocation when the
+/// stemmer leaves it unchanged (the common case for short and stop-like
+/// words, and for every token of a script the stemmer does not touch).
+#[inline]
+fn stem_owned(stemmer: &rust_stemmers::Stemmer, word: String) -> String {
+    match stemmer.stem(&word) {
+        std::borrow::Cow::Borrowed(_) => word,
+        std::borrow::Cow::Owned(stemmed) => stemmed,
+    }
+}
+
+/// Run `f` with the cached Snowball stemmers for `languages`, in order.
+///
+/// The thread-local cache is borrowed once per tokenization call instead of
+/// once per token, so the hot loop pays no `RefCell` borrow or hash lookup.
+fn with_stemmers<R>(languages: &[Language], f: impl FnOnce(&[&rust_stemmers::Stemmer]) -> R) -> R {
     STEMMER_CACHE.with(|cache| {
         let mut cache = cache.borrow_mut();
-        let stemmer = cache
-            .entry(language)
-            .or_insert_with(|| rust_stemmers::Stemmer::create(language.to_algorithm()));
-        stemmer.stem(word).into_owned()
+        for language in languages {
+            cache
+                .entry(*language)
+                .or_insert_with(|| rust_stemmers::Stemmer::create(language.to_algorithm()));
+        }
+        let stemmers: Vec<&rust_stemmers::Stemmer> =
+            languages.iter().map(|language| &cache[language]).collect();
+        f(&stemmers)
     })
 }
 
@@ -629,22 +647,27 @@ impl DynamicStemmer {
     fn tokenize_with_languages(&self, text: &str, languages: &[Language]) -> Vec<Token> {
         match languages {
             [] => tokenize_and_clean(text, |s| s),
-            [single] if single.script() == Script::Latin => {
-                let language = *single;
-                tokenize_and_clean(text, |s| {
-                    if Script::of_token(&s) == Script::Latin {
-                        stem_cached(language, &s)
-                    } else {
-                        s
-                    }
+            [single] => {
+                let script = single.script();
+                with_stemmers(languages, |stemmers| {
+                    let stemmer = stemmers[0];
+                    tokenize_and_clean(text, |s| {
+                        if Script::of_token(&s) == script {
+                            stem_owned(stemmer, s)
+                        } else {
+                            s
+                        }
+                    })
                 })
             }
-            many => tokenize_and_clean(text, |s| {
-                let script = Script::of_token(&s);
-                match many.iter().find(|language| language.script() == script) {
-                    Some(language) => stem_cached(*language, &s),
-                    None => s,
-                }
+            many => with_stemmers(many, |stemmers| {
+                tokenize_and_clean(text, |s| {
+                    let script = Script::of_token(&s);
+                    match many.iter().position(|language| language.script() == script) {
+                        Some(index) => stem_owned(stemmers[index], s),
+                        None => s,
+                    }
+                })
             }),
         }
     }
@@ -837,6 +860,10 @@ impl Clone for BoxedTokenizer {
 #[derive(Clone)]
 pub struct TokenizerRegistry {
     tokenizers: Arc<RwLock<HashMap<String, BoxedTokenizer>>>,
+    /// Parsed `stem(...)` specs, keyed by their spec string. Query conversion
+    /// resolves the field tokenizer on every request; parsing the spec each
+    /// time was measurable at query rates.
+    dynamic: Arc<RwLock<HashMap<String, BoxedTokenizer>>>,
 }
 
 impl TokenizerRegistry {
@@ -844,6 +871,7 @@ impl TokenizerRegistry {
     pub fn new() -> Self {
         let registry = Self {
             tokenizers: Arc::new(RwLock::new(HashMap::new())),
+            dynamic: Arc::new(RwLock::new(HashMap::new())),
         };
         registry.register_defaults();
         registry
@@ -950,13 +978,21 @@ impl TokenizerRegistry {
 
     /// Get a tokenizer by name or by a `stem(by: ..., default: ...)` spec.
     ///
-    /// Dynamic specs are not stored in the registry: a fresh
-    /// [`DynamicStemmer`] is built from the spec on every call.
+    /// Dynamic specs are parsed once per distinct spec string and cached; a
+    /// malformed spec is not cached and yields `None` on every call.
     pub fn get(&self, name: &str) -> Option<BoxedTokenizer> {
         if name.starts_with("stem(") {
-            return TokenizerSpec::parse(name)
+            if let Some(tokenizer) = self.dynamic.read().get(name) {
+                return Some(tokenizer.clone());
+            }
+            let tokenizer = TokenizerSpec::parse(name)
                 .ok()
-                .and_then(|spec| spec.dynamic_tokenizer());
+                .and_then(|spec| spec.dynamic_tokenizer())?;
+            self.dynamic
+                .write()
+                .entry(name.to_string())
+                .or_insert_with(|| tokenizer.clone());
+            return Some(tokenizer);
         }
         let tokenizers = self.tokenizers.read();
         tokenizers.get(name).cloned()

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -132,6 +132,15 @@ pub fn convert_query(
                 if prefix.is_empty() {
                     return Err("Prefix query must not be empty".to_string());
                 }
+                if schema
+                    .get_field_entry(field)
+                    .is_some_and(|entry| entry.chunked)
+                {
+                    return Err(format!(
+                        "Prefix queries are not supported on chunked text field '{}'; use a MatchQuery or PhraseQuery",
+                        match_query.field
+                    ));
+                }
                 return Ok(Box::new(PrefixQuery::text(field, prefix)));
             }
 
@@ -740,6 +749,11 @@ pub fn schema_to_sdl(schema: &Schema) -> String {
 
         if entry.indexed {
             let mut idx_params = Vec::new();
+
+            // Chunked text: every value is its own BM25 unit
+            if entry.chunked {
+                idx_params.push("chunked".to_string());
+            }
 
             // Positions (for text/sparse)
             if let Some(pos) = entry.positions {
@@ -1656,6 +1670,40 @@ mod tests {
         let mut too_wide = base;
         too_wide.matryoshka_dims = 4;
         assert!(convert_reranker(&too_wide, &schema).is_err());
+    }
+
+    #[test]
+    fn schema_to_sdl_renders_chunked_text_fields() {
+        let input = r#"
+            index documents {
+                field languages: text<raw_ci> [fast]
+                field content: text<stem(by: languages, default: simple)> [indexed<chunked, token_position>]
+            }
+        "#;
+        let schema = hermes_core::dsl::sdl::parse_sdl(input).unwrap()[0].to_schema();
+        let rendered = schema_to_sdl(&schema);
+        assert!(
+            rendered.contains("indexed<chunked, token_position>"),
+            "{rendered}"
+        );
+        let reparsed = hermes_core::dsl::sdl::parse_sdl(&rendered).unwrap()[0].to_schema();
+        let entry = reparsed
+            .get_field_entry(reparsed.get_field("content").unwrap())
+            .unwrap();
+        assert!(entry.chunked);
+
+        // Prefix queries cannot be re-keyed from chunk ids to documents.
+        let query = proto::Query {
+            query: Some(ProtoQueryType::Match(proto::MatchQuery {
+                field: "content".to_string(),
+                text: "need*".to_string(),
+                tokenizer_hint: String::new(),
+            })),
+        };
+        let error = convert_query(&query, &schema, None, None, &QueryShapeLimits::default())
+            .err()
+            .expect("prefix on a chunked field must be rejected");
+        assert!(error.contains("chunked"), "{error}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Full-text over chunks, the way sparse/dense vector fields already work. A text field declared `indexed<chunked>` indexes **every value as its own BM25 unit**; hits report the matching chunks as `ordinal_scores`, aligned with the vector ordinals of the same chunk, so `FusionQuery` compounds a passage found by BM25 and by a vector and clients can render the matching passage. Design: `docs/chunked-text-fields.md`.

- Postings/positions of a chunked field are keyed by a dense per-field **virtual chunk id** (existing `BlockPostingList`/`PositionPostingList` formats unchanged); a `.chunks` sidecar maps ids to `(doc, ordinal, length)`.
- BM25 gets **real length normalisation** for chunked fields (each chunk's token count); IDF and average length are computed over chunks. Non-chunked fields keep the historic `tf`-as-length approximation.
- Block-Max MaxScore runs over chunks (2× over-fetch), folded to documents with `Max` and served by `VectorTopKResultScorer`; `TermQuery`, `MatchQuery` and `PhraseQuery` all report chunk ordinals; positions restart per chunk so a phrase never spans two chunks; `PrefixQuery` fails loudly on chunked fields.
- Merges stack chunked postings with per-field virtual-id offsets and concatenate the maps; BP reorder identity-copies the sidecar.
- Schema: text-only, implies `multi`, only `token_position` allowed with it; `GetIndexInfo` renders `chunked`. No wire change.

## Fixes found on the way

- Text MaxScore was disabled whenever positions were collected, which is the default server search path **and** every fusion sub-query, so multi-term BM25 ran through the exhaustive `BooleanScorer`. It now stays off only for fields whose position mode tracks element ordinals (`positions`/`ordinal`).
- MUST+SHOULD filter push-down also works when positions are requested (the bitset-predicate shortcut is skipped since bitsets cannot report positions).
- Boolean unions merge same-`(field, position)` contributions instead of reporting one chunk twice.
- Tokenizer: stemmers are fetched once per call instead of once per token, unchanged stems keep their allocation, and parsed `stem(...)` specs are cached in `TokenizerRegistry`. Measured: en stemming 50.9 → 55.2 MiB/s; the rest is Snowball itself (~120 ns/word).

## Tests

- `hermes-core/src/index/tests/chunked.rs`: per-chunk ordinals for OR/term queries, phrase confined to one chunk, shorter chunk outranks longer at equal tf, ordinals survive a forced merge, fusion with sparse vectors compounds only on shared ordinals, filters compose at document level, prefix rejection.
- `segment::chunk_map` round-trip, merge with doc offsets, corrupt-file rejection; SDL parse/reject tests; `schema_to_sdl` round-trip in the server.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, `cargo doc` all green.

## Activation

A chunked field needs a rebuilt index generation, and `chunked` fails SDL parsing on older servers: deploy the release to every server and the broker before creating the new generation.