### PR TITLE
feat(core): filter dynamic stop words with phrase offsets

### DIFF
--- a/docs/dynamic-tokenizer-and-phrase.md
+++ b/docs/dynamic-tokenizer-and-phrase.md
@@ -22,11 +22,12 @@ body), `DynamicStemmer` interprets it.
 
 ```
 field languages: text<raw_ci> [fast]
-field content: text<stem(by: languages, default: simple)> [indexed<token_position>]
+field content: text<stem(by: languages, default: simple, stop_words: true)> [indexed<token_position>]
 ```
 
-`stem(by: <field>, default: <language|simple>)` is a parameterized tokenizer
-spec. Its canonical string form is stored in the existing
+`stem(by: <field>, default: <language|simple>, stop_words: <true|false>)` is a
+parameterized tokenizer spec (`stop_words` defaults to false). Its canonical
+string form is stored in the existing
 `FieldEntry.tokenizer`, so `metadata.json` has no new field and old indexes
 load unchanged. `parse_sdl` fails loudly when the `by` field is missing or not
 a text field, when the default language is unknown, and (new for all schemas)
@@ -61,6 +62,24 @@ tokenizer_hint`. The server resolves the field's tokenizer as before and calls
 client passes the query language. Static tokenizers ignore the hint, so
 clients may always send it.
 
+### Stop words and phrase offsets
+
+When `stop_words: true`, the dynamic tokenizer removes a cleaned token when it
+is in the stop-word list of the first hinted language for that token's script.
+The token contributes no dictionary term, posting, term frequency, or position
+entry. Unsupported languages (including Tamil in the `stop-words` crate) and
+tokens whose script has no hinted language are retained; Hermes never silently
+borrows another language's list.
+
+Removal does not collapse the positions of later tokens. The phrase query
+converter keeps the surviving tokens' original offsets, and the positional
+scorer compares those offsets rather than assuming every surviving term was
+adjacent. For example, `"quantum of the art"` becomes `quantum@0, art@3` both
+while indexing and while parsing the phrase. As with Tantivy/Lucene-style
+stop-word filters, this proves ordered distance but cannot prove which removed
+stop words occupied the gap. Ordinary `MatchQuery` uses the same filtered
+stream.
+
 ### Merges
 
 Segment merges union term dictionaries and never re-tokenize, so per-document
@@ -74,7 +93,8 @@ message PhraseQuery { string field = 1; string text = 2; uint32 slop = 3; string
 ```
 
 `text` is tokenized server-side with the field's tokenizer (and hint), terms
-must occur consecutively (`slop` 0) or within `slop` positions. Requires
+must occur at their tokenized offsets (`slop` 0) or within `slop` positions.
+Requires
 `indexed<token_position>` or `indexed<positions>`; without positions
 `hermes_core::PhraseQuery` degrades to a MUST of the terms, and a single
 token collapses to a `TermQuery`. Scored with BM25. The query-language parser
@@ -102,4 +122,4 @@ resolution of a `stem(...)` spec is cached per spec string in
 
 - JSON (`SchemaFieldConfig`) schemas: the dynamic spec is SDL-only.
 - Highlighting / matched-position export.
-- Stop-word filtering for dynamic fields.
+- Per-index custom stop-word dictionaries.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -146,13 +146,16 @@ argument of `TermQuery`, `MatchQuery` and `PhraseQuery`:
 
 ```
 field languages: text<raw_ci> [fast]
-field content: text<stem(by: languages, default: simple)> [indexed<token_position>]
+field content: text<stem(by: languages, default: simple, stop_words: true)> [indexed<token_position>]
 ```
 
 - `by` names a text field of the same index; all of its values in a document
   form the hint (`"ru,en"`).
 - `default` is the language used when a document (or query) carries no
   recognised hint; `simple` means no stemming.
+- `stop_words` defaults to `false`; when `true`, words from the selected
+  language's list are omitted from postings while later token positions retain
+  their gaps, so phrase queries still enforce the original distances.
 - Each token is stemmed with the first hinted language whose script matches
   the token (Snowball stemmers are script-local), so Cyrillic and Latin text
   in one document both stem correctly; same-script languages use the first
@@ -193,7 +196,7 @@ See `docs/chunked-text-fields.md` for the design.
 | `simple`                  | `default`    | Whitespace split, punctuation stripped, lowercased |
 | `raw`                     |              | Whole value as one token, unchanged                |
 | `raw_ci`                  |              | Whole value as one token, lowercased               |
-| `stem(by: F, default: L)` |              | Dynamic stemmer hinted by field `F` (see above)    |
+| `stem(by: F, default: L, stop_words: true)` |              | Dynamic stemmer with optional stop-word filtering |
 | `en_stem`                 | `english`    | English Snowball stemmer                           |
 | `de_stem`                 | `german`     | German Snowball stemmer                            |
 | `fr_stem`                 | `french`     | French Snowball stemmer                            |

--- a/hermes-core/src/dsl/ql/mod.rs
+++ b/hermes-core/src/dsl/ql/mod.rs
@@ -16,7 +16,7 @@ use super::schema::{Field, Schema};
 use crate::query::{
     BooleanQuery, DEFAULT_DENSE_RERANK_FACTOR, PhraseQuery, PrefixQuery, Query, TermQuery,
 };
-use crate::tokenizer::{BoxedTokenizer, TokenizerRegistry};
+use crate::tokenizer::{BoxedTokenizer, Token, TokenizerRegistry};
 
 #[derive(Parser)]
 #[grammar = "dsl/ql/ql.pest"]
@@ -595,10 +595,13 @@ impl QueryLanguageParser {
         };
 
         let tokenizer = self.get_tokenizer(field_id);
-        let tokens: Vec<String> = tokenizer
+        let tokens: Vec<Token> = tokenizer
             .tokenize(phrase)
             .into_iter()
-            .map(|t| t.text.to_lowercase())
+            .map(|mut token| {
+                token.text = token.text.to_lowercase();
+                token
+            })
             .collect();
 
         if tokens.is_empty() {
@@ -606,13 +609,16 @@ impl QueryLanguageParser {
         }
 
         if tokens.len() == 1 {
-            return Ok(Box::new(TermQuery::text(field_id, &tokens[0])));
+            return Ok(Box::new(TermQuery::text(field_id, &tokens[0].text)));
         }
 
         // Positional phrase query; on a field without positions it degrades to
         // an AND of the terms inside PhraseQuery itself.
-        let phrase_terms = |tokens: &[String]| -> Vec<Vec<u8>> {
-            tokens.iter().map(|t| t.clone().into_bytes()).collect()
+        let phrase_terms = |tokens: &[Token]| -> Vec<(u32, Vec<u8>)> {
+            tokens
+                .iter()
+                .map(|token| (token.position, token.text.clone().into_bytes()))
+                .collect()
         };
 
         // If no field specified and multiple default fields, wrap in OR
@@ -620,20 +626,26 @@ impl QueryLanguageParser {
             let mut outer = BooleanQuery::new();
             for &f in &self.default_fields {
                 let tokenizer = self.get_tokenizer(f);
-                let tokens: Vec<String> = tokenizer
+                let tokens: Vec<Token> = tokenizer
                     .tokenize(phrase)
                     .into_iter()
-                    .map(|t| t.text.to_lowercase())
+                    .map(|mut token| {
+                        token.text = token.text.to_lowercase();
+                        token
+                    })
                     .collect();
                 if tokens.is_empty() {
                     continue;
                 }
-                outer = outer.should(PhraseQuery::new(f, phrase_terms(&tokens)));
+                outer = outer.should(PhraseQuery::new_with_offsets(f, phrase_terms(&tokens)));
             }
             return Ok(Box::new(outer));
         }
 
-        Ok(Box::new(PhraseQuery::new(field_id, phrase_terms(&tokens))))
+        Ok(Box::new(PhraseQuery::new_with_offsets(
+            field_id,
+            phrase_terms(&tokens),
+        )))
     }
 
     fn get_tokenizer(&self, field: Field) -> BoxedTokenizer {
@@ -708,6 +720,26 @@ mod tests {
 
         // Should parse quoted phrase
         let _query = parser.parse("\"hello world\"").unwrap();
+    }
+
+    #[test]
+    fn phrase_query_keeps_offsets_across_filtered_stop_words() {
+        let mut builder = SchemaBuilder::default();
+        let content = builder.add_text_field_with_tokenizer(
+            "content",
+            true,
+            true,
+            "stem(by: languages, default: en, stop_words: true)",
+        );
+        builder.add_text_field_with_tokenizer("languages", false, false, "raw_ci");
+        let parser = QueryLanguageParser::new(
+            Arc::new(builder.build()),
+            vec![content],
+            Arc::new(TokenizerRegistry::default()),
+        );
+
+        let query = parser.parse("content:\"quantum of the art\"").unwrap();
+        assert!(query.to_string().contains("quantum@0 art@3"), "{query}");
     }
 
     #[test]

--- a/hermes-core/src/index/tests/chunked.rs
+++ b/hermes-core/src/index/tests/chunked.rs
@@ -188,6 +188,52 @@ async fn chunked_phrase_never_crosses_a_chunk_boundary() {
 }
 
 #[tokio::test]
+async fn chunked_phrase_honours_stop_word_position_gaps() {
+    use crate::tokenizer::TokenizerRegistry;
+
+    let tokenizer_spec = "stem(by: languages, default: simple, stop_words: true)";
+    let mut sb = SchemaBuilder::default();
+    let languages = sb.add_text_field_with_tokenizer("languages", false, true, "raw_ci");
+    let content = sb.add_text_field_with_tokenizer("content", true, false, tokenizer_spec);
+    sb.set_chunked(content, true);
+    sb.set_positions(content, PositionMode::TokenPosition);
+    let schema = sb.build();
+
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), schema, IndexConfig::default())
+        .await
+        .unwrap();
+    for chunks in [
+        ["quantum of the art", "unrelated words"],
+        ["quantum art", "quantum of the art"],
+    ] {
+        let mut document = Document::new();
+        document.add_text(languages, "en");
+        for chunk in chunks {
+            document.add_text(content, chunk);
+        }
+        writer.add_document(document).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    let tokenizer = TokenizerRegistry::new().get(tokenizer_spec).unwrap();
+    let terms = tokenizer
+        .tokenize_hinted("quantum of the art", Some("en"))
+        .into_iter()
+        .map(|token| (token.position, token.text.into_bytes()))
+        .collect();
+    let phrase = PhraseQuery::new_with_offsets(content, terms);
+
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let (results, _) = searcher.search_with_positions(&phrase, 10).await.unwrap();
+    assert_eq!(results.len(), 2, "{results:?}");
+    assert_eq!(ordinals(by_doc(&results, 0)), vec![0]);
+    assert_eq!(ordinals(by_doc(&results, 1)), vec![1]);
+}
+
+#[tokio::test]
 async fn chunked_bm25_normalises_by_real_chunk_length() {
     let f = chunked_schema();
     let dir = RamDirectory::new();

--- a/hermes-core/src/index/tests/search.rs
+++ b/hermes-core/src/index/tests/search.rs
@@ -734,3 +734,58 @@ async fn phrase_query_matches_consecutive_stemmed_terms() {
         .unwrap();
     assert_eq!(hits(response), vec![0, 1, 2]);
 }
+
+#[tokio::test]
+async fn stop_words_are_not_indexed_and_phrase_offsets_keep_the_gap() {
+    use crate::dsl::PositionMode;
+    use crate::query::{PhraseQuery, TermQuery};
+    use crate::tokenizer::TokenizerRegistry;
+
+    let tokenizer_spec = "stem(by: languages, default: simple, stop_words: true)";
+    let mut schema_builder = SchemaBuilder::default();
+    let languages =
+        schema_builder.add_text_field_with_tokenizer("languages", false, true, "raw_ci");
+    let content =
+        schema_builder.add_text_field_with_tokenizer("content", true, true, tokenizer_spec);
+    schema_builder.set_positions(content, PositionMode::TokenPosition);
+    let schema = schema_builder.build();
+
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    for text in ["quantum of the art", "quantum art", "art of the quantum"] {
+        let mut doc = Document::new();
+        doc.add_text(languages, "en");
+        doc.add_text(content, text);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    let index = Index::open(dir, config).await.unwrap();
+
+    let hits = |response: crate::query::SearchResponse| {
+        let mut ids: Vec<u32> = response.hits.iter().map(|hit| hit.address.doc_id).collect();
+        ids.sort_unstable();
+        ids
+    };
+
+    let stop_word = index
+        .search(&TermQuery::text(content, "of"), 10)
+        .await
+        .unwrap();
+    assert!(
+        stop_word.hits.is_empty(),
+        "stop words must have no postings"
+    );
+
+    let tokenizer = TokenizerRegistry::new().get(tokenizer_spec).unwrap();
+    let terms = tokenizer
+        .tokenize_hinted("quantum of the art", Some("en"))
+        .into_iter()
+        .map(|token| (token.position, token.text.into_bytes()))
+        .collect();
+    let phrase = PhraseQuery::new_with_offsets(content, terms);
+    let response = index.search(&phrase, 10).await.unwrap();
+    assert_eq!(hits(response), vec![0]);
+}

--- a/hermes-core/src/query/phrase.rs
+++ b/hermes-core/src/query/phrase.rs
@@ -18,6 +18,8 @@ pub struct PhraseQuery {
     pub field: Field,
     /// Terms in the phrase, in order
     pub terms: Vec<Vec<u8>>,
+    /// Original tokenizer positions for each surviving term.
+    pub term_offsets: Vec<u32>,
     /// Optional slop (max distance between terms, 0 = exact phrase)
     pub slop: u32,
     /// Optional global statistics for cross-segment IDF
@@ -31,7 +33,21 @@ impl std::fmt::Display for PhraseQuery {
             .iter()
             .map(|t| String::from_utf8_lossy(t))
             .collect();
-        write!(f, "Phrase({}:\"{}\"", self.field.0, terms.join(" "))?;
+        let contiguous = self
+            .term_offsets
+            .windows(2)
+            .all(|offsets| offsets[1] == offsets[0].saturating_add(1));
+        let rendered = if contiguous {
+            terms.join(" ")
+        } else {
+            terms
+                .iter()
+                .zip(&self.term_offsets)
+                .map(|(term, offset)| format!("{term}@{offset}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        };
+        write!(f, "Phrase({}:\"{}\"", self.field.0, rendered)?;
         if self.slop > 0 {
             write!(f, "~{}", self.slop)?;
         }
@@ -49,6 +65,7 @@ impl std::fmt::Debug for PhraseQuery {
         f.debug_struct("PhraseQuery")
             .field("field", &self.field)
             .field("terms", &terms)
+            .field("term_offsets", &self.term_offsets)
             .field("slop", &self.slop)
             .finish()
     }
@@ -57,9 +74,27 @@ impl std::fmt::Debug for PhraseQuery {
 impl PhraseQuery {
     /// Create a new exact phrase query
     pub fn new(field: Field, terms: Vec<Vec<u8>>) -> Self {
+        let term_offsets = (0..terms.len() as u32).collect();
         Self {
             field,
             terms,
+            term_offsets,
+            slop: 0,
+            global_stats: None,
+        }
+    }
+
+    /// Create an exact phrase from terms and their original tokenizer positions.
+    ///
+    /// Position gaps are retained when filters suppress tokens, so a query such
+    /// as `quantum of the art` can contain only the indexed terms at offsets 0 and
+    /// 3 while still requiring the same distance between them.
+    pub fn new_with_offsets(field: Field, terms: Vec<(u32, Vec<u8>)>) -> Self {
+        let (term_offsets, terms) = terms.into_iter().unzip();
+        Self {
+            field,
+            terms,
+            term_offsets,
             slop: 0,
             global_stats: None,
         }
@@ -71,17 +106,12 @@ impl PhraseQuery {
     /// the query terms match the indexed stems.
     pub fn text(field: Field, phrase: &str) -> Self {
         use crate::tokenizer::Tokenizer;
-        let terms: Vec<Vec<u8>> = crate::tokenizer::SimpleTokenizer
+        let terms = crate::tokenizer::SimpleTokenizer
             .tokenize(phrase)
             .into_iter()
-            .map(|token| token.text.into_bytes())
+            .map(|token| (token.position, token.text.into_bytes()))
             .collect();
-        Self {
-            field,
-            terms,
-            slop: 0,
-            global_stats: None,
-        }
+        Self::new_with_offsets(field, terms)
     }
 
     /// Set slop (max distance between terms)
@@ -105,6 +135,7 @@ impl PhraseQuery {
 /// pass over the matching chunks only.
 fn build_chunked_phrase_scorer<'a>(
     term_data: Vec<(BlockPostingList, PositionPostingList)>,
+    term_offsets: Vec<u32>,
     slop: u32,
     reader: &SegmentReader,
     field: Field,
@@ -123,8 +154,15 @@ fn build_chunked_phrase_scorer<'a>(
         .map(|(p, _)| super::bm25_idf(p.doc_count() as f32, num_chunks))
         .sum();
     let (postings, positions): (Vec<_>, Vec<_>) = term_data.into_iter().unzip();
-    let mut scorer = PhraseScorer::new(postings, positions, slop, idf, chunk_map.avg_len())
-        .with_chunk_lengths(chunk_map.clone());
+    let mut scorer = PhraseScorer::new(
+        postings,
+        positions,
+        term_offsets,
+        slop,
+        idf,
+        chunk_map.avg_len(),
+    )
+    .with_chunk_lengths(chunk_map.clone());
 
     use super::docset::DocSet as _;
     let mut raw: Vec<(u32, u16, f32)> = Vec::new();
@@ -143,6 +181,7 @@ fn build_chunked_phrase_scorer<'a>(
 /// Build a PhraseScorer from already-fetched term data.
 fn build_phrase_scorer<'a>(
     term_data: Vec<(BlockPostingList, PositionPostingList)>,
+    term_offsets: Vec<u32>,
     slop: u32,
     reader: &SegmentReader,
     field: Field,
@@ -160,6 +199,7 @@ fn build_phrase_scorer<'a>(
     Box::new(PhraseScorer::new(
         postings,
         positions,
+        term_offsets,
         slop,
         idf,
         avg_field_len,
@@ -203,6 +243,7 @@ impl Query for PhraseQuery {
     ) -> ScorerFuture<'a> {
         let field = self.field;
         let terms = self.terms.clone();
+        let term_offsets = self.term_offsets.clone();
         let slop = self.slop;
 
         Box::pin(async move {
@@ -230,9 +271,22 @@ impl Query for PhraseQuery {
             }
 
             if reader.is_chunked_field(field) {
-                return build_chunked_phrase_scorer(term_data, slop, reader, field, limit);
+                return build_chunked_phrase_scorer(
+                    term_data,
+                    term_offsets,
+                    slop,
+                    reader,
+                    field,
+                    limit,
+                );
             }
-            Ok(build_phrase_scorer(term_data, slop, reader, field))
+            Ok(build_phrase_scorer(
+                term_data,
+                term_offsets,
+                slop,
+                reader,
+                field,
+            ))
         })
     }
 
@@ -284,10 +338,21 @@ impl Query for PhraseQuery {
         }
 
         if reader.is_chunked_field(self.field) {
-            return build_chunked_phrase_scorer(term_data, self.slop, reader, self.field, limit);
+            return build_chunked_phrase_scorer(
+                term_data,
+                self.term_offsets.clone(),
+                self.slop,
+                reader,
+                self.field,
+                limit,
+            );
         }
         Ok(build_phrase_scorer(
-            term_data, self.slop, reader, self.field,
+            term_data,
+            self.term_offsets.clone(),
+            self.slop,
+            reader,
+            self.field,
         ))
     }
 
@@ -322,6 +387,8 @@ struct PhraseScorer {
     posting_iters: Vec<BlockPostingIterator<'static>>,
     /// Position iterators for each term
     position_lists: Vec<PositionPostingList>,
+    /// Original tokenizer positions aligned with `position_lists`.
+    term_offsets: Vec<u32>,
     /// Max slop between terms
     slop: u32,
     /// Current matching document
@@ -341,6 +408,7 @@ impl PhraseScorer {
     fn new(
         posting_lists: Vec<BlockPostingList>,
         position_lists: Vec<PositionPostingList>,
+        term_offsets: Vec<u32>,
         slop: u32,
         idf: f32,
         avg_field_len: f32,
@@ -354,6 +422,7 @@ impl PhraseScorer {
         let mut scorer = Self {
             posting_iters,
             position_lists,
+            term_offsets,
             slop,
             current_doc: 0,
             idf,
@@ -454,14 +523,21 @@ impl PhraseScorer {
 
     /// Check if a phrase exists starting from the given position
     fn check_phrase_from_position(&self, start_pos: u32, term_positions: &[Vec<u32>]) -> bool {
-        let mut expected_pos = start_pos;
+        let Some(&first_offset) = self.term_offsets.first() else {
+            return false;
+        };
 
         for (i, positions) in term_positions.iter().enumerate() {
             if i == 0 {
                 continue; // Skip first term, already matched
             }
 
-            expected_pos += 1;
+            let Some(relative_offset) = self.term_offsets[i].checked_sub(first_offset) else {
+                return false;
+            };
+            let Some(expected_pos) = start_pos.checked_add(relative_offset) else {
+                return false;
+            };
 
             // Find a position within slop distance
             let found = positions.iter().any(|&pos| {

--- a/hermes-core/src/tokenizer/mod.rs
+++ b/hermes-core/src/tokenizer/mod.rs
@@ -15,8 +15,9 @@ pub use hf_tokenizer::{TokenizerCache, tokenizer_cache};
 #[cfg(feature = "native")]
 pub use idf_weights::{IdfWeights, IdfWeightsCache, idf_weights_cache};
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock};
 
 use parking_lot::RwLock;
 use rust_stemmers::Algorithm;
@@ -177,18 +178,27 @@ fn clean_word(word: &str) -> String {
 /// Used by `SimpleTokenizer` (identity transform) and `StemmerTokenizer` (stem transform).
 /// The transform receives an owned `String` so identity transforms avoid extra allocations.
 fn tokenize_and_clean(text: &str, transform: impl Fn(String) -> String) -> Vec<Token> {
+    tokenize_and_clean_filter(text, |token| Some(transform(token)))
+}
+
+/// Shared tokenization logic with optional token suppression.
+///
+/// Positions advance for every non-empty cleaned token, including suppressed
+/// ones. This mirrors Tantivy's filtering behavior: removed tokens have no
+/// posting, while surviving tokens retain gaps for offset-aware phrases.
+fn tokenize_and_clean_filter(
+    text: &str,
+    transform: impl Fn(String) -> Option<String>,
+) -> Vec<Token> {
     let mut tokens = Vec::with_capacity(text.len() / 5);
     let mut position = 0u32;
     for (offset, word) in split_whitespace_with_offsets(text) {
         if !word.is_empty() {
             let cleaned = clean_word(word);
             if !cleaned.is_empty() {
-                tokens.push(Token::new(
-                    transform(cleaned),
-                    position,
-                    offset,
-                    offset + word.len(),
-                ));
+                if let Some(token) = transform(cleaned) {
+                    tokens.push(Token::new(token, position, offset, offset + word.len()));
+                }
                 position += 1;
             }
         }
@@ -256,8 +266,8 @@ impl Language {
         }
     }
 
-    fn to_stop_words_language(self) -> LANGUAGE {
-        match self {
+    fn to_stop_words_language(self) -> Option<LANGUAGE> {
+        Some(match self {
             Language::Arabic => LANGUAGE::Arabic,
             Language::Danish => LANGUAGE::Danish,
             Language::Dutch => LANGUAGE::Dutch,
@@ -274,10 +284,67 @@ impl Language {
             Language::Russian => LANGUAGE::Russian,
             Language::Spanish => LANGUAGE::Spanish,
             Language::Swedish => LANGUAGE::Swedish,
-            Language::Tamil => LANGUAGE::English, // Tamil not supported, fallback to English
+            Language::Tamil => return None,
             Language::Turkish => LANGUAGE::Turkish,
-        }
+        })
     }
+}
+
+static STOP_WORDS: LazyLock<HashMap<Language, HashSet<String>>> = LazyLock::new(|| {
+    [
+        Language::Arabic,
+        Language::Danish,
+        Language::Dutch,
+        Language::English,
+        Language::Finnish,
+        Language::French,
+        Language::German,
+        Language::Greek,
+        Language::Hungarian,
+        Language::Italian,
+        Language::Norwegian,
+        Language::Portuguese,
+        Language::Romanian,
+        Language::Russian,
+        Language::Spanish,
+        Language::Swedish,
+        Language::Turkish,
+    ]
+    .into_iter()
+    .map(|language| {
+        let words = stop_words::get(
+            language
+                .to_stop_words_language()
+                .expect("listed languages have stop-word dictionaries"),
+        )
+        .iter()
+        .map(|word| clean_word(word))
+        .filter(|word| !word.is_empty())
+        .collect();
+        (language, words)
+    })
+    .collect()
+});
+
+static WARNED_UNSUPPORTED_STOP_WORDS: AtomicBool = AtomicBool::new(false);
+
+fn warn_if_stop_words_unsupported(languages: &[Language]) {
+    if languages
+        .iter()
+        .any(|language| language.to_stop_words_language().is_none())
+        && !WARNED_UNSUPPORTED_STOP_WORDS.swap(true, Ordering::Relaxed)
+    {
+        log::warn!(
+            "stop_words is enabled, but no stop-word dictionary exists for Tamil; Tamil tokens will be retained"
+        );
+    }
+}
+
+#[inline]
+fn is_language_stop_word(language: Language, word: &str) -> bool {
+    STOP_WORDS
+        .get(&language)
+        .is_some_and(|words| words.contains(word))
 }
 
 /// Stop word filter tokenizer - wraps another tokenizer and filters out stop words
@@ -289,15 +356,19 @@ pub struct StopWordTokenizer<T: Tokenizer> {
     stop_words: HashSet<String>,
 }
 
-use std::collections::HashSet;
-
 impl<T: Tokenizer> StopWordTokenizer<T> {
     /// Create a new stop word tokenizer wrapping the given tokenizer
     pub fn new(inner: T, language: Language) -> Self {
-        let stop_words: HashSet<String> = stop_words::get(language.to_stop_words_language())
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
+        let stop_words = match language.to_stop_words_language() {
+            Some(language) => stop_words::get(language)
+                .iter()
+                .map(|word| (*word).to_string())
+                .collect(),
+            None => {
+                warn_if_stop_words_unsupported(&[language]);
+                HashSet::new()
+            }
+        };
         Self { inner, stop_words }
     }
 
@@ -613,17 +684,28 @@ fn with_stemmers<R>(languages: &[Language], f: impl FnOnce(&[&rust_stemmers::Ste
 /// Because Snowball stemmers are script-local, one field can hold mixed
 /// Cyrillic/Latin documents and still stem each part correctly.
 ///
-/// Declared in SDL as `text<stem(by: <field>, default: <language|simple>)>`;
+/// Declared in SDL as
+/// `text<stem(by: <field>, default: <language|simple>, stop_words: true)>`;
 /// see [`TokenizerSpec`].
 #[derive(Debug, Clone, Default)]
 pub struct DynamicStemmer {
     default: Option<Language>,
+    stop_words: bool,
 }
 
 impl DynamicStemmer {
     /// Create a dynamic stemmer; `default` applies when no hint is present.
     pub fn new(default: Option<Language>) -> Self {
-        Self { default }
+        Self {
+            default,
+            stop_words: false,
+        }
+    }
+
+    /// Enable or disable language-specific stop-word suppression.
+    pub fn with_stop_words(mut self, enabled: bool) -> Self {
+        self.stop_words = enabled;
+        self
     }
 
     /// Default language used when no hint is given.
@@ -645,30 +727,47 @@ impl DynamicStemmer {
     }
 
     fn tokenize_with_languages(&self, text: &str, languages: &[Language]) -> Vec<Token> {
+        if self.stop_words {
+            warn_if_stop_words_unsupported(languages);
+        }
         match languages {
             [] => tokenize_and_clean(text, |s| s),
             [single] => {
                 let script = single.script();
+                let filter_stop_words = self.stop_words;
                 with_stemmers(languages, |stemmers| {
                     let stemmer = stemmers[0];
-                    tokenize_and_clean(text, |s| {
+                    tokenize_and_clean_filter(text, |s| {
                         if Script::of_token(&s) == script {
-                            stem_owned(stemmer, s)
+                            if filter_stop_words && is_language_stop_word(*single, &s) {
+                                None
+                            } else {
+                                Some(stem_owned(stemmer, s))
+                            }
                         } else {
-                            s
+                            Some(s)
                         }
                     })
                 })
             }
-            many => with_stemmers(many, |stemmers| {
-                tokenize_and_clean(text, |s| {
-                    let script = Script::of_token(&s);
-                    match many.iter().position(|language| language.script() == script) {
-                        Some(index) => stem_owned(stemmers[index], s),
-                        None => s,
-                    }
+            many => {
+                let filter_stop_words = self.stop_words;
+                with_stemmers(many, |stemmers| {
+                    tokenize_and_clean_filter(text, |s| {
+                        let script = Script::of_token(&s);
+                        match many.iter().position(|language| language.script() == script) {
+                            Some(index) => {
+                                if filter_stop_words && is_language_stop_word(many[index], &s) {
+                                    None
+                                } else {
+                                    Some(stem_owned(stemmers[index], s))
+                                }
+                            }
+                            None => Some(s),
+                        }
+                    })
                 })
-            }),
+            }
         }
     }
 }
@@ -700,9 +799,9 @@ impl Tokenizer for DynamicStemmer {
 /// Parsed form of a tokenizer name in the schema.
 ///
 /// Plain names refer to a registered tokenizer (`simple`, `en_stem`, ...).
-/// `stem(by: <field>, default: <language|simple>)` declares a
-/// [`DynamicStemmer`] whose per-document hint is read from `<field>` in the
-/// same document. The canonical string form is stored in
+/// `stem(by: <field>, default: <language|simple>, stop_words: <bool>)`
+/// declares a [`DynamicStemmer`] whose per-document hint is read from `<field>`
+/// in the same document. The canonical string form is stored in
 /// `FieldEntry::tokenizer`, so index metadata needs no new field.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TokenizerSpec {
@@ -714,6 +813,8 @@ pub enum TokenizerSpec {
         by: String,
         /// Language applied when the hint field is absent; `None` = simple.
         default: Option<Language>,
+        /// Whether language-specific stop words are omitted from postings.
+        stop_words: bool,
     },
 }
 
@@ -732,6 +833,7 @@ impl TokenizerSpec {
         };
         let mut by = None;
         let mut default = None;
+        let mut filter_stop_words = false;
         for param in params.split(',') {
             let param = param.trim();
             if param.is_empty() {
@@ -754,6 +856,15 @@ impl TokenizerSpec {
                         })?),
                     };
                 }
+                "stop_words" => match value {
+                    "true" => filter_stop_words = true,
+                    "false" => filter_stop_words = false,
+                    _ => {
+                        return Err(format!(
+                            "tokenizer spec '{spec}': 'stop_words' must be true or false"
+                        ));
+                    }
+                },
                 other => {
                     return Err(format!(
                         "tokenizer spec '{spec}': unknown parameter '{other}'"
@@ -762,7 +873,11 @@ impl TokenizerSpec {
             }
         }
         let by = by.ok_or_else(|| format!("tokenizer spec '{spec}' requires 'by: <field>'"))?;
-        Ok(TokenizerSpec::DynamicStem { by, default })
+        Ok(TokenizerSpec::DynamicStem {
+            by,
+            default,
+            stop_words: filter_stop_words,
+        })
     }
 
     /// Field whose values hint the tokenizer, for dynamic specs.
@@ -777,9 +892,13 @@ impl TokenizerSpec {
     pub fn dynamic_tokenizer(&self) -> Option<BoxedTokenizer> {
         match self {
             TokenizerSpec::Named(_) => None,
-            TokenizerSpec::DynamicStem { default, .. } => {
-                Some(Box::new(DynamicStemmer::new(*default)))
-            }
+            TokenizerSpec::DynamicStem {
+                default,
+                stop_words,
+                ..
+            } => Some(Box::new(
+                DynamicStemmer::new(*default).with_stop_words(*stop_words),
+            )),
         }
     }
 }
@@ -788,12 +907,20 @@ impl std::fmt::Display for TokenizerSpec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TokenizerSpec::Named(name) => f.write_str(name),
-            TokenizerSpec::DynamicStem { by, default } => {
+            TokenizerSpec::DynamicStem {
+                by,
+                default,
+                stop_words,
+            } => {
                 let default = match default {
                     None => "simple".to_string(),
                     Some(language) => language_code(*language).to_string(),
                 };
-                write!(f, "stem(by: {by}, default: {default})")
+                write!(f, "stem(by: {by}, default: {default}")?;
+                if *stop_words {
+                    f.write_str(", stop_words: true")?;
+                }
+                f.write_str(")")
             }
         }
     }
@@ -976,7 +1103,7 @@ impl TokenizerRegistry {
         tokenizers.insert(name.to_string(), Box::new(tokenizer));
     }
 
-    /// Get a tokenizer by name or by a `stem(by: ..., default: ...)` spec.
+    /// Get a tokenizer by name or by a `stem(by: ..., default: ..., stop_words: ...)` spec.
     ///
     /// Dynamic specs are parsed once per distinct spec string and cached; a
     /// malformed spec is not cached and yields `None` on every call.
@@ -1421,6 +1548,21 @@ mod tests {
     }
 
     #[test]
+    fn dynamic_stemmer_stop_words_preserve_position_gaps() {
+        let stemmer = DynamicStemmer::new(None).with_stop_words(true);
+        let tokens = hinted(&stemmer, "Quantum of the arts", Some("en"));
+
+        assert_eq!(texts(&tokens), vec!["quantum", "art"]);
+        assert_eq!(
+            tokens
+                .iter()
+                .map(|token| token.position)
+                .collect::<Vec<_>>(),
+            vec![0, 3]
+        );
+    }
+
+    #[test]
     fn script_detection_covers_supported_stemmer_scripts() {
         assert_eq!(Script::of_token("hello"), Script::Latin);
         assert_eq!(Script::of_token("straße"), Script::Latin);
@@ -1445,7 +1587,8 @@ mod tests {
             spec,
             TokenizerSpec::DynamicStem {
                 by: "languages".to_string(),
-                default: None
+                default: None,
+                stop_words: false,
             }
         );
         assert_eq!(spec.to_string(), "stem(by: languages, default: simple)");
@@ -1453,11 +1596,26 @@ mod tests {
 
         let spec = TokenizerSpec::parse("stem(by: lang, default: english)").unwrap();
         assert_eq!(spec.to_string(), "stem(by: lang, default: en)");
+        let stop_words =
+            TokenizerSpec::parse("stem(by: lang, default: english, stop_words: true)").unwrap();
+        assert_eq!(
+            stop_words,
+            TokenizerSpec::DynamicStem {
+                by: "lang".to_string(),
+                default: Some(Language::English),
+                stop_words: true,
+            }
+        );
+        assert_eq!(
+            stop_words.to_string(),
+            "stem(by: lang, default: en, stop_words: true)"
+        );
         assert_eq!(
             TokenizerSpec::parse("stem(by: lang)").unwrap(),
             TokenizerSpec::DynamicStem {
                 by: "lang".to_string(),
-                default: None
+                default: None,
+                stop_words: false,
             }
         );
 
@@ -1465,6 +1623,7 @@ mod tests {
         assert!(TokenizerSpec::parse("stem(by: lang, default: klingon)").is_err());
         assert!(TokenizerSpec::parse("stem(by: lang").is_err());
         assert!(TokenizerSpec::parse("stem(by: lang, color: red)").is_err());
+        assert!(TokenizerSpec::parse("stem(by: lang, stop_words: yes)").is_err());
         assert!(TokenizerSpec::parse("en_stem(foo)").is_err());
         assert!(TokenizerSpec::parse("").is_err());
     }
@@ -1482,6 +1641,18 @@ mod tests {
         assert_eq!(
             texts(&tokenizer.tokenize("Running Foxes")),
             vec!["running", "foxes"]
+        );
+        let tokenizer = registry
+            .get("stem(by: languages, default: simple, stop_words: true)")
+            .expect("dynamic stop-word spec resolves without registration");
+        let tokens = tokenizer.tokenize_hinted("Quantum of the art", Some("en"));
+        assert_eq!(texts(&tokens), vec!["quantum", "art"]);
+        assert_eq!(
+            tokens
+                .iter()
+                .map(|token| token.position)
+                .collect::<Vec<_>>(),
+            vec![0, 3]
         );
         assert!(
             registry

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -40,7 +40,7 @@ fn field_tokens(
     text: &str,
     tokenizer_hint: &str,
     shape: &QueryShapeLimits,
-) -> Result<(hermes_core::Field, Vec<String>), String> {
+) -> Result<(hermes_core::Field, Vec<hermes_core::Token>), String> {
     let field = schema
         .get_field(field_name)
         .ok_or_else(|| format!("Field '{field_name}' not found"))?;
@@ -60,11 +60,7 @@ fn field_tokens(
         .get(tokenizer_name)
         .unwrap_or_else(|| Box::new(hermes_core::SimpleTokenizer));
     let hint = Some(tokenizer_hint.trim()).filter(|hint| !hint.is_empty());
-    let tokens: Vec<String> = tokenizer
-        .tokenize_hinted(text, hint)
-        .into_iter()
-        .map(|t| t.text)
-        .collect();
+    let tokens = tokenizer.tokenize_hinted(text, hint);
     validate_token_expansion(kind, tokens.len(), shape.max_text_query_tokens)?;
     Ok((field, tokens))
 }
@@ -114,11 +110,11 @@ pub fn convert_query(
                 return Err(format!("No tokens in term '{}'", term_query.term));
             }
             if tokens.len() == 1 {
-                Ok(Box::new(TermQuery::text(field, &tokens[0])))
+                Ok(Box::new(TermQuery::text(field, &tokens[0].text)))
             } else {
                 let mut query = BooleanQuery::new();
                 for token in tokens {
-                    query = query.must(TermQuery::text(field, &token));
+                    query = query.must(TermQuery::text(field, &token.text));
                 }
                 Ok(Box::new(query))
             }
@@ -162,13 +158,13 @@ pub fn convert_query(
 
             if tokens.len() == 1 {
                 // Single token - use TermQuery directly
-                return Ok(Box::new(TermQuery::text(field, &tokens[0])));
+                return Ok(Box::new(TermQuery::text(field, &tokens[0].text)));
             }
 
             // Multiple tokens - use BooleanQuery with SHOULD clauses (MaxScore fast path)
             let mut query = BooleanQuery::new();
             for token in tokens {
-                query = query.should(TermQuery::text(field, &token));
+                query = query.should(TermQuery::text(field, &token.text));
             }
             Ok(Box::new(query))
         }
@@ -189,9 +185,12 @@ pub fn convert_query(
             }
             // PhraseQuery itself collapses one term to a TermQuery and, on a
             // field without positions, degrades to a MUST of the terms.
-            let terms = tokens.into_iter().map(String::into_bytes).collect();
+            let terms = tokens
+                .into_iter()
+                .map(|token| (token.position, token.text.into_bytes()))
+                .collect();
             Ok(Box::new(
-                PhraseQuery::new(field, terms).with_slop(phrase_query.slop),
+                PhraseQuery::new_with_offsets(field, terms).with_slop(phrase_query.slop),
             ))
         }
         Some(ProtoQueryType::Boolean(bool_query)) => {
@@ -1367,6 +1366,44 @@ mod tests {
         .unwrap()
         .to_string();
         assert!(static_hint.contains("fox"), "{static_hint}");
+    }
+
+    #[test]
+    fn stop_word_queries_drop_terms_but_keep_phrase_offsets() {
+        let mut builder = hermes_core::SchemaBuilder::default();
+        builder.add_text_field_with_tokenizer("languages", false, false, "raw_ci");
+        builder.add_text_field_with_tokenizer(
+            "content",
+            true,
+            false,
+            "stem(by: languages, default: simple, stop_words: true)",
+        );
+        let schema = builder.build();
+
+        let phrase = convert_query(
+            &phrase_proto("content", "quantum of the art", 0, "en"),
+            &schema,
+            None,
+            None,
+            &shape(),
+        )
+        .unwrap()
+        .to_string();
+        assert!(phrase.contains("quantum@0 art@3"), "{phrase}");
+
+        let matched = convert_query(
+            &match_proto("content", "quantum of the art", "en"),
+            &schema,
+            None,
+            None,
+            &shape(),
+        )
+        .unwrap()
+        .to_string();
+        assert!(matched.contains("quantum"), "{matched}");
+        assert!(matched.contains("art"), "{matched}");
+        assert!(!matched.contains(" of "), "{matched}");
+        assert!(!matched.contains(" the "), "{matched}");
     }
 
     #[test]

--- a/hermes-wasm/src/query.rs
+++ b/hermes-wasm/src/query.rs
@@ -299,7 +299,7 @@ fn field_tokens(
     tokenizer_hint: Option<&str>,
     schema: &Schema,
     tokenizers: &TokenizerRegistry,
-) -> Result<(hermes_core::Field, Vec<String>), JsValue> {
+) -> Result<(hermes_core::Field, Vec<hermes_core::Token>), JsValue> {
     let field = schema
         .get_field(field_name)
         .ok_or_else(|| JsValue::from_str(&format!("Unknown field: '{}'", field_name)))?;
@@ -311,11 +311,7 @@ fn field_tokens(
         .get(tokenizer_name)
         .unwrap_or_else(|| Box::new(hermes_core::SimpleTokenizer));
     let hint = tokenizer_hint.map(str::trim).filter(|h| !h.is_empty());
-    let tokens: Vec<String> = tok
-        .tokenize_hinted(text, hint)
-        .into_iter()
-        .map(|t| t.text)
-        .collect();
+    let tokens = tok.tokenize_hinted(text, hint);
     if tokens.is_empty() {
         return Err(JsValue::from_str("No tokens in query"));
     }
@@ -334,14 +330,14 @@ fn tokenize_and_build(
 ) -> Result<Box<dyn Query>, JsValue> {
     let (field, tokens) = field_tokens(field_name, text, tokenizer_hint, schema, tokenizers)?;
     if tokens.len() == 1 {
-        return Ok(Box::new(TermQuery::text(field, &tokens[0])));
+        return Ok(Box::new(TermQuery::text(field, &tokens[0].text)));
     }
     let mut bq = BooleanQuery::new();
     for token in tokens {
         if must {
-            bq = bq.must(TermQuery::text(field, &token));
+            bq = bq.must(TermQuery::text(field, &token.text));
         } else {
-            bq = bq.should(TermQuery::text(field, &token));
+            bq = bq.should(TermQuery::text(field, &token.text));
         }
     }
     Ok(Box::new(bq))
@@ -383,8 +379,13 @@ pub(crate) fn convert_query(
             schema,
             tokenizers,
         )?;
-        let terms = tokens.into_iter().map(String::into_bytes).collect();
-        return Ok(Box::new(PhraseQuery::new(field, terms).with_slop(pq.slop)));
+        let terms = tokens
+            .into_iter()
+            .map(|token| (token.position, token.text.into_bytes()))
+            .collect();
+        return Ok(Box::new(
+            PhraseQuery::new_with_offsets(field, terms).with_slop(pq.slop),
+        ));
     }
 
     if let Some(ref bq) = js.boolean {


### PR DESCRIPTION
Adds stop_words as an opt-in parameter of the dynamic stem tokenizer. Filtered tokens produce no terms or postings, while surviving terms retain their original positions. Phrase offsets now flow through core, gRPC conversion, WASM, QL, and chunked-field scoring.

Compatibility: stop_words defaults to false, so existing tokenizer specs and indexes are unchanged.

Validation:
- cargo test -p hermes-core -p hermes-server -p hermes-wasm
- cargo clippy for changed packages and all targets with warnings denied
- rustdoc for changed packages with warnings denied
- cargo fmt check