### PR TITLE
feat(broker): partitioned indexes across shards

### DIFF
--- a/docs/broker.md
+++ b/docs/broker.md
@@ -103,21 +103,51 @@ the hermes namespace. Static mode (`--discovery static --backend
 "id=..,addr=..,shard=..[,role=..]"`) feeds the identical machinery and is
 what local development and the integration tests use.
 
-## Phase 2 (designed, not yet built): partitioned indexes
+## Phase 2: partitioned indexes
 
-One logical index across several shards. Fan out per-shard with
-`offset=0, limit=offset+limit` (candidate_limit forwards unchanged — the
-per-shard window keeps it valid; multi-shard windows above the server's
-10 000 limit cap are rejected). Merge policy: RRF over shard-local ranks when
-the query is rank-shaped (top-level `FusionQuery`, `reranker.rrf_k > 0`,
-`PrefixQuery` — their scores are shard-local), score merge for pure
-dense/binary similarity (corpus-independent). Dedup key `(segment_id,
-doc_id)` — segment ids are UUIDv7-like, collision-safe across shards.
-`total_hits` = saturating sum ("documents scored", as ever, not matched).
-Writes route documents by a pinned FNV-1a 64 hash of the primary key;
-partition order = placement-rule order (an immutable contract);
-repartitioning = full rebuild. Partial shard failure fails the request —
-a silently-partial result set is a wrong answer.
+One logical index across several shards, declared by a multi-shard placement
+rule: `--placement "documents*=2,3,4"`. Partition order = rule order (an
+immutable contract: repartitioning or reordering = full rebuild). Every
+partition must host the index; a partition without it fails the request
+with `FAILED_PRECONDITION` instead of serving a partial view.
+
+Writes:
+
+- `CreateIndex` creates the index on every partition master (the schema is
+  sent verbatim to each).
+- `BatchIndexDocuments` and streaming `IndexDocuments` route each document
+  to the partition of a pinned FNV-1a 64 hash of its primary key (the field
+  declared `primary` in the schema, read once via `GetIndexInfo` and cached
+  per index). A document without the primary key is refused at the broker
+  with its request position; `DocumentError.index` values from a partition
+  are mapped back to request positions. The stream's 512-message / 4 MiB
+  flushes are split per partition.
+- `Commit`, `ForceMerge`, `Reorder`, `DeleteIndex`, `RetrainVectorIndex`
+  and `AlterVectorIndex` go to every partition master; counts are summed,
+  `success` is the conjunction.
+
+Reads:
+
+- `Search` first asks every partition for `GetTextStats` of the query's
+  text terms (skipped for queries without BM25 terms or when the caller
+  already supplied `text_stats`), sums them, and sends the sum as
+  `SearchRequest.text_stats` so every partition scores with corpus-wide
+  document frequencies and lengths. Each partition is then queried with
+  `offset=0, limit=offset+limit` (`candidate_limit` forwards unchanged;
+  windows above the server's 10 000 cap are rejected) and the responses
+  merge by score descending, ties by `(segment_id, doc_id)` (segment ids
+  are UUIDv7-like, collision-safe across shards). Rank-fused (RRF) and
+  dense scores are functions of shard-local ranks or corpus-independent
+  and merge the same way. `total_hits` = saturating sum, timings = maximum,
+  `truncated` = any. Admission takes one permit per partition backend.
+- `GetDocument` asks every partition; the one holding the segment answers.
+- `GetIndexInfo` sums document/segment/memory counts and per-field stats;
+  `GetTextStats` merges like the search prepass.
+
+Partial partition failure fails the request (`partition '<shard>' of index
+'<name>': <status>`) — a silently-partial result set is a wrong answer.
+The admin `GetTopology` reports `merge_policy = "score"` and the cached
+primary-key field for partitioned indexes.
 
 ## Phase 3 (designed, not yet built): master/follower replication
 

--- a/hermes-broker/README.md
+++ b/hermes-broker/README.md
@@ -21,6 +21,10 @@ Design doc: [docs/broker.md](../docs/broker.md). Metrics:
   wins), so dated index families stay on their shard. The same rules pin
   reads/writes when an index name transiently exists on two shards during a
   host-to-host migration.
+- Partitions an index across shards with a shard list:
+  `--placement "documents*=2,3,4"`. Documents hash by primary key to one
+  partition; searches fan out with shared BM25 statistics and merge by score;
+  every other RPC fans out to all partitions. See `docs/broker.md`.
 - Evicts unreachable backends after a grace period and recovers them after
   two successful probes; propagates client deadlines untouched (no
   broker-imposed timeouts); mirrors hermes-server's admission, message-size

--- a/hermes-broker/src/admin_service.rs
+++ b/hermes-broker/src/admin_service.rs
@@ -83,11 +83,12 @@ impl BrokerService for BrokerAdminService {
                     replicas,
                 });
             }
+            let partitioned = route.partitions().is_some();
             indexes.push(IndexTopology {
                 index_name: name.clone(),
                 partitions,
-                merge_policy: "passthrough".to_string(),
-                primary_key_field: String::new(),
+                merge_policy: if partitioned { "score" } else { "passthrough" }.to_string(),
+                primary_key_field: self.ctx.primary_key_cached(name).unwrap_or_default(),
                 ambiguous: route.ambiguous(),
             });
         }

--- a/hermes-broker/src/context.rs
+++ b/hermes-broker/src/context.rs
@@ -1,9 +1,11 @@
 //! Shared state handed to every gRPC service implementation.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use arc_swap::ArcSwap;
+use parking_lot::RwLock;
 use tokio::sync::{Notify, Semaphore};
 use tonic::Status;
 
@@ -26,6 +28,9 @@ pub struct BrokerContext {
     /// Set when the shutdown signal fires; new RPCs are refused while tonic
     /// drains in-flight ones.
     pub shutting_down: Arc<AtomicBool>,
+    /// Primary-key field per partitioned index, resolved from its schema on
+    /// the first write (`routes::primary_key_field`).
+    pub primary_keys: RwLock<HashMap<String, String>>,
 }
 
 impl BrokerContext {

--- a/hermes-broker/src/index_service.rs
+++ b/hermes-broker/src/index_service.rs
@@ -3,8 +3,14 @@
 //! contracts (duplicate-primary-key detection, backpressure partial-batch
 //! semantics, `DocumentError.index` positions) are byte-faithful.
 //!
+//! A partitioned index (a placement rule listing several shards) fans every
+//! write out: CreateIndex, Commit, ForceMerge, Reorder, DeleteIndex, Retrain
+//! and Alter go to every partition master and all must succeed; documents
+//! go to the partition their primary key hashes to (`partition::route_documents`),
+//! with error positions mapped back to the request.
+//!
 //! CreateIndex is the one placement decision the broker owns: a glob rule
-//! (or the default policy) picks the shard for a new index, which is how
+//! (or the default policy) picks the shard(s) for a new index, which is how
 //! dated full-build names land on the right host.
 
 use std::sync::Arc;
@@ -15,8 +21,9 @@ use prost::Message;
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::client::forward_timeout;
-use crate::context::{BrokerContext, code_label};
+use crate::context::BrokerContext;
 use crate::metrics as m;
+use crate::partition;
 use crate::proto::hermes::index_service_server::IndexService;
 use crate::proto::hermes::{
     AlterVectorIndexRequest, AlterVectorIndexResponse, BatchIndexDocumentsRequest,
@@ -26,6 +33,7 @@ use crate::proto::hermes::{
     ListIndexesResponse, NamedDocument, ReorderRequest, ReorderResponse, RetrainVectorIndexRequest,
     RetrainVectorIndexResponse,
 };
+use crate::routes::{Route, Target, record_backend};
 
 /// Streaming IndexDocuments is buffered per index and forwarded as
 /// BatchIndexDocuments once either threshold is reached (mirrors the
@@ -37,65 +45,134 @@ pub struct BrokerIndexService {
     pub ctx: Arc<BrokerContext>,
 }
 
-fn record_backend(backend: &str, rpc: &'static str, started: Instant, code: tonic::Code) {
-    metrics::histogram!(
-        m::BACKEND_DURATION,
-        "backend" => backend.to_string(),
-        "rpc" => rpc,
-    )
-    .record(started.elapsed().as_secs_f64());
-    metrics::counter!(
-        m::BACKEND_REQUESTS,
-        "backend" => backend.to_string(),
-        "rpc" => rpc,
-        "code" => code_label(code),
-    )
-    .increment(1);
-}
-
-impl BrokerIndexService {
-    /// Resolve the master channel for a write against an existing index,
-    /// counting refusals.
-    fn write_route(
-        &self,
-        index_name: &str,
-    ) -> Result<(crate::client::BackendChannels, String), Status> {
-        let snapshot = self.ctx.snapshot.load();
-        let backend = snapshot
-            .select_write_backend(index_name)
-            .inspect_err(|status| {
-                metrics::counter!(
-                    m::WRITE_REJECTED,
-                    "index" => index_name.to_string(),
-                    "reason" => code_label(status.code()),
-                )
-                .increment(1);
-            })?;
-        let channels = self.ctx.pool.get(&backend.endpoint.addr)?;
-        Ok((channels, backend.endpoint.id.0.clone()))
-    }
-}
-
-/// One unary write RPC forwarded whole to the resolved master.
+/// One unary write RPC sent whole to every target of the route (one for an
+/// unpartitioned index); all must succeed, responses are folded by `merge`.
 macro_rules! forward_write {
-    ($self:ident, $request:ident, $method:ident, $rpc_name:literal) => {{
+    ($self:ident, $request:ident, $method:ident, $rpc_name:literal, $merge:expr) => {{
         $self.ctx.check_admission()?;
         let timeout = forward_timeout($request.metadata());
         let req = $request.into_inner();
-        let (channels, backend_id) = $self.write_route(&req.index_name)?;
-        let mut outbound = Request::new(req);
-        if let Some(t) = timeout {
-            outbound.set_timeout(t);
+        let index_name = req.index_name.clone();
+        let route = $self.ctx.write_route(&index_name)?;
+        let calls = route.targets().iter().map(|target| {
+            let mut outbound = Request::new(req.clone());
+            if let Some(t) = timeout {
+                outbound.set_timeout(t);
+            }
+            let mut client = target.channels.index.clone();
+            let target = target.clone();
+            async move {
+                let started = Instant::now();
+                let result = client.$method(outbound).await;
+                (target, started, result)
+            }
+        });
+        let mut responses = Vec::with_capacity(route.targets().len());
+        for (target, started, result) in futures::future::join_all(calls).await {
+            let code = result
+                .as_ref()
+                .map(|_| tonic::Code::Ok)
+                .unwrap_or_else(|s| s.code());
+            record_backend(&target.backend_id, $rpc_name, started, code);
+            match result {
+                Ok(response) => responses.push(response.into_inner()),
+                Err(status) if route.is_partitioned() => {
+                    return Err(partition::partition_failure(
+                        &index_name,
+                        &target.shard,
+                        status,
+                    ));
+                }
+                Err(status) => return Err(status),
+            }
         }
-        let started = Instant::now();
-        let result = channels.index.clone().$method(outbound).await;
-        let code = result
-            .as_ref()
-            .map(|_| tonic::Code::Ok)
-            .unwrap_or_else(|s| s.code());
-        record_backend(&backend_id, $rpc_name, started, code);
-        result.map(|r| Response::new(r.into_inner()))
+        let merge = $merge;
+        Ok(Response::new(merge(responses)))
     }};
+}
+
+impl BrokerIndexService {
+    /// Send one batch to the route: whole to a single master, or split by
+    /// primary key across the partitions.
+    async fn write_batch(
+        &self,
+        index_name: &str,
+        documents: Vec<NamedDocument>,
+        timeout: Option<Duration>,
+    ) -> Result<BatchIndexDocumentsResponse, Status> {
+        let route = self.ctx.write_route(index_name)?;
+        match route {
+            Route::Single(target) => {
+                let mut outbound = Request::new(BatchIndexDocumentsRequest {
+                    index_name: index_name.to_string(),
+                    documents,
+                });
+                if let Some(t) = timeout {
+                    outbound.set_timeout(t);
+                }
+                let started = Instant::now();
+                let result = target
+                    .channels
+                    .index
+                    .clone()
+                    .batch_index_documents(outbound)
+                    .await;
+                let code = result
+                    .as_ref()
+                    .map(|_| tonic::Code::Ok)
+                    .unwrap_or_else(|s| s.code());
+                record_backend(&target.backend_id, "batch_index_documents", started, code);
+                Ok(result?.into_inner())
+            }
+            Route::Partitioned(targets) => {
+                let primary_key = self.ctx.primary_key_field(index_name, &targets[0]).await?;
+                let routed = partition::route_documents(documents, &primary_key, targets.len());
+                let calls = routed
+                    .groups
+                    .into_iter()
+                    .zip(targets.iter())
+                    .filter(|((_, documents), _)| !documents.is_empty())
+                    .map(|((positions, documents), target)| {
+                        let mut outbound = Request::new(BatchIndexDocumentsRequest {
+                            index_name: index_name.to_string(),
+                            documents,
+                        });
+                        if let Some(t) = timeout {
+                            outbound.set_timeout(t);
+                        }
+                        let mut client = target.channels.index.clone();
+                        let target: Target = target.clone();
+                        async move {
+                            let started = Instant::now();
+                            let result = client.batch_index_documents(outbound).await;
+                            (target, positions, started, result)
+                        }
+                    });
+                let mut responses = Vec::with_capacity(targets.len());
+                for (target, positions, started, result) in futures::future::join_all(calls).await {
+                    let code = result
+                        .as_ref()
+                        .map(|_| tonic::Code::Ok)
+                        .unwrap_or_else(|s| s.code());
+                    record_backend(&target.backend_id, "batch_index_documents", started, code);
+                    match result {
+                        Ok(response) => responses.push((positions, response.into_inner())),
+                        Err(status) => {
+                            return Err(partition::partition_failure(
+                                index_name,
+                                &target.shard,
+                                status,
+                            ));
+                        }
+                    }
+                }
+                Ok(partition::merge_batch_responses(
+                    responses,
+                    routed.unroutable,
+                ))
+            }
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -107,50 +184,78 @@ impl IndexService for BrokerIndexService {
         self.ctx.check_admission()?;
         let timeout = forward_timeout(request.metadata());
         let req = request.into_inner();
-        let (addr, backend_id, shard) = {
+        let index_name = req.index_name.clone();
+        let targets: Vec<(String, String, String)> = {
             let snapshot = self.ctx.snapshot.load();
-            let backend = snapshot
-                .select_create_backend(&req.index_name, &self.ctx.placement)
+            snapshot
+                .select_create_backends(&index_name, &self.ctx.placement)
                 .inspect_err(|status| {
                     metrics::counter!(
                         m::WRITE_REJECTED,
-                        "index" => req.index_name.clone(),
-                        "reason" => code_label(status.code()),
+                        "index" => index_name.clone(),
+                        "reason" => crate::context::code_label(status.code()),
                     )
                     .increment(1);
-                })?;
-            (
-                backend.endpoint.addr.clone(),
-                backend.endpoint.id.0.clone(),
-                backend.endpoint.shard.0.clone(),
-            )
+                })?
+                .into_iter()
+                .map(|backend| {
+                    (
+                        backend.endpoint.addr.clone(),
+                        backend.endpoint.id.0.clone(),
+                        backend.endpoint.shard.0.clone(),
+                    )
+                })
+                .collect()
         };
-        info!(
-            "creating index '{}' on shard '{}' (backend {})",
-            req.index_name, shard, backend_id
-        );
-        let channels = self.ctx.pool.get(&addr)?;
-        let index_name = req.index_name.clone();
-        let mut outbound = Request::new(req);
-        if let Some(t) = timeout {
-            outbound.set_timeout(t);
+        let partitioned = targets.len() > 1;
+        for (_, backend_id, shard) in &targets {
+            info!(
+                "creating index '{}' on shard '{}' (backend {}){}",
+                index_name,
+                shard,
+                backend_id,
+                if partitioned {
+                    format!(", partition of {}", targets.len())
+                } else {
+                    String::new()
+                }
+            );
         }
-        let started = Instant::now();
-        let result = channels.index.clone().create_index(outbound).await;
-        let code = result
-            .as_ref()
-            .map(|_| tonic::Code::Ok)
-            .unwrap_or_else(|s| s.code());
-        record_backend(&backend_id, "create_index", started, code);
-        if result.is_ok() {
-            // Make the new index routable without waiting a poll interval.
-            self.ctx.refresh.notify_one();
+        let mut success = true;
+        for (addr, backend_id, shard) in &targets {
+            let channels = self.ctx.pool.get(addr)?;
+            let mut outbound = Request::new(req.clone());
+            if let Some(t) = timeout {
+                outbound.set_timeout(t);
+            }
+            let started = Instant::now();
+            let result = channels.index.clone().create_index(outbound).await;
+            let code = result
+                .as_ref()
+                .map(|_| tonic::Code::Ok)
+                .unwrap_or_else(|s| s.code());
+            record_backend(backend_id, "create_index", started, code);
+            match result {
+                Ok(response) => success &= response.into_inner().success,
+                Err(status) => {
+                    info!(
+                        "create_index '{index_name}' failed on shard '{shard}': {}",
+                        status.code()
+                    );
+                    // Make any partition that did get created routable, so a
+                    // retry sees AlreadyExists there instead of a gap.
+                    self.ctx.refresh.notify_one();
+                    return Err(if partitioned {
+                        partition::partition_failure(&index_name, shard, status)
+                    } else {
+                        status
+                    });
+                }
+            }
         }
-        result
-            .map(|r| Response::new(r.into_inner()))
-            .inspect_err(|status| {
-                info!("create_index '{index_name}' failed: {}", status.code());
-            })
+        // Make the new index routable without waiting a poll interval.
+        self.ctx.refresh.notify_one();
+        Ok(Response::new(CreateIndexResponse { success }))
     }
 
     async fn index_documents(
@@ -161,17 +266,15 @@ impl IndexService for BrokerIndexService {
         let budget = forward_timeout(request.metadata());
         let started = Instant::now();
         let mut stream = request.into_inner();
-
         let mut current_index: Option<String> = None;
         let mut buffer: Vec<NamedDocument> = Vec::new();
         let mut buffered_bytes = 0usize;
         let mut indexed_count = 0u32;
         let mut errors = Vec::new();
-
         // Forward one buffered run as a BatchIndexDocuments to the index's
-        // current master. NOTE: like hermes-server's own stream handling,
-        // DocumentError.index positions are relative to the flushed batch,
-        // not the whole stream.
+        // current master (or partition masters). NOTE: like hermes-server's
+        // own stream handling, DocumentError.index positions are relative to
+        // the flushed batch, not the whole stream.
         async fn flush(
             service: &BrokerIndexService,
             index_name: &str,
@@ -184,34 +287,24 @@ impl IndexService for BrokerIndexService {
             if documents.is_empty() {
                 return Ok(());
             }
-            let (channels, backend_id) = service.write_route(index_name)?;
             metrics::counter!(m::STREAM_FLUSHES, "index" => index_name.to_string()).increment(1);
-            let mut outbound = Request::new(BatchIndexDocumentsRequest {
-                index_name: index_name.to_string(),
-                documents,
-            });
-            if let Some(total) = budget {
-                let remaining = total.saturating_sub(started.elapsed());
-                if remaining.is_zero() {
-                    return Err(Status::deadline_exceeded(
-                        "client deadline exhausted mid-stream",
-                    ));
+            let timeout = match budget {
+                Some(total) => {
+                    let remaining = total.saturating_sub(started.elapsed());
+                    if remaining.is_zero() {
+                        return Err(Status::deadline_exceeded(
+                            "client deadline exhausted mid-stream",
+                        ));
+                    }
+                    Some(remaining)
                 }
-                outbound.set_timeout(remaining);
-            }
-            let call_started = Instant::now();
-            let result = channels.index.clone().batch_index_documents(outbound).await;
-            let code = result
-                .as_ref()
-                .map(|_| tonic::Code::Ok)
-                .unwrap_or_else(|s| s.code());
-            record_backend(&backend_id, "batch_index_documents", call_started, code);
-            let response = result?.into_inner();
+                None => None,
+            };
+            let response = service.write_batch(index_name, documents, timeout).await?;
             *indexed_count += response.indexed_count;
             errors.extend(response.errors);
             Ok(())
         }
-
         while let Some(message) = stream.message().await? {
             if current_index.as_deref() != Some(message.index_name.as_str()) {
                 if let Some(previous) = current_index.take() {
@@ -261,7 +354,6 @@ impl IndexService for BrokerIndexService {
             )
             .await?;
         }
-
         Ok(Response::new(IndexDocumentsResponse {
             indexed_count,
             errors,
@@ -272,41 +364,75 @@ impl IndexService for BrokerIndexService {
         &self,
         request: Request<BatchIndexDocumentsRequest>,
     ) -> Result<Response<BatchIndexDocumentsResponse>, Status> {
-        forward_write!(
-            self,
-            request,
-            batch_index_documents,
-            "batch_index_documents"
-        )
+        self.ctx.check_admission()?;
+        let timeout = forward_timeout(request.metadata());
+        let req = request.into_inner();
+        let response = self
+            .write_batch(&req.index_name, req.documents, timeout)
+            .await?;
+        Ok(Response::new(response))
     }
 
     async fn commit(
         &self,
         request: Request<CommitRequest>,
     ) -> Result<Response<CommitResponse>, Status> {
-        forward_write!(self, request, commit, "commit")
+        forward_write!(self, request, commit, "commit", |parts: Vec<
+            CommitResponse,
+        >| {
+            CommitResponse {
+                success: parts.iter().all(|p| p.success),
+                num_docs: parts.iter().fold(0u32, |n, p| n.saturating_add(p.num_docs)),
+            }
+        })
     }
 
     async fn force_merge(
         &self,
         request: Request<ForceMergeRequest>,
     ) -> Result<Response<ForceMergeResponse>, Status> {
-        forward_write!(self, request, force_merge, "force_merge")
+        forward_write!(self, request, force_merge, "force_merge", |parts: Vec<
+            ForceMergeResponse,
+        >| {
+            ForceMergeResponse {
+                success: parts.iter().all(|p| p.success),
+                num_segments: parts
+                    .iter()
+                    .fold(0u32, |n, p| n.saturating_add(p.num_segments)),
+            }
+        })
     }
 
     async fn reorder(
         &self,
         request: Request<ReorderRequest>,
     ) -> Result<Response<ReorderResponse>, Status> {
-        forward_write!(self, request, reorder, "reorder")
+        forward_write!(self, request, reorder, "reorder", |parts: Vec<
+            ReorderResponse,
+        >| {
+            ReorderResponse {
+                success: parts.iter().all(|p| p.success),
+                num_segments: parts
+                    .iter()
+                    .fold(0u32, |n, p| n.saturating_add(p.num_segments)),
+            }
+        })
     }
 
     async fn delete_index(
         &self,
         request: Request<DeleteIndexRequest>,
     ) -> Result<Response<DeleteIndexResponse>, Status> {
-        let result = forward_write!(self, request, delete_index, "delete_index");
+        let index_name = request.get_ref().index_name.clone();
+        let result = forward_write!(self, request, delete_index, "delete_index", |parts: Vec<
+            DeleteIndexResponse,
+        >| {
+            DeleteIndexResponse {
+                success: parts.iter().all(|p| p.success),
+            }
+        });
         if result.is_ok() {
+            self.ctx.forget_index(&index_name);
             self.ctx.refresh.notify_one();
         }
         result
@@ -330,13 +456,34 @@ impl IndexService for BrokerIndexService {
         &self,
         request: Request<RetrainVectorIndexRequest>,
     ) -> Result<Response<RetrainVectorIndexResponse>, Status> {
-        forward_write!(self, request, retrain_vector_index, "retrain_vector_index")
+        forward_write!(
+            self,
+            request,
+            retrain_vector_index,
+            "retrain_vector_index",
+            |parts: Vec<RetrainVectorIndexResponse>| RetrainVectorIndexResponse {
+                success: parts.iter().all(|p| p.success),
+            }
+        )
     }
 
     async fn alter_vector_index(
         &self,
         request: Request<AlterVectorIndexRequest>,
     ) -> Result<Response<AlterVectorIndexResponse>, Status> {
-        forward_write!(self, request, alter_vector_index, "alter_vector_index")
+        forward_write!(
+            self,
+            request,
+            alter_vector_index,
+            "alter_vector_index",
+            |parts: Vec<AlterVectorIndexResponse>| AlterVectorIndexResponse {
+                publication_generation: parts
+                    .iter()
+                    .map(|p| p.publication_generation)
+                    .max()
+                    .unwrap_or_default(),
+                state: parts.first().map(|p| p.state).unwrap_or_default(),
+            }
+        )
     }
 }

--- a/hermes-broker/src/main.rs
+++ b/hermes-broker/src/main.rs
@@ -13,9 +13,11 @@ mod discovery;
 mod index_service;
 mod kube_discovery;
 mod metrics;
+mod partition;
 mod placement;
 mod poller;
 mod proto;
+mod routes;
 mod search_service;
 mod topology;
 
@@ -91,7 +93,9 @@ struct Args {
 
     /// CreateIndex placement rule (repeatable, first match wins): "pattern=shard",
     /// e.g. "documents*=0". Also pins reads/writes when an index name appears
-    /// on several shards during a migration.
+    /// on several shards during a migration. A shard list ("documents*=2,3,4")
+    /// declares a partitioned index: documents hash by primary key across the
+    /// listed shards (in that order) and reads fan out and merge.
     #[arg(long = "placement")]
     placements: Vec<String>,
 
@@ -292,10 +296,16 @@ async fn async_main(args: Args) -> Result<()> {
         .map(|s| placement::parse_placement(s))
         .collect::<Result<Vec<_>>>()?;
     for rule in &placement_rules {
-        info!(
-            "placement rule: {} -> shard '{}'",
-            rule.pattern, rule.shard.0
-        );
+        let shards: Vec<&str> = rule.shards.iter().map(|s| s.0.as_str()).collect();
+        if shards.len() == 1 {
+            info!("placement rule: {} -> shard '{}'", rule.pattern, shards[0]);
+        } else {
+            info!(
+                "placement rule: {} -> partitions [{}]",
+                rule.pattern,
+                shards.join(", ")
+            );
+        }
     }
     let placement = Arc::new(PlacementRules::new(placement_rules, args.placement_default));
 
@@ -405,6 +415,7 @@ async fn async_main(args: Args) -> Result<()> {
             .map(|n| Arc::new(Semaphore::new(n))),
         read_rotation: AtomicUsize::new(0),
         shutting_down: Arc::clone(&shutting_down),
+        primary_keys: parking_lot::RwLock::new(std::collections::HashMap::new()),
     });
 
     let search_service = search_service::BrokerSearchService {

--- a/hermes-broker/src/partition.rs
+++ b/hermes-broker/src/partition.rs
@@ -1,0 +1,545 @@
+//! Partitioned indexes: one logical index spread over several shards
+//! (`--placement "documents_2026*=2,3,4"`, see `docs/broker.md`, phase 2).
+//!
+//! Pure helpers the services use: the write router (documents go to the
+//! partition their primary key hashes to), the read merge (per-shard
+//! responses folded into one), and the primary-key field lookup from a
+//! schema. Nothing here talks to the network.
+
+use std::collections::BTreeMap;
+
+use tonic::Status;
+
+use crate::proto::hermes::{
+    BatchIndexDocumentsResponse, DocumentError, FieldValue, GetIndexInfoResponse,
+    IndexingBufferStats, MemoryStats, NamedDocument, Query, SearchHit, SearchResponse,
+    SearchTimings, SegmentReaderStats, TermDocFreq, TextFieldStats, TextStats, VectorFieldStats,
+    field_value, query,
+};
+
+/// FNV-1a 64 of the primary key bytes: the pinned partition hash. Changing
+/// it moves every document, so it is part of the on-disk contract.
+pub fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+    }
+    hash
+}
+
+/// Partition (0-based) of a primary key among `partitions`.
+pub fn partition_of(primary_key: &[u8], partitions: usize) -> usize {
+    debug_assert!(partitions > 0);
+    (fnv1a64(primary_key) % partitions as u64) as usize
+}
+
+/// Name of the field declared `primary` in a schema SDL, e.g.
+/// `field id: text<raw_ci> [indexed, stored, fast, primary]`.
+pub fn primary_key_field(schema_sdl: &str) -> Option<String> {
+    for line in schema_sdl.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("field ") else {
+            continue;
+        };
+        let Some((name, decl)) = rest.split_once(':') else {
+            continue;
+        };
+        let Some(open) = decl.find('[') else {
+            continue;
+        };
+        let attrs = decl[open + 1..].trim_end_matches(']');
+        if attrs.split(',').any(|attr| {
+            attr.trim()
+                .split('<')
+                .next()
+                .is_some_and(|a| a.trim() == "primary")
+        }) {
+            return Some(name.trim().to_string());
+        }
+    }
+    None
+}
+
+/// Bytes hashed for a primary key value (numbers as their decimal text, so
+/// the same key written as text or number lands on the same partition).
+fn key_bytes(value: &FieldValue) -> Option<Vec<u8>> {
+    match value.value.as_ref()? {
+        field_value::Value::Text(text) => Some(text.as_bytes().to_vec()),
+        field_value::Value::U64(n) => Some(n.to_string().into_bytes()),
+        field_value::Value::I64(n) => Some(n.to_string().into_bytes()),
+        field_value::Value::F64(n) => Some(n.to_string().into_bytes()),
+        field_value::Value::BytesValue(bytes) => Some(bytes.clone()),
+        field_value::Value::JsonValue(text) => Some(text.as_bytes().to_vec()),
+        _ => None,
+    }
+}
+
+/// Documents grouped by partition, remembering each document's position in
+/// the request so per-partition error indexes map back to it.
+pub struct RoutedBatch {
+    /// Per partition: (original positions, documents).
+    pub groups: Vec<(Vec<usize>, Vec<NamedDocument>)>,
+    /// Documents that could not be routed, as errors at their positions.
+    pub unroutable: Vec<DocumentError>,
+}
+
+/// Split a batch by the primary key hash.
+pub fn route_documents(
+    documents: Vec<NamedDocument>,
+    primary_key: &str,
+    partitions: usize,
+) -> RoutedBatch {
+    let mut groups: Vec<(Vec<usize>, Vec<NamedDocument>)> =
+        (0..partitions).map(|_| (Vec::new(), Vec::new())).collect();
+    let mut unroutable = Vec::new();
+    for (position, document) in documents.into_iter().enumerate() {
+        let key = document
+            .fields
+            .iter()
+            .find(|entry| entry.name == primary_key)
+            .and_then(|entry| entry.value.as_ref())
+            .and_then(key_bytes);
+        match key {
+            Some(key) if !key.is_empty() => {
+                let partition = partition_of(&key, partitions);
+                groups[partition].0.push(position);
+                groups[partition].1.push(document);
+            }
+            _ => unroutable.push(DocumentError {
+                index: position as u32,
+                error: format!(
+                    "document has no '{primary_key}' primary key value; a partitioned index cannot route it"
+                ),
+            }),
+        }
+    }
+    RoutedBatch { groups, unroutable }
+}
+
+/// Whether a query scores any text term (BM25), i.e. needs corpus-wide
+/// statistics shared across partitions.
+pub fn has_text_terms(query: &Query) -> bool {
+    match &query.query {
+        Some(query::Query::Term(_))
+        | Some(query::Query::Match(_))
+        | Some(query::Query::Phrase(_)) => true,
+        Some(query::Query::Boolean(b)) => b
+            .must
+            .iter()
+            .chain(&b.should)
+            .chain(&b.must_not)
+            .any(has_text_terms),
+        Some(query::Query::Boost(b)) => b.query.as_deref().is_some_and(has_text_terms),
+        Some(query::Query::Fusion(f)) => f
+            .queries
+            .iter()
+            .any(|w| w.query.as_ref().is_some_and(has_text_terms)),
+        _ => false,
+    }
+}
+
+/// Fold per-partition batch responses (with their original positions) into
+/// one, error indexes mapped back to request positions.
+pub fn merge_batch_responses(
+    responses: Vec<(Vec<usize>, BatchIndexDocumentsResponse)>,
+    unroutable: Vec<DocumentError>,
+) -> BatchIndexDocumentsResponse {
+    let mut merged = BatchIndexDocumentsResponse {
+        indexed_count: 0,
+        error_count: unroutable.len() as u32,
+        errors: unroutable,
+    };
+    for (positions, response) in responses {
+        merged.indexed_count = merged.indexed_count.saturating_add(response.indexed_count);
+        merged.error_count = merged.error_count.saturating_add(response.error_count);
+        for error in response.errors {
+            let index = positions
+                .get(error.index as usize)
+                .map(|p| *p as u32)
+                .unwrap_or(error.index);
+            merged.errors.push(DocumentError {
+                index,
+                error: error.error,
+            });
+        }
+    }
+    merged.errors.sort_by_key(|e| e.index);
+    merged
+}
+
+/// Merge per-partition search responses for `offset`/`limit`: hits by score
+/// descending (ties by address), `total_hits` summed, timings at their
+/// maximum, `truncated` if any partition truncated. Every partition scored
+/// with the same global statistics, so scores are comparable; rank-fused
+/// (RRF) scores are functions of shard-local ranks and merge the same way.
+pub fn merge_search_responses(
+    responses: Vec<SearchResponse>,
+    offset: usize,
+    limit: usize,
+) -> SearchResponse {
+    let mut hits: Vec<SearchHit> = Vec::new();
+    let mut total_hits: u64 = 0;
+    let mut took_ms: u64 = 0;
+    let mut timings: Option<SearchTimings> = None;
+    let mut truncated = false;
+    for response in responses {
+        total_hits = total_hits.saturating_add(response.total_hits);
+        took_ms = took_ms.max(response.took_ms);
+        truncated |= response.truncated;
+        if let Some(t) = response.timings {
+            let merged = timings.get_or_insert_with(SearchTimings::default);
+            merged.search_us = merged.search_us.max(t.search_us);
+            merged.rerank_us = merged.rerank_us.max(t.rerank_us);
+            merged.load_us = merged.load_us.max(t.load_us);
+            merged.total_us = merged.total_us.max(t.total_us);
+        }
+        hits.extend(response.hits);
+    }
+    hits.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| address_key(a).cmp(&address_key(b)))
+    });
+    let hits: Vec<SearchHit> = hits.into_iter().skip(offset).take(limit).collect();
+    SearchResponse {
+        hits,
+        total_hits,
+        took_ms,
+        timings,
+        truncated,
+    }
+}
+
+fn address_key(hit: &SearchHit) -> (String, u32) {
+    hit.address
+        .as_ref()
+        .map(|a| (a.segment_id.clone(), a.doc_id))
+        .unwrap_or_default()
+}
+
+/// Sum per-partition text statistics: document and corpus counts add up,
+/// average lengths are weighted by corpus size, term frequencies add up.
+pub fn merge_text_stats(parts: Vec<TextStats>) -> TextStats {
+    let mut total_docs: u64 = 0;
+    // field → (num_docs, sum of field lengths, term → doc freq)
+    type FieldAcc = (u64, f64, BTreeMap<Vec<u8>, u64>);
+    let mut fields: BTreeMap<String, FieldAcc> = BTreeMap::new();
+    for part in parts {
+        total_docs = total_docs.saturating_add(part.total_docs);
+        for field in part.fields {
+            let entry = fields.entry(field.field).or_default();
+            entry.0 = entry.0.saturating_add(field.corpus_size);
+            entry.1 += f64::from(field.avg_len) * field.corpus_size as f64;
+            for term in field.terms {
+                let df = entry.2.entry(term.term).or_insert(0);
+                *df = df.saturating_add(term.doc_freq);
+            }
+        }
+    }
+    TextStats {
+        total_docs,
+        fields: fields
+            .into_iter()
+            .map(
+                |(field, (corpus_size, weighted_len, terms))| TextFieldStats {
+                    field,
+                    corpus_size,
+                    avg_len: if corpus_size > 0 {
+                        (weighted_len / corpus_size as f64) as f32
+                    } else {
+                        0.0
+                    },
+                    terms: terms
+                        .into_iter()
+                        .map(|(term, doc_freq)| TermDocFreq { term, doc_freq })
+                        .collect(),
+                },
+            )
+            .collect(),
+    }
+}
+
+/// Aggregate per-partition index info: counts and byte sizes add up, the
+/// schema and text-field facts come from the first partition (every
+/// partition was created from the same schema).
+pub fn merge_index_info(parts: Vec<GetIndexInfoResponse>) -> GetIndexInfoResponse {
+    let mut iter = parts.into_iter();
+    let Some(mut merged) = iter.next() else {
+        return GetIndexInfoResponse::default();
+    };
+    let mut vectors: BTreeMap<String, VectorFieldStats> = merged
+        .vector_stats
+        .drain(..)
+        .map(|v| (v.field_name.clone(), v))
+        .collect();
+    for part in iter {
+        merged.num_docs = merged.num_docs.saturating_add(part.num_docs);
+        merged.num_segments = merged.num_segments.saturating_add(part.num_segments);
+        merged.memory_stats = match (merged.memory_stats.take(), part.memory_stats) {
+            (Some(a), Some(b)) => Some(add_memory_stats(a, b)),
+            (a, b) => a.or(b),
+        };
+        for v in part.vector_stats {
+            match vectors.get_mut(&v.field_name) {
+                Some(existing) => {
+                    let total = existing.total_vectors.saturating_add(v.total_vectors);
+                    if total > 0 {
+                        existing.avg_terms_per_vector = ((f64::from(existing.avg_terms_per_vector)
+                            * existing.total_vectors as f64
+                            + f64::from(v.avg_terms_per_vector) * v.total_vectors as f64)
+                            / total as f64)
+                            as f32;
+                    }
+                    existing.total_vectors = total;
+                }
+                None => {
+                    vectors.insert(v.field_name.clone(), v);
+                }
+            }
+        }
+    }
+    merged.vector_stats = vectors.into_values().collect();
+    merged
+}
+
+fn add_memory_stats(a: MemoryStats, b: MemoryStats) -> MemoryStats {
+    MemoryStats {
+        total_bytes: a.total_bytes.saturating_add(b.total_bytes),
+        indexing_buffer: match (a.indexing_buffer, b.indexing_buffer) {
+            (Some(x), Some(y)) => Some(IndexingBufferStats {
+                total_bytes: x.total_bytes.saturating_add(y.total_bytes),
+                postings_bytes: x.postings_bytes.saturating_add(y.postings_bytes),
+                sparse_vectors_bytes: x
+                    .sparse_vectors_bytes
+                    .saturating_add(y.sparse_vectors_bytes),
+                dense_vectors_bytes: x.dense_vectors_bytes.saturating_add(y.dense_vectors_bytes),
+                interner_bytes: x.interner_bytes.saturating_add(y.interner_bytes),
+                position_index_bytes: x
+                    .position_index_bytes
+                    .saturating_add(y.position_index_bytes),
+                pending_docs: x.pending_docs.saturating_add(y.pending_docs),
+                unique_terms: x.unique_terms.saturating_add(y.unique_terms),
+            }),
+            (x, y) => x.or(y),
+        },
+        segment_reader: match (a.segment_reader, b.segment_reader) {
+            (Some(x), Some(y)) => Some(SegmentReaderStats {
+                total_bytes: x.total_bytes.saturating_add(y.total_bytes),
+                term_dict_cache_bytes: x
+                    .term_dict_cache_bytes
+                    .saturating_add(y.term_dict_cache_bytes),
+                store_cache_bytes: x.store_cache_bytes.saturating_add(y.store_cache_bytes),
+                sparse_index_bytes: x.sparse_index_bytes.saturating_add(y.sparse_index_bytes),
+                dense_index_bytes: x.dense_index_bytes.saturating_add(y.dense_index_bytes),
+                num_segments_loaded: x.num_segments_loaded.saturating_add(y.num_segments_loaded),
+            }),
+            (x, y) => x.or(y),
+        },
+    }
+}
+
+/// A partition's failure fails the whole request: a silently partial
+/// answer over a partitioned index is a wrong answer.
+pub fn partition_failure(index_name: &str, shard: &str, status: Status) -> Status {
+    Status::new(
+        status.code(),
+        format!(
+            "index '{index_name}' partition on shard '{shard}': {}",
+            status.message()
+        ),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::hermes::{DocAddress, FieldEntry};
+
+    fn doc(id: &str) -> NamedDocument {
+        NamedDocument {
+            fields: vec![FieldEntry {
+                name: "id".to_string(),
+                value: Some(FieldValue {
+                    value: Some(field_value::Value::Text(id.to_string())),
+                }),
+            }],
+        }
+    }
+
+    #[test]
+    fn hash_is_pinned_and_keys_route_deterministically() {
+        // FNV-1a 64 reference values.
+        assert_eq!(fnv1a64(b""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(fnv1a64(b"a"), 0xaf63_dc4c_8601_ec8c);
+        assert_eq!(fnv1a64(b"foobar"), 0x85944171f73967e8);
+        let a = partition_of(b"doc-1", 3);
+        assert_eq!(partition_of(b"doc-1", 3), a);
+        // Numbers route like their decimal text.
+        let text = key_bytes(&FieldValue {
+            value: Some(field_value::Value::Text("42".to_string())),
+        });
+        let number = key_bytes(&FieldValue {
+            value: Some(field_value::Value::U64(42)),
+        });
+        assert_eq!(text, number);
+    }
+
+    #[test]
+    fn primary_key_comes_from_the_schema() {
+        let sdl = "index documents {\n    field id: text<raw_ci> [indexed, stored, fast, primary]\n    field uris: text<raw_ci> [indexed, stored<multi>]\n}";
+        assert_eq!(primary_key_field(sdl).as_deref(), Some("id"));
+        assert_eq!(
+            primary_key_field("index x {\n field a: text<raw> [indexed]\n}"),
+            None
+        );
+    }
+
+    #[test]
+    fn documents_are_routed_by_key_and_errors_map_back() {
+        let docs: Vec<NamedDocument> = (0..30).map(|i| doc(&format!("doc-{i}"))).collect();
+        let mut unkeyed = NamedDocument::default();
+        unkeyed.fields.push(FieldEntry {
+            name: "title".to_string(),
+            value: None,
+        });
+        let mut all = docs;
+        all.push(unkeyed);
+        let routed = route_documents(all, "id", 3);
+        assert_eq!(routed.groups.len(), 3);
+        let routed_count: usize = routed.groups.iter().map(|(_, d)| d.len()).sum();
+        assert_eq!(routed_count, 30);
+        assert!(
+            routed.groups.iter().all(|(_, d)| !d.is_empty()),
+            "every partition gets some"
+        );
+        assert_eq!(routed.unroutable.len(), 1);
+        assert_eq!(routed.unroutable[0].index, 30);
+        // The same key always lands on the same partition.
+        let again = route_documents(vec![doc("doc-7")], "id", 3);
+        let first = routed
+            .groups
+            .iter()
+            .position(|(positions, _)| positions.contains(&7))
+            .unwrap();
+        assert!(!again.groups[first].1.is_empty());
+
+        // A partition error at its local position maps to the request position.
+        let (positions, _) = &routed.groups[first];
+        let local = positions.iter().position(|p| *p == 7).unwrap();
+        let merged = merge_batch_responses(
+            vec![(
+                positions.clone(),
+                BatchIndexDocumentsResponse {
+                    indexed_count: positions.len() as u32 - 1,
+                    error_count: 1,
+                    errors: vec![DocumentError {
+                        index: local as u32,
+                        error: "boom".to_string(),
+                    }],
+                },
+            )],
+            routed.unroutable,
+        );
+        assert_eq!(merged.error_count, 2);
+        assert_eq!(merged.errors[0].index, 7);
+        assert_eq!(merged.errors[1].index, 30);
+    }
+
+    fn hit(segment: &str, doc_id: u32, score: f32) -> SearchHit {
+        SearchHit {
+            address: Some(DocAddress {
+                segment_id: segment.to_string(),
+                doc_id,
+            }),
+            score,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn search_responses_merge_by_score_with_offset_and_limit() {
+        let a = SearchResponse {
+            hits: vec![hit("a", 1, 0.9), hit("a", 2, 0.5), hit("a", 3, 0.1)],
+            total_hits: 3,
+            took_ms: 5,
+            timings: Some(SearchTimings {
+                search_us: 100,
+                ..Default::default()
+            }),
+            truncated: false,
+        };
+        let b = SearchResponse {
+            hits: vec![hit("b", 1, 0.7), hit("b", 2, 0.5)],
+            total_hits: 2,
+            took_ms: 9,
+            timings: Some(SearchTimings {
+                search_us: 300,
+                ..Default::default()
+            }),
+            truncated: true,
+        };
+        let merged = merge_search_responses(vec![a, b], 1, 3);
+        let order: Vec<(String, u32)> = merged.hits.iter().map(address_key).collect();
+        // 0.9(a1) skipped by offset; then 0.7(b1), 0.5(a2 before b2 by address), 0.5(b2)
+        assert_eq!(
+            order,
+            vec![
+                ("b".to_string(), 1),
+                ("a".to_string(), 2),
+                ("b".to_string(), 2)
+            ]
+        );
+        assert_eq!(merged.total_hits, 5);
+        assert_eq!(merged.took_ms, 9);
+        assert_eq!(merged.timings.unwrap().search_us, 300);
+        assert!(merged.truncated);
+    }
+
+    #[test]
+    fn text_stats_and_index_info_add_up() {
+        let stats = |docs: u64, corpus: u64, avg: f32, df: u64| TextStats {
+            total_docs: docs,
+            fields: vec![TextFieldStats {
+                field: "content".to_string(),
+                corpus_size: corpus,
+                avg_len: avg,
+                terms: vec![TermDocFreq {
+                    term: b"cell".to_vec(),
+                    doc_freq: df,
+                }],
+            }],
+        };
+        let merged = merge_text_stats(vec![stats(10, 100, 10.0, 3), stats(30, 300, 20.0, 5)]);
+        assert_eq!(merged.total_docs, 40);
+        assert_eq!(merged.fields[0].corpus_size, 400);
+        assert!((merged.fields[0].avg_len - 17.5).abs() < 1e-5);
+        assert_eq!(merged.fields[0].terms[0].doc_freq, 8);
+
+        let info = |docs: u32, segments: u32| GetIndexInfoResponse {
+            index_name: "documents".to_string(),
+            num_docs: docs,
+            num_segments: segments,
+            schema: "index documents {}".to_string(),
+            memory_stats: Some(MemoryStats {
+                total_bytes: 10,
+                indexing_buffer: None,
+                segment_reader: None,
+            }),
+            vector_stats: vec![VectorFieldStats {
+                field_name: "v".to_string(),
+                vector_type: "sparse".to_string(),
+                total_vectors: docs as u64,
+                dimension: 0,
+                avg_terms_per_vector: 2.0,
+            }],
+            text_fields: vec![],
+        };
+        let merged = merge_index_info(vec![info(5, 2), info(7, 3)]);
+        assert_eq!(merged.num_docs, 12);
+        assert_eq!(merged.num_segments, 5);
+        assert_eq!(merged.memory_stats.unwrap().total_bytes, 20);
+        assert_eq!(merged.vector_stats[0].total_vectors, 12);
+    }
+}

--- a/hermes-broker/src/placement.rs
+++ b/hermes-broker/src/placement.rs
@@ -11,7 +11,10 @@ use crate::topology::ShardId;
 #[derive(Debug, Clone)]
 pub struct PlacementRule {
     pub pattern: String,
-    pub shard: ShardId,
+    /// One shard pins the index to it; several shards partition the index
+    /// across them, in this (immutable) order: writes hash the primary key
+    /// to a position in this list, reads fan out to all of them.
+    pub shards: Vec<ShardId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -35,27 +38,47 @@ impl PlacementRules {
     }
 
     /// First rule whose glob matches the index name.
-    pub fn shard_for(&self, index_name: &str) -> Option<&ShardId> {
+    /// Shards of the first matching rule.
+    pub fn shards_for(&self, index_name: &str) -> Option<&[ShardId]> {
         self.rules
             .iter()
             .find(|r| glob_match(&r.pattern, index_name))
-            .map(|r| &r.shard)
+            .map(|r| r.shards.as_slice())
+    }
+
+    /// First shard of the first matching rule (the whole placement for an
+    /// unpartitioned index).
+    pub fn shard_for(&self, index_name: &str) -> Option<&ShardId> {
+        self.shards_for(index_name)
+            .and_then(|shards| shards.first())
     }
 }
 
 /// Parse one `--placement "pattern=shard"` argument. The shard id follows the
 /// last `=` so patterns themselves may not contain `=` (index names cannot
 /// either, per hermes-server's index-name validation).
+/// `pattern=shard` or `pattern=shardA,shardB,...` (partitions in order).
 pub fn parse_placement(s: &str) -> anyhow::Result<PlacementRule> {
-    let (pattern, shard) = s
-        .rsplit_once('=')
-        .ok_or_else(|| anyhow::anyhow!("invalid --placement '{s}': expected 'pattern=shard'"))?;
-    if pattern.is_empty() || shard.is_empty() {
+    let (pattern, shards) = s.rsplit_once('=').ok_or_else(|| {
+        anyhow::anyhow!("invalid --placement '{s}': expected 'pattern=shard[,shard...]'")
+    })?;
+    if pattern.is_empty() || shards.is_empty() {
         anyhow::bail!("invalid --placement '{s}': empty pattern or shard");
+    }
+    let mut parsed: Vec<ShardId> = Vec::new();
+    for shard in shards.split(',') {
+        let shard = shard.trim();
+        if shard.is_empty() {
+            anyhow::bail!("invalid --placement '{s}': empty shard id");
+        }
+        if parsed.iter().any(|p| p.0 == shard) {
+            anyhow::bail!("invalid --placement '{s}': shard '{shard}' listed twice");
+        }
+        parsed.push(ShardId(shard.to_string()));
     }
     Ok(PlacementRule {
         pattern: pattern.to_string(),
-        shard: ShardId(shard.to_string()),
+        shards: parsed,
     })
 }
 
@@ -126,6 +149,20 @@ mod tests {
         assert!(parse_placement("documents*=").is_err());
         let rule = parse_placement("social*=fin2").unwrap();
         assert_eq!(rule.pattern, "social*");
-        assert_eq!(rule.shard.0, "fin2");
+        assert_eq!(rule.shards.len(), 1);
+        assert_eq!(rule.shards[0].0, "fin2");
+    }
+
+    #[test]
+    fn placement_parses_partition_lists() {
+        let rule = parse_placement("documents_2026*=2, 3,4").unwrap();
+        let shards: Vec<&str> = rule.shards.iter().map(|s| s.0.as_str()).collect();
+        assert_eq!(shards, vec!["2", "3", "4"]);
+        assert!(parse_placement("documents*=2,,3").is_err());
+        assert!(parse_placement("documents*=2,2").is_err());
+        let rules = PlacementRules::new(vec![rule], PlacementDefault::Single);
+        assert_eq!(rules.shards_for("documents_20260905").unwrap().len(), 3);
+        assert_eq!(rules.shard_for("documents_20260905").unwrap().0, "2");
+        assert!(rules.shards_for("social").is_none());
     }
 }

--- a/hermes-broker/src/routes.rs
+++ b/hermes-broker/src/routes.rs
@@ -1,0 +1,179 @@
+//! Route resolution shared by the search and index services: one backend
+//! for an unpartitioned index, one backend per partition for a partitioned
+//! one, plus the per-index primary-key field a partitioned write hashes.
+
+use std::time::Instant;
+
+use tonic::{Request, Status};
+
+use crate::client::BackendChannels;
+use crate::context::{BrokerContext, code_label};
+use crate::metrics as m;
+use crate::partition;
+use crate::proto::hermes::GetIndexInfoRequest;
+
+/// One backend a request goes to.
+#[derive(Clone)]
+pub struct Target {
+    pub shard: String,
+    pub backend_id: String,
+    pub channels: BackendChannels,
+}
+
+/// Where a request for an index goes.
+pub enum Route {
+    Single(Box<Target>),
+    /// One target per partition, in placement-rule order.
+    Partitioned(Vec<Target>),
+}
+
+impl Route {
+    pub fn targets(&self) -> &[Target] {
+        match self {
+            Route::Single(target) => std::slice::from_ref(target.as_ref()),
+            Route::Partitioned(targets) => targets,
+        }
+    }
+
+    pub fn is_partitioned(&self) -> bool {
+        matches!(self, Route::Partitioned(_))
+    }
+}
+
+pub fn record_backend(backend: &str, rpc: &'static str, started: Instant, code: tonic::Code) {
+    metrics::histogram!(
+        m::BACKEND_DURATION,
+        "backend" => backend.to_string(),
+        "rpc" => rpc,
+    )
+    .record(started.elapsed().as_secs_f64());
+    metrics::counter!(
+        m::BACKEND_REQUESTS,
+        "backend" => backend.to_string(),
+        "rpc" => rpc,
+        "code" => code_label(code),
+    )
+    .increment(1);
+}
+
+impl BrokerContext {
+    /// Backend(s) serving a read for `index_name`.
+    pub fn read_route(&self, index_name: &str) -> Result<Route, Status> {
+        let snapshot = self.snapshot.load();
+        if let Some(partitions) = snapshot.partitions(index_name)? {
+            let mut targets = Vec::with_capacity(partitions.len());
+            for shard in partitions {
+                let selection =
+                    snapshot.select_read_backend_on(index_name, shard, self.next_rotation())?;
+                if selection.stale {
+                    metrics::counter!(
+                        m::STALE_TOPOLOGY_SERVES,
+                        "backend" => selection.backend.endpoint.id.0.clone()
+                    )
+                    .increment(1);
+                }
+                targets.push(Target {
+                    shard: shard.0.clone(),
+                    backend_id: selection.backend.endpoint.id.0.clone(),
+                    channels: self.pool.get(&selection.backend.endpoint.addr)?,
+                });
+            }
+            return Ok(Route::Partitioned(targets));
+        }
+        let selection = snapshot.select_read_backend(index_name, self.next_rotation())?;
+        if selection.ambiguous {
+            metrics::counter!(m::AMBIGUOUS_INDEX, "index" => index_name.to_string()).increment(1);
+        }
+        if selection.stale {
+            metrics::counter!(
+                m::STALE_TOPOLOGY_SERVES,
+                "backend" => selection.backend.endpoint.id.0.clone()
+            )
+            .increment(1);
+        }
+        Ok(Route::Single(Box::new(Target {
+            shard: selection.backend.endpoint.shard.0.clone(),
+            backend_id: selection.backend.endpoint.id.0.clone(),
+            channels: self.pool.get(&selection.backend.endpoint.addr)?,
+        })))
+    }
+
+    /// Master(s) a write for `index_name` goes to.
+    pub fn write_route(&self, index_name: &str) -> Result<Route, Status> {
+        let snapshot = self.snapshot.load();
+        let reject = |status: Status| {
+            metrics::counter!(
+                m::WRITE_REJECTED,
+                "index" => index_name.to_string(),
+                "reason" => code_label(status.code()),
+            )
+            .increment(1);
+            status
+        };
+        if let Some(partitions) = snapshot.partitions(index_name).map_err(reject)? {
+            let mut targets = Vec::with_capacity(partitions.len());
+            for shard in partitions {
+                let master = snapshot
+                    .select_write_backend_on(index_name, shard)
+                    .map_err(reject)?;
+                targets.push(Target {
+                    shard: shard.0.clone(),
+                    backend_id: master.endpoint.id.0.clone(),
+                    channels: self.pool.get(&master.endpoint.addr)?,
+                });
+            }
+            return Ok(Route::Partitioned(targets));
+        }
+        let master = snapshot.select_write_backend(index_name).map_err(reject)?;
+        Ok(Route::Single(Box::new(Target {
+            shard: master.endpoint.shard.0.clone(),
+            backend_id: master.endpoint.id.0.clone(),
+            channels: self.pool.get(&master.endpoint.addr)?,
+        })))
+    }
+
+    /// The field a partitioned index hashes documents by, read once from
+    /// the schema of one partition and cached.
+    pub async fn primary_key_field(
+        &self,
+        index_name: &str,
+        target: &Target,
+    ) -> Result<String, Status> {
+        if let Some(field) = self.primary_keys.read().get(index_name) {
+            return Ok(field.clone());
+        }
+        let started = Instant::now();
+        let result = target
+            .channels
+            .search
+            .clone()
+            .get_index_info(Request::new(GetIndexInfoRequest {
+                index_name: index_name.to_string(),
+            }))
+            .await;
+        let code = result
+            .as_ref()
+            .map(|_| tonic::Code::Ok)
+            .unwrap_or_else(|s| s.code());
+        record_backend(&target.backend_id, "get_index_info", started, code);
+        let info = result?.into_inner();
+        let field = partition::primary_key_field(&info.schema).ok_or_else(|| {
+            Status::failed_precondition(format!(
+                "index '{index_name}' is partitioned but its schema declares no primary key field"
+            ))
+        })?;
+        self.primary_keys
+            .write()
+            .insert(index_name.to_string(), field.clone());
+        Ok(field)
+    }
+
+    /// Cached primary-key field, if a write has resolved it.
+    pub fn primary_key_cached(&self, index_name: &str) -> Option<String> {
+        self.primary_keys.read().get(index_name).cloned()
+    }
+
+    pub fn forget_index(&self, index_name: &str) {
+        self.primary_keys.write().remove(index_name);
+    }
+}

--- a/hermes-broker/src/search_service.rs
+++ b/hermes-broker/src/search_service.rs
@@ -1,7 +1,12 @@
-//! SearchService pass-through: exact index → its backend, request and
-//! response forwarded verbatim. The broker adds only admission (never more
-//! in-flight searches per backend than the backend itself would admit),
-//! deadline propagation, and routing metrics.
+//! SearchService routing: reads go to a routable replica of the shard
+//! hosting the index and are forwarded verbatim.
+//!
+//! A partitioned index fans reads out: `Search` first collects the text
+//! statistics of the query's terms from every partition and sends the sum
+//! back with each partition's request (so BM25 scores are comparable across
+//! partitions), then merges the per-partition windows by score
+//! (`partition::merge_search_responses`). `GetDocument` asks every
+//! partition, `GetIndexInfo` and `GetTextStats` aggregate.
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -11,53 +16,148 @@ use tonic::{Request, Response, Status};
 use crate::client::{capacity_exhausted, forward_timeout};
 use crate::context::{BrokerContext, code_label};
 use crate::metrics as m;
+use crate::partition;
 use crate::proto::hermes::search_service_server::SearchService;
 use crate::proto::hermes::{
     GetDocumentRequest, GetDocumentResponse, GetIndexInfoRequest, GetIndexInfoResponse,
     GetTextStatsRequest, GetTextStatsResponse, SearchRequest, SearchResponse,
 };
+use crate::routes::{Route, Target, record_backend};
+
+/// hermes-server refuses result windows above this; a partitioned search
+/// widens every partition's window to `offset + limit`, which must fit.
+const MAX_PARTITION_WINDOW: u32 = 10_000;
 
 pub struct BrokerSearchService {
     pub ctx: Arc<BrokerContext>,
 }
 
-impl BrokerSearchService {
-    /// Resolve the read backend for an index, recording routing metrics.
-    fn read_route(
-        &self,
-        index_name: &str,
-    ) -> Result<(crate::client::BackendChannels, String), Status> {
-        let snapshot = self.ctx.snapshot.load();
-        let selection = snapshot.select_read_backend(index_name, self.ctx.next_rotation())?;
-        if selection.ambiguous {
-            metrics::counter!(m::AMBIGUOUS_INDEX, "index" => index_name.to_string()).increment(1);
+/// One unary read RPC sent whole to every target of the route; all must
+/// succeed (a partitioned read with a missing partition is a wrong answer).
+macro_rules! forward_read {
+    ($self:ident, $req:expr, $timeout:expr, $route:expr, $method:ident, $rpc_name:literal) => {{
+        let req = $req;
+        let index_name = req.index_name.clone();
+        let route: &Route = $route;
+        let calls = route.targets().iter().map(|target| {
+            let mut outbound = Request::new(req.clone());
+            if let Some(t) = $timeout {
+                outbound.set_timeout(t);
+            }
+            let mut client = target.channels.search.clone();
+            let target: Target = target.clone();
+            async move {
+                let started = Instant::now();
+                let result = client.$method(outbound).await;
+                (target, started, result)
+            }
+        });
+        let mut responses = Vec::with_capacity(route.targets().len());
+        for (target, started, result) in futures::future::join_all(calls).await {
+            let code = result
+                .as_ref()
+                .map(|_| tonic::Code::Ok)
+                .unwrap_or_else(|s| s.code());
+            record_backend(&target.backend_id, $rpc_name, started, code);
+            match result {
+                Ok(response) => responses.push(response.into_inner()),
+                Err(status) if route.is_partitioned() => {
+                    return Err(partition::partition_failure(
+                        &index_name,
+                        &target.shard,
+                        status,
+                    ));
+                }
+                Err(status) => return Err(status),
+            }
         }
-        if selection.stale {
-            metrics::counter!(
-                m::STALE_TOPOLOGY_SERVES,
-                "backend" => selection.backend.endpoint.id.0.clone()
-            )
-            .increment(1);
-        }
-        let channels = self.ctx.pool.get(&selection.backend.endpoint.addr)?;
-        Ok((channels, selection.backend.endpoint.id.0.clone()))
-    }
+        Ok::<_, Status>(responses)
+    }};
 }
 
-fn record_backend(backend: &str, rpc: &'static str, started: Instant, code: tonic::Code) {
-    metrics::histogram!(
-        m::BACKEND_DURATION,
-        "backend" => backend.to_string(),
-        "rpc" => rpc,
-    )
-    .record(started.elapsed().as_secs_f64());
-    metrics::counter!(
-        m::BACKEND_REQUESTS,
-        "backend" => backend.to_string(),
-        "rpc" => rpc,
-        "code" => code_label(code),
-    )
-    .increment(1);
+impl BrokerSearchService {
+    /// Admission for one search on every target of the route: try_acquire
+    /// (never queue), so overload is reported immediately with the same
+    /// message hermes-server uses.
+    fn admit(
+        &self,
+        index_name: &str,
+        route: &Route,
+    ) -> Result<Vec<tokio::sync::OwnedSemaphorePermit>, Status> {
+        let mut permits = Vec::with_capacity(route.targets().len() + 1);
+        if let Some(global) = &self.ctx.global_search_permits {
+            permits.push(global.clone().try_acquire_owned().map_err(|_| {
+                metrics::counter!(
+                    m::ADMISSION_REJECTED,
+                    "index" => index_name.to_string(), "scope" => "global"
+                )
+                .increment(1);
+                capacity_exhausted()
+            })?);
+        }
+        for target in route.targets() {
+            permits.push(
+                target
+                    .channels
+                    .search_permits
+                    .clone()
+                    .try_acquire_owned()
+                    .map_err(|_| {
+                        metrics::counter!(
+                            m::ADMISSION_REJECTED,
+                            "index" => index_name.to_string(), "scope" => "backend"
+                        )
+                        .increment(1);
+                        capacity_exhausted()
+                    })?,
+            );
+        }
+        Ok(permits)
+    }
+
+    async fn search_partitioned(
+        &self,
+        mut req: SearchRequest,
+        timeout: Option<std::time::Duration>,
+        route: &Route,
+    ) -> Result<SearchResponse, Status> {
+        let offset = req.offset;
+        let limit = req.limit;
+        let window = offset.saturating_add(limit);
+        if window > MAX_PARTITION_WINDOW {
+            return Err(Status::invalid_argument(format!(
+                "offset + limit = {window} exceeds the {MAX_PARTITION_WINDOW} window a partitioned index can merge"
+            )));
+        }
+        // Shared BM25 statistics: every partition scores with the sum.
+        if req.text_stats.is_none()
+            && let Some(query) = req.query.clone()
+            && partition::has_text_terms(&query)
+        {
+            let stats = forward_read!(
+                self,
+                GetTextStatsRequest {
+                    index_name: req.index_name.clone(),
+                    query: Some(query),
+                },
+                timeout,
+                route,
+                get_text_stats,
+                "get_text_stats"
+            )?;
+            req.text_stats = Some(partition::merge_text_stats(
+                stats.into_iter().filter_map(|s| s.stats).collect(),
+            ));
+        }
+        req.offset = 0;
+        req.limit = window;
+        let responses = forward_read!(self, req, timeout, route, search, "search")?;
+        Ok(partition::merge_search_responses(
+            responses,
+            offset as usize,
+            limit as usize,
+        ))
+    }
 }
 
 #[tonic::async_trait]
@@ -73,47 +173,25 @@ impl SearchService for BrokerSearchService {
         let started = Instant::now();
 
         let result: Result<SearchResponse, Status> = async {
-            let (channels, backend_id) = self.read_route(&req.index_name)?;
-
-            // try_acquire (never queue): overload is reported immediately with
-            // the same message hermes-server uses, so client backoff/retry
-            // logic cannot tell the broker and the backend apart.
-            let _global = match &self.ctx.global_search_permits {
-                Some(permits) => Some(permits.clone().try_acquire_owned().map_err(|_| {
-                    metrics::counter!(
-                        m::ADMISSION_REJECTED,
-                        "index" => index_name.clone(), "scope" => "global"
-                    )
-                    .increment(1);
-                    capacity_exhausted()
-                })?),
-                None => None,
-            };
-            let _backend = channels
-                .search_permits
-                .clone()
-                .try_acquire_owned()
-                .map_err(|_| {
-                    metrics::counter!(
-                        m::ADMISSION_REJECTED,
-                        "index" => index_name.clone(), "scope" => "backend"
-                    )
-                    .increment(1);
-                    capacity_exhausted()
-                })?;
-
-            let mut outbound = Request::new(req);
-            if let Some(t) = timeout {
-                outbound.set_timeout(t);
+            let route = self.ctx.read_route(&req.index_name)?;
+            let _permits = self.admit(&index_name, &route)?;
+            match &route {
+                Route::Single(target) => {
+                    let mut outbound = Request::new(req);
+                    if let Some(t) = timeout {
+                        outbound.set_timeout(t);
+                    }
+                    let call_started = Instant::now();
+                    let result = target.channels.search.clone().search(outbound).await;
+                    let code = result
+                        .as_ref()
+                        .map(|_| tonic::Code::Ok)
+                        .unwrap_or_else(|s| s.code());
+                    record_backend(&target.backend_id, "search", call_started, code);
+                    result.map(|r| r.into_inner())
+                }
+                Route::Partitioned(_) => self.search_partitioned(req, timeout, &route).await,
             }
-            let call_started = Instant::now();
-            let result = channels.search.clone().search(outbound).await;
-            let code = result
-                .as_ref()
-                .map(|_| tonic::Code::Ok)
-                .unwrap_or_else(|s| s.code());
-            record_backend(&backend_id, "search", call_started, code);
-            result.map(|r| r.into_inner())
         }
         .await;
 
@@ -142,24 +220,49 @@ impl SearchService for BrokerSearchService {
         self.ctx.check_admission()?;
         let timeout = forward_timeout(request.metadata());
         let req = request.into_inner();
-        let (channels, backend_id) = self.read_route(&req.index_name)?;
-        let mut outbound = Request::new(req);
-        if let Some(t) = timeout {
-            outbound.set_timeout(t);
+        let route = self.ctx.read_route(&req.index_name)?;
+        // A document address names a segment, which lives on exactly one
+        // partition: ask every partition, the one that has it answers.
+        let calls = route.targets().iter().map(|target| {
+            let mut outbound = Request::new(req.clone());
+            if let Some(t) = timeout {
+                outbound.set_timeout(t);
+            }
+            let mut client = target.channels.search.clone();
+            let target: Target = target.clone();
+            async move {
+                let started = Instant::now();
+                let result = client.get_document(outbound).await;
+                (target, started, result)
+            }
+        });
+        let mut not_found: Option<Status> = None;
+        let mut failure: Option<Status> = None;
+        for (target, started, result) in futures::future::join_all(calls).await {
+            let code = result
+                .as_ref()
+                .map(|_| tonic::Code::Ok)
+                .unwrap_or_else(|s| s.code());
+            record_backend(&target.backend_id, "get_document", started, code);
+            match result {
+                Ok(response) => return Ok(Response::new(response.into_inner())),
+                Err(status) if status.code() == tonic::Code::NotFound => {
+                    not_found.get_or_insert(status);
+                }
+                Err(status) => {
+                    failure.get_or_insert(if route.is_partitioned() {
+                        partition::partition_failure(&req.index_name, &target.shard, status)
+                    } else {
+                        status
+                    });
+                }
+            }
         }
-        let started = Instant::now();
-        let result = channels.search.clone().get_document(outbound).await;
-        let code = result
-            .as_ref()
-            .map(|_| tonic::Code::Ok)
-            .unwrap_or_else(|s| s.code());
-        record_backend(&backend_id, "get_document", started, code);
-        result.map(|r| Response::new(r.into_inner()))
+        Err(failure
+            .or(not_found)
+            .unwrap_or_else(|| Status::not_found("document not found")))
     }
 
-    /// One index lives on one shard today, so the statistics of that shard
-    /// are the whole; a scatter-gather broker sums this per shard and sends
-    /// the total back as `SearchRequest.text_stats`.
     async fn get_text_stats(
         &self,
         request: Request<GetTextStatsRequest>,
@@ -167,19 +270,17 @@ impl SearchService for BrokerSearchService {
         self.ctx.check_admission()?;
         let timeout = forward_timeout(request.metadata());
         let req = request.into_inner();
-        let (channels, backend_id) = self.read_route(&req.index_name)?;
-        let mut outbound = Request::new(req);
-        if let Some(t) = timeout {
-            outbound.set_timeout(t);
-        }
-        let started = Instant::now();
-        let result = channels.search.clone().get_text_stats(outbound).await;
-        let code = result
-            .as_ref()
-            .map(|_| tonic::Code::Ok)
-            .unwrap_or_else(|s| s.code());
-        record_backend(&backend_id, "get_text_stats", started, code);
-        result.map(|r| Response::new(r.into_inner()))
+        let route = self.ctx.read_route(&req.index_name)?;
+        let responses =
+            forward_read!(self, req, timeout, &route, get_text_stats, "get_text_stats")?;
+        let stats = if route.is_partitioned() {
+            Some(partition::merge_text_stats(
+                responses.into_iter().filter_map(|r| r.stats).collect(),
+            ))
+        } else {
+            responses.into_iter().next().and_then(|r| r.stats)
+        };
+        Ok(Response::new(GetTextStatsResponse { stats }))
     }
 
     async fn get_index_info(
@@ -189,18 +290,9 @@ impl SearchService for BrokerSearchService {
         self.ctx.check_admission()?;
         let timeout = forward_timeout(request.metadata());
         let req = request.into_inner();
-        let (channels, backend_id) = self.read_route(&req.index_name)?;
-        let mut outbound = Request::new(req);
-        if let Some(t) = timeout {
-            outbound.set_timeout(t);
-        }
-        let started = Instant::now();
-        let result = channels.search.clone().get_index_info(outbound).await;
-        let code = result
-            .as_ref()
-            .map(|_| tonic::Code::Ok)
-            .unwrap_or_else(|s| s.code());
-        record_backend(&backend_id, "get_index_info", started, code);
-        result.map(|r| Response::new(r.into_inner()))
+        let route = self.ctx.read_route(&req.index_name)?;
+        let responses =
+            forward_read!(self, req, timeout, &route, get_index_info, "get_index_info")?;
+        Ok(Response::new(partition::merge_index_info(responses)))
     }
 }

--- a/hermes-broker/src/topology.rs
+++ b/hermes-broker/src/topology.rs
@@ -115,25 +115,40 @@ pub struct ShardGroup {
 pub struct IndexRoute {
     /// Shard ids on which routable backends advertise this index (sorted).
     pub shards: BTreeSet<ShardId>,
-    /// Placement rule match, if any.
-    pub ruled_shard: Option<ShardId>,
+    /// Shards of the matching placement rule, in rule order: one shard pins
+    /// the index, several partition it (`partitions`). Empty = no rule.
+    pub ruled: Vec<ShardId>,
 }
 
 impl IndexRoute {
+    /// The one shard a rule pins the index to (unpartitioned routes).
+    pub fn ruled_shard(&self) -> Option<&ShardId> {
+        match self.ruled.as_slice() {
+            [only] => Some(only),
+            _ => None,
+        }
+    }
+
+    /// Partition shards, in order, when the rule lists several.
+    pub fn partitions(&self) -> Option<&[ShardId]> {
+        (self.ruled.len() > 1).then_some(self.ruled.as_slice())
+    }
+
     /// Seen on several shards with no rule pinning one — migration transient.
+    /// A partitioned index is never ambiguous: every shard of its rule is a
+    /// partition.
     pub fn ambiguous(&self) -> bool {
-        self.shards.len() > 1
-            && !self
-                .ruled_shard
-                .as_ref()
-                .is_some_and(|r| self.shards.contains(r))
+        if self.partitions().is_some() {
+            return false;
+        }
+        self.shards.len() > 1 && !self.ruled_shard().is_some_and(|r| self.shards.contains(r))
     }
 
     /// The shard a read goes to. Ambiguous routes resolve to the
     /// lexicographically-first shard so behavior stays deterministic during
     /// migrations; the bool reports the ambiguity for metrics.
     fn read_shard(&self) -> (&ShardId, bool) {
-        if let Some(ruled) = &self.ruled_shard
+        if let Some(ruled) = self.ruled_shard()
             && let Some(shard) = self.shards.get(ruled)
         {
             return (shard, false);
@@ -199,7 +214,10 @@ impl TopologySnapshot {
                     .entry(name.clone())
                     .or_insert_with(|| IndexRoute {
                         shards: BTreeSet::new(),
-                        ruled_shard: placement.shard_for(name).cloned(),
+                        ruled: placement
+                            .shards_for(name)
+                            .map(<[ShardId]>::to_vec)
+                            .unwrap_or_default(),
                     })
                     .shards
                     .insert(backend.endpoint.shard.clone());
@@ -242,6 +260,41 @@ impl TopologySnapshot {
     ) -> Result<ReadSelection<'_>, Status> {
         let route = self.route(index_name)?;
         let (shard, ambiguous) = route.read_shard();
+        let mut selection = self.select_read_backend_on(index_name, shard, rotation)?;
+        selection.ambiguous = ambiguous;
+        Ok(selection)
+    }
+
+    /// Partition shards of `index_name` when its placement rule lists
+    /// several; every partition must advertise the index (a partially
+    /// present partitioned index cannot answer correctly).
+    pub fn partitions(&self, index_name: &str) -> Result<Option<&[ShardId]>, Status> {
+        let route = self.route(index_name)?;
+        let Some(partitions) = route.partitions() else {
+            return Ok(None);
+        };
+        let missing: Vec<&str> = partitions
+            .iter()
+            .filter(|shard| !route.shards.contains(shard))
+            .map(|shard| shard.0.as_str())
+            .collect();
+        if !missing.is_empty() {
+            return Err(Status::unavailable(format!(
+                "index '{index_name}' is partitioned over {} shards but partition(s) [{}] carry no healthy copy",
+                partitions.len(),
+                missing.join(", ")
+            )));
+        }
+        Ok(Some(partitions))
+    }
+
+    /// Pick the backend serving a read for `index_name` on one shard.
+    pub fn select_read_backend_on(
+        &self,
+        index_name: &str,
+        shard: &ShardId,
+        rotation: usize,
+    ) -> Result<ReadSelection<'_>, Status> {
         let group = self.shards.get(shard).ok_or_else(|| {
             Status::internal(format!("shard '{}' vanished from snapshot", shard.0))
         })?;
@@ -259,7 +312,7 @@ impl TopologySnapshot {
             return Ok(ReadSelection {
                 backend: b,
                 stale: false,
-                ambiguous,
+                ambiguous: false,
             });
         }
         // Grace path: no healthy replica; better a possibly-stale answer from
@@ -268,13 +321,64 @@ impl TopologySnapshot {
             return Ok(ReadSelection {
                 backend: b,
                 stale: true,
-                ambiguous,
+                ambiguous: false,
             });
         }
         Err(Status::unavailable(format!(
             "index '{index_name}': no routable replica on shard '{}'",
             shard.0
         )))
+    }
+
+    /// The master of one partition shard of `index_name`.
+    pub fn select_write_backend_on(
+        &self,
+        index_name: &str,
+        shard: &ShardId,
+    ) -> Result<&Backend, Status> {
+        let master = self.shard_master(shard)?;
+        if !master.routable() {
+            return Err(Status::unavailable(format!(
+                "index '{index_name}': shard '{}' master '{}' is unavailable",
+                shard.0, master.endpoint.id.0
+            )));
+        }
+        Ok(master)
+    }
+
+    /// The masters CreateIndex lands on: one per shard of the placement
+    /// rule (several for a partitioned index), or the single shard the
+    /// placement default picks.
+    pub fn select_create_backends(
+        &self,
+        index_name: &str,
+        placement: &PlacementRules,
+    ) -> Result<Vec<&Backend>, Status> {
+        match placement.shards_for(index_name) {
+            Some(shards) if shards.len() > 1 => {
+                let mut masters = Vec::with_capacity(shards.len());
+                for shard in shards {
+                    if !self.shards.contains_key(shard) {
+                        return Err(Status::failed_precondition(format!(
+                            "placement rule for '{index_name}' partitions over shard '{}' but no backend carries that shard id",
+                            shard.0
+                        )));
+                    }
+                    let master = self.shard_master(shard)?;
+                    if !master.routable() {
+                        return Err(Status::unavailable(format!(
+                            "shard '{}' master '{}' is unavailable",
+                            shard.0, master.endpoint.id.0
+                        )));
+                    }
+                    masters.push(master);
+                }
+                Ok(masters)
+            }
+            _ => self
+                .select_create_backend(index_name, placement)
+                .map(|backend| vec![backend]),
+        }
     }
 
     /// The unique master of a shard, or why there is none. A single unlabeled
@@ -324,7 +428,7 @@ impl TopologySnapshot {
         let route = self.route(index_name)?;
         let shard = if route.shards.len() == 1 {
             route.shards.iter().next().expect("len checked")
-        } else if let Some(ruled) = &route.ruled_shard
+        } else if let Some(ruled) = route.ruled_shard()
             && route.shards.contains(ruled)
         {
             route.shards.get(ruled).expect("contains checked")

--- a/hermes-broker/tests/broker_integration.rs
+++ b/hermes-broker/tests/broker_integration.rs
@@ -381,3 +381,297 @@ async fn get_index_info_and_get_document_pass_through() {
         .await
         .unwrap();
 }
+
+/// Three partitions of `documents` on shards 2, 3 and 4 (a multi-shard
+/// placement rule): writes hash by primary key, reads fan out and merge.
+async fn partitioned_fixture() -> (Vec<MockBackend>, BrokerProc) {
+    let mocks: Vec<MockBackend> = (0..3).map(|_| MockBackend::new(&["documents"])).collect();
+    let mut specs = Vec::new();
+    for (i, mock) in mocks.iter().enumerate() {
+        mock.state.lock().schema =
+            "index documents {\n  field id: text<raw_ci> [indexed, stored, fast, primary]\n  field title: text [indexed]\n}"
+                .to_string();
+        let addr = mock.spawn().await;
+        specs.push(backend_spec(&format!("m{i}"), &addr, &(i + 2).to_string()));
+    }
+    let broker = spawn_broker(&specs, &["--placement", "documents*=2,3,4"]);
+    wait_for_indexes(&broker, &["documents"], Duration::from_secs(10)).await;
+    (mocks, broker)
+}
+
+fn text_doc(id: &str) -> NamedDocument {
+    NamedDocument {
+        fields: vec![FieldEntry {
+            name: "id".to_string(),
+            value: Some(FieldValue {
+                value: Some(field_value::Value::Text(id.to_string())),
+            }),
+        }],
+    }
+}
+
+fn scored_hit(id: &str, score: f32) -> SearchHit {
+    let mut fields = std::collections::HashMap::new();
+    fields.insert(
+        "id".to_string(),
+        FieldValueList {
+            values: vec![FieldValue {
+                value: Some(field_value::Value::Text(id.to_string())),
+            }],
+        },
+    );
+    SearchHit {
+        score,
+        fields,
+        ..Default::default()
+    }
+}
+
+fn hit_id(hit: &SearchHit) -> String {
+    match &hit.fields["id"].values[0].value {
+        Some(field_value::Value::Text(t)) => t.clone(),
+        other => panic!("unexpected id value {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn partitioned_create_and_commit_fan_out_to_every_partition() {
+    let (mocks, broker) = partitioned_fixture().await;
+    let mut index = broker_index_client(&broker).await;
+    index
+        .create_index(CreateIndexRequest {
+            index_name: "documents_20260904".to_string(),
+            schema: "index documents_20260904 {}".to_string(),
+        })
+        .await
+        .unwrap();
+    let commit = index
+        .commit(CommitRequest {
+            index_name: "documents".to_string(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(commit.success);
+    // Each mock reports 7 docs on commit.
+    assert_eq!(commit.num_docs, 21);
+    for mock in &mocks {
+        let state = mock.state.lock();
+        assert_eq!(state.creates, vec!["documents_20260904"]);
+        assert_eq!(state.commits, vec!["documents"]);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn partitioned_batches_are_hash_routed_by_primary_key() {
+    let (mocks, broker) = partitioned_fixture().await;
+    let ids: Vec<String> = (0..300).map(|i| format!("doc-{i}")).collect();
+    let documents: Vec<NamedDocument> = ids.iter().map(|id| text_doc(id)).collect();
+    let response = broker_index_client(&broker)
+        .await
+        .batch_index_documents(BatchIndexDocumentsRequest {
+            index_name: "documents".to_string(),
+            documents,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(response.indexed_count, 300);
+    assert_eq!(response.error_count, 0);
+
+    let counts: Vec<usize> = mocks
+        .iter()
+        .map(|mock| {
+            let state = mock.state.lock();
+            assert_eq!(state.batches.len(), 1, "one batch per partition");
+            state.batches[0].1
+        })
+        .collect();
+    assert_eq!(counts.iter().sum::<usize>(), 300);
+    assert!(
+        counts.iter().all(|c| *c > 50),
+        "FNV-1a should spread 300 keys across 3 partitions, got {counts:?}"
+    );
+
+    // Same keys again land on the same partitions: routing is a pure
+    // function of the key.
+    let documents: Vec<NamedDocument> = ids.iter().map(|id| text_doc(id)).collect();
+    broker_index_client(&broker)
+        .await
+        .batch_index_documents(BatchIndexDocumentsRequest {
+            index_name: "documents".to_string(),
+            documents,
+        })
+        .await
+        .unwrap();
+    for (mock, count) in mocks.iter().zip(&counts) {
+        let state = mock.state.lock();
+        assert_eq!(state.batches[1].1, *count);
+    }
+
+    // A document without the primary key is refused at the broker with its
+    // request position, and never reaches a backend.
+    let response = broker_index_client(&broker)
+        .await
+        .batch_index_documents(BatchIndexDocumentsRequest {
+            index_name: "documents".to_string(),
+            documents: vec![
+                text_doc("doc-a"),
+                NamedDocument { fields: vec![] },
+                text_doc("doc-b"),
+            ],
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(response.indexed_count, 2);
+    assert_eq!(response.error_count, 1);
+    assert_eq!(response.errors.len(), 1);
+    assert_eq!(response.errors[0].index, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn partitioned_stream_routes_each_flush_by_primary_key() {
+    let (mocks, broker) = partitioned_fixture().await;
+    let stream = tokio_stream::iter((0..100).map(|i| IndexDocumentRequest {
+        index_name: "documents".to_string(),
+        fields: text_doc(&format!("doc-{i}")).fields,
+    }));
+    let response = broker_index_client(&broker)
+        .await
+        .index_documents(stream)
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(response.indexed_count, 100);
+    let total: usize = mocks
+        .iter()
+        .map(|m| m.state.lock().batches.iter().map(|b| b.1).sum::<usize>())
+        .sum();
+    assert_eq!(total, 100);
+    assert!(mocks.iter().all(|m| !m.state.lock().batches.is_empty()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn partitioned_search_merges_by_score_with_shared_stats() {
+    let (mocks, broker) = partitioned_fixture().await;
+    let canned = [
+        vec![scored_hit("p0-a", 9.0), scored_hit("p0-b", 3.0)],
+        vec![
+            scored_hit("p1-a", 7.0),
+            scored_hit("p1-b", 6.0),
+            scored_hit("p1-c", 1.0),
+        ],
+        vec![scored_hit("p2-a", 8.0)],
+    ];
+    for (mock, hits) in mocks.iter().zip(canned) {
+        let mut state = mock.state.lock();
+        state.search_response = SearchResponse {
+            hits,
+            total_hits: 100,
+            took_ms: 5,
+            timings: None,
+            truncated: false,
+        };
+    }
+
+    let mut request = simple_search_request("documents");
+    request.query = Some(Query {
+        query: Some(query::Query::Match(MatchQuery {
+            field: "title".to_string(),
+            text: "quantum".to_string(),
+            ..Default::default()
+        })),
+    });
+    request.offset = 1;
+    request.limit = 3;
+    let response = broker_search_client(&broker)
+        .await
+        .search(request)
+        .await
+        .unwrap()
+        .into_inner();
+    let ids: Vec<String> = response.hits.iter().map(hit_id).collect();
+    // Global order: p0-a 9, p2-a 8, p1-a 7, p1-b 6, p1-c 1, p0-b 3 → offset 1, limit 3.
+    assert_eq!(ids, vec!["p2-a", "p1-a", "p1-b"]);
+    assert_eq!(response.total_hits, 300);
+
+    for mock in &mocks {
+        let state = mock.state.lock();
+        assert_eq!(state.search_requests.len(), 1);
+        let sent = &state.search_requests[0];
+        // Every partition is asked for the full window from the top.
+        assert_eq!(sent.offset, 0);
+        assert_eq!(sent.limit, 4);
+        // ...with the merged corpus statistics attached.
+        assert_eq!(sent.text_stats.as_ref().map(|s| s.total_docs), Some(126));
+    }
+
+    // A query without text terms skips the statistics round trip.
+    broker_search_client(&broker)
+        .await
+        .search(simple_search_request("documents"))
+        .await
+        .unwrap();
+    for mock in &mocks {
+        let state = mock.state.lock();
+        assert_eq!(state.search_requests.len(), 2);
+        assert!(state.search_requests[1].text_stats.is_none());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn partitioned_reads_aggregate_and_fail_on_any_partition() {
+    let (mocks, broker) = partitioned_fixture().await;
+    let mut search = broker_search_client(&broker).await;
+    let info = search
+        .get_index_info(GetIndexInfoRequest {
+            index_name: "documents".to_string(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(info.num_docs, 126);
+    assert_eq!(info.num_segments, 9);
+    assert!(info.schema.contains("primary"));
+
+    // GetDocument: the partition holding the segment answers.
+    mocks[0].state.lock().document_missing = true;
+    mocks[1].state.lock().document_missing = true;
+    search
+        .get_document(GetDocumentRequest {
+            index_name: "documents".to_string(),
+            address: Some(DocAddress {
+                segment_id: "seg".to_string(),
+                doc_id: 1,
+            }),
+        })
+        .await
+        .unwrap();
+    mocks[2].state.lock().document_missing = true;
+    let missing = search
+        .get_document(GetDocumentRequest {
+            index_name: "documents".to_string(),
+            address: Some(DocAddress {
+                segment_id: "seg".to_string(),
+                doc_id: 1,
+            }),
+        })
+        .await
+        .unwrap_err();
+    assert_eq!(missing.code(), tonic::Code::NotFound);
+
+    // A dead partition makes the whole read fail rather than return a
+    // partial answer.
+    mocks[1].state.lock().unavailable = true;
+    let failed = search
+        .search(simple_search_request("documents"))
+        .await
+        .unwrap_err();
+    assert_eq!(failed.code(), tonic::Code::Unavailable);
+    assert!(
+        failed.message().contains("partition"),
+        "{}",
+        failed.message()
+    );
+}

--- a/hermes-broker/tests/support/mod.rs
+++ b/hermes-broker/tests/support/mod.rs
@@ -46,6 +46,13 @@ pub struct MockState {
     pub deletes: Vec<String>,
     /// Recorded index names per Search call.
     pub searches: Vec<String>,
+    /// Recorded full Search requests (offset/limit/text_stats as received).
+    pub search_requests: Vec<SearchRequest>,
+    /// Schema SDL returned by GetIndexInfo (a `primary` field makes the
+    /// index partitionable).
+    pub schema: String,
+    /// When set, GetDocument answers NOT_FOUND.
+    pub document_missing: bool,
 }
 
 #[derive(Clone)]
@@ -58,6 +65,7 @@ impl MockBackend {
         Self {
             state: Arc::new(Mutex::new(MockState {
                 indexes: indexes.iter().map(|s| s.to_string()).collect(),
+                schema: "index mock {}".to_string(),
                 ..Default::default()
             })),
         }
@@ -115,7 +123,8 @@ impl SearchService for MockBackend {
         let req = request.into_inner();
         let mut state = self.state.lock();
         state.search_timeouts.push(timeout);
-        state.searches.push(req.index_name);
+        state.searches.push(req.index_name.clone());
+        state.search_requests.push(req);
         Ok(Response::new(state.search_response.clone()))
     }
 
@@ -124,6 +133,9 @@ impl SearchService for MockBackend {
         _request: Request<GetDocumentRequest>,
     ) -> Result<Response<GetDocumentResponse>, Status> {
         self.check_available()?;
+        if self.state.lock().document_missing {
+            return Err(Status::not_found("document not found"));
+        }
         Ok(Response::new(GetDocumentResponse {
             fields: Default::default(),
         }))
@@ -153,7 +165,7 @@ impl SearchService for MockBackend {
             index_name: req.index_name,
             num_docs: 42,
             num_segments: 3,
-            schema: "index mock {}".to_string(),
+            schema: self.state.lock().schema.clone(),
             memory_stats: None,
             vector_stats: vec![],
             text_fields: vec![],


### PR DESCRIPTION
## Summary
- `--placement "pattern=a,b,c"` declares a partitioned index; partition order = rule order.
- Writes: documents hash by primary key (FNV-1a 64) to one partition; error positions map back; create/commit/force_merge/reorder/delete/retrain/alter fan out to every partition master.
- Reads: search merges `GetTextStats` from all partitions into `SearchRequest.text_stats` (skipped for term-free queries), widens each partition to `offset+limit` (≤ 10 000) and merges by score; `GetDocument` first-success; `GetIndexInfo`/`GetTextStats` aggregate; any partition failure fails the request.
- Admin `GetTopology` reports `merge_policy = "score"` and the cached primary-key field.

## Tests
- Unit: hash pinning, primary-key parsing, routing + error mapping, score merge with offset/limit, stats/info sums.
- Integration (3 mock backends on shards 2/3/4): create/commit fan-out, hash-routed batches and streams, unroutable documents, merged search with shared stats, aggregated info, get_document fallback, partition failure.