### PR TITLE
fix(tokenizer): segment text in bounded windows

### DIFF
--- a/hermes-core/src/tokenizer/lex.rs
+++ b/hermes-core/src/tokenizer/lex.rs
@@ -61,6 +61,68 @@ use super::{
 /// URLs, which no query types and which bloat the dictionary.
 pub const DEFAULT_MAX_TOKEN_LENGTH: usize = 64;
 
+/// Segmenters see the text in windows of at most this many characters.
+///
+/// ICU's dictionary segmentation of Han text is quadratic in the length of
+/// the run it is handed: one 2.4 MB Chinese book took 105 s as a single
+/// call and 0.2 s in windows. A window ends at the first whitespace or
+/// punctuation after `SEGMENT_WINDOW_SOFT` characters, or unconditionally at
+/// `SEGMENT_WINDOW_HARD` (text with neither in thousands of characters is not
+/// prose; a split there costs at most one word boundary).
+const SEGMENT_WINDOW_SOFT: usize = 1024;
+const SEGMENT_WINDOW_HARD: usize = 4096;
+
+/// Windows of `text` as (byte offset, slice), contiguous and covering.
+fn segment_windows(text: &str) -> Vec<(usize, &str)> {
+    let mut windows = Vec::new();
+    let mut start = 0usize;
+    let mut chars_in_window = 0usize;
+    for (offset, c) in text.char_indices() {
+        chars_in_window += 1;
+        let cut = chars_in_window >= SEGMENT_WINDOW_HARD
+            || (chars_in_window >= SEGMENT_WINDOW_SOFT && (c.is_whitespace() || is_break_punct(c)));
+        if cut {
+            let end = offset + c.len_utf8();
+            windows.push((start, &text[start..end]));
+            start = end;
+            chars_in_window = 0;
+        }
+    }
+    if start < text.len() || windows.is_empty() {
+        windows.push((start, &text[start..]));
+    }
+    windows
+}
+
+/// Punctuation that ends a segmentation window: ASCII sentence and clause
+/// marks plus their CJK full-width forms.
+fn is_break_punct(c: char) -> bool {
+    matches!(
+        c,
+        '.' | ','
+            | ';'
+            | ':'
+            | '!'
+            | '?'
+            | ')'
+            | ']'
+            | '}'
+            | '。'
+            | '，'
+            | '、'
+            | '；'
+            | '：'
+            | '！'
+            | '？'
+            | '」'
+            | '』'
+            | '）'
+            | '】'
+            | '〉'
+            | '》'
+    )
+}
+
 /// Word segmentation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Segmenter {
@@ -472,18 +534,23 @@ impl LexTokenizer {
             }
             Segmenter::Icu if self.options.cjk == CjkMode::Dictionary => {
                 for (start, end, kind) in morph_spans(text, ctx.hints) {
-                    match kind {
-                        SpanKind::Japanese => {
-                            emitter.morph_run(start, &text[start..end], cjk_morph::japanese)
+                    for (offset, window) in segment_windows(&text[start..end]) {
+                        let base = start + offset;
+                        match kind {
+                            SpanKind::Japanese => {
+                                emitter.morph_run(base, window, cjk_morph::japanese)
+                            }
+                            SpanKind::Korean => emitter.morph_run(base, window, cjk_morph::korean),
+                            SpanKind::Icu => emitter.icu_span(base, window),
                         }
-                        SpanKind::Korean => {
-                            emitter.morph_run(start, &text[start..end], cjk_morph::korean)
-                        }
-                        SpanKind::Icu => emitter.icu_span(start, &text[start..end]),
                     }
                 }
             }
-            Segmenter::Icu => emitter.icu_span(0, text),
+            Segmenter::Icu => {
+                for (offset, window) in segment_windows(text) {
+                    emitter.icu_span(offset, window);
+                }
+            }
         }
         emitter.flush_run();
         emitter.tokens
@@ -947,6 +1014,56 @@ mod tests {
 
     fn lex(spec: &str) -> LexTokenizer {
         LexTokenizer::new(LexOptions::parse(spec).unwrap())
+    }
+
+    #[test]
+    fn segment_windows_cut_at_punctuation_after_the_soft_size_and_cover_the_text() {
+        let sentence = "量子计算机的研究进展，";
+        let text: String = sentence.repeat(2000);
+        let windows = segment_windows(&text);
+        assert!(windows.len() > 1);
+        let mut expected_start = 0;
+        for (offset, window) in &windows {
+            assert_eq!(*offset, expected_start);
+            expected_start += window.len();
+            let chars = window.chars().count();
+            assert!(chars <= SEGMENT_WINDOW_SOFT + sentence.chars().count());
+            assert!(window.ends_with('，') || expected_start == text.len());
+        }
+        assert_eq!(expected_start, text.len());
+
+        // No break characters at all: hard cuts, still covering.
+        let solid: String = "的".repeat(10_000);
+        let windows = segment_windows(&solid);
+        assert_eq!(windows.len(), 10_000 / SEGMENT_WINDOW_HARD + 1);
+        assert_eq!(
+            windows.iter().map(|(_, w)| w.len()).sum::<usize>(),
+            solid.len()
+        );
+        assert_eq!(segment_windows(""), vec![(0, "")]);
+    }
+
+    #[test]
+    fn long_han_run_tokenizes_in_bounded_time_with_continuous_positions() {
+        let tokenizer = lex("by: languages, default: en, han: simplified");
+        let text: String = "量子计算机的研究进展".repeat(20_000);
+        let started = std::time::Instant::now();
+        let tokens = tokenizer.tokenize_with(&text, Some("zh"), Purpose::Index);
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(20),
+            "200k Han characters took {:?}",
+            started.elapsed()
+        );
+        assert!(tokens.len() > 20_000);
+        let mut last_position = 0;
+        let mut last_end = 0;
+        for token in tokens.iter().filter(|t| !t.variant) {
+            assert!(token.position >= last_position);
+            assert!(token.offset_from >= last_end || token.offset_from == last_end);
+            last_position = token.position;
+            last_end = token.offset_to;
+        }
+        assert_eq!(last_end, text.len());
     }
 
     #[test]

--- a/hermes-core/src/tokenizer/lex.rs
+++ b/hermes-core/src/tokenizer/lex.rs
@@ -53,7 +53,7 @@ use std::collections::{HashMap, HashSet};
 use parking_lot::RwLock;
 
 use super::{
-    Language, Purpose, Script, Token, Tokenizer, cjk_morph, clean_word, language_code, light_stem,
+    Language, Purpose, Script, Token, Tokenizer, cjk_morph, language_code, light_stem,
     parse_language_opt, split_whitespace_with_offsets, with_stemmers,
 };
 
@@ -92,6 +92,167 @@ fn segment_windows(text: &str) -> Vec<(usize, &str)> {
         windows.push((start, &text[start..]));
     }
     windows
+}
+
+/// Split one segment into lowercase alphanumeric words at the punctuation
+/// the segmenter left inside it, the way a standard analyzer with the
+/// possessive and elision filters does:
+///
+/// - any character that is not a letter, digit or mark is a boundary
+///   (`state-of-the-art` → `state of the art`, `HbA1c/HDL-c` → `hba1c hdl c`,
+///   `end.of.sentence.Next` → `end of sentence next`);
+/// - an apostrophe between letters splits the word into parts: a trailing
+///   English contraction or possessive (`'s`, `'t`, `'re`, `'ve`, `'ll`,
+///   `'d`, `'m`) is dropped (`John's` → `john`, `don't` → `don`), leading
+///   elided articles and conjunctions (`l'`, `d'`, `qu'`, `dell'`, …) are
+///   dropped (`l'homme` → `homme`, `qu'il` → `il`, `O'Neil` → `neil`), and
+///   what remains are separate words (`aujourd'hui` → `aujourd hui`);
+/// - a dotted acronym is joined (`U.S.A.` → `usa`, `e.g.` → `eg`);
+/// - a dot between digits is kept (`3.14`, `0.05`, `1.2.3`) and a comma
+///   between digits is dropped (`1,000` → `1000`);
+/// - soft hyphens, zero-width joiners and other invisible joiners are
+///   dropped without splitting (`soft\u{ad}hyphen` → `softhyphen`).
+///
+/// Returns `(from, to, piece)` byte spans into `segment`.
+fn split_word(segment: &str) -> Vec<(usize, usize, String)> {
+    // Fast path: already a clean lowercase word.
+    if segment
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit())
+    {
+        return vec![(0, segment.len(), segment.to_string())];
+    }
+    let chars: Vec<(usize, char)> = segment.char_indices().collect();
+    let acronym = segment.contains('.') && is_dotted_acronym(segment);
+    let mut pieces: Vec<(usize, usize, String)> = Vec::new();
+    // Parts of the word joined by apostrophes so far (`rock'n'roll`).
+    let mut group: Vec<(usize, usize, String)> = Vec::new();
+    let mut piece = String::new();
+    let mut piece_from = 0usize;
+    let mut piece_to = 0usize;
+    for (i, &(offset, c)) in chars.iter().enumerate() {
+        let prev = (i > 0).then(|| chars[i - 1].1);
+        let next = chars.get(i + 1).map(|(_, n)| *n);
+        let between = |test: fn(char) -> bool| prev.is_some_and(test) && next.is_some_and(test);
+        let action = if c.is_alphanumeric() || is_mark(c) {
+            Piece::Keep
+        } else if is_joiner(c) {
+            Piece::Join
+        } else if is_apostrophe(c) && between(char::is_alphabetic) {
+            Piece::Apostrophe
+        } else if c == '.' && acronym {
+            Piece::Join
+        } else if c == '.' && between(|d| d.is_ascii_digit()) {
+            Piece::Keep
+        } else if c == ',' && between(|d| d.is_ascii_digit()) {
+            // Thousands separator: `1,000` → `1000`, the form people type.
+            Piece::Join
+        } else {
+            Piece::Boundary
+        };
+        match action {
+            Piece::Keep => {
+                if piece.is_empty() {
+                    piece_from = offset;
+                }
+                piece.extend(c.to_lowercase());
+                piece_to = offset + c.len_utf8();
+            }
+            Piece::Join => {}
+            Piece::Apostrophe => {
+                group.push((piece_from, piece_to, std::mem::take(&mut piece)));
+            }
+            Piece::Boundary => {
+                if !piece.is_empty() {
+                    group.push((piece_from, piece_to, std::mem::take(&mut piece)));
+                }
+                resolve_apostrophes(&mut group, &mut pieces);
+            }
+        }
+    }
+    if !piece.is_empty() {
+        group.push((piece_from, piece_to, piece));
+    }
+    resolve_apostrophes(&mut group, &mut pieces);
+    pieces
+}
+
+enum Piece {
+    Keep,
+    Join,
+    Apostrophe,
+    Boundary,
+}
+
+/// Emit the parts of an apostrophe-joined word: drop a trailing English
+/// contraction/possessive suffix and leading elided prefixes.
+fn resolve_apostrophes(
+    group: &mut Vec<(usize, usize, String)>,
+    pieces: &mut Vec<(usize, usize, String)>,
+) {
+    if group.len() > 1 {
+        if group
+            .last()
+            .is_some_and(|(_, _, part)| CONTRACTION_SUFFIXES.contains(&part.as_str()))
+        {
+            group.pop();
+        }
+        while group.len() > 1
+            && group.first().is_some_and(|(_, _, part)| {
+                part.chars().count() <= 2 || ELISION_PREFIXES.contains(&part.as_str())
+            })
+        {
+            group.remove(0);
+        }
+    }
+    pieces.append(group);
+}
+
+/// English contractions and the possessive: dropped after an apostrophe.
+const CONTRACTION_SUFFIXES: &[&str] = &["s", "t", "re", "ve", "ll", "d", "m"];
+
+/// Elided articles, prepositions and conjunctions of French, Italian and
+/// Catalan longer than two letters (shorter ones are dropped by length).
+const ELISION_PREFIXES: &[&str] = &[
+    "qu", "lorsqu", "jusqu", "puisqu", "quoiqu", "dell", "nell", "sull", "dall", "all", "coll",
+    "degl", "dagl", "negl", "sugl", "quest", "quell", "sant", "anch",
+];
+
+/// `U.S.A.`, `e.g.`: every run between dots is exactly one letter
+/// (`Ph.D.` splits into `ph d` like a standard analyzer).
+fn is_dotted_acronym(segment: &str) -> bool {
+    let mut runs = 0;
+    for run in segment.split('.') {
+        if run.is_empty() {
+            continue;
+        }
+        let mut letters = run.chars();
+        match (letters.next(), letters.next()) {
+            (Some(c), None) if c.is_alphabetic() => runs += 1,
+            _ => return false,
+        }
+    }
+    runs >= 2
+}
+
+fn is_mark(c: char) -> bool {
+    // Combining marks (Mn/Mc/Me) that survive NFKC, e.g. in Indic scripts.
+    matches!(c as u32, 0x0300..=0x036F | 0x0483..=0x0489 | 0x0591..=0x05BD | 0x0610..=0x061A
+        | 0x064B..=0x065F | 0x0900..=0x0903 | 0x093A..=0x094F | 0x0951..=0x0957 | 0x0962..=0x0963
+        | 0x0E31 | 0x0E34..=0x0E3A | 0x0E47..=0x0E4E | 0x1AB0..=0x1AFF | 0x1DC0..=0x1DFF
+        | 0x20D0..=0x20FF | 0xFE20..=0xFE2F)
+}
+
+/// Invisible characters that join the letters around them.
+fn is_joiner(c: char) -> bool {
+    matches!(
+        c,
+        '\u{00AD}' | '\u{200C}' | '\u{200D}' | '\u{2060}' | '\u{FEFF}' | '\u{034F}'
+    )
+}
+
+fn is_apostrophe(c: char) -> bool {
+    matches!(c, '\'' | '\u{2019}' | '\u{2018}' | '\u{02BC}' | '\u{FF07}')
 }
 
 /// Punctuation that ends a segmentation window: ASCII sentence and clause
@@ -694,22 +855,30 @@ impl Emitter<'_> {
         }
     }
 
-    /// A word from the segmenter (non-CJK): NFKC, lowercase, punctuation
-    /// stripped, then routed to its language.
+    /// A word from the segmenter (non-CJK): NFKC, split at punctuation the
+    /// segmenter kept inside it, lowercase, then routed to its language.
     fn word(&mut self, offset: usize, raw: &str) {
         self.flush_run();
         if raw.is_empty() {
             return;
         }
-        let cleaned = if self.options.segmenter == Segmenter::Simple || raw.is_ascii() {
-            clean_word(raw)
+        if raw.is_ascii() {
+            for (from, to, piece) in split_word(raw) {
+                self.emit_word(piece, offset + from, offset + to);
+            }
         } else {
             use unicode_normalization::UnicodeNormalization;
             let normalized: String = raw.nfkc().collect();
-            clean_word(&normalized)
-        };
-        if !cleaned.is_empty() {
-            self.emit_word(cleaned, offset, offset + raw.len());
+            // Offsets of pieces point into the normalized form; report the
+            // whole raw segment as the source span when NFKC changed it.
+            let same_length = normalized.len() == raw.len();
+            for (from, to, piece) in split_word(&normalized) {
+                if same_length {
+                    self.emit_word(piece, offset + from, offset + to);
+                } else {
+                    self.emit_word(piece, offset, offset + raw.len());
+                }
+            }
         }
     }
 
@@ -985,6 +1154,25 @@ fn icu_word_segmenter() -> &'static icu_segmenter::WordSegmenterBorrowed<'static
 }
 
 /// Stop words of a language (NLTK lists), shared for the process lifetime.
+/// Entries of the NLTK lists that are pieces of contractions and elisions
+/// (`don't` → `don`, `t`; `l'homme` → `l`, `homme`) rather than words. The
+/// tokenizer never produces those pieces, and as stop words they would
+/// delete real single-letter tokens: `vitamin D`, `T cell`, `Y chromosome`.
+fn is_stop_list_fragment(language: Language, word: &str) -> bool {
+    if word.contains('\'') || word.contains('\u{2019}') {
+        return true;
+    }
+    match language {
+        Language::English => matches!(
+            word,
+            "s" | "t" | "d" | "ll" | "m" | "o" | "re" | "ve" | "y" | "ain" | "ma"
+        ),
+        Language::French => matches!(word, "c" | "d" | "j" | "l" | "m" | "n" | "s" | "t" | "qu"),
+        Language::Italian => matches!(word, "l" | "c" | "d" | "m" | "n" | "s" | "t" | "v"),
+        _ => false,
+    }
+}
+
 fn stop_word_set(language: Language) -> Option<&'static HashSet<String>> {
     static SETS: std::sync::OnceLock<RwLock<HashMap<Language, &'static HashSet<String>>>> =
         std::sync::OnceLock::new();
@@ -995,6 +1183,7 @@ fn stop_word_set(language: Language) -> Option<&'static HashSet<String>> {
     let set: &'static HashSet<String> = Box::leak(Box::new(
         stop_words::get(language.to_stop_words_language())
             .iter()
+            .filter(|word| !is_stop_list_fragment(language, word))
             .map(|word| word.to_string())
             .collect(),
     ));
@@ -1014,6 +1203,54 @@ mod tests {
 
     fn lex(spec: &str) -> LexTokenizer {
         LexTokenizer::new(LexOptions::parse(spec).unwrap())
+    }
+
+    #[test]
+    fn split_word_cleans_punctuation_like_a_standard_analyzer() {
+        let words = |s: &str| {
+            split_word(s)
+                .into_iter()
+                .map(|(_, _, w)| w)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(words("state-of-the-art"), ["state", "of", "the", "art"]);
+        assert_eq!(words("HbA1c/HDL-c"), ["hba1c", "hdl", "c"]);
+        assert_eq!(
+            words("end.of.sentence.Next"),
+            ["end", "of", "sentence", "next"]
+        );
+        assert_eq!(words("don't"), ["don"]);
+        assert_eq!(words("it's"), ["it"]);
+        assert_eq!(words("we're"), ["we"]);
+        assert_eq!(words("O'Neil"), ["neil"]);
+        assert_eq!(words("rock'n'roll"), ["rock", "n", "roll"]);
+        assert_eq!(words("John\u{2019}s"), ["john"]);
+        assert_eq!(words("cats'"), ["cats"]);
+        assert_eq!(words("l'homme"), ["homme"]);
+        assert_eq!(words("qu'il"), ["il"]);
+        assert_eq!(words("dell'acqua"), ["acqua"]);
+        assert_eq!(words("aujourd'hui"), ["aujourd", "hui"]);
+        assert_eq!(words("'quoted'"), ["quoted"]);
+        assert_eq!(words("U.S.A."), ["usa"]);
+        assert_eq!(words("e.g."), ["eg"]);
+        assert_eq!(words("Ph.D."), ["ph", "d"]);
+        assert_eq!(words("3.14"), ["3.14"]);
+        assert_eq!(words("p<0.05"), ["p", "0.05"]);
+        assert_eq!(words("1.2.3"), ["1.2.3"]);
+        assert_eq!(words("1,000,000"), ["1000000"]);
+        assert_eq!(words("word..."), ["word"]);
+        assert_eq!(words("soft\u{ad}hyphen"), ["softhyphen"]);
+        assert_eq!(words("zero\u{200d}width"), ["zerowidth"]);
+        assert_eq!(words("(test)"), ["test"]);
+        assert_eq!(words("C++"), ["c"]);
+        assert_eq!(words("#tag"), ["tag"]);
+        assert_eq!(words("α-synuclein"), ["α", "synuclein"]);
+        assert_eq!(words("---"), Vec::<String>::new());
+        // Byte spans point at the pieces in the segment.
+        assert_eq!(
+            split_word("Foo-Bar"),
+            vec![(0, 3, "foo".to_string()), (4, 7, "bar".to_string())]
+        );
     }
 
     #[test]
@@ -1165,7 +1402,30 @@ mod tests {
             .into_iter()
             .map(|t| t.text)
             .collect();
-        assert_eq!(tokens, vec!["floatzero", "p53"]);
+        assert_eq!(tokens, vec!["float", "zero", "p53"]);
+    }
+
+    #[test]
+    fn single_letter_words_survive_stop_words() {
+        let tokenizer = lex("by: languages, default: en, stop_words: true");
+        let words = |text: &str, hint: &str| {
+            tokenizer
+                .tokenize_with(text, Some(hint), Purpose::Index)
+                .into_iter()
+                .filter(|t| !t.variant)
+                .map(|t| t.text)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            words("vitamin D and T cells", "en"),
+            ["vitamin", "d", "t", "cells"]
+        );
+        assert_eq!(words("the Y chromosome", "en"), ["y", "chromosome"]);
+        assert_eq!(words("a cat", "en"), ["cat"]);
+        assert_eq!(
+            words("la vitamine D et l'homme", "fr"),
+            ["vitamine", "d", "homme"]
+        );
     }
 
     #[test]

--- a/hermes-core/src/tokenizer/mod.rs
+++ b/hermes-core/src/tokenizer/mod.rs
@@ -1217,7 +1217,7 @@ mod tests {
                 "determinants",
                 "p53",
                 "co2",
-                "101007",
+                "10.1007",
                 "s1",
                 "resume"
             ]
@@ -1243,7 +1243,7 @@ mod tests {
                 "Float-zero café",
                 Some("en")
             )),
-            vec!["floatzero", "cafe"]
+            vec!["float", "zero", "cafe"]
         );
         // Cyrillic folding drops combining marks but keeps the letters.
         assert_eq!(texts(&hinted(&plain, "ёлка", None)), vec!["елка"]);

--- a/hermes-core/tests/tokenizer_scaling_probe.rs
+++ b/hermes-core/tests/tokenizer_scaling_probe.rs
@@ -1,0 +1,160 @@
+//! Scaling probe: add_document cost versus document shape for a chunked
+//! lex-tokenized text field. Run with --release --nocapture.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use hermes_core::dsl::sdl::parse_sdl;
+use hermes_core::tokenizer::TokenizerRegistry;
+use hermes_core::{Document, SegmentBuilder, SegmentBuilderConfig};
+
+fn xorshift(seed: &mut u64) -> u64 {
+    *seed ^= *seed << 13;
+    *seed ^= *seed >> 7;
+    *seed ^= *seed << 17;
+    *seed
+}
+
+fn shape(kind: &str, seed: &mut u64, words: usize) -> String {
+    let mut out = String::with_capacity(words * 8);
+    match kind {
+        "english" => {
+            for _ in 0..words {
+                out.push_str(&format!("word{} ", xorshift(seed) % 5000));
+            }
+        }
+        "unique" => {
+            for _ in 0..words {
+                out.push_str(&format!("u{:x} ", xorshift(seed)));
+            }
+        }
+        "repeated" => {
+            for _ in 0..words {
+                out.push_str("same ");
+            }
+        }
+        "longtoken" => {
+            // one run of letters without any break, `words` * 6 bytes long
+            for _ in 0..words {
+                out.push_str("abcdef");
+            }
+        }
+        "chinese" => {
+            let chars: Vec<char> = "的一是不了人我在有他这为之大来以个中上们到说国和地也子时道出而要于就下得可你年生自会那后能对着事其里所去行过家十用发天如然作方成者多日都三小军二无同么经法当起与好看学进种将还分此心前面又定见只主没公从".chars().collect();
+            for _ in 0..words {
+                out.push(chars[(xorshift(seed) % chars.len() as u64) as usize]);
+            }
+        }
+        "japanese" => {
+            let parts = [
+                "量子",
+                "コンピュータ",
+                "の",
+                "研究",
+                "を",
+                "食べました",
+                "学校",
+                "東京",
+                "で",
+                "は",
+            ];
+            for _ in 0..words {
+                out.push_str(parts[(xorshift(seed) % parts.len() as u64) as usize]);
+            }
+        }
+        "numbers" => {
+            for _ in 0..words {
+                out.push_str(&format!("{},", xorshift(seed) % 100000));
+            }
+        }
+        "mixed" => {
+            for i in 0..words {
+                if i % 3 == 0 {
+                    out.push_str("Über-straße/2024 ");
+                } else {
+                    out.push_str(&format!("wörd{} ", xorshift(seed) % 3000));
+                }
+            }
+        }
+        _ => unreachable!(),
+    }
+    out
+}
+
+#[test]
+#[ignore]
+fn chunked_lex_add_document_scaling() {
+    let sdl = r#"index t {
+  field id: text<raw_ci> [indexed, stored, fast, primary]
+  field languages: text<raw_ci> [indexed, stored, fast]
+  field content: text<lex(by: languages, default: en, stop_words: true, han: simplified)> [indexed<chunked, token_position>]
+}"#;
+    let defs = parse_sdl(sdl).unwrap();
+    let schema = Arc::new(defs[0].to_schema());
+    let registry = TokenizerRegistry::new();
+    let content = schema.get_field("content").unwrap();
+    let id = schema.get_field("id").unwrap();
+    let languages = schema.get_field("languages").unwrap();
+    let kinds: Vec<&str> = std::env::var("SHAPES")
+        .map(|s| s.split(',').map(|k| k.to_string()).collect::<Vec<_>>())
+        .unwrap_or_else(|_| {
+            vec![
+                "english".into(),
+                "unique".into(),
+                "repeated".into(),
+                "longtoken".into(),
+                "chinese".into(),
+                "japanese".into(),
+                "numbers".into(),
+                "mixed".into(),
+            ]
+        })
+        .into_iter()
+        .map(|k| Box::leak(k.into_boxed_str()) as &str)
+        .collect();
+    for kind in kinds {
+        let single: bool = std::env::var("SINGLE").is_ok();
+        for &chunks in &[500usize, 2000] {
+            let (chunks, words_per_chunk) = if single {
+                (1usize, 400 * chunks)
+            } else {
+                (chunks, 400)
+            };
+            let mut builder =
+                SegmentBuilder::new(schema.clone(), SegmentBuilderConfig::default()).unwrap();
+            for (field, entry) in schema.fields() {
+                if let Some(ref name) = entry.tokenizer
+                    && let Some(tok) = registry.get(name)
+                {
+                    builder.set_tokenizer(field, tok);
+                }
+            }
+            let mut seed = 0x9e3779b97f4a7c15u64;
+            let mut doc = Document::new();
+            doc.add_text(id, format!("doc-{kind}-{chunks}"));
+            doc.add_text(
+                languages,
+                if kind == "chinese" {
+                    "zh"
+                } else if kind == "japanese" {
+                    "ja"
+                } else {
+                    "en"
+                },
+            );
+            let mut bytes = 0;
+            for _ in 0..chunks {
+                let text = shape(kind, &mut seed, words_per_chunk);
+                bytes += text.len();
+                doc.add_text(content, text);
+            }
+            let started = Instant::now();
+            builder.add_document(doc).unwrap();
+            eprintln!(
+                "{kind:10} chunks={chunks:5} words/chunk={words_per_chunk:7} bytes={:8} add_document={:?}",
+                bytes,
+                started.elapsed(),
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
### Bounded segmentation windows (stall root cause)
- ICU's dictionary segmentation of Han text is quadratic in run length: a 2.4 MB Chinese book took 105 s in a single call (0.6 MB: 2 s). Twelve such books pinned all 12 indexing workers of the `documents_20260904` full build for 27 minutes, filled the queue (backpressure) and timed out the auto-commit (`0/12 workers flushed`).
- `LexTokenizer` now hands segmenters (ICU and the lindera runs) windows cut at whitespace/punctuation after 1024 characters, or unconditionally at 4096. Positions, offsets and CJK bigram runs stay continuous across windows. Same book: 0.23 s.

### Punctuation cleaning like a standard analyzer
- Segments kept whole by the segmenter are split at interior punctuation (`state-of-the-art` → `state of the art`, `end.of.sentence.Next` → `end of sentence next`, `HbA1c/HDL-c` → `hba1c hdl c`); the simple segmenter no longer glues hyphenated words.
- Apostrophes: trailing English contraction/possessive dropped (`John's` → `john`, `don't` → `don`), leading elisions dropped (`l'homme` → `homme`, `qu'il` → `il`, `dell'acqua` → `acqua`), remaining parts split.
- Dotted acronyms join (`U.S.A.` → `usa`, `e.g.` → `eg`); decimal points stay (`3.14`, `10.1007`); thousands separators go (`1,000` → `1000`); soft hyphens / zero-width joiners dropped.
- NLTK stop lists lose their contraction/elision fragments (en: `s t d ll m o re ve y ain ma`; fr/it elided articles): the tokenizer never produces them, and as stop words they deleted `vitamin D`, `T cell`, `Y chromosome`. Single-letter tokens remain indexed (Lucene, Tantivy, PostgreSQL and Xapian have no minimum length; only MySQL's legacy full-text drops short words), which scholarly text needs (`hepatitis B`, `factor V`, `C. elegans`).

## Tests
- Unit: window cutting/coverage; 200k-character Han run tokenizes in bounded time with monotonic positions; `split_word` table (hyphens, slashes, dots, apostrophes, acronyms, decimals, joiners); single-letter words survive stop words in English and French.
- `hermes-core/tests/tokenizer_scaling_probe.rs` (ignored): add_document cost across document shapes; run with `--release --ignored --nocapture`.