### PR TITLE
fix(broker): collect text stats from fusion leaves

### DIFF
--- a/hermes-broker/src/partition.rs
+++ b/hermes-broker/src/partition.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use tonic::Status;
 
 use crate::proto::hermes::{
-    BatchIndexDocumentsResponse, DocumentError, FieldValue, GetIndexInfoResponse,
+    BatchIndexDocumentsResponse, BooleanQuery, DocumentError, FieldValue, GetIndexInfoResponse,
     IndexingBufferStats, MemoryStats, NamedDocument, Query, SearchHit, SearchResponse,
     SearchTimings, SegmentReaderStats, TermDocFreq, TextFieldStats, TextStats, VectorFieldStats,
     field_value, query,
@@ -117,25 +117,57 @@ pub fn route_documents(
     RoutedBatch { groups, unroutable }
 }
 
-/// Whether a query scores any text term (BM25), i.e. needs corpus-wide
-/// statistics shared across partitions.
-pub fn has_text_terms(query: &Query) -> bool {
-    match &query.query {
-        Some(query::Query::Term(_))
-        | Some(query::Query::Match(_))
-        | Some(query::Query::Phrase(_)) => true,
-        Some(query::Query::Boolean(b)) => b
-            .must
-            .iter()
-            .chain(&b.should)
-            .chain(&b.must_not)
-            .any(has_text_terms),
-        Some(query::Query::Boost(b)) => b.query.as_deref().is_some_and(has_text_terms),
-        Some(query::Query::Fusion(f)) => f
-            .queries
-            .iter()
-            .any(|w| w.query.as_ref().is_some_and(has_text_terms)),
-        _ => false,
+/// Collect text-bearing leaves into a query `GetTextStats` can convert.
+///
+/// Fusion is a searcher-level operation and `hermes-server` deliberately
+/// rejects it in the ordinary query converter used by `GetTextStats`. A
+/// partitioned hybrid search still needs corpus-wide BM25 statistics, so the
+/// broker sends only its term/match/phrase leaves for statistics while the
+/// original fusion remains unchanged for the actual search.
+pub fn text_stats_query(query: &Query) -> Option<Query> {
+    fn collect(query: &Query, leaves: &mut Vec<Query>) {
+        match &query.query {
+            Some(query::Query::Term(_))
+            | Some(query::Query::Match(_))
+            | Some(query::Query::Phrase(_)) => leaves.push(query.clone()),
+            Some(query::Query::Boolean(boolean)) => {
+                for clause in boolean
+                    .must
+                    .iter()
+                    .chain(&boolean.should)
+                    .chain(&boolean.must_not)
+                {
+                    collect(clause, leaves);
+                }
+            }
+            Some(query::Query::Boost(boost)) => {
+                if let Some(inner) = boost.query.as_deref() {
+                    collect(inner, leaves);
+                }
+            }
+            Some(query::Query::Fusion(fusion)) => {
+                for weighted in &fusion.queries {
+                    if let Some(inner) = weighted.query.as_ref() {
+                        collect(inner, leaves);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut leaves = Vec::new();
+    collect(query, &mut leaves);
+    match leaves.len() {
+        0 => None,
+        1 => leaves.pop(),
+        _ => Some(Query {
+            query: Some(query::Query::Boolean(BooleanQuery {
+                must: vec![],
+                should: leaves,
+                must_not: vec![],
+            })),
+        }),
     }
 }
 
@@ -355,7 +387,10 @@ pub fn partition_failure(index_name: &str, shard: &str, status: Status) -> Statu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::hermes::{DocAddress, FieldEntry};
+    use crate::proto::hermes::{
+        DocAddress, FieldEntry, FusionQuery, MatchQuery, PhraseQuery, SparseVectorQuery,
+        WeightedQuery,
+    };
 
     fn doc(id: &str) -> NamedDocument {
         NamedDocument {
@@ -394,6 +429,63 @@ mod tests {
             primary_key_field("index x {\n field a: text<raw> [indexed]\n}"),
             None
         );
+    }
+
+    #[test]
+    fn fusion_stats_query_keeps_only_text_leaves() {
+        let text_query = |kind| Query { query: Some(kind) };
+        let query = Query {
+            query: Some(query::Query::Fusion(FusionQuery {
+                queries: vec![
+                    WeightedQuery {
+                        query: Some(text_query(query::Query::SparseVector(SparseVectorQuery {
+                            field: "sparse_vectors".to_string(),
+                            ..Default::default()
+                        }))),
+                        weight: 1.0,
+                    },
+                    WeightedQuery {
+                        query: Some(Query {
+                            query: Some(query::Query::Boolean(BooleanQuery {
+                                must: vec![text_query(query::Query::Match(MatchQuery {
+                                    field: "content".to_string(),
+                                    text: "quantum".to_string(),
+                                    ..Default::default()
+                                }))],
+                                should: vec![text_query(query::Query::Phrase(PhraseQuery {
+                                    field: "content".to_string(),
+                                    text: "quantum field".to_string(),
+                                    ..Default::default()
+                                }))],
+                                must_not: vec![],
+                            })),
+                        }),
+                        weight: 0.8,
+                    },
+                ],
+                ..Default::default()
+            })),
+        };
+
+        let stats = text_stats_query(&query).expect("fusion has text leaves");
+        let Some(query::Query::Boolean(boolean)) = stats.query else {
+            panic!("multiple text leaves should become a boolean query");
+        };
+        assert_eq!(boolean.should.len(), 2);
+        assert!(matches!(
+            boolean.should[0].query,
+            Some(query::Query::Match(_))
+        ));
+        assert!(matches!(
+            boolean.should[1].query,
+            Some(query::Query::Phrase(_))
+        ));
+
+        let vector_only = text_query(query::Query::SparseVector(SparseVectorQuery {
+            field: "sparse_vectors".to_string(),
+            ..Default::default()
+        }));
+        assert!(text_stats_query(&vector_only).is_none());
     }
 
     #[test]

--- a/hermes-broker/src/search_service.rs
+++ b/hermes-broker/src/search_service.rs
@@ -131,8 +131,7 @@ impl BrokerSearchService {
         }
         // Shared BM25 statistics: every partition scores with the sum.
         if req.text_stats.is_none()
-            && let Some(query) = req.query.clone()
-            && partition::has_text_terms(&query)
+            && let Some(query) = req.query.as_ref().and_then(partition::text_stats_query)
         {
             let stats = forward_read!(
                 self,

--- a/hermes-broker/tests/broker_integration.rs
+++ b/hermes-broker/tests/broker_integration.rs
@@ -617,6 +617,62 @@ async fn partitioned_search_merges_by_score_with_shared_stats() {
         let state = mock.state.lock();
         assert_eq!(state.search_requests.len(), 2);
         assert!(state.search_requests[1].text_stats.is_none());
+        assert_eq!(state.text_stats_requests.len(), 1);
+    }
+
+    // Hybrid retrieval is a top-level fusion. GetTextStats cannot execute a
+    // FusionQuery, so the broker must send only the BM25 leaf for statistics
+    // while preserving the fusion in the actual Search request.
+    let mut hybrid = simple_search_request("documents");
+    hybrid.query = Some(Query {
+        query: Some(query::Query::Fusion(FusionQuery {
+            queries: vec![
+                WeightedQuery {
+                    query: Some(Query {
+                        query: Some(query::Query::SparseVector(SparseVectorQuery {
+                            field: "sparse_vectors".to_string(),
+                            ..Default::default()
+                        })),
+                    }),
+                    weight: 1.0,
+                },
+                WeightedQuery {
+                    query: Some(Query {
+                        query: Some(query::Query::Match(MatchQuery {
+                            field: "content".to_string(),
+                            text: "quantum".to_string(),
+                            ..Default::default()
+                        })),
+                    }),
+                    weight: 1.0,
+                },
+            ],
+            ..Default::default()
+        })),
+    });
+    broker_search_client(&broker)
+        .await
+        .search(hybrid)
+        .await
+        .unwrap();
+    for mock in &mocks {
+        let state = mock.state.lock();
+        assert_eq!(state.search_requests.len(), 3);
+        assert!(matches!(
+            state.search_requests[2]
+                .query
+                .as_ref()
+                .and_then(|query| query.query.as_ref()),
+            Some(query::Query::Fusion(_))
+        ));
+        assert_eq!(state.text_stats_requests.len(), 2);
+        assert!(matches!(
+            state.text_stats_requests[1]
+                .query
+                .as_ref()
+                .and_then(|query| query.query.as_ref()),
+            Some(query::Query::Match(_))
+        ));
     }
 }
 

--- a/hermes-broker/tests/e2e_real_server.rs
+++ b/hermes-broker/tests/e2e_real_server.rs
@@ -297,3 +297,88 @@ async fn broker_routes_real_hermes_servers() {
         .into_inner();
     assert_eq!(empty.hits.len(), 0);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs the hermes-server binary; see module docs"]
+async fn partitioned_fusion_collects_text_stats_from_real_servers() {
+    let server_a = spawn_server();
+    let server_b = spawn_server();
+    wait_server_ready(&server_a.addr).await;
+    wait_server_ready(&server_b.addr).await;
+
+    let broker = spawn_broker(
+        &[
+            format!("id=a,addr={},shard=0", server_a.addr),
+            format!("id=b,addr={},shard=1", server_b.addr),
+        ],
+        &["--placement", "docs*=0,1"],
+    );
+    wait_for_indexes(&broker, &[], Duration::from_secs(10)).await;
+
+    let index_name = "docs_fusion_e2e";
+    let schema = SCHEMA.replace("index e2e", &format!("index {index_name}"));
+    let mut index = broker_index_client(&broker).await;
+    index
+        .create_index(CreateIndexRequest {
+            index_name: index_name.to_string(),
+            schema,
+        })
+        .await
+        .unwrap();
+    wait_for_indexes(&broker, &[index_name], Duration::from_secs(10)).await;
+    index
+        .batch_index_documents(BatchIndexDocumentsRequest {
+            index_name: index_name.to_string(),
+            documents: vec![
+                doc("doc-1", "quantum field theory"),
+                doc("doc-2", "another quantum document"),
+            ],
+        })
+        .await
+        .unwrap();
+    index
+        .commit(CommitRequest {
+            index_name: index_name.to_string(),
+        })
+        .await
+        .unwrap();
+
+    let match_query = |text: &str| Query {
+        query: Some(query::Query::Match(MatchQuery {
+            field: "title".to_string(),
+            text: text.to_string(),
+            ..Default::default()
+        })),
+    };
+    let response = broker_search_client(&broker)
+        .await
+        .search(SearchRequest {
+            index_name: index_name.to_string(),
+            query: Some(Query {
+                query: Some(query::Query::Fusion(FusionQuery {
+                    queries: vec![
+                        WeightedQuery {
+                            query: Some(match_query("quantum")),
+                            weight: 1.0,
+                        },
+                        WeightedQuery {
+                            query: Some(match_query("document")),
+                            weight: 1.0,
+                        },
+                    ],
+                    rrf_k: 60.0,
+                    ..Default::default()
+                })),
+            }),
+            limit: 10,
+            fields_to_load: vec!["id".to_string(), "title".to_string()],
+            ..Default::default()
+        })
+        .await
+        .expect("partitioned fusion with BM25 terms should collect shared stats")
+        .into_inner();
+    // Fusion total_hits sums the contributing ranked-list counts; hits are
+    // de-duplicated by document address in the fused result.
+    assert_eq!(response.total_hits, 3);
+    assert_eq!(response.hits.len(), 2);
+}

--- a/hermes-broker/tests/support/mod.rs
+++ b/hermes-broker/tests/support/mod.rs
@@ -48,6 +48,8 @@ pub struct MockState {
     pub searches: Vec<String>,
     /// Recorded full Search requests (offset/limit/text_stats as received).
     pub search_requests: Vec<SearchRequest>,
+    /// Recorded statistics queries, which must not contain FusionQuery.
+    pub text_stats_requests: Vec<GetTextStatsRequest>,
     /// Schema SDL returned by GetIndexInfo (a `primary` field makes the
     /// index partitionable).
     pub schema: String,
@@ -146,7 +148,10 @@ impl SearchService for MockBackend {
         request: Request<GetTextStatsRequest>,
     ) -> Result<Response<GetTextStatsResponse>, Status> {
         self.check_available()?;
-        let _ = request.into_inner();
+        self.state
+            .lock()
+            .text_stats_requests
+            .push(request.into_inner());
         Ok(Response::new(GetTextStatsResponse {
             stats: Some(TextStats {
                 total_docs: 42,


### PR DESCRIPTION
## Summary
- extract term, match, and phrase leaves before partition-wide `GetTextStats` calls
- preserve the original top-level `FusionQuery` for the actual search
- cover partitioned hybrid search with mock and real hermes-server regressions

## Production failure
Partitioned hybrid search returned `INVALID_ARGUMENT`: `FusionQuery is only supported at the top level of SearchRequest.query`. The broker was forwarding the whole fusion to `GetTextStats`, whose ordinary query converter cannot execute fusion.

## Verification
- `cargo +1.98.0 fmt --all -- --check`
- `cargo +1.98.0 test -p hermes-broker`
- `cargo +1.98.0 test -p hermes-broker --test e2e_real_server -- --ignored`
- `cargo +1.98.0 clippy -p hermes-broker --all-targets -- -D warnings`