### PR TITLE
feat(core): optimize full-text indexing and filtered search

### DIFF
--- a/docs/chunked-bm25.md
+++ b/docs/chunked-bm25.md
@@ -1,0 +1,89 @@
+# BM25 over equal-length chunks
+
+Status: research note + decisions (2026-09-04). Mechanism: `docs/chunked-text-fields.md`.
+
+Hermes splits a document's text into fixed-size chunks before building the
+inverted index of a `chunked` text field. Each chunk is a scoring unit with
+its own posting entry and length; the document score is the maximum over its
+chunks (MaxP). This note records what the literature says about that setup
+and which of it Hermes applies.
+
+## What is applied
+
+1. **Chunk length floor.** The BM25 length of a chunk is
+   `max(len, nominal_len)`, where `nominal_len` is the 90th-percentile chunk
+   length of the field in the segment — the chunk size the corpus was split
+   at, computed from the `.chunks` length column when the segment opens
+   (`ChunkMap::length_floor`). With equal-length chunks the normaliser
+   `1 − b + b · len / avg` is a constant for every full chunk; `b` only acts on
+   the short last chunk of a document, which it _rewards_ (at `tf = 1`,
+   `k1 = 1.2`, `b = 0.75` a half-length tail scores ≈ 22 % higher per term).
+   Nothing in the literature says a short tail is likelier to be relevant, and
+   Kaszkiel & Zobel found the opposite: under plain length normalisation
+   "over 95 % of the top-ranked passages were of 50 words", which they fixed
+   with a minimum passage length (SIGIR 1997) and, for fixed windows, by
+   dropping length normalisation altogether (JASIST 2001). The floor keeps
+   `b` meaningful for the (rare) chunk longer than nominal and removes the
+   tail reward; every full chunk and every tail chunk now share one
+   normaliser. (Flooring at the _average_ is not enough: tails pull the
+   average below the chunk size, so full chunks would be penalised relative
+   to tails.) Implemented in `TermCursor` (MaxScore) and `PhraseScorer`.
+
+2. **MaxP stays the aggregation.** Best-passage ranking is the robust choice
+   across classical and neural studies: Callan (SIGIR 1994; best passage beat
+   summing passages), Kaszkiel & Zobel (1997, 2001), Dai & Callan (SIGIR 2019,
+   MaxP > FirstP > SumP), Zhang, Yates & Lin (ECIR 2021: "MaxP almost always
+   significantly outperforms the other approaches"), Nguyen, MacAvaney & Yates
+   (2023: Sum "bias towards longer documents", Mean corrects it but
+   underperforms Max). Sum is length-biased and mean dilutes (Bendersky &
+   Kurland 2008). Hermes' `MultiValueCombiner::Max` for chunked text is kept.
+
+3. **`k1`, `b` unchanged** (`1.2`, `0.75`). Within a 200–300-token chunk
+   `tf` is small and saturation matters little. Anserini's tuned MS MARCO
+   passage run uses `k1 = 0.82`, `b = 0.68`; that is evidence that tuning can
+   help a specific collection, not a portable replacement for the defaults.
+   With the length floor `b` is almost inert among full chunks. A Hermes
+   change therefore needs a labelled set (see "Measure").
+
+## What is not applied (and why)
+
+- **Document-level IDF.** Chunk-level `df` counts every chunk of a long
+  document that repeats a term, lowering that term's IDF. Kaszkiel & Zobel and
+  Callan used document-level statistics for passage ranking; Anserini's
+  passage-indexed MS MARCO run uses passage-level IDF and matches the
+  document index after tuning. No controlled comparison exists. Switching
+  needs a document-level `df` per term in the term dictionary; it is planned
+  for the next term-dictionary format revision, not done here.
+- **Chunk-count prior.** A document with `n` chunks has `n` draws at a high
+  chunk score. No paper quantifies this for BM25 MaxP; BM25 caps each term's
+  contribution, so the effect is bounded (unlike log-sum-exp, which adds
+  exactly `ln n / t`, the bias that `docs/…` and the combiner history record
+  for the vector path). Diagnose before correcting: bin documents by chunk
+  count and compare retrieved-vs-relevant rates (Singhal 1996; Lv & Zhai
+  2011); only then apply `score − c · log n`.
+- **Hybrid document + passage score** (`α · BM25_doc + (1 − α) · max_chunk`,
+  Callan 1994 D+W: always better than either alone; Bendersky & Kurland
+  2008; Sheetrit et al. 2020). Best-supported classical option, but it needs
+  a document-level `tf` (sum over chunks) per candidate, i.e. a second index
+  or a per-query scan of every chunk of every candidate. Deferred.
+
+## Measure
+
+Both deferred items and any `k1`/`b` change must be measured on the
+search-quality benchmark (`benchmarks/search-quality`) before changing
+defaults; the length floor changes only tail-chunk scores and is pinned by
+`index::tests::chunked` (a short tail chunk no longer outranks a full chunk
+with the same `tf`).
+
+## Primary references
+
+- James P. Callan, [“Passage-Level Evidence in Document Retrieval”](https://www.sigmod.org/publications/dblp/db/conf/sigir/Callan94.html), SIGIR 1994.
+- Marcin Kaszkiel and Justin Zobel, [“Effective Ranking with Arbitrary Passages”](<https://doi.org/10.1002/1532-2890(2000)9999:9999%3C::AID-ASI1075%3E3.0.CO;2-%23>), JASIST 2001.
+- Michael Bendersky and Oren Kurland, [“Utilizing Passage-Based Language Models for Document Retrieval”](https://doi.org/10.1007/978-3-540-78646-7_17), ECIR 2008.
+- Zhuyun Dai and Jamie Callan, [“Deeper Text Understanding for IR with Contextual Neural Language Modeling”](https://doi.org/10.1145/3331184.3331303), SIGIR 2019.
+- Xinyu Zhang, Andrew Yates, and Jimmy Lin, [“Comparing Score Aggregation Approaches for Document Retrieval with Pretrained Transformers”](https://doi.org/10.1007/978-3-030-72240-1_11), ECIR 2021.
+- Thong Nguyen, Sean MacAvaney, and Andrew Yates, [“Adapting Learned Sparse Retrieval for Long Documents”](https://doi.org/10.1145/3539618.3591943), SIGIR 2023.
+- Amit Singhal, Chris Buckley, and Mandar Mitra, [“Pivoted Document Length Normalization”](https://doi.org/10.1145/243199.243206), SIGIR 1996.
+- Yuanhua Lv and ChengXiang Zhai, [“Lower-Bounding Term Frequency Normalization”](https://doi.org/10.1145/2063576.2063584), CIKM 2011.
+- Eilon Sheetrit, Anna Shtok, and Oren Kurland, [“A Passage-Based Approach to Learning to Rank Documents”](https://doi.org/10.1007/s10791-020-09369-x), Information Retrieval Journal 2020.
+- Anserini, [MS MARCO passage reproduction settings](https://github.com/castorini/anserini/blob/master/docs/reproduce/from-document-collection/msmarco-v1-passage.docTTTTTquery.md).

--- a/docs/posting-codecs.md
+++ b/docs/posting-codecs.md
@@ -1,0 +1,116 @@
+# Posting block codecs
+
+Status: design (2026-09-04), implemented.
+
+## Problem
+
+`BlockPostingList` (`structures/postings/posting.rs`) is the only posting
+format the index writes: 128-posting blocks of delta-coded doc ids and term
+frequencies, each array packed at a width rounded up to 0/8/16/32 bits so it
+decodes with plain SIMD widening. The repository also carried six standalone
+codecs (exact-width BP128, vertical BP128, OptP4D, Elias-Fano, partitioned
+Elias-Fano, Roaring) plus an `IndexOptimization` knob (`-O adaptive | size |
+performance` in `hermes-tool index`) whose documented effect — "OptP4D + zstd
+22", "Roaring + zstd 3" — was never wired: `IndexConfig.optimization` was
+stored and never read.
+
+The repository's own benchmark (`cargo bench --bench posting_compression --
+summary`, Apple M4) shows what the alternatives are worth:
+
+| codec            | size, % of raw (avg) | decode, M ints/s |
+| ---------------- | -------------------- | ---------------- |
+| rounded 8/16/32  | 27.3                 | 750              |
+| exact BP128      | 15.1                 | 674              |
+| OptP4D (patched) | 12.2                 | 534              |
+| partitioned EF   | 15.7                 | 27               |
+| Elias-Fano       | 16.6                 | 8                |
+| Roaring          | 39.4                 | 336              |
+
+Only exact bit-packing and OptP4D buy anything: 1.8–2.2× smaller postings for
+10–30 % slower decoding. Elias-Fano variants decode 25–100× slower and Roaring
+is both larger and slower on the posting shapes this engine sees.
+
+## Design
+
+### One container, per-block codec
+
+The container stays: `[stream][L0 skip entries][L1][footer]`, 128-posting
+blocks, zero-copy `OwnedBytes`, block-max `max_tf` per L0 entry, and merges
+that copy blocks verbatim with an 8-byte header patch. What changes is the
+block payload. The 8-byte block header
+
+```text
+[count: u16][first_doc: u32][doc_bits: u8][tf_bits: u8]
+```
+
+now stores the **codec in the top two bits of `doc_bits`** (low six bits =
+width, values ≤ 32):
+
+| codec     | id  | payload                                                                                  |
+| --------- | --- | ---------------------------------------------------------------------------------------- |
+| `Rounded` | 0   | unchanged: `(count−1)` deltas at 0/8/16/32 bits, then `count` tfs at 0/8/16/32 bits      |
+| `Packed`  | 1   | deltas bit-packed at the exact width, byte-padded; tfs likewise (`tf_bits` exact)        |
+| `Pfor`    | 2   | per array: `[n_exceptions: u8][packed low bits at width][exception (pos u8, high u32)…]` |
+
+`Rounded` keeps codec id 0 and the existing 0/8/16/32 payload representation.
+That makes it the low-overhead performance baseline; compatibility is governed
+by the format-5 gate below, not by the individual block representation.
+
+`Packed` uses `bits_needed(max)` per array. `Pfor` is the OptP4D block
+encoding already in the tree: the width minimising `n·b + exceptions·(8+32)`
+with at most 10 % exceptions, exceptions storing the high bits.
+
+Block sizes are derived from the L0 offsets (`next.offset − offset`, or
+`stream_len − offset` for the last block) instead of from the header, so a
+payload can carry variable-length exception tables. Decoding dispatches on the
+codec id per block; a posting list — and, after a merge, a single list — may
+mix codecs freely.
+
+### Selection
+
+`IndexConfig.optimization` finally does something, and `IndexConfig` also
+gets an explicit `posting_codec`:
+
+| `-O` / `IndexOptimization` | posting codec | term dictionary zstd |
+| -------------------------- | ------------- | -------------------- |
+| `adaptive` (default)       | `Rounded`     | 9                    |
+| `performance`              | `Rounded`     | 1                    |
+| `size`                     | `Pfor`        | 22                   |
+
+`Packed` is selectable through `IndexConfig::posting_codec` (and
+`hermes-tool index --posting-codec`) for deployments that want most of the
+size win with SIMD-friendly single-array decode. The default stays `Rounded`:
+changing the default codec is a cross-architecture performance decision that
+the numbers above (one machine, synthetic lists) do not justify on their own.
+
+The merger writes the index's codec on its decode–re-encode path (inline or
+mixed sources) and copies blocks verbatim on its fast path, so a segment
+merged from `size` and `adaptive` sources simply contains both kinds of
+blocks.
+
+### Format break (fail loud)
+
+This layout ships with metadata format **5** for every index. The reader
+accepts only format 5 and STB5 term dictionaries; old indexes must be rebuilt.
+Unknown per-block codec ids are rejected instead of being decoded as rounded
+32-bit blocks.
+
+### What is not wired
+
+Elias-Fano, partitioned Elias-Fano, Roaring and vertical BP128 remain library
+codecs (`structures::postings`, exercised by `benches/posting_compression`)
+because the benchmark gives them no configuration in which they win. Wiring
+them would mean a second executor path (they are not 128-block layouts) for a
+measured loss.
+
+## Validation
+
+- `posting::tests`: round trip, `seek`/`advance` equality and byte-identical
+  `Rounded` output against the pre-change layout for every codec, including
+  lists with delta and tf outliers that force exceptions.
+- Streaming and in-memory concatenation of mixed-codec sources.
+- Index-level: `-O size` writes Pfor blocks, survives decode/re-encode merges,
+  and searches identically.
+- `benches/core_structures.rs`: `block_postings/{rounded,packed,pfor}` —
+  serialized size, sequential decode, and skip-seek, on the production
+  container rather than the standalone codecs.

--- a/hermes-core/benches/core_structures.rs
+++ b/hermes-core/benches/core_structures.rs
@@ -316,6 +316,123 @@ fn bench_fast_field_blockwise(c: &mut Criterion) {
     group.finish();
 }
 
+/// Term-dictionary point lookups with restart points every 16 entries.
+#[cfg(feature = "sync")]
+fn bench_term_dict_lookup(c: &mut Criterion) {
+    use hermes_core::directories::{FileHandle, OwnedBytes};
+    use hermes_core::structures::{AsyncSSTableReader, SSTableWriter, TermInfo};
+
+    let mut keys: Vec<Vec<u8>> = (0..200_000u64)
+        .map(|i| {
+            let mut key = (i % 5).to_le_bytes()[..4].to_vec();
+            key.extend_from_slice(
+                format!("term{:08x}", i.wrapping_mul(0x9E37_79B9) % 50_000_000).as_bytes(),
+            );
+            key
+        })
+        .collect();
+    keys.sort();
+    keys.dedup();
+    let build = || -> AsyncSSTableReader<TermInfo> {
+        let mut writer = SSTableWriter::<_, TermInfo>::new(Vec::new());
+        for (i, key) in keys.iter().enumerate() {
+            writer
+                .insert(key, &TermInfo::external(i as u64 * 4096, 4096, 17))
+                .unwrap();
+        }
+        let bytes = writer.finish().unwrap();
+        let handle = FileHandle::from_bytes(OwnedBytes::new(bytes));
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let reader = rt
+            .block_on(AsyncSSTableReader::<TermInfo>::open(handle, 4096))
+            .unwrap();
+        rt.block_on(reader.preload_all_blocks()).unwrap();
+        reader
+    };
+    let reader = build();
+    // Random existing keys.
+    let probes: Vec<&[u8]> = (0..4096usize)
+        .map(|i| keys[(i * 7919) % keys.len()].as_slice())
+        .collect();
+
+    let mut group = c.benchmark_group("core_structures/term_dict_lookup");
+    group.throughput(Throughput::Elements(probes.len() as u64));
+    group.bench_function("restart_points", |bencher| {
+        bencher.iter(|| {
+            let mut found = 0usize;
+            for key in &probes {
+                found += usize::from(black_box(reader.get_sync(key).unwrap()).is_some());
+            }
+            black_box(found)
+        })
+    });
+    group.finish();
+}
+
+#[cfg(not(feature = "sync"))]
+fn bench_term_dict_lookup(_: &mut Criterion) {}
+
+/// Phrase-style position access: for every candidate document in order, the
+/// old random-access lookup re-decodes the block from its start, the
+/// sequential cursor decodes each block once.
+fn bench_position_access(c: &mut Criterion) {
+    use hermes_core::structures::PositionPostingList;
+
+    let mut list = PositionPostingList::new();
+    let mut doc = 0u32;
+    for i in 0..100_000u32 {
+        doc += 1 + (i % 3);
+        let positions: Vec<u32> = (0..6).map(|k| 3 + k * 7 + (i % 5)).collect();
+        list.push(doc, positions);
+    }
+    let mut bytes = Vec::new();
+    list.serialize(&mut bytes).unwrap();
+    let list = PositionPostingList::deserialize(&bytes).unwrap();
+    // Every 4th document is a candidate (a conjunction that keeps 25%).
+    let candidates: Vec<u32> = {
+        let mut it = list.iter();
+        let mut docs = Vec::new();
+        let mut n = 0usize;
+        while it.doc() != u32::MAX {
+            if n.is_multiple_of(4) {
+                docs.push(it.doc());
+            }
+            n += 1;
+            it.advance();
+        }
+        docs
+    };
+
+    let mut group = c.benchmark_group("core_structures/position_access");
+    group.throughput(Throughput::Elements(candidates.len() as u64));
+    group.bench_function("random_access_per_candidate", |bencher| {
+        let mut buf = Vec::new();
+        bencher.iter(|| {
+            let mut total = 0usize;
+            for &doc in &candidates {
+                if list.get_positions_into(doc, &mut buf) {
+                    total += buf.len();
+                }
+            }
+            black_box(total)
+        })
+    });
+    group.bench_function("sequential_cursor", |bencher| {
+        bencher.iter(|| {
+            let mut cursor = list.iter();
+            let mut total = 0usize;
+            for &doc in &candidates {
+                cursor.seek(doc);
+                if cursor.doc() == doc {
+                    total += cursor.positions().len();
+                }
+            }
+            black_box(total)
+        })
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_top_k,
@@ -326,5 +443,7 @@ criterion_group!(
     bench_slice_cache_churn,
     bench_combiner,
     bench_fast_field_blockwise,
+    bench_term_dict_lookup,
+    bench_position_access,
 );
 criterion_main!(benches);

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -26,11 +26,10 @@ const INDEX_META_TMP_FILENAME: &str = "metadata.json.tmp";
 
 /// Current metadata.json format version written by this build.
 ///
-/// `load` refuses metadata stamped with a newer version: serde_json silently
-/// drops fields it does not know about, so loading newer metadata would
-/// misread index state and the next save would destructively rewrite the
-/// unknown fields away.
-pub const INDEX_META_FORMAT_VERSION: u32 = 4;
+/// `load` requires this exact version. Metadata/segment compatibility is a
+/// clean rebuild boundary; serde_json would otherwise silently drop fields it
+/// does not know and a later save could destructively rewrite index state.
+pub const INDEX_META_FORMAT_VERSION: u32 = 5;
 
 /// Index-level centroids/codebooks are deliberately bounded before they are
 /// read or decoded. Besides limiting ordinary corruption damage, the matching
@@ -988,7 +987,7 @@ mod tests {
             .await
             .expect_err("metadata from a newer format version must be refused, not silently pruned")
             .to_string();
-        assert!(error.contains("version 4"), "{error}");
+        assert!(error.contains("version 5"), "{error}");
         assert!(error.contains("incompatible"), "{error}");
     }
 
@@ -1008,7 +1007,7 @@ mod tests {
             .await
             .expect_err("temp-file recovery must apply the same version gate")
             .to_string();
-        assert!(error.contains("version 4"), "{error}");
+        assert!(error.contains("version 5"), "{error}");
     }
 
     #[tokio::test]

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -353,8 +353,14 @@ pub struct IndexConfig {
     pub vector_training_memory_bytes: usize,
     /// Merge policy for background segment merging
     pub merge_policy: Box<dyn crate::merge::MergePolicy>,
-    /// Index optimization mode (adaptive, size-optimized, performance-optimized)
+    /// Index optimization mode (adaptive, size-optimized, performance-optimized).
+    /// Selects the term-dictionary compression level and, unless
+    /// `posting_codec` overrides it, the posting block codec
+    /// (`docs/posting-codecs.md`).
     pub optimization: crate::structures::IndexOptimization,
+    /// Explicit posting block codec; `None` derives it from `optimization`
+    /// (`size` → `Pfor`, everything else → `Rounded`).
+    pub posting_codec: Option<crate::structures::PostingCodec>,
     /// Reload interval in milliseconds for IndexReader (how often to check for new segments)
     pub reload_interval_ms: u64,
     /// Maximum number of concurrent background merges per index (default: 4)
@@ -518,6 +524,7 @@ impl Default for IndexConfig {
             // cannot hold slots indefinitely.
             merge_policy: Box::new(crate::merge::TieredMergePolicy::large_scale()),
             optimization: crate::structures::IndexOptimization::default(),
+            posting_codec: None,
             reload_interval_ms: 1000, // 1 second default
             max_concurrent_merges: 4,
             #[cfg(feature = "native")]
@@ -543,6 +550,14 @@ impl Default for IndexConfig {
     }
 }
 
+impl IndexConfig {
+    /// Posting block codec new segments and merges are written with.
+    pub fn effective_posting_codec(&self) -> crate::structures::PostingCodec {
+        self.posting_codec
+            .unwrap_or_else(|| self.optimization.default_posting_codec())
+    }
+}
+
 /// Build the segment-lifecycle owner from the corresponding index policy.
 ///
 /// `Index` and `IndexWriter` both support create/open entry points. Routing
@@ -555,19 +570,22 @@ fn segment_manager_from_config<D: crate::directories::DirectoryWriter + 'static>
     metadata: IndexMetadata,
     config: &IndexConfig,
 ) -> Arc<crate::merge::SegmentManager<D>> {
-    Arc::new(crate::merge::SegmentManager::new(
-        Arc::clone(directory),
-        Arc::clone(schema),
-        metadata,
-        config.merge_policy.clone_box(),
-        config.term_cache_blocks,
-        config.max_concurrent_merges,
-        Arc::clone(&config.background_merge_permits),
-        config.merge_bp_time_budget,
-        config.bp_memory_budget_bytes,
-        Arc::clone(&config.background_reorder_permits),
-        config.background_reorder_pool.clone(),
-    ))
+    Arc::new(
+        crate::merge::SegmentManager::new(
+            Arc::clone(directory),
+            Arc::clone(schema),
+            metadata,
+            config.merge_policy.clone_box(),
+            config.term_cache_blocks,
+            config.max_concurrent_merges,
+            Arc::clone(&config.background_merge_permits),
+            config.merge_bp_time_budget,
+            config.bp_memory_budget_bytes,
+            Arc::clone(&config.background_reorder_permits),
+            config.background_reorder_pool.clone(),
+        )
+        .with_posting_config(config.optimization, config.effective_posting_codec()),
+    )
 }
 
 /// Multi-segment async Index

--- a/hermes-core/src/index/tests/boolean.rs
+++ b/hermes-core/src/index/tests/boolean.rs
@@ -987,3 +987,305 @@ async fn test_narrow_range_with_wide_must_not_term_returns_exact_docs() {
         "narrow range minus wide MUST_NOT term must return exactly the difference"
     );
 }
+
+// ── Filtered text MaxScore (filters pushed into the executor) ────────────
+
+/// 1000 docs with identical two-term text and a fast u64 `timestamp = i`.
+/// Every text query ties on score, so any post-filtering of a truncated
+/// window would keep only the lowest doc ids.
+async fn create_filtered_text_index() -> (
+    Index<crate::directories::MmapDirectory>,
+    crate::dsl::Field, // content (text)
+    crate::dsl::Field, // kind (text, fast) — "even" / "odd"
+    crate::dsl::Field, // timestamp (u64 fast)
+) {
+    use crate::directories::MmapDirectory;
+
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let dir = MmapDirectory::new(tmp_dir.path());
+
+    let mut sb = SchemaBuilder::default();
+    let content = sb.add_text_field("content", true, true);
+    let kind = sb.add_text_field("kind", true, true);
+    let timestamp = sb.add_u64_field("timestamp", false, true);
+    sb.set_fast(timestamp, true);
+    let schema = sb.build();
+
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    for i in 0u64..1000 {
+        let mut doc = Document::new();
+        // Docs 990..=999 carry an extra "gamma" so a required/excluded term
+        // has a selective posting list at the top of the id range.
+        if i >= 990 {
+            doc.add_text(content, "alpha beta gamma");
+        } else {
+            doc.add_text(content, "alpha beta");
+        }
+        doc.add_text(kind, if i % 2 == 0 { "even" } else { "odd" });
+        doc.add_u64(timestamp, i);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    writer.force_merge().await.unwrap();
+
+    let index = Index::open(dir, config).await.unwrap();
+    assert_eq!(index.num_docs().await.unwrap(), 1000);
+    (index, content, kind, timestamp)
+}
+
+fn doc_ids(results: &crate::query::SearchResponse) -> HashSet<u32> {
+    results.hits.iter().map(|h| h.address.doc_id).collect()
+}
+
+/// Two-term text SHOULD + a range MUST matching 5 of 1000 docs at the top of
+/// the id range: the filter must be applied inside MaxScore, not to a
+/// truncated top-2k window (which held docs 0..19 and returned nothing).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_text_should_with_selective_range_must_returns_all_matches() {
+    let (index, content, _kind, timestamp) = create_filtered_text_index().await;
+
+    let q = BooleanQuery::new()
+        .must(RangeQuery::u64(timestamp, Some(995), Some(999)))
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"));
+    let results = index.search(&q, 10).await.unwrap();
+    assert_eq!(doc_ids(&results), (995u32..=999).collect::<HashSet<_>>());
+
+    // Enough matches to fill the window: exactly `limit` hits, all in range.
+    let q = BooleanQuery::new()
+        .must(RangeQuery::u64(timestamp, Some(900), Some(999)))
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"));
+    let results = index.search(&q, 10).await.unwrap();
+    assert_eq!(results.hits.len(), 10);
+    assert!(doc_ids(&results).iter().all(|&d| (900..=999).contains(&d)));
+}
+
+/// SHOULD text + MUST_NOT range only (no MUST): previously fell to the
+/// exhaustive BooleanScorer; now the negated predicate is pushed into
+/// MaxScore. Excluding 0..=994 must leave exactly 995..=999.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_text_should_with_must_not_range_excludes_inside_executor() {
+    let (index, content, _kind, timestamp) = create_filtered_text_index().await;
+
+    let q = BooleanQuery::new()
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"))
+        .must_not(RangeQuery::u64(timestamp, None, Some(994)));
+    let results = index.search(&q, 10).await.unwrap();
+    assert_eq!(doc_ids(&results), (995u32..=999).collect::<HashSet<_>>());
+}
+
+/// MUST text term (no fast column) is a scoring requirement: its docs
+/// (990..=999) drive the result, the SHOULD terms add their BM25 — so every
+/// hit scores strictly higher than the same query without the requirement —
+/// and a required term absent from the index matches nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_text_should_with_required_text_term_scores_and_filters() {
+    let (index, content, _kind, _ts) = create_filtered_text_index().await;
+
+    let filtered = BooleanQuery::new()
+        .must(TermQuery::text(content, "gamma"))
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"));
+    let results = index.search(&filtered, 20).await.unwrap();
+    assert_eq!(doc_ids(&results), (990u32..=999).collect::<HashSet<_>>());
+
+    let unfiltered = BooleanQuery::new()
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"));
+    let base = index.search(&unfiltered, 20).await.unwrap();
+    let base_top = base.hits[0].score;
+    for hit in &results.hits {
+        assert!(
+            hit.score > base_top,
+            "required term must add its BM25: {} <= {}",
+            hit.score,
+            base_top
+        );
+    }
+
+    // A required term that exists nowhere matches nothing.
+    let none = BooleanQuery::new()
+        .must(TermQuery::text(content, "zeta"))
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"));
+    assert!(index.search(&none, 20).await.unwrap().hits.is_empty());
+}
+
+/// Lucene semantics for a scoring MUST: SHOULD is optional. Requiring "gamma"
+/// with a SHOULD that matches nothing still returns every "gamma" doc, and a
+/// SHOULD that matches only some of them ranks those first.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_required_text_term_keeps_docs_without_should_match() {
+    let (index, content, kind, timestamp) = create_filtered_text_index().await;
+
+    let q = BooleanQuery::new()
+        .must(TermQuery::text(content, "gamma"))
+        .should(TermQuery::text(content, "zeta"));
+    let results = index.search(&q, 20).await.unwrap();
+    assert_eq!(doc_ids(&results), (990u32..=999).collect::<HashSet<_>>());
+
+    let q = BooleanQuery::new()
+        .must(TermQuery::text(content, "gamma"))
+        .must(RangeQuery::u64(timestamp, Some(994), Some(999)))
+        .should(TermQuery::text(kind, "even"));
+    let results = index.search(&q, 20).await.unwrap();
+    assert_eq!(doc_ids(&results), (994u32..=999).collect::<HashSet<_>>());
+    for hit in &results.hits[..3] {
+        assert_eq!(
+            hit.address.doc_id % 2,
+            0,
+            "even docs match SHOULD and rank first"
+        );
+    }
+}
+
+/// MUST_NOT text term on the SHOULD field is an excluded cursor: dropping
+/// "gamma" removes exactly 990..=999 and the window fills from the rest.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_text_should_with_excluded_text_term() {
+    let (index, content, _kind, timestamp) = create_filtered_text_index().await;
+
+    let q = BooleanQuery::new()
+        .must(RangeQuery::u64(timestamp, Some(985), Some(999)))
+        .must_not(TermQuery::text(content, "gamma"))
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"));
+    let results = index.search(&q, 20).await.unwrap();
+    assert_eq!(doc_ids(&results), (985u32..=989).collect::<HashSet<_>>());
+}
+
+/// MUST term on another text field (no fast column) is a requirement that
+/// drives; the range filter and the SHOULD terms apply on top: "odd" ∧
+/// 990..=999, exact, no truncation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_text_should_with_must_term_on_other_field() {
+    let (index, content, kind, timestamp) = create_filtered_text_index().await;
+
+    let q = BooleanQuery::new()
+        .must(TermQuery::text(kind, "odd"))
+        .must(RangeQuery::u64(timestamp, Some(990), Some(999)))
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"));
+    let results = index.search(&q, 20).await.unwrap();
+    let expected: HashSet<u32> = (990u32..=999).filter(|d| d % 2 == 1).collect();
+    assert_eq!(doc_ids(&results), expected);
+}
+
+/// Multi-field SHOULD (content + kind) with a selective range MUST: each
+/// per-field executor gets the filter, and the union is exact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_multi_field_text_should_with_range_must() {
+    let (index, content, kind, timestamp) = create_filtered_text_index().await;
+
+    let q = BooleanQuery::new()
+        .must(RangeQuery::u64(timestamp, Some(995), Some(999)))
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"))
+        .should(TermQuery::text(kind, "even"));
+    let results = index.search(&q, 10).await.unwrap();
+    assert_eq!(doc_ids(&results), (995u32..=999).collect::<HashSet<_>>());
+    // Even docs match one more clause and must rank first.
+    assert!(results.hits[0].address.doc_id % 2 == 0);
+    assert!(results.hits[1].address.doc_id % 2 == 0);
+}
+
+/// Per-field top-k truncation is not exact for multi-field SHOULD scoring: a
+/// document can rank below the local cutoff in every field but win after its
+/// field scores are summed. Filter push-down must preserve that winner.
+#[tokio::test]
+async fn test_filtered_multi_field_text_uses_global_score_before_topk() {
+    use crate::directories::RamDirectory;
+
+    let mut schema = SchemaBuilder::default();
+    let left = schema.add_text_field("left", true, false);
+    let right = schema.add_text_field("right", true, false);
+    let filter = schema.add_u64_field("filter", false, false);
+    schema.set_fast(filter, true);
+    let schema = schema.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    let field_text = |needle_count: usize, salt: usize| {
+        let mut tokens = vec!["needle".to_string(); needle_count];
+        tokens.extend((needle_count..20).map(|i| format!("f{salt}x{i}")));
+        tokens.join(" ")
+    };
+    for doc_id in 0..5usize {
+        let (left_tf, right_tf) = match doc_id {
+            0 | 1 => (10, 0),
+            2 | 3 => (0, 10),
+            _ => (2, 2),
+        };
+        let mut doc = Document::new();
+        doc.add_text(left, field_text(left_tf, doc_id * 2));
+        doc.add_text(right, field_text(right_tf, doc_id * 2 + 1));
+        doc.add_u64(filter, 1);
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+    let index = Index::open(dir, config).await.unwrap();
+
+    let query = BooleanQuery::new()
+        .must(RangeQuery::u64(filter, Some(1), Some(1)))
+        .should(TermQuery::text(left, "needle"))
+        .should(TermQuery::text(right, "needle"));
+    let results = index.search(&query, 1).await.unwrap();
+    assert_eq!(results.hits.len(), 1, "{results:?}");
+    assert_eq!(
+        results.hits[0].address.doc_id, 4,
+        "the moderate score from both fields must beat a high score from only one: {results:?}"
+    );
+}
+
+/// A nested pure-SHOULD Boolean (the server's multi-token match shape) is
+/// flattened into the outer SHOULD list, so the filter still reaches the
+/// executor instead of a truncated opaque sub-scorer.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_nested_should_boolean_is_flattened_for_filters() {
+    let (index, content, _kind, timestamp) = create_filtered_text_index().await;
+
+    let inner = BooleanQuery::new()
+        .should(TermQuery::text(content, "alpha"))
+        .should(TermQuery::text(content, "beta"));
+    let q = BooleanQuery::new()
+        .must(RangeQuery::u64(timestamp, Some(995), Some(999)))
+        .should(inner);
+    let results = index.search(&q, 10).await.unwrap();
+    assert_eq!(doc_ids(&results), (995u32..=999).collect::<HashSet<_>>());
+}
+
+/// A prefix of the lexicographically smallest term of the segment sorts
+/// before the first term-dictionary block key; the scan must still start at
+/// block 0 ("al" is a prefix of "alpha", the smallest term).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_prefix_query_matches_prefix_of_smallest_term() {
+    let (index, content, _kind, _ts) = create_filtered_text_index().await;
+
+    let al = index
+        .search(&PrefixQuery::text(content, "al"), 2000)
+        .await
+        .unwrap();
+    assert_eq!(
+        al.hits.len(),
+        1000,
+        "prefix of the smallest term lost its matches"
+    );
+    let be = index
+        .search(&PrefixQuery::text(content, "be"), 2000)
+        .await
+        .unwrap();
+    assert_eq!(be.hits.len(), 1000);
+    let none = index
+        .search(&PrefixQuery::text(content, "aa"), 2000)
+        .await
+        .unwrap();
+    assert!(none.hits.is_empty());
+}

--- a/hermes-core/src/index/tests/chunked.rs
+++ b/hermes-core/src/index/tests/chunked.rs
@@ -5,8 +5,8 @@ use crate::directories::RamDirectory;
 use crate::dsl::{Document, Field, PositionMode, Schema, SchemaBuilder};
 use crate::index::{Index, IndexConfig, IndexWriter};
 use crate::query::{
-    BooleanQuery, FusionMethod, MultiValueCombiner, PhraseQuery, PrefixQuery, SearchResult,
-    SparseVectorQuery, TermQuery,
+    BooleanQuery, FusionMethod, MultiValueCombiner, PhraseQuery, PrefixQuery, RangeQuery,
+    SearchResult, SparseVectorQuery, TermQuery,
 };
 
 struct Fields {
@@ -187,6 +187,10 @@ async fn chunked_phrase_never_crosses_a_chunk_boundary() {
     assert_eq!(ordinals(by_doc(&results, 1)), vec![1]);
 }
 
+/// Chunk lengths normalise BM25 above the nominal chunk length (the 90th
+/// percentile of the field's chunk lengths) and are floored at it below
+/// (`docs/chunked-bm25.md`): a chunk far longer than nominal scores lower
+/// than a nominal chunk with the same `tf`; a shorter one scores the same.
 #[tokio::test]
 async fn chunked_bm25_normalises_by_real_chunk_length() {
     let f = chunked_schema();
@@ -194,24 +198,42 @@ async fn chunked_bm25_normalises_by_real_chunk_length() {
     let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
         .await
         .unwrap();
-    let long = format!("needle {}", "filler ".repeat(40));
-    writer.add_document(doc(&f, "article", &[&long])).unwrap();
+    // Nine nominal chunks of 10 tokens establish the nominal length.
+    for i in 0..9 {
+        let nominal = format!(
+            "needle {}",
+            (0..9)
+                .map(|j| format!("n{i}x{j}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        writer
+            .add_document(doc(&f, "article", &[&nominal]))
+            .unwrap();
+    }
+    let long = format!("needle {}", "filler ".repeat(200));
+    writer.add_document(doc(&f, "article", &[&long])).unwrap(); // doc 9
     writer
-        .add_document(doc(&f, "article", &["needle filler filler"]))
-        .unwrap();
+        .add_document(doc(&f, "article", &["needle short"]))
+        .unwrap(); // doc 10
     writer.commit().await.unwrap();
 
     let index = open(dir).await;
     let reader = index.reader().await.unwrap();
     let searcher = reader.searcher().await.unwrap();
     let (results, _) = searcher
-        .search_with_positions(&TermQuery::text(f.content, "needle"), 10)
+        .search_with_positions(&TermQuery::text(f.content, "needle"), 20)
         .await
         .unwrap();
-    assert_eq!(results.len(), 2);
+    assert_eq!(results.len(), 11);
+    let nominal = by_doc(&results, 0).score;
     assert!(
-        by_doc(&results, 1).score > by_doc(&results, 0).score,
-        "same tf, shorter chunk must score higher: {results:?}"
+        by_doc(&results, 9).score < nominal,
+        "same tf, chunk longer than nominal must score lower: {results:?}"
+    );
+    assert!(
+        (by_doc(&results, 10).score - nominal).abs() < 1e-5,
+        "same tf, chunk shorter than nominal scores like a nominal one: {results:?}"
     );
 }
 
@@ -617,7 +639,7 @@ async fn chunked_text_field_reorders_through_its_chunk_map() {
     // The new documents change idf and average length, so compare the
     // matched documents (and, for the exact-match queries, their ordinals)
     // rather than scores.
-    let merged = snapshot(&open(dir).await, &queries, number).await;
+    let merged = snapshot(&open(dir.clone()).await, &queries, number).await;
     for (i, (a, b)) in after.iter().zip(&merged).enumerate() {
         let a: Vec<(u64, Vec<u32>)> = a.iter().map(|(d, _, o)| (*d, o.clone())).collect();
         let b: Vec<(u64, Vec<u32>)> = b
@@ -633,11 +655,18 @@ async fn chunked_text_field_reorders_through_its_chunk_map() {
         }
         assert_eq!(a, b, "query {i}");
     }
-    assert!(
-        merged[0].iter().any(|(d, _, _)| *d >= 600),
-        "{:?}",
-        merged[0]
-    );
+    // The short-tail length floor deliberately removes the old ranking boost
+    // for the new two-token chunks, so they need not enter an unfiltered
+    // top-50 dominated by repeated terms in the older six-token chunks.
+    // Address them through a range filter to verify the merged postings and
+    // chunk map contain every newly appended document.
+    let new_docs = BooleanQuery::new()
+        .must(RangeQuery::u64(number, Some(600), Some(639)))
+        .should(TermQuery::text(content, "quantum"))
+        .should(TermQuery::text(content, "photon"))
+        .should(TermQuery::text(content, "kernel"));
+    let response = open(dir).await.search(&new_docs, 50).await.unwrap();
+    assert_eq!(response.hits.len(), 40, "{response:?}");
 }
 
 #[tokio::test]
@@ -663,4 +692,87 @@ async fn chunked_field_rejects_prefix_queries_loudly() {
         error.to_string().contains("chunked"),
         "prefix on a chunked field must fail with an actionable message: {error}"
     );
+}
+
+/// A short tail chunk is scored with the length floored at the average chunk
+/// length (`docs/chunked-bm25.md`): with the same `tf` it must not outrank a
+/// full-length chunk, and its score must equal the full chunk's.
+#[tokio::test]
+async fn chunked_short_tail_chunk_is_not_rewarded() {
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    let full = |i: usize| {
+        let mut words = vec!["needle".to_string()];
+        for j in 0..99 {
+            words.push(format!("w{i}x{j}"));
+        }
+        words.join(" ")
+    };
+    // doc 0: two full chunks, the needle in the second.
+    writer
+        .add_document(doc(
+            &f,
+            "a",
+            &[&full(0).replace("needle", "blank"), &full(1)],
+        ))
+        .unwrap();
+    // doc 1: one full chunk without the needle and a 4-token tail with it.
+    writer
+        .add_document(doc(
+            &f,
+            "b",
+            &[&full(2).replace("needle", "blank"), "needle tail end here"],
+        ))
+        .unwrap();
+    writer.commit().await.unwrap();
+    let index = open(dir).await;
+
+    let results = index
+        .search(&TermQuery::text(f.content, "needle"), 10)
+        .await
+        .unwrap();
+    assert_eq!(results.hits.len(), 2, "{results:?}");
+    let a = by_doc_hits(&results.hits, 0);
+    let b = by_doc_hits(&results.hits, 1);
+    assert!(
+        (a - b).abs() < 1e-5,
+        "tail chunk (len 4) must score like a full chunk: full={a} tail={b}"
+    );
+}
+
+/// Boolean exclusion stays document-scoped even though chunked postings use
+/// virtual chunk ids: a forbidden term in a different chunk must still remove
+/// the whole document.
+#[tokio::test]
+async fn chunked_must_not_excludes_a_match_from_another_chunk() {
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    writer
+        .add_document(doc(&f, "a", &["needle lives here", "forbidden elsewhere"]))
+        .unwrap();
+    writer
+        .add_document(doc(&f, "b", &["needle lives here", "clean elsewhere"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+    let index = open(dir).await;
+
+    let query = BooleanQuery::new()
+        .should(TermQuery::text(f.content, "needle"))
+        .must_not(TermQuery::text(f.content, "forbidden"));
+    let results = index.search(&query, 10).await.unwrap();
+    assert_eq!(results.hits.len(), 1, "{results:?}");
+    assert_eq!(results.hits[0].address.doc_id, 1, "{results:?}");
+}
+
+fn by_doc_hits(hits: &[crate::query::SearchHit], doc_id: u32) -> f32 {
+    hits.iter()
+        .find(|h| h.address.doc_id == doc_id)
+        .unwrap_or_else(|| panic!("doc {doc_id} missing"))
+        .score
 }

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -4,6 +4,7 @@ mod boolean;
 mod chunked;
 mod merge;
 mod pin;
+mod posting_codecs;
 mod primary_key;
 mod range;
 mod search;

--- a/hermes-core/src/index/tests/posting_codecs.rs
+++ b/hermes-core/src/index/tests/posting_codecs.rs
@@ -1,0 +1,59 @@
+//! End-to-end coverage for posting-codec selection and compatibility stamps.
+
+use crate::directories::RamDirectory;
+use crate::dsl::{Document, SchemaBuilder};
+use crate::index::{Index, IndexConfig, IndexMetadata, IndexWriter};
+use crate::structures::{IndexOptimization, PostingCodec};
+
+#[tokio::test]
+async fn size_optimization_survives_reencoding_merge() {
+    let mut schema = SchemaBuilder::default();
+    let body = schema.add_text_field("body", true, false);
+    let schema = schema.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        optimization: IndexOptimization::SizeOptimized,
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+
+    // One inline source plus one external source forces the merger's
+    // decode/remap/re-encode path for "needle".
+    let mut first = Document::new();
+    first.add_text(body, "needle");
+    writer.add_document(first).unwrap();
+    writer.commit().await.unwrap();
+    for i in 0..8 {
+        let mut doc = Document::new();
+        doc.add_text(body, format!("needle value{i}"));
+        writer.add_document(doc).unwrap();
+    }
+    writer.commit().await.unwrap();
+
+    let metadata = IndexMetadata::load(&dir).await.unwrap();
+    assert_eq!(
+        metadata.version,
+        crate::index::metadata::INDEX_META_FORMAT_VERSION,
+        "new text layouts use the current index format"
+    );
+
+    writer.force_merge().await.unwrap();
+    drop(writer);
+    let index = Index::open(dir.clone(), config).await.unwrap();
+    let segments = index.segment_readers().await.unwrap();
+    assert_eq!(segments.len(), 1);
+    let postings = segments[0]
+        .get_postings(body, b"needle")
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(postings.num_blocks() > 0);
+    assert!(
+        (0..postings.num_blocks())
+            .all(|block| { postings.block_codec(block) == Some(PostingCodec::Pfor) }),
+        "merge re-encoding must retain the configured size codec"
+    );
+}

--- a/hermes-core/src/index/wasm_writer.rs
+++ b/hermes-core/src/index/wasm_writer.rs
@@ -34,6 +34,14 @@ const DEFAULT_WASM_MEMORY_BUDGET: usize = 32 * 1024 * 1024;
 /// Minimum docs before auto-flush (avoids tiny segments).
 const MIN_DOCS_BEFORE_FLUSH: u32 = 100;
 
+fn default_builder_config(index_config: &IndexConfig) -> SegmentBuilderConfig {
+    SegmentBuilderConfig {
+        optimization: index_config.optimization,
+        posting_codec: index_config.effective_posting_codec(),
+        ..SegmentBuilderConfig::default()
+    }
+}
+
 /// Single-threaded IndexWriter for WASM targets.
 ///
 /// Documents are buffered in a `SegmentBuilder` and flushed to segments
@@ -55,7 +63,8 @@ pub struct IndexWriter<D: DirectoryWriter + 'static> {
 impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Create a new index in the directory.
     pub async fn create(directory: D, schema: Schema, config: IndexConfig) -> Result<Self> {
-        Self::create_with_config(directory, schema, config, SegmentBuilderConfig::default()).await
+        let builder_config = default_builder_config(&config);
+        Self::create_with_config(directory, schema, config, builder_config).await
     }
 
     /// Create a new index with custom builder config.
@@ -84,7 +93,8 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
     /// Open an existing index for writing.
     pub async fn open(directory: D, config: IndexConfig) -> Result<Self> {
-        Self::open_with_config(directory, config, SegmentBuilderConfig::default()).await
+        let builder_config = default_builder_config(&config);
+        Self::open_with_config(directory, config, builder_config).await
     }
 
     /// Open an existing index with custom builder config.
@@ -413,5 +423,21 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
     /// Number of documents in the current (uncommitted) builder.
     pub fn pending_docs(&self) -> u32 {
         self.builder.as_ref().map(|b| b.num_docs()).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::default_builder_config;
+
+    #[test]
+    fn standard_builder_config_honors_index_posting_policy() {
+        let config = crate::index::IndexConfig {
+            optimization: crate::structures::IndexOptimization::SizeOptimized,
+            ..Default::default()
+        };
+        let builder = default_builder_config(&config);
+        assert_eq!(builder.optimization, config.optimization);
+        assert_eq!(builder.posting_codec, crate::structures::PostingCodec::Pfor);
     }
 }

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -99,6 +99,8 @@ fn hard_flush_threshold(memory_budget: usize) -> usize {
 fn default_builder_config(index_config: &IndexConfig) -> SegmentBuilderConfig {
     SegmentBuilderConfig {
         num_compression_threads: index_config.num_compression_threads,
+        optimization: index_config.optimization,
+        posting_codec: index_config.effective_posting_codec(),
         ..SegmentBuilderConfig::default()
     }
 }
@@ -709,8 +711,14 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
 
         let metadata = super::IndexMetadata::new((*schema).clone());
 
+        // A custom builder config is authoritative for the physical text
+        // layout, including merge re-encoding and the metadata compatibility
+        // gate.
+        let mut segment_config = config.clone();
+        segment_config.optimization = builder_config.optimization;
+        segment_config.posting_codec = Some(builder_config.posting_codec);
         let segment_manager =
-            super::segment_manager_from_config(&directory, &schema, metadata, &config);
+            super::segment_manager_from_config(&directory, &schema, metadata, &segment_config);
         segment_manager.update_metadata(|_| {}).await?;
 
         Ok(Self::new_with_parts(
@@ -756,8 +764,12 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         // Directory-layer metrics (cold writes, lazy reads) carry the index label
         directory.set_index_label(schema.index_label());
 
+        // See `create_with_config`: custom builders define the on-disk layout.
+        let mut segment_config = config.clone();
+        segment_config.optimization = builder_config.optimization;
+        segment_config.posting_codec = Some(builder_config.posting_codec);
         let segment_manager =
-            super::segment_manager_from_config(&directory, &schema, metadata, &config);
+            super::segment_manager_from_config(&directory, &schema, metadata, &segment_config);
         let swept = segment_manager.cleanup_orphan_segments().await?;
         if swept > 0 {
             log::warn!(

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -867,6 +867,10 @@ pub struct SegmentManager<D: DirectoryWriter + 'static> {
     directory: Arc<D>,
     /// Schema for segment operations
     schema: Arc<crate::dsl::Schema>,
+    /// Compression mode used for term dictionaries produced by merges.
+    optimization: crate::structures::IndexOptimization,
+    /// Posting codec used by new segments and merge re-encoding.
+    posting_codec: crate::structures::PostingCodec,
     /// Term cache blocks for segment readers during merge
     term_cache_blocks: usize,
     /// Hard concurrency limit for background merges. A semaphore permit is
@@ -1018,6 +1022,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             delete_fn,
             directory,
             schema,
+            optimization: crate::structures::IndexOptimization::default(),
+            posting_codec: crate::structures::PostingCodec::default(),
             term_cache_blocks,
             merge_permits: Arc::new(Semaphore::new(max_concurrent_merges.max(1))),
             global_merge_permits,
@@ -1028,6 +1034,18 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             background_reorder_pool,
             replacement_refresh: parking_lot::RwLock::new(None),
         }
+    }
+
+    /// Set the persisted text-index layout selected by `IndexConfig` (or by
+    /// an explicit `SegmentBuilderConfig` override).
+    pub fn with_posting_config(
+        mut self,
+        optimization: crate::structures::IndexOptimization,
+        posting_codec: crate::structures::PostingCodec,
+    ) -> Self {
+        self.optimization = optimization;
+        self.posting_codec = posting_codec;
+        self
     }
 
     pub(crate) fn set_replacement_refresh<F, Fut>(&self, refresh: F)
@@ -2051,6 +2069,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             ids,
             output_id,
             self.term_cache_blocks,
+            self.optimization,
+            self.posting_codec,
             trained.as_deref(),
             reorder_bmp,
             granularity,
@@ -2278,6 +2298,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         segment_ids_to_merge: &[String],
         output_segment_id: SegmentId,
         term_cache_blocks: usize,
+        optimization: crate::structures::IndexOptimization,
+        posting_codec: crate::structures::PostingCodec,
         trained: Option<&TrainedVectorStructures>,
         reorder_bmp: bool,
         granularity: crate::segment::reorder::BpGranularity,
@@ -2397,6 +2419,7 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
         );
 
         let merger = SegmentMerger::new(Arc::clone(schema))
+            .with_posting_config(optimization, posting_codec)
             .with_bmp_reorder(reorder_bmp)
             .with_granularity(granularity)
             .with_bp_budget(crate::segment::BpBudget {
@@ -3775,6 +3798,8 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
             self.bp_memory_budget_bytes,
             bp_budget,
             granularity,
+            self.optimization,
+            self.posting_codec,
             rayon_pool,
             Some(self.active_operations.cancellation_flag()),
         )

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -157,6 +157,29 @@ impl BooleanQuery {
     }
 }
 
+/// Flatten nested pure-SHOULD Boolean queries into one SHOULD list.
+///
+/// `OR(OR(a, b), c)` scores exactly like `OR(a, b, c)`, and only the flat
+/// form reaches MaxScore and filter push-down. The nested form would be an
+/// opaque sub-scorer whose top-k truncation can hide matches from the outer
+/// query.
+fn flatten_should(should: &[Arc<dyn Query>]) -> std::borrow::Cow<'_, [Arc<dyn Query>]> {
+    if !should.iter().any(|query| query.should_children().is_some()) {
+        return std::borrow::Cow::Borrowed(should);
+    }
+
+    fn push_flat(out: &mut Vec<Arc<dyn Query>>, query: &Arc<dyn Query>) {
+        match query.should_children() {
+            Some(children) => children.iter().for_each(|child| push_flat(out, child)),
+            None => out.push(Arc::clone(query)),
+        }
+    }
+
+    let mut flat = Vec::with_capacity(should.len());
+    should.iter().for_each(|query| push_flat(&mut flat, query));
+    std::borrow::Cow::Owned(flat)
+}
+
 /// Build a SHOULD-only scorer from a vec of optimized scorers.
 fn build_should_scorer<'a>(scorers: Vec<Box<dyn Scorer + 'a>>) -> Box<dyn Scorer + 'a> {
     if scorers.is_empty() {
@@ -194,7 +217,8 @@ macro_rules! boolean_plan {
      $scorer_fn:ident, $get_postings_fn:ident, $execute_fn:ident
      $(, $aw:tt)*) => {{
         let must: &[Arc<dyn Query>] = &$must;
-        let should_all: &[Arc<dyn Query>] = &$should;
+        let should_flat = flatten_should(&$should);
+        let should_all: &[Arc<dyn Query>] = &should_flat;
         let must_not: &[Arc<dyn Query>] = &$must_not;
         let global_stats: Option<&Arc<GlobalStats>> = $global_stats;
         let reader: &SegmentReader = $reader;
@@ -394,7 +418,7 @@ macro_rules! boolean_plan {
         // predicates carry no positions to lose and verifier scorers keep
         // theirs. Only the posting-list bitset shortcut is skipped when
         // positions are requested, because a bitset cannot report them.
-        if !should.is_empty() && !must.is_empty() {
+        if !should.is_empty() && (!must.is_empty() || !must_not.is_empty()) {
             // ── 3-text. Text SHOULD with materializable filters ──────────
             //
             // When every SHOULD clause is a text term and the MUST/MUST_NOT
@@ -429,11 +453,95 @@ macro_rules! boolean_plan {
                 }
                 all_text.then_some(groups)
             };
-            if let Some(groups) = text_groups
+            if must.iter().all(|query| {
+                query.is_filter()
+                    || query.as_doc_predicate(reader).is_some()
+                    || (!matches!(
+                        query.decompose(),
+                        super::QueryDecomposition::TextTerm(_)
+                    ) && query.as_doc_bitset(reader).is_some())
+            })
+                && let Some(groups) = text_groups
+                && (groups.len() == 1
+                    || ($proximity.is_none()
+                        && groups
+                            .iter()
+                            .all(|(field, _)| !reader.is_chunked_field(*field))))
                 && let Some(bitset) = build_combined_bitset(must, must_not, reader)
             {
                 let bitset = std::sync::Arc::new(bitset);
                 let single_field = groups.len() == 1;
+
+                // Scores from different fields are additive. Running a
+                // separate top-k per field and merging those windows is not
+                // exact: a document just below every local cutoff can still
+                // win after its field scores are summed. Non-chunked text
+                // fields share document ids, so put all of their cursors in
+                // one executor and apply the filter there.
+                if !single_field {
+                    let mut cursors = Vec::new();
+                    for (field, infos) in groups {
+                        let corpus_size = reader.text_corpus_size(field);
+                        let avg_field_len = global_stats
+                            .map(|stats| stats.avg_field_len(field))
+                            .unwrap_or_else(|| reader.avg_field_len(field));
+                        let params = super::Bm25Params::for_field(reader.schema(), field);
+                        let mut posting_lists = Vec::with_capacity(infos.len());
+                        let mut term_bytes = Vec::with_capacity(infos.len());
+                        for info in &infos {
+                            if let Some(postings) =
+                                reader.$get_postings_fn(field, &info.term) $(. $aw)* ?
+                            {
+                                let idf = compute_idf(
+                                    &postings,
+                                    field,
+                                    &info.term,
+                                    corpus_size,
+                                    global_stats,
+                                ) * info.weight;
+                                posting_lists.push((postings, idf));
+                                term_bytes.push(info.term.clone());
+                            }
+                        }
+                        cap_terms(&mut posting_lists, &mut term_bytes, $text_tuning.1);
+                        cursors.extend(posting_lists.into_iter().map(|(postings, idf)| {
+                            super::TermCursor::text_with_params(
+                                postings,
+                                idf,
+                                avg_field_len,
+                                reader.doc_lengths(field).map(super::LengthSource::Docs),
+                                params,
+                            )
+                        }));
+                    }
+
+                    let filter = bitset.clone();
+                    let predicate: super::DocPredicate<'_> =
+                        Box::new(move |doc_id| filter.contains(doc_id));
+                    let mut executor = super::MaxScoreExecutor::new(
+                        cursors,
+                        limit,
+                        $text_tuning.0,
+                    )
+                    .with_metric_labels(reader.schema().index_label(), "<multiple>")
+                    .with_predicate(predicate)
+                    .with_budget(scorer_options.shared_threshold.clone());
+                    if $text_tuning.0 <= 1.0 && scorer_options.initial_threshold > 0.0 {
+                        executor.seed_threshold(scorer_options.initial_threshold);
+                    }
+                    let results = executor.execute_sync()?;
+                    let found = results.len() as u32;
+                    let should_scorer: Box<dyn Scorer + '_> =
+                        Box::new(super::planner::TopKResultScorer::new(results));
+                    if !must.is_empty() && (found as usize) < limit && bitset.count() > found {
+                        return Ok(Box::new(super::planner::BitsetFillScorer::new(
+                            should_scorer,
+                            bitset,
+                        )));
+                    }
+                    return Ok(should_scorer);
+                }
+
                 let group_limit = if single_field {
                     limit
                 } else {
@@ -508,7 +616,11 @@ macro_rules! boolean_plan {
                     found
                 );
                 let should_scorer = build_should_scorer(scorers);
-                if complete && (found as usize) < limit && bitset.count() > found {
+                if !must.is_empty()
+                    && complete
+                    && (found as usize) < limit
+                    && bitset.count() > found
+                {
                     return Ok(Box::new(super::planner::BitsetFillScorer::new(
                         should_scorer,
                         bitset,
@@ -652,16 +764,10 @@ macro_rules! boolean_plan {
                 }
             }
 
-            // 3c. PredicatedScorer fallback. Filters can discard candidates,
-            // so use the same bounded candidate budget as other query paths.
-            let has_filters = !predicates.is_empty()
-                || !must_verifiers.is_empty()
-                || !must_not_verifiers.is_empty();
-            let should_limit = if has_filters {
-                super::max_candidate_limit(limit)
-            } else {
-                limit
-            };
+            // 3c. Generic fallback — never filter a truncated SHOULD window.
+            // Sparse retrieval keeps its combined candidate executor. Other
+            // query shapes use the individual SHOULD streams so filters and
+            // scoring requirements see the complete document streams.
             let mut should_options = scorer_options.without_threshold();
             if should_is_sparse {
                 // The outer decomposition built this plan from the complete
@@ -671,9 +777,11 @@ macro_rules! boolean_plan {
                 // and remain cleared.
                 should_options.lsp_plan = scorer_options.lsp_plan.clone();
             }
-            let should_scorer = if should.len() == 1 {
-                should[0].$scorer_fn(reader, should_limit, should_options) $(. $aw)* ?
-            } else {
+            let proximity_should = $proximity.is_some();
+            let combined_should = should.len() == 1 || should_is_sparse || proximity_should;
+            let should_scorer: Option<Box<dyn Scorer + '_>> = if should.len() == 1 {
+                Some(should[0].$scorer_fn(reader, limit, should_options.clone()) $(. $aw)* ?)
+            } else if should_is_sparse || proximity_should {
                 let sub = BooleanQuery {
                     must: Vec::new(),
                     should: should.to_vec(),
@@ -683,39 +791,81 @@ macro_rules! boolean_plan {
                     text_heap_factor: $text_tuning.0,
                     max_terms: $text_tuning.1,
                 };
-                sub.$scorer_fn(reader, should_limit, should_options) $(. $aw)* ?
+                // Proximity is a positive second-stage bonus. Preserve the
+                // complete SHOULD stream before applying outer requirements;
+                // a bounded BM25-only window can omit the document whose
+                // proximity bonus would promote it. Chunked fields use their
+                // virtual-id corpus size, plain fields their document count.
+                let sub_limit = if proximity_should {
+                    should
+                        .first()
+                        .and_then(|query| match query.decompose() {
+                            super::QueryDecomposition::TextTerm(info) => {
+                                Some(reader.text_corpus_size(info.field) as usize)
+                            }
+                            _ => None,
+                        })
+                        .unwrap_or(reader.num_docs() as usize)
+                        .max(limit)
+                } else {
+                    super::max_candidate_limit(limit)
+                };
+                Some(sub.$scorer_fn(
+                    reader,
+                    sub_limit,
+                    should_options.clone(),
+                ) $(. $aw)* ?)
+            } else {
+                None
+            };
+            let should_scorers: Vec<Box<dyn Scorer + '_>> = match should_scorer {
+                Some(scorer) => vec![scorer],
+                None => {
+                    let mut scorers = Vec::with_capacity(should.len());
+                    for query in should {
+                        scorers.push(query.$scorer_fn(
+                            reader,
+                            limit,
+                            should_options.clone(),
+                        ) $(. $aw)* ?);
+                    }
+                    scorers
+                }
             };
 
-            let use_predicated =
-                must_verifiers.is_empty() || should_scorer.size_hint() >= limit as u32;
-
-            if use_predicated {
+            if must_verifiers.is_empty() {
+                let should_scorer = build_should_scorer(should_scorers);
                 log::debug!(
-                    "BooleanQuery planner: PredicatedScorer {} preds + {} must_v + {} must_not_v, \
-                     SHOULD size_hint={}, over_fetch={}",
-                    predicates.len(), must_verifiers.len(), must_not_verifiers.len(),
-                    should_scorer.size_hint(), should_limit
+                    "BooleanQuery planner: PredicatedScorer {} preds + {} must_not_v, \
+                     SHOULD size_hint={}, combined={}",
+                    predicates.len(), must_not_verifiers.len(),
+                    should_scorer.size_hint(), combined_should
                 );
                 return Ok(Box::new(super::PredicatedScorer::new(
-                    should_scorer, predicates, must_verifiers, must_not_verifiers,
+                    should_scorer, predicates, Vec::new(), must_not_verifiers,
                 )));
             }
 
-            // size_hint < limit with verifiers → BooleanScorer
+            // Scoring MUST clauses drive the conjunction; SHOULD is optional.
             log::debug!(
-                "BooleanQuery planner: BooleanScorer fallback, size_hint={} < limit={}, \
-                 {} must_v + {} must_not_v",
-                should_scorer.size_hint(), limit,
-                must_verifiers.len(), must_not_verifiers.len()
+                "BooleanQuery planner: required-clause BooleanScorer {} must + {} should, \
+                 {} preds + {} must_not_v",
+                must_verifiers.len(), should_scorers.len(),
+                predicates.len(), must_not_verifiers.len()
             );
-            let mut scorer = BooleanScorer {
+            let mut driver = BooleanScorer {
                 must: must_verifiers,
-                should: vec![should_scorer],
-                must_not: must_not_verifiers,
+                should: should_scorers,
+                must_not: Vec::new(),
                 current_doc: 0,
             };
-            scorer.current_doc = scorer.find_next_match();
-            return Ok(Box::new(scorer));
+            driver.current_doc = driver.find_next_match();
+            return Ok(Box::new(super::PredicatedScorer::new(
+                Box::new(driver),
+                predicates,
+                Vec::new(),
+                must_not_verifiers,
+            )));
         }
 
         // ── 4. Standard BooleanScorer fallback ───────────────────────────
@@ -841,6 +991,14 @@ impl Query for BooleanQuery {
         extract_all_sparse_infos(&self.should)
             .map(super::QueryDecomposition::SparseTerms)
             .unwrap_or(super::QueryDecomposition::Opaque)
+    }
+
+    fn should_children(&self) -> Option<&[Arc<dyn Query>]> {
+        if self.must.is_empty() && self.must_not.is_empty() && !self.should.is_empty() {
+            Some(&self.should)
+        } else {
+            None
+        }
     }
 
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<super::DocBitset> {

--- a/hermes-core/src/query/phrase.rs
+++ b/hermes-core/src/query/phrase.rs
@@ -434,7 +434,7 @@ enum Lengths {
 impl Lengths {
     fn length(&self, id: u32) -> u32 {
         match self {
-            Lengths::Chunks(map) => map.length(id),
+            Lengths::Chunks(map) => map.bm25_length(id),
             Lengths::Docs(lengths) => lengths.length(id),
         }
     }

--- a/hermes-core/src/query/scoring.rs
+++ b/hermes-core/src/query/scoring.rs
@@ -456,7 +456,7 @@ impl LengthSource<'_> {
     #[inline]
     pub fn length(&self, id: u32) -> u32 {
         match self {
-            LengthSource::Chunks(map) => map.length(id),
+            LengthSource::Chunks(map) => map.bm25_length(id),
             LengthSource::Docs(lengths) => lengths.length(id),
         }
     }

--- a/hermes-core/src/query/traits.rs
+++ b/hermes-core/src/query/traits.rs
@@ -365,6 +365,18 @@ macro_rules! define_query_traits {
             fn bitset_cardinality_estimate(&self, _reader: &SegmentReader) -> Option<u64> {
                 None
             }
+
+            /// For a query that is a pure disjunction of sub-queries (a Boolean
+            /// query with only SHOULD clauses and no boost), the clauses.
+            ///
+            /// The boolean planner flattens these into the enclosing SHOULD
+            /// list: `OR(OR(a, b), c)` scores exactly like `OR(a, b, c)`, and
+            /// the flat form is eligible for MaxScore and filter push-down
+            /// where the nested form would be an opaque, top-k-truncated
+            /// sub-scorer.
+            fn should_children(&self) -> Option<&[std::sync::Arc<dyn Query>]> {
+                None
+            }
         }
 
         /// Scored document stream: a DocSet that also provides scores.
@@ -441,6 +453,10 @@ impl Query for Box<dyn Query> {
 
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<DocBitset> {
         (**self).as_doc_bitset(reader)
+    }
+
+    fn should_children(&self) -> Option<&[std::sync::Arc<dyn Query>]> {
+        (**self).should_children()
     }
 
     fn bitset_cardinality_estimate(&self, reader: &SegmentReader) -> Option<u64> {

--- a/hermes-core/src/segment/builder/config.rs
+++ b/hermes-core/src/segment/builder/config.rs
@@ -62,6 +62,11 @@ pub struct SegmentBuilderConfig {
     pub interner_capacity: usize,
     /// Initial capacity for posting lists hashmap
     pub posting_map_capacity: usize,
+    /// Term-dictionary compression / bloom configuration (from the index
+    /// optimization mode).
+    pub optimization: crate::structures::IndexOptimization,
+    /// Posting block codec (`docs/posting-codecs.md`).
+    pub posting_codec: crate::structures::PostingCodec,
 }
 
 impl Default for SegmentBuilderConfig {
@@ -78,6 +83,8 @@ impl Default for SegmentBuilderConfig {
             num_compression_threads: 1,
             interner_capacity: 1_000_000,
             posting_map_capacity: 500_000,
+            optimization: crate::structures::IndexOptimization::default(),
+            posting_codec: crate::structures::PostingCodec::default(),
         }
     }
 }

--- a/hermes-core/src/segment/builder/mod.rs
+++ b/hermes-core/src/segment/builder/mod.rs
@@ -1461,6 +1461,8 @@ impl SegmentBuilder {
         #[cfg(feature = "native")]
         let num_compression_threads = self.config.num_compression_threads;
         let compression_level = self.config.compression_level;
+        let optimization = self.config.optimization;
+        let posting_codec = self.config.posting_codec;
         let dense_vectors = std::mem::take(&mut self.dense_vectors);
         let binary_dense_vectors = std::mem::take(&mut self.binary_dense_vectors);
         let mut sparse_vectors = std::mem::take(&mut self.sparse_vectors);
@@ -1528,6 +1530,7 @@ impl SegmentBuilder {
                                     &length_lookup,
                                     &mut term_dict_writer,
                                     &mut postings_writer,
+                                    (optimization, posting_codec),
                                     spill_arg,
                                 )
                             },
@@ -1595,6 +1598,7 @@ impl SegmentBuilder {
                 &length_lookup,
                 &mut term_dict_writer,
                 &mut postings_writer,
+                (optimization, posting_codec),
             )?;
             store::build_store_streaming_from_buffer(
                 &self.store_buffer,

--- a/hermes-core/src/segment/builder/postings.rs
+++ b/hermes-core/src/segment/builder/postings.rs
@@ -180,6 +180,7 @@ pub(super) type SpillIndex = HashMap<TermKey, Vec<(u64, u32)>>;
 ///
 /// When `spill_reader` is provided, large posting lists that were spilled to
 /// disk during indexing are loaded and merged with their in-memory tails.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn build_postings_streaming(
     inverted_index: HashMap<TermKey, PostingListBuilder>,
     term_interner: Rodeo,
@@ -187,11 +188,16 @@ pub(super) fn build_postings_streaming(
     lengths: &LengthLookup<'_>,
     term_dict_writer: &mut dyn Write,
     postings_writer: &mut dyn Write,
+    posting_config: (
+        crate::structures::IndexOptimization,
+        crate::structures::PostingCodec,
+    ),
     #[cfg(feature = "native")] spill_reader: Option<(
         &mut std::io::BufReader<std::fs::File>,
         &SpillIndex,
     )>,
 ) -> Result<()> {
+    let (optimization, posting_codec) = posting_config;
     // Phase 0 (native only): Load spilled postings back into PostingListBuilders.
     // Spilled data (sorted by doc_id) is prepended before in-memory tail.
     #[cfg(feature = "native")]
@@ -304,10 +310,11 @@ pub(super) fn build_postings_streaming(
         // block records the shortest scoring unit it covers for its bound.
         let field_id = u32::from_le_bytes([key[0], key[1], key[2], key[3]]);
         let length_of = |id: u32| lengths.length(field_id, id);
-        let block_list = crate::structures::BlockPostingList::from_posting_list_with(
+        let block_list = crate::structures::BlockPostingList::from_posting_list_with_options(
             &full_postings,
             has_positions,
             Some(&length_of),
+            posting_codec,
         )?;
         block_list.serialize(&mut posting_bytes)?;
         let result = SerializedPosting::External {
@@ -332,7 +339,10 @@ pub(super) fn build_postings_streaming(
 
     // Phase 3: Stream directly to writers (no intermediate Vec<u8> accumulation)
     let mut postings_offset = 0u64;
-    let mut writer = SSTableWriter::<_, TermInfo>::new(term_dict_writer);
+    let mut writer = SSTableWriter::<_, TermInfo>::with_config(
+        term_dict_writer,
+        crate::structures::SSTableWriterConfig::from_optimization(optimization),
+    );
 
     for (key, serialized_posting) in serialized {
         let term_info = match serialized_posting {

--- a/hermes-core/src/segment/chunk_map.rs
+++ b/hermes-core/src/segment/chunk_map.rs
@@ -234,6 +234,32 @@ pub struct ChunkMap {
     lengths: OwnedBytes,
     num_chunks: u32,
     total_tokens: u64,
+    /// Nominal chunk length: the 90th-percentile chunk length of the field in
+    /// this segment. BM25 floors every chunk length at this value so a short
+    /// tail chunk is not rewarded for being short (`docs/chunked-bm25.md`).
+    length_floor: u32,
+}
+
+/// 90th-percentile of a little-endian `u16` length column (0 when empty).
+fn nominal_chunk_length(lengths: &[u8]) -> u32 {
+    let n = lengths.len() / 2;
+    if n == 0 {
+        return 0;
+    }
+    let mut histogram = vec![0u32; u16::MAX as usize + 1];
+    for pair in lengths.chunks_exact(2) {
+        histogram[u16::from_le_bytes([pair[0], pair[1]]) as usize] += 1;
+    }
+    // Smallest length such that at least 90 % of the chunks are ≤ it.
+    let target = (n as u64 * 9).div_ceil(10);
+    let mut seen = 0u64;
+    for (len, &count) in histogram.iter().enumerate() {
+        seen += u64::from(count);
+        if seen >= target {
+            return len as u32;
+        }
+    }
+    u16::MAX as u32
 }
 
 impl ChunkMap {
@@ -255,6 +281,19 @@ impl ChunkMap {
         } else {
             (self.total_tokens as f64 / f64::from(self.num_chunks)) as f32
         }
+    }
+
+    /// Nominal chunk length (90th percentile), the BM25 length floor.
+    #[inline]
+    pub fn length_floor(&self) -> u32 {
+        self.length_floor
+    }
+
+    /// BM25 length of virtual id `vid`: its token count floored at the
+    /// nominal chunk length.
+    #[inline]
+    pub fn bm25_length(&self, vid: u32) -> u32 {
+        self.length(vid).max(self.length_floor)
     }
 
     /// Document owning virtual id `vid`.
@@ -375,6 +414,7 @@ pub fn read_chunk_maps(bytes: OwnedBytes) -> io::Result<ChunkMapFile> {
                 let doc_ids = bytes.slice(offset..offset + n * 4);
                 let ordinals = bytes.slice(offset + n * 4..offset + n * 6);
                 let lengths = bytes.slice(offset + n * 6..end);
+                let length_floor = nominal_chunk_length(lengths.as_slice());
                 file.chunk_maps.insert(
                     field_id,
                     ChunkMap {
@@ -383,6 +423,7 @@ pub fn read_chunk_maps(bytes: OwnedBytes) -> io::Result<ChunkMapFile> {
                         lengths,
                         num_chunks: count,
                         total_tokens,
+                        length_floor,
                     },
                 );
             }

--- a/hermes-core/src/segment/merger/mod.rs
+++ b/hermes-core/src/segment/merger/mod.rs
@@ -284,6 +284,12 @@ pub(crate) async fn append_and_delete_temp<D: DirectoryWriter>(
 /// Segment merger - merges multiple segments into one
 pub struct SegmentMerger {
     schema: Arc<Schema>,
+    /// Term-dictionary compression settings used for the merged segment.
+    optimization: crate::structures::IndexOptimization,
+    /// Codec used whenever a merge must decode and re-encode postings.
+    /// External blocks still take the zero-copy concatenation path and retain
+    /// their per-block codecs.
+    posting_codec: crate::structures::PostingCodec,
     /// Run BP reordering on BMP sparse fields while writing the merged blob
     /// (instead of byte-level block stacking). The output segment is then
     /// already ordered, so the standalone reorder pass is unnecessary.
@@ -318,6 +324,8 @@ impl SegmentMerger {
     pub fn new(schema: Arc<Schema>) -> Self {
         Self {
             schema,
+            optimization: crate::structures::IndexOptimization::default(),
+            posting_codec: crate::structures::PostingCodec::default(),
             reorder_bmp: false,
             background_pool: None,
             granularity: crate::segment::reorder::BpGranularity::Auto,
@@ -327,6 +335,18 @@ impl SegmentMerger {
             reorder_permits: None,
             reorder_priority: ReorderPriority::AutomaticMerge,
         }
+    }
+
+    /// Configure term-dictionary compression and posting re-encoding for the
+    /// output segment.
+    pub fn with_posting_config(
+        mut self,
+        optimization: crate::structures::IndexOptimization,
+        posting_codec: crate::structures::PostingCodec,
+    ) -> Self {
+        self.optimization = optimization;
+        self.posting_codec = posting_codec;
+        self
     }
 
     /// Enable BP reordering of BMP fields during the merge (see `reorder_bmp`).

--- a/hermes-core/src/segment/merger/postings.rs
+++ b/hermes-core/src/segment/merger/postings.rs
@@ -121,7 +121,10 @@ impl SegmentMerger {
 
         // Write SSTable entries inline — no buffering needed since
         // SSTableWriter<&mut OffsetWriter> is Send (OffsetWriter is Send).
-        let mut term_dict_writer = SSTableWriter::<&mut OffsetWriter, TermInfo>::new(term_dict);
+        let mut term_dict_writer = SSTableWriter::<&mut OffsetWriter, TermInfo>::with_config(
+            term_dict,
+            crate::structures::SSTableWriterConfig::from_optimization(self.optimization),
+        );
         let mut terms_processed = 0usize;
         let mut serialize_buf: Vec<u8> = Vec::new();
         // Pre-allocate sources buffer outside loop — reused for every term
@@ -298,11 +301,12 @@ impl SegmentMerger {
                 return Ok(inline);
             }
             let offset = postings_out.offset();
-            let block = if any_positions {
-                BlockPostingList::from_posting_list_with_positions(&merged)?
-            } else {
-                BlockPostingList::from_posting_list(&merged)?
-            };
+            let block = BlockPostingList::from_posting_list_with_options(
+                &merged,
+                any_positions,
+                None,
+                self.posting_codec,
+            )?;
             buf.clear();
             block.serialize(buf)?;
             postings_out.write_all(buf)?;

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -953,6 +953,8 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
     memory_budget: usize,
     bp_budget: crate::segment::BpBudget,
     granularity: BpGranularity,
+    optimization: crate::structures::IndexOptimization,
+    posting_codec: crate::structures::PostingCodec,
     rayon_pool: Option<Arc<rayon::ThreadPool>>,
     cancellation: Option<Arc<std::sync::atomic::AtomicBool>>,
 ) -> Result<(String, u32, bool)> {
@@ -1047,6 +1049,7 @@ pub(crate) async fn reorder_segment<D: Directory + DirectoryWriter>(
             &dst_files,
             schema,
             &text_plans,
+            (optimization, posting_codec),
             cancellation.as_deref(),
         )
         .await?;

--- a/hermes-core/src/segment/text_reorder.rs
+++ b/hermes-core/src/segment/text_reorder.rs
@@ -32,8 +32,8 @@ use crate::segment::reader::SegmentReader;
 use crate::segment::types::SegmentFiles;
 use crate::segment::{OffsetWriter, SegmentMerger};
 use crate::structures::{
-    BlockPostingList, PositionStreamEncoder, PostingList, SSTableWriter, TERMINATED, TermInfo,
-    TermPositions,
+    BlockPostingList, PositionStreamEncoder, PostingCodec, PostingList, SSTableWriter, TERMINATED,
+    TermInfo, TermPositions,
 };
 
 /// Minimum partition of the bisection: one posting block, the pruning unit.
@@ -285,8 +285,10 @@ pub(crate) async fn rewrite_text_files<D: Directory + DirectoryWriter>(
     dst_files: &SegmentFiles,
     schema: &Arc<Schema>,
     plans: &[TextReorderPlan],
+    posting_config: (crate::structures::IndexOptimization, PostingCodec),
     cancellation: Option<&std::sync::atomic::AtomicBool>,
 ) -> Result<()> {
+    let (optimization, posting_codec) = posting_config;
     let started = std::time::Instant::now();
     let by_field: FxHashMap<u32, &TextReorderPlan> =
         plans.iter().map(|plan| (plan.field.0, plan)).collect();
@@ -302,13 +304,17 @@ pub(crate) async fn rewrite_text_files<D: Directory + DirectoryWriter>(
         );
     }
 
-    let merger = SegmentMerger::new(Arc::clone(schema));
+    let merger =
+        SegmentMerger::new(Arc::clone(schema)).with_posting_config(optimization, posting_codec);
     let mut postings_out = OffsetWriter::new(dir.streaming_writer_cold(&dst_files.postings).await?);
     let mut positions_out =
         OffsetWriter::new(dir.streaming_writer_cold(&dst_files.positions).await?);
     let mut term_dict_out =
         OffsetWriter::new(dir.streaming_writer_cold(&dst_files.term_dict).await?);
-    let mut term_dict = SSTableWriter::<&mut OffsetWriter, TermInfo>::new(&mut term_dict_out);
+    let mut term_dict = SSTableWriter::<&mut OffsetWriter, TermInfo>::with_config(
+        &mut term_dict_out,
+        crate::structures::SSTableWriterConfig::from_optimization(optimization),
+    );
     let mut buf: Vec<u8> = Vec::new();
     let mut sources: Vec<(usize, TermInfo, u32)> = Vec::with_capacity(1);
     let mut terms = 0usize;
@@ -335,6 +341,7 @@ pub(crate) async fn rewrite_text_files<D: Directory + DirectoryWriter>(
                     &mut postings_out,
                     &mut positions_out,
                     &mut buf,
+                    posting_codec,
                 )
                 .await?
             }
@@ -435,6 +442,7 @@ pub(crate) async fn rewrite_text_files<D: Directory + DirectoryWriter>(
 /// Rewrite one term of a planned field: postings sorted by the new virtual
 /// ids, positions re-encoded in that order, block bounds from the new
 /// lengths.
+#[allow(clippy::too_many_arguments)]
 async fn reorder_term(
     reader: &SegmentReader,
     info: &TermInfo,
@@ -443,6 +451,7 @@ async fn reorder_term(
     postings_out: &mut OffsetWriter,
     positions_out: &mut OffsetWriter,
     buf: &mut Vec<u8>,
+    posting_codec: PostingCodec,
 ) -> Result<TermInfo> {
     // (new vid, tf, positions of the old vid)
     let mut entries: Vec<(u32, u32, Vec<u32>)> = Vec::new();
@@ -503,7 +512,12 @@ async fn reorder_term(
         return Ok(inline);
     }
     let length_of = |vid: u32| new_lengths.get(vid as usize).copied().unwrap_or(1);
-    let block = BlockPostingList::from_posting_list_with(&list, has_positions, Some(&length_of))?;
+    let block = BlockPostingList::from_posting_list_with_options(
+        &list,
+        has_positions,
+        Some(&length_of),
+        posting_codec,
+    )?;
     buf.clear();
     block.serialize(buf)?;
     let posting_offset = postings_out.offset();

--- a/hermes-core/src/structures/mod.rs
+++ b/hermes-core/src/structures/mod.rs
@@ -62,6 +62,7 @@ pub use postings::{
     PositionStream,
     PositionStreamEncoder,
     Posting,
+    PostingCodec,
     PostingFormat,
     PostingList,
     PostingListIterator,

--- a/hermes-core/src/structures/postings/mod.rs
+++ b/hermes-core/src/structures/postings/mod.rs
@@ -50,8 +50,8 @@ pub use positions_v2::{
     POSITION_STREAM_BLOCK, PositionStream, PositionStreamEncoder, TermPositions,
 };
 pub use posting::{
-    BLOCK_SIZE as POSTING_BLOCK_SIZE, BlockPostingIterator, BlockPostingList, Posting, PostingList,
-    PostingListIterator, TERMINATED,
+    BLOCK_SIZE as POSTING_BLOCK_SIZE, BlockPostingIterator, BlockPostingList, Posting,
+    PostingCodec, PostingList, PostingListIterator, TERMINATED,
 };
 pub use posting_common::{
     BLOCK_SIZE as COMMON_BLOCK_SIZE, RoundedBitWidth, SkipEntry, SkipList, pack_deltas_fixed,

--- a/hermes-core/src/structures/postings/opt_p4d.rs
+++ b/hermes-core/src/structures/postings/opt_p4d.rs
@@ -28,7 +28,7 @@ const MAX_EXCEPTIONS_RATIO: f32 = 0.10;
 
 /// Find the optimal bit width for a block of values
 /// Returns (bit_width, exception_count, total_bits)
-fn find_optimal_bit_width(values: &[u32]) -> (u8, usize, usize) {
+pub(crate) fn find_optimal_bit_width(values: &[u32]) -> (u8, usize, usize) {
     if values.is_empty() {
         return (0, 0, 0);
     }
@@ -96,7 +96,7 @@ fn find_optimal_bit_width(values: &[u32]) -> (u8, usize, usize) {
 /// - For exceptions (values >= 2^b), store only the HIGH (32-b) bits separately with positions
 ///
 /// Returns the packed bytes and a list of exceptions (position, high_bits)
-fn pack_with_exceptions(values: &[u32], bit_width: u8) -> (Vec<u8>, Vec<(u8, u32)>) {
+pub(crate) fn pack_with_exceptions(values: &[u32], bit_width: u8) -> (Vec<u8>, Vec<(u8, u32)>) {
     if bit_width == 0 {
         // All values must be 0, exceptions store full value
         let exceptions: Vec<(u8, u32)> = values
@@ -169,7 +169,7 @@ fn pack_with_exceptions(values: &[u32], bit_width: u8) -> (Vec<u8>, Vec<(u8, u32
 /// - Reconstruct: value = (high_bits << b) | low_bits
 ///
 /// Uses SIMD acceleration for common bit widths (8, 16, 32)
-fn unpack_with_exceptions(
+pub(crate) fn unpack_with_exceptions(
     packed: &[u8],
     bit_width: u8,
     exceptions: &[(u8, u32)],

--- a/hermes-core/src/structures/postings/posting.rs
+++ b/hermes-core/src/structures/postings/posting.rs
@@ -1,17 +1,230 @@
 //! Posting list implementation with compact representation
 //!
-//! Text blocks use SIMD-friendly packed bit-width encoding:
-//! - Doc IDs: delta-encoded, packed at rounded bit width (0/8/16/32)
-//! - Term frequencies: packed at rounded bit width
-//! - Same SIMD primitives as sparse blocks (`simd::pack_rounded` / `unpack_rounded`)
+//! Text blocks hold 128 postings: delta-coded doc ids followed by term
+//! frequencies, each array encoded by one of the [`PostingCodec`]s
+//! (`docs/posting-codecs.md`):
+//! - `Rounded` (default): widths rounded to 0/8/16/32 bits, SIMD widening
+//! - `Packed`: exact bit widths (BP128 style)
+//! - `Pfor`: exact width with patched exceptions (OptP4D style)
+//!
+//! The codec is stored per block in the header, so a single list (for example
+//! the output of a merge) may mix codecs.
 
 use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{self, Read, Write};
 
+use super::opt_p4d::{find_optimal_bit_width, pack_with_exceptions, unpack_with_exceptions};
 use super::posting_common::{read_vint, write_vint};
 use crate::DocId;
 use crate::directories::OwnedBytes;
 use crate::structures::simd;
+
+/// Encoding of the packed arrays inside one posting block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PostingCodec {
+    /// Widths rounded up to 0/8/16/32 bits; decodes with plain SIMD widening.
+    /// This is the low-overhead performance baseline.
+    #[default]
+    Rounded = 0,
+    /// Exact bit widths (BP128 style): ~1.8× smaller than `Rounded` on the
+    /// repository benchmark for ~10 % slower decoding.
+    Packed = 1,
+    /// Exact width with up to 10 % patched exceptions (OptP4D style):
+    /// smallest, ~30 % slower decoding than `Rounded`.
+    Pfor = 2,
+}
+
+impl PostingCodec {
+    /// Codec id stored in the top two bits of the block header's `doc_bits`.
+    const HEADER_SHIFT: u32 = 6;
+    const WIDTH_MASK: u8 = 0x3F;
+
+    fn from_header_byte(doc_bits: u8) -> io::Result<(Self, u8)> {
+        let width = doc_bits & Self::WIDTH_MASK;
+        let codec = match doc_bits >> Self::HEADER_SHIFT {
+            0 => PostingCodec::Rounded,
+            1 => PostingCodec::Packed,
+            2 => PostingCodec::Pfor,
+            other => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "posting block uses unknown codec id {other}; the index was written by a \
+                         newer Hermes"
+                    ),
+                ));
+            }
+        };
+        if width > 32 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("posting block doc-id width {width} exceeds 32 bits"),
+            ));
+        }
+        Ok((codec, width))
+    }
+
+    fn header_byte(self, width: u8) -> u8 {
+        ((self as u8) << Self::HEADER_SHIFT) | width
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "rounded" | "default" => Some(PostingCodec::Rounded),
+            "packed" | "bp128" | "exact" => Some(PostingCodec::Packed),
+            "pfor" | "optp4d" | "patched" => Some(PostingCodec::Pfor),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for PostingCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            PostingCodec::Rounded => "rounded",
+            PostingCodec::Packed => "packed",
+            PostingCodec::Pfor => "pfor",
+        })
+    }
+}
+
+// ── Exact-width bit packing (Packed codec) ───────────────────────────────
+
+/// Bytes needed for `count` values at `width` bits.
+#[inline]
+fn packed_bytes(count: usize, width: u8) -> usize {
+    (count * width as usize).div_ceil(8)
+}
+
+/// Pack `values` at `width` bits each (little-endian bit order) into `out`.
+fn pack_bits(values: &[u32], width: u8, out: &mut Vec<u8>) {
+    if width == 0 || values.is_empty() {
+        return;
+    }
+    if width == 32 {
+        for &v in values {
+            out.extend_from_slice(&v.to_le_bytes());
+        }
+        return;
+    }
+    let start = out.len();
+    out.resize(start + packed_bytes(values.len(), width), 0);
+    let dst = &mut out[start..];
+    let mut bit_pos = 0usize;
+    for &v in values {
+        let mut acc = (v as u64) << (bit_pos & 7);
+        let mut byte = bit_pos >> 3;
+        let mut remaining = (bit_pos & 7) + width as usize;
+        while remaining > 0 {
+            dst[byte] |= acc as u8;
+            acc >>= 8;
+            byte += 1;
+            remaining = remaining.saturating_sub(8);
+        }
+        bit_pos += width as usize;
+    }
+}
+
+/// Unpack `count` values of `width` bits from `input` into `out`.
+///
+/// Reads stay inside `input` (no over-read past the block), so this is safe
+/// on the last block of a mapped stream.
+fn unpack_bits(input: &[u8], width: u8, out: &mut [u32], count: usize) {
+    match width {
+        0 => out[..count].fill(0),
+        8 => simd::unpack_8bit(input, out, count),
+        16 => simd::unpack_16bit(input, out, count),
+        32 => simd::unpack_32bit(input, out, count),
+        _ => {
+            let mask = (1u64 << width) - 1;
+            let mut bit_pos = 0usize;
+            for slot in out[..count].iter_mut() {
+                let byte = bit_pos >> 3;
+                let word = if byte + 8 <= input.len() {
+                    u64::from_le_bytes(input[byte..byte + 8].try_into().unwrap())
+                } else {
+                    let mut word = 0u64;
+                    for (i, &b) in input[byte..].iter().enumerate() {
+                        word |= (b as u64) << (i * 8);
+                    }
+                    word
+                };
+                *slot = ((word >> (bit_pos & 7)) & mask) as u32;
+                bit_pos += width as usize;
+            }
+        }
+    }
+}
+
+// ── Patched packing (Pfor codec) ─────────────────────────────────────────
+
+/// Payload of one `Pfor` array: `[n_exceptions u8][packed low bits][(pos u8, high u32) × n]`.
+fn pack_pfor(values: &[u32], out: &mut Vec<u8>) -> u8 {
+    let (width, _, _) = find_optimal_bit_width(values);
+    let (packed, exceptions) = pack_with_exceptions(values, width);
+    out.push(exceptions.len() as u8);
+    out.extend_from_slice(&packed);
+    for (pos, high) in exceptions {
+        out.push(pos);
+        out.extend_from_slice(&high.to_le_bytes());
+    }
+    width
+}
+
+/// Byte length of a `Pfor` array payload for `count` values at `width`.
+fn pfor_payload_len(input: &[u8], count: usize, width: u8) -> io::Result<usize> {
+    let n_exceptions = *input
+        .first()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "posting block truncated"))?
+        as usize;
+    Ok(1 + packed_bytes(count, width) + n_exceptions * 5)
+}
+
+fn unpack_pfor(input: &[u8], width: u8, out: &mut [u32], count: usize) -> io::Result<()> {
+    let n_exceptions = *input
+        .first()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "posting block truncated"))?
+        as usize;
+    let packed_len = packed_bytes(count, width);
+    let table_at = 1 + packed_len;
+    if input.len() < table_at + n_exceptions * 5 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "posting block exception table truncated",
+        ));
+    }
+    let packed = &input[1..table_at];
+    let mut exceptions: [(u8, u32); 128] = [(0, 0); 128];
+    for (i, entry) in input[table_at..table_at + n_exceptions * 5]
+        .chunks_exact(5)
+        .enumerate()
+        .take(128)
+    {
+        exceptions[i] = (
+            entry[0],
+            u32::from_le_bytes([entry[1], entry[2], entry[3], entry[4]]),
+        );
+    }
+    if width == 0 {
+        // No low bits: every non-zero value is an exception carrying the value.
+        out[..count].fill(0);
+        for &(pos, value) in &exceptions[..n_exceptions.min(128)] {
+            if (pos as usize) < count {
+                out[pos as usize] = value;
+            }
+        }
+        return Ok(());
+    }
+    unpack_with_exceptions(
+        packed,
+        width,
+        &exceptions[..n_exceptions.min(128)],
+        count,
+        out,
+    );
+    Ok(())
+}
 
 /// A posting entry containing doc_id and term frequency
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -363,21 +576,82 @@ fn write_l0(buf: &mut Vec<u8>, first_doc: u32, last_doc: u32, offset: u32, bound
     buf.extend_from_slice(&bounds.to_le_bytes());
 }
 
-/// Compute block data size from the 8-byte header at `stream[pos..]`.
-///
-/// Header: `[count: u16][first_doc: u32][doc_id_bits: u8][tf_bits: u8]`
-/// Data size = 8 + (count-1) × bytes_per_value(doc_id_bits) + count × bytes_per_value(tf_bits)
+/// Byte length of block `idx` from the L0 offsets: the next block's offset
+/// (or the stream end) minus this block's offset. Header-independent, so a
+/// block payload may carry codec-specific variable-length data.
 #[inline]
-fn block_data_size(stream: &[u8], pos: usize) -> usize {
-    let count = u16::from_le_bytes(stream[pos..pos + 2].try_into().unwrap()) as usize;
-    let doc_rounded = simd::RoundedBitWidth::from_u8(stream[pos + 6]);
-    let tf_rounded = simd::RoundedBitWidth::from_u8(stream[pos + 7]);
-    let delta_bytes = if count > 1 {
-        (count - 1) * doc_rounded.bytes_per_value()
+fn block_len_from_l0(l0_bytes: &[u8], l0_count: usize, stream_len: usize, idx: usize) -> usize {
+    let (_, _, offset, _) = read_l0(l0_bytes, idx);
+    let end = if idx + 1 < l0_count {
+        read_l0(l0_bytes, idx + 1).2 as usize
     } else {
-        0
+        stream_len
     };
-    8 + delta_bytes + count * tf_rounded.bytes_per_value()
+    end.saturating_sub(offset as usize)
+}
+
+/// Encoded doc-id delta array and tf array of one block, with the header
+/// width bytes to store for them.
+struct EncodedBlock {
+    doc_bits: u8,
+    tf_bits: u8,
+}
+
+/// Append the packed arrays of one block to `stream` using `codec`.
+fn encode_block_arrays(
+    codec: PostingCodec,
+    deltas: &[u32],
+    tfs: &[u32],
+    stream: &mut Vec<u8>,
+) -> EncodedBlock {
+    match codec {
+        PostingCodec::Rounded => {
+            let max_delta = deltas.iter().copied().max().unwrap_or(0);
+            let doc_bits = simd::round_bit_width(simd::bits_needed(max_delta));
+            let max_tf = tfs.iter().copied().max().unwrap_or(0);
+            let tf_bits = simd::round_bit_width(simd::bits_needed(max_tf));
+            if !deltas.is_empty() {
+                let rounded = simd::RoundedBitWidth::from_u8(doc_bits);
+                let start = stream.len();
+                stream.resize(start + deltas.len() * rounded.bytes_per_value(), 0);
+                simd::pack_rounded(deltas, rounded, &mut stream[start..]);
+            }
+            {
+                let rounded = simd::RoundedBitWidth::from_u8(tf_bits);
+                let start = stream.len();
+                stream.resize(start + tfs.len() * rounded.bytes_per_value(), 0);
+                simd::pack_rounded(tfs, rounded, &mut stream[start..]);
+            }
+            EncodedBlock {
+                doc_bits: codec.header_byte(doc_bits),
+                tf_bits,
+            }
+        }
+        PostingCodec::Packed => {
+            let max_delta = deltas.iter().copied().max().unwrap_or(0);
+            let doc_bits = simd::bits_needed(max_delta);
+            let max_tf = tfs.iter().copied().max().unwrap_or(0);
+            let tf_bits = simd::bits_needed(max_tf);
+            pack_bits(deltas, doc_bits, stream);
+            pack_bits(tfs, tf_bits, stream);
+            EncodedBlock {
+                doc_bits: codec.header_byte(doc_bits),
+                tf_bits,
+            }
+        }
+        PostingCodec::Pfor => {
+            let doc_bits = if deltas.is_empty() {
+                0
+            } else {
+                pack_pfor(deltas, stream)
+            };
+            let tf_bits = pack_pfor(tfs, stream);
+            EncodedBlock {
+                doc_bits: codec.header_byte(doc_bits),
+                tf_bits,
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -428,7 +702,15 @@ impl BlockPostingList {
     /// [packed tfs: count × bytes_per_value(tf_bits)]
     /// ```
     pub fn from_posting_list(list: &PostingList) -> io::Result<Self> {
-        Self::build(list, false, None)
+        Self::build(list, false, None, PostingCodec::Rounded)
+    }
+
+    /// Build a list using an explicit per-block codec.
+    pub fn from_posting_list_with_codec(
+        list: &PostingList,
+        codec: PostingCodec,
+    ) -> io::Result<Self> {
+        Self::build(list, false, None, codec)
     }
 
     /// Like [`Self::from_posting_list`], for a term whose positions are
@@ -436,7 +718,7 @@ impl BlockPostingList {
     /// it (the cumulative term frequency), so a reader can address the
     /// stream from the doc postings alone.
     pub fn from_posting_list_with_positions(list: &PostingList) -> io::Result<Self> {
-        Self::build(list, true, None)
+        Self::build(list, true, None, PostingCodec::Rounded)
     }
 
     /// Build with position cursors on demand and, when `length_of` is given,
@@ -448,13 +730,24 @@ impl BlockPostingList {
         with_positions: bool,
         length_of: Option<&dyn Fn(DocId) -> u32>,
     ) -> io::Result<Self> {
-        Self::build(list, with_positions, length_of)
+        Self::build(list, with_positions, length_of, PostingCodec::Rounded)
+    }
+
+    /// Build with the complete physical layout policy used by index writers.
+    pub fn from_posting_list_with_options(
+        list: &PostingList,
+        with_positions: bool,
+        length_of: Option<&dyn Fn(DocId) -> u32>,
+        codec: PostingCodec,
+    ) -> io::Result<Self> {
+        Self::build(list, with_positions, length_of, codec)
     }
 
     fn build(
         list: &PostingList,
         with_positions: bool,
         length_of: Option<&dyn Fn(DocId) -> u32>,
+        codec: PostingCodec,
     ) -> io::Result<Self> {
         let mut stream: Vec<u8> = Vec::new();
         let mut l0_buf: Vec<u8> = Vec::new();
@@ -498,37 +791,22 @@ impl BlockPostingList {
                 deltas.push(posting.doc_id - prev);
                 prev = posting.doc_id;
             }
-            let max_delta = deltas.iter().copied().max().unwrap_or(0);
-            let doc_id_bits = simd::round_bit_width(simd::bits_needed(max_delta));
 
             // Collect TFs
             tf_buf.clear();
             tf_buf.extend(block.iter().map(|p| p.term_freq));
-            let tf_bits = simd::round_bit_width(simd::bits_needed(block_max_tf));
 
-            // Write 8-byte header: [count: u16][first_doc: u32][doc_id_bits: u8][tf_bits: u8]
+            // Write 8-byte header: [count: u16][first_doc: u32][doc_bits: u8][tf_bits: u8]
+            // (`doc_bits` carries the codec id in its top two bits); the
+            // packed arrays follow.
             stream.write_u16::<LittleEndian>(count as u16)?;
             stream.write_u32::<LittleEndian>(base_doc_id)?;
-            stream.push(doc_id_bits);
-            stream.push(tf_bits);
-
-            // Write packed doc_id deltas ((count-1) values)
-            if count > 1 {
-                let rounded = simd::RoundedBitWidth::from_u8(doc_id_bits);
-                let byte_count = (count - 1) * rounded.bytes_per_value();
-                let start = stream.len();
-                stream.resize(start + byte_count, 0);
-                simd::pack_rounded(&deltas, rounded, &mut stream[start..]);
-            }
-
-            // Write packed TFs (count values)
-            {
-                let rounded = simd::RoundedBitWidth::from_u8(tf_bits);
-                let byte_count = count * rounded.bytes_per_value();
-                let start = stream.len();
-                stream.resize(start + byte_count, 0);
-                simd::pack_rounded(&tf_buf, rounded, &mut stream[start..]);
-            }
+            let header_at = stream.len();
+            stream.push(0);
+            stream.push(0);
+            let encoded = encode_block_arrays(codec, &deltas, &tf_buf, &mut stream);
+            stream[header_at] = encoded.doc_bits;
+            stream[header_at + 1] = encoded.tf_bits;
 
             // L0 skip entry with the block's bounds
             let block_min_len = length_of.map_or(1, |length_of| {
@@ -826,7 +1104,7 @@ impl BlockPostingList {
                 let (first_doc, last_doc, offset, word) = source.read_l0_entry(block_idx);
                 let (block_max_tf, block_min_len) = unpack_bounds(word, source.len_bounds);
                 let bounds = pack_bounds(block_max_tf, block_min_len.unwrap_or(1));
-                let blk_size = block_data_size(&source.stream, offset as usize);
+                let blk_size = source.block_len(block_idx);
                 let block_bytes = &source.stream[offset as usize..offset as usize + blk_size];
 
                 let count = u16::from_le_bytes(block_bytes[0..2].try_into().unwrap());
@@ -886,8 +1164,8 @@ impl BlockPostingList {
     /// Streaming merge: write blocks directly to output writer (bounded memory).
     ///
     /// **Zero-materializing**: reads L0 entries directly from source bytes
-    /// (mmap or &[u8]) without parsing into Vecs. Block sizes computed from
-    /// the 8-byte header (deterministic with packed encoding).
+    /// (mmap or &[u8]) without parsing into Vecs. Block sizes come from the
+    /// L0 offsets, so blocks of any codec are copied verbatim.
     ///
     /// Output L0 + L1 are buffered (bounded O(total_blocks × 16 + total_blocks/8 × 4)).
     /// Block data flows source → output writer without intermediate buffering.
@@ -951,8 +1229,9 @@ impl BlockPostingList {
                     out_cursors.extend_from_slice(&(cursor + positions_before).to_le_bytes());
                 }
 
-                // Compute block size from header
-                let blk_size = block_data_size(src_stream, offset as usize);
+                // Block size from the neighbouring L0 offset (codec-independent)
+                let blk_size =
+                    block_len_from_l0(&raw[l0_base..], meta.l0_count, meta.stream_len, i);
                 let block = &src_stream[offset as usize..offset as usize + blk_size];
 
                 // Write output L0 entry
@@ -1068,35 +1347,43 @@ impl BlockPostingList {
 
         let (_, _, offset, _) = self.read_l0_entry(block_idx);
         let pos = offset as usize;
-        let blk_size = block_data_size(&self.stream, pos);
+        let blk_size = self.block_len(block_idx);
         let block_data = &self.stream[pos..pos + blk_size];
 
-        // 8-byte header: [count: u16][first_doc: u32][doc_id_bits: u8][tf_bits: u8]
+        // 8-byte header: [count: u16][first_doc: u32][doc_bits: u8][tf_bits: u8]
         let count = u16::from_le_bytes(block_data[0..2].try_into().unwrap()) as usize;
         let first_doc = u32::from_le_bytes(block_data[2..6].try_into().unwrap());
-        let doc_id_bits = block_data[6];
+        let (codec, doc_width) = PostingCodec::from_header_byte(block_data[6]).ok()?;
 
         doc_ids.clear();
         doc_ids.resize(count, 0);
         doc_ids[0] = first_doc;
 
-        let doc_rounded = simd::RoundedBitWidth::from_u8(doc_id_bits);
+        let payload = &block_data[8..];
         let deltas_bytes = if count > 1 {
-            (count - 1) * doc_rounded.bytes_per_value()
+            match codec {
+                PostingCodec::Rounded => {
+                    let rounded = simd::RoundedBitWidth::from_u8(doc_width);
+                    let bytes = (count - 1) * rounded.bytes_per_value();
+                    simd::unpack_rounded(&payload[..bytes], rounded, &mut doc_ids[1..], count - 1);
+                    bytes
+                }
+                PostingCodec::Packed => {
+                    let bytes = packed_bytes(count - 1, doc_width);
+                    unpack_bits(&payload[..bytes], doc_width, &mut doc_ids[1..], count - 1);
+                    bytes
+                }
+                PostingCodec::Pfor => {
+                    let bytes = pfor_payload_len(payload, count - 1, doc_width).ok()?;
+                    unpack_pfor(&payload[..bytes], doc_width, &mut doc_ids[1..], count - 1).ok()?;
+                    bytes
+                }
+            }
         } else {
             0
         };
-
-        if count > 1 {
-            simd::unpack_rounded(
-                &block_data[8..8 + deltas_bytes],
-                doc_rounded,
-                &mut doc_ids[1..],
-                count - 1,
-            );
-            for i in 1..count {
-                doc_ids[i] += doc_ids[i - 1];
-            }
+        for i in 1..count {
+            doc_ids[i] = doc_ids[i].wrapping_add(doc_ids[i - 1]);
         }
 
         let tfs_start = 8 + deltas_bytes;
@@ -1113,19 +1400,56 @@ impl BlockPostingList {
         count: usize,
         tfs: &mut Vec<u32>,
     ) {
-        let blk_size = block_data_size(&self.stream, block_offset);
-        let block_data = &self.stream[block_offset..block_offset + blk_size];
+        let block_data = &self.stream[block_offset..];
+        let codec = PostingCodec::from_header_byte(block_data[6])
+            .map(|(codec, _)| codec)
+            .unwrap_or_default();
         let tf_bits = block_data[7];
-        let tf_rounded = simd::RoundedBitWidth::from_u8(tf_bits);
 
         tfs.clear();
         tfs.resize(count, 0);
-        simd::unpack_rounded(
-            &block_data[tf_start..tf_start + count * tf_rounded.bytes_per_value()],
-            tf_rounded,
-            tfs,
-            count,
-        );
+        let payload = &block_data[tf_start..];
+        match codec {
+            PostingCodec::Rounded => {
+                let rounded = simd::RoundedBitWidth::from_u8(tf_bits);
+                simd::unpack_rounded(
+                    &payload[..count * rounded.bytes_per_value()],
+                    rounded,
+                    tfs,
+                    count,
+                );
+            }
+            PostingCodec::Packed => {
+                unpack_bits(
+                    &payload[..packed_bytes(count, tf_bits)],
+                    tf_bits,
+                    tfs,
+                    count,
+                );
+            }
+            PostingCodec::Pfor => {
+                if let Ok(len) = pfor_payload_len(payload, count, tf_bits) {
+                    let _ = unpack_pfor(&payload[..len], tf_bits, tfs, count);
+                }
+            }
+        }
+    }
+
+    /// Byte length of block `block_idx` (from the L0 offsets).
+    #[inline]
+    fn block_len(&self, block_idx: usize) -> usize {
+        block_len_from_l0(&self.l0_bytes, self.l0_count, self.stream.len(), block_idx)
+    }
+
+    /// Codec of block `block_idx` (diagnostics).
+    pub fn block_codec(&self, block_idx: usize) -> Option<PostingCodec> {
+        if block_idx >= self.l0_count {
+            return None;
+        }
+        let (_, _, offset, _) = self.read_l0_entry(block_idx);
+        PostingCodec::from_header_byte(self.stream[offset as usize + 6])
+            .ok()
+            .map(|(codec, _)| codec)
     }
 
     /// First doc_id of a block (from L0 skip entry). Returns `None` if out of range.
@@ -1969,34 +2293,127 @@ mod tests {
     }
 
     #[test]
-    fn test_block_data_size_helper() {
-        // Build a posting list and verify block_data_size matches actual block sizes
-        let docs: Vec<(u32, u32)> = (0..500u32).map(|i| (i * 7, (i % 20) + 1)).collect();
-        let bpl = build_bpl(&docs);
-
-        for blk in 0..bpl.num_blocks() {
-            let (_, _, offset, _) = bpl.read_l0_entry(blk);
-            let computed_size = block_data_size(&bpl.stream, offset as usize);
-
-            // Verify: next block's offset - this block's offset should equal computed_size
-            // (for all but last block)
-            if blk + 1 < bpl.num_blocks() {
-                let (_, _, next_offset, _) = bpl.read_l0_entry(blk + 1);
-                assert_eq!(
-                    computed_size,
-                    (next_offset - offset) as usize,
-                    "block_data_size mismatch at block {}",
-                    blk
-                );
-            } else {
-                // Last block: offset + size should equal stream length
-                assert_eq!(
-                    offset as usize + computed_size,
-                    bpl.stream.len(),
-                    "last block size mismatch"
-                );
-            }
+    fn block_len_matches_l0_offsets() {
+        // Block lengths derive from neighbouring L0 offsets and add up to the stream.
+        let bpl = build_bpl(&(0..1000).map(|i| (i * 3, 1 + i % 4)).collect::<Vec<_>>());
+        let mut total = 0usize;
+        for b in 0..bpl.num_blocks() {
+            let (_, _, offset, _) = bpl.read_l0_entry(b);
+            assert_eq!(offset as usize, total, "block {b} offset");
+            total += bpl.block_len(b);
         }
+        assert_eq!(total, bpl.stream.len());
+    }
+
+    /// Every codec round-trips doc ids and tfs exactly, `seek` agrees with
+    /// `Rounded`, and `Rounded` output is byte-identical to the historic
+    /// layout (codec id 0, widths 0/8/16/32).
+    #[test]
+    fn every_codec_round_trips_and_seeks() {
+        let mut postings: Vec<(u32, u32)> = Vec::new();
+        let mut doc = 0u32;
+        for i in 0..5000u32 {
+            // Mostly small gaps with rare huge ones (forces exceptions / wide
+            // blocks), tfs mostly 1-3 with rare outliers.
+            doc += if i % 97 == 0 { 100_000 } else { 1 + i % 7 };
+            let tf = if i % 131 == 0 { 5000 } else { 1 + i % 3 };
+            postings.push((doc, tf));
+        }
+        let mut list = PostingList::new();
+        for &(d, tf) in &postings {
+            list.push(d, tf);
+        }
+        let rounded = BlockPostingList::from_posting_list(&list).unwrap();
+        let mut sizes = Vec::new();
+        for codec in [
+            PostingCodec::Rounded,
+            PostingCodec::Packed,
+            PostingCodec::Pfor,
+        ] {
+            let bpl = BlockPostingList::from_posting_list_with_codec(&list, codec).unwrap();
+            assert_eq!(collect_postings(&bpl), postings, "{codec}");
+            for b in 0..bpl.num_blocks() {
+                assert_eq!(bpl.block_codec(b), Some(codec));
+                assert_eq!(bpl.block_max_tf(b), rounded.block_max_tf(b));
+            }
+            // Serialized round trip (both copying and zero-copy paths).
+            let bytes = serialize_bpl(&bpl);
+            let back = BlockPostingList::deserialize(&bytes).unwrap();
+            assert_eq!(collect_postings(&back), postings, "{codec} deserialize");
+            let back =
+                BlockPostingList::deserialize_zero_copy(OwnedBytes::new(bytes.clone())).unwrap();
+            assert_eq!(collect_postings(&back), postings, "{codec} zero-copy");
+            // Seeks land on the same docs as the reference layout.
+            let mut a = rounded.iterator();
+            let mut b = back.iterator();
+            for target in (0..postings.last().unwrap().0 + 10).step_by(2_003) {
+                assert_eq!(a.seek(target), b.seek(target), "{codec} seek {target}");
+                assert_eq!(a.term_freq(), b.term_freq());
+            }
+            sizes.push((codec, bytes.len()));
+        }
+        let rounded_bytes = serialize_bpl(&rounded);
+        assert_eq!(
+            serialize_bpl(
+                &BlockPostingList::from_posting_list_with_codec(&list, PostingCodec::Rounded)
+                    .unwrap()
+            ),
+            rounded_bytes,
+            "Rounded must stay byte-identical"
+        );
+        // Header byte of a Rounded block: codec 0, rounded width.
+        assert!(matches!(rounded.stream[6], 0 | 8 | 16 | 32));
+        let size = |c: PostingCodec| sizes.iter().find(|(k, _)| *k == c).unwrap().1;
+        assert!(size(PostingCodec::Packed) < size(PostingCodec::Rounded));
+        assert!(size(PostingCodec::Pfor) < size(PostingCodec::Packed));
+    }
+
+    /// Blocks of different codecs merge by verbatim copy and decode correctly.
+    #[test]
+    fn mixed_codec_sources_concatenate() {
+        let a: Vec<(u32, u32)> = (0..300u32).map(|i| (i * 5, 1 + i % 9)).collect();
+        let b: Vec<(u32, u32)> = (0..300u32).map(|i| (i * 11 + 3, 2 + i % 5)).collect();
+        let list_a = {
+            let mut l = PostingList::new();
+            a.iter().for_each(|&(d, t)| l.push(d, t));
+            BlockPostingList::from_posting_list_with_codec(&l, PostingCodec::Pfor).unwrap()
+        };
+        let list_b = {
+            let mut l = PostingList::new();
+            b.iter().for_each(|&(d, t)| l.push(d, t));
+            BlockPostingList::from_posting_list_with_codec(&l, PostingCodec::Packed).unwrap()
+        };
+        let offset_b = a.last().unwrap().0 + 1;
+        let expected: Vec<(u32, u32)> = a
+            .iter()
+            .copied()
+            .chain(b.iter().map(|&(d, t)| (d + offset_b, t)))
+            .collect();
+
+        let merged = BlockPostingList::concatenate_blocks(&[
+            (list_a.clone(), 0),
+            (list_b.clone(), offset_b),
+        ])
+        .unwrap();
+        assert_eq!(collect_postings(&merged), expected);
+
+        let bytes_a = serialize_bpl(&list_a);
+        let bytes_b = serialize_bpl(&list_b);
+        let mut out = Vec::new();
+        let (docs, written) = BlockPostingList::concatenate_streaming(
+            &[(bytes_a.as_slice(), 0), (bytes_b.as_slice(), offset_b)],
+            &mut out,
+        )
+        .unwrap();
+        assert_eq!(docs, 600);
+        assert_eq!(written, out.len());
+        let streamed = BlockPostingList::deserialize(&out).unwrap();
+        assert_eq!(collect_postings(&streamed), expected);
+        assert_eq!(streamed.block_codec(0), Some(PostingCodec::Pfor));
+        assert_eq!(
+            streamed.block_codec(streamed.num_blocks() - 1),
+            Some(PostingCodec::Packed)
+        );
     }
 
     #[test]

--- a/hermes-core/src/structures/postings/posting_format.rs
+++ b/hermes-core/src/structures/postings/posting_format.rs
@@ -1,15 +1,12 @@
-//! Unified posting list format with automatic compression selection
+//! Legacy standalone posting-list codecs and optimization policy.
 //!
-//! Automatically selects the best compression method based on posting list characteristics:
+//! The standalone `PostingFormat` codecs below remain available for benchmarks
+//! and direct library users. Production indexing writes `BlockPostingList`
+//! with the codec selected by `IndexOptimization`:
 //! - **Inline**: 1-3 postings stored directly in TermInfo (no separate I/O)
-//! - **HorizontalBP128**: Horizontal layout with SIMD (fastest encoding + decoding)
-//! - **Partitioned EF**: Best compression for large lists (>20K)
-//! - **Roaring**: Bitmap-based for very frequent terms (>1% of corpus), fastest iteration
-//!
-//! Supports three optimization modes:
-//! - **Adaptive**: Balanced compression/speed (default, zstd level 7)
-//! - **SizeOptimized**: Best compression ratio (OptP4D + zstd level 22)
-//! - **PerformanceOptimized**: Fastest decoding (Roaring + zstd level 3)
+//! - **Adaptive**: rounded blocks + term-dictionary zstd level 9
+//! - **SizeOptimized**: patched-exception blocks + zstd level 22
+//! - **PerformanceOptimized**: rounded blocks + zstd level 1
 
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::io::{self, Read, Write};
@@ -30,15 +27,12 @@ pub const PARTITIONED_EF_THRESHOLD: usize = 20_000;
 /// Index optimization mode for balancing compression ratio vs speed
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum IndexOptimization {
-    /// Balanced compression and speed (zstd level 7)
-    /// Uses adaptive format selection based on posting list characteristics
+    /// Balanced compression and speed (rounded blocks, zstd level 9).
     #[default]
     Adaptive,
-    /// Optimize for smallest index size (zstd level 22)
-    /// Prefers OptP4D for best compression ratio (optimal bit-width + patched exceptions)
+    /// Optimize for smallest index size (patched exceptions, zstd level 22).
     SizeOptimized,
-    /// Optimize for fastest query performance (zstd level 3)
-    /// Prefers Roaring bitmaps for fastest iteration
+    /// Optimize for fastest query performance (rounded blocks, zstd level 1).
     PerformanceOptimized,
 }
 
@@ -46,9 +40,21 @@ impl IndexOptimization {
     /// Get the zstd compression level for this optimization mode
     pub fn zstd_level(&self) -> i32 {
         match self {
-            IndexOptimization::Adaptive => 7,
+            IndexOptimization::Adaptive => 9,
             IndexOptimization::SizeOptimized => 22,
-            IndexOptimization::PerformanceOptimized => 3,
+            IndexOptimization::PerformanceOptimized => 1,
+        }
+    }
+
+    /// Posting block codec implied by this mode (`docs/posting-codecs.md`):
+    /// `SizeOptimized` packs with patched exceptions, the others keep the
+    /// SIMD-widening rounded layout.
+    pub fn default_posting_codec(&self) -> super::posting::PostingCodec {
+        match self {
+            IndexOptimization::SizeOptimized => super::posting::PostingCodec::Pfor,
+            IndexOptimization::Adaptive | IndexOptimization::PerformanceOptimized => {
+                super::posting::PostingCodec::Rounded
+            }
         }
     }
 

--- a/hermes-core/src/structures/sstable.rs
+++ b/hermes-core/src/structures/sstable.rs
@@ -31,9 +31,14 @@ use super::vint::{read_vint, write_vint};
 use crate::compression::{CompressionDict, CompressionLevel};
 use crate::directories::{FileHandle, OwnedBytes};
 
-/// SSTable magic number - version 4 with memory-efficient index
-/// Uses FST-based or mmap'd block index to avoid heap allocation
-pub const SSTABLE_MAGIC: u32 = 0x53544234; // "STB4"
+/// SSTable magic number written by this build — version 5: data blocks carry
+/// restart points (every `RESTART_INTERVAL` entries a full key plus a trailer
+/// of restart offsets), so a point lookup binary-searches the restarts and
+/// decodes at most `RESTART_INTERVAL` entries instead of scanning the block.
+pub const SSTABLE_MAGIC: u32 = 0x53544235; // "STB5"
+
+/// Entries between two restart points inside a data block (v5).
+pub const RESTART_INTERVAL: usize = 16;
 
 /// Block size for SSTable (16KB default)
 pub const BLOCK_SIZE: usize = 16 * 1024;
@@ -935,6 +940,11 @@ pub struct SSTableWriter<W: Write, V: SSTableValue> {
     /// Bloom filter key hashes — compact (u64, u64) pairs instead of full keys.
     /// Filter is built at finish() time with correct sizing.
     bloom_hashes: Vec<(u64, u64)>,
+    /// Byte offsets (within the uncompressed block) of the current block's
+    /// restart entries.
+    block_restarts: Vec<u32>,
+    /// Entries written into the current block so far.
+    block_entry_count: usize,
     _phantom: std::marker::PhantomData<V>,
 }
 
@@ -957,6 +967,8 @@ impl<W: Write, V: SSTableValue> SSTableWriter<W, V> {
             config,
             dictionary: None,
             bloom_hashes: Vec::new(),
+            block_restarts: Vec::new(),
+            block_entry_count: 0,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -978,6 +990,8 @@ impl<W: Write, V: SSTableValue> SSTableWriter<W, V> {
             config,
             dictionary: Some(dictionary),
             bloom_hashes: Vec::new(),
+            block_restarts: Vec::new(),
+            block_entry_count: 0,
             _phantom: std::marker::PhantomData,
         }
     }
@@ -992,7 +1006,15 @@ impl<W: Write, V: SSTableValue> SSTableWriter<W, V> {
             self.bloom_hashes.push(bloom_hash_pair(key));
         }
 
-        let prefix_len = common_prefix_len(&self.prev_key, key);
+        // Every RESTART_INTERVAL-th entry is a restart: written with a full
+        // key so a lookup can start decoding there.
+        let restart = self.block_entry_count.is_multiple_of(RESTART_INTERVAL);
+        let prefix_len = if restart {
+            self.block_restarts.push(self.block_buffer.len() as u32);
+            0
+        } else {
+            common_prefix_len(&self.prev_key, key)
+        };
         let suffix = &key[prefix_len..];
 
         write_vint(&mut self.block_buffer, prefix_len as u64)?;
@@ -1003,6 +1025,7 @@ impl<W: Write, V: SSTableValue> SSTableWriter<W, V> {
         self.prev_key.clear();
         self.prev_key.extend_from_slice(key);
         self.num_entries += 1;
+        self.block_entry_count += 1;
 
         if self.block_buffer.len() >= BLOCK_SIZE {
             self.flush_block()?;
@@ -1016,6 +1039,15 @@ impl<W: Write, V: SSTableValue> SSTableWriter<W, V> {
         if self.block_buffer.is_empty() {
             return Ok(());
         }
+
+        // v5 trailer: restart offsets then their count.
+        for offset in &self.block_restarts {
+            self.block_buffer.extend_from_slice(&offset.to_le_bytes());
+        }
+        self.block_buffer
+            .extend_from_slice(&(self.block_restarts.len() as u32).to_le_bytes());
+        self.block_restarts.clear();
+        self.block_entry_count = 0;
 
         // Compress block with dictionary if available
         let compressed = if let Some(ref dict) = self.dictionary {
@@ -1158,6 +1190,79 @@ pub struct AsyncSSTableReader<V: SSTableValue> {
     _phantom: std::marker::PhantomData<V>,
 }
 
+/// A decompressed data block split into its entry stream and restart table.
+struct BlockParts<'b> {
+    entries: &'b [u8],
+    /// Little-endian `u32` offsets into `entries`, ascending; empty for v4.
+    restart_table: &'b [u8],
+}
+
+impl<'b> BlockParts<'b> {
+    fn split(block: &'b [u8]) -> io::Result<Self> {
+        if block.len() < 4 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SSTable block shorter than its restart trailer",
+            ));
+        }
+        let count_at = block.len() - 4;
+        let count = u32::from_le_bytes(block[count_at..].try_into().unwrap()) as usize;
+        let table_len = count.checked_mul(4).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "SSTable restart table overflow")
+        })?;
+        let table_at = count_at.checked_sub(table_len).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SSTable restart table exceeds its block",
+            )
+        })?;
+        Ok(Self {
+            entries: &block[..table_at],
+            restart_table: &block[table_at..count_at],
+        })
+    }
+
+    #[inline]
+    fn num_restarts(&self) -> usize {
+        self.restart_table.len() / 4
+    }
+
+    #[inline]
+    fn restart_offset(&self, i: usize) -> io::Result<usize> {
+        let at = i * 4;
+        let offset =
+            u32::from_le_bytes(self.restart_table[at..at + 4].try_into().unwrap()) as usize;
+        if offset >= self.entries.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SSTable restart offset outside the block",
+            ));
+        }
+        Ok(offset)
+    }
+
+    /// The full key stored at restart `i` (restart entries carry no prefix).
+    fn restart_key(&self, i: usize) -> io::Result<&'b [u8]> {
+        let offset = self.restart_offset(i)?;
+        let mut reader = &self.entries[offset..];
+        let prefix_len = read_vint(&mut reader)?;
+        if prefix_len != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "SSTable restart entry has a non-zero key prefix",
+            ));
+        }
+        let suffix_len = read_vint(&mut reader)? as usize;
+        if suffix_len > reader.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "SSTable restart key truncated",
+            ));
+        }
+        Ok(&reader[..suffix_len])
+    }
+}
+
 /// Bounded block cache with a contention-free read path.
 ///
 /// Normal reads use [`BlockCache::peek`] under a shared lock and deliberately
@@ -1251,7 +1356,10 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
         if magic != SSTABLE_MAGIC {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Invalid SSTable magic: 0x{:08X}", magic),
+                format!(
+                    "Invalid SSTable magic: 0x{magic:08X} (required STB5); the term dictionary \
+                     was written by an incompatible Hermes"
+                ),
             ));
         }
 
@@ -1751,8 +1859,36 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
         self.search_block(&block_data, key)
     }
 
+    /// Entry stream of a decompressed block (without the v5 restart trailer).
+    fn block_entries<'b>(&self, block_data: &'b [u8]) -> io::Result<&'b [u8]> {
+        Ok(BlockParts::split(block_data)?.entries)
+    }
+
     fn search_block(&self, block_data: &[u8], target_key: &[u8]) -> io::Result<Option<V>> {
-        let mut reader = block_data;
+        let parts = BlockParts::split(block_data)?;
+
+        // v5: binary-search the restart keys for the last restart whose key
+        // is <= target, then decode at most RESTART_INTERVAL entries from it.
+        let start = if parts.num_restarts() > 0 {
+            let (mut lo, mut hi) = (0usize, parts.num_restarts());
+            while lo < hi {
+                let mid = lo + (hi - lo) / 2;
+                if parts.restart_key(mid)? <= target_key {
+                    lo = mid + 1;
+                } else {
+                    hi = mid;
+                }
+            }
+            if lo == 0 {
+                // Target sorts before the first key of the block.
+                return Ok(None);
+            }
+            parts.restart_offset(lo - 1)?
+        } else {
+            0
+        };
+
+        let mut reader = &parts.entries[start..];
         let mut current_key = Vec::new();
 
         while !reader.is_empty() {
@@ -1794,7 +1930,7 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
 
         for block_idx in 0..self.block_index.len() {
             let block_data = self.load_block(block_idx).await?;
-            let mut reader = &block_data[..];
+            let mut reader = self.block_entries(&block_data)?;
             let mut current_key = Vec::new();
 
             while !reader.is_empty() {
@@ -1827,16 +1963,16 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
             return Ok((Vec::new(), false));
         }
 
-        let start_block = match self.block_index.locate(prefix) {
-            Some(idx) => idx,
-            None => return Ok((Vec::new(), false)),
-        };
+        // `locate` returns `None` when `prefix` sorts before the first key of
+        // block 0. That is a miss for a point lookup, but a prefix of the
+        // smallest key still matches entries in block 0, so scans start there.
+        let start_block = self.block_index.locate(prefix).unwrap_or(0);
 
         let mut results = Vec::new();
 
         for block_idx in start_block..self.block_index.len() {
             let block_data = self.load_block(block_idx).await?;
-            let mut reader = &block_data[..];
+            let mut reader = self.block_entries(&block_data)?;
             let mut current_key = Vec::new();
 
             while !reader.is_empty() {
@@ -1875,16 +2011,14 @@ impl<V: SSTableValue> AsyncSSTableReader<V> {
             return Ok((Vec::new(), false));
         }
 
-        let start_block = match self.block_index.locate(prefix) {
-            Some(idx) => idx,
-            None => return Ok((Vec::new(), false)),
-        };
+        // See `prefix_scan_limited`: a prefix of the smallest key lives in block 0.
+        let start_block = self.block_index.locate(prefix).unwrap_or(0);
 
         let mut results = Vec::new();
 
         for block_idx in start_block..self.block_index.len() {
             let block_data = self.load_block_sync(block_idx)?;
-            let mut reader = &block_data[..];
+            let mut reader = self.block_entries(&block_data)?;
             let mut current_key = Vec::new();
 
             while !reader.is_empty() {
@@ -1911,6 +2045,8 @@ pub struct AsyncSSTableIterator<'a, V: SSTableValue> {
     current_block: usize,
     block_data: Option<Arc<[u8]>>,
     block_offset: usize,
+    /// End of the entry stream in `block_data` (excludes the restart trailer).
+    block_entries_end: usize,
     current_key: Vec<u8>,
     finished: bool,
 }
@@ -1922,6 +2058,7 @@ impl<'a, V: SSTableValue> AsyncSSTableIterator<'a, V> {
             current_block: 0,
             block_data: None,
             block_offset: 0,
+            block_entries_end: 0,
             current_key: Vec::new(),
             finished: reader.block_index.is_empty(),
         }
@@ -1933,7 +2070,9 @@ impl<'a, V: SSTableValue> AsyncSSTableIterator<'a, V> {
             return Ok(false);
         }
 
-        self.block_data = Some(self.reader.load_block(self.current_block).await?);
+        let block = self.reader.load_block(self.current_block).await?;
+        self.block_entries_end = self.reader.block_entries(&block)?.len();
+        self.block_data = Some(block);
         self.block_offset = 0;
         self.current_key.clear();
         self.current_block += 1;
@@ -1952,14 +2091,14 @@ impl<'a, V: SSTableValue> AsyncSSTableIterator<'a, V> {
 
         loop {
             let block = self.block_data.as_ref().unwrap();
-            if self.block_offset >= block.len() {
+            if self.block_offset >= self.block_entries_end {
                 if !self.load_next_block().await? {
                     return Ok(None);
                 }
                 continue;
             }
 
-            let mut reader = &block[self.block_offset..];
+            let mut reader = &block[self.block_offset..self.block_entries_end];
             let start_len = reader.len();
 
             let value = decode_block_entry(&mut reader, &mut self.current_key)?;
@@ -2101,6 +2240,127 @@ mod tests {
             let mut reader = buf.as_slice();
             let decoded = read_vint(&mut reader).unwrap();
             assert_eq!(val, decoded, "Failed for value {}", val);
+        }
+    }
+
+    fn keyed_table(num_keys: usize) -> (Vec<u8>, Vec<Vec<u8>>) {
+        let mut keys: Vec<Vec<u8>> = (0..num_keys)
+            .map(|i| format!("field{:02}/term{:07}", i % 7, i * 7919 % 100_003).into_bytes())
+            .collect();
+        keys.sort();
+        keys.dedup();
+        let mut writer = SSTableWriter::<_, u64>::new(Vec::new());
+        for (i, key) in keys.iter().enumerate() {
+            writer.insert(key, &(i as u64)).unwrap();
+        }
+        (writer.finish().unwrap(), keys)
+    }
+
+    async fn check_every_key_and_scan(bytes: Vec<u8>, keys: &[Vec<u8>]) {
+        let handle = FileHandle::from_bytes(OwnedBytes::new(bytes));
+        let reader = AsyncSSTableReader::<u64>::open(handle, 8).await.unwrap();
+        assert!(reader.block_index.len() > 3, "test needs several blocks");
+
+        // Every key is found with its value; the key just before / after is not.
+        for (i, key) in keys.iter().enumerate() {
+            assert_eq!(reader.get(key).await.unwrap(), Some(i as u64), "key {i}");
+            let mut before = key.clone();
+            *before.last_mut().unwrap() -= 1;
+            let mut after = key.clone();
+            after.push(0);
+            assert!(
+                reader.get(&before).await.unwrap().is_none() || keys.binary_search(&before).is_ok()
+            );
+            assert!(
+                reader.get(&after).await.unwrap().is_none() || keys.binary_search(&after).is_ok()
+            );
+        }
+        assert!(reader.get(b"").await.unwrap().is_none());
+        assert!(reader.get(b"zzz").await.unwrap().is_none());
+
+        // Iteration and prefix scans see exactly the entries, in order.
+        let mut it = reader.iter();
+        let mut seen = Vec::new();
+        while let Some((k, v)) = it.next().await.unwrap() {
+            assert_eq!(v as usize, seen.len());
+            seen.push(k);
+        }
+        assert_eq!(seen, keys);
+        let scanned = reader.prefix_scan(b"field03/").await.unwrap();
+        let expected: Vec<&Vec<u8>> = keys.iter().filter(|k| k.starts_with(b"field03/")).collect();
+        assert_eq!(scanned.len(), expected.len());
+        assert!(scanned.iter().zip(expected).all(|((k, _), e)| k == e));
+        assert_eq!(reader.all_entries().await.unwrap().len(), keys.len());
+        let batch: Vec<&[u8]> = keys.iter().step_by(97).map(|k| k.as_slice()).collect();
+        let got = reader.get_batch(&batch).await.unwrap();
+        assert!(got.iter().all(|v| v.is_some()));
+    }
+
+    /// v5 blocks: restart points every RESTART_INTERVAL entries, lookups
+    /// binary-search them, scans and iteration skip the trailer.
+    #[cfg(feature = "native")]
+    #[tokio::test]
+    async fn v5_restart_points_find_every_key_across_blocks() {
+        let (bytes, keys) = keyed_table(20_000);
+        check_every_key_and_scan(bytes, &keys).await;
+    }
+
+    /// An unknown magic is refused with an actionable message.
+    #[cfg(feature = "native")]
+    #[tokio::test]
+    async fn unknown_sstable_magic_is_refused() {
+        let (mut bytes, _) = keyed_table(100);
+        let n = bytes.len();
+        bytes[n - 4..].copy_from_slice(&0x5354_4236u32.to_le_bytes()); // "STB6"
+        let handle = FileHandle::from_bytes(OwnedBytes::new(bytes));
+        let err = match AsyncSSTableReader::<u64>::open(handle, 8).await {
+            Ok(_) => panic!("unknown magic must be refused"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("incompatible Hermes"), "{err}");
+    }
+
+    /// A prefix that sorts before the first key of block 0 (a strict prefix
+    /// of the smallest key) must still find its matches in block 0.
+    #[cfg(feature = "native")]
+    #[tokio::test]
+    async fn prefix_scan_matches_prefix_of_smallest_key() {
+        let mut writer = SSTableWriter::<_, u64>::new(Vec::new());
+        writer.insert(b"apple", &1).unwrap();
+        writer.insert(b"apricot", &2).unwrap();
+        writer.insert(b"banana", &3).unwrap();
+        let bytes = writer.finish().unwrap();
+        let handle = FileHandle::from_bytes(OwnedBytes::new(bytes));
+        let reader = AsyncSSTableReader::<u64>::open(handle, 4).await.unwrap();
+
+        let keys = |entries: Vec<(Vec<u8>, u64)>| -> Vec<Vec<u8>> {
+            entries.into_iter().map(|(k, _)| k).collect()
+        };
+
+        // "ap" < "apple", so `locate` reports "before block 0"; the scan must
+        // still start at block 0 and return both "ap" keys.
+        assert_eq!(
+            keys(reader.prefix_scan(b"ap").await.unwrap()),
+            vec![b"apple".to_vec(), b"apricot".to_vec()]
+        );
+        assert_eq!(
+            keys(reader.prefix_scan(b"a").await.unwrap()),
+            vec![b"apple".to_vec(), b"apricot".to_vec()]
+        );
+        assert_eq!(
+            keys(reader.prefix_scan(b"ba").await.unwrap()),
+            vec![b"banana".to_vec()]
+        );
+        // Prefixes that sort before every key but match nothing stay empty.
+        assert!(reader.prefix_scan(b"0").await.unwrap().is_empty());
+
+        #[cfg(feature = "sync")]
+        {
+            assert_eq!(
+                keys(reader.prefix_scan_sync(b"ap").unwrap()),
+                vec![b"apple".to_vec(), b"apricot".to_vec()]
+            );
+            assert!(reader.prefix_scan_sync(b"0").unwrap().is_empty());
         }
     }
 

--- a/hermes-tool/src/index_ops.rs
+++ b/hermes-tool/src/index_ops.rs
@@ -156,6 +156,7 @@ pub async fn index_documents(
     indexing_threads: Option<usize>,
     compression_threads: Option<usize>,
     optimization: hermes_core::structures::IndexOptimization,
+    posting_codec: Option<hermes_core::structures::PostingCodec>,
 ) -> Result<()> {
     let optimization_mode = optimization;
 
@@ -167,6 +168,7 @@ pub async fn index_documents(
         num_compression_threads: compression_threads
             .unwrap_or(default_config.num_compression_threads),
         optimization: optimization_mode,
+        posting_codec,
         ..default_config
     };
     let mut writer = IndexWriter::open(dir, config.clone()).await?;
@@ -186,11 +188,11 @@ pub async fn index_documents(
             .collect::<Vec<_>>()
     );
     info!(
-        "Indexing threads: {}, Compression threads: {}, Optimization: {:?} (zstd level {})",
+        "Indexing threads: {}, Compression threads: {}, Optimization: {:?}, posting codec: {}",
         config.num_indexing_threads,
         config.num_compression_threads,
         optimization_mode,
-        optimization_mode.zstd_level()
+        config.effective_posting_codec()
     );
 
     let count = if use_stdin {
@@ -742,6 +744,7 @@ mod tests {
             None,
             None,
             hermes_core::structures::IndexOptimization::default(),
+            None,
         )
         .await
         .unwrap();
@@ -768,6 +771,7 @@ mod tests {
             None,
             None,
             hermes_core::structures::IndexOptimization::default(),
+            None,
         )
         .await
         .unwrap();

--- a/hermes-tool/src/main.rs
+++ b/hermes-tool/src/main.rs
@@ -106,12 +106,33 @@ struct Cli {
 /// Index optimization mode for balancing compression ratio vs query speed
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum OptimizationMode {
-    /// Balanced compression/speed (zstd level 7)
+    /// Rounded posting codec, term dictionary zstd level 9
     Adaptive,
-    /// Best compression ratio (OptP4D + zstd level 22)
+    /// Patched-exception posting codec (pfor), term dictionary zstd level 22
     Size,
-    /// Fastest queries (Roaring + zstd level 3)
+    /// Rounded posting codec, term dictionary zstd level 1
     Performance,
+}
+
+/// Posting block codec (see docs/posting-codecs.md)
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum PostingCodecArg {
+    /// Widths rounded to 0/8/16/32 bits: fastest decode, largest
+    Rounded,
+    /// Exact bit widths (BP128): ~1.8x smaller, ~10% slower decode
+    Packed,
+    /// Exact widths with patched exceptions (OptP4D): smallest, ~30% slower decode
+    Pfor,
+}
+
+impl PostingCodecArg {
+    fn to_posting_codec(self) -> hermes_core::structures::PostingCodec {
+        match self {
+            Self::Rounded => hermes_core::structures::PostingCodec::Rounded,
+            Self::Packed => hermes_core::structures::PostingCodec::Packed,
+            Self::Pfor => hermes_core::structures::PostingCodec::Pfor,
+        }
+    }
 }
 
 impl OptimizationMode {
@@ -180,11 +201,15 @@ enum Commands {
         compression_threads: Option<usize>,
 
         /// Index optimization mode
-        /// - adaptive: balanced compression/speed (zstd level 7)
-        /// - size: best compression ratio (OptP4D + zstd level 22)
-        /// - performance: fastest queries (Roaring + zstd level 3)
+        /// - adaptive: rounded posting codec, term dictionary zstd 9
+        /// - size: pfor posting codec, term dictionary zstd 22
+        /// - performance: rounded posting codec, term dictionary zstd 1
         #[arg(short = 'O', long, default_value = "adaptive")]
         optimization: OptimizationMode,
+
+        /// Posting block codec override (default: derived from --optimization)
+        #[arg(long)]
+        posting_codec: Option<PostingCodecArg>,
     },
 
     /// Commit pending changes
@@ -473,6 +498,7 @@ async fn main() -> Result<()> {
             indexing_threads,
             compression_threads,
             optimization,
+            posting_codec,
         } => {
             index_ops::index_documents(
                 index,
@@ -483,6 +509,7 @@ async fn main() -> Result<()> {
                 indexing_threads,
                 compression_threads,
                 optimization.to_index_optimization(),
+                posting_codec.map(PostingCodecArg::to_posting_codec),
             )
             .await?;
         }


### PR DESCRIPTION
## Summary

- make filtered text search exact for selective MUST and MUST_NOT filters, scoring requirements, nested disjunctions, and multi-field score aggregation
- add production Rounded, Packed, and Pfor posting block codecs, wire optimization policy through builds, merges, and reorders, and add SSTable restart points
- adapt chunked BM25 with a p90 nominal-length floor while retaining MaxP document aggregation
- move index metadata and term dictionaries to the format-5 clean rebuild boundary; backward compatibility is intentionally not provided

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo check --workspace --all-targets
- cargo check -p hermes-core --no-default-features --features native --all-targets
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps
- cargo test --workspace