### PR TITLE
ci: cache and unify Hermes image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.context
+.git
+.github
+.idea
+.vscode
+target
+**/target
+**/__pycache__
+**/.pytest_cache
+**/.venv
+**/node_modules
+**/pkg
+*.log

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -297,7 +297,8 @@ jobs:
           ref: ${{ github.ref }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        id: buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -306,9 +307,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}/hermes-server
           tags: |
@@ -316,34 +317,46 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=v${{ needs.bump-version.outputs.new_version }}
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
+      - name: Cache Cargo build data
+        id: cargo-cache
+        uses: actions/cache@v5
+        with:
+          path: .buildkit-cargo-cache
+          key: buildkit-cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            buildkit-cargo-${{ runner.os }}-
+
+      - name: Restore Cargo cache mounts
+        uses: reproducible-containers/buildkit-cache-dance@v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-map: |
+            {
+              ".buildkit-cargo-cache/registry": {
+                "target": "/usr/local/cargo/registry",
+                "id": "hermes-cargo-registry",
+                "sharing": "locked"
+              },
+              ".buildkit-cargo-cache/git": {
+                "target": "/usr/local/cargo/git",
+                "id": "hermes-cargo-git",
+                "sharing": "locked"
+              },
+              ".buildkit-cargo-cache/target": {
+                "target": "/app/target",
+                "id": "hermes-cargo-target",
+                "sharing": "locked"
+              }
+            }
+          skip-extraction: ${{ steps.cargo-cache.outputs.cache-hit }}
+
+      - name: Build and push Hermes image
+        uses: docker/build-push-action@v7
         with:
           context: .
-          file: hermes-server/Dockerfile
+          file: Dockerfile.release
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Extract broker metadata
-        id: broker-meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository }}/hermes-broker
-          tags: |
-            type=semver,pattern={{version}},value=v${{ needs.bump-version.outputs.new_version }}
-            type=semver,pattern={{major}}.{{minor}},value=v${{ needs.bump-version.outputs.new_version }}
-            type=raw,value=latest
-
-      - name: Build and push broker
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: hermes-broker/Dockerfile
-          push: true
-          tags: ${{ steps.broker-meta.outputs.tags }}
-          labels: ${{ steps.broker-meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=hermes-image
+          cache-to: type=gha,scope=hermes-image,mode=max

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,54 @@
+# syntax=docker/dockerfile:1
+
+# Build both production binaries together so Cargo compiles their shared
+# dependency graph only once.
+FROM rust:1.98.0-slim-bookworm AS builder
+
+RUN apt-get update && apt-get install -y \
+    protobuf-compiler \
+    pkg-config \
+    libssl-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Cargo.toml Cargo.lock ./
+COPY hermes-broker ./hermes-broker
+COPY hermes-core ./hermes-core
+COPY hermes-llm ./hermes-llm
+COPY hermes-mal ./hermes-mal
+COPY hermes-mal-python ./hermes-mal-python
+COPY hermes-tokenizer ./hermes-tokenizer
+COPY hermes-train ./hermes-train
+COPY hermes-server ./hermes-server
+COPY hermes-tool ./hermes-tool
+COPY hermes-wasm ./hermes-wasm
+COPY hermes-proto ./hermes-proto
+
+# Layer caching alone is ineffective after a version bump changes the
+# manifests. These cache mounts let Cargo reuse downloaded crates and compiled
+# dependencies while the output copies remain normal image layers.
+RUN --mount=type=cache,id=hermes-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=hermes-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=hermes-cargo-target,target=/app/target,sharing=locked \
+    cargo build --locked --release \
+        -p hermes-server --bin hermes-server \
+        -p hermes-broker --bin hermes-broker \
+    && install -Dm755 target/release/hermes-server /out/hermes-server \
+    && install -Dm755 target/release/hermes-broker /out/hermes-broker
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+EXPOSE 50051
+
+COPY --from=builder /out/hermes-server /usr/local/bin/hermes-server
+COPY --from=builder /out/hermes-broker /usr/local/bin/hermes-broker
+
+# Run the server by default. Supplying `hermes-broker` as the container command
+# starts the broker from this same image.
+CMD ["hermes-server"]

--- a/hermes-broker/README.md
+++ b/hermes-broker/README.md
@@ -46,3 +46,15 @@ cargo test -p hermes-broker                      # unit + mock-backend integrati
 cargo build -p hermes-server --bin hermes-server # e2e prerequisite
 cargo test -p hermes-broker --test e2e_real_server -- --ignored
 ```
+
+## Container image
+
+The published Hermes image contains both the server and broker binaries. It
+starts `hermes-server` by default; select the broker with a command override:
+
+```bash
+docker run --rm -p 50051:50051 \
+  ghcr.io/spacefrontiers/hermes/hermes-server:latest \
+  hermes-broker --discovery static \
+  --backend "id=local,addr=10.0.0.10:50051,shard=0"
+```

--- a/hermes-server/README.md
+++ b/hermes-server/README.md
@@ -362,8 +362,13 @@ Or pull from GitHub Container Registry:
 
 ```bash
 docker pull ghcr.io/spacefrontiers/hermes/hermes-server:latest
-docker run -p 50051:50051 -v ./data:/data ghcr.io/spacefrontiers/hermes/hermes-server:latest --data-dir /data
+docker run -p 50051:50051 -v ./data:/data \
+  ghcr.io/spacefrontiers/hermes/hermes-server:latest \
+  hermes-server --data-dir /data
 ```
+
+The published image also contains `hermes-broker`. Override the command to run
+it instead of the default server process.
 
 ## License
 


### PR DESCRIPTION
## Summary
- build `hermes-server` and `hermes-broker` together and ship both in one container image
- default to `hermes-server`; run the broker with a container command override
- persist Cargo registry, git, and target cache mounts between publish runs
- isolate the BuildKit layer cache under an explicit Hermes image scope
- trim the Docker build context and update container usage docs

## Why
The previous publish job built the server and broker sequentially. Release 1.8.119 spent 13m23s on the server build and then another 4m03s on the broker build. Both builds also wrote the default BuildKit cache scope, and version bumps invalidated the monolithic Cargo layer.

## Validation
- `actionlint .github/workflows/publish.yml`
- `git diff --check`
- `cargo build --locked --release -p hermes-server --bin hermes-server -p hermes-broker --bin hermes-broker`
- commit hooks (YAML, prettier, whitespace, merge-conflict checks)