### PR TITLE
perf(core): stream BM25 segment merges

### DIFF
--- a/docs/lexical-vertical.md
+++ b/docs/lexical-vertical.md
@@ -78,7 +78,7 @@ doc_freq, position_offset, position_len }`. FST or raw mmap index. Not in
 - IDF (`query/global_stats.rs`): lazily aggregated over the segments of one
   searcher; no cross-shard statistics (broker phase 2 merges by RRF).
 
-## Position list format v2
+## Position list format v3
 
 Status: implemented (2026-09-03), `structures/postings/positions_v2.rs`.
 
@@ -91,10 +91,11 @@ One position stream per term, addressed through the doc postings instead of
 through its own skip list:
 
 ```text
-.pos  per term:  [block 0]...[block n-1][block offsets: u32 × n]
-                 [footer: n u32, total_positions u64, magic "POS2"]
+.pos  per term:  [block 0]...[block n-1]
+                 [block index: (byte offset u32, value start u64) × n]
+                 [footer: n u32, total_positions u64, magic "POS3"]
 block:           [count u16][bits u8][pad u8][packed values: count × bytes(bits)]
-                 128 values per block, the last one partial
+                 at most 128 values per block
 ```
 
 - Values are **deltas**: a document's positions are sorted, the first is
@@ -111,7 +112,9 @@ pack_rounded`, 0/8/16/32 bits), so decode is the same SIMD widening.
   before the block's first document (cumulative tf). Inside a block the
   position of document _j_ is `cursor + Σ tf[0..j]`, which the iterator
   keeps as a running prefix (`BlockPostingIterator::position_cursor`).
-  `cursor / 128` is the block, `cursor % 128` the offset in it.
+  The position block index maps that logical cursor to a physical block and
+  offset. Fresh streams have full interior blocks; merged streams may retain
+  a short source tail as an interior block.
 - The doc-posting footer grew by `total_positions u64 + flags u32 + magic
 u32` ("BPL2"); a list ending in the magic has the extension, a legacy
   list ends with its `max_tf` (≤ 65 535 by the builder's u16 tf), so both
@@ -124,31 +127,29 @@ candidate, asks each term's `TermPositions` for
 `[cursor, cursor + tf)`: one or two blocks decoded from the mmap into a
 reused scratch buffer, delta-summed into the term's buffer, then the
 offset-aware sliding match. Nothing is copied to the heap up front.
-`TermPositions::Legacy` wraps the pre-v2 list for segments written before
-the change. Still to do: `MADV_RANDOM` on `.pos` and a bounded `WILLNEED`
-on the candidate's ranges.
+Still to do: `MADV_RANDOM` on `.pos` and a bounded `WILLNEED` on the
+candidate's ranges.
 
 ### Size
 
 With stop words removed and per-chunk restarts, in-document deltas are
 roughly `chunk_len / tf`, so most blocks use 8-bit values: about 1 byte per
-position plus 4 bytes per 128, against 2–3 bytes of absolute vint plus a
+position plus 12 bytes per 128, against 2–3 bytes of absolute vint plus a
 count per document and 20 B of skip entry per 128 documents before. The
 `u64` cursor costs 8 B per 128 postings.
 
 ### Merge
 
-Values are doc-agnostic, so a merge re-packs every source's blocks into one
-fresh stream (`PositionStreamEncoder::push_values`), and the block copy of
-the doc postings shifts each source's cursors by the values of the sources
-before it (`Footer::total_positions`). A legacy source is decoded per
-document and re-encoded, and its doc postings take the decode-and-rebuild
-path so the merged term always addresses a v2 stream.
+Values are doc-agnostic, so a merge copies every encoded source block
+verbatim and rebuilds only the `(byte offset, value start)` index and footer.
+The block copy of the doc postings shifts each source's cursors by the values
+of the sources before it (`Footer::total_positions`). Inline doc postings
+that no longer fit inline are promoted to tiny blocks; existing external
+blocks are never decoded or re-encoded.
 
 ### Compatibility
 
-No production index carries positioned text fields yet; a legacy positioned
-segment is still readable and is converted by its first merge.
+Metadata format version 6 is a clean rebuild boundary for this layout.
 
 ## Doc postings and skip metadata
 

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -29,7 +29,7 @@ const INDEX_META_TMP_FILENAME: &str = "metadata.json.tmp";
 /// `load` requires this exact version. Metadata/segment compatibility is a
 /// clean rebuild boundary; serde_json would otherwise silently drop fields it
 /// does not know and a later save could destructively rewrite index state.
-pub const INDEX_META_FORMAT_VERSION: u32 = 5;
+pub const INDEX_META_FORMAT_VERSION: u32 = 6;
 
 /// Index-level centroids/codebooks are deliberately bounded before they are
 /// read or decoded. Besides limiting ordinary corruption damage, the matching
@@ -987,7 +987,7 @@ mod tests {
             .await
             .expect_err("metadata from a newer format version must be refused, not silently pruned")
             .to_string();
-        assert!(error.contains("version 5"), "{error}");
+        assert!(error.contains("version 6"), "{error}");
         assert!(error.contains("incompatible"), "{error}");
     }
 
@@ -1007,7 +1007,7 @@ mod tests {
             .await
             .expect_err("temp-file recovery must apply the same version gate")
             .to_string();
-        assert!(error.contains("version 5"), "{error}");
+        assert!(error.contains("version 6"), "{error}");
     }
 
     #[tokio::test]

--- a/hermes-core/src/index/tests/posting_codecs.rs
+++ b/hermes-core/src/index/tests/posting_codecs.rs
@@ -6,7 +6,7 @@ use crate::index::{Index, IndexConfig, IndexMetadata, IndexWriter};
 use crate::structures::{IndexOptimization, PostingCodec};
 
 #[tokio::test]
-async fn size_optimization_survives_reencoding_merge() {
+async fn inline_source_is_promoted_without_reencoding_external_blocks() {
     let mut schema = SchemaBuilder::default();
     let body = schema.add_text_field("body", true, false);
     let schema = schema.build();
@@ -20,8 +20,8 @@ async fn size_optimization_survives_reencoding_merge() {
         .await
         .unwrap();
 
-    // One inline source plus one external source forces the merger's
-    // decode/remap/re-encode path for "needle".
+    // One inline source plus one external source must become two copied blocks;
+    // combining all nine postings into one block would expose re-encoding.
     let mut first = Document::new();
     first.add_text(body, "needle");
     writer.add_document(first).unwrap();
@@ -51,9 +51,14 @@ async fn size_optimization_survives_reencoding_merge() {
         .unwrap()
         .unwrap();
     assert!(postings.num_blocks() > 0);
+    assert_eq!(
+        postings.num_blocks(),
+        2,
+        "inline promotion must not collapse/re-encode the external block"
+    );
     assert!(
         (0..postings.num_blocks())
             .all(|block| { postings.block_codec(block) == Some(PostingCodec::Pfor) }),
-        "merge re-encoding must retain the configured size codec"
+        "external and promoted inline blocks retain the configured size codec"
     );
 }

--- a/hermes-core/src/segment/merger/postings.rs
+++ b/hermes-core/src/segment/merger/postings.rs
@@ -3,24 +3,20 @@
 //! Uses a min-heap to merge terms from all segments in sorted order
 //! without loading all terms into memory at once.
 //!
-//! Optimization: For terms that exist in only one segment, we copy the
-//! posting data directly without decode/encode. Only terms that exist
-//! in multiple segments need full merge.
-
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
-use std::io::Write;
+//! Encoded posting and position blocks are copied directly for both single-
+//! and multi-segment terms. Inline postings are promoted to tiny encoded
+//! blocks only when the merged term no longer fits inline.
 
 use super::OffsetWriter;
 use super::SegmentMerger;
 use super::chunk_maps::chunk_offsets;
 use super::doc_offsets;
 use crate::Result;
+use crate::directories::OwnedBytes;
 use crate::segment::reader::SegmentReader;
-use crate::structures::{
-    BlockPostingList, PositionPostingList, PositionStream, PositionStreamEncoder, PostingList,
-    SSTableWriter, TERMINATED, TermInfo,
-};
+use crate::structures::{BlockPostingList, PositionStream, PostingList, SSTableWriter, TermInfo};
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
 
 /// Entry for k-way merge heap
 struct MergeEntry {
@@ -126,7 +122,6 @@ impl SegmentMerger {
             crate::structures::SSTableWriterConfig::from_optimization(self.optimization),
         );
         let mut terms_processed = 0usize;
-        let mut serialize_buf: Vec<u8> = Vec::new();
         // Pre-allocate sources buffer outside loop — reused for every term
         let mut sources: Vec<(usize, TermInfo, u32)> = Vec::with_capacity(segments.len());
 
@@ -181,13 +176,7 @@ impl SegmentMerger {
 
             // Process this term (handles both single-source and multi-source)
             let term_info = self
-                .merge_term(
-                    segments,
-                    &mut sources,
-                    postings_out,
-                    positions_out,
-                    &mut serialize_buf,
-                )
+                .merge_term(segments, &mut sources, postings_out, positions_out)
                 .await?;
 
             // Write directly to SSTable (no buffering)
@@ -211,176 +200,157 @@ impl SegmentMerger {
         Ok(terms_processed)
     }
 
-    /// Merge a single term's postings + positions from one or more source segments.
+    /// Merge a single term's postings + positions from one or more segments.
     ///
-    /// Fast path: when all sources are external, uses block-level
-    /// concatenation (O(blocks) instead of O(postings)), including the
-    /// single-source case.
-    /// Otherwise: full decode → remap doc IDs → re-encode.
+    /// Existing external posting and position blocks are always copied in
+    /// their encoded form. Inline postings remain inline when the combined
+    /// value fits; otherwise each tiny inline source is encoded as one block
+    /// and concatenated with the untouched external blocks.
     pub(crate) async fn merge_term(
         &self,
         segments: &[SegmentReader],
         sources: &mut [(usize, TermInfo, u32)],
         postings_out: &mut OffsetWriter,
         positions_out: &mut OffsetWriter,
-        buf: &mut Vec<u8>,
     ) -> Result<TermInfo> {
         sources.sort_by_key(|(_, _, off)| *off);
 
-        let any_positions = sources
+        let has_positions = sources
+            .first()
+            .is_some_and(|(_, info, _)| info.position_info().is_some());
+        if sources
             .iter()
-            .any(|(_, ti, _)| ti.position_info().is_some());
-        let all_external = sources
-            .iter()
-            .all(|(_, ti, _)| ti.external_info().is_some());
+            .any(|(_, info, _)| info.position_info().is_some() != has_positions)
+        {
+            return Err(crate::Error::Corruption(
+                "cannot merge a term with inconsistent position data".into(),
+            ));
+        }
 
-        // Read every external source's postings up front (in parallel); the
-        // slow path below decodes them and the fast path copies their blocks.
+        // Preserve genuinely tiny terms inline. Decoding here is bounded by
+        // MAX_INLINE_POSTINGS and never touches an external posting list.
+        if !has_positions
+            && sources
+                .iter()
+                .all(|(_, info, _)| matches!(info, TermInfo::Inline { .. }))
+        {
+            let mut postings = Vec::new();
+            for (_, info, doc_offset) in sources.iter() {
+                let (ids, tfs) = info.decode_inline().expect("checked inline source");
+                postings.extend(
+                    ids.into_iter()
+                        .zip(tfs)
+                        .map(|(doc, tf)| (doc + doc_offset, tf)),
+                );
+            }
+            if let Some(inline) =
+                TermInfo::try_inline_iter(postings.len(), postings.iter().copied())
+            {
+                return Ok(inline);
+            }
+        }
+
+        // Range reads return Arc/mmap-backed slices, so ordinary external
+        // sources are not copied into an intermediate Vec. Reads still run in
+        // parallel for lazy/remote directories.
         let read_futs: Vec<_> = sources
             .iter()
-            .map(|(seg_idx, ti, doc_off)| {
+            .map(|(seg_idx, ti, _)| {
                 let external = ti.external_info();
                 let seg = &segments[*seg_idx];
-                let doc_off = *doc_off;
                 async move {
                     Ok::<_, crate::Error>(match external {
-                        Some((off, len)) => Some((seg.read_postings(off, len).await?, doc_off)),
+                        Some((off, len)) => Some(seg.read_postings(off, len).await?),
                         None => None,
                     })
                 }
             })
             .collect();
-        let raw_sources: Vec<Option<(Vec<u8>, u32)>> =
+        let external_sources: Vec<Option<OwnedBytes>> =
             futures::future::try_join_all(read_futs).await?;
-        // Block copies keep position cursors only when every source has
-        // them; a legacy source with positions (no cursors) is re-encoded so
-        // the merged term always addresses a v2 stream.
-        let cursors_ready = !any_positions
-            || raw_sources.iter().all(|raw| {
-                raw.as_ref()
-                    .is_some_and(|(bytes, _)| BlockPostingList::has_cursors_bytes(bytes))
-            });
 
-        // === Merge postings ===
-        let (posting_offset, posting_len, doc_count) = if all_external && cursors_ready {
-            // Fast path: streaming merge (blocks → output writer, no buffering)
-            let refs: Vec<(&[u8], u32)> = raw_sources
-                .iter()
-                .flatten()
-                .map(|(b, off)| (b.as_slice(), *off))
-                .collect();
-            let offset = postings_out.offset();
-            let (doc_count, bytes_written) =
-                BlockPostingList::concatenate_streaming(&refs, postings_out)?;
-            (offset, bytes_written as u64, doc_count)
-        } else {
-            // Decode all sources into a flat PostingList, remap doc IDs
-            let mut merged = PostingList::new();
-            for ((_, ti, doc_off), raw) in sources.iter().zip(&raw_sources) {
-                if let Some((ids, tfs)) = ti.decode_inline() {
-                    for (id, tf) in ids.into_iter().zip(tfs) {
-                        merged.add(id + doc_off, tf);
+        let mut posting_sources = Vec::with_capacity(sources.len());
+        for ((_, info, doc_offset), external) in sources.iter().zip(external_sources) {
+            let bytes = match external {
+                Some(bytes) => bytes,
+                None => {
+                    let (ids, tfs) = info.decode_inline().ok_or_else(|| {
+                        crate::Error::Corruption(
+                            "term has neither inline nor external postings".into(),
+                        )
+                    })?;
+                    let mut postings = PostingList::with_capacity(ids.len());
+                    for (doc, tf) in ids.into_iter().zip(tfs) {
+                        postings.push(doc, tf);
                     }
-                } else {
-                    let (bytes, _) = raw.as_ref().expect("external term has posting bytes");
-                    let bpl = BlockPostingList::deserialize(bytes)?;
-                    let mut it = bpl.iterator();
-                    while it.doc() != TERMINATED {
-                        merged.add(it.doc() + doc_off, it.term_freq());
-                        it.advance();
-                    }
+                    let block = BlockPostingList::from_posting_list_with_options(
+                        &postings,
+                        false,
+                        None,
+                        self.posting_codec,
+                    )?;
+                    let mut encoded = Vec::new();
+                    block.serialize(&mut encoded)?;
+                    OwnedBytes::new(encoded)
                 }
-            }
-            // Try to inline (only when no positions)
-            if !any_positions
-                && let Some(inline) = TermInfo::try_inline_iter(
-                    merged.doc_count() as usize,
-                    merged.iter().map(|p| (p.doc_id, p.term_freq)),
-                )
-            {
-                return Ok(inline);
-            }
-            let offset = postings_out.offset();
-            let block = BlockPostingList::from_posting_list_with_options(
-                &merged,
-                any_positions,
-                None,
-                self.posting_codec,
-            )?;
-            buf.clear();
-            block.serialize(buf)?;
-            postings_out.write_all(buf)?;
-            (offset, buf.len() as u64, merged.doc_count())
-        };
-        drop(raw_sources);
-
-        // === Merge positions (if any source has them) ===
-        if any_positions {
-            // Read all position data in parallel
-            let pos_futs: Vec<_> = sources
-                .iter()
-                .filter_map(|(seg_idx, ti, doc_off)| {
-                    let (pos_off, pos_len) = ti.position_info()?;
-                    let seg = &segments[*seg_idx];
-                    let doc_off = *doc_off;
-                    Some(async move {
-                        match seg.read_position_bytes(pos_off, pos_len).await? {
-                            Some(bytes) => Ok::<_, crate::Error>(Some((bytes, doc_off))),
-                            None => Ok(None),
-                        }
-                    })
-                })
-                .collect();
-            let raw_pos: Vec<(Vec<u8>, u32)> = futures::future::try_join_all(pos_futs)
-                .await?
-                .into_iter()
-                .flatten()
-                .collect();
-            if !raw_pos.is_empty() {
-                // Re-pack every source into one v2 stream: v2 sources
-                // contribute their raw delta values block by block, legacy
-                // lists are decoded per document. The values of source k
-                // land after those of sources 0..k, matching the cursor
-                // rebasing of the block copy above.
-                let offset = positions_out.offset();
-                let mut encoder = PositionStreamEncoder::new(&mut *positions_out);
-                let mut values: Vec<u32> = Vec::with_capacity(128);
-                for (bytes, _) in raw_pos {
-                    if PositionStream::is_stream(&bytes) {
-                        let stream =
-                            PositionStream::open(crate::directories::OwnedBytes::new(bytes))?;
-                        for idx in 0..stream.num_blocks() {
-                            if !stream.decode_block(idx, &mut values) {
-                                return Err(crate::Error::Corruption(
-                                    "position stream block failed to decode during merge".into(),
-                                ));
-                            }
-                            encoder.push_values(&values)?;
-                        }
-                    } else {
-                        let legacy = PositionPostingList::deserialize(&bytes)?;
-                        let mut it = legacy.iter();
-                        while it.doc() != TERMINATED {
-                            values.clear();
-                            values.extend_from_slice(it.positions());
-                            // Legacy term frequencies saturate at u16::MAX.
-                            values.truncate(u16::MAX as usize);
-                            encoder.push_doc(&mut values)?;
-                            it.advance();
-                        }
-                    }
-                }
-                let (_total, bytes_written) = encoder.finish()?;
-                return Ok(TermInfo::external_with_positions(
-                    posting_offset,
-                    posting_len,
-                    doc_count,
-                    offset,
-                    bytes_written,
+            };
+            if BlockPostingList::has_cursors_bytes(bytes.as_slice()) != has_positions {
+                return Err(crate::Error::Corruption(
+                    "posting position cursors do not match term position data".into(),
                 ));
             }
+            posting_sources.push((bytes, *doc_offset));
         }
 
-        Ok(TermInfo::external(posting_offset, posting_len, doc_count))
+        let posting_refs: Vec<_> = posting_sources
+            .iter()
+            .map(|(bytes, offset)| (bytes.as_slice(), *offset))
+            .collect();
+        let posting_offset = postings_out.offset();
+        let (doc_count, posting_len) =
+            BlockPostingList::concatenate_streaming(&posting_refs, postings_out)?;
+
+        if has_positions {
+            let pos_futs: Vec<_> = sources
+                .iter()
+                .map(|(seg_idx, ti, _)| {
+                    let (pos_off, pos_len) = ti
+                        .position_info()
+                        .expect("position consistency checked above");
+                    let seg = &segments[*seg_idx];
+                    async move {
+                        seg.read_position_bytes(pos_off, pos_len)
+                            .await?
+                            .ok_or_else(|| {
+                                crate::Error::Corruption(
+                                    "term has positions but the segment has no position file"
+                                        .into(),
+                                )
+                            })
+                    }
+                })
+                .collect();
+            let position_sources = futures::future::try_join_all(pos_futs).await?;
+            let position_refs: Vec<_> = position_sources
+                .iter()
+                .map(|bytes| bytes.as_slice())
+                .collect();
+            let position_offset = positions_out.offset();
+            let (_, position_len) =
+                PositionStream::concatenate_streaming(&position_refs, positions_out)?;
+            return Ok(TermInfo::external_with_positions(
+                posting_offset,
+                posting_len as u64,
+                doc_count,
+                position_offset,
+                position_len,
+            ));
+        }
+
+        Ok(TermInfo::external(
+            posting_offset,
+            posting_len as u64,
+            doc_count,
+        ))
     }
 }

--- a/hermes-core/src/segment/reader/mod.rs
+++ b/hermes-core/src/segment/reader/mod.rs
@@ -89,7 +89,7 @@ use std::sync::Arc;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::vector_data::LazyFlatVectorData;
-use crate::directories::{Directory, FileHandle};
+use crate::directories::{Directory, FileHandle, OwnedBytes};
 use crate::dsl::{DenseVectorQuantization, Document, Field, Schema};
 use crate::observe::DenseAnnScanStats;
 use crate::query::{MAX_DENSE_NPROBE, MAX_DENSE_RERANK_FACTOR};
@@ -2715,21 +2715,19 @@ impl SegmentReader {
     }
 
     /// Read raw posting bytes at offset
-    pub async fn read_postings(&self, offset: u64, len: u64) -> Result<Vec<u8>> {
+    pub async fn read_postings(&self, offset: u64, len: u64) -> Result<OwnedBytes> {
         let range = checked_file_range(offset, len, self.postings_handle.len(), "posting")?;
-        let bytes = self.postings_handle.read_bytes_range(range).await?;
-        Ok(bytes.to_vec())
+        Ok(self.postings_handle.read_bytes_range(range).await?)
     }
 
     /// Read raw position bytes at offset (for merge)
-    pub async fn read_position_bytes(&self, offset: u64, len: u64) -> Result<Option<Vec<u8>>> {
+    pub async fn read_position_bytes(&self, offset: u64, len: u64) -> Result<Option<OwnedBytes>> {
         let handle = match &self.positions_handle {
             Some(h) => h,
             None => return Ok(None),
         };
         let range = checked_file_range(offset, len, handle.len(), "position")?;
-        let bytes = handle.read_bytes_range(range).await?;
-        Ok(Some(bytes.to_vec()))
+        Ok(Some(handle.read_bytes_range(range).await?))
     }
 
     /// Check if this segment has a positions file

--- a/hermes-core/src/segment/text_reorder.rs
+++ b/hermes-core/src/segment/text_reorder.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use rustc_hash::FxHashMap;
 
 use crate::Result;
-use crate::directories::{Directory, DirectoryWriter, OwnedBytes};
+use crate::directories::{Directory, DirectoryWriter};
 use crate::dsl::{Field, FieldType, Schema};
 use crate::segment::builder::graph_bisection::{
     BpProgressLabel, ForwardIndex, graph_bisection_with_progress,
@@ -70,7 +70,7 @@ async fn read_postings(reader: &SegmentReader, info: &TermInfo) -> Result<Vec<(u
         crate::Error::Corruption("term has neither inline nor external postings".into())
     })?;
     let bytes = reader.read_postings(offset, len).await?;
-    let list = BlockPostingList::deserialize(&bytes)?;
+    let list = BlockPostingList::deserialize(bytes.as_slice())?;
     let mut it = list.iterator();
     let mut out = Vec::with_capacity(list.doc_count() as usize);
     while it.doc() != TERMINATED {
@@ -354,7 +354,6 @@ pub(crate) async fn rewrite_text_files<D: Directory + DirectoryWriter>(
                         &mut sources,
                         &mut postings_out,
                         &mut positions_out,
-                        &mut buf,
                     )
                     .await?
             }
@@ -466,7 +465,7 @@ async fn reorder_term(
                         "term has positions but the segment has no file".into(),
                     )
                 })?;
-            Some(TermPositions::open(OwnedBytes::new(bytes))?)
+            Some(TermPositions::open(bytes)?)
         }
         None => None,
     };
@@ -479,7 +478,7 @@ async fn reorder_term(
             crate::Error::Corruption("term has neither inline nor external postings".into())
         })?;
         let bytes = reader.read_postings(offset, len).await?;
-        let list = BlockPostingList::deserialize(&bytes)?;
+        let list = BlockPostingList::deserialize(bytes.as_slice())?;
         let mut it = list.iterator();
         let mut scratch = Vec::new();
         while it.doc() != TERMINATED {

--- a/hermes-core/src/structures/postings/positions_v2.rs
+++ b/hermes-core/src/structures/postings/positions_v2.rs
@@ -1,27 +1,27 @@
-//! Position stream v2: positions addressed through the doc postings.
+//! Position stream v3: positions addressed through the doc postings.
 //!
 //! One stream per term, referenced by `TermInfo::External { position_offset,
 //! position_len }`:
 //!
 //! ```text
 //! [block 0][block 1]...[block n-1]
-//! [block offsets: u32 × n]                      byte offset of each block
-//! [footer: num_blocks u32, total_positions u64, magic u32 "POS2"]   16 bytes
+//! [block index: (byte_offset u32, value_start u64) × n]
+//! [footer: num_blocks u32, total_positions u64, magic u32 "POS3"]   16 bytes
 //! block: [count u16][bits u8][pad u8][packed values: count × bytes_per_value(bits)]
 //! ```
 //!
 //! The values form one flat sequence in posting order: for every document
 //! (or chunk) its sorted positions, delta-coded (`p0, p1 - p0, ...`). Blocks
-//! hold exactly [`POSITION_STREAM_BLOCK`] values except the last one, so the
-//! `i`-th value lives in block `i / 128`. The doc postings record, per doc
-//! block, how many values precede the block ([`BlockPostingList::pos_cursor`])
-//! and the posting iterator adds the term frequencies of the postings before
-//! the current one ([`BlockPostingIterator::position_cursor`]); a reader then
-//! decodes only the one or two blocks covering `[cursor, cursor + tf)`.
+//! hold at most [`POSITION_STREAM_BLOCK`] values. The block index records both
+//! the physical byte offset and logical value start, so interior blocks may be
+//! short. The doc postings record, per doc block, how many values precede the
+//! block ([`BlockPostingList::pos_cursor`]) and the posting iterator adds the
+//! term frequencies of the postings before the current one
+//! ([`BlockPostingIterator::position_cursor`]).
 //!
-//! Because the stream is doc-agnostic, a merge re-packs the sources' values
-//! into fresh 128-value blocks without decoding deltas, and the cursors of the
-//! merged doc postings are the sources' cursors shifted by the number of
+//! Because the logical starts do not require interior blocks to be full, merge
+//! copies every encoded source block verbatim and rebuilds only the block index
+//! and footer. The cursors of merged doc postings are shifted by the number of
 //! values that precede each source.
 //!
 //! [`BlockPostingList::pos_cursor`]: super::BlockPostingList::pos_cursor
@@ -40,15 +40,16 @@ use crate::structures::simd;
 pub const POSITION_STREAM_BLOCK: usize = 128;
 
 const BLOCK_HEADER: usize = 4;
+const INDEX_ENTRY: usize = 12;
 const FOOTER: usize = 16;
-/// "POS2" little-endian.
-const MAGIC: u32 = 0x3253_4F50;
+/// "POS3" little-endian.
+const MAGIC: u32 = 0x3353_4F50;
 
 /// Streaming writer of one term's position stream.
 pub struct PositionStreamEncoder<W: Write> {
     writer: W,
     pending: Vec<u32>,
-    offsets: Vec<u32>,
+    index: Vec<(u32, u64)>,
     written: u64,
     total: u64,
     scratch: Vec<u8>,
@@ -59,7 +60,7 @@ impl<W: Write> PositionStreamEncoder<W> {
         Self {
             writer,
             pending: Vec::with_capacity(POSITION_STREAM_BLOCK),
-            offsets: Vec::new(),
+            index: Vec::new(),
             written: 0,
             total: 0,
             scratch: Vec::with_capacity(BLOCK_HEADER + POSITION_STREAM_BLOCK * 4),
@@ -107,7 +108,8 @@ impl<W: Write> PositionStreamEncoder<W> {
                 "position stream exceeds u32::MAX bytes",
             ));
         }
-        self.offsets.push(self.written as u32);
+        self.index
+            .push((self.written as u32, self.total - self.pending.len() as u64));
         let max = self.pending.iter().copied().max().unwrap_or(0);
         let width = simd::RoundedBitWidth::from_exact(simd::bits_needed(max));
         let count = self.pending.len();
@@ -128,14 +130,15 @@ impl<W: Write> PositionStreamEncoder<W> {
     /// `(total_positions, bytes_written)`.
     pub fn finish(mut self) -> io::Result<(u64, u64)> {
         self.flush_block()?;
-        for &offset in &self.offsets {
+        for &(offset, value_start) in &self.index {
             self.writer.write_u32::<LittleEndian>(offset)?;
+            self.writer.write_u64::<LittleEndian>(value_start)?;
         }
         self.writer
-            .write_u32::<LittleEndian>(self.offsets.len() as u32)?;
+            .write_u32::<LittleEndian>(self.index.len() as u32)?;
         self.writer.write_u64::<LittleEndian>(self.total)?;
         self.writer.write_u32::<LittleEndian>(MAGIC)?;
-        let bytes = self.written + (self.offsets.len() * 4) as u64 + FOOTER as u64;
+        let bytes = self.written + (self.index.len() * INDEX_ENTRY) as u64 + FOOTER as u64;
         Ok((self.total, bytes))
     }
 }
@@ -145,39 +148,56 @@ impl<W: Write> PositionStreamEncoder<W> {
 pub struct PositionStream {
     bytes: OwnedBytes,
     num_blocks: usize,
-    offsets_start: usize,
+    index_start: usize,
     total: u64,
+    canonical_blocks: bool,
 }
 
 impl PositionStream {
-    /// Whether `raw` ends with a v2 footer (legacy lists end with a doc count).
+    /// Whether `raw` ends with a current position-stream footer.
     pub fn is_stream(raw: &[u8]) -> bool {
         raw.len() >= FOOTER && u32::from_le_bytes(raw[raw.len() - 4..].try_into().unwrap()) == MAGIC
     }
 
     pub fn open(bytes: OwnedBytes) -> io::Result<Self> {
-        let raw = bytes.as_slice();
-        if !Self::is_stream(raw) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "position stream footer missing",
-            ));
-        }
-        let f = raw.len() - FOOTER;
-        let num_blocks = u32::from_le_bytes(raw[f..f + 4].try_into().unwrap()) as usize;
-        let total = u64::from_le_bytes(raw[f + 4..f + 12].try_into().unwrap());
-        let offsets_start = f.checked_sub(num_blocks * 4).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "position stream offsets table longer than the stream",
-            )
-        })?;
+        let (num_blocks, index_start, total) = Self::parse_layout(bytes.as_slice())?;
+        // Freshly encoded streams keep every interior block full, retaining
+        // the original O(1) cursor-to-block calculation. Only concatenated
+        // streams with partial interior source tails need the index search.
+        let canonical_blocks = num_blocks == 0
+            || Self::index_entry(bytes.as_slice(), index_start, num_blocks - 1).1
+                == (num_blocks as u64 - 1) * POSITION_STREAM_BLOCK as u64;
         Ok(Self {
             bytes,
             num_blocks,
-            offsets_start,
+            index_start,
             total,
+            canonical_blocks,
         })
+    }
+
+    fn parse_layout(raw: &[u8]) -> io::Result<(usize, usize, u64)> {
+        if !Self::is_stream(raw) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "current position stream footer missing",
+            ));
+        }
+        let footer_start = raw.len() - FOOTER;
+        let num_blocks =
+            u32::from_le_bytes(raw[footer_start..footer_start + 4].try_into().unwrap()) as usize;
+        let total =
+            u64::from_le_bytes(raw[footer_start + 4..footer_start + 12].try_into().unwrap());
+        let index_len = num_blocks.checked_mul(INDEX_ENTRY).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "position block index overflows")
+        })?;
+        let index_start = footer_start.checked_sub(index_len).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "position block index longer than the stream",
+            )
+        })?;
+        Ok((num_blocks, index_start, total))
     }
 
     pub fn total_positions(&self) -> u64 {
@@ -188,39 +208,85 @@ impl PositionStream {
         self.num_blocks
     }
 
-    fn block_range(&self, idx: usize) -> Option<(usize, usize)> {
+    #[inline]
+    fn index_entry(raw: &[u8], index_start: usize, idx: usize) -> (usize, u64) {
+        let p = index_start + idx * INDEX_ENTRY;
+        (
+            u32::from_le_bytes(raw[p..p + 4].try_into().unwrap()) as usize,
+            u64::from_le_bytes(raw[p + 4..p + 12].try_into().unwrap()),
+        )
+    }
+
+    fn block_range(&self, idx: usize) -> Option<(usize, usize, u64)> {
         if idx >= self.num_blocks {
             return None;
         }
         let raw = self.bytes.as_slice();
-        let read_offset = |i: usize| {
-            let p = self.offsets_start + i * 4;
-            u32::from_le_bytes(raw[p..p + 4].try_into().unwrap()) as usize
-        };
-        let start = read_offset(idx);
+        let (start, value_start) = Self::index_entry(raw, self.index_start, idx);
         let end = if idx + 1 < self.num_blocks {
-            read_offset(idx + 1)
+            Self::index_entry(raw, self.index_start, idx + 1).0
         } else {
-            self.offsets_start
+            self.index_start
         };
-        (start <= end && end <= self.offsets_start).then_some((start, end))
+        (start <= end && end <= self.index_start).then_some((start, end, value_start))
+    }
+
+    fn block_count(raw: &[u8]) -> Option<usize> {
+        if raw.len() < BLOCK_HEADER {
+            return None;
+        }
+        let count = u16::from_le_bytes(raw[0..2].try_into().unwrap()) as usize;
+        if count == 0 || count > POSITION_STREAM_BLOCK {
+            return None;
+        }
+        let bytes_per_value = match raw[2] {
+            0 => 0,
+            8 => 1,
+            16 => 2,
+            32 => 4,
+            _ => return None,
+        };
+        (raw.len() == BLOCK_HEADER + count * bytes_per_value).then_some(count)
+    }
+
+    fn locate_value(&self, cursor: u64) -> Option<(usize, usize)> {
+        if cursor >= self.total || self.num_blocks == 0 {
+            return None;
+        }
+        if self.canonical_blocks {
+            let idx = usize::try_from(cursor / POSITION_STREAM_BLOCK as u64).ok()?;
+            return Some((idx, (cursor % POSITION_STREAM_BLOCK as u64) as usize));
+        }
+        let raw = self.bytes.as_slice();
+        let mut low = 0usize;
+        let mut high = self.num_blocks;
+        while low < high {
+            let mid = low + (high - low) / 2;
+            let value_start = Self::index_entry(raw, self.index_start, mid).1;
+            if value_start <= cursor {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        let idx = low.checked_sub(1)?;
+        let (start, end, value_start) = self.block_range(idx)?;
+        let count = Self::block_count(&raw[start..end])?;
+        let in_block = usize::try_from(cursor.checked_sub(value_start)?).ok()?;
+        (in_block < count).then_some((idx, in_block))
     }
 
     /// Decode block `idx` (raw delta values) into `out`.
     pub fn decode_block(&self, idx: usize, out: &mut Vec<u32>) -> bool {
-        let Some((start, end)) = self.block_range(idx) else {
+        let Some((start, end, _)) = self.block_range(idx) else {
             return false;
         };
         let raw = &self.bytes.as_slice()[start..end];
-        if raw.len() < BLOCK_HEADER {
+        let Some(count) = Self::block_count(raw) else {
             return false;
-        }
-        let count = u16::from_le_bytes(raw[0..2].try_into().unwrap()) as usize;
+        };
         let width = simd::RoundedBitWidth::from_u8(raw[2]);
         let needed = BLOCK_HEADER + count * width.bytes_per_value();
-        if raw.len() < needed || count > POSITION_STREAM_BLOCK {
-            return false;
-        }
         out.clear();
         out.resize(count, 0);
         simd::unpack_rounded(&raw[BLOCK_HEADER..needed], width, out, count);
@@ -241,12 +307,17 @@ impl PositionStream {
         if tf == 0 {
             return true;
         }
-        if cursor + tf as u64 > self.total {
+        if cursor
+            .checked_add(tf as u64)
+            .is_none_or(|end| end > self.total)
+        {
             return false;
         }
-        let mut idx = (cursor / POSITION_STREAM_BLOCK as u64) as usize;
-        let mut in_block = (cursor % POSITION_STREAM_BLOCK as u64) as usize;
+        let Some((mut idx, mut in_block)) = self.locate_value(cursor) else {
+            return false;
+        };
         let mut remaining = tf as usize;
+        let mut next_cursor = cursor;
         let mut prev = 0u32;
         out.reserve(remaining);
         while remaining > 0 {
@@ -259,10 +330,138 @@ impl PositionStream {
                 out.push(prev);
             }
             remaining -= take;
+            next_cursor += take as u64;
             in_block = 0;
             idx += 1;
+            if remaining > 0
+                && self
+                    .block_range(idx)
+                    .is_none_or(|(_, _, value_start)| value_start != next_cursor)
+            {
+                return false;
+            }
         }
         true
+    }
+
+    /// Concatenate current-format streams by copying encoded blocks verbatim.
+    /// Only the compact block index and footer are rebuilt.
+    pub fn concatenate_streaming<W: Write>(
+        sources: &[&[u8]],
+        writer: &mut W,
+    ) -> crate::Result<(u64, u64)> {
+        let layouts: Vec<_> = sources
+            .iter()
+            .map(|raw| Self::parse_layout(raw))
+            .collect::<io::Result<_>>()?;
+
+        // The common single-source/zero-offset merge can preserve the entire
+        // stream, including its already valid index and footer.
+        if sources.len() == 1 {
+            let raw = sources[0];
+            let total = layouts[0].2;
+            Self::validate_blocks(raw, total)?;
+            writer.write_all(raw)?;
+            return Ok((total, raw.len() as u64));
+        }
+
+        let total_blocks: usize = layouts.iter().map(|(blocks, _, _)| *blocks).sum();
+        let total_blocks_u32 = u32::try_from(total_blocks).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "position stream has more than u32::MAX blocks",
+            )
+        })?;
+        let mut out_index = Vec::with_capacity(total_blocks * INDEX_ENTRY);
+        let mut data_written = 0u64;
+        let mut total_positions = 0u64;
+
+        for (raw, &(num_blocks, index_start, source_total)) in sources.iter().zip(&layouts) {
+            let mut expected_start = 0u64;
+            for idx in 0..num_blocks {
+                let (start, value_start) = Self::index_entry(raw, index_start, idx);
+                let end = if idx + 1 < num_blocks {
+                    Self::index_entry(raw, index_start, idx + 1).0
+                } else {
+                    index_start
+                };
+                if start > end || end > index_start || value_start != expected_start {
+                    return Err(crate::Error::Corruption(
+                        "invalid position block index during merge".into(),
+                    ));
+                }
+                let block = &raw[start..end];
+                let count = Self::block_count(block).ok_or_else(|| {
+                    crate::Error::Corruption("invalid position block during merge".into())
+                })?;
+                if data_written > u32::MAX as u64 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "position stream exceeds u32::MAX bytes during merge",
+                    )
+                    .into());
+                }
+                out_index.write_u32::<LittleEndian>(data_written as u32)?;
+                out_index.write_u64::<LittleEndian>(
+                    total_positions.checked_add(value_start).ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "position count overflows u64 during merge",
+                        )
+                    })?,
+                )?;
+                writer.write_all(block)?;
+                data_written += block.len() as u64;
+                expected_start += count as u64;
+            }
+            if expected_start != source_total {
+                return Err(crate::Error::Corruption(
+                    "position stream total does not match its blocks".into(),
+                ));
+            }
+            total_positions = total_positions.checked_add(source_total).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "position count overflows u64 during merge",
+                )
+            })?;
+        }
+
+        writer.write_all(&out_index)?;
+        writer.write_u32::<LittleEndian>(total_blocks_u32)?;
+        writer.write_u64::<LittleEndian>(total_positions)?;
+        writer.write_u32::<LittleEndian>(MAGIC)?;
+        let bytes_written = data_written + out_index.len() as u64 + FOOTER as u64;
+        Ok((total_positions, bytes_written))
+    }
+
+    fn validate_blocks(raw: &[u8], expected_total: u64) -> io::Result<()> {
+        let (num_blocks, index_start, _) = Self::parse_layout(raw)?;
+        let mut total = 0u64;
+        for idx in 0..num_blocks {
+            let (start, value_start) = Self::index_entry(raw, index_start, idx);
+            let end = if idx + 1 < num_blocks {
+                Self::index_entry(raw, index_start, idx + 1).0
+            } else {
+                index_start
+            };
+            if start > end || end > index_start || value_start != total {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid position block index",
+                ));
+            }
+            total += Self::block_count(&raw[start..end]).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "invalid position block")
+            })? as u64;
+        }
+        if total != expected_total {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "position stream total does not match its blocks",
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -350,6 +549,7 @@ mod tests {
         assert_eq!(total, docs.iter().map(|d| d.len() as u64).sum::<u64>());
         assert!(PositionStream::is_stream(&buf));
         let stream = PositionStream::open(OwnedBytes::new(buf)).unwrap();
+        assert!(stream.canonical_blocks);
         assert_eq!(stream.total_positions(), total);
         assert_eq!(stream.num_blocks(), total.div_ceil(128) as usize);
         let expected: Vec<Vec<u32>> = docs
@@ -387,6 +587,85 @@ mod tests {
         let all: Vec<Vec<u32>> = a.iter().chain(&b).cloned().collect();
         let (direct, _) = encode(&all);
         assert_eq!(merged, direct);
+    }
+
+    #[test]
+    fn streaming_concatenation_copies_non_aligned_blocks_verbatim() {
+        // Both sources end with partial blocks. A merged stream therefore has
+        // an interior short block and exercises the v3 logical-start index.
+        let a: Vec<Vec<u32>> = (0..43)
+            .map(|doc| {
+                (0..doc % 5 + 1)
+                    .map(|position| doc + position * 7)
+                    .collect()
+            })
+            .collect();
+        let b: Vec<Vec<u32>> = (0..51)
+            .map(|doc| {
+                (0..doc % 4 + 1)
+                    .map(|position| doc * 2 + position)
+                    .collect()
+            })
+            .collect();
+        let (encoded_a, total_a) = encode(&a);
+        let (encoded_b, total_b) = encode(&b);
+        assert_ne!(total_a % POSITION_STREAM_BLOCK as u64, 0);
+        assert_ne!(total_b % POSITION_STREAM_BLOCK as u64, 0);
+
+        let source_blocks = |raw: &[u8]| {
+            let stream = PositionStream::open(OwnedBytes::new(raw.to_vec())).unwrap();
+            (0..stream.num_blocks())
+                .map(|idx| {
+                    let (start, end, _) = stream.block_range(idx).unwrap();
+                    raw[start..end].to_vec()
+                })
+                .collect::<Vec<_>>()
+        };
+        let expected_blocks: Vec<Vec<u8>> = source_blocks(&encoded_a)
+            .into_iter()
+            .chain(source_blocks(&encoded_b))
+            .collect();
+
+        let mut merged = Vec::new();
+        let (total, written) = PositionStream::concatenate_streaming(
+            &[encoded_a.as_slice(), encoded_b.as_slice()],
+            &mut merged,
+        )
+        .unwrap();
+        assert_eq!(total, total_a + total_b);
+        assert_eq!(written as usize, merged.len());
+
+        let stream = PositionStream::open(OwnedBytes::new(merged.clone())).unwrap();
+        assert!(!stream.canonical_blocks);
+        let actual_blocks: Vec<Vec<u8>> = (0..stream.num_blocks())
+            .map(|idx| {
+                let (start, end, _) = stream.block_range(idx).unwrap();
+                merged[start..end].to_vec()
+            })
+            .collect();
+        assert_eq!(actual_blocks, expected_blocks, "encoded blocks changed");
+        assert_eq!(stream.num_blocks(), expected_blocks.len());
+
+        let all: Vec<Vec<u32>> = a.iter().chain(&b).cloned().collect();
+        let expected: Vec<Vec<u32>> = all
+            .iter()
+            .map(|positions| {
+                let mut positions = positions.clone();
+                positions.sort_unstable();
+                positions
+            })
+            .collect();
+        assert_eq!(read_all(&stream, &all), expected);
+    }
+
+    #[test]
+    fn single_source_streaming_concatenation_is_an_exact_copy() {
+        let (encoded, total) = encode(&[(0..137).collect()]);
+        let mut copied = Vec::new();
+        let result =
+            PositionStream::concatenate_streaming(&[encoded.as_slice()], &mut copied).unwrap();
+        assert_eq!(result, (total, encoded.len() as u64));
+        assert_eq!(copied, encoded);
     }
 
     /// Size of the two formats on a synthetic "content" term: run with

--- a/hermes-core/src/structures/postings/posting.rs
+++ b/hermes-core/src/structures/postings/posting.rs
@@ -1195,6 +1195,14 @@ impl BlockPostingList {
             merged_min_len = merged_min_len.min(if footer.len_bounds { footer.min_len } else { 1 });
             metas.push(footer);
         }
+
+        // The common single-source term in the first segment needs no doc-id
+        // rebasing and already has a valid index/footer. Copy it wholesale.
+        if sources.len() == 1 && sources[0].1 == 0 {
+            writer.write_all(sources[0].0)?;
+            return Ok((metas[0].doc_count, sources[0].0.len()));
+        }
+
         let all_cursors = metas.iter().all(|m| m.has_cursors);
         if !all_cursors && metas.iter().any(|m| m.has_cursors) {
             return Err(crate::Error::Corruption(


### PR DESCRIPTION
## Summary
- preserve encoded external BM25 posting blocks during every ordinary segment merge
- promote only tiny inline sources instead of decoding and rebuilding external postings
- introduce POS3 logical block starts so encoded position blocks concatenate verbatim
- keep mmap and Arc-backed term ranges without intermediate whole-term Vec copies
- bump the clean index rebuild boundary to metadata format 6

## Validation
- cargo test -p hermes-core --lib (1273 passed, 11 ignored)
- cargo clippy -p hermes-core --lib --tests -- -D warnings
- cargo check --workspace --all-targets
- regression coverage for byte-identical non-aligned position blocks, inline/external merges, chunked phrase search, and multi-round merges