### PR TITLE
fix(k8s): set Hermes server command explicitly

### DIFF
--- a/hermes-server/k8s/deployment.yaml
+++ b/hermes-server/k8s/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         - name: hermes-server
           image: ghcr.io/spacefrontiers/hermes/hermes-server:latest
           imagePullPolicy: Always
+          # Kubernetes args replace the image CMD, so keep the executable
+          # explicit when supplying server flags below.
+          command:
+            - "hermes-server"
           args:
             - "--addr"
             - "0.0.0.0:50051"


### PR DESCRIPTION
## Summary
- make the server executable explicit in the Kubernetes deployment
- prevent Kubernetes `args` from replacing the image CMD and trying to execute `--addr`

## Validation
- `kubectl kustomize hermes-server/k8s`
- repository commit hooks