### PR TITLE
Fix BM25 pruning contract and lazily fold phrase results

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -39,6 +39,18 @@ Sources: [core benches](../hermes-core/benches/),
 
 ## CPU microbenchmarks
 
+The standalone example `bm25_execution_benchmark` builds 20,000 documents with
+four positioned text chunks each, then measures warm top-40 match, phrase and
+phrase-bonus searches. It prints ordered doc/score/ordinal bit signatures and
+ten samples after warmup. The deliberately high term frequencies stress phrase
+intersection; it is not a production-query or recall benchmark.
+
+```bash
+cargo build --locked --release -p hermes-core --example bm25_execution_benchmark
+# macOS: process peak RSS includes fixture construction, not only query scratch.
+/usr/bin/time -l target/release/examples/bm25_execution_benchmark
+```
+
 ```bash
 # Compile all core benchmark targets without running their workloads.
 cargo bench --locked -p hermes-core --no-run

--- a/docs/chunked-bm25.md
+++ b/docs/chunked-bm25.md
@@ -69,6 +69,59 @@ and which of it Hermes applies.
 
 ## Measure
 
+### Execution follow-up (2026-09-05)
+
+The deployed latency review identifies execution work, not a reason to change
+BM25 defaults or replace phrase bonuses with approximate proximity scores.
+The following execution changes are implemented (not yet deployed):
+
+- Text and sparse use one `heap_factor` convention: `0 < factor < 1` raises
+  the pruning threshold to `threshold / factor`; 1 is exact. The Match RPC's
+  unset/zero value selects 1; non-finite, negative and above-one wire values
+  are rejected. There is no compatibility translation for former text values
+  above 1. Native builders/executors use the same internal factor floor as
+  sparse (0.01).
+- Carry a deadline-only context into nested scorers: never reuse an outer
+  score floor in a component's different score space. Check during phrase
+  construction/intersection and single-term execution, not only collection.
+  Phrase bitset materialization carries the same context and never returns a
+  partial negative filter. An already-expired query does not begin scoring;
+  cancelled chunked phrase construction skips its final all-hit fold.
+  Deadline truncation is cooperative, not preemption of outstanding I/O.
+- Keep one decoded position block (128 u32 values) per phrase term, bound to
+  that term's immutable stream. Match ascending position lists with monotone
+  cursors; preserve offset gaps, repeated terms, slop and phrase frequency.
+  Chunk-to-document folding remains reorder-safe; a chunk map is NOT generally
+  document-ID sorted, so streaming by assumed document order is invalid.
+- Floor list/block/group length minima by the same segment-local nominal
+  length used in scoring. Cache only the last block/group bound per term.
+
+These changes leave persisted bytes and scoring formulas unchanged. Phrase
+folding must still expose all matches when used as a mandatory constraint;
+bounded candidate rescoring is a separate, opt-in ranking policy. Same-build fixtures,
+score-bit comparisons, budget regressions and measured evidence belong in
+[the performance review](search-performance-review.md).
+
+### Lazy phrase folding (implemented 2026-09-05)
+
+At chunk-map open, verify document-ID monotonicity once with a sequential
+column scan, retaining only a boolean. This is derived metadata: no on-disk
+format or merge writer changes. For verified ordered maps, fold the phrase
+stream one document at a time using the existing Max combiner and preserving
+ordinal encounter order. Scratch holds one document's matching ordinals plus
+one matching-chunk lookahead, not all corpus hits. Seek translates a document
+target into a chunk lower bound with binary search. No top-k cutoff may hide
+mandatory matches. Cancellation must discard any partially folded document.
+
+Reordered maps keep the eager, stable grouping path; they never enter the
+ordered streaming implementation. Tests compare both paths against the existing
+fold's doc IDs, score bits and ordinals, including seeks and cancelled
+construction. Ordered maps add one sequential scan of four bytes per chunk at
+open and retain one boolean. Query folding retains at most one document's
+matching ordinals, not a corpus-sized result vector. Broad phrase queries avoid
+all-hit sorting and allocations, but still perform positional verification.
+See the same-fixture measurements in the performance review.
+
 Both deferred items and any `k1`/`b` change need a held-out full-query
 search-quality evaluation before changing defaults. The previously referenced
 `benchmarks/search-quality` directory is not included in this repository.

--- a/docs/lexical-vertical.md
+++ b/docs/lexical-vertical.md
@@ -244,10 +244,12 @@ Metadata format version 6 is a clean rebuild boundary for this layout.
 - **Phrase as a scoring clause.** Still open: a `PhraseQuery` in SHOULD is a
   verifier; its block bound would be the minimum of its terms' bounds.
 - **Approximate and anytime modes** (implemented 2026-09-03).
-  `MatchQuery.heap_factor` (> 1) reuses the sparse threshold scaling for the
+  `MatchQuery.heap_factor` (0 < factor < 1) uses the sparse threshold scaling for the
   text executors: the collector's floor is divided by the factor, so
   candidates that cannot beat `threshold / heap_factor` are skipped and the
-  result is a subset of the exact top-k with exact scores. An approximate
+  retained candidates have exact scores, but exact top-k recall is not guaranteed.
+  Zero/unset or 1 selects exact search; non-finite, negative and >1 RPC values
+  are rejected (contract unified on 2026-09-05, without legacy translation). An approximate
   pass neither seeds from nor publishes to the segment-shared threshold, so
   it can never lower an exact clause's floor. `SearchRequest.time_budget_ms`
   is the anytime knob: the deadline travels on `SharedThreshold`, every text

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -73,6 +73,227 @@ errors are not retried in a loop. See [the lifecycle contract](segment-lifecycle
 for recovery and forced-termination limits. This does not alter sparse reorder
 policy, ANN construction, scoring, or persisted formats.
 
+## Deployed BM25 latency review (1.8.122, 2026-09-05)
+
+This follow-up is diagnostic only: no production settings, index data or search
+implementation were changed. All four servers and the broker were healthy on
+1.8.122. The document index contained 10,339,428 documents and 177,707,964 text
+chunks; `machine` and `learning` occurred in 2,247,060 and 3,371,715 chunks.
+Indexing/maintenance and other searches remained active. Segment count changed
+from 20 to 15 during the observation window (approximately 11:50–12:00 UTC).
+
+Sequential gRPC probes requested top 40, loaded only `id`, used the same query
+text for BM25 and server-tokenized sparse search, and had a 30-second RPC limit.
+These are small live samples, not controlled benchmarks, recall comparisons or
+production percentile estimates. Times below are median `timings.search_us`
+over three repetitions: the broker reports the maximum backend phase time,
+excluding its statistics round trip and the client's SSH/network overhead.
+
+| Query                | Plain content BM25 | BM25 + separate phrase bonus | Bounded proximity rescoring | Sparse |
+| -------------------- | -----------------: | ---------------------------: | --------------------------: | -----: |
+| `history of germany` |              85 ms |                       186 ms |                       68 ms |  53 ms |
+| `machine learning`   |             140 ms |                       493 ms |                      116 ms |  21 ms |
+
+For `machine learning`, plain BM25 ranged from 134–233 ms, phrase-bonus search
+from 416–858 ms, and sparse from 16–118 ms. The phrase-bonus request exposed
+217,093 intermediate hits versus 548 for plain BM25; these are executor results
+seen by collection, **not** posting-visit counters. ID loading took 5–19 ms in
+the plain case and 7–12 ms with the phrase bonus. A nine-term query did not show
+a consistent BM25/sparse disadvantage: two plain-BM25 samples were 169/260 ms
+versus sparse 173/281 ms. No equivalent dense query embedding was supplied, so
+there is no matched dense latency or recall claim from this review.
+
+Observed request shapes included `SHOULD(Match(content), Boost(Phrase(content)))`.
+Plain text already selects the windowed block-max MaxScore executor; enabling
+WAND/MaxScore from scratch is not the missing optimization. Production logs
+also contain slow fusion requests, but currently do not identify each fused
+subquery's cost, so their full latency cannot be attributed to BM25 alone.
+
+### Confirmed issues and recommended order
+
+1. **Fix the text pruning-factor contract.** The converter accepts
+   `MatchQuery.heap_factor > 1`, and `BooleanQuery::with_text_heap_factor`
+   preserves that value. `MaxScoreExecutor::new` then clamps it to `[0.01, 1]`:
+   every supported approximate text value becomes exact `1`. On one document
+   shard, factors 1 and 100 returned identical ordered IDs, scores and `seen`
+   counts in both paired runs; scoring was 104–107 ms in all four requests.
+   Normalize the public text convention to the executor's sparse convention
+   explicitly and add an RPC-to-executor regression. Keep approximation opt-in
+   and measure recall before selecting a default.
+
+2. **Make budgets effective through scorer construction.** With a 1 ms text
+   budget on the same shard, `machine learning` plain BM25 reported truncation
+   after 10 ms of search, but the phrase-only path spent 385 ms and reported
+   `truncated=false`. A single-term `machine` query spent 67 ms and also reported
+   no truncation. The phrase-bonus request spent 282 ms before reporting
+   truncation: its eager phrase construction had already run. Thread the budget
+   through phrase verification and single-term chunked execution; do not present
+   the RPC deadline as cancellation of already-started blocking CPU work.
+   The existing fusion budget/statistics finding below also applies.
+
+3. **Optimize phrase verification without changing match semantics.**
+   `build_chunked_phrase_scorer` drains all matching chunks into a vector and
+   folds all matching documents, even when the phrase only supplies an optional
+   bonus. `PositionStream::read_into` re-decodes its position block on each
+   access; its scratch retains capacity, not a keyed decoded-block cache.
+   Phrase matching also restarts linear position scans for each starting
+   position. Prototype per-term bounded position cursors/caches and monotone
+   positional intersection, then a lazy, top-k-aware composition that preserves
+   mandatory phrase constraints. The existing bounded `proximity_weight` stage
+   is an optional ranking alternative, **not** an equivalent replacement: on
+   `history of germany` its top 40 overlapped the separate-phrase version in
+   only 25 results (35 for `machine learning`). Benchmark rank-safe kernel
+   changes separately from any candidate-limited ranking change.
+
+4. **Tighten existing chunk bounds before changing codecs or scoring.**
+   `LengthLookup::length` writes raw chunk lengths into block minima, while
+   scoring uses `ChunkMap::bm25_length`, floored at the nominal chunk length.
+   List/block/group bounds use the raw minimum, so they can be conservatively
+   loose. Applying the same floor when computing query-time upper bounds is a
+   format-preserving, rank-safe candidate, subject to exact-top-k oracle tests.
+   Cache bounds per active block/group rather than recomputing the same BM25
+   divisions for successive windows; Lucene's
+   [MaxScoreCache](https://lucene.apache.org/core/9_12_1/core/org/apache/lucene/search/MaxScoreCache.html)
+   uses this separation. Cross-segment pruning for chunked results additionally
+   needs a floor backed by **distinct documents**, not a raw top-chunk heap.
+   None of these proposed kernel speedups has been measured in this review.
+
+The sampled document shard had zero CPU quota throttling, no swap or OOM events,
+and zero recent memory-pressure averages, but some CPU contention. These checks
+do not rule out page-cache misses or quantify per-query peak scratch. No
+instruction-level CPU profile or controlled cold-cache/cross-architecture
+benchmark was obtained. Preserve scoring, formats and production defaults until
+the proposed changes pass the harness and a representative quality/performance
+comparison. Local raw probes and the reproducible sequential client are retained
+in `.context/bm25-remote-probes-20260905.json` and
+`.context/bm25_remote_probe.py`.
+
+Validation for this diagnostic/documentation follow-up:
+`python3 scripts/check_search.py check` passed all four steps on Rust 1.98.1,
+including 1,284 core tests, 56 server tests, broker/tool tests, Clippy, formatting
+and the native-without-sync boundary. Evidence is in
+`.context/search-harness/20260905T120227.417351Z-check/`. The additional `full`
+harness, WASM and performance benchmarks were not rerun: no search implementation
+was changed, and these existing tests do not establish coverage of the newly
+identified bugs.
+
+## BM25 execution fixes following the deployed review
+
+Implemented against `5cecf189` with Rust 1.98.1. The preceding section records
+the observation phase, before these fixes; publication/deployment are separate
+release operations.
+
+- Text and sparse now share the executor's reciprocal convention: factors below
+  1 enable extra pruning (`threshold / factor`). RPC zero/unset or 1 selects
+  exact search; negative, non-finite and >1 RPC values fail validation, without
+  legacy translation. Single-token conversion no longer bypasses explicitly
+  requested text pruning, and nested query flattening preserves tuning. The
+  shared executor's existing 0.01 factor floor caps the effective multiplier at 100. Exact defaults and sparse tuning are unchanged.
+- Nested scorers keep the deadline/truncation state while discarding the outer
+  score floor. Term/phrase construction, phrase intersection, phrase bitsets,
+  text executor entry and generic collection check it. Cancelled bitsets never
+  escape as complete negative filters. An expired request can return no hits;
+  cancelled chunked phrase construction does not start its all-hit sort/fold.
+  Legacy non-phrase materializers have boundary checks, not preemption inside
+  their work; outstanding I/O is still not interrupted.
+- Phrase and proximity readers retain one decoded position block per term.
+  Phrase slop/offset matching uses monotone position cursors rather than
+  restarting each list scan for each starting position. Frequency, repeated
+  terms, offset gaps, independent slop intervals and chunk boundaries stay intact.
+- Text list/block/group score bounds apply the scoring chunk-length floor.
+  Two one-entry bound caches per text cursor remove repeated BM25 divisions;
+  no encoder, merge writer, persistent format or score formula changed.
+
+The failing regressions reproduced equal exact/approximate rankings, ignored
+expired construction budgets, and raw-length bounds before their respective
+fixes. Coverage also includes converter-to-executor behavior for one/multiple
+terms on plain/chunked fields, opposite text/sparse factor conventions, exact
+top-k oracles, nested floor isolation, cancellation after an initial phrase
+match, generous-budget score/ordinal/negative-filter equivalence, position
+frequency oracles, and cached reads across copied short blocks and backward
+seeks. Reading preserves the original encoded position bytes.
+
+### Same-fixture local measurements
+
+`hermes-core/examples/bm25_execution_benchmark.rs`: 20,000 RAM documents,
+80,000 positioned chunks, top 40 with ordinals, one indexing/search thread,
+current-thread async entry, default release flags on the same Apple Silicon
+Mac, Rust 1.98.1 (`48a229cea`). Each run has a warmup plus ten timed searches.
+The corpus deliberately repeats terms 40–60 times in most chunks: it stresses
+the positional kernel and is not representative of every production query.
+
+| Query               | Before median | After medians, three runs |
+| ------------------- | ------------: | ------------------------: |
+| Plain BM25          |       1.43 ms |              1.30–1.40 ms |
+| Phrase              |      36.48 ms |            11.53–11.66 ms |
+| BM25 + phrase bonus |      38.53 ms |            13.57–13.96 ms |
+
+The before/after ordered document IDs, score bits, ordinal score bits and seen
+counts are identical in all runs. The final repeats ran after this task's
+compilers/tests stopped; the shared Mac was not CPU-isolated. These are local
+synthetic improvements (about 3.1x phrase and 2.8x phrase-bonus), not production
+latency/recall estimates or evidence to change ranking defaults. Plain BM25 is
+effectively unchanged on this tied-score fixture; no standalone speedup is
+claimed for tighter bounds here.
+
+Process peak RSS from `/usr/bin/time -l`, including fixture construction, was
+109.5 MB before and 108.9–113.4 MB after. This is not isolated query scratch or
+evidence of reduced memory. Each position cache holds at most 128 u32 values
+(512 bytes) per term plus small metadata; the score-bound caches add 16 bytes
+per text cursor. These measurements precede lazy folding (below). Per-document
+position buffers remain. Fusion deadline/statistics propagation (see remaining
+findings), and production/cold-cache/recall evaluation are still follow-ups,
+not completed by this patch.
+
+Raw local evidence: `.context/bm25-before*.log`, `.context/bm25-final-{1,2,3}*.log`.
+Full validation passed in `.context/search-harness/20260905T124157.496034Z-full/`,
+including both real-server broker tests; the final collector-boundary adjustments
+passed `check` in `20260905T124513.498918Z-check/` (1,295 core tests passed,
+12 ignored, plus server/broker/tool/integration tests). Final WASM build and all
+four JS tests passed after `npm ci`. GPU/full-workspace and production performance
+checks were not run.
+
+### Incremental lazy-folding validation
+
+Verified doc-ordered chunk maps now yield one folded document at a time, with
+one matching-chunk lookahead. Reordered maps retain stable eager aggregation.
+Both paths match the old fold's document IDs, score bits and ordinal encounter
+order, including missing chunks and zero scores. A counted-cursor test proves
+construction consumes only one document, and a seek skips directly to a late
+document; the index-level test verifies matches beyond the requested top-k.
+Expired iteration clears the current score/ordinals and marks truncation.
+
+Three paired runs of the same 20K-document fixture above compared a preserved
+pre-lazy binary with the final binary, both Rust 1.98.1 release, same Apple M4.
+All this task's compilers/tests had stopped, but the shared Mac still had other
+application/test activity, so these remain exploratory warm-cache measurements.
+
+| Query               | Before lazy folding, medians | After lazy folding, medians |
+| ------------------- | ---------------------------: | --------------------------: |
+| Plain BM25          |                 1.29–1.37 ms |                1.33–1.42 ms |
+| Phrase              |               11.73–12.15 ms |              11.11–11.12 ms |
+| BM25 + phrase bonus |               13.77–13.87 ms |              12.87–12.90 ms |
+
+Ordered IDs, exact score bits, ordinal score bits and seen counts match in all
+three pairs. Lazy folding adds roughly 5–9% phrase and 6–7% phrase-bonus savings
+on this fixture, not another multi-fold kernel speedup. Plain BM25 is not helped
+by phrase folding. Process peak RSS (including ingestion) was 107.2–113.6 MB
+before and 112.5–116.0 MB after: no process-memory reduction is established.
+The structural query-scratch reduction is from all matching chunks/documents
+to one document's ordinals; the opener adds a four-byte-per-chunk sequential
+order check and one retained boolean. Reordered segments do not get this folding
+benefit. No persisted bytes or merge writer changed.
+
+Final `full` harness passed all eight steps in
+`.context/search-harness/20260905T130936.230637Z-full/`: 1,299 core tests passed,
+12 ignored, 58 server tests, broker/tool/integration tests, both real-server
+broker tests, Clippy, portable/native boundaries and API docs. WASM release plus
+four JS tests and regenerated TypeScript plus four client tests passed. The
+documentation check passed via `uv run scripts/check_docs.py` (plain Python
+lacked its declared Markdown dependency). npm reported two existing WASM dev
+dependency audit findings; dependency upgrades are outside this patch.
+Raw paired evidence: `.context/bm25-lazy-{before,after}-{1,2,3}*.log`.
+
 ## Rust and low-level continuation
 
 The [Rust hot-path review](rust-hot-path-review.md) extends this pass with

--- a/hermes-client-typescript/src/generated/hermes.ts
+++ b/hermes-client-typescript/src/generated/hermes.ts
@@ -210,7 +210,7 @@ export interface SparseVectorQuery {
   text: string;
   /** How to combine scores for multi-value fields */
   combiner: MultiValueCombiner;
-  /** Approximate search factor (1.0 = exact, 0.8 = ~20% faster) */
+  /** Approximate search factor (1 = exact, 0.8 prunes more; 0 = use default) */
   heapFactor: number;
   /** Temperature for LogSumExp (default: 1.5) */
   combinerTemperature: number;
@@ -318,8 +318,8 @@ export interface MatchQuery {
   proximityWindow: number;
   /**
    * Approximate MaxScore: scale the pruning threshold by 1/heap_factor
-   * (0 or 1 = exact, rank-safe; 1.5 prunes more aggressively at some
-   * recall cost). Same semantics as SparseVectorQuery.heap_factor.
+   * (0/unset or 1 = exact, rank-safe; 0.8 prunes more aggressively at some
+   * recall cost). Must be finite and in [0, 1], like SparseVectorQuery.heap_factor.
    */
   heapFactor: number;
   /**

--- a/hermes-core/examples/bm25_execution_benchmark.rs
+++ b/hermes-core/examples/bm25_execution_benchmark.rs
@@ -1,0 +1,111 @@
+//! Same-fixture warm BM25/phrase benchmark; no production latency claim.
+//! cargo run --locked --release -p hermes-core --example bm25_execution_benchmark
+use hermes_core::directories::RamDirectory;
+use hermes_core::dsl::PositionMode;
+use hermes_core::index::{Index, IndexConfig, IndexWriter};
+use hermes_core::query::{BooleanQuery, BoostQuery, PhraseQuery, Query, TermQuery};
+use hermes_core::{Document, SchemaBuilder};
+use std::time::Instant;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut schema = SchemaBuilder::default();
+    let body = schema.add_text_field_with_tokenizer("body", true, false, "simple");
+    schema.set_positions(body, PositionMode::TokenPosition);
+    schema.set_chunked(body, true);
+    let directory = RamDirectory::new();
+    let config = IndexConfig {
+        num_threads: 1,
+        num_indexing_threads: 1,
+        max_indexing_memory_bytes: 512 * 1024 * 1024,
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+        .await
+        .unwrap();
+    for id in 0..20_000 {
+        let mut doc = Document::new();
+        for chunk in 0..4 {
+            let text = match (id + chunk) % 4 {
+                0 => "machine learning padding ".repeat(40),
+                1 => "machine padding learning ".repeat(40),
+                2 => "learning machine ".repeat(60),
+                _ => "machine learning".to_string(),
+            };
+            doc.add_text(body, text);
+        }
+        let mut attempts = 0;
+        loop {
+            match writer.add_document(doc.clone()) {
+                Ok(()) => break,
+                Err(hermes_core::Error::QueueFull) if attempts < 10_000 => {
+                    attempts += 1;
+                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                }
+                Err(error) => panic!("fixture ingestion: {error}"),
+            }
+        }
+    }
+    writer.commit().await.unwrap();
+    drop(writer);
+    let index = Index::open(directory, config).await.unwrap();
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let plain = || {
+        BooleanQuery::new()
+            .should(TermQuery::text(body, "machine"))
+            .should(TermQuery::text(body, "learning"))
+    };
+    let phrase = || PhraseQuery::text(body, "machine learning");
+    let queries: Vec<(&str, Box<dyn Query>)> = vec![
+        ("match", Box::new(plain())),
+        ("phrase", Box::new(phrase())),
+        (
+            "phrase_bonus",
+            Box::new(
+                BooleanQuery::new()
+                    .should(plain())
+                    .should(BoostQuery::new(phrase(), 2.0)),
+            ),
+        ),
+    ];
+    for (name, query) in queries {
+        let mut timings = Vec::new();
+        let mut expected = None;
+        for iteration in 0..11 {
+            let start = Instant::now();
+            let (hits, seen) = searcher
+                .search_with_positions(query.as_ref(), 40)
+                .await
+                .unwrap();
+            let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+            let signature: Vec<_> = hits
+                .iter()
+                .map(|hit| {
+                    (
+                        hit.doc_id,
+                        hit.score.to_bits(),
+                        hit.positions
+                            .iter()
+                            .flat_map(|(_, p)| p.iter().map(|p| (p.position, p.score.to_bits())))
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            if let Some(expected) = &expected {
+                assert_eq!(&signature, expected);
+            } else {
+                println!("{name} seen={seen} signature={signature:?}");
+                expected = Some(signature);
+            }
+            if iteration > 0 {
+                timings.push(elapsed);
+            }
+        }
+        timings.sort_by(f64::total_cmp);
+        println!(
+            "{name} median_ms={:.3} samples_ms={timings:?}",
+            timings[timings.len() / 2]
+        );
+    }
+}

--- a/hermes-core/src/index/tests/chunked.rs
+++ b/hermes-core/src/index/tests/chunked.rs
@@ -71,6 +71,186 @@ async fn open(dir: RamDirectory) -> Index<RamDirectory> {
 }
 
 #[tokio::test]
+async fn expired_budget_stops_chunked_term_and_phrase_construction() {
+    use crate::query::{Query, ScorerOptions, SharedThreshold};
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    writer
+        .add_document(doc(&f, "article", &["machine learning"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let segment = &searcher.segment_readers()[0];
+    let queries: Vec<Box<dyn Query>> = vec![
+        Box::new(TermQuery::text(f.content, "machine")),
+        Box::new(PhraseQuery::text(f.content, "machine learning")),
+        Box::new(
+            BooleanQuery::new()
+                .should(PhraseQuery::text(f.content, "machine learning"))
+                .should(TermQuery::text(f.content, "learning")),
+        ),
+    ];
+    for query in queries {
+        let shared = SharedThreshold::for_limit(1).with_deadline(Some(std::time::Instant::now()));
+        let options = ScorerOptions {
+            shared_threshold: Some(shared.clone()),
+            ..Default::default()
+        };
+        let scorer = query
+            .scorer_with_options(segment, 1, options.clone())
+            .await
+            .unwrap();
+        assert_eq!(scorer.doc(), crate::structures::TERMINATED, "{query}");
+        assert!(shared.truncated(), "{query}");
+        #[cfg(feature = "sync")]
+        {
+            let scorer = query.scorer_sync_with_options(segment, 1, options).unwrap();
+            assert_eq!(scorer.doc(), crate::structures::TERMINATED, "{query}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn generous_phrase_budgets_preserve_scores_ordinals_and_negative_filters() {
+    use crate::query::{BoostQuery, Query};
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    for i in 0..100 {
+        let chunks = match i % 3 {
+            0 => ["machine learning machine learning", "machine"],
+            1 => ["machine padding learning", "learning machine"],
+            _ => ["machine learning", "padding machine learning"],
+        };
+        writer.add_document(doc(&f, "article", &chunks)).unwrap();
+    }
+    writer.commit().await.unwrap();
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let phrase = || PhraseQuery::text(f.content, "machine learning");
+    let term = || TermQuery::text(f.content, "machine");
+    let queries: Vec<Box<dyn Query>> = vec![
+        Box::new(phrase()),
+        Box::new(
+            BooleanQuery::new()
+                .must(phrase())
+                .should(term())
+                .should(TermQuery::text(f.content, "learning")),
+        ),
+        Box::new(BooleanQuery::new().should(term()).must_not(phrase())),
+        Box::new(
+            BooleanQuery::new()
+                .should(term())
+                .should(BoostQuery::new(phrase(), 2.0)),
+        ),
+    ];
+    for query in queries {
+        let (exact, _) = searcher
+            .search_with_positions(query.as_ref(), 40)
+            .await
+            .unwrap();
+        let (budgeted, _, truncated) = searcher
+            .search_with_positions_budgeted(
+                query.as_ref(),
+                40,
+                Some(std::time::Instant::now() + std::time::Duration::from_secs(600)),
+            )
+            .await
+            .unwrap();
+        assert!(!truncated);
+        let signature = |hits: Vec<SearchResult>| {
+            hits.into_iter()
+                .map(|hit| {
+                    (
+                        hit.doc_id,
+                        hit.score.to_bits(),
+                        hit.positions
+                            .into_iter()
+                            .map(|(field, positions)| {
+                                (
+                                    field,
+                                    positions
+                                        .into_iter()
+                                        .map(|p| (p.position, p.score.to_bits()))
+                                        .collect::<Vec<_>>(),
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(signature(exact), signature(budgeted), "{query}");
+    }
+}
+
+#[tokio::test]
+async fn ordered_chunked_phrase_is_a_lazy_seekable_document_stream() {
+    use crate::query::{Query, ScorerOptions};
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    for _ in 0..100 {
+        writer
+            .add_document(doc(
+                &f,
+                "article",
+                &["alpha beta", "padding", "alpha beta alpha beta"],
+            ))
+            .unwrap();
+    }
+    writer.commit().await.unwrap();
+    let index = open(dir).await;
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let phrase = PhraseQuery::text(f.content, "alpha beta");
+    let mut scorer = phrase
+        .scorer_with_options(
+            &searcher.segment_readers()[0],
+            1,
+            ScorerOptions::with_positions(),
+        )
+        .await
+        .unwrap();
+    assert!(
+        scorer.precomputed_top_k(1, true).is_none(),
+        "construction must not materialize an all-hit ranked vector"
+    );
+    assert_eq!(scorer.doc(), 0);
+    assert_eq!(
+        scorer.seek(90),
+        90,
+        "a mandatory phrase must expose matches beyond top-k"
+    );
+    assert_eq!(
+        scorer.matched_positions().unwrap()[0]
+            .1
+            .iter()
+            .map(|p| p.position)
+            .collect::<Vec<_>>(),
+        vec![0, 2]
+    );
+    assert_eq!(scorer.seek(80), 90, "seeks cannot move backwards");
+    assert_eq!(scorer.advance(), 91);
+    assert_eq!(
+        scorer.seek(crate::structures::TERMINATED),
+        crate::structures::TERMINATED
+    );
+    assert_eq!(scorer.advance(), crate::structures::TERMINATED);
+    assert_eq!(scorer.score(), 0.0);
+}
+
+#[tokio::test]
 async fn chunked_match_scores_chunks_and_reports_ordinals() {
     let f = chunked_schema();
     let dir = RamDirectory::new();

--- a/hermes-core/src/index/tests/search.rs
+++ b/hermes-core/src/index/tests/search.rs
@@ -1277,7 +1277,7 @@ async fn text_maxscore_honours_max_terms_and_heap_factor() {
         .should(TermQuery::text(body, "rare"));
     let exact = ids(index.search(&full, 30).await.unwrap());
     let approx = ids(index
-        .search(&full.clone().with_text_heap_factor(1.5), 30)
+        .search(&full.clone().with_text_heap_factor(0.6), 30)
         .await
         .unwrap());
     assert!(!approx.is_empty());
@@ -1347,7 +1347,10 @@ async fn text_maxscore_stops_at_the_deadline() {
         .unwrap();
     assert!(truncated, "an expired deadline must flag the response");
     assert!(partial.len() <= 10);
-    assert!(!partial.is_empty(), "best-so-far results are returned");
+    assert!(
+        partial.is_empty(),
+        "an already-expired query must not start scoring"
+    );
     // Best-so-far stays a valid ranking: scores are exact and descending.
     assert!(partial.windows(2).all(|w| w[0].score >= w[1].score));
 }

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -28,8 +28,8 @@ pub struct BooleanQuery {
     /// Proximity rescoring of the text MaxScore result (SHOULD terms in
     /// query order); `None` = off.
     proximity: Option<super::ProximityConfig>,
-    /// Approximate text MaxScore: threshold scaled by `1 / heap_factor`
-    /// (> 1 prunes beyond rank safety). 1.0 = exact.
+    /// Approximate text MaxScore: threshold divided by `heap_factor`
+    /// (< 1 prunes beyond rank safety, like sparse). 1.0 = exact.
     text_heap_factor: f32,
     /// Keep only the rarest `max_terms` SHOULD text terms of a field group
     /// (0 = all): long-query cap.
@@ -84,7 +84,7 @@ impl std::fmt::Display for BooleanQuery {
         if let Some(proximity) = &self.proximity {
             write!(f, " ~proximity({}, {})", proximity.weight, proximity.window)?;
         }
-        if self.text_heap_factor > 1.0 {
+        if self.text_heap_factor < 1.0 {
             write!(f, " ~heap({})", self.text_heap_factor)?;
         }
         if self.max_terms > 0 {
@@ -142,10 +142,12 @@ impl BooleanQuery {
         self
     }
 
-    /// Approximate text MaxScore (threshold × `1 / heap_factor`); values
-    /// at or below 1 keep the exact, rank-safe traversal.
+    /// Approximate text MaxScore (threshold / `heap_factor`), like sparse.
+    /// 1 is exact; [0, 1) prunes more aggressively, with an effective 0.01
+    /// floor. Non-finite values and values outside [0, 1] fail construction
+    /// of the scorer. RPC zero/unset is normalized to 1 by the adapter.
     pub fn with_text_heap_factor(mut self, heap_factor: f32) -> Self {
-        self.text_heap_factor = if heap_factor > 1.0 { heap_factor } else { 1.0 };
+        self.text_heap_factor = heap_factor;
         self
     }
 
@@ -224,6 +226,14 @@ macro_rules! boolean_plan {
         let reader: &SegmentReader = $reader;
         let limit: usize = $limit;
         let scorer_options: super::ScorerOptions = $scorer_options;
+        if !$text_tuning.0.is_finite() || !(0.0..=1.0).contains(&$text_tuning.0) {
+            return Err(crate::Error::Query(
+                "Text heap_factor must be finite and between 0 and 1".into(),
+            ));
+        }
+        if scorer_options.stop_if_expired() {
+            return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
+        }
 
         // Cap SHOULD clauses to MAX_QUERY_TERMS, but only count queries that need
         // posting-list cursors. Fast-field predicates (O(1) per doc) are exempt.
@@ -272,13 +282,14 @@ macro_rules! boolean_plan {
             if must.len() == 1 && should.is_empty() {
                 return must[0].$scorer_fn(reader, limit, scorer_options) $(.  $aw)* ;
             }
-            if should.len() == 1 && must.is_empty() {
+            if should.len() == 1 && must.is_empty() && $text_tuning.0 == 1.0 {
                 return should[0].$scorer_fn(reader, limit, scorer_options) $(. $aw)* ;
             }
         }
 
         // ── 2. Pure OR → MaxScore optimisations ──────────────────────────
-        if must.is_empty() && must_not.is_empty() && should.len() >= 2 {
+        if must.is_empty() && must_not.is_empty()
+            && (should.len() >= 2 || (should.len() == 1 && $text_tuning.0 < 1.0)) {
             // 2a. Text MaxScore (single-field, all term queries)
             if let Some((mut infos, text_field, avg_field_len, num_docs)) =
                 prepare_text_maxscore(should, reader, global_stats)
@@ -459,7 +470,7 @@ macro_rules! boolean_plan {
                     || (!matches!(
                         query.decompose(),
                         super::QueryDecomposition::TextTerm(_)
-                    ) && query.as_doc_bitset(reader).is_some())
+                    ) && scorer_options.doc_bitset(query.as_ref(), reader).is_some())
             })
                 && let Some(groups) = text_groups
                 && (groups.len() == 1
@@ -467,8 +478,11 @@ macro_rules! boolean_plan {
                         && groups
                             .iter()
                             .all(|(field, _)| !reader.is_chunked_field(*field))))
-                && let Some(bitset) = build_combined_bitset(must, must_not, reader)
+                && let Some(bitset) = build_combined_bitset(must, must_not, reader, &scorer_options)
             {
+                if scorer_options.stop_if_expired() {
+                    return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
+                }
                 let bitset = std::sync::Arc::new(bitset);
                 let single_field = groups.len() == 1;
 
@@ -526,7 +540,7 @@ macro_rules! boolean_plan {
                     .with_metric_labels(reader.schema().index_label(), "<multiple>")
                     .with_predicate(predicate)
                     .with_budget(scorer_options.shared_threshold.clone());
-                    if $text_tuning.0 <= 1.0 && scorer_options.initial_threshold > 0.0 {
+                    if $text_tuning.0 == 1.0 && scorer_options.initial_threshold > 0.0 {
                         executor.seed_threshold(scorer_options.initial_threshold);
                     }
                     let results = executor.execute_sync()?;
@@ -651,7 +665,7 @@ macro_rules! boolean_plan {
                     log::debug!("BooleanQuery planner 3a: MUST clause → predicate ({})", q);
                     predicates.push(pred);
                 } else if bitset_predicates_allowed {
-                    if let Some(bitset) = q.as_doc_bitset(reader) {
+                    if let Some(bitset) = scorer_options.doc_bitset(q.as_ref(), reader) {
                         log::debug!("BooleanQuery planner 3a: MUST clause → bitset predicate ({})", q);
                         predicates.push(Box::new(move |doc_id| bitset.contains(doc_id)));
                     } else {
@@ -675,7 +689,7 @@ macro_rules! boolean_plan {
                         Box::new(move |doc_id| !pred(doc_id));
                     predicates.push(negated);
                 } else if bitset_predicates_allowed {
-                    if let Some(bitset) = q.as_doc_bitset(reader) {
+                    if let Some(bitset) = scorer_options.doc_bitset(q.as_ref(), reader) {
                         log::debug!("BooleanQuery planner 3a: MUST_NOT clause → bitset predicate ({})", q);
                         predicates.push(Box::new(move |doc_id| !bitset.contains(doc_id)));
                     } else {
@@ -691,6 +705,9 @@ macro_rules! boolean_plan {
             }
 
             // 3b. Fast path: pure predicates + sparse SHOULD → BMP or MaxScore w/ predicate
+            if scorer_options.stop_if_expired() {
+                return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
+            }
             if must_verifiers.is_empty()
                 && must_not_verifiers.is_empty()
                 && !predicates.is_empty()
@@ -700,7 +717,10 @@ macro_rules! boolean_plan {
                 if let Some(infos) = sparse_infos {
                     // Try BMP with bitset first: build compact bitset from MUST/MUST_NOT
                     // posting lists (O(M) for term queries) for fast per-slot lookup.
-                    let bitset_result = build_combined_bitset(must, must_not, reader);
+                    let bitset_result = build_combined_bitset(must, must_not, reader, &scorer_options);
+                    if scorer_options.stop_if_expired() {
+                        return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
+                    }
                     if let Some(ref bitset) = bitset_result {
                         let bitset_pred = |doc_id: crate::DocId| bitset.contains(doc_id);
                         if let Some((raw, info)) =
@@ -748,7 +768,7 @@ macro_rules! boolean_plan {
                     for q in must {
                         if let Some(pred) = q.as_doc_predicate(reader) {
                             predicates.push(pred);
-                        } else if let Some(bitset) = q.as_doc_bitset(reader) {
+                        } else if let Some(bitset) = scorer_options.doc_bitset(q.as_ref(), reader) {
                             predicates.push(Box::new(move |doc_id| bitset.contains(doc_id)));
                         }
                     }
@@ -757,7 +777,7 @@ macro_rules! boolean_plan {
                             let negated: super::DocPredicate<'_> =
                                 Box::new(move |doc_id| !pred(doc_id));
                             predicates.push(negated);
-                        } else if let Some(bitset) = q.as_doc_bitset(reader) {
+                        } else if let Some(bitset) = scorer_options.doc_bitset(q.as_ref(), reader) {
                             predicates.push(Box::new(move |doc_id| !bitset.contains(doc_id)));
                         }
                     }
@@ -994,7 +1014,13 @@ impl Query for BooleanQuery {
     }
 
     fn should_children(&self) -> Option<&[Arc<dyn Query>]> {
-        if self.must.is_empty() && self.must_not.is_empty() && !self.should.is_empty() {
+        if self.must.is_empty()
+            && self.must_not.is_empty()
+            && !self.should.is_empty()
+            && self.proximity.is_none()
+            && self.text_heap_factor == 1.0
+            && self.max_terms == 0
+        {
             Some(&self.should)
         } else {
             None
@@ -1002,6 +1028,17 @@ impl Query for BooleanQuery {
     }
 
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<super::DocBitset> {
+        self.as_doc_bitset_with_options(reader, &super::ScorerOptions::default())
+    }
+
+    fn as_doc_bitset_with_options(
+        &self,
+        reader: &SegmentReader,
+        options: &super::ScorerOptions,
+    ) -> Option<super::DocBitset> {
+        if options.stop_if_expired() {
+            return None;
+        }
         if self.must.is_empty() && self.should.is_empty() {
             return None;
         }
@@ -1011,7 +1048,7 @@ impl Query for BooleanQuery {
         // MUST clauses: intersect bitsets (AND)
         let mut result: Option<super::DocBitset> = None;
         for q in &self.must {
-            let bs = q.as_doc_bitset(reader)?;
+            let bs = options.doc_bitset(q.as_ref(), reader)?;
             match result {
                 None => result = Some(bs),
                 Some(ref mut acc) => acc.intersect_with(&bs),
@@ -1022,7 +1059,7 @@ impl Query for BooleanQuery {
         if !self.should.is_empty() {
             let mut should_union = super::DocBitset::new(num_docs);
             for q in &self.should {
-                let bs = q.as_doc_bitset(reader)?;
+                let bs = options.doc_bitset(q.as_ref(), reader)?;
                 should_union.union_with(&bs);
             }
             match result {
@@ -1041,13 +1078,17 @@ impl Query for BooleanQuery {
         if let Some(ref mut acc) = result {
             for q in &self.must_not {
                 {
-                    let bs = q.as_doc_bitset(reader)?;
+                    let bs = options.doc_bitset(q.as_ref(), reader)?;
                     acc.subtract(&bs);
                 }
             }
         }
 
-        result
+        if options.stop_if_expired() {
+            None
+        } else {
+            result
+        }
     }
 
     fn as_doc_predicate<'a>(&self, reader: &'a SegmentReader) -> Option<super::DocPredicate<'a>> {

--- a/hermes-core/src/query/collector.rs
+++ b/hermes-core/src/query/collector.rs
@@ -752,12 +752,31 @@ pub async fn collect_segment_with_limit_seeded<C: Collector>(
 
 /// Drive a scorer through a collector (shared by async and sync paths).
 fn drive_scorer<C: Collector>(scorer: &mut dyn super::Scorer, collector: &mut C) {
+    drive_scorer_budgeted(scorer, collector, None);
+}
+
+fn drive_scorer_budgeted<C: Collector>(
+    scorer: &mut dyn super::Scorer,
+    collector: &mut C,
+    budget: Option<&super::SharedThreshold>,
+) {
     let needs_positions = collector.needs_positions();
     let mut doc = scorer.doc();
     while doc != TERMINATED {
+        // Check after advance/seek too: an expired negative verifier must
+        // never turn an incomplete exclusion check into a collected hit.
+        if budget.is_some_and(super::SharedThreshold::stop_if_expired) {
+            break;
+        }
         let score = scorer.score();
+        if budget.is_some_and(super::SharedThreshold::stop_if_expired) {
+            break;
+        }
         if needs_positions && collector.would_collect(doc, score) {
             let positions = scorer.matched_positions().unwrap_or_default();
+            if budget.is_some_and(super::SharedThreshold::stop_if_expired) {
+                break;
+            }
             collector.collect_owned(doc, score, positions);
         } else {
             collector.collect(doc, score, &[]);
@@ -892,7 +911,7 @@ pub(crate) fn search_segment_shared_sync_planned(
     let options = super::ScorerOptions {
         collect_positions,
         initial_threshold: shared_threshold.get(),
-        shared_threshold: Some(shared_threshold),
+        shared_threshold: Some(shared_threshold.clone()),
         lsp_plan,
         global_stats,
     };
@@ -901,6 +920,7 @@ pub(crate) fn search_segment_shared_sync_planned(
         scorer.as_mut(),
         segment_limit,
         collect_positions,
+        Some(&shared_threshold),
     ))
 }
 
@@ -913,6 +933,7 @@ fn top_k_from_scorer(
     scorer: &mut dyn super::Scorer,
     segment_limit: usize,
     collect_positions: bool,
+    budget: Option<&super::SharedThreshold>,
 ) -> (Vec<SearchResult>, u32) {
     if let Some(ranked) = scorer.precomputed_top_k(segment_limit, collect_positions) {
         return ranked;
@@ -922,7 +943,7 @@ fn top_k_from_scorer(
     } else {
         TopKCollector::new(segment_limit)
     };
-    drive_scorer(scorer, &mut collector);
+    drive_scorer_budgeted(scorer, &mut collector, budget);
     collector.into_results_with_count()
 }
 
@@ -985,7 +1006,7 @@ pub(crate) async fn search_segment_shared_planned(
     let options = super::ScorerOptions {
         collect_positions,
         initial_threshold: shared_threshold.get(),
-        shared_threshold: Some(shared_threshold),
+        shared_threshold: Some(shared_threshold.clone()),
         lsp_plan,
         global_stats,
     };
@@ -996,6 +1017,7 @@ pub(crate) async fn search_segment_shared_planned(
         scorer.as_mut(),
         segment_limit,
         collect_positions,
+        Some(&shared_threshold),
     ))
 }
 

--- a/hermes-core/src/query/phrase.rs
+++ b/hermes-core/src/query/phrase.rs
@@ -7,6 +7,7 @@ use crate::segment::SegmentReader;
 use crate::structures::{BlockPostingIterator, BlockPostingList, TERMINATED, TermPositions};
 use crate::{DocId, Score};
 
+use super::docset::DocSet;
 use super::{CountFuture, EmptyScorer, GlobalStats, Query, Scorer, ScorerFuture};
 
 /// Phrase query - matches documents containing terms in consecutive positions
@@ -136,15 +137,15 @@ impl PhraseQuery {
 /// virtual chunk ids, positions restart per chunk so a phrase never spans two
 /// chunks), then fold the chunk hits into documents with per-ordinal scores.
 ///
-/// The phrase is a conjunction, so draining the positional scorer costs one
-/// pass over the matching chunks only.
+/// The scorer intersects the term postings and verifies positions in each
+/// conjunction candidate; only actual phrase hits enter the document fold.
 fn build_chunked_phrase_scorer<'a>(
     term_data: Vec<(BlockPostingList, TermPositions)>,
     offsets: &[u32],
     slop: u32,
     reader: &SegmentReader,
     field: Field,
-    limit: usize,
+    budget: Option<super::SharedThreshold>,
 ) -> crate::Result<Box<dyn Scorer + 'a>> {
     let Some(chunk_map) = reader.chunk_map(field) else {
         return Err(crate::Error::Corruption(format!(
@@ -159,25 +160,176 @@ fn build_chunked_phrase_scorer<'a>(
         .map(|(p, _)| super::bm25_idf(p.doc_count() as f32, num_chunks))
         .sum();
     let (postings, positions): (Vec<_>, Vec<_>) = term_data.into_iter().unzip();
-    let mut scorer =
-        PhraseScorer::new(postings, positions, offsets, slop, idf, chunk_map.avg_len())
-            .with_lengths(Lengths::Chunks(chunk_map.clone()))
-            .with_params(super::Bm25Params::for_field(reader.schema(), field));
+    let scorer = PhraseScorer::new(
+        postings,
+        positions,
+        offsets,
+        slop,
+        idf,
+        chunk_map.avg_len(),
+        budget.clone(),
+    )
+    .with_lengths(Lengths::Chunks(chunk_map.clone()))
+    .with_params(super::Bm25Params::for_field(reader.schema(), field));
 
-    use super::docset::DocSet as _;
+    Ok(fold_chunked_phrase_scorer(
+        scorer,
+        chunk_map.clone(),
+        field.0,
+        budget,
+    ))
+}
+
+/// Ordered maps need only one document's ordinals and one matching-chunk
+/// lookahead. Reordered maps retain the stable, all-document aggregation.
+fn fold_chunked_phrase_scorer<'a, S: Scorer + 'a>(
+    mut scorer: S,
+    chunk_map: crate::segment::chunk_map::ChunkMap,
+    field_id: u32,
+    budget: Option<super::SharedThreshold>,
+) -> Box<dyn Scorer + 'a> {
+    if chunk_map.is_doc_ordered() {
+        let mut folded = ChunkedPhraseScorer {
+            inner: scorer,
+            chunk_map,
+            field_id,
+            budget,
+            current_doc: TERMINATED,
+            score: 0.0,
+            ordinals: crate::segment::VectorOrdinals::new(),
+        };
+        folded.fold_next_document();
+        return Box::new(folded);
+    }
     let mut raw: Vec<(u32, u16, f32)> = Vec::new();
     while scorer.doc() != TERMINATED {
+        if budget
+            .as_ref()
+            .is_some_and(super::SharedThreshold::stop_if_expired)
+        {
+            return Box::new(EmptyScorer);
+        }
         let (doc_id, ordinal) = chunk_map.resolve(scorer.doc());
         raw.push((doc_id, ordinal, scorer.score()));
         scorer.advance();
     }
+    if budget
+        .as_ref()
+        .is_some_and(super::SharedThreshold::stop_if_expired)
+    {
+        // Do not start an all-hit sort/fold after cancellation.
+        return Box::new(EmptyScorer);
+    }
     // Every matching document is kept: a phrase is also used as a MUST
     // constraint (verifier or bitset), where truncating to `limit` would
     // silently reject documents that do contain the phrase.
-    let _ = limit;
     let combined =
         crate::segment::combine_ordinal_results(raw, super::MultiValueCombiner::Max, usize::MAX);
-    Ok(Box::new(super::vector::VectorResultScorer::new(combined, field.0)) as Box<dyn Scorer + 'a>)
+    Box::new(super::vector::VectorResultScorer::new(combined, field_id))
+}
+
+struct ChunkedPhraseScorer<S> {
+    inner: S,
+    chunk_map: crate::segment::chunk_map::ChunkMap,
+    field_id: u32,
+    budget: Option<super::SharedThreshold>,
+    current_doc: DocId,
+    score: Score,
+    ordinals: crate::segment::VectorOrdinals,
+}
+
+impl<S: Scorer> ChunkedPhraseScorer<S> {
+    fn finish(&mut self) -> DocId {
+        self.current_doc = TERMINATED;
+        self.score = 0.0;
+        self.ordinals.clear();
+        TERMINATED
+    }
+
+    fn expired(&self) -> bool {
+        self.budget
+            .as_ref()
+            .is_some_and(super::SharedThreshold::stop_if_expired)
+    }
+
+    fn fold_next_document(&mut self) -> DocId {
+        if self.expired() || self.inner.doc() == TERMINATED {
+            return self.finish();
+        }
+        let doc = self.chunk_map.doc_id(self.inner.doc());
+        self.ordinals.clear();
+        loop {
+            self.ordinals.push((
+                u32::from(self.chunk_map.ordinal(self.inner.doc())),
+                self.inner.score(),
+            ));
+            self.inner.advance();
+            // Never expose a partial document's max score or ordinal list.
+            if self.expired() {
+                return self.finish();
+            }
+            if self.inner.doc() == TERMINATED || self.chunk_map.doc_id(self.inner.doc()) != doc {
+                break;
+            }
+        }
+        self.current_doc = doc;
+        self.score = super::MultiValueCombiner::Max.combine(&self.ordinals);
+        doc
+    }
+}
+
+impl<S: Scorer> DocSet for ChunkedPhraseScorer<S> {
+    fn doc(&self) -> DocId {
+        self.current_doc
+    }
+
+    fn advance(&mut self) -> DocId {
+        if self.current_doc == TERMINATED {
+            return TERMINATED;
+        }
+        self.fold_next_document()
+    }
+
+    fn seek(&mut self, target: DocId) -> DocId {
+        if self.current_doc >= target {
+            return self.current_doc;
+        }
+        if target == TERMINATED || self.expired() {
+            return self.finish();
+        }
+        let vid = self.chunk_map.lower_bound_doc(target);
+        if vid == self.chunk_map.num_chunks() {
+            return self.finish();
+        }
+        self.inner.seek(vid);
+        self.fold_next_document()
+    }
+
+    fn size_hint(&self) -> u32 {
+        if self.current_doc == TERMINATED {
+            0
+        } else {
+            self.inner.size_hint().saturating_add(1)
+        }
+    }
+}
+
+impl<S: Scorer> Scorer for ChunkedPhraseScorer<S> {
+    fn score(&self) -> Score {
+        self.score
+    }
+
+    fn matched_positions(&self) -> Option<super::MatchedPositions> {
+        (self.current_doc != TERMINATED).then(|| {
+            vec![(
+                self.field_id,
+                self.ordinals
+                    .iter()
+                    .map(|&(ordinal, score)| super::ScoredPosition::new(ordinal, score))
+                    .collect(),
+            )]
+        })
+    }
 }
 
 /// Build a PhraseScorer from already-fetched term data.
@@ -187,6 +339,7 @@ fn build_phrase_scorer<'a>(
     slop: u32,
     reader: &SegmentReader,
     field: Field,
+    budget: Option<super::SharedThreshold>,
 ) -> Box<dyn Scorer + 'a> {
     let idf: f32 = term_data
         .iter()
@@ -198,8 +351,16 @@ fn build_phrase_scorer<'a>(
         .sum();
     let avg_field_len = reader.avg_field_len(field);
     let (postings, positions): (Vec<_>, Vec<_>) = term_data.into_iter().unzip();
-    let mut scorer = PhraseScorer::new(postings, positions, offsets, slop, idf, avg_field_len)
-        .with_params(super::Bm25Params::for_field(reader.schema(), field));
+    let mut scorer = PhraseScorer::new(
+        postings,
+        positions,
+        offsets,
+        slop,
+        idf,
+        avg_field_len,
+        budget,
+    )
+    .with_params(super::Bm25Params::for_field(reader.schema(), field));
     if let Some(lengths) = reader.doc_lengths(field) {
         scorer = scorer.with_lengths(Lengths::Docs(lengths.clone()));
     }
@@ -213,7 +374,7 @@ fn build_phrase_scorer<'a>(
 macro_rules! phrase_early_returns {
     ($field:expr, $terms:expr, $reader:expr, $limit:expr,
      $scorer_fn:ident, $options:expr $(, $aw:tt)*) => {
-        if $terms.is_empty() {
+        if $options.stop_if_expired() || $terms.is_empty() {
             return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
         }
         if $terms.len() == 1 {
@@ -278,11 +439,21 @@ impl Query for PhraseQuery {
 
             if reader.is_chunked_field(field) {
                 return build_chunked_phrase_scorer(
-                    term_data, &offsets, slop, reader, field, limit,
+                    term_data,
+                    &offsets,
+                    slop,
+                    reader,
+                    field,
+                    options.shared_threshold,
                 );
             }
             Ok(build_phrase_scorer(
-                term_data, &offsets, slop, reader, field,
+                term_data,
+                &offsets,
+                slop,
+                reader,
+                field,
+                options.shared_threshold,
             ))
         })
     }
@@ -341,7 +512,7 @@ impl Query for PhraseQuery {
                 self.slop,
                 reader,
                 self.field,
-                limit,
+                options.shared_threshold,
             );
         }
         Ok(build_phrase_scorer(
@@ -350,6 +521,7 @@ impl Query for PhraseQuery {
             self.slop,
             reader,
             self.field,
+            options.shared_threshold,
         ))
     }
 
@@ -358,7 +530,16 @@ impl Query for PhraseQuery {
     /// MaxScore executors as an O(1) predicate instead of a verifier.
     #[cfg(feature = "sync")]
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<super::DocBitset> {
-        if self.terms.is_empty() {
+        self.as_doc_bitset_with_options(reader, &super::ScorerOptions::default())
+    }
+
+    #[cfg(feature = "sync")]
+    fn as_doc_bitset_with_options(
+        &self,
+        reader: &SegmentReader,
+        options: &super::ScorerOptions,
+    ) -> Option<super::DocBitset> {
+        if options.stop_if_expired() || self.terms.is_empty() {
             return None;
         }
         let mut bitset = super::DocBitset::new(reader.num_docs());
@@ -371,6 +552,9 @@ impl Query for PhraseQuery {
             let chunk_map = reader.chunk_map(self.field);
             let mut it = list.iterator();
             while it.doc() != TERMINATED {
+                if options.stop_if_expired() {
+                    return None;
+                }
                 let doc = chunk_map.map_or(it.doc(), |map| map.doc_id(it.doc()));
                 bitset.set(doc);
                 it.advance();
@@ -378,13 +562,20 @@ impl Query for PhraseQuery {
             return Some(bitset);
         }
         let mut scorer = self
-            .scorer_sync_with_options(reader, usize::MAX, super::ScorerOptions::with_positions())
+            .scorer_sync_with_options(reader, usize::MAX, options.without_threshold())
             .ok()?;
         while scorer.doc() != TERMINATED {
+            if options.stop_if_expired() {
+                return None;
+            }
             bitset.set(scorer.doc());
             scorer.advance();
         }
-        Some(bitset)
+        if options.stop_if_expired() {
+            None
+        } else {
+            Some(bitset)
+        }
     }
 
     /// Matches are at most the rarest term's postings; the planner only
@@ -442,12 +633,13 @@ impl Lengths {
 
 /// Scorer that checks phrase positions
 struct PhraseScorer {
+    budget: Option<super::SharedThreshold>,
     /// Posting iterators for each term
     posting_iters: Vec<BlockPostingIterator<'static>>,
     /// Positions of each term (legacy list or cursor-addressed stream)
-    position_lists: Vec<TermPositions>,
-    /// One decoded position block, reused across documents and terms
-    position_scratch: Vec<u32>,
+    position_lists: Vec<crate::structures::postings::TermPositionCursor>,
+    /// Position-list cursors advance monotonically within a matching unit.
+    position_indices: Vec<usize>,
     /// Required distance of each term from the first one (`offsets[i] -
     /// offsets[0]`); `deltas[0]` is 0.
     deltas: Vec<u32>,
@@ -472,6 +664,7 @@ struct PhraseScorer {
 }
 
 impl PhraseScorer {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         posting_lists: Vec<BlockPostingList>,
         position_lists: Vec<TermPositions>,
@@ -479,6 +672,7 @@ impl PhraseScorer {
         slop: u32,
         idf: f32,
         avg_field_len: f32,
+        budget: Option<super::SharedThreshold>,
     ) -> Self {
         let posting_iters: Vec<_> = posting_lists
             .into_iter()
@@ -493,9 +687,13 @@ impl PhraseScorer {
             .map(|i| offsets.get(i).map_or(i as u32, |o| o - first))
             .collect();
         let mut scorer = Self {
+            budget: budget.filter(|b| b.deadline().is_some()),
             posting_iters,
-            position_lists,
-            position_scratch: Vec::new(),
+            position_lists: position_lists
+                .into_iter()
+                .map(TermPositions::into_cursor)
+                .collect(),
+            position_indices: vec![0; num_terms],
             deltas,
             slop,
             current_doc: 0,
@@ -551,6 +749,13 @@ impl PhraseScorer {
         }
 
         loop {
+            if self
+                .budget
+                .as_ref()
+                .is_some_and(super::SharedThreshold::stop_if_expired)
+            {
+                return TERMINATED;
+            }
             let max_doc = self.posting_iters.iter().map(|it| it.doc()).max().unwrap();
 
             if max_doc == TERMINATED {
@@ -582,13 +787,7 @@ impl PhraseScorer {
         for i in 0..self.position_lists.len() {
             let cursor = self.posting_iters[i].position_cursor();
             let tf = self.posting_iters[i].term_freq();
-            if !self.position_lists[i].positions_into(
-                doc_id,
-                cursor,
-                tf,
-                &mut self.position_scratch,
-                &mut self.position_bufs[i],
-            ) {
+            if !self.position_lists[i].read_into(doc_id, cursor, tf, &mut self.position_bufs[i]) {
                 return false;
             }
         }
@@ -600,42 +799,48 @@ impl PhraseScorer {
     }
 
     /// Number of phrase occurrences in the internal reusable buffers.
-    fn count_phrase_matches_in_bufs(&self) -> u32 {
-        if self.position_bufs.is_empty() || self.position_bufs[0].is_empty() {
-            return 0;
-        }
-        self.position_bufs[0]
-            .iter()
-            .filter(|&&first_pos| self.check_phrase_from_position(first_pos, &self.position_bufs))
-            .count() as u32
+    fn count_phrase_matches_in_bufs(&mut self) -> u32 {
+        count_phrase_matches(
+            &self.position_bufs,
+            &self.deltas,
+            self.slop,
+            &mut self.position_indices,
+        )
     }
+}
 
-    /// Check if a phrase exists starting from the given position
-    fn check_phrase_from_position(&self, start_pos: u32, term_positions: &[Vec<u32>]) -> bool {
-        for (i, positions) in term_positions.iter().enumerate() {
-            if i == 0 {
-                continue; // Skip first term, already matched
+/// Count starts with a match in every term's independent slop interval.
+/// Ascending starts make each interval monotone: O(terms * starts + positions),
+/// preserving repeated terms and the existing (not edit-distance) slop rule.
+fn count_phrase_matches(
+    bufs: &[Vec<u32>],
+    deltas: &[u32],
+    slop: u32,
+    indices: &mut [usize],
+) -> u32 {
+    let Some(first) = bufs.first() else {
+        return 0;
+    };
+    indices.fill(0);
+    let mut matches = 0;
+    'starts: for &start in first {
+        for i in 1..bufs.len() {
+            let expected = u64::from(start) + u64::from(deltas[i]);
+            let low = expected.saturating_sub(u64::from(slop));
+            let high = expected + u64::from(slop);
+            while indices[i] < bufs[i].len() && u64::from(bufs[i][indices[i]]) < low {
+                indices[i] += 1;
             }
-
-            let expected_pos = start_pos + self.deltas[i];
-
-            // Find a position within slop distance
-            let found = positions.iter().any(|&pos| {
-                if self.slop == 0 {
-                    pos == expected_pos
-                } else {
-                    let diff = pos.abs_diff(expected_pos);
-                    diff <= self.slop
-                }
-            });
-
-            if !found {
-                return false;
+            let Some(&position) = bufs[i].get(indices[i]) else {
+                return matches;
+            };
+            if u64::from(position) > high {
+                continue 'starts;
             }
         }
-
-        true
+        matches += 1;
     }
+    matches
 }
 
 impl super::docset::DocSet for PhraseScorer {
@@ -693,5 +898,246 @@ impl Scorer for PhraseScorer {
         };
 
         self.params.score(tf, self.idf, doc_len, self.avg_field_len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ChunkHits {
+        hits: Vec<(u32, f32)>,
+        at: usize,
+        advances: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl DocSet for ChunkHits {
+        fn doc(&self) -> DocId {
+            self.hits.get(self.at).map_or(TERMINATED, |h| h.0)
+        }
+        fn advance(&mut self) -> DocId {
+            self.advances
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.at = (self.at + 1).min(self.hits.len());
+            self.doc()
+        }
+        fn seek(&mut self, target: DocId) -> DocId {
+            self.at += self.hits[self.at..].partition_point(|h| h.0 < target);
+            self.doc()
+        }
+        fn size_hint(&self) -> u32 {
+            (self.hits.len() - self.at) as u32
+        }
+    }
+    impl Scorer for ChunkHits {
+        fn score(&self) -> Score {
+            self.hits.get(self.at).map_or(0.0, |h| h.1)
+        }
+    }
+
+    fn test_chunk_map(owners: &[(u32, u16)]) -> crate::segment::chunk_map::ChunkMap {
+        use crate::segment::chunk_map::{ChunkMapBuilder, read_chunk_maps, write_chunk_maps};
+        let mut builder = ChunkMapBuilder::default();
+        for &(doc, ordinal) in owners {
+            builder.push(doc, ordinal, 10).unwrap();
+        }
+        let mut bytes = Vec::new();
+        write_chunk_maps(&mut bytes, &[(0, &builder)], &[]).unwrap();
+        read_chunk_maps(crate::directories::OwnedBytes::new(bytes))
+            .unwrap()
+            .chunk_maps
+            .remove(&0)
+            .unwrap()
+    }
+
+    fn chunk_hits(hits: Vec<(u32, f32)>) -> ChunkHits {
+        ChunkHits {
+            hits,
+            at: 0,
+            advances: Arc::default(),
+        }
+    }
+
+    #[test]
+    fn lazy_phrase_fold_matches_stable_eager_oracle_including_reordered_ordinals() {
+        for owners in [
+            vec![],
+            vec![(0, 0)],
+            vec![(2, 2), (2, 0), (2, 1), (5, 1), (5, 0), (9, 0)],
+            vec![(5, 1), (2, 2), (9, 0), (2, 0), (5, 0), (2, 1)],
+        ] {
+            let map = test_chunk_map(&owners);
+            assert_eq!(
+                map.is_doc_ordered(),
+                owners.windows(2).all(|p| p[0].0 <= p[1].0)
+            );
+            for stride in [1, 2, 3] {
+                let hits: Vec<_> = (0..owners.len() as u32)
+                    .step_by(stride)
+                    .map(|vid| (vid, (vid % 3) as f32 * 0.5))
+                    .collect();
+                let raw: Vec<_> = hits
+                    .iter()
+                    .map(|&(vid, score)| {
+                        let (doc, ord) = map.resolve(vid);
+                        (doc, ord, score)
+                    })
+                    .collect();
+                let expected = crate::segment::combine_ordinal_results(
+                    raw,
+                    super::super::MultiValueCombiner::Max,
+                    usize::MAX,
+                );
+                let mut expected = super::super::vector::VectorResultScorer::new(expected, 7);
+                let mut actual = fold_chunked_phrase_scorer(chunk_hits(hits), map.clone(), 7, None);
+                while expected.doc() != TERMINATED {
+                    assert_eq!(actual.doc(), expected.doc());
+                    assert_eq!(actual.score().to_bits(), expected.score().to_bits());
+                    let signature = |s: &dyn Scorer| {
+                        s.matched_positions()
+                            .unwrap()
+                            .into_iter()
+                            .map(|(field, positions)| {
+                                (
+                                    field,
+                                    positions
+                                        .into_iter()
+                                        .map(|p| (p.position, p.score.to_bits()))
+                                        .collect::<Vec<_>>(),
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                    };
+                    assert_eq!(signature(actual.as_ref()), signature(&expected));
+                    actual.advance();
+                    expected.advance();
+                }
+                assert_eq!(actual.doc(), TERMINATED);
+                assert_eq!(actual.advance(), TERMINATED);
+                assert_eq!(actual.score(), 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn lazy_phrase_fold_only_consumes_one_document_and_can_skip_to_late_matches() {
+        let owners: Vec<_> = (0..100)
+            .flat_map(|doc| [(doc * 2, 0), (doc * 2, 1)])
+            .collect();
+        let inner = chunk_hits((0..200).map(|vid| (vid, vid as f32)).collect());
+        let advances = inner.advances.clone();
+        let mut scorer = fold_chunked_phrase_scorer(inner, test_chunk_map(&owners), 0, None);
+        assert_eq!(advances.load(std::sync::atomic::Ordering::Relaxed), 2);
+        assert_eq!(scorer.doc(), 0);
+        assert_eq!(scorer.seek(179), 180);
+        assert_eq!(advances.load(std::sync::atomic::Ordering::Relaxed), 4);
+        assert_eq!(scorer.score(), 181.0);
+        assert_eq!(scorer.seek(179), 180);
+        assert_eq!(scorer.seek(199), TERMINATED);
+        assert!(scorer.matched_positions().is_none());
+        assert_eq!(scorer.advance(), TERMINATED);
+    }
+
+    #[test]
+    fn lazy_phrase_fold_discards_current_result_at_budget_boundary() {
+        let inner = chunk_hits(vec![(0, 1.0), (1, 2.0), (2, 3.0)]);
+        let advances = inner.advances.clone();
+        let mut scorer = ChunkedPhraseScorer {
+            inner,
+            chunk_map: test_chunk_map(&[(0, 0), (1, 0), (1, 1)]),
+            field_id: 0,
+            budget: None,
+            current_doc: TERMINATED,
+            score: 0.0,
+            ordinals: crate::segment::VectorOrdinals::new(),
+        };
+        assert_eq!(scorer.fold_next_document(), 0);
+        assert_eq!(scorer.score(), 1.0);
+        let budget = super::super::SharedThreshold::for_limit(1)
+            .with_deadline(Some(std::time::Instant::now()));
+        scorer.budget = Some(budget.clone());
+        assert_eq!(scorer.advance(), TERMINATED);
+        assert_eq!(scorer.score(), 0.0);
+        assert!(scorer.matched_positions().is_none());
+        assert!(budget.truncated());
+        assert_eq!(advances.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn phrase_stops_when_budget_expires_after_first_match() {
+        use super::super::docset::DocSet;
+        use crate::structures::{PositionStreamEncoder, PostingList};
+        let mut lists = Vec::new();
+        let mut positions = Vec::new();
+        for term in 0..2 {
+            let mut list = PostingList::new();
+            let mut bytes = Vec::new();
+            let mut encoder = PositionStreamEncoder::new(&mut bytes);
+            for doc in 0..1000 {
+                list.push(doc, 1);
+                encoder
+                    .push_doc(&mut [if doc == 0 { term } else { term * 10 }])
+                    .unwrap();
+            }
+            encoder.finish().unwrap();
+            lists.push(BlockPostingList::from_posting_list_with(&list, true, None).unwrap());
+            positions
+                .push(TermPositions::open(crate::directories::OwnedBytes::new(bytes)).unwrap());
+        }
+        let mut scorer = PhraseScorer::new(lists, positions, &[0, 1], 0, 1.0, 2.0, None);
+        assert_eq!(scorer.doc(), 0);
+        let budget = super::super::SharedThreshold::for_limit(10)
+            .with_deadline(Some(std::time::Instant::now()));
+        scorer.budget = Some(budget.clone());
+        assert_eq!(scorer.advance(), TERMINATED);
+        assert_eq!(scorer.score(), 0.0);
+        assert!(budget.truncated());
+        assert_eq!(
+            scorer.position_bufs,
+            vec![vec![0], vec![1]],
+            "no further positions decoded"
+        );
+    }
+
+    #[test]
+    fn monotone_phrase_frequency_matches_naive_offsets_slop_and_repeated_terms() {
+        for seed in 0..100u32 {
+            let a: Vec<_> = (0..200).filter(|i| (i * 17 + seed) % 11 < 5).collect();
+            let b: Vec<_> = (0..200).filter(|i| (i * 13 + seed) % 19 < 4).collect();
+            for bufs in [
+                vec![a.clone(), b.clone()],
+                vec![a.clone(), b.clone(), a.clone()],
+            ] {
+                for slop in [0, 1, 3, 100] {
+                    let deltas = [0, 2, 7];
+                    let expected = bufs[0]
+                        .iter()
+                        .filter(|&&start| {
+                            bufs.iter().enumerate().skip(1).all(|(i, positions)| {
+                                positions
+                                    .iter()
+                                    .any(|&p| p.abs_diff(start + deltas[i]) <= slop)
+                            })
+                        })
+                        .count() as u32;
+                    assert_eq!(
+                        count_phrase_matches(&bufs, &deltas, slop, &mut [0; 3]),
+                        expected
+                    );
+                }
+            }
+        }
+        assert_eq!(
+            count_phrase_matches(&[vec![0, 0, 5], vec![1, 6]], &[0, 1], 0, &mut [0; 2]),
+            3
+        );
+        assert_eq!(
+            count_phrase_matches(&[vec![u32::MAX], vec![0]], &[0, 1], 0, &mut [0; 2]),
+            0
+        );
+        assert_eq!(
+            count_phrase_matches(&[vec![1], vec![]], &[0, 1], 3, &mut [0; 2]),
+            0
+        );
     }
 }

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -120,7 +120,7 @@ pub(super) fn finish_text_maxscore<'a>(
     }
     executor = executor.with_budget(budget.cloned());
     // An approximate pass neither consumes nor publishes the exact floor.
-    let exact = heap_factor <= 1.0;
+    let exact = heap_factor == 1.0;
     let initial = shared_threshold.get();
     if initial > 0.0 && proximity.is_none() && exact {
         executor.seed_threshold(initial);
@@ -658,7 +658,11 @@ pub(super) fn build_combined_bitset(
     must: &[std::sync::Arc<dyn super::Query>],
     must_not: &[std::sync::Arc<dyn super::Query>],
     reader: &crate::segment::SegmentReader,
+    options: &super::ScorerOptions,
 ) -> Option<super::DocBitset> {
+    if options.stop_if_expired() {
+        return None;
+    }
     if must.is_empty() && must_not.is_empty() {
         return None;
     }
@@ -688,7 +692,7 @@ pub(super) fn build_combined_bitset(
         match result {
             None => {
                 // Seed: materialize the narrowest clause.
-                let bs = q.as_doc_bitset(reader)?;
+                let bs = options.doc_bitset(q.as_ref(), reader)?;
                 acc_count = bs.count() as u64;
                 result = Some(bs);
             }
@@ -701,7 +705,7 @@ pub(super) fn build_combined_bitset(
                     probed = true;
                 }
                 if !probed {
-                    let bs = q.as_doc_bitset(reader)?;
+                    let bs = options.doc_bitset(q.as_ref(), reader)?;
                     acc.intersect_with(&bs);
                 }
                 acc_count = acc.count() as u64;
@@ -725,7 +729,7 @@ pub(super) fn build_combined_bitset(
         match result {
             None => {
                 // No MUST clauses — start with all-ones, then subtract
-                let bs = q.as_doc_bitset(reader)?;
+                let bs = options.doc_bitset(q.as_ref(), reader)?;
                 let mut all = super::DocBitset::new(num_docs);
                 all.bits.fill(u64::MAX);
                 // Clear bits beyond num_docs
@@ -750,7 +754,7 @@ pub(super) fn build_combined_bitset(
                     probed = true;
                 }
                 if !probed {
-                    let bs = q.as_doc_bitset(reader)?;
+                    let bs = options.doc_bitset(q.as_ref(), reader)?;
                     acc.subtract(&bs);
                 }
                 acc_count = acc.count() as u64;
@@ -758,7 +762,11 @@ pub(super) fn build_combined_bitset(
         }
     }
 
-    result
+    if options.stop_if_expired() {
+        None
+    } else {
+        result
+    }
 }
 
 // ── Result scorers ───────────────────────────────────────────────────────

--- a/hermes-core/src/query/proximity.rs
+++ b/hermes-core/src/query/proximity.rs
@@ -105,13 +105,12 @@ pub(crate) fn rescore_sync(
         let list = reader.get_postings_sync(field, term)?;
         let positions = reader.get_positions_sync(field, term)?;
         cursors.push(match (list, positions) {
-            (Some(list), Some(positions)) => Some((list.into_iterator(), positions)),
+            (Some(list), Some(positions)) => Some((list.into_iterator(), positions.into_cursor())),
             _ => None,
         });
     }
     let mut order: Vec<usize> = (0..hits.len()).collect();
     order.sort_unstable_by_key(|&i| hits[i].doc_id);
-    let mut scratch: Vec<u32> = Vec::new();
     let mut bufs: Vec<Vec<u32>> = vec![Vec::new(); terms.len()];
     let avg = avg_len.max(1.0);
     for i in order {
@@ -122,13 +121,7 @@ pub(crate) fn rescore_sync(
                 && it.doc() != TERMINATED
                 && it.seek(doc) == doc
             {
-                positions.positions_into(
-                    doc,
-                    it.position_cursor(),
-                    it.term_freq(),
-                    &mut scratch,
-                    &mut bufs[t],
-                );
+                positions.read_into(doc, it.position_cursor(), it.term_freq(), &mut bufs[t]);
             }
         }
         let len = lengths

--- a/hermes-core/src/query/scoring.rs
+++ b/hermes-core/src/query/scoring.rs
@@ -353,6 +353,26 @@ impl SharedThreshold {
         self.deadline
     }
 
+    /// Keep cancellation/observability, but isolate a component's score space.
+    pub(crate) fn budget_only(&self) -> Self {
+        Self {
+            floor: std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            k: usize::MAX,
+            deadline: self.deadline,
+            truncated: self.truncated.clone(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn stop_if_expired(&self) -> bool {
+        if self.expired() {
+            self.mark_truncated();
+            true
+        } else {
+            false
+        }
+    }
+
     /// Whether the deadline has passed.
     #[inline]
     pub fn expired(&self) -> bool {
@@ -518,6 +538,9 @@ enum CursorVariant<'a> {
         /// list stores one and scoring uses real lengths (a `tf`-as-length
         /// score is not bounded by a real-length bound).
         length_bounds: bool,
+        length_floor: u32,
+        block_bound: CachedScoreBound,
+        group_bound: CachedScoreBound,
         /// Average length used by the bounds (matches the scoring average).
         avg_len: f32,
         /// Per-field k1/b, used by the block and group bounds.
@@ -534,6 +557,30 @@ enum CursorVariant<'a> {
         skip_start: usize,
         block_data_offset: u64,
     },
+}
+
+/// One query-local memoized bound, not a corpus-sized table. Atomic packing
+/// keeps shared read access Sync without a lock or separate key/value races.
+struct CachedScoreBound(std::sync::atomic::AtomicU64);
+
+impl CachedScoreBound {
+    fn new() -> Self {
+        Self(std::sync::atomic::AtomicU64::new(u64::MAX))
+    }
+
+    fn get_or_compute(&self, key: usize, compute: impl FnOnce() -> f32) -> f32 {
+        use std::sync::atomic::Ordering::Relaxed;
+        // Posting block counts are bounded by the u32 posting-id space.
+        let key = key as u64;
+        let entry = self.0.load(Relaxed);
+        if entry >> 32 == key {
+            return f32::from_bits(entry as u32);
+        }
+        let score = compute();
+        self.0
+            .store((key << 32) | u64::from(score.to_bits()), Relaxed);
+        score
+    }
 }
 
 // ── TermCursor async/sync macros ──────────────────────────────────────────
@@ -651,10 +698,17 @@ impl<'a> TermCursor<'a> {
         let max_tf = posting_list.max_tf() as f32;
         let safe_avg = avg_field_len.max(1.0);
         let length_bounds = lengths.is_some() && posting_list.min_len().is_some();
+        let length_floor = match lengths {
+            Some(LengthSource::Chunks(map)) => map.length_floor(),
+            _ => 0,
+        };
         let max_score = match posting_list.min_len() {
-            Some(min_len) if length_bounds => {
-                params.upper_bound_with_len(max_tf.max(1.0), idf, min_len as f32, safe_avg)
-            }
+            Some(min_len) if length_bounds => params.upper_bound_with_len(
+                max_tf.max(1.0),
+                idf,
+                min_len.max(length_floor) as f32,
+                safe_avg,
+            ),
             _ => params.upper_bound(max_tf.max(1.0), idf),
         };
         let num_blocks = posting_list.num_blocks();
@@ -680,6 +734,9 @@ impl<'a> TermCursor<'a> {
                 denom_len_coeff: params.k1 * params.b / safe_avg,
                 lengths,
                 length_bounds,
+                length_floor,
+                block_bound: CachedScoreBound::new(),
+                group_bound: CachedScoreBound::new(),
                 avg_len: safe_avg,
                 params,
                 tfs: Vec::with_capacity(128),
@@ -857,21 +914,23 @@ impl<'a> TermCursor<'a> {
                 list,
                 idf,
                 length_bounds,
+                length_floor,
+                block_bound,
                 avg_len,
                 params,
                 ..
-            } => {
+            } => block_bound.get_or_compute(idx, || {
                 let (max_tf, min_len) = list.block_bounds(idx).unwrap_or((0, None));
                 match min_len {
                     Some(min_len) if *length_bounds => params.upper_bound_with_len(
                         (max_tf as f32).max(1.0),
                         *idf,
-                        min_len as f32,
+                        min_len.max(*length_floor) as f32,
                         *avg_len,
                     ),
                     _ => params.upper_bound((max_tf as f32).max(1.0), *idf),
                 }
-            }
+            }),
             CursorVariant::Sparse { .. } => self.max_score,
         }
     }
@@ -883,21 +942,25 @@ impl<'a> TermCursor<'a> {
                 list,
                 idf,
                 length_bounds,
+                length_floor,
+                group_bound,
                 avg_len,
                 params,
                 ..
             } => {
                 let (max_tf, min_len) = list.group_bounds(idx)?;
-                Some(if *length_bounds {
-                    params.upper_bound_with_len(
-                        (max_tf as f32).max(1.0),
-                        *idf,
-                        min_len as f32,
-                        *avg_len,
-                    )
-                } else {
-                    params.upper_bound((max_tf as f32).max(1.0), *idf)
-                })
+                Some(group_bound.get_or_compute(list.next_group_block(idx), || {
+                    if *length_bounds {
+                        params.upper_bound_with_len(
+                            (max_tf as f32).max(1.0),
+                            *idf,
+                            min_len.max(*length_floor) as f32,
+                            *avg_len,
+                        )
+                    } else {
+                        params.upper_bound((max_tf as f32).max(1.0), *idf)
+                    }
+                }))
             }
             CursorVariant::Sparse { .. } => None,
         }
@@ -1802,6 +1865,13 @@ impl<'a> MaxScoreExecutor<'a> {
     /// approximate `heap_factor` mode scales the threshold as in the
     /// document-at-a-time loop.
     pub(crate) fn execute_windowed(&mut self) -> crate::Result<Vec<ScoredDoc>> {
+        if self
+            .budget
+            .as_ref()
+            .is_some_and(SharedThreshold::stop_if_expired)
+        {
+            return Ok(Vec::new());
+        }
         let n = self.cursors.len();
         for cursor in &mut self.cursors {
             cursor.ensure_block_loaded_sync()?;
@@ -2305,6 +2375,118 @@ mod tests {
             .filter(|hit| exact.iter().any(|e| e.doc_id == hit.doc_id))
             .count();
         assert!(overlap >= 25, "overlap {overlap} of 50");
+    }
+
+    #[test]
+    fn text_heap_factor_below_one_actually_changes_pruning() {
+        let params = super::super::Bm25Params::default();
+        let corpus = random_corpus(7, 20_000, 6);
+        let lengths = crate::segment::chunk_map::DocLengths::from_lengths(&corpus.lengths);
+        let lists = build_lists(&corpus, Some(&lengths));
+        let mut exact = MaxScoreExecutor::text(
+            lists.clone(),
+            lengths.avg_len(),
+            50,
+            Some(&lengths),
+            params,
+            1.0,
+        );
+        let mut approximate =
+            MaxScoreExecutor::text(lists, lengths.avg_len(), 50, Some(&lengths), params, 0.01);
+        let exact = exact.execute_windowed().unwrap();
+        let approximate = approximate.execute_windowed().unwrap();
+        assert_ne!(
+            exact.iter().map(|hit| hit.doc_id).collect::<Vec<_>>(),
+            approximate.iter().map(|hit| hit.doc_id).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn text_and_sparse_factors_have_identical_conventions() {
+        for factor in [0.0, 0.01, 0.5, 1.0] {
+            let text = MaxScoreExecutor::text(
+                Vec::new(),
+                1.0,
+                1,
+                None,
+                super::super::Bm25Params::default(),
+                factor,
+            );
+            let sparse = MaxScoreExecutor::new(Vec::new(), 1, factor);
+            assert_eq!(text.inv_heap_factor, sparse.inv_heap_factor);
+            assert_eq!(text.inv_heap_factor, factor.clamp(0.01, 1.0).recip());
+        }
+    }
+
+    #[test]
+    fn chunk_bounds_use_the_same_length_floor_as_scoring() {
+        use crate::segment::chunk_map::{ChunkMapBuilder, read_chunk_maps, write_chunk_maps};
+        use crate::structures::{BlockPostingList, PostingList};
+        let mut chunks = ChunkMapBuilder::default();
+        let mut postings = PostingList::new();
+        for id in 0..2048 {
+            chunks
+                .push(id / 4, (id % 4) as u16, if id % 4 == 0 { 1 } else { 200 })
+                .unwrap();
+            postings.push(id, 1);
+        }
+        let mut bytes = Vec::new();
+        write_chunk_maps(&mut bytes, &[(0, &chunks)], &[]).unwrap();
+        let maps = read_chunk_maps(crate::directories::OwnedBytes::new(bytes)).unwrap();
+        let map = &maps.chunk_maps[&0];
+        let list =
+            BlockPostingList::from_posting_list_with(&postings, false, Some(&|id| map.length(id)))
+                .unwrap();
+        assert_eq!(list.min_len(), Some(1));
+        let params = super::super::Bm25Params::default();
+        let cursor = TermCursor::text_with_params(
+            list,
+            2.0,
+            map.avg_len(),
+            Some(LengthSource::Chunks(map)),
+            params,
+        );
+        let expected = params.upper_bound_with_len(1.0, 2.0, 200.0, map.avg_len());
+        assert_eq!(cursor.max_score.to_bits(), expected.to_bits());
+        for block in 0..cursor.num_blocks {
+            assert_eq!(cursor.text_block_bound(block).to_bits(), expected.to_bits());
+            assert_eq!(
+                cursor.text_group_bound(block).unwrap().to_bits(),
+                expected.to_bits()
+            );
+        }
+    }
+
+    #[test]
+    fn nested_scorers_keep_deadline_but_not_outer_score_floor() {
+        let shared = SharedThreshold::for_limit(10).with_deadline(Some(std::time::Instant::now()));
+        shared.raise(100.0);
+        let options = super::super::ScorerOptions {
+            shared_threshold: Some(shared.clone()),
+            initial_threshold: 100.0,
+            ..Default::default()
+        }
+        .without_threshold();
+        assert_eq!(options.initial_threshold, 0.0);
+        let nested = options.shared_threshold.unwrap();
+        assert_eq!(nested.get(), 0.0);
+        assert!(!nested.covers(10));
+        assert!(nested.stop_if_expired());
+        assert!(shared.truncated());
+        nested.raise(200.0);
+        assert_eq!(shared.get(), 100.0);
+    }
+
+    #[test]
+    fn score_bound_cache_reuses_only_its_last_key() {
+        let cache = CachedScoreBound::new();
+        assert_eq!(cache.get_or_compute(0, || 1.5), 1.5);
+        assert_eq!(
+            cache.get_or_compute(0, || panic!("recomputed active bound")),
+            1.5
+        );
+        assert_eq!(cache.get_or_compute(1, || 2.5), 2.5);
+        assert_eq!(cache.get_or_compute(0, || 3.5), 3.5);
     }
 
     #[test]

--- a/hermes-core/src/query/term.rs
+++ b/hermes-core/src/query/term.rs
@@ -103,13 +103,17 @@ fn compute_term_idf(
 //   $($aw)*          – .await  (present for async, absent for sync)
 macro_rules! term_plan {
     ($field:expr, $term:expr, $global_stats:expr, $reader:expr, $limit:expr,
-     $load_positions:expr, $get_postings_fn:ident, $get_positions_fn:ident
+     $load_positions:expr, $budget:expr, $get_postings_fn:ident, $get_positions_fn:ident
      $(, $aw:tt)*) => {{
         let field: Field = $field;
         let term: &[u8] = $term;
         let global_stats: Option<&Arc<GlobalStats>> = $global_stats;
         let reader: &SegmentReader = $reader;
         let limit: usize = $limit;
+        let budget: Option<&super::SharedThreshold> = $budget;
+        if budget.is_some_and(super::SharedThreshold::stop_if_expired) {
+            return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
+        }
 
         // Non-indexed fields → fast-field-only path
         let is_indexed = reader.schema().get_field_entry(field).is_none_or(|e| e.indexed);
@@ -137,7 +141,7 @@ macro_rules! term_plan {
                     None,
                     None,
                     1.0,
-                    None,
+                    budget,
                 )
             }
             Some(posting_list) => {
@@ -152,6 +156,7 @@ macro_rules! term_plan {
 
                 let mut scorer = TermScorer::new(posting_list, idf, avg_field_len, 1.0)
                     .with_params(super::Bm25Params::for_field(reader.schema(), field));
+                scorer.budget = budget.filter(|b| b.deadline().is_some()).cloned();
                 if let Some(lengths) = reader.doc_lengths(field) {
                     scorer = scorer.with_doc_lengths(lengths.clone());
                 }
@@ -198,6 +203,7 @@ impl Query for TermQuery {
                 reader,
                 limit,
                 load_positions,
+                options.shared_threshold.as_ref(),
                 get_postings,
                 get_positions,
                 await
@@ -243,6 +249,7 @@ impl Query for TermQuery {
             reader,
             limit,
             options.collect_positions,
+            options.shared_threshold.as_ref(),
             get_postings_sync,
             get_positions_sync
         )
@@ -308,6 +315,7 @@ impl Query for TermQuery {
 }
 
 struct TermScorer {
+    budget: Option<super::SharedThreshold>,
     iterator: crate::structures::BlockPostingIterator<'static>,
     idf: f32,
     /// Average field length for this field
@@ -332,6 +340,7 @@ impl TermScorer {
         field_boost: f32,
     ) -> Self {
         Self {
+            budget: None,
             iterator: posting_list.into_iterator(),
             idf,
             avg_field_len,
@@ -368,14 +377,27 @@ impl TermScorer {
 
 impl super::docset::DocSet for TermScorer {
     fn doc(&self) -> DocId {
+        if self
+            .budget
+            .as_ref()
+            .is_some_and(super::SharedThreshold::stop_if_expired)
+        {
+            return TERMINATED;
+        }
         self.iterator.doc()
     }
 
     fn advance(&mut self) -> DocId {
+        if self.doc() == TERMINATED {
+            return TERMINATED;
+        }
         self.iterator.advance()
     }
 
     fn seek(&mut self, target: DocId) -> DocId {
+        if self.doc() == TERMINATED {
+            return TERMINATED;
+        }
         self.iterator.seek(target)
     }
 

--- a/hermes-core/src/query/traits.rs
+++ b/hermes-core/src/query/traits.rs
@@ -60,10 +60,30 @@ impl ScorerOptions {
         Self {
             collect_positions: self.collect_positions,
             initial_threshold: 0.0,
-            shared_threshold: None,
+            shared_threshold: self
+                .shared_threshold
+                .as_ref()
+                .filter(|shared| shared.deadline().is_some())
+                .map(super::SharedThreshold::budget_only),
             lsp_plan: None,
             global_stats: self.global_stats.clone(),
         }
+    }
+
+    pub(crate) fn stop_if_expired(&self) -> bool {
+        self.shared_threshold
+            .as_ref()
+            .is_some_and(super::SharedThreshold::stop_if_expired)
+    }
+
+    /// Materialization uses the same budget as scoring. Implementations must
+    /// never return a partial bitset (especially for MUST_NOT).
+    pub(crate) fn doc_bitset(
+        &self,
+        query: &dyn Query,
+        reader: &SegmentReader,
+    ) -> Option<DocBitset> {
+        query.as_doc_bitset_with_options(reader, self)
     }
 }
 
@@ -357,6 +377,15 @@ macro_rules! define_query_traits {
                 None
             }
 
+            /// Budget-aware materialization. `None` means unsupported or
+            /// cancelled; cancellation must flag the shared budget, and a
+            /// partial bitset must never escape as a complete filter.
+            fn as_doc_bitset_with_options(&self, reader: &SegmentReader, options: &ScorerOptions) -> Option<DocBitset> {
+                if options.stop_if_expired() { return None; }
+                let bitset = self.as_doc_bitset(reader);
+                if options.stop_if_expired() { None } else { bitset }
+            }
+
             /// Cheap estimate of how many docs this filter clause matches in
             /// the segment. Used by the boolean planner to order MUST/MUST_NOT
             /// evaluation: the narrowest clause is materialized first and wider
@@ -418,6 +447,13 @@ define_query_traits!(Send + Sync);
 define_query_traits!();
 
 impl Query for Box<dyn Query> {
+    fn as_doc_bitset_with_options(
+        &self,
+        reader: &SegmentReader,
+        options: &ScorerOptions,
+    ) -> Option<DocBitset> {
+        (**self).as_doc_bitset_with_options(reader, options)
+    }
     fn scorer<'a>(&self, reader: &'a SegmentReader, limit: usize) -> ScorerFuture<'a> {
         (**self).scorer(reader, limit)
     }

--- a/hermes-core/src/segment/chunk_map.rs
+++ b/hermes-core/src/segment/chunk_map.rs
@@ -19,8 +19,8 @@
 //! Virtual ids are assigned in indexing order, and documents are indexed in
 //! doc-id order, so `doc_ids` starts out non-decreasing. A reorder pass on a
 //! field with the `reorder` attribute permutes the virtual ids (BP over the
-//! field's postings, `segment/text_reorder.rs`); no query path depends on the
-//! order. Merges concatenate sections and add the document offset to
+//! field's postings, `segment/text_reorder.rs`). Readers verify doc-id order
+//! at open before enabling ordered query paths. Merges concatenate sections and add the document offset to
 //! `doc_ids`; ordinals and lengths are copied verbatim.
 //!
 //! A doc-length section stores the token count of the field in every
@@ -238,6 +238,8 @@ pub struct ChunkMap {
     /// this segment. BM25 floors every chunk length at this value so a short
     /// tail chunk is not rewarded for being short (`docs/chunked-bm25.md`).
     length_floor: u32,
+    /// Derived once at open; never persisted or assumed from schema flags.
+    doc_ids_monotonic: bool,
 }
 
 /// 90th-percentile of a little-endian `u16` length column (0 when empty).
@@ -263,6 +265,26 @@ fn nominal_chunk_length(lengths: &[u8]) -> u32 {
 }
 
 impl ChunkMap {
+    pub(crate) fn is_doc_ordered(&self) -> bool {
+        self.doc_ids_monotonic
+    }
+
+    /// First virtual id owned by a document at or after `target`.
+    /// Only valid for a verified doc-ordered map; num_chunks means exhausted.
+    pub(crate) fn lower_bound_doc(&self, target: DocId) -> u32 {
+        debug_assert!(self.is_doc_ordered());
+        let (mut lo, mut hi) = (0, self.num_chunks);
+        while lo < hi {
+            let mid = lo + (hi - lo) / 2;
+            if self.doc_id(mid) < target {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+        lo
+    }
+
     /// Number of chunks (virtual ids) in this segment.
     #[inline]
     pub fn num_chunks(&self) -> u32 {
@@ -415,6 +437,11 @@ pub fn read_chunk_maps(bytes: OwnedBytes) -> io::Result<ChunkMapFile> {
                 let ordinals = bytes.slice(offset + n * 4..offset + n * 6);
                 let lengths = bytes.slice(offset + n * 6..end);
                 let length_floor = nominal_chunk_length(lengths.as_slice());
+                let doc_ids_monotonic = doc_ids
+                    .as_slice()
+                    .chunks_exact(4)
+                    .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                    .is_sorted();
                 file.chunk_maps.insert(
                     field_id,
                     ChunkMap {
@@ -424,6 +451,7 @@ pub fn read_chunk_maps(bytes: OwnedBytes) -> io::Result<ChunkMapFile> {
                         num_chunks: count,
                         total_tokens,
                         length_floor,
+                        doc_ids_monotonic,
                     },
                 );
             }

--- a/hermes-core/src/structures/postings/mod.rs
+++ b/hermes-core/src/structures/postings/mod.rs
@@ -46,6 +46,7 @@ pub use positions::{
     MAX_ELEMENT_ORDINAL, MAX_TOKEN_POSITION, PositionPostingIterator, PositionPostingList,
     PostingWithPositions, decode_element_ordinal, decode_token_position, encode_position,
 };
+pub(crate) use positions_v2::TermPositionCursor;
 pub use positions_v2::{
     POSITION_STREAM_BLOCK, PositionStream, PositionStreamEncoder, TermPositions,
 };

--- a/hermes-core/src/structures/postings/positions_v2.rs
+++ b/hermes-core/src/structures/postings/positions_v2.rs
@@ -153,6 +153,14 @@ pub struct PositionStream {
     canonical_blocks: bool,
 }
 
+#[derive(Default)]
+struct PositionBlockCache {
+    index: Option<usize>,
+    values: Vec<u32>,
+    #[cfg(test)]
+    decodes: usize,
+}
+
 impl PositionStream {
     /// Whether `raw` ends with a current position-stream footer.
     pub fn is_stream(raw: &[u8]) -> bool {
@@ -294,13 +302,29 @@ impl PositionStream {
     }
 
     /// Positions of one document: the `tf` values starting at `cursor`,
-    /// delta-decoded into absolute positions. `scratch` holds one decoded
-    /// block between calls.
+    /// delta-decoded into absolute positions. `scratch` reuses allocation;
+    /// sequential consumers should use a term-bound `TermPositionCursor`.
     pub fn read_into(
         &self,
         cursor: u64,
         tf: u32,
         scratch: &mut Vec<u32>,
+        out: &mut Vec<u32>,
+    ) -> bool {
+        let mut cache = PositionBlockCache {
+            values: std::mem::take(scratch),
+            ..Default::default()
+        };
+        let found = self.read_cached(cursor, tf, &mut cache, out);
+        *scratch = cache.values;
+        found
+    }
+
+    fn read_cached(
+        &self,
+        cursor: u64,
+        tf: u32,
+        cache: &mut PositionBlockCache,
         out: &mut Vec<u32>,
     ) -> bool {
         out.clear();
@@ -321,11 +345,22 @@ impl PositionStream {
         let mut prev = 0u32;
         out.reserve(remaining);
         while remaining > 0 {
-            if !self.decode_block(idx, scratch) || scratch.len() <= in_block {
+            if cache.index != Some(idx) {
+                cache.index = None;
+                if !self.decode_block(idx, &mut cache.values) {
+                    return false;
+                }
+                cache.index = Some(idx);
+                #[cfg(test)]
+                {
+                    cache.decodes += 1;
+                }
+            }
+            if cache.values.len() <= in_block {
                 return false;
             }
-            let take = remaining.min(scratch.len() - in_block);
-            for &delta in &scratch[in_block..in_block + take] {
+            let take = remaining.min(cache.values.len() - in_block);
+            for &delta in &cache.values[in_block..in_block + take] {
                 prev = prev.wrapping_add(delta);
                 out.push(prev);
             }
@@ -474,7 +509,35 @@ pub enum TermPositions {
     Stream(PositionStream),
 }
 
+/// Query-local cursor bound to one immutable term stream. At most one decoded
+/// block (128 u32 values) is retained; seeking backwards safely replaces it.
+pub(crate) struct TermPositionCursor {
+    positions: TermPositions,
+    cache: PositionBlockCache,
+}
+
+impl TermPositionCursor {
+    pub(crate) fn read_into(
+        &mut self,
+        doc: DocId,
+        cursor: u64,
+        tf: u32,
+        out: &mut Vec<u32>,
+    ) -> bool {
+        match &self.positions {
+            TermPositions::Legacy(list) => list.get_positions_into(doc, out),
+            TermPositions::Stream(stream) => stream.read_cached(cursor, tf, &mut self.cache, out),
+        }
+    }
+}
+
 impl TermPositions {
+    pub(crate) fn into_cursor(self) -> TermPositionCursor {
+        TermPositionCursor {
+            positions: self,
+            cache: PositionBlockCache::default(),
+        }
+    }
     pub fn open(bytes: OwnedBytes) -> io::Result<Self> {
         if PositionStream::is_stream(bytes.as_slice()) {
             Ok(TermPositions::Stream(PositionStream::open(bytes)?))
@@ -512,6 +575,66 @@ impl TermPositions {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn term_cursor_reuses_blocks_and_isolates_terms_and_backward_seeks() {
+        let docs: Vec<Vec<u32>> = (0..200).map(|i| vec![i, i + 3]).collect();
+        let (bytes, _) = encode(&docs);
+        let mut cursor = TermPositions::open(OwnedBytes::new(bytes.clone()))
+            .unwrap()
+            .into_cursor();
+        let mut out = Vec::new();
+        for (id, expected) in docs.iter().enumerate() {
+            assert!(cursor.read_into(id as u32, id as u64 * 2, 2, &mut out));
+            assert_eq!(&out, expected);
+        }
+        assert_eq!(
+            cursor.cache.decodes,
+            400usize.div_ceil(POSITION_STREAM_BLOCK)
+        );
+        assert!(cursor.read_into(0, 0, 2, &mut out));
+        assert_eq!(out, docs[0]);
+        let decodes = cursor.cache.decodes;
+        assert!(cursor.read_into(1, 2, 2, &mut out));
+        assert_eq!(cursor.cache.decodes, decodes);
+        let (other_bytes, _) = encode(&[vec![99, 100]]);
+        let mut other = TermPositions::open(OwnedBytes::new(other_bytes))
+            .unwrap()
+            .into_cursor();
+        assert!(other.read_into(0, 0, 2, &mut out));
+        assert_eq!(out, vec![99, 100]);
+        assert!(!cursor.read_into(0, u64::MAX, 2, &mut out));
+        assert!(cursor.read_into(0, 0, 0, &mut out));
+        assert!(out.is_empty());
+        let TermPositions::Stream(stream) = cursor.positions else {
+            unreachable!()
+        };
+        assert_eq!(
+            stream.bytes.as_slice(),
+            bytes,
+            "reading must not modify encoded blocks"
+        );
+    }
+
+    #[test]
+    fn term_cursor_handles_copied_short_blocks_and_cross_block_documents() {
+        let first = vec![vec![1, 4, 9]; 13];
+        let second = vec![vec![10, 20, 30]; 80];
+        let (a, _) = encode(&first);
+        let (b, _) = encode(&second);
+        let mut merged = Vec::new();
+        PositionStream::concatenate_streaming(&[&a, &b], &mut merged).unwrap();
+        let mut cursor = TermPositions::open(OwnedBytes::new(merged))
+            .unwrap()
+            .into_cursor();
+        let mut out = Vec::new();
+        for (doc, expected) in first.iter().chain(&second).enumerate() {
+            assert!(cursor.read_into(doc as u32, doc as u64 * 3, 3, &mut out));
+            assert_eq!(&out, expected);
+        }
+        assert_eq!(cursor.cache.decodes, 3);
+        assert!(cursor.cache.values.capacity() <= POSITION_STREAM_BLOCK);
+    }
 
     fn encode(docs: &[Vec<u32>]) -> (Vec<u8>, u64) {
         let mut buf = Vec::new();

--- a/hermes-proto/hermes.proto
+++ b/hermes-proto/hermes.proto
@@ -117,7 +117,7 @@ message SparseVectorQuery {
   repeated float values = 3;     // Pre-computed token values
   string text = 4;               // Raw text (tokenized server-side if tokenizer configured)
   MultiValueCombiner combiner = 5;  // How to combine scores for multi-value fields
-  float heap_factor = 6;         // Approximate search factor (1.0 = exact, 0.8 = ~20% faster)
+  float heap_factor = 6;         // Approximate search factor (1 = exact, 0.8 prunes more; 0 = use default)
   float combiner_temperature = 7;   // Temperature for LogSumExp (default: 1.5)
   uint32 combiner_top_k = 8;        // K for WeightedTopK (default: 5)
   float combiner_decay = 9;         // Decay for WeightedTopK (default: 0.7)
@@ -200,8 +200,8 @@ message MatchQuery {
   // Unordered window size; 0 = 8.
   uint32 proximity_window = 5;
   // Approximate MaxScore: scale the pruning threshold by 1/heap_factor
-  // (0 or 1 = exact, rank-safe; 1.5 prunes more aggressively at some
-  // recall cost). Same semantics as SparseVectorQuery.heap_factor.
+  // (0/unset or 1 = exact, rank-safe; 0.8 prunes more aggressively at some
+  // recall cost). Must be finite and in [0, 1], like SparseVectorQuery.heap_factor.
   float heap_factor = 6;
   // Long queries: keep only the `max_terms` rarest (highest idf) tokens for
   // scoring; 0 = all tokens. Approximate.

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -189,6 +189,17 @@ pub fn convert_query(
             }
         }
         Some(ProtoQueryType::Match(match_query)) => {
+            if !match_query.heap_factor.is_finite()
+                || !(0.0..=1.0).contains(&match_query.heap_factor)
+            {
+                return Err("MatchQuery heap_factor must be finite and between 0 and 1".into());
+            }
+            // Protobuf zero/unset selects the exact default, like sparse.
+            let heap_factor = if match_query.heap_factor == 0.0 {
+                1.0
+            } else {
+                match_query.heap_factor
+            };
             // Trailing `*` → PrefixQuery (no tokenization, raw lowercased prefix)
             if let Some(prefix) = match_query.text.strip_suffix('*') {
                 let field = schema
@@ -247,8 +258,9 @@ pub fn convert_query(
                 }
             };
 
-            if distinct.len() == 1 {
-                // Single token - use TermQuery directly
+            if distinct.len() == 1 && heap_factor == 1.0 {
+                // Exact single token: keep the direct path. Tuned text must
+                // reach the text executor even when tokenization leaves one term.
                 let (token, count) = &distinct[0];
                 return Ok(term_clause(token, *count));
             }
@@ -264,8 +276,8 @@ pub fn convert_query(
                     match_query.proximity_window,
                 ));
             }
-            if match_query.heap_factor > 1.0 {
-                query = query.with_text_heap_factor(match_query.heap_factor);
+            if heap_factor < 1.0 {
+                query = query.with_text_heap_factor(heap_factor);
             }
             if match_query.max_terms > 0 {
                 query = query.with_max_terms(match_query.max_terms as usize);
@@ -1434,6 +1446,92 @@ pub fn text_stats_from_proto(
 
 #[cfg(test)]
 mod tests {
+    #[tokio::test]
+    async fn match_heap_factor_reaches_text_executor_for_one_and_multiple_terms() {
+        use hermes_core::directories::RamDirectory;
+        use hermes_core::index::{Index, IndexConfig, IndexWriter};
+        for chunked in [false, true] {
+            let mut builder = hermes_core::SchemaBuilder::default();
+            let body = builder.add_text_field_with_tokenizer("body", true, false, "simple");
+            builder.set_chunked(body, chunked);
+            let schema = builder.build();
+            let dir = RamDirectory::new();
+            let config = IndexConfig {
+                num_indexing_threads: 1,
+                ..Default::default()
+            };
+            let mut writer = IndexWriter::create(dir.clone(), schema.clone(), config.clone())
+                .await
+                .unwrap();
+            for id in 0..512 {
+                let text = if id < 128 {
+                    "machine learning padding padding padding padding"
+                } else {
+                    "machine learning machine learning machine learning"
+                };
+                let mut doc = hermes_core::Document::new();
+                doc.add_text(body, text);
+                writer.add_document(doc).unwrap();
+            }
+            writer.commit().await.unwrap();
+            let index = Index::open(dir, config).await.unwrap();
+            let reader = index.reader().await.unwrap();
+            let searcher = reader.searcher().await.unwrap();
+            for text in ["machine", "machine learning"] {
+                let mut rankings = Vec::new();
+                for factor in [1.0, 0.01, 0.0] {
+                    let query = convert_query(
+                        &proto::Query {
+                            query: Some(ProtoQueryType::Match(proto::MatchQuery {
+                                field: "body".into(),
+                                text: text.into(),
+                                heap_factor: factor,
+                                ..Default::default()
+                            })),
+                        },
+                        &schema,
+                        None,
+                        None,
+                        &shape(),
+                    )
+                    .unwrap();
+                    let (hits, _) = searcher
+                        .search_with_count(query.as_ref(), 10)
+                        .await
+                        .unwrap();
+                    rankings.push(hits.iter().map(|hit| hit.doc_id).collect::<Vec<_>>());
+                }
+                assert_ne!(rankings[0], rankings[1], "chunked={chunked}, text={text}");
+                assert_eq!(
+                    rankings[0], rankings[2],
+                    "zero must select the exact default"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn match_heap_factor_rejects_old_and_invalid_wire_values() {
+        let schema = stemmed_text_schema();
+        for factor in [-1.0, 1.5, f32::INFINITY, f32::NAN] {
+            let result = convert_query(
+                &proto::Query {
+                    query: Some(ProtoQueryType::Match(proto::MatchQuery {
+                        field: "body".into(),
+                        text: "running foxes".into(),
+                        heap_factor: factor,
+                        ..Default::default()
+                    })),
+                },
+                &schema,
+                None,
+                None,
+                &shape(),
+            );
+            assert!(result.is_err(), "must reject {factor}");
+        }
+    }
+
     #[test]
     fn match_query_deduplicates_repeated_tokens() {
         let mut builder = hermes_core::SchemaBuilder::default();
@@ -2050,7 +2148,7 @@ mod tests {
                     tokenizer_hint: String::new(),
                     proximity_weight: 0.0,
                     proximity_window: 0,
-                    heap_factor: 1.5,
+                    heap_factor: 0.6,
                     max_terms: 2,
                 })),
             },
@@ -2061,7 +2159,7 @@ mod tests {
         )
         .unwrap()
         .to_string();
-        assert!(tuned.contains("~heap(1.5)"), "{tuned}");
+        assert!(tuned.contains("~heap(0.6)"), "{tuned}");
         assert!(tuned.contains("~max_terms(2)"), "{tuned}");
         let off = convert_query(
             &match_proto("body", "running foxes", ""),


### PR DESCRIPTION
## Summary

- Unify BM25 and sparse `heap_factor`: `0 < factor < 1` enables extra pruning; RPC zero/unset and 1 are exact. Reject the old >1 contract and invalid floats, with no compatibility translation.
- Preserve nested deadlines through term/phrase construction, negative filters and collection; keep component score floors isolated.
- Reuse one decoded position block per term and monotone phrase position cursors; tighten/cache BM25 bounds using the existing chunk length floor.
- Lazily fold phrase hits one document at a time on verified doc-ordered maps. Preserve stable eager aggregation for reordered maps, exact score/ordinal semantics, and all mandatory matches beyond top-k.
- No persisted-format/writer changes, scoring-formula changes or approximate-default tuning.

## Validation

- Full eight-step search harness passed: 1,299 core tests (12 ignored), 58 server tests, broker/tool/integration tests and both real-server broker tests, Clippy, native/portable builds and API docs.
- WASM release + four JS tests; regenerated TypeScript + four client tests; documentation/link check passed. Existing two WASM dev-dependency audit findings remain out of scope.
- New behavior-named regressions failed before implementation and pass now. Ordered/reordered folding matches IDs, score bits and ordinal results; counted cursor proves lazy construction/seeking.
- Same Rust 1.98.1 release/M4/20K-document fixture: original phrase 36.48 ms → final ~11.11 ms; phrase bonus 38.53 ms → ~12.88 ms. Incremental lazy-folding paired medians: phrase 11.73–12.15 → 11.11–11.12 ms; bonus 13.77–13.87 → 12.87–12.90 ms. All result signatures/seen counts identical. Shared-machine warm synthetic evidence, not production percentiles; no default tuning or process-RSS reduction claimed.
- Full details, memory limits and remaining fusion/cold-cache/recall work in `docs/search-performance-review.md`.
