### PR TITLE
perf(core): cache budgeted graph bisection gains

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ claim as implemented or as current performance.
 - [Cold IO for merges (hot-metadata-pinning Phase 2)](cold-io.md)
 - [Merge-Time BP Reordering](merge-time-reorder.md)
 - [Budgeted (Partial) BP Reordering](budgeted-reorder.md)
+- [Reordering Performance Review](reordering-performance-review.md)
 - [Block-Level Reorder with Stats-Guided Granularity](block-level-reorder.md)
 
 ## Vector retrieval and compression

--- a/docs/budgeted-reorder.md
+++ b/docs/budgeted-reorder.md
@@ -212,3 +212,29 @@ cheaper gain-cooling stop because a serial full-vocabulary objective scan costs
 more there than the posting passes it can avoid. Long passes log progress every
 30 seconds and export aggregate depth, partition, iteration, entity-pass, swap,
 duration, and stop-reason metrics.
+
+## Gain arithmetic review (2026-09-05)
+
+Before this pass, the gain loop recomputed two logarithms and a division per posting.
+Within a refinement, each term has only two possible signed contributions,
+one for each source half. Document term order and strict floating-point
+operation order determine gain bits, median ties, and persisted permutations;
+reassociation of this reduction is therefore not an admissible SIMD shortcut.
+
+The implemented optimization caches those two contributions once
+per active term per refinement, then gathers and sums them in the original
+document term order. It reuses the cache across partitions on each admitted
+degree lane and charges `8 × vocabulary × lanes` bytes plus vector descriptors
+against remaining graph scratch allowance before allocation. Cache admission
+does not drop extra dimensions or reduce the existing degree-lane count; when
+it does not fit, the kernel retains direct computation. This changes expensive
+arithmetic from posting-proportional to active-term-proportional while leaving CSR traversal,
+selection, stopping rules, formats, and rewrite ownership unchanged.
+
+Same-fixture timings, exact gain/permutation bytes, memory accounting, assembly
+and validation are recorded in the
+[reordering review](reordering-performance-review.md). This cache uses remaining
+allowance without changing dimension selection or degree-lane admission. It
+does not fix the text adapter's older incomplete memory accounting; that
+adapter retains direct gain computation until its complete remaining budget
+can be supplied.

--- a/docs/reordering-performance-review.md
+++ b/docs/reordering-performance-review.md
@@ -1,0 +1,293 @@
+# Reordering performance review — 2026-09-05
+
+Review base: `98c86059`, Rust 1.98.1 / LLVM 22.1.8. Measurements cover Apple
+M4/macOS and Intel Xeon 8581C/Linux. This review covers the BP computation,
+forward graph construction, BMP record/block rewrites, and chunked-text
+reorder. It does not establish production latency or Linux cold-I/O behavior.
+
+## Entry points and invariants
+
+`IndexWriter::reorder` and the server optimizer reach
+`SegmentManager::reorder_single_segment`, which owns source/output claims and
+calls `segment::reorder::reorder_segment`. Merge-time BMP reorder reaches the
+same `reorder_bmp_field` through `segment::merger::sparse`. Explicit record or
+block granularity bypasses the coherence estimator; `Auto` chooses per field.
+The shared background pool and reorder gate remain the scheduling owners.
+
+BMP record reorder builds a padding-aware, compact-term CSR, refines a
+permutation, and transposes postings through bounded sorted windows. Block
+reorder bisects header-term sets and copies block payloads, remapping document
+IDs and rebuilding grids. Chunked-text reorder builds its own CSR in
+`text_reorder`, uses the same BP kernel, then permutes virtual chunk IDs,
+postings, positions and chunk maps. Document IDs, stores and unrelated fields
+retain their semantics. ANN artifacts are never trained by these paths.
+
+The kernel is shared by native builds with/without sync, with a sequential
+non-native implementation. The segment reorder adapters are native-only;
+portable compilation still covers the graph module. There is no protocol or
+persisted format change in this pass (BMP V19 and text/chunk formats remain
+owned by their existing encoders).
+
+For `P` CSR postings, `N` entities, `T` compact terms, and `L` admitted degree
+lanes, the graph has `4P + 8(N+1)` CSR bytes, `20N` bytes of entity scratch
+(order, gains, output and `usize` ranks on this 64-bit host), and approximately
+`8.1875TL` degree/initialization bytes. Repeated refinements and levels revisit
+postings; this is not an O(P) algorithm overall. Graph scratch is allocated
+once and lanes are reused across level-synchronized partitions. The budgeted
+gain cache described below adds at most `8TL` heap bytes.
+
+## Implemented: remove repeated gain arithmetic
+
+Previously each posting evaluated two log lookups (calling `log2` when a
+degree exceeded 4095) and a division. During a refinement, these values depend
+only on the term degrees and the document's half. The kernel now computes the
+two signed contributions once per active term and gathers them in the original
+document-term order. Half directions, both subtraction operations, division,
+and each floating-point addition retain their order. Median tie breaking,
+quickselect's within-half order, objective stopping and convergence rules are
+unchanged. Deadline-limited runs can naturally complete more work.
+
+Cache allocation is optional and admitted from spare graph memory after the
+existing degree-lane choice; it never drops additional dimensions or reduces
+lanes. Admission charges cache payload, degree payload, lane descriptors,
+entity/CSR scratch and the log table, using checked arithmetic. Tight budgets
+retain direct computation. The chunked-text caller's `from_csr` path retains
+direct computation too: its current budget omits caller-owned plans and
+construction buffers, so spare memory cannot safely be established there.
+The cache does not fix that older policy. Cache state is refreshed only for
+active terms and reused across refinements and partitions; no allocation or
+cache synchronization occurs per document/posting. Debug BP logs report cache
+admission.
+
+The initial prototype kept cached and direct scoring in one large callback.
+M4 assembly showed a direct call and register spills per document even in the
+cached branch. Dispatch now occurs once per refinement through a generic
+`fill_gains` helper, separating the small cached callback from the logarithmic
+fallback. The compiler still emits a direct call per document; its cached
+callback uses a 16-byte frame versus the prototype's 128-byte frame. The
+posting loop has scalar loads/additions and bounds checks, with no division,
+logarithm or call. No `dyn Fn`, virtual scoring call, forced inline
+attribute, unchecked gather, or architecture-specific default was introduced.
+
+The cached posting reduction deliberately remains strict scalar arithmetic.
+Reassociating a document's sum to obtain SIMD would change gain bits, ties,
+and output order. A future SIMD experiment can instead batch independent
+document accumulators while preserving each document's addition order; it
+must account for ragged CSR rows, scattered term accesses and cross-platform
+results. Generic closures alone are not evidence of virtual dispatch.
+
+## Measurements and validation
+
+The ignored `graph_bisection::gain_tests::bench_bp_gain_review` runs a fixed
+seed, four-thread pool and default release flags. Each fixture has one warmup
+and three timed full graph calls, including graph scratch allocation and
+destruction. Input construction, permutation validation, byte capture and
+destruction of returned orders are outside timing. The coarse fixture stops
+at 524,288 entities to isolate large-partition work; the others descend to 32.
+The sparse fixture intentionally has low posting reuse and an oversized
+vocabulary as a control. No default is tuned from these synthetic fixtures.
+
+Three paired runs, alternating before/after order, produced these ranges of
+per-run medians. All compilers and this task's other CPU-heavy checks had
+stopped; the shared Mac was not CPU-isolated. The earlier prototype run was
+slower in both binaries, so the final paired comparison is used here.
+
+| Fixture                    | Entities / postings    |         Before |          After | Paired speedup |
+| -------------------------- | ---------------------- | -------------: | -------------: | -------------: |
+| Mixed terms, full depth    | 100,003 / 4,339,473    | 164.8–172.0 ms | 109.2–111.5 ms |     1.48–1.57× |
+| Sparse control, full depth | 100,003 / 394,309      |   45.7–47.2 ms |   41.3–42.5 ms |     1.11–1.12× |
+| Coarse, popular terms      | 1,048,577 / 11,944,199 | 360.7–374.6 ms | 158.7–161.0 ms |     2.26–2.33× |
+
+Complete permutation bytes match across revisions and every repetition.
+Process peak RSS, including all three fixture constructions and validation,
+was 144.4–153.4 MB before and 142.8–150.5 MB after. Those overlapping ranges
+do not establish a memory reduction. The exact additional cache payload is
+512 KiB, 4 MiB and 32 KiB respectively, plus 24 bytes per lane for its vector
+descriptor on this host. It fits the admitted allowance and is reused; cache
+admission never expands the configured budget.
+
+Raw paired evidence: `.context/bp-{before,after}-{1,2,3}.log`, permutations in
+`.context/bp-{before,after}-paired-output/`, environment in
+`.context/bp-environment.json`, and assembly in `.context/bp-final-{gains,doc-0}.asm`.
+The preserved original and final test binaries are `.context/bp-{before,after}`.
+These are local, gitignored artifacts, not portable benchmark distributions.
+
+The separate public-entry fixture
+`index::tests::bmp::bench_reorder_review_bytes` indexes 32,771 sparse records,
+reorders, reopens and compares full-hit document/score bits before and after.
+Across original and cached binaries, its complete 4,108,761-byte `.sparse`
+file and 275,160 bytes of captured query results also matched. These bytes
+exclude random segment IDs in metadata. The small public-entry fixture is a
+correctness check, not a repeated end-to-end throughput benchmark. Logs and
+bytes are in `.context/bp-bytes-{before,final}*`.
+
+Reproduction:
+
+```sh
+cargo test --locked -p hermes-core --release --lib --no-run
+# Run the emitted test executable directly, after compilation stops:
+HERMES_BP_EVIDENCE_DIR=.context/reorder-evidence /usr/bin/time -l \
+  <test-executable> bench_bp_gain_review --ignored --nocapture --test-threads=1
+HERMES_BP_EVIDENCE_DIR=.context/reorder-evidence \
+  <test-executable> bench_reorder_review_bytes --ignored --nocapture --test-threads=1
+```
+
+Use the same added fixtures against the review base; neither benchmark needs
+a public core API solely for measurement.
+
+### x86_64 Linux validation
+
+The same source and fixtures were tested on an idle GCE `c4-highmem-48`
+instance with an Intel Xeon Platinum 8581C, Debian Linux 6.1, and the same
+Rust 1.98.1 / LLVM 22.1.8 compiler release. Both revisions were built with
+default release flags and separately with
+`RUSTFLAGS='-C target-cpu=x86-64-v3'` (AVX2). All four builds completed before
+tests and timings began. Each process was pinned with `taskset -c 0,1,2,3`
+to four distinct physical cores; BP retained its fixed four-thread pool.
+This was a cloud VM, not a dedicated physical host.
+
+As on M4, each process had one warmup and three timed calls per fixture;
+three process pairs alternated before/after execution order. Ranges below
+are the three per-process medians and paired speedups. These remain synthetic
+whole-BP timings, not production reorder throughput or cold-storage results.
+
+| Compiler target  | Fixture                    |         Before |          After | Paired speedup |
+| ---------------- | -------------------------- | -------------: | -------------: | -------------: |
+| Default x86_64   | Mixed terms, full depth    | 326.3–331.8 ms | 186.4–191.4 ms |     1.70–1.76× |
+| Default x86_64   | Sparse control, full depth |   94.8–96.1 ms |   77.2–79.0 ms |     1.20–1.23× |
+| Default x86_64   | Coarse, popular terms      | 506.7–516.1 ms | 175.1–180.7 ms |     2.81–2.93× |
+| x86-64-v3 / AVX2 | Mixed terms, full depth    | 313.2–317.2 ms | 180.8–181.1 ms |     1.73–1.75× |
+| x86-64-v3 / AVX2 | Sparse control, full depth |   92.4–95.9 ms |   74.5–78.3 ms |     1.22–1.24× |
+| x86-64-v3 / AVX2 | Coarse, popular terms      | 495.6–506.9 ms | 173.1–175.3 ms |     2.85–2.89× |
+
+GNU `time -v` measured process peak RSS across all fixture constructions,
+timed calls and permutation checks. Default-target RSS was 95.39–95.44 MiB
+before and 95.24–95.57 MiB after; AVX2 was 95.28–95.59 MiB before and
+95.72–95.87 MiB after. This does not establish a memory reduction. The exact
+cache payload remains 512 KiB, 4 MiB and 32 KiB for the respective fixtures,
+plus descriptors, admitted within the existing graph budget.
+
+Each optimized binary passed 1,299 core library tests with 13 ignored. The
+ignored BP and public-entry fixtures were then run explicitly. Complete
+permutation bytes matched across both revisions, both x86 compiler targets
+and all three process repetitions. The 4,108,761-byte sparse file and
+275,160-byte query-score capture also matched across both revisions and
+targets, and matched the M4 captures. The mixed and sparse permutations
+matched M4 too. The coarse permutation differed between Linux/x86 and
+macOS/ARM in both the original and optimized implementation: this change
+preserves output within each tested platform, without establishing a new
+cross-platform permutation guarantee.
+
+For Linux, replace the macOS timing wrapper above with:
+
+```sh
+HERMES_BP_EVIDENCE_DIR=.context/reorder-evidence /usr/bin/time -v \
+  taskset -c 0,1,2,3 <test-executable> \
+  bench_bp_gain_review --ignored --nocapture --test-threads=1
+```
+
+Raw binaries, logs, outputs, CPU/compiler metadata and byte hashes are in
+`.context/bp-x86/evidence/`; the source manifest, runner and calculated summary
+are in `.context/bp-x86/`. Evidence was copied back and its archive SHA-256
+verified before removing this task's remote scratch directory. These are
+local, gitignored evidence files, as with the M4 captures.
+
+### Validation status
+
+The resumed audit rechecked all three saved permutation files, the sparse
+blob and query-score capture byte for byte. It also reviewed cache refresh
+after degree updates, lane reuse, checked allocation admission and the
+native/sequential gain dispatch. The implementation remains the one measured
+above; this continuation adds review and validation records.
+
+| Check                                   | Result                                                                                                                                                                                                           |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `python3 scripts/check_search.py check` | Passed: contracts, format, Clippy, core/server/broker/tool tests with metrics, and native-without-sync compilation. Evidence: `.context/search-harness/20260905T144827.006019Z-check/`.                          |
+| Gain regressions                        | Three passed: exact gain bits including log-table overflow, half direction and empty rows; cache admission limits; complete permutations and reused cache storage. Evidence: `.context/bp-final-gain-tests.log`. |
+| Portable Rust library                   | `cargo check --locked -p hermes-core --no-default-features --lib` passed. Evidence: `.context/bp-resume-portable-check.log`.                                                                                     |
+| WASM                                    | `bash build.sh`, `npm ci` and `npm test -- --run` passed; four tests across two files. Evidence: `.context/bp-resume-wasm-{build,npm,tests}.log`.                                                                |
+| Documentation                           | `uv run scripts/check_docs.py` passed: 71 Markdown files, 247 local links and 20 benchmark targets. Evidence: `.context/bp-resume-docs-check.log`.                                                               |
+
+The earlier attempt to run Rust library tests without the native feature
+failed to compile because other test modules reference native-only APIs
+(`Index`, `MmapDirectory`, Rayon and loader helpers). See
+`.context/bp-portable-tests.log`. A portable library/WASM build is not evidence
+that this Rust test suite passes. No lifecycle or RPC code changed, so the
+additional `full` harness (API docs and real-server broker tests) was not run.
+Production-corpus timings, Linux cold I/O and runs on a dedicated physical
+host remain unmeasured.
+
+## Remaining findings and experiments
+
+1. **P1 — Chunked-text memory admission is incomplete.**
+   `text_reorder::plan_field` budgets only 12 bytes per selected posting.
+   Vocabulary arrays, chunk counts, fill cursors, retained plans and graph
+   entity scratch are additional allocations. `ForwardIndex::from_csr`
+   chooses degree lanes using CSR bytes alone. `reorder_term` also materializes
+   a `Vec<u32>` per matching chunk, retains all positions for the term, sorts
+   32-byte entries on this host, then copies IDs/frequencies into a
+   `PostingList`. `rewrite_text_files` additionally retains new length arrays,
+   chunk-map builders for every chunked field and ordinary-text norm columns;
+   these costs include fields whose order did not change. High-df positioned
+   terms can therefore exceed the advertised pass memory budget even after
+   graph terms were filtered. Bring text under
+   the owning component's complete budget model; stream postings to CSR in
+   bounded passes and store positions in flat, budgeted runs. Test tiny budgets,
+   multiple reordered fields, large positioned terms and peak heap. No bounded
+   memory claim for the entire text path follows from this kernel improvement.
+
+2. **P1 — Text truncation can disappear as successful convergence.**
+   `plan_field` returns `None` for an identity permutation or zero retained
+   terms, losing `converged = false` from zero-time/memory-limited BP.
+   `reorder_segment` treats an empty text-plan list as converged. A depth cap
+   above the text posting-block size is likewise not reflected in the plan's
+   convergence flag. This can prevent optimizer deepening even though useful
+   work remains. Text also starts the full BP time budget after graph building,
+   unlike BMP's subtraction of elapsed build time. Return outcome/convergence
+   independently of whether bytes require rewriting, and regress zero-time,
+   no-retained-term and depth-capped passes at the index boundary. Planning
+   currently ignores out-of-range posting IDs while rewrite indexes the inverse
+   map directly; reject corrupt IDs explicitly in the same follow-up.
+
+3. **P2 — Rank scratch still costs eight bytes per entity on 64-bit hosts.**
+   The graph allocates `Vec<usize>` of length N before refinement, including
+   coarse levels that use radix selection and never consult it. Quickselect
+   only uses local indices below 1,048,576, so a `u32` rank representation could
+   save `4N` bytes (about 221 MiB at 58M entities). Another option is bounded
+   per-lane rank storage sized for the largest quickselect partition. Compare
+   complete permutation bytes: quickselect's within-half permutation is part
+   of BP's symmetry breaking. Do not substitute a different stable sort merely
+   because median membership matches.
+
+4. **P2 — Record transpose and grid sorting remain substantial work.**
+   Each record window counts source postings, scans again to fill 12-byte
+   routed tuples, comparison-sorts by output block/dimension/slot/impact, and
+   serially encodes output blocks. Window allocations are bounded, but repeated
+   source-block visits can amplify decode cost under scattering. Measure
+   source-block scans, tuple bytes, window count and phase time before trying
+   counted partitioning/radix sorting or parallel encoding. Preserve exact
+   slot/impact order, budget the overlap of scratch/output buffers, and compare
+   complete sparse bytes. Blockwise reorder already copies compatible payloads;
+   avoid converting it into a record rebuild. Historical parallel-encoding
+   wording in `budgeted-reorder.md` is not a description of today's routed
+   serial output loop.
+
+5. **P2 — Smaller serial/heap costs deserve isolated measurements.**
+   Candidate discovery maintains a heap even when every eligible term fits.
+   Radix selection scans gains four times and creates boxed histograms through
+   Rayon fold/reduce; `ranked` initialization and final partition copying add
+   memory traffic each refinement. The level scheduler replays O(depth) path
+   bits per claimed partition and uses shared progress atomics per iteration.
+   These are code-path findings, not demonstrated dominant costs. Benchmark
+   them separately after the arithmetic saving, preserving deterministic
+   candidate/term order and the existing memory/lifecycle protocol. Writer
+   trait-object dispatch occurs at output boundaries; removing it without
+   measuring call frequency is lower priority than reducing scans and sorts.
+
+Production follow-up should use the same corpus before/after, track elapsed
+phase times, peak heap/RSS and faults, encoded bytes, permutation/query
+correctness, and pruning quality at a fixed work/deadline budget. Run both
+warm/cold storage and concurrent search workloads on Linux. The x86 default
+and AVX2 evidence above supports this arithmetic-preserving cache; future
+architecture-sensitive defaults still need their own comparisons against
+the portable scalar path.

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -316,6 +316,21 @@ New distributions default to `.context/search-harness/criterion` so compiler
 output cleanup does not remove them. Earlier evidence paths below describe the
 original runs, which used Cargo's target directory.
 
+## Reordering continuation
+
+The [reordering performance review](reordering-performance-review.md) traces
+record/block BMP and chunked-text BP, removes repeated per-posting gain
+arithmetic with an optional budgeted term cache, and records byte/permutation
+and assembly evidence. It also records outstanding text memory/convergence
+gaps, rank scratch, transpose sorting and scheduling experiments. The kernel
+change preserves arithmetic order and existing formats; it does not resolve
+the text-path findings or establish production performance. Synthetic BP
+speedups are 1.11–2.33× on Apple M4 and 1.20–2.93× on an Intel Xeon 8581C
+with default and AVX2 builds. Before/after permutations and sparse/query bytes
+match within each tested platform; the original coarse permutation already
+differs between macOS/ARM and Linux/x86. Both x86 builds passed 1,299 core
+library tests, and peak process RSS stayed around 95–96 MiB on that fixture.
+
 ## Benchmark evidence
 
 Fixture: `hermes-core/benches/segment_merge.rs`; two RAM segments, each with

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3574,6 +3574,120 @@ async fn bench_forward_index_build() {
     );
 }
 
+/// Reproducible public-entry fixture for byte comparisons across BP revisions.
+/// Run with HERMES_BP_EVIDENCE_DIR set to retain the sparse blob and query bits.
+#[tokio::test]
+#[ignore]
+async fn bench_reorder_review_bytes() {
+    use crate::directories::Directory;
+    const DOCS: usize = 32_771;
+    let (schema, _, sparse) = bmp_schema_with_config(SparseVectorConfig {
+        format: SparseFormat::Bmp,
+        weight_quantization: WeightQuantization::UInt8,
+        bmp_block_size: 32,
+        dims: Some(4096),
+        max_weight: Some(5.0),
+        ..SparseVectorConfig::default()
+    });
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        num_indexing_threads: 1,
+        max_indexing_memory_bytes: 1024 * 1024 * 1024,
+        ..IndexConfig::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    let mut random = 0xc0ffee1234567890u64;
+    for i in 0..DOCS {
+        let mut values = vec![(0, 1.0)];
+        for j in 0..24 {
+            random ^= random << 13;
+            random ^= random >> 7;
+            random ^= random << 17;
+            let dim = if j % 2 == 0 {
+                1 + random as u32 % 255
+            } else {
+                256 + ((i * 7919 % 64) * 32 + random as usize % 32) as u32
+            };
+            values.push((dim, 0.5 + (random % 100) as f32 / 25.0));
+        }
+        values.sort_by_key(|&(dim, _)| dim);
+        values.dedup_by_key(|value| value.0);
+        loop {
+            let mut doc = Document::new();
+            doc.add_sparse_vector(sparse, values.clone());
+            match writer.add_document(doc) {
+                Ok(()) => break,
+                Err(crate::Error::QueueFull) => tokio::task::yield_now().await,
+                Err(error) => panic!("{error}"),
+            }
+        }
+    }
+    writer.commit().await.unwrap();
+    let mut expected = Vec::new();
+    let mut query_bytes = Vec::new();
+    for pass in 0..2 {
+        let index = Index::open(dir.clone(), config.clone()).await.unwrap();
+        let reader = index.reader().await.unwrap();
+        let searcher = reader.searcher().await.unwrap();
+        for (q, terms) in [vec![(0, 1.0)], vec![(5, 0.8), (270, 1.1)]]
+            .into_iter()
+            .enumerate()
+        {
+            let hits = searcher
+                .search(&SparseVectorQuery::new(sparse, terms), DOCS)
+                .await
+                .unwrap();
+            if q == 0 {
+                assert_eq!(hits.len(), DOCS);
+            }
+            let mut bits: Vec<_> = hits
+                .iter()
+                .map(|hit| (hit.doc_id, hit.score.to_bits()))
+                .collect();
+            bits.sort_unstable();
+            if pass == 0 {
+                expected.push(bits);
+            } else {
+                assert_eq!(bits, expected[q]);
+                query_bytes.extend(
+                    bits.iter()
+                        .flat_map(|&(id, score)| [id.to_le_bytes(), score.to_le_bytes()].concat()),
+                );
+            }
+        }
+        if pass == 1 {
+            if let Some(path) = std::env::var_os("HERMES_BP_EVIDENCE_DIR") {
+                let path = std::path::PathBuf::from(path);
+                std::fs::create_dir_all(&path).unwrap();
+                let segments = index.segment_readers().await.unwrap();
+                assert_eq!(segments.len(), 1);
+                let files = crate::segment::SegmentFiles::new(segments[0].meta().id);
+                let bytes = dir
+                    .open_read(&files.sparse)
+                    .await
+                    .unwrap()
+                    .read_bytes()
+                    .await
+                    .unwrap();
+                std::fs::write(path.join("reordered.sparse"), bytes.as_slice()).unwrap();
+                std::fs::write(path.join("query-bits.bin"), &query_bytes).unwrap();
+            }
+        } else {
+            drop(searcher);
+            drop(index);
+            let started = std::time::Instant::now();
+            writer.reorder().await.unwrap();
+            println!(
+                "public writer.reorder: {:.3} ms",
+                started.elapsed().as_secs_f64() * 1000.0
+            );
+        }
+    }
+}
+
 /// Regression: a block with more than 65,535 postings overflowed the u16
 /// posting prefix sums at build time (bmp_block_size=256 × ~300-dim docs
 /// hits this in production), silently corrupting the block; the reader's

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -23,6 +23,7 @@ const PARALLEL_BP_MIN_ENTITIES: usize = 1_048_576;
 const MIN_RELATIVE_OBJECTIVE_IMPROVEMENT: f64 = 1e-6;
 const MIN_OBJECTIVE_ITERATIONS: usize = 4;
 const OBJECTIVE_STALL_ITERATIONS: usize = 2;
+const LOG_TABLE_SIZE: usize = 4096;
 
 fn term_degree_bytes(num_terms: usize) -> usize {
     let bitmap_words = num_terms.div_ceil(64);
@@ -215,6 +216,20 @@ fn parallel_bisect_lanes(
     affordable_nodes.min(worker_limit)
 }
 
+/// Spend only spare graph memory on gain caching. In particular, this must
+/// not change candidate selection or the number of degree lanes admitted by
+/// the existing policy. Tight budgets keep the direct arithmetic path.
+fn gain_cache_fits(budget: usize, non_degree_bytes: usize, terms: usize, lanes: usize) -> bool {
+    let required = terms
+        .checked_mul(std::mem::size_of::<[f32; 2]>())
+        .and_then(|cache| cache.checked_add(term_degree_bytes(terms)))
+        .and_then(|lane| lane.checked_add(std::mem::size_of::<TermDegrees>()))
+        .and_then(|lane| lane.checked_mul(lanes))
+        .and_then(|all_lanes| all_lanes.checked_add(non_degree_bytes))
+        .and_then(|graph| graph.checked_add(LOG_TABLE_SIZE * std::mem::size_of::<f32>()));
+    terms > 0 && required.is_some_and(|bytes| bytes <= budget)
+}
+
 /// Per-partition left/right term degrees with direct compact-term indexing.
 ///
 /// Recursive BP used to zero two `num_terms`-long vectors at every node. At
@@ -226,6 +241,9 @@ struct TermDegrees {
     values: Vec<std::mem::MaybeUninit<[u32; 2]>>,
     initialized: Vec<u64>,
     touched_words: Vec<u32>,
+    /// Optional, budgeted scratch. Refreshed for active terms before scoring,
+    /// reused across all refinements and partitions on this lane.
+    gain_cache: Vec<[f32; 2]>,
 }
 
 impl TermDegrees {
@@ -237,6 +255,7 @@ impl TermDegrees {
             values,
             initialized: vec![0; bitmap_words],
             touched_words: Vec::with_capacity(bitmap_words),
+            gain_cache: Vec::new(),
         }
     }
 
@@ -277,6 +296,42 @@ impl TermDegrees {
         // SAFETY: an initialized bit is published only after the slot write;
         // scoring reads degrees after construction, with no concurrent writes.
         unsafe { *self.values[term].assume_init_ref() }
+    }
+
+    fn refresh_gain_cache(&mut self, log_table: &[f32]) {
+        if self.gain_cache.is_empty() {
+            return;
+        }
+        for &word_idx in &self.touched_words {
+            let word_idx = word_idx as usize;
+            let mut pending = self.initialized[word_idx];
+            while pending != 0 {
+                let bit = pending.trailing_zeros() as usize;
+                let term = word_idx * 64 + bit;
+                // SAFETY: pending contains only initialized degree slots.
+                let [left, right] = unsafe { *self.values[term].assume_init_ref() };
+                // Preserve both subtraction operations, division, and final
+                // sign exactly. Combining the logs/penalty or reassociating
+                // the document reduction would change median ties.
+                self.gain_cache[term] = [
+                    if left == 0 {
+                        0.0
+                    } else {
+                        fast_log2_lookup(right as usize + 2, log_table)
+                            - fast_log2_lookup(left as usize, log_table)
+                            - std::f32::consts::LOG2_E / (1.0 + right as f32)
+                    },
+                    if right == 0 {
+                        0.0
+                    } else {
+                        -(fast_log2_lookup(left as usize + 2, log_table)
+                            - fast_log2_lookup(right as usize, log_table)
+                            - std::f32::consts::LOG2_E / (1.0 + left as f32))
+                    },
+                ];
+                pending &= pending - 1;
+            }
+        }
     }
 
     fn merge_from(&mut self, other: &Self) {
@@ -381,6 +436,7 @@ pub(crate) struct ForwardIndex {
     /// allowed by the memory budget. Recursion divides this allowance between
     /// children without rounding non-power-of-two worker pools down.
     parallel_bisect_lanes: usize,
+    cache_gains: bool,
     /// True when the configured memory limit forced graph signal to be
     /// discarded. Callers must not report the resulting order as fully
     /// converged: a later pass with a larger budget may still improve it.
@@ -417,6 +473,10 @@ impl ForwardIndex {
             offsets,
             num_terms,
             parallel_bisect_lanes: lanes.max(1),
+            // The text caller retains additional plans/construction buffers
+            // outside this graph's accounting. It cannot safely admit the
+            // optional cache until it supplies a complete remaining budget.
+            cache_gains: false,
             budget_limited,
         }
     }
@@ -569,6 +629,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited: false,
         };
     }
@@ -602,6 +663,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited: true,
         };
     }
@@ -638,6 +700,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited: true,
         };
     };
@@ -686,6 +749,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited,
         };
     }
@@ -809,6 +873,12 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         offsets,
         num_terms: num_active_terms,
         parallel_bisect_lanes,
+        cache_gains: gain_cache_fits(
+            memory_budget_bytes,
+            non_degree_bytes,
+            num_active_terms,
+            parallel_bisect_lanes,
+        ),
         budget_limited,
     }
 }
@@ -831,6 +901,7 @@ pub(crate) fn build_forward_index_from_blocks(
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited: false,
         };
     }
@@ -862,6 +933,7 @@ pub(crate) fn build_forward_index_from_blocks(
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited: true,
         };
     }
@@ -885,6 +957,7 @@ pub(crate) fn build_forward_index_from_blocks(
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited: true,
         };
     };
@@ -920,6 +993,7 @@ pub(crate) fn build_forward_index_from_blocks(
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited,
         };
     }
@@ -995,6 +1069,12 @@ pub(crate) fn build_forward_index_from_blocks(
         offsets,
         num_terms,
         parallel_bisect_lanes,
+        cache_gains: gain_cache_fits(
+            memory_budget_bytes,
+            non_degree_bytes,
+            num_terms,
+            parallel_bisect_lanes,
+        ),
         budget_limited,
     }
 }
@@ -1830,16 +1910,17 @@ pub(crate) fn graph_bisection_with_progress(
     let degree_lanes = fwd.parallel_bisect_lanes.max(1);
     #[cfg(not(feature = "native"))]
     let degree_lanes = 1usize;
-    let log_table = build_log_table(4096);
+    let log_table = build_log_table(LOG_TABLE_SIZE);
     let progress = BpProgress::new(progress_label, n, fwd.total_postings(), depth, degree_lanes);
 
     log::debug!(
-        "BP graph_bisection: n={}, min_partition={}, max_iters={}, depth=~{}, time_budget={:?}",
+        "BP graph_bisection: n={}, min_partition={}, max_iters={}, depth=~{}, time_budget={:?}, gain_cache={}",
         n,
         effective_min_partition,
         max_iters,
         depth,
         budget.time_budget,
+        fwd.cache_gains,
     );
 
     #[cfg(feature = "native")]
@@ -1886,7 +1967,13 @@ pub(crate) fn graph_bisection_with_progress(
         let mut partitioned = vec![0u32; n];
         let mut ranked = vec![0usize; n];
         let mut degree_workspaces: Vec<TermDegrees> = (0..degree_lanes)
-            .map(|_| TermDegrees::new(fwd.num_terms))
+            .map(|_| {
+                let mut lane = TermDegrees::new(fwd.num_terms);
+                if fwd.cache_gains {
+                    lane.gain_cache = vec![[0.0; 2]; fwd.num_terms];
+                }
+                lane
+            })
             .collect();
         bisect_level_synchronized(
             &mut docs,
@@ -2330,7 +2417,7 @@ fn bisect_partition(
             docs,
             context.fwd,
             mid,
-            &degree_workspaces[0],
+            &mut degree_workspaces[0],
             context.log_table,
             gains,
             allow_inner_parallelism,
@@ -2471,13 +2558,28 @@ fn compute_gains(
     docs: &[u32],
     fwd: &ForwardIndex,
     mid: usize,
-    degrees: &TermDegrees,
+    degrees: &mut TermDegrees,
     log_table: &[f32],
     gains: &mut [f32],
     allow_inner_parallelism: bool,
 ) {
-    #[cfg(not(feature = "native"))]
-    let _ = allow_inner_parallelism;
+    degrees.refresh_gain_cache(log_table);
+    debug_assert_eq!(docs.len(), gains.len());
+    if !degrees.gain_cache.is_empty() {
+        // Dispatch once per refinement, keeping this small gather/reduction
+        // callback separate from the logarithmic fallback. This avoids its
+        // branch and large spill frame in sequential and Rayon leaf workers.
+        let cache = degrees.gain_cache.as_slice();
+        fill_gains(gains, allow_inner_parallelism, |i| {
+            let side = usize::from(i >= mid);
+            let mut gain = 0.0f32;
+            for &term in fwd.doc_terms(docs[i] as usize) {
+                gain += cache[term as usize][side];
+            }
+            gain
+        });
+        return;
+    }
 
     // Single coherent key: HIGH = belongs in the RIGHT half.
     // Left docs get +approx_one(from=left, to=right) — a misplaced left doc
@@ -2506,22 +2608,33 @@ fn compute_gains(
         g
     };
 
+    fill_gains(gains, allow_inner_parallelism, gain_for_doc);
+}
+
+fn fill_gains(
+    gains: &mut [f32],
+    allow_inner_parallelism: bool,
+    gain_for_doc: impl Fn(usize) -> f32 + FrequencyParallelSafe,
+) {
+    #[cfg(not(feature = "native"))]
+    let _ = allow_inner_parallelism;
+
     #[cfg(feature = "native")]
     {
-        if allow_inner_parallelism && docs.len() > 4096 {
+        if allow_inner_parallelism && gains.len() > 4096 {
             gains
                 .par_iter_mut()
                 .enumerate()
                 .for_each(|(i, gain)| *gain = gain_for_doc(i));
         } else {
-            for (i, gain) in gains.iter_mut().enumerate().take(docs.len()) {
+            for (i, gain) in gains.iter_mut().enumerate() {
                 *gain = gain_for_doc(i);
             }
         }
     }
     #[cfg(not(feature = "native"))]
     {
-        for (i, gain) in gains.iter_mut().enumerate().take(docs.len()) {
+        for (i, gain) in gains.iter_mut().enumerate() {
             *gain = gain_for_doc(i);
         }
     }
@@ -2549,6 +2662,9 @@ fn fast_log2_lookup(val: usize, table: &[f32]) -> f32 {
         (val as f32).log2()
     }
 }
+
+#[cfg(test)]
+mod gain_tests;
 
 #[cfg(test)]
 mod tests {
@@ -2710,6 +2826,7 @@ mod tests {
             offsets,
             num_terms: TERMS,
             parallel_bisect_lanes: 4,
+            cache_gains: false,
             budget_limited: false,
         };
         let docs: Vec<u32> = (0..N as u32)
@@ -2806,6 +2923,7 @@ mod tests {
             offsets,
             num_terms,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited: false,
         }
     }
@@ -2895,6 +3013,7 @@ mod tests {
             offsets,
             num_terms: TERMS,
             parallel_bisect_lanes: 8,
+            cache_gains: false,
             budget_limited: false,
         };
         let pool = rayon::ThreadPoolBuilder::new()
@@ -2932,6 +3051,7 @@ mod tests {
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
+            cache_gains: false,
             budget_limited: false,
         };
         let (perm, _) = graph_bisection(&fwd, 4, 20, BpBudget::full());

--- a/hermes-core/src/segment/builder/graph_bisection/gain_tests.rs
+++ b/hermes-core/src/segment/builder/graph_bisection/gain_tests.rs
@@ -1,0 +1,230 @@
+use super::*;
+
+// Preserve the original posting-by-posting arithmetic as a test oracle. Its
+// operation order matters: gain bits determine ties and the persisted order.
+fn reference_gains(
+    docs: &[u32],
+    fwd: &ForwardIndex,
+    mid: usize,
+    degrees: &TermDegrees,
+    log_table: &[f32],
+) -> Vec<f32> {
+    docs.iter()
+        .enumerate()
+        .map(|(i, &doc)| {
+            let in_left = i < mid;
+            let mut gain = 0.0f32;
+            for &term in fwd.doc_terms(doc as usize) {
+                let [left, right] = degrees.get(term as usize);
+                let (from, to) = if in_left {
+                    (left, right)
+                } else {
+                    (right, left)
+                };
+                let movement = fast_log2_lookup(to as usize + 2, log_table)
+                    - fast_log2_lookup(from as usize, log_table)
+                    - std::f32::consts::LOG2_E / (1.0 + to as f32);
+                gain += if in_left { movement } else { -movement };
+            }
+            gain
+        })
+        .collect()
+}
+
+fn fixture(n: usize, vocabulary: usize, width: usize, lanes: usize) -> ForwardIndex {
+    let mut terms = Vec::with_capacity(n * width);
+    let mut offsets = Vec::with_capacity(n + 1);
+    offsets.push(0);
+    let mut random = 0xc0ffee1234567890u64;
+    let mut row = Vec::with_capacity(width);
+    for doc in 0..n {
+        // Mixed popular and topic-local terms in a shuffled arrival order.
+        // Empty rows and uneven term counts also exercise the CSR boundaries.
+        if doc % 97 != 0 {
+            row.clear();
+            let topic = (doc * 7919) % 64;
+            for i in 0..width {
+                random ^= random << 13;
+                random ^= random >> 7;
+                random ^= random << 17;
+                let term = if i % 2 == 0 {
+                    random as usize % (vocabulary / 16).max(1)
+                } else {
+                    (topic * (vocabulary / 64) + random as usize % 64) % vocabulary
+                };
+                row.push(term as u32);
+            }
+            row.sort_unstable();
+            row.dedup();
+            terms.extend_from_slice(&row);
+        }
+        offsets.push(terms.len() as u64);
+    }
+    ForwardIndex {
+        terms,
+        offsets,
+        num_terms: vocabulary,
+        parallel_bisect_lanes: lanes,
+        cache_gains: true,
+        budget_limited: false,
+    }
+}
+
+#[test]
+fn gain_bits_preserve_half_direction_empty_rows_and_reused_degrees() {
+    let fwd = fixture(10_003, 257, 24, 1);
+    let mut docs: Vec<u32> = (0..fwd.num_docs() as u32).collect();
+    let log_table = build_log_table(4096);
+    let mut workspaces = [TermDegrees::new(fwd.num_terms)];
+    let mut gains = vec![0.0; docs.len()];
+    for mid in [1, 5001, 10_002] {
+        docs.rotate_left(31);
+        build_term_degrees(&docs, mid, &fwd, &mut workspaces, None);
+        let expected = reference_gains(&docs, &fwd, mid, &workspaces[0], &log_table);
+        for cached in [false, true] {
+            if cached {
+                workspaces[0]
+                    .gain_cache
+                    .resize(fwd.num_terms, [f32::NAN; 2]);
+            } else {
+                workspaces[0].gain_cache.clear();
+            }
+            for parallel in [false, true] {
+                compute_gains(
+                    &docs,
+                    &fwd,
+                    mid,
+                    &mut workspaces[0],
+                    &log_table,
+                    &mut gains,
+                    parallel,
+                );
+                assert_eq!(
+                    gains.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                    expected.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                    "mid={mid}, parallel={parallel}, cached={cached}",
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn gain_cache_requires_spare_memory_for_every_existing_lane() {
+    let terms = 130;
+    let lanes = 3;
+    let fixed = 20_000;
+    let required = fixed
+        + LOG_TABLE_SIZE * std::mem::size_of::<f32>()
+        + lanes * (term_degree_bytes(terms) + terms * 8 + std::mem::size_of::<TermDegrees>());
+    assert!(!gain_cache_fits(required - 1, fixed, terms, lanes));
+    assert!(gain_cache_fits(required, fixed, terms, lanes));
+    assert!(!gain_cache_fits(usize::MAX, fixed, usize::MAX, lanes));
+    assert!(!gain_cache_fits(usize::MAX, fixed, terms, usize::MAX));
+    assert!(!gain_cache_fits(usize::MAX, fixed, 0, lanes));
+}
+
+#[test]
+fn cached_gains_preserve_full_permutations_and_reuse_lane_storage() {
+    let mut fwd = fixture(2051, 1024, 24, 1);
+    fwd.cache_gains = false;
+    let direct = graph_bisection(&fwd, 32, 12, BpBudget::full());
+    fwd.cache_gains = true;
+    assert_eq!(graph_bisection(&fwd, 32, 12, BpBudget::full()), direct);
+
+    let docs: Vec<u32> = (0..fwd.num_docs() as u32).collect();
+    let mut degrees = [TermDegrees::new(fwd.num_terms)];
+    degrees[0].gain_cache = vec![[f32::NAN; 2]; fwd.num_terms];
+    let cache_ptr = degrees[0].gain_cache.as_ptr();
+    let logs = build_log_table(4096);
+    // Deep partitions omit most of the preceding partition's terms. A reused
+    // cache must read only freshly initialized degrees and current terms.
+    for subset in [&docs[..], &docs[10..43], &docs[900..911]] {
+        let mid = subset.len() / 2;
+        build_term_degrees(subset, mid, &fwd, &mut degrees, None);
+        let expected = reference_gains(subset, &fwd, mid, &degrees[0], &logs);
+        let mut actual = vec![0.0; subset.len()];
+        compute_gains(
+            subset,
+            &fwd,
+            mid,
+            &mut degrees[0],
+            &logs,
+            &mut actual,
+            false,
+        );
+        assert_eq!(
+            actual.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+            expected.iter().map(|v| v.to_bits()).collect::<Vec<_>>()
+        );
+        assert_eq!(degrees[0].gain_cache.as_ptr(), cache_ptr);
+    }
+}
+
+/// Run the same fixture/binary separately from compilers and other benchmarks.
+/// Optional HERMES_BP_EVIDENCE_DIR captures complete little-endian permutations
+/// for byte comparison between revisions, outside the timed work.
+#[cfg(feature = "native")]
+#[test]
+#[ignore]
+fn bench_bp_gain_review() {
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(4)
+        .build()
+        .unwrap();
+    let output = std::env::var_os("HERMES_BP_EVIDENCE_DIR").map(std::path::PathBuf::from);
+    if let Some(path) = &output {
+        std::fs::create_dir_all(path).unwrap();
+    }
+    for (name, n, vocabulary, width, min_partition) in [
+        ("mixed", 100_003, 16_384, 48, 32),
+        ("sparse", 100_003, 131_072, 4, 32),
+        ("coarse", 1_048_577, 1024, 12, 524_288),
+    ] {
+        let fwd = fixture(n, vocabulary, width, 4);
+        let mut expected = None;
+        let mut times = Vec::new();
+        for round in 0..4 {
+            let started = std::time::Instant::now();
+            let (order, converged) = pool.install(|| {
+                graph_bisection_with_progress(
+                    &fwd,
+                    min_partition,
+                    12,
+                    BpBudget::full(),
+                    None,
+                    BpProgressLabel {
+                        index: "review",
+                        field: name,
+                        entity_kind: "records",
+                    },
+                )
+            });
+            let elapsed = started.elapsed();
+            assert!(converged);
+            if round > 0 {
+                times.push(elapsed.as_secs_f64() * 1000.0);
+            }
+            if let Some(prior) = &expected {
+                assert_eq!(&order, prior);
+            } else {
+                if let Some(path) = &output {
+                    let bytes: Vec<_> = order.iter().flat_map(|id| id.to_le_bytes()).collect();
+                    std::fs::write(path.join(format!("{name}.bin")), bytes).unwrap();
+                }
+                let mut sorted = order.clone();
+                sorted.sort_unstable();
+                assert!(sorted.iter().enumerate().all(|(i, &id)| i == id as usize));
+                expected = Some(order);
+            }
+        }
+        times.sort_by(f64::total_cmp);
+        println!(
+            "BP {name}: docs={n} postings={} terms={vocabulary} lanes=4 median_ms={:.3} rounds_ms={times:?} degree_bytes_per_lane={} gain_cache_bytes={}",
+            fwd.total_postings(),
+            times[1],
+            term_degree_bytes(vocabulary),
+            vocabulary * 8 * 4,
+        );
+    }
+}


### PR DESCRIPTION
BP refinement previously recomputed logarithms and division for every posting. Cache the two signed contributions once per active term and refinement, then sum them in the original document-term order. The cache uses only spare graph memory after term selection and degree-lane admission; tight budgets and the text adapter retain direct computation.

The accompanying review records the algorithm, allocation and dispatch findings, measured evidence, and remaining text memory/convergence issues. Formats, selection, scheduling, and publication behavior are unchanged.

Measured fixed-seed, four-thread synthetic whole-BP speedups (three paired process runs, same compiler/host/flags within each comparison):

| Fixture | Apple M4 | Xeon 8581C, default x86 | Xeon 8581C, AVX2 |
| --- | ---: | ---: | ---: |
| Mixed, full depth | 1.48–1.57× | 1.70–1.76× | 1.73–1.75× |
| Sparse control, full depth | 1.11–1.12× | 1.20–1.23× | 1.22–1.24× |
| Coarse, popular terms | 2.26–2.33× | 2.81–2.93× | 2.85–2.89× |

Linux peak process RSS stayed around 95–96 MiB. Exact added cache payloads were 512 KiB, 4 MiB and 32 KiB respectively, plus descriptors, within the existing budget. These are synthetic BP measurements, not production or cold-storage throughput claims.

Validation:

- `python3 scripts/check_search.py check`: passed, including native-without-sync compilation.
- Default x86 and AVX2 release builds: each passed 1,299 core tests, with 13 ignored; the ignored BP and public-entry comparison fixtures were then run explicitly.
- Complete permutations matched before/after, across x86 flags and repetitions. The complete sparse file and query-score bits matched before/after and also matched M4. The coarse permutation already differed between Mac and Linux before this change; no cross-platform permutation guarantee is introduced.
- Portable library compilation, WASM build and four JS tests, docs checks, and focused gain regressions passed.
- [PR CI](https://github.com/SpaceFrontiers/hermes/actions/runs/33974512151) passed all ten jobs, including workspace tests and release build, API documentation, real-server broker tests, and the native-without-sync and CUDA compile boundaries.

The optional portable Rust unit-test attempt remains blocked by existing native-only imports in other test modules. The local `full` harness was not run; PR CI separately passed API documentation and real-server broker tests. Production cold-I/O measurements remain unmeasured. Full details and reproduction instructions are in `docs/reordering-performance-review.md`.
