### PR TITLE
Fix index deletion and reorder stalls; finish BMP format and fusion filters

### DIFF
--- a/docs/bmp-forward-index.md
+++ b/docs/bmp-forward-index.md
@@ -1,38 +1,43 @@
 # BMP forward values and candidate scoring
 
-Status: implemented, 2026-09-05. L1 remains opt-in.
+Status: current-format implementation complete. Deploy against rebuilt indexes
+or indexes whose BMP blobs already use the current envelope. L1 remains opt-in.
 
-BMP owns both sparse retrieval and exact stored sparse values. L1 must score a
-logical `(document, ordinal)` without an inverse physical-ID sidecar or a scan
-of the corpus. BP should read these same values when building its graph and
-rewriting records. The quantized impacts, pruning and query quantization remain
-identical to inverted BMP scoring; this is not a second sparse scoring model.
+BMP owns sparse retrieval and exact stored sparse values. L1 addresses a logical
+`(document, ordinal)` without an inverse physical-ID sidecar or a corpus scan.
+BP reads the same values when building its graph and rewriting records. The
+quantized impacts, pruning and query quantization match inverted BMP scoring.
 
-## V20 representation
+## One representation with optional storage
 
-The V19 block payload, offset table, grids and physical document maps keep their
-encodings. V20 appends a forward section before the existing 80-byte footer and
-uses magic `BMPA`. The section contains:
+Every BMP blob uses the current `BMPA` envelope: adaptive inverted blocks, their
+offset table, compressed pruning grids, physical document maps, a forward-storage
+section, and the 80-byte footer. Forward storage changes that section, never the
+format version. Already-published forward-enabled bytes remain unchanged.
+
+An enabled section contains:
 
 - Quantized vector payload in ascending `(document, ordinal)` order. Each entry
-  is dimension `u32 LE` followed by impact `u8`, with nondecreasing dims. Repeated dimensions retain every impact, preserving
-  the existing additive posting semantics.
+  is dimension `u32 LE` followed by impact `u8`, with nondecreasing dimensions.
+  Repeated dimensions retain every impact, preserving additive posting semantics.
 - A sorted directory: document `u32`, ordinal `u16`, reserved zero `u16`, and
   payload-relative byte offset `u64` per vector.
-- A 16-byte trailer: vector count `u32`, reserved zero `u32`, payload bytes `u64`.
-  Unknown reserved bits are rejected. The payload length terminates the final
-  vector. The retired search prototype's uniqueness certificate is not part of
-  this format; experimental blobs carrying it must be rebuilt.
+- A 16-byte trailer: vector count `u32`, flags `u32 = 0`, payload bytes `u64`.
+  The payload length terminates the final vector.
 
-Space overhead is 5 bytes per retained posting, 16 bytes per vector, and 16
-bytes per field. The forward section is file-backed and evictable; opening
-validates compact directory bounds/order and scoring validates selected payloads.
-Neither forward directory nor payload is pinned; both remain evictable. Lookup uses binary search;
-scoring visits only nominated vectors and intersects sorted query dimensions.
+A disabled section consists of exactly one 16-byte trailer: zero vector count,
+flags `u32 = 1`, and zero payload length. Unknown flags, missing trailers, hidden
+payloads, invalid counts and invalid empty blobs are errors. Older BMP envelopes
+are rejected before payload access. Hermes 1.8.125 can migrate old offline
+indexes before they are opened by a current-format-only server.
 
-## Build, merge, reorder and compatibility
+Enabled storage costs 5 bytes per retained posting, 16 bytes per vector, and 16
+bytes per field. Disabled storage costs 16 bytes per field. The directory and
+payload stay file-backed and evictable; neither is pinned. Opening validates
+compact directory bounds and order; scoring validates the selected vectors.
+Lookup uses binary search and intersects only nominated vectors with query terms.
 
-### Optional storage
+## Configuration and scoring
 
 The per-field `bmp_forward_index` setting defaults to `true`. In SDL:
 
@@ -40,58 +45,61 @@ The per-field `bmp_forward_index` setting defaults to `true`. In SDL:
 field sparse: sparse_vector [indexed<format: bmp, dims: 105879, bmp_forward_index: false>]
 ```
 
-With storage disabled, ingestion emits the existing V19 representation and skips
-forward-payload construction. Ordinary merges and both BP granularities omit the
-forward section, including when their sources contain it. The inverted payload
-and scoring semantics are preserved. Existing forward values may still accelerate
-BP's graph/rewrite reads; disabled storage never triggers a legacy forward upgrade.
-BP still builds its bounded transient graph from inverted postings when needed.
-This option changes replacement output, not immutable live source files. A field
-excluded from an explicit reorder remains a byte-identical copy, as before.
+The setting is persisted in schema JSON and reported in server SDL. With storage
+disabled, ingestion, ordinary merges and both BP granularities omit the values
+and write the disabled marker. A field excluded from explicit reorder remains
+a byte-identical copy. A setting changes replacement output, not immutable live
+source files.
 
-The setting is persisted in schema JSON and reported in server SDL. BMP search
-always uses inverted scoring and has no forward-completion option. L1 candidate
-backfill and BP use stored forward values whenever present, without a dispatch
-heuristic or separate enable switch.
-Enabling storage for existing V19 data requires explicit reorder/rebuild; ordinary
-merge never synthesizes forward values. With storage enabled, mixed V19/V20 copy
-merges still require an explicit upgrade. With storage disabled, both source
-versions can copy their compatible inverted representations into V19 output.
+BMP search always scores inverted blocks. L1 backfill and record BP use stored
+forward values whenever present, without a heuristic or another enable switch.
+When values are absent, BP builds its bounded transient graph from inverted
+postings. L1 can locate candidates in a logically ordered document map and probe
+only their blocks and query terms. An unordered map without forward values
+cannot backfill missing scores; it fails with actionable guidance. It never
+turns an unsupported lookup into a missing-value default.
 
-L1 can backfill V19 by locating candidates in a logically ordered document map,
-then probing only their blocks and query terms. After BP makes that map unordered,
-missing-score backfill requires stored forward values; it fails with actionable
-guidance rather than scanning the corpus or substituting a missing default for
-an unsupported lookup. `backfill: false` still uses organic scores and learned
-missing defaults. Full-text and sparse MaxScore backfill use their own postings
-readers and are unaffected by this BMP-only storage option.
+`backfill: false` still uses organic scores and learned missing defaults.
+Full-text and sparse MaxScore backfill use their own postings readers and are
+unaffected by this BMP storage option.
+
+## Build, merge and option transitions
 
 Ingestion emits the same retained quantized entries as the inverted builder.
-It keeps the already-admitted per-dimension input until forward output, uses a
-k-way cursor heap over dimensions and an 8-byte offset per retained vector,
-and does not build another posting-sized heap representation. Peak accounting
-includes input postings plus grids during inverted output, then input postings
-plus offsets during forward output. This increases input lifetime, not its size.
-Ordinary V20 merge concatenates payload bytes and streams directory entries,
-adjusting document IDs and byte offsets with bounded scratch. BP changes only
-physical inverted order, so existing forward payloads also copy through record
-and block reorder without decoding or re-quantizing them.
+It retains the already-admitted per-dimension input through forward output,
+uses a k-way cursor heap over dimensions and an 8-byte offset per retained
+vector, and never builds another posting-sized heap representation. Peak
+accounting includes input postings plus grids during inverted output, then
+input postings plus offsets during forward output.
 
-V19 remains readable for retrieval. With forward storage enabled, explicit reorder can construct its missing
-forward values under the existing reorder memory budget, using a sorted bounded
-physical permutation and existing block decoders. This migration is allowed to
-decode; ordinary merge is not. All-legacy ordinary merges preserve V19, and with
-storage enabled mixed V19/V20 ordinary merges fail with migration guidance instead of discarding
-capability or reconstructing values implicitly. Unknown versions fail loudly.
+Ordinary merge concatenates existing forward payload bytes and streams directory
+entries, adjusting only document IDs and byte offsets with bounded scratch. BP
+changes physical inverted order, so both record and block reorder also copy
+existing forward payloads without decoding or re-quantizing them.
+
+Copy-only merge never materializes absent values. With storage enabled, mixed
+presence requires explicit reorder with a uniform storage policy. With storage
+disabled, compatible inverted representations can be copied regardless of the
+source's storage setting. All-absent copy inputs retain the disabled marker.
+
+Explicitly enabling storage later uses the same current envelope. Reorder can
+materialize its absent values under the existing memory budget, using a sorted
+physical permutation and block decoders. It admits 12 bytes per real vector of
+directory scratch and streams payload output. Existing forward payloads always
+use the copy path. There is no older-format reader, writer or merge dispatch.
+
 Generation claims, cold output, fsync, publication and cleanup remain owned by
-the existing sparse segment lifecycle. No new sidecar or preparation RPC exists.
+the existing sparse segment lifecycle. No sidecar or second preparation protocol
+is introduced.
 
 ## Validation and cost evidence
 
-Required evidence: quantized forward/inverted score equality, missing values and
-ordinals, payload byte identity across merge and both BP modes, V19 reopen and
-explicit migration, incompatible/corrupt input rejection, cancellation and
-writer failure. Compare BP graph and record rewrite against the existing path.
-Measure storage bytes, build and merge working memory, candidate scoring and BP
-with the same fixtures/compiler before claiming a speedup. Record results in
-[the performance review](search-performance-review.md).
+Regression coverage includes enabled byte identity, old-envelope rejection,
+strict optional/empty-section validation, quantized forward/inverted equality,
+missing values and ordinals, copy merge and both BP modes, bounded option
+transitions, cancellation and partial writer failure. Sync, native async and
+WASM use the same format gate.
+
+Compare BP graph and record rewrite against the inverted path with the same
+fixture, compiler and machine. Storage, working memory and scoring evidence are
+recorded in [the performance review](search-performance-review.md).

--- a/docs/candidate-rescoring.md
+++ b/docs/candidate-rescoring.md
@@ -92,6 +92,13 @@ features or independent votes. Initial L1 branches support one-field scoring
 queries and SHOULD/Boost compositions; unsupported eligibility expressions
 inside a scoring branch fail with guidance to use the common filter.
 
+Exclusion-only common filters support both `Boolean(must_not: [...])` and
+`Boolean(must: [AllQuery], must_not: [...])`. `AllQuery` includes documents
+with missing metadata and uses a constant score of one when searched directly;
+common filters never contribute scoring features. Its scorer uses constant
+memory and shares the document-universe cursor with Boolean exclusion. Common
+eligibility uses the existing bounded bitmap, with no storage or wire change.
+
 A branch omitted from weights still nominates and exports its feature, but
 contributes zero. Unknown coefficient/transform names, duplicate or empty branch
 names, all-zero models and non-finite values are errors. A schema field without

--- a/docs/candidate-rescoring.md
+++ b/docs/candidate-rescoring.md
@@ -222,11 +222,11 @@ BM25/phrase frequency and length-normalization code and dense/binary SIMD
 kernels. Sparse scoring probes the stored quantized impacts for every retained
 query dimension, even when that dimension did not nominate the candidate.
 
-Dense flat storage already supports logical document/ordinal lookup. V20 BMP
+Dense flat storage already supports logical document/ordinal lookup. Current BMP
 uses quantized forward vectors inside `.sparse`; CHNK V3 uses addressed chunk
 metadata inside `.chunks`. Ordered legacy maps can be searched directly;
-reordered V19 BMP and V1/V2 text maps require explicit Reorder before their
-missing cells can be backfilled. BMP storage is optional per field via
+Unordered BMP maps without forward storage and unordered text maps require
+explicit Reorder before their missing cells can be backfilled. BMP storage is optional per field via
 `bmp_forward_index` (default true). With it disabled, ordered BMP maps locate
 candidates by binary search and score their query-term postings in selected
 blocks. BP-reordered BMP maps need this setting enabled and explicit
@@ -400,5 +400,15 @@ The serving contract is `candidate_scoring_version = 2`, with response markers
 including defaults, and rejects old or mixed ranking markers. RRF candidate
 export retains `fusion_candidates_v1`; global RRF retains `global_rrf_v1`.
 Deploy server and broker support together before activating L1; there is no
-mixed-version fallback to rank fusion. Stored V20 BMP and CHNK V3 generations
+mixed-version fallback to rank fusion. Current BMP and CHNK V3 generations
 require readers that understand these formats.
+
+### Exclusion-only common filters
+
+A nonempty Boolean `must_not` list with no positive clauses denotes every
+segment document except the excluded matches. An entirely empty Boolean still
+matches nothing. Fusion applies this eligibility before each branch selects
+its candidates; exclusions create neither scores nor passage ordinals. Native
+indexed terms materialize the complement in the bounded document bitmap,
+including when an excluded term is absent. The async/portable scorer streams
+the same complement without an all-document result heap.

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -836,3 +836,64 @@ Validation:
   complete runs then passed. Production logging is unchanged.
 
 No new search-latency or throughput claim is made by this cleanup.
+
+## Deletion and maintenance admission (2026-09-06)
+
+Production recreation exposed three lifecycle ordering bugs. Deletion evicted
+the registry handle but did not stop the manager before waiting for issued
+handles, allowing old Reorder work to retain maintenance capacity. A handler
+that already held the index could then wait for its writer behind the delete
+lease, forming a second handle-drain cycle. Registry open also swept alleged
+orphans before acquiring the OS writer lock, which could delete another
+process's unpublished output. Behavior-named regressions reproduced all three.
+
+Deletion now stops manager admission and signals cancellation before the handle
+drain; reopening checks the deletion marker before waiting for the lease. Open
+uses the existing locked writer opener before loading metadata or cleaning up;
+the returned index and writer share one segment manager. This also closes the
+stale-snapshot window if another writer finishes during open. Actual blocking work, publication
+and deferred deletion still drain before directory removal.
+
+Reorder's shared-writer entry point commits admitted input, releases the writer
+lock during maintenance, and uses the existing manager and primary-key refresh
+path. Its retained writer Arc preserves the OS lock. Manual BP now uses the
+configured background CPU pool. Tests hold all BP capacity while committing
+new documents, preserve committed and pending primary keys across replacement,
+and cancel queued maintenance without releasing the other index's permit.
+
+The observed fresh-index stall was maintenance waiting, not multi-minute BMP
+encoding: new-field BP/rewrite phases logged about 0.2–0.7 seconds while
+publication retried 120-second timeouts. After recovery/recreation, all three
+documents shards were committing again (94,442 documents at 21:09 UTC). These
+are incident observations, not a controlled throughput benchmark.
+
+Focused regression evidence is in the parent workspace's
+`.context/lifecycle-{delete,reopen,writer-owner}-red.log`,
+`.context/lifecycle-maintenance-tests.log` and
+`.context/lifecycle-registry-tests.log`. The lifecycle-only `check` and all eight
+`full` stages passed (1,341 core, 68 server, 50 broker unit, 13 broker integration
+and two real-server tests), as did native-without-sync maintenance regressions.
+One initial broad run hit a mock broker's ephemeral-port collision; rerunning
+with `RUST_TEST_THREADS=1` passed without changing production or test behavior.
+
+The API also uses an explicit `AllQuery` inside exclusion filters. The existing
+wire variant now maps to a core query sharing the all-document cursor and
+bounded bitmap. Regressions cover both common-filter spellings in all fusion
+modes, missing metadata, bitmap tail bounds and forward-only cursor seeking.
+The wire conversion regression first failed with the unimplemented-query error.
+Final combined validation passed:
+
+- `check`: `.context/search-harness/20260905T213650.334212Z-check/`.
+- All eight `full` stages:
+  `.context/search-harness/20260905T213942.454422Z-full/` (1,344 core tests,
+  17 manual experiments ignored, 70 server, 50 broker unit, 13 broker integration
+  and two real-server RPC tests).
+- Native without sync: both match-all regressions and all three maintenance
+  regressions passed. WASM release build and all five runtime tests passed.
+  Logs: parent workspace `.context/final-engine2-{async,wasm-build,wasm-test}.log`.
+- The lock-before-metadata regression failed before the final opener change;
+  both registry ownership regressions then passed. Red evidence:
+  `.context/lifecycle-open-snapshot-red.log` in the parent workspace.
+  An interim full run was interrupted to make that final change; its process
+  group cancellation reported an OS error, so only the complete final run above
+  is used as validation evidence.

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -794,3 +794,45 @@ Final validation:
 The earlier production-corpus, controlled cold-storage, concurrent-load and x86
 runtime performance limitations still apply; this storage option makes no new
 performance claim or change to BMP search behavior.
+
+## Current BMP format and exclusion filters (2026-09-05 follow-up)
+
+BMP now has one accepted/emitted envelope. Optional forward storage is an
+explicit section with enabled or disabled state; disabling it no longer writes
+an older format. The published enabled representation is unchanged. Disabled
+fields add a 16-byte marker. Older readers/writers and version-based merge
+selection are removed. The earlier V19/V20 comparisons above are historical
+measurements from the migration release, not current compatibility guarantees.
+Deploy against rebuilt indexes or after every live BMP blob passes the current
+format audit. The operator chose a fresh rebuild instead of waiting for the
+one-time forward materialization and BP pass over existing production segments.
+
+The common fusion filter exposed an exclusion-only Boolean bug: no positive
+clause produced an empty scorer and an unsupported bitmap, so small segments
+returned nothing and large segments could reject the materialization fallback.
+The Boolean owner now supplies a neutral document universe, subtracts excluded
+matches and preserves entirely empty Boolean semantics. Absent indexed exclusion
+terms produce complete empty bitmaps instead of an unsupported result. Native
+bitmap materialization is O(segment words + exclusion postings), with the same
+fusion bitmap budget; async Boolean scoring streams the complement. Regressions
+cover pre-selection exclusion in RRF, L1 and feature export, cross-partition
+exclusions, absent terms, tail-bit bounds and exhausted scorers.
+
+Validation:
+
+- Required `check` passed: `.context/search-harness/20260905T204939.904681Z-check/`.
+- All eight `full` stages passed:
+  `.context/search-harness/20260905T205133.222273Z-full/`, including 1,339 core
+  unit tests (17 manual experiments ignored), 65 server tests, 50 broker unit
+  tests, 13 broker integration tests, and both real-server RPC tests.
+- Native without sync passed the exclusion regression and all 11 selected
+  forward-storage tests. WASM release build and all five runtime tests passed.
+  Supporting logs are in the parent workspace's
+  `.context/bmp-current-{async,wasm-build,wasm-test}.log`.
+- The enabled fixture is byte-identical to release 1.8.125: 12,713 bytes,
+  FNV-1a-64 `5ccfbcdae3690623`. Disabled storage preserves every inverted byte.
+- The first broad run exposed an existing log-capture race with unrelated
+  parallel tests. The capture now accepts only its owning test thread; both
+  complete runs then passed. Production logging is unchanged.
+
+No new search-latency or throughput claim is made by this cleanup.

--- a/docs/segment-lifecycle.md
+++ b/docs/segment-lifecycle.md
@@ -92,7 +92,10 @@ Index deletion follows this order:
 
 1. Acquire the per-index registry lease and create `.deleting`, serializing
    against open/create.
-2. Stop accepting new lifecycle claims.
+2. Stop accepting new lifecycle claims and signal maintenance cancellation,
+   before waiting for issued handles. A Reorder can hold an index handle while
+   waiting for shared BP capacity; waiting for that handle first prevents the
+   cancellation that would release it.
 3. Drain search and writer handles already issued by the registry.
 4. Signal and join indexing OS threads.
 5. Drop unpublished prepared segments and cached readers/writer handles.
@@ -104,6 +107,21 @@ installed, so client cancellation does not abandon a live writer. If the
 process exits during step 7, the `.deleting` marker causes the remaining
 directory to be removed on the next server startup.
 
+An evicted index's marker is checked before waiting for its open/delete lease,
+and again after acquiring the lease. A request that obtained an index handle
+just before deletion must fail its later writer lookup promptly; it cannot wait
+for deletion while retaining a handle that deletion needs to drain.
+
+Manual Reorder commits the admitted indexing generation while holding the
+writer lock, then releases that lock before waiting for maintenance capacity or
+rewriting segments. Core retains the shared writer handle and uses the existing
+segment claims, publication, snapshot refresh and primary-key refresh path.
+Manual BP uses the same bounded CPU pool as background maintenance.
+Concurrent ingestion can publish new segments while the bounded maintenance
+snapshot is processed. Deletion still drains the operation before unlinking its
+files; neither a client timeout nor cancellation is evidence that blocking work
+has stopped.
+
 ## Orphans versus corruption
 
 An orphan is a segment ID absent from metadata, active operations, and the
@@ -111,6 +129,13 @@ reader/deletion tracker. Exclusive writer open and the background optimizer may
 sweep it. The sweep deletes every discovered path belonging to that ID,
 including unknown legacy or partial suffixes, and safely ignores malformed
 names. Read-only `Index::open` does not mutate the directory.
+
+Registry open uses core's locked writer opener: it acquires the OS single-writer
+lock before reading metadata or sweeping crash leftovers. The returned index
+and writer share that same segment manager, so there is no stale pre-lock
+metadata snapshot or second lifecycle owner.
+Its per-name mutex serializes callers within one server process; it cannot prove
+that another process has stopped producing files in the same directory.
 
 A missing file for a **metadata-live** segment is not an orphan. Normal cleanup
 must never make the metadata internally consistent by silently dropping its

--- a/hermes-broker/tests/e2e_real_server.rs
+++ b/hermes-broker/tests/e2e_real_server.rs
@@ -304,7 +304,7 @@ async fn broker_routes_real_hermes_servers() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs the hermes-server binary; see module docs"]
-async fn partitioned_fusion_collects_text_stats_from_real_servers() {
+async fn partitioned_fusion_uses_global_text_stats_and_exclusion_filters() {
     let server_a = spawn_server();
     let server_b = spawn_server();
     wait_server_ready(&server_a.addr).await;
@@ -481,6 +481,47 @@ async fn partitioned_fusion_collects_text_stats_from_real_servers() {
             raw.document["topic"],
             original.candidate_scores.as_ref().unwrap().document["topic"],
             "organic scores are preserved across backfill settings"
+        );
+    }
+    for (excluded, expected) in [("doc-1", "doc-2"), ("doc-2", "doc-1"), ("absent", "doc-2")] {
+        let mut filtered = request.clone();
+        filtered.limit = 1;
+        let Some(query::Query::Fusion(fusion)) = filtered.query.as_mut().unwrap().query.as_mut()
+        else {
+            unreachable!()
+        };
+        fusion.candidate_depth = 1;
+        fusion.filters = vec![Query {
+            query: Some(query::Query::Boolean(BooleanQuery {
+                must_not: vec![Query {
+                    query: Some(query::Query::Term(TermQuery {
+                        field: "id".into(),
+                        term: excluded.into(),
+                        ..Default::default()
+                    })),
+                }],
+                ..Default::default()
+            })),
+        }];
+        let result = broker_search_client(&broker)
+            .await
+            .search(filtered)
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(result.hits.len(), 1);
+        assert_eq!(
+            result.hits[0].fields["id"].values[0].value,
+            Some(field_value::Value::Text(expected.into()))
+        );
+        assert_eq!(
+            result.hits[0]
+                .candidate_scores
+                .as_ref()
+                .unwrap()
+                .document
+                .len(),
+            2
         );
     }
     let mut export = request;

--- a/hermes-core/src/index/mod.rs
+++ b/hermes-core/src/index/mod.rs
@@ -684,6 +684,31 @@ impl<D: crate::directories::DirectoryWriter + 'static> Index<D> {
         })
     }
 
+    /// Open a search index and its sole writer under one lifecycle owner.
+    ///
+    /// The writer lock precedes metadata loading and crash cleanup. Use this
+    /// when opening for mutation; `open` remains a read-only operation.
+    pub async fn open_with_writer(
+        directory: D,
+        config: IndexConfig,
+    ) -> Result<(Self, IndexWriter<D>)> {
+        let search_resources = searcher::SearcherResources::new(
+            config.term_cache_blocks,
+            config.store_cache_budget_bytes,
+            config.num_threads,
+            config.bmp_io_concurrency,
+        )?;
+        let writer = IndexWriter::open(directory, config.clone()).await?;
+        let index = Self {
+            directory: Arc::clone(&writer.directory),
+            config,
+            search_resources,
+            segment_manager: Arc::clone(writer.segment_manager()),
+            cached_reader: tokio::sync::OnceCell::new(),
+        };
+        Ok((index, writer))
+    }
+
     /// Get the schema
     pub fn schema(&self) -> Arc<Schema> {
         self.schema_arc()

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3756,7 +3756,7 @@ async fn bench_reorder_review_bytes() {
 #[tokio::test]
 async fn test_bmp_block_posting_overflow_256() {
     // 256 docs × 301 dims each → 77,056 postings in block 0 (> u16::MAX).
-    // The V19 adaptive payload exceeds its 15-bit narrow-offset range, forcing
+    // The adaptive payload exceeds its 15-bit narrow-offset range, forcing
     // the u32-wide fallback. Needle dims sort after the shared dense mass and
     // exercise terms near the end of that wide payload.
     let config = SparseVectorConfig {

--- a/hermes-core/src/index/tests/boolean.rs
+++ b/hermes-core/src/index/tests/boolean.rs
@@ -1289,3 +1289,62 @@ async fn test_prefix_query_matches_prefix_of_smallest_term() {
         .unwrap();
     assert!(none.hits.is_empty());
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exclusion_only_boolean_filters_match_the_remaining_documents() {
+    use crate::query::{FilteredQuery, Query};
+    use std::sync::Arc;
+
+    let (index, content, _, _) = create_boolean_test_index().await;
+    let exclude_self = BooleanQuery::new().must_not(TermQuery::text(content, "doc0"));
+    let result = index.search(&exclude_self, 100).await.unwrap();
+    assert_eq!(result.hits.len(), 99);
+    assert!(result.hits.iter().all(|hit| hit.address.doc_id != 0));
+    assert!(
+        index
+            .search(&BooleanQuery::new(), 100)
+            .await
+            .unwrap()
+            .hits
+            .is_empty()
+    );
+
+    let filter = FilteredQuery::new(
+        Arc::new(PrefixQuery::new(content, "doc")),
+        vec![Arc::new(exclude_self.clone())],
+    );
+    let result = index.search(&filter, 1).await.unwrap();
+    assert_eq!(result.hits.len(), 1);
+    assert_ne!(result.hits[0].address.doc_id, 0);
+
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let segment = &searcher.segment_readers()[0];
+    assert_eq!(exclude_self.count_estimate(segment).await.unwrap(), 100);
+    // Drive the async stream explicitly even in a sync-enabled build.
+    let mut scorer = exclude_self.scorer(segment, 100).await.unwrap();
+    let mut docs = Vec::new();
+    while scorer.doc() != crate::TERMINATED {
+        docs.push(scorer.doc());
+        scorer.advance();
+    }
+    assert_eq!(docs, (1..100).collect::<Vec<_>>());
+    assert_eq!(scorer.seek(crate::TERMINATED), crate::TERMINATED);
+    assert_eq!(scorer.advance(), crate::TERMINATED);
+
+    #[cfg(feature = "sync")]
+    {
+        let bits = exclude_self
+            .as_doc_bitset(segment)
+            .expect("exclusions must materialize without a corpus-sized top-k fallback");
+        assert_eq!(bits.count(), 99);
+        assert!(!bits.contains(0));
+        assert_eq!(bits.next_set_bit(100), None);
+        let no_match = BooleanQuery::new().must_not(TermQuery::text(content, "absent"));
+        let bits = no_match
+            .as_doc_bitset(segment)
+            .expect("an absent exclusion is a complete filter");
+        assert_eq!(bits.count(), 100);
+        assert_eq!(bits.next_set_bit(100), None);
+    }
+}

--- a/hermes-core/src/index/tests/maintenance.rs
+++ b/hermes-core/src/index/tests/maintenance.rs
@@ -1,0 +1,138 @@
+use crate::directories::RamDirectory;
+use crate::index::{Index, IndexConfig, IndexWriter, ReorderConcurrencyGate, ReorderPriority};
+use crate::{Document, Error, SchemaBuilder};
+use std::sync::Arc;
+use std::time::Duration;
+
+async fn reorder_waiting_for_capacity(cancel: bool) {
+    let gate = Arc::new(ReorderConcurrencyGate::new(1));
+    let occupied = gate.acquire(ReorderPriority::Optimizer).await.unwrap();
+    let mut schema = SchemaBuilder::default();
+    let id = schema.add_text_field("id", true, true);
+    schema.set_fast(id, true);
+    schema.set_primary_key(id);
+    let index = Index::create(
+        RamDirectory::new(),
+        schema.build(),
+        IndexConfig {
+            num_indexing_threads: 1,
+            merge_policy: Box::new(crate::merge::NoMergePolicy),
+            background_reorder_permits: gate,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let mut initial_writer = index.writer();
+    initial_writer.init_primary_key_dedup().await.unwrap();
+    let document = |key: &str| {
+        let mut doc = Document::new();
+        doc.add_text(id, key);
+        doc
+    };
+    initial_writer.add_document(document("first")).unwrap();
+    let writer = Arc::new(tokio::sync::RwLock::new(initial_writer));
+    let snapshot_ready = Arc::new(tokio::sync::Notify::new());
+    let operation = {
+        let writer = Arc::clone(&writer);
+        let ready = Arc::clone(&snapshot_ready);
+        tokio::spawn(async move {
+            IndexWriter::reorder_with_shared_writer(&writer, move || {
+                ready.notify_one();
+                std::future::ready(Ok(()))
+            })
+            .await
+        })
+    };
+    tokio::time::timeout(Duration::from_secs(5), snapshot_ready.notified())
+        .await
+        .expect("reorder did not commit and capture its snapshot");
+    assert!(!operation.is_finished(), "maintenance gate was bypassed");
+
+    if cancel {
+        // Deletion signals this before waiting for the RPC's issued handles.
+        // Cancellation must wake the queued operation even while the other
+        // index retains all shared maintenance capacity.
+        index.segment_manager().begin_shutdown();
+        let result = tokio::time::timeout(Duration::from_secs(2), operation)
+            .await
+            .expect("maintenance cancellation waited for another index's BP pass")
+            .unwrap();
+        assert!(matches!(result, Err(Error::IndexClosed)));
+        drop(occupied);
+    } else {
+        let mut live_writer = tokio::time::timeout(Duration::from_secs(2), writer.write())
+            .await
+            .expect("queued maintenance retained the ingestion writer lock");
+        live_writer.add_document(document("second")).unwrap();
+        live_writer.commit().await.unwrap();
+        live_writer.add_document(document("pending")).unwrap();
+        drop(live_writer);
+        assert_eq!(index.num_docs().await.unwrap(), 2);
+        assert!(!operation.is_finished());
+
+        drop(occupied);
+        tokio::time::timeout(Duration::from_secs(5), operation)
+            .await
+            .expect("reorder did not finish after capacity became available")
+            .unwrap()
+            .unwrap();
+        let mut live_writer = writer.write().await;
+        for key in ["first", "second", "pending"] {
+            assert!(matches!(
+                live_writer.add_document(document(key)),
+                Err(Error::DuplicatePrimaryKey(_))
+            ));
+        }
+        live_writer.commit().await.unwrap();
+        index.reader().await.unwrap().reload().await.unwrap();
+        assert_eq!(index.num_docs().await.unwrap(), 3);
+    }
+    writer.write().await.shutdown().await.unwrap();
+    drop(writer);
+    index.segment_manager().wait_for_shutdown().await;
+}
+
+#[tokio::test]
+async fn queued_reorder_allows_ingestion_and_preserves_primary_key_state() {
+    reorder_waiting_for_capacity(false).await;
+}
+
+#[tokio::test]
+async fn deleting_index_cancels_reorder_without_waiting_for_other_indexes() {
+    reorder_waiting_for_capacity(true).await;
+}
+
+#[tokio::test]
+async fn opening_index_with_writer_shares_commits_and_lifecycle_ownership() {
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
+    let mut initial = IndexWriter::create(
+        dir.clone(),
+        SchemaBuilder::default().build(),
+        config.clone(),
+    )
+    .await
+    .unwrap();
+    initial.add_document(Document::new()).unwrap();
+    initial.commit().await.unwrap();
+    initial.shutdown().await.unwrap();
+    drop(initial);
+
+    let (index, mut writer) = Index::open_with_writer(dir, config).await.unwrap();
+    assert!(Arc::ptr_eq(
+        index.segment_manager(),
+        writer.segment_manager()
+    ));
+    assert_eq!(index.num_docs().await.unwrap(), 1);
+    writer.add_document(Document::new()).unwrap();
+    writer.commit().await.unwrap();
+    index.reader().await.unwrap().reload().await.unwrap();
+    assert_eq!(index.num_docs().await.unwrap(), 2);
+    writer.shutdown().await.unwrap();
+    drop(writer);
+    index.segment_manager().wait_for_shutdown().await;
+}

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -2,6 +2,7 @@ mod basic;
 mod bmp;
 mod boolean;
 mod chunked;
+mod maintenance;
 mod merge;
 mod pin;
 mod posting_codecs;

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -1756,6 +1756,28 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             .await
     }
 
+    /// Reorder behind a shared writer without holding its lock during
+    /// maintenance admission or segment rewriting. The retained Arc keeps
+    /// the single-writer file lock alive until the operation finishes.
+    pub async fn reorder_with_shared_writer<F, Fut>(
+        writer: &Arc<tokio::sync::RwLock<Self>>,
+        refresh_external: F,
+    ) -> Result<()>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = Result<()>>,
+    {
+        let segment_manager = {
+            let mut writer = writer.write().await;
+            writer.commit().await?;
+            Arc::clone(&writer.segment_manager)
+        };
+        segment_manager
+            .reorder_segments_with_snapshot_refresh(refresh_external)
+            .await?;
+        writer.read().await.persist_replacement_snapshot().await
+    }
+
     /// Reorder while refreshing an external reader after each durable segment
     /// replacement, so retired sources are released during a long pass.
     pub async fn reorder_with_snapshot_refresh<F, Fut>(&mut self, refresh_external: F) -> Result<()>

--- a/hermes-core/src/merge/segment_manager.rs
+++ b/hermes-core/src/merge/segment_manager.rs
@@ -3559,7 +3559,11 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
 
         for seg_id in segment_ids {
             match self
-                .reorder_single_segment(&seg_id, None, crate::segment::BpBudget::full())
+                .reorder_single_segment(
+                    &seg_id,
+                    Some(self.background_cpu_pool()),
+                    crate::segment::BpBudget::full(),
+                )
                 .await
             {
                 Ok(true) => refresh_snapshots().await?,

--- a/hermes-core/src/query/all.rs
+++ b/hermes-core/src/query/all.rs
@@ -1,0 +1,159 @@
+//! The complete document universe, including documents with missing fields.
+use super::{AllDocSet, CountFuture, DocBitset, DocPredicate, DocSet, Query, Scorer, ScorerFuture};
+use crate::segment::SegmentReader;
+use crate::{DocId, Score};
+
+/// Matches every document, including documents with missing fields.
+#[derive(Debug, Clone, Copy)]
+pub struct AllQuery;
+
+impl std::fmt::Display for AllQuery {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("All")
+    }
+}
+
+impl Query for AllQuery {
+    fn scorer<'a>(&self, reader: &'a SegmentReader, _limit: usize) -> ScorerFuture<'a> {
+        let scorer = AllScorer::new(reader.num_docs());
+        Box::pin(async move { Ok(Box::new(scorer) as Box<dyn Scorer>) })
+    }
+
+    #[cfg(feature = "sync")]
+    fn scorer_sync<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        _limit: usize,
+    ) -> crate::Result<Box<dyn Scorer + 'a>> {
+        Ok(Box::new(AllScorer::new(reader.num_docs())))
+    }
+
+    fn count_estimate<'a>(&self, reader: &'a SegmentReader) -> CountFuture<'a> {
+        let count = reader.num_docs();
+        Box::pin(async move { Ok(count) })
+    }
+
+    fn is_filter(&self) -> bool {
+        true
+    }
+
+    fn as_doc_predicate<'a>(&self, reader: &'a SegmentReader) -> Option<DocPredicate<'a>> {
+        let count = reader.num_docs();
+        Some(Box::new(move |doc| doc < count))
+    }
+
+    fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<DocBitset> {
+        Some(DocBitset::all(reader.num_docs()))
+    }
+}
+
+struct AllScorer(AllDocSet);
+
+impl AllScorer {
+    fn new(count: u32) -> Self {
+        Self(AllDocSet::new(count))
+    }
+}
+
+impl DocSet for AllScorer {
+    fn doc(&self) -> DocId {
+        self.0.doc()
+    }
+
+    fn advance(&mut self) -> DocId {
+        self.0.advance()
+    }
+
+    fn seek(&mut self, target: DocId) -> DocId {
+        self.0.seek(target)
+    }
+
+    fn size_hint(&self) -> u32 {
+        self.0.size_hint()
+    }
+}
+
+impl Scorer for AllScorer {
+    fn score(&self) -> Score {
+        1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TERMINATED;
+    #[tokio::test]
+    async fn exclusion_filter_includes_documents_without_metadata_in_every_execution_path() {
+        use crate::query::{BooleanQuery, FilteredQuery, RangeQuery};
+        use crate::{Document, Index, IndexConfig, IndexWriter, RamDirectory, Schema};
+        use std::sync::Arc;
+        let mut schema = Schema::builder();
+        let date = schema.add_i64_field("date", true, false);
+        schema.set_fast(date, true);
+        let dir = RamDirectory::new();
+        let config = IndexConfig::default();
+        let mut writer = IndexWriter::create(dir.clone(), schema.build(), config.clone())
+            .await
+            .unwrap();
+        for date_value in [Some(-1), Some(0), None] {
+            let mut doc = Document::new();
+            if let Some(value) = date_value {
+                doc.add_i64(date, value);
+            }
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().await.unwrap();
+        let index = Index::open(dir, config).await.unwrap();
+        let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+        let reader = &searcher.segment_readers()[0];
+        let filter =
+            BooleanQuery::new()
+                .must(AllQuery)
+                .must_not(RangeQuery::i64(date, Some(0), Some(0)));
+        let predicate = filter.as_doc_predicate(reader).unwrap();
+        let bits = filter.as_doc_bitset(reader).unwrap();
+        for doc in 0..3 {
+            assert_eq!(predicate(doc), doc != 1);
+            assert_eq!(bits.contains(doc), doc != 1);
+        }
+        let query = FilteredQuery::new(Arc::new(AllQuery), vec![Arc::new(filter)]);
+        let check = |mut scorer: Box<dyn Scorer + '_>| {
+            let mut docs = Vec::new();
+            while scorer.doc() != TERMINATED {
+                docs.push(scorer.doc());
+                scorer.advance();
+            }
+            assert_eq!(docs, [0, 2]);
+        };
+        check(query.scorer(reader, 10).await.unwrap());
+        #[cfg(feature = "sync")]
+        check(
+            query
+                .scorer_sync_with_options(reader, 10, super::super::ScorerOptions::default())
+                .unwrap(),
+        );
+    }
+
+    #[test]
+    fn complete_universe_has_no_tail_documents_and_seek_never_rewinds() {
+        for count in [0, 1, 63, 64, 65, 129] {
+            let bits = DocBitset::all(count);
+            let mut scorer = AllScorer::new(count);
+            for doc in 0..count {
+                assert!(bits.contains(doc));
+                assert_eq!(scorer.doc(), doc);
+                assert_eq!(scorer.score(), 1.0);
+                scorer.advance();
+            }
+            assert_eq!(bits.next_set_bit(count), None);
+            assert_eq!(scorer.doc(), TERMINATED);
+            assert_eq!(scorer.advance(), TERMINATED);
+            assert_eq!(scorer.seek(0), TERMINATED);
+        }
+        let mut scorer = AllScorer::new(10);
+        assert_eq!(scorer.seek(5), 5);
+        assert_eq!(scorer.seek(2), 5);
+        assert_eq!(scorer.advance(), 6);
+    }
+}

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -2023,8 +2023,8 @@ fn score_forward_units(
 
 /// Exact candidate probes use the very same integer query quantization and
 /// dequantization as exhaustive BMP retrieval. Nomination/LSP never enters
-/// this path. Targets are sorted forward rows in V20 and real physical slots
-/// in V19, as resolved by the owning candidate-address reader.
+/// this path. Targets are sorted forward rows when stored and real physical slots
+/// without forward storage, as resolved by the owning candidate-address reader.
 pub(crate) fn score_bmp_candidates(
     index: &BmpIndex,
     terms: &[(u32, f32)],

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -891,6 +891,10 @@ macro_rules! boolean_plan {
 
         // ── 4. Standard BooleanScorer fallback ───────────────────────────
         let mut must_scorers = Vec::with_capacity(must.len());
+        if must.is_empty() && should.is_empty() && !must_not.is_empty() {
+            must_scorers.push(Box::new(super::AllDocSet::new(reader.num_docs()))
+                as Box<dyn Scorer + '_>);
+        }
         for q in must {
             must_scorers.push(q.$scorer_fn(
                 reader, limit, scorer_options.without_threshold()
@@ -1052,14 +1056,15 @@ impl Query for BooleanQuery {
         if options.stop_if_expired() {
             return None;
         }
-        if self.must.is_empty() && self.should.is_empty() {
+        if self.must.is_empty() && self.should.is_empty() && self.must_not.is_empty() {
             return None;
         }
 
         let num_docs = reader.num_docs();
 
         // MUST clauses: intersect bitsets (AND)
-        let mut result: Option<super::DocBitset> = None;
+        let mut result = (self.must.is_empty() && self.should.is_empty())
+            .then(|| super::DocBitset::all(num_docs));
         for q in &self.must {
             let bs = options.doc_bitset(q.as_ref(), reader)?;
             match result {
@@ -1106,7 +1111,7 @@ impl Query for BooleanQuery {
 
     fn as_doc_predicate<'a>(&self, reader: &'a SegmentReader) -> Option<super::DocPredicate<'a>> {
         // Need at least some clauses
-        if self.must.is_empty() && self.should.is_empty() {
+        if self.must.is_empty() && self.should.is_empty() && self.must_not.is_empty() {
             return None;
         }
 
@@ -1146,6 +1151,7 @@ impl Query for BooleanQuery {
     fn count_estimate<'a>(&self, reader: &'a SegmentReader) -> CountFuture<'a> {
         let must = self.must.clone();
         let should = self.should.clone();
+        let has_exclusions = !self.must_not.is_empty();
 
         Box::pin(async move {
             if !must.is_empty() {
@@ -1163,6 +1169,8 @@ impl Query for BooleanQuery {
                     sum = sum.saturating_add(q.count_estimate(reader).await?);
                 }
                 Ok(sum)
+            } else if has_exclusions {
+                Ok(reader.num_docs())
             } else {
                 Ok(0)
             }

--- a/hermes-core/src/query/docset.rs
+++ b/hermes-core/src/query/docset.rs
@@ -234,7 +234,7 @@ impl DocSet for AllDocSet {
 
     #[inline]
     fn seek(&mut self, target: DocId) -> DocId {
-        self.current = target;
+        self.current = self.current.max(target);
         self.doc()
     }
 

--- a/hermes-core/src/query/docset.rs
+++ b/hermes-core/src/query/docset.rs
@@ -226,7 +226,9 @@ impl DocSet for AllDocSet {
 
     #[inline]
     fn advance(&mut self) -> DocId {
-        self.current += 1;
+        if self.current < self.num_docs {
+            self.current += 1;
+        }
         self.doc()
     }
 

--- a/hermes-core/src/query/mod.rs
+++ b/hermes-core/src/query/mod.rs
@@ -17,6 +17,7 @@ pub const fn max_candidate_limit(result_window: usize) -> usize {
     result_window.saturating_mul(MAX_CANDIDATE_OVERSUBSCRIPTION)
 }
 
+mod all;
 mod bm25;
 pub(crate) mod bmp;
 mod boolean;
@@ -42,6 +43,7 @@ mod term;
 mod traits;
 mod vector;
 
+pub use all::AllQuery;
 pub use bm25::*;
 pub use boolean::*;
 pub use boost::*;

--- a/hermes-core/src/query/term.rs
+++ b/hermes-core/src/query/term.rs
@@ -293,8 +293,10 @@ impl Query for TermQuery {
         }
         // Build bitset from posting list: O(M) where M = matching doc count.
         // Much faster than O(N) fast-field scan for selective terms.
-        let pl = reader.get_postings_sync(self.field, &self.term).ok()??;
         let mut bitset = super::DocBitset::new(reader.num_docs());
+        let Some(pl) = reader.get_postings_sync(self.field, &self.term).ok()? else {
+            return Some(bitset);
+        };
         let mut iter = pl.iterator();
         loop {
             let doc = iter.doc();

--- a/hermes-core/src/query/traits.rs
+++ b/hermes-core/src/query/traits.rs
@@ -122,6 +122,18 @@ impl DocBitset {
         }
     }
 
+    /// The segment's document universe, with padding bits left clear.
+    pub(crate) fn all(num_docs: u32) -> Self {
+        let mut result = Self::new(num_docs);
+        result.bits.fill(u64::MAX);
+        if !num_docs.is_multiple_of(64)
+            && let Some(last) = result.bits.last_mut()
+        {
+            *last = (1u64 << (num_docs % 64)) - 1;
+        }
+        result
+    }
+
     /// Set bit for `doc_id`.
     #[inline]
     pub fn set(&mut self, doc_id: u32) {
@@ -536,6 +548,14 @@ impl Query for Box<dyn Query> {
 
 /// Empty scorer for terms that don't exist
 pub struct EmptyScorer;
+
+// A document universe is a neutral required cursor for exclusion-only Boolean
+// queries. It adds neither a relevance score nor matched positions.
+impl Scorer for super::AllDocSet {
+    fn score(&self) -> Score {
+        0.0
+    }
+}
 
 impl super::docset::DocSet for EmptyScorer {
     fn doc(&self) -> DocId {

--- a/hermes-core/src/segment/bmp_adaptive.rs
+++ b/hermes-core/src/segment/bmp_adaptive.rs
@@ -1,4 +1,4 @@
-//! Adaptive per-block payload codec for BMP V19.
+//! Adaptive per-block payload codec for BMP.
 //!
 //! A block keeps sorted `u32` dimensions, but adapts the rest of its header
 //! and payload to the data:
@@ -774,10 +774,10 @@ mod tests {
                 }
             }
             let bytes = encode(32, &dimensions, &counts, &maxima, &postings);
-            let v18_bytes = 8 + 9 * num_terms + postings.len();
+            let flat_bound = 8 + 9 * num_terms + postings.len();
             assert!(
-                bytes.len() <= v18_bytes,
-                "terms={num_terms}: V19={} > V18={v18_bytes}",
+                bytes.len() <= flat_bound,
+                "terms={num_terms}: adaptive={} > flat bound={flat_bound}",
                 bytes.len(),
             );
         }

--- a/hermes-core/src/segment/bmp_forward.rs
+++ b/hermes-core/src/segment/bmp_forward.rs
@@ -7,7 +7,8 @@ use crate::directories::OwnedBytes;
 use crate::{Error, Result};
 
 const ROW_BYTES: usize = 16;
-const TRAILER_BYTES: usize = 16;
+pub(super) const TRAILER_BYTES: usize = 16;
+const STORAGE_DISABLED: u32 = 1;
 
 #[derive(Clone)]
 pub(crate) struct BmpForward {
@@ -21,6 +22,26 @@ fn corrupt(message: &str) -> Error {
 }
 
 impl BmpForward {
+    pub(crate) fn parse_optional(
+        bytes: OwnedBytes,
+        count: u32,
+        docs: u32,
+        dims: u32,
+    ) -> Result<Option<Self>> {
+        let trailer = bytes
+            .len()
+            .checked_sub(TRAILER_BYTES)
+            .ok_or_else(|| corrupt("missing storage trailer"))?;
+        let flags = u32::from_le_bytes(bytes[trailer + 4..trailer + 8].try_into().unwrap());
+        if flags == STORAGE_DISABLED {
+            if bytes.len() != TRAILER_BYTES || bytes[..4] != [0; 4] || bytes[8..] != [0; 8] {
+                return Err(corrupt("disabled storage has a payload or vector count"));
+            }
+            return Ok(None);
+        }
+        Self::parse(bytes, count, docs, dims).map(Some)
+    }
+
     pub(crate) fn parse(bytes: OwnedBytes, count: u32, docs: u32, dims: u32) -> Result<Self> {
         let trailer = bytes
             .len()
@@ -160,6 +181,15 @@ impl BmpForward {
         self.rows.madvise(advice);
         self.payload.madvise(advice);
     }
+}
+
+#[cfg(any(feature = "native", feature = "wasm", test))]
+pub(crate) fn write_disabled(writer: &mut dyn std::io::Write) -> std::io::Result<u64> {
+    use byteorder::{LittleEndian, WriteBytesExt};
+    writer.write_u32::<LittleEndian>(0)?;
+    writer.write_u32::<LittleEndian>(STORAGE_DISABLED)?;
+    writer.write_u64::<LittleEndian>(0)?;
+    Ok(TRAILER_BYTES as u64)
 }
 
 /// A background scan validates once before BP's repeated infallible passes.

--- a/hermes-core/src/segment/bmp_forward/rewrite.rs
+++ b/hermes-core/src/segment/bmp_forward/rewrite.rs
@@ -1,4 +1,4 @@
-//! Representation-preserving merge/reorder, with explicit budgeted V19 upgrade.
+//! Representation-preserving merge/reorder and budgeted forward-storage enablement.
 use super::*;
 use crate::segment::{BmpIndex, OffsetWriter};
 use std::io::Write;
@@ -16,35 +16,39 @@ struct SourcePlan<'a> {
     bmp: &'a BmpIndex,
     doc_offset: u32,
     payload_offset: u64,
-    /// Only the explicit V19 migration constructs a physical permutation.
-    legacy_slots: Vec<u32>,
-    legacy_offsets: Vec<u64>,
+    /// Only explicitly enabling absent forward storage constructs a physical permutation.
+    missing_slots: Vec<u32>,
+    missing_offsets: Vec<u64>,
 }
 
 pub(crate) fn validate_copy_sources(sources: &[(&BmpIndex, u32)]) -> Result<bool> {
-    let legacy = sources
+    let absent = sources
         .iter()
         .filter(|(bmp, _)| bmp.forward().is_none())
         .count();
-    if legacy != 0 && legacy != sources.len() {
-        return Err(Error::Schema("cannot copy-merge BMP V19 and V20; explicitly reorder the V19 segments to add forward values first".into()));
+    if absent != 0 && absent != sources.len() {
+        return Err(Error::Schema("cannot copy-merge BMP sources with and without forward values; explicitly reorder with a uniform forward-storage policy first".into()));
     }
-    Ok(legacy == 0)
+    Ok(absent == 0)
 }
 
-/// Returns whether a V20 section was written. Ordinary all-V19 merge remains
-/// V19. Mixed ordinary merges refuse to rebuild or discard a forward section.
+/// Writes the current-format storage section and reports whether values exist.
+/// Copy-only merges never materialize absent values; disabled output has an
+/// explicit marker, and mixed presence requires an explicit storage transition.
 pub(crate) fn write_forward_sources(
     sources: &[(&BmpIndex, u32)],
     paths: &[Option<&std::path::Path>],
     writer: &mut OffsetWriter,
-    upgrade_budget: Option<usize>,
+    materialize_budget: Option<usize>,
     cancellation: Option<&AtomicBool>,
+    store_forward: bool,
 ) -> Result<bool> {
-    if upgrade_budget.is_none() && !validate_copy_sources(sources)? {
+    cancelled(cancellation)?;
+    if !store_forward || (materialize_budget.is_none() && !validate_copy_sources(sources)?) {
+        write_disabled(writer)?;
         return Ok(false);
     }
-    let mut remaining = upgrade_budget.unwrap_or(0);
+    let mut remaining = materialize_budget.unwrap_or(0);
     let mut plans = Vec::with_capacity(sources.len());
     let mut count = 0u32;
     let mut previous_last = None;
@@ -58,15 +62,15 @@ pub(crate) fn write_forward_sources(
         if bmp.forward().is_none() {
             let bytes = (bmp.num_real_docs() as usize)
                 .checked_mul(12)
-                .ok_or_else(|| corrupt("migration directory size overflow"))?;
+                .ok_or_else(|| corrupt("forward directory size overflow"))?;
             remaining = remaining.checked_sub(bytes).ok_or_else(|| Error::Schema(
-                "BMP V19 forward migration exceeds the reorder memory budget; increase bp-memory-budget-mb".into()))?;
+                "BMP forward materialization exceeds the reorder memory budget; increase bp-memory-budget-mb".into()))?;
             slots = Vec::with_capacity(bmp.num_real_docs() as usize);
             bmp.visit_real_slots_for_rewrite(|slot| slots.push(slot as u32))?;
             slots.sort_unstable_by_key(|&slot| bmp.virtual_to_doc(slot));
             offsets = Vec::with_capacity(slots.len());
             log::info!(
-                "[bmp_forward] migrating {} V19 vectors; directory scratch={} bytes",
+                "[bmp_forward] materializing {} vectors; directory scratch={} bytes",
                 slots.len(),
                 bytes
             );
@@ -100,8 +104,8 @@ pub(crate) fn write_forward_sources(
             bmp,
             doc_offset,
             payload_offset: 0,
-            legacy_slots: slots,
-            legacy_offsets: offsets,
+            missing_slots: slots,
+            missing_offsets: offsets,
         });
     }
     let start = writer.offset();
@@ -118,11 +122,11 @@ pub(crate) fn write_forward_sources(
                 "BMP forward payload",
             )?;
         } else {
-            // An explicit one-time migration probes source blocks in logical
+            // Explicit storage enablement probes source blocks in logical
             // order. Only its directory is buffered; payload streams directly.
-            for &slot in &plan.legacy_slots {
+            for &slot in &plan.missing_slots {
                 cancelled(cancellation)?;
-                plan.legacy_offsets
+                plan.missing_offsets
                     .push(writer.offset() - start - plan.payload_offset);
                 let block_id = slot / plan.bmp.bmp_block_size;
                 plan.bmp.validate_block_for_rewrite(block_id)?;
@@ -138,7 +142,7 @@ pub(crate) fn write_forward_sources(
                     }
                 }
                 if !found {
-                    return Err(corrupt("real legacy vector has no postings"));
+                    return Err(corrupt("real vector has no postings"));
                 }
             }
         }
@@ -155,10 +159,10 @@ pub(crate) fn write_forward_sources(
             let (key, offset) = if let Some(forward) = plan.bmp.forward() {
                 (forward.key(i), forward.offset(i))
             } else {
-                let (doc, ordinal) = plan.bmp.virtual_to_doc(plan.legacy_slots[i as usize]);
+                let (doc, ordinal) = plan.bmp.virtual_to_doc(plan.missing_slots[i as usize]);
                 (
                     LogicalUnit { doc, ordinal },
-                    plan.legacy_offsets[i as usize],
+                    plan.missing_offsets[i as usize],
                 )
             };
             Ok((

--- a/hermes-core/src/segment/bmp_forward/tests.rs
+++ b/hermes-core/src/segment/bmp_forward/tests.rs
@@ -60,14 +60,15 @@ fn parse(bytes: Vec<u8>, docs: u32, vectors: u32) -> BmpIndex {
     .unwrap()
 }
 
-fn legacy(source: &BmpIndex, docs: u32) -> BmpIndex {
+fn without_forward(source: &BmpIndex, docs: u32) -> BmpIndex {
     let mut bytes = source.read_raw_blob().unwrap().to_vec();
     let footer = bytes.len() - crate::segment::format::BMP_BLOB_FOOTER_SIZE;
     let start = u64::from_le_bytes(bytes[footer + 60..footer + 68].try_into().unwrap()) as usize
         + source.num_virtual_docs as usize * 6;
     bytes.drain(start..footer);
-    let end = bytes.len();
-    bytes[end - 4..].copy_from_slice(&crate::segment::format::BMP_BLOB_MAGIC_V19.to_le_bytes());
+    let mut marker = Vec::new();
+    write_disabled(&mut marker).unwrap();
+    bytes.splice(start..start, marker);
     parse(bytes, docs, source.total_vectors)
 }
 
@@ -97,6 +98,37 @@ fn forward_values(source: &BmpForward) -> BTreeMap<(u32, u16, u32), u32> {
 }
 
 #[test]
+fn disabled_forward_storage_keeps_the_current_bmp_envelope() {
+    let source = fixture_with_storage(137, true, false);
+    let bytes = source.read_raw_blob().unwrap();
+    assert_eq!(
+        u32::from_le_bytes(bytes[bytes.len() - 4..].try_into().unwrap()),
+        crate::segment::format::BMP_BLOB_MAGIC,
+    );
+    assert!(source.forward().is_none());
+}
+
+#[test]
+fn current_bmp_reader_rejects_a_legacy_envelope() {
+    let current = fixture(137);
+    let old = without_forward(&current, 137);
+    let mut bytes = old.read_raw_blob().unwrap().to_vec();
+    let footer = bytes.len() - crate::segment::format::BMP_BLOB_FOOTER_SIZE;
+    bytes.drain(footer - TRAILER_BYTES..footer);
+    let end = bytes.len();
+    bytes[end - 4..].copy_from_slice(&0x39504d42u32.to_le_bytes());
+    let bytes = OwnedBytes::new(bytes);
+    let result = BmpIndex::parse(
+        FileHandle::from_bytes(bytes.clone()),
+        0,
+        bytes.len() as u64,
+        137,
+        old.total_vectors,
+    );
+    assert!(result.is_err(), "legacy BMP must require offline migration");
+}
+
+#[test]
 fn forward_values_preserve_quantized_postings_duplicates_and_real_ordinals() {
     let bmp = fixture(137);
     let forward = bmp.forward().unwrap();
@@ -113,9 +145,9 @@ fn forward_values_preserve_quantized_postings_duplicates_and_real_ordinals() {
 }
 
 #[test]
-fn legacy_and_forward_candidate_scores_sum_all_duplicate_dimension_impacts() {
+fn inverted_and_forward_candidate_scores_sum_all_duplicate_dimension_impacts() {
     let current = fixture(137);
-    let old = legacy(&current, 137);
+    let old = without_forward(&current, 137);
     let query = [(0, 1.0), (31, 0.3)];
     let forward = crate::query::bmp::score_bmp_candidates(&current, &query, &[0]).unwrap();
     let inverted = crate::query::bmp::score_bmp_candidates(&old, &query, &[0]).unwrap();
@@ -125,7 +157,7 @@ fn legacy_and_forward_candidate_scores_sum_all_duplicate_dimension_impacts() {
 #[test]
 fn forward_candidate_scores_preserve_repeated_query_dimensions() {
     let current = fixture(137);
-    let old = legacy(&current, 137);
+    let old = without_forward(&current, 137);
     // Both the query and the document repeat dimension zero. Quantization is
     // per query entry, so combining raw query weights would change the score.
     let query = [(0, 1.0), (0, 0.3), (31, 0.2)];
@@ -144,7 +176,9 @@ async fn forward_merge_copies_payload_and_remaps_only_directory_with_document_ga
             .await
             .unwrap(),
     );
-    assert!(write_forward_sources(&[(&a, 0), (&b, 25)], &[], &mut writer, None, None).unwrap());
+    assert!(
+        write_forward_sources(&[(&a, 0), (&b, 25)], &[], &mut writer, None, None, true).unwrap()
+    );
     writer.finish().unwrap();
     let bytes = dir
         .open_read(Path::new("forward"))
@@ -175,9 +209,9 @@ async fn forward_merge_copies_payload_and_remaps_only_directory_with_document_ga
 }
 
 #[tokio::test]
-async fn legacy_migration_is_explicit_budgeted_and_preserves_forward_bytes() {
+async fn enabling_forward_storage_is_explicit_budgeted_and_preserves_forward_bytes() {
     let current = fixture(137);
-    let old = legacy(&current, 137);
+    let old = without_forward(&current, 137);
     assert!(old.forward().is_none());
     assert_eq!(inverted_values(&old), inverted_values(&current));
     let dir = RamDirectory::new();
@@ -186,25 +220,66 @@ async fn legacy_migration_is_explicit_budgeted_and_preserves_forward_bytes() {
             .await
             .unwrap(),
     );
-    assert!(!write_forward_sources(&[(&old, 0)], &[], &mut writer, None, None).unwrap());
-    assert_eq!(writer.offset(), 0);
+    assert!(!write_forward_sources(&[(&old, 0)], &[], &mut writer, None, None, true).unwrap());
+    assert_eq!(writer.offset(), TRAILER_BYTES as u64);
+    writer.finish().unwrap();
+    let disabled = dir
+        .open_read(Path::new("forward"))
+        .await
+        .unwrap()
+        .read_bytes()
+        .await
+        .unwrap();
     assert!(
-        write_forward_sources(&[(&old, 0), (&current, 137)], &[], &mut writer, None, None).is_err()
+        BmpForward::parse_optional(disabled, current.num_real_docs(), 137, 32)
+            .unwrap()
+            .is_none()
     );
-    assert!(write_forward_sources(&[(&old, 0)], &[], &mut writer, Some(1), None).is_err());
+    let mut writer = OffsetWriter::new(
+        dir.streaming_writer_cold(Path::new("materialized"))
+            .await
+            .unwrap(),
+    );
+    assert!(
+        write_forward_sources(
+            &[(&old, 0), (&current, 137)],
+            &[],
+            &mut writer,
+            None,
+            None,
+            true
+        )
+        .is_err()
+    );
+    assert!(write_forward_sources(&[(&old, 0)], &[], &mut writer, Some(1), None, true).is_err());
     assert_eq!(writer.offset(), 0);
     let cancel = std::sync::atomic::AtomicBool::new(true);
     assert!(matches!(
-        write_forward_sources(&[(&current, 0)], &[], &mut writer, None, Some(&cancel)),
+        write_forward_sources(
+            &[(&current, 0)],
+            &[],
+            &mut writer,
+            None,
+            Some(&cancel),
+            true
+        ),
         Err(Error::IndexClosed)
     ));
     assert_eq!(writer.offset(), 0);
     assert!(
-        write_forward_sources(&[(&old, 0)], &[], &mut writer, Some(1024 * 1024), None).unwrap()
+        write_forward_sources(
+            &[(&old, 0)],
+            &[],
+            &mut writer,
+            Some(1024 * 1024),
+            None,
+            true
+        )
+        .unwrap()
     );
     writer.finish().unwrap();
     let bytes = dir
-        .open_read(Path::new("forward"))
+        .open_read(Path::new("materialized"))
         .await
         .unwrap()
         .read_bytes()
@@ -229,7 +304,7 @@ async fn record_and_block_bp_copy_forward_bytes_and_preserve_quantized_values() 
     for granularity in [BpGranularity::Records, BpGranularity::Blocks] {
         for old in [false, true] {
             let input = if old {
-                legacy(&source, 513)
+                without_forward(&source, 513)
             } else {
                 source.clone()
             };
@@ -393,7 +468,7 @@ fn measure_forward_candidate_scoring_and_bp_graph() {
     .unwrap();
     let build_ms = build.elapsed().as_secs_f64() * 1000.0;
     let current = parse(bytes, DOCS, DOCS);
-    let old = legacy(&current, DOCS);
+    let old = without_forward(&current, DOCS);
     let query: Vec<_> = (0..64).map(|i| (i * 61, 0.7)).collect();
     let targets: Vec<_> = (0..128).map(|i| i * 127).collect();
     assert_eq!(
@@ -411,7 +486,7 @@ fn measure_forward_candidate_scoring_and_bp_graph() {
         current.read_raw_blob().unwrap().len(),
         current.forward().unwrap().encoded_bytes()
     );
-    for (label, bmp) in [("V19", &old), ("V20", &current)] {
+    for (label, bmp) in [("without forward", &old), ("with forward", &current)] {
         let mut score_times = Vec::new();
         let mut graph_times = Vec::new();
         for _ in 0..11 {
@@ -505,7 +580,8 @@ fn forward_copy_propagates_partial_writer_failure_and_mid_payload_cancellation()
         fail_after: 7,
         cancel: None,
     }));
-    let error = write_forward_sources(&[(&source, 0)], &[], &mut writer, None, None).unwrap_err();
+    let error =
+        write_forward_sources(&[(&source, 0)], &[], &mut writer, None, None, true).unwrap_err();
     assert!(
         error
             .to_string()
@@ -519,7 +595,7 @@ fn forward_copy_propagates_partial_writer_failure_and_mid_payload_cancellation()
         cancel: Some(cancel.clone()),
     }));
     assert!(matches!(
-        write_forward_sources(&[(&source, 0)], &[], &mut writer, None, Some(&cancel)),
+        write_forward_sources(&[(&source, 0)], &[], &mut writer, None, Some(&cancel), true),
         Err(Error::IndexClosed)
     ));
     assert!(writer.offset() > 0);
@@ -530,12 +606,12 @@ fn forward_copy_propagates_partial_writer_failure_and_mid_payload_cancellation()
 }
 
 #[tokio::test]
-async fn forward_duplicate_impacts_survive_copy_merge_and_legacy_upgrade() {
+async fn forward_duplicate_impacts_survive_copy_merge_and_storage_enablement() {
     for duplicate in [false, true] {
         let a = fixture_with_duplicates(17, false);
         let b = fixture_with_duplicates(17, duplicate);
         for migrate in [false, true] {
-            let old = legacy(&b, 17);
+            let old = without_forward(&b, 17);
             let source = if migrate { &old } else { &b };
             let dir = RamDirectory::new();
             let mut writer = OffsetWriter::new(
@@ -549,6 +625,7 @@ async fn forward_duplicate_impacts_survive_copy_merge_and_legacy_upgrade() {
                 &mut writer,
                 migrate.then_some(1024 * 1024),
                 None,
+                true,
             )
             .unwrap();
             writer.finish().unwrap();
@@ -580,7 +657,7 @@ async fn forward_duplicate_impacts_survive_copy_merge_and_legacy_upgrade() {
 async fn bp_can_omit_forward_storage_without_changing_inverted_values() {
     use crate::segment::reorder::{BpGranularity, reorder_bmp_field};
     let current = fixture(137);
-    let old = legacy(&current, 137);
+    let old = without_forward(&current, 137);
     for source in [&current, &old] {
         for granularity in [BpGranularity::Records, BpGranularity::Blocks] {
             let dir = RamDirectory::new();
@@ -652,10 +729,104 @@ fn disabling_forward_storage_preserves_every_inverted_byte() {
     assert!(disabled.forward().is_none());
     assert_eq!(
         disabled.read_raw_blob().unwrap().as_slice(),
-        legacy(&enabled, 137).read_raw_blob().unwrap().as_slice()
+        without_forward(&enabled, 137)
+            .read_raw_blob()
+            .unwrap()
+            .as_slice()
     );
     assert_eq!(
         enabled.read_raw_blob().unwrap().len() - disabled.read_raw_blob().unwrap().len(),
-        enabled.forward().unwrap().encoded_bytes()
+        enabled.forward().unwrap().encoded_bytes() - TRAILER_BYTES
     );
+}
+
+#[test]
+fn optional_storage_rejects_missing_markers_unknown_flags_and_hidden_payloads() {
+    let source = fixture_with_storage(137, true, false);
+    let bytes = source.read_raw_blob().unwrap().to_vec();
+    let trailer = bytes.len() - crate::segment::format::BMP_BLOB_FOOTER_SIZE - TRAILER_BYTES;
+    let reject = |bytes: Vec<u8>| {
+        let len = bytes.len() as u64;
+        assert!(
+            BmpIndex::parse(
+                FileHandle::from_bytes(OwnedBytes::new(bytes)),
+                0,
+                len,
+                137,
+                source.total_vectors
+            )
+            .is_err()
+        );
+    };
+    for (offset, value) in [(0, 1u32), (4, 2), (4, 3), (8, 5)] {
+        let mut corrupt = bytes.clone();
+        corrupt[trailer + offset..trailer + offset + 4].copy_from_slice(&value.to_le_bytes());
+        reject(corrupt);
+    }
+    let mut absent = bytes.clone();
+    absent.drain(trailer..trailer + TRAILER_BYTES);
+    reject(absent);
+    let mut hidden = bytes;
+    hidden.insert(trailer, 0);
+    reject(hidden);
+
+    let enabled = fixture(137);
+    let mut payload = enabled.read_raw_blob().unwrap().to_vec();
+    let flags = payload.len() - crate::segment::format::BMP_BLOB_FOOTER_SIZE - TRAILER_BYTES + 4;
+    payload[flags..flags + 4].copy_from_slice(&STORAGE_DISABLED.to_le_bytes());
+    reject(payload);
+}
+
+#[test]
+fn empty_bmp_blobs_validate_their_storage_section_and_footer() {
+    let mut bytes = Vec::new();
+    write_disabled(&mut bytes).unwrap();
+    crate::segment::builder::bmp::write_bmp_footer(
+        &mut bytes, 0, 0, 0, 0, 0, 0, 32, 32, 0, 5.0, 0, 0, 4,
+    )
+    .unwrap();
+    let read = |bytes: Vec<u8>| {
+        let len = bytes.len() as u64;
+        BmpIndex::parse(
+            FileHandle::from_bytes(OwnedBytes::new(bytes)),
+            0,
+            len,
+            137,
+            0,
+        )
+    };
+    let empty = read(bytes.clone()).unwrap();
+    assert_eq!(empty.num_blocks, 0);
+    assert!(empty.forward().is_none());
+    for offset in [
+        4,
+        TRAILER_BYTES,
+        TRAILER_BYTES + 8,
+        TRAILER_BYTES + 16,
+        TRAILER_BYTES + 52,
+    ] {
+        let mut corrupt = bytes.clone();
+        corrupt[offset] = 2;
+        assert!(read(corrupt).is_err());
+    }
+    let mut missing_section = bytes.clone();
+    missing_section.drain(..TRAILER_BYTES);
+    assert!(read(missing_section).is_err());
+    let mut hidden_payload = bytes.clone();
+    hidden_payload.insert(0, 0);
+    assert!(read(hidden_payload).is_err());
+    bytes[4..8].copy_from_slice(&0u32.to_le_bytes());
+    let empty = read(bytes).unwrap();
+    assert_eq!(empty.forward().unwrap().len(), 0);
+}
+
+#[test]
+fn enabled_forward_storage_keeps_the_published_bytes() {
+    let source = fixture(137);
+    let bytes = source.read_raw_blob().unwrap();
+    let hash = bytes.iter().fold(0xcbf29ce484222325u64, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    });
+    assert_eq!(bytes.len(), 12_713);
+    assert_eq!(hash, 0x5ccfbcdae3690623);
 }

--- a/hermes-core/src/segment/builder/bmp.rs
+++ b/hermes-core/src/segment/builder/bmp.rs
@@ -1,4 +1,4 @@
-//! BMP (Block-Max Pruning) index builder for sparse vectors — **V20 format**.
+//! BMP (Block-Max Pruning) index builder for sparse vectors — **current format**.
 //!
 //! Builds a block-at-a-time (BAAT) index using **compact virtual coordinates**:
 //! sequential IDs are assigned to unique `(doc_id, ordinal)` pairs. A lookup
@@ -22,7 +22,7 @@
 //! Forward output adds O(dimensions) cursors and 8-byte/vector offsets while
 //! borrowing the same input; see the format design for the full cost model.
 //!
-//! ## BMP V20 Blob Layout (data-first, block-interleaved)
+//! ## BMP Blob Layout (data-first, block-interleaved)
 //!
 //! ```text
 //! Section B:  block_data         [per-block interleaved data]   variable-length
@@ -42,7 +42,7 @@
 //!   term_max_impacts: [packed-u4 × num_terms]          conservative maxima
 //!   payload: sparse [(u8, u8)] or dense [u8; block_size] per term
 //!
-//! BMP V20 Footer (80 bytes; same offsets as V19):
+//! BMP footer (80 bytes):
 //!   total_terms: u64              //  0- 7  (stats only)
 //!   total_postings: u64           //  8-15  (stats only)
 //!   grid_offset: u64              // 16-23  (byte offset of Section D)
@@ -102,7 +102,7 @@ use crate::segment::bmp_grid::{
 use crate::segment::format::{BMP_BLOB_FOOTER_SIZE, BMP_BLOB_MAGIC};
 use crate::segment::reader::bmp::BMP_SUPERBLOCK_SIZE;
 
-/// Build a BMP V20 blob from per-dimension postings.
+/// Build a BMP blob from per-dimension postings.
 ///
 /// **Takes ownership** of the postings HashMap. All per-dim Vecs are moved
 /// out of the HashMap into `dim_vecs` before the K-way merge starts, and
@@ -316,7 +316,6 @@ pub(crate) fn build_bmp_blob(
     let mut total_terms: u64 = 0;
     let mut total_postings: u64 = 0;
     let mut cumulative_bytes: u64 = 0;
-    let mut legacy_block_bytes: u64 = 0;
     let mut dense_terms: u64 = 0;
     let mut wide_blocks: u64 = 0;
     let mut last_block_filled: i64 = -1;
@@ -422,10 +421,6 @@ pub(crate) fn build_bmp_blob(
             )?;
             dense_terms = dense_terms.saturating_add(encoding.dense_terms as u64);
             wide_blocks += u64::from(encoding.wide_offsets);
-            legacy_block_bytes = legacy_block_bytes.saturating_add(
-                8u64.saturating_add((blk_dim_ids.len() as u64).saturating_mul(9))
-                    .saturating_add(blk_postings.len() as u64),
-            );
 
             writer.write_all(&blk_buf)?;
             cumulative_bytes += blk_buf.len() as u64;
@@ -443,10 +438,9 @@ pub(crate) fn build_bmp_blob(
     grid_entries.sort_unstable();
 
     log::info!(
-        "[bmp_build] V{} vectors={} padded={} blocks={} dims={} \
-         terms={} postings={} grid_entries={} section_b={} legacy_v18_section_b={} \
-         adaptive_ratio={:.3} dense_terms={} ({:.2}%) wide_blocks={}",
-        if store_forward { 20 } else { 19 },
+        "[bmp_build] vectors={} padded={} blocks={} dims={} \
+         terms={} postings={} grid_entries={} section_b={} \
+         dense_terms={} ({:.2}%) wide_blocks={} forward_storage={}",
         num_real_docs,
         num_virtual_docs,
         num_blocks,
@@ -455,11 +449,10 @@ pub(crate) fn build_bmp_blob(
         total_postings,
         grid_entries.len(),
         crate::format_bytes(cumulative_bytes),
-        crate::format_bytes(legacy_block_bytes),
-        cumulative_bytes as f64 / legacy_block_bytes.max(1) as f64,
         dense_terms,
         dense_terms as f64 * 100.0 / total_terms.max(1) as f64,
         wide_blocks,
+        store_forward,
     );
 
     // Release inverted traversal state. Forward output still borrows dim_vecs.
@@ -530,10 +523,12 @@ pub(crate) fn build_bmp_blob(
             max_weight_scale,
             writer,
         )?;
+    } else {
+        bytes_written += crate::segment::bmp_forward::write_disabled(writer)?;
     }
     drop(vid_pairs);
 
-    // V20 with forward values; V19 when storage is disabled.
+    // One current envelope, with an explicit optional-storage section.
     write_bmp_footer(
         writer,
         total_terms,
@@ -549,7 +544,6 @@ pub(crate) fn build_bmp_blob(
         doc_map_offset,
         num_real_docs as u32,
         grid_bits,
-        store_forward,
     )?;
     bytes_written += BMP_BLOB_FOOTER_SIZE as u64;
 
@@ -649,7 +643,6 @@ pub(crate) fn write_bmp_footer(
     doc_map_offset: u64,
     num_real_docs: u32,
     grid_bits: u8,
-    has_forward: bool,
 ) -> std::io::Result<()> {
     writer.write_u64::<LittleEndian>(total_terms)?; //  0- 7
     writer.write_u64::<LittleEndian>(total_postings)?; //  8-15
@@ -664,11 +657,7 @@ pub(crate) fn write_bmp_footer(
     writer.write_u64::<LittleEndian>(doc_map_offset)?; // 60-67
     writer.write_u32::<LittleEndian>(num_real_docs)?; // 68-71
     writer.write_u32::<LittleEndian>(grid_bits as u32)?; // 72-75
-    writer.write_u32::<LittleEndian>(if has_forward {
-        BMP_BLOB_MAGIC
-    } else {
-        crate::segment::format::BMP_BLOB_MAGIC_V19
-    })?; // 76-79
+    writer.write_u32::<LittleEndian>(BMP_BLOB_MAGIC)?; // 76-79
     Ok(())
 }
 
@@ -1671,7 +1660,6 @@ mod tests {
             66,
             77,
             4,
-            true,
         )
         .unwrap();
 

--- a/hermes-core/src/segment/format.rs
+++ b/hermes-core/src/segment/format.rs
@@ -92,22 +92,14 @@ pub fn read_dense_toc(
 /// Field header: field_id(4) + quant(1) + num_dims(4) + total_vectors(4) = 13B
 pub const SPARSE_FOOTER_MAGIC: u32 = 0x34525053;
 
-/// Legacy BMP V19 blob footer magic ("BMP9" in LE).
-///
-/// V19 keeps V18's LSP/0 pruning hierarchy and replaces each block's flat
-/// header/payload with adaptive u16/u32 byte offsets, packed-u4 term maxima,
-/// and per-term sparse-pair or dense-impact encoding.
-///
-/// Every grid retains independently addressable, locally bit-packed 256-cell
-/// groups. Packed block-header maxima reconstruct conservative u8
-/// representatives that re-quantize to exactly the persisted u4/u2 cells.
-/// V20 reuses this inverted encoding and adds logical forward values. V19
-/// remains readable; older encodings require a rebuild. See docs/bmp-forward-index.md.
-pub const BMP_BLOB_MAGIC_V19: u32 = 0x39504D42;
-/// V20 appends quantized forward values; all V19 inverted sections are unchanged.
+/// Current BMP blob footer magic ("BMPA" in LE). Adaptive inverted blocks,
+/// compressed pruning grids and physical document maps are followed by the
+/// mandatory optional-storage section (forward values or a disabled marker).
+/// Older BMP envelopes are rejected; enabling/disabling storage never changes
+/// the envelope version.
 pub const BMP_BLOB_MAGIC: u32 = 0x41504D42;
 
-/// BMP V19/V20 blob footer size.
+/// BMP blob footer size.
 pub const BMP_BLOB_FOOTER_SIZE: usize = 80;
 
 /// V3 footer size: skip_offset(8) + toc_offset(8) + num_fields(4) + magic(4) = 24
@@ -144,7 +136,7 @@ pub struct SparseFieldToc {
 impl SparseFieldToc {
     /// Build the sentinel TOC entry used by the self-contained BMP blob.
     pub(crate) fn bmp(field_id: u32, total_vectors: u32, blob_offset: u64, blob_len: u64) -> Self {
-        // V19 always stores u32 dimensions and u8 impacts regardless of the
+        // BMP always stores u32 dimensions and u8 impacts regardless of the
         // generic sparse schema knobs. Persist the physical representation,
         // not a misleading caller-supplied MaxScore descriptor.
         let config = crate::structures::SparseVectorConfig {

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -120,7 +120,7 @@ impl SegmentMerger {
                         .try_fold(0u32, |total, vectors| total.checked_add(vectors))
                         .ok_or_else(|| {
                             crate::Error::Internal(
-                                "merged BMP vector count exceeds the V19 u32 format limit".into(),
+                                "merged BMP vector count exceeds the BMP u32 format limit".into(),
                             )
                         })?;
                     let bmp_block_size = sparse_config
@@ -608,7 +608,7 @@ fn validate_sparse_merge_source(dim_id: u32, source_index: usize, raw: &DimRawDa
     Ok(())
 }
 
-/// Merge BMP fields with the **streaming block-copy V19 format**.
+/// Merge BMP fields with the **streaming block-copy BMP format**.
 ///
 /// Block-copy merge: all segments share the same `dims`, `bmp_block_size`,
 /// and `max_weight_scale`, so blocks are self-contained and can be copied directly.
@@ -621,7 +621,7 @@ fn validate_sparse_merge_source(dim_id: u32, source_index: usize, raw: &DimRawDa
 /// 4. Stream Sections E+H — ceil-u4 values decoded/repacked into the output
 ///    superblock and coarse-superblock coordinate systems
 /// 5. Stream Section F+G (doc_map) — bulk copy with offset patching
-/// 6. Write the V19 footer
+/// 6. Write the BMP footer
 ///
 /// Peak memory is one row's group descriptors/selectors, one superblock row,
 /// and fixed-size copy/decode buffers; it does not scale with postings.
@@ -692,14 +692,14 @@ fn merge_bmp_field(
             .checked_add(bmp.num_blocks)
             .ok_or_else(|| {
                 crate::Error::Internal(
-                    "merged BMP block count exceeds the V19 u32 format limit".into(),
+                    "merged BMP block count exceeds the BMP u32 format limit".into(),
                 )
             })?;
         num_real_docs_total = num_real_docs_total
             .checked_add(bmp.num_real_docs())
             .ok_or_else(|| {
                 crate::Error::Internal(
-                    "merged BMP real-document count exceeds the V19 u32 format limit".into(),
+                    "merged BMP real-document count exceeds the BMP u32 format limit".into(),
                 )
             })?;
     }
@@ -714,7 +714,7 @@ fn merge_bmp_field(
         .filter(|&count| count <= u32::MAX as usize)
         .ok_or_else(|| {
             crate::Error::Internal(
-                "merged BMP virtual-document count exceeds the V19 u32 format limit".into(),
+                "merged BMP virtual-document count exceeds the BMP u32 format limit".into(),
             )
         })?;
     // Pre-compute aggregate stats (needed for footer, independent of block order)
@@ -900,14 +900,14 @@ fn merge_bmp_field(
         )?;
     }
 
-    let has_forward = store_forward
-        && crate::segment::bmp_forward::write_forward_sources(
-            &sources,
-            &source_paths,
-            writer,
-            None,
-            cancellation,
-        )?;
+    crate::segment::bmp_forward::write_forward_sources(
+        &sources,
+        &source_paths,
+        writer,
+        None,
+        cancellation,
+        store_forward,
+    )?;
 
     // ── Phase 6: Write versioned footer ───────────────────────────────────────
     write_bmp_footer(
@@ -925,7 +925,6 @@ fn merge_bmp_field(
         doc_map_offset,
         num_real_docs_total,
         grid_bits,
-        has_forward,
     )
     .map_err(crate::Error::Io)?;
 

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -1,6 +1,6 @@
-//! BMP (Block-Max Pruning) index reader for sparse vectors — **V19/V20 zero-copy**.
+//! BMP (Block-Max Pruning) index reader for sparse vectors — **current format, zero-copy**.
 //!
-//! V19 uses fixed `dims` (vocabulary size) and dim_id directly in per-block data.
+//! BMP uses fixed `dims` (vocabulary size) and dim_id directly in per-block data.
 //! Grid is indexed by dim_id as row index (no Section C dim_ids array).
 //! Data-first layout: block data (Section B) appears before block_data_starts
 //! (Section A). The reader derives the Section A offset from
@@ -86,9 +86,9 @@ pub struct BmpDimStats {
     pub top_dims: Vec<(u32, u64)>,
 }
 
-/// BMP V19/V20 index for a single sparse field — fully zero-copy mmap-backed.
+/// BMP index for a single sparse field — fully zero-copy mmap-backed.
 ///
-/// V19 format with Recursive Graph Bisection (BP) document ordering.
+/// Adaptive blocks with Recursive Graph Bisection (BP) document ordering.
 ///
 /// All data sections are `OwnedBytes` slices into the same underlying mmap Arc.
 /// No heap allocation — the superblock grid is persisted on disk and loaded as
@@ -175,14 +175,14 @@ pub struct BmpIndex {
 // inherits Send+Sync automatically through its fields.
 
 impl BmpIndex {
-    /// Parse a BMP V19 or V20 blob from the given file handle.
+    /// Parse a current BMP blob from the given file handle.
     ///
     /// Reads the footer, then acquires the entire blob as a single
     /// `OwnedBytes` and slices it into zero-copy sections.
     ///
-    /// V19 data-first layout: Section B (per-block interleaved data) first,
+    /// Data-first layout: Section B (per-block interleaved data) first,
     /// then Section A (block_data_starts with u64 entries), grids, doc_map.
-    /// V20 appends logical forward values before the shared footer.
+    /// The forward-storage section precedes the footer.
     pub fn parse(
         handle: FileHandle,
         blob_offset: u64,
@@ -190,7 +190,7 @@ impl BmpIndex {
         total_docs: u32,
         total_vectors: u32,
     ) -> crate::Result<Self> {
-        use crate::segment::format::{BMP_BLOB_FOOTER_SIZE, BMP_BLOB_MAGIC, BMP_BLOB_MAGIC_V19};
+        use crate::segment::format::{BMP_BLOB_FOOTER_SIZE, BMP_BLOB_MAGIC};
 
         if blob_len < BMP_BLOB_FOOTER_SIZE as u64 {
             return Err(crate::Error::Corruption(
@@ -223,11 +223,11 @@ impl BmpIndex {
         let grid_bits_raw = u32::from_le_bytes(fb[72..76].try_into().unwrap());
         let magic = u32::from_le_bytes(fb[76..80].try_into().unwrap());
 
-        if magic != BMP_BLOB_MAGIC && magic != BMP_BLOB_MAGIC_V19 {
+        if magic != BMP_BLOB_MAGIC {
             return Err(crate::Error::Corruption(format!(
-                "Invalid BMP blob magic: {:#x} (expected BMP9 {:#x} or BMPA {:#x}); rebuild \
-                 the index with this version.",
-                magic, BMP_BLOB_MAGIC_V19, BMP_BLOB_MAGIC
+                "Unsupported BMP blob magic: {:#x} (expected BMPA {:#x}); migrate or rebuild \
+                 the index with a compatible Hermes release.",
+                magic, BMP_BLOB_MAGIC
             )));
         }
         let grid_bits: u8 = match grid_bits_raw {
@@ -243,12 +243,43 @@ impl BmpIndex {
 
         // Handle empty index
         if num_blocks == 0 {
-            if num_virtual_docs != 0 || num_real_docs != 0 {
+            if blob_len
+                != (BMP_BLOB_FOOTER_SIZE + crate::segment::bmp_forward::TRAILER_BYTES) as u64
+            {
+                return Err(crate::Error::Corruption(
+                    "empty BMP index must contain only the storage trailer and footer".into(),
+                ));
+            }
+            if num_virtual_docs != 0
+                || num_real_docs != 0
+                || total_terms != 0
+                || total_postings != 0
+                || grid_offset != 0
+                || sb_grid_offset != 0
+                || coarse_grid_offset != 0
+                || doc_map_offset != 0
+            {
                 return Err(crate::Error::Corruption(format!(
                     "empty BMP index has non-zero document counts (virtual={}, real={})",
                     num_virtual_docs, num_real_docs
                 )));
             }
+            if !(1..=256).contains(&bmp_block_size)
+                || !max_weight_scale.is_finite()
+                || max_weight_scale <= 0.0
+            {
+                return Err(crate::Error::Corruption(
+                    "invalid empty BMP block size or scale".into(),
+                ));
+            }
+            let forward = crate::segment::bmp_forward::BmpForward::parse_optional(
+                handle
+                    .read_bytes_range_sync(blob_offset..footer_start)
+                    .map_err(crate::Error::Io)?,
+                0,
+                total_docs,
+                dims,
+            )?;
             return Ok(Self {
                 bmp_block_size,
                 num_blocks,
@@ -263,7 +294,7 @@ impl BmpIndex {
                 num_real_docs,
                 single_valued: true,
                 logically_ordered: true,
-                forward: None,
+                forward,
                 block_data_starts_bytes: OwnedBytes::empty(),
                 block_data_bytes: OwnedBytes::empty(),
                 block_grid: CompressedGrid::empty(),
@@ -389,25 +420,19 @@ impl BmpIndex {
         let dm_ords_end = dm_ids_end.checked_add(dm_ords_len).ok_or_else(|| {
             crate::Error::Corruption("BMP ordinal map end overflows usize".into())
         })?;
-        if dm_ords_end > data_len_usize
-            || (magic == BMP_BLOB_MAGIC_V19 && dm_ords_end != data_len_usize)
-        {
+        if dm_ords_end > data_len_usize {
             return Err(crate::Error::Corruption(format!(
                 "BMP data length mismatch: sections end at {}, blob data ends at {}",
                 dm_ords_end, data_len_usize
             )));
         }
 
-        let forward = if magic == BMP_BLOB_MAGIC {
-            Some(crate::segment::bmp_forward::BmpForward::parse(
-                blob.slice(dm_ords_end..data_len_usize),
-                num_real_docs,
-                total_docs,
-                dims,
-            )?)
-        } else {
-            None
-        };
+        let forward = crate::segment::bmp_forward::BmpForward::parse_optional(
+            blob.slice(dm_ords_end..data_len_usize),
+            num_real_docs,
+            total_docs,
+            dims,
+        )?;
 
         // Slice into sections (all zero-copy — just offset adjustments on same Arc)
         let block_grid = CompressedGrid::parse(
@@ -1348,7 +1373,7 @@ mod safety_tests {
     #[test]
     fn rewrite_validation_rejects_out_of_range_local_slot() {
         let mut blob = test_blob();
-        // One-term narrow V19 header: count(4) + dim(4) + offsets(4) + max(1).
+        // One-term narrow adaptive header: count(4) + dim(4) + offsets(4) + max(1).
         blob[13] = 64;
         let index = parse(blob).unwrap();
         let error = index.validate_block_for_rewrite(0).unwrap_err();

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -1629,7 +1629,7 @@ fn reorder_bmp_field_blockwise(
     }
     if num_blocks_total > u32::MAX as usize {
         return Err(crate::Error::Internal(
-            "reordered BMP block count exceeds the V19 u32 format limit".into(),
+            "reordered BMP block count exceeds the BMP u32 format limit".into(),
         ));
     }
     let num_virtual_docs = num_blocks_total
@@ -1637,7 +1637,7 @@ fn reorder_bmp_field_blockwise(
         .filter(|&count| count <= u32::MAX as usize)
         .ok_or_else(|| {
             crate::Error::Internal(
-                "reordered BMP virtual-document count exceeds the V19 u32 format limit".into(),
+                "reordered BMP virtual-document count exceeds the BMP u32 format limit".into(),
             )
         })?;
 
@@ -1833,7 +1833,7 @@ fn reorder_bmp_field_blockwise(
             .checked_add(b.num_real_docs())
             .ok_or_else(|| {
                 crate::Error::Internal(
-                    "reordered BMP real-document count exceeds the V19 u32 format limit".into(),
+                    "reordered BMP real-document count exceeds the BMP u32 format limit".into(),
                 )
             })?;
     }
@@ -1849,14 +1849,14 @@ fn reorder_bmp_field_blockwise(
 
     drop(permuted_blocks);
     let forward_sources: Vec<_> = sources.iter().map(|(bmp, offset)| (bmp, *offset)).collect();
-    let has_forward = store_forward
-        && crate::segment::bmp_forward::write_forward_sources(
-            &forward_sources,
-            &[],
-            &mut writer,
-            Some(memory_budget),
-            cancellation,
-        )?;
+    crate::segment::bmp_forward::write_forward_sources(
+        &forward_sources,
+        &[],
+        &mut writer,
+        Some(memory_budget),
+        cancellation,
+        store_forward,
+    )?;
 
     // Footer
     write_bmp_footer(
@@ -1874,7 +1874,6 @@ fn reorder_bmp_field_blockwise(
         doc_map_offset,
         num_real_docs,
         grid_bits,
-        has_forward,
     )
     .map_err(crate::Error::Io)?;
 
@@ -2261,7 +2260,7 @@ pub(crate) fn reorder_bmp_field(
     }
     if num_real_docs > u32::MAX as usize {
         return Err(crate::Error::Internal(
-            "reordered BMP real-document count exceeds the V19 u32 format limit".into(),
+            "reordered BMP real-document count exceeds the BMP u32 format limit".into(),
         ));
     }
 
@@ -2396,7 +2395,7 @@ pub(crate) fn reorder_bmp_field(
     let new_num_blocks = num_real_docs.div_ceil(effective_block_size);
     if new_num_blocks > u32::MAX as usize {
         return Err(crate::Error::Internal(
-            "reordered BMP block count exceeds the V19 u32 format limit".into(),
+            "reordered BMP block count exceeds the BMP u32 format limit".into(),
         ));
     }
     let new_num_virtual_docs = new_num_blocks
@@ -2404,7 +2403,7 @@ pub(crate) fn reorder_bmp_field(
         .filter(|&count| count <= u32::MAX as usize)
         .ok_or_else(|| {
             crate::Error::Internal(
-                "reordered BMP virtual-document count exceeds the V19 u32 format limit".into(),
+                "reordered BMP virtual-document count exceeds the BMP u32 format limit".into(),
             )
         })?;
 
@@ -2678,14 +2677,14 @@ pub(crate) fn reorder_bmp_field(
     drop(encoded_block);
     drop(block_encode_scratch);
     let forward_sources: Vec<_> = sources.iter().map(|(bmp, offset)| (bmp, *offset)).collect();
-    let has_forward = store_forward
-        && crate::segment::bmp_forward::write_forward_sources(
-            &forward_sources,
-            &[],
-            &mut writer,
-            Some(memory_budget),
-            cancellation.as_deref(),
-        )?;
+    crate::segment::bmp_forward::write_forward_sources(
+        &forward_sources,
+        &[],
+        &mut writer,
+        Some(memory_budget),
+        cancellation.as_deref(),
+        store_forward,
+    )?;
 
     // Versioned footer.
     write_bmp_footer(
@@ -2703,7 +2702,6 @@ pub(crate) fn reorder_bmp_field(
         doc_map_offset,
         num_real_docs as u32,
         grid_bits,
-        has_forward,
     )
     .map_err(crate::Error::Io)?;
 

--- a/hermes-core/src/structures/postings/sparse/config.rs
+++ b/hermes-core/src/structures/postings/sparse/config.rs
@@ -255,7 +255,7 @@ pub struct SparseVectorConfig {
     #[serde(default = "default_bmp_grid_bits")]
     pub bmp_grid_bits: u8,
     /// Store quantized forward values in BMP blobs for L1 and BP (default true).
-    /// False emits V19 without the additional payload; normal BMP search is inverted.
+    /// False emits a disabled-storage marker; normal BMP search is inverted.
     #[serde(default = "default_bmp_forward_index", skip_serializing_if = "is_true")]
     pub bmp_forward_index: bool,
     /// Static pruning: fraction of postings to keep per inverted list (SEISMIC-style)

--- a/hermes-core/src/structures/vector/progress.rs
+++ b/hermes-core/src/structures/vector/progress.rs
@@ -175,13 +175,18 @@ mod tests {
 
     static CAPTURED: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 
-    struct CaptureLogger;
+    struct CaptureLogger {
+        thread: std::thread::ThreadId,
+    }
 
     impl log::Log for CaptureLogger {
         fn enabled(&self, _: &log::Metadata<'_>) -> bool {
-            true
+            std::thread::current().id() == self.thread
         }
         fn log(&self, record: &log::Record<'_>) {
+            if !self.enabled(record.metadata()) {
+                return;
+            }
             CAPTURED
                 .get_or_init(Default::default)
                 .lock()
@@ -195,7 +200,9 @@ mod tests {
     /// retrains at once and their output interleaves.
     #[test]
     fn training_progress_lines_carry_the_index_name() {
-        let _ = log::set_boxed_logger(Box::new(CaptureLogger));
+        let _ = log::set_boxed_logger(Box::new(CaptureLogger {
+            thread: std::thread::current().id(),
+        }));
         log::set_max_level(log::LevelFilter::Info);
 
         let phase = PhaseProgress::start(

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -328,11 +328,7 @@ pub fn convert_query(
                 boost: boost_query.boost,
             }))
         }
-        Some(ProtoQueryType::All(_)) => {
-            // Match all - use a boolean query with no clauses that matches everything
-            // For now, return an error as we don't have AllQuery implemented
-            Err("AllQuery not yet implemented".to_string())
-        }
+        Some(ProtoQueryType::All(_)) => Ok(Box::new(hermes_core::query::AllQuery)),
         Some(ProtoQueryType::SparseVector(sv_query)) => {
             let field = schema
                 .get_field(&sv_query.field)
@@ -1467,6 +1463,15 @@ pub fn text_stats_from_proto(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn match_all_is_valid_for_common_exclusion_filters() {
+        let schema = hermes_core::Schema::builder().build();
+        let query = proto::Query {
+            query: Some(ProtoQueryType::All(proto::AllQuery {})),
+        };
+        assert!(convert_query(&query, &schema, None, None, &shape()).is_ok());
+    }
+
     #[tokio::test]
     async fn match_heap_factor_reaches_text_executor_for_one_and_multiple_terms() {
         use hermes_core::directories::RamDirectory;

--- a/hermes-server/src/index_service.rs
+++ b/hermes-server/src/index_service.rs
@@ -435,18 +435,15 @@ impl IndexService for IndexServiceImpl {
         let writer = self.registry.get_writer(&req.index_name).await?;
 
         let reload_index = Arc::clone(&index);
-        writer
-            .write()
-            .await
-            .reorder_with_snapshot_refresh(move || {
-                let index = Arc::clone(&reload_index);
-                async move {
-                    index.reader().await?.reload().await?;
-                    Ok(())
-                }
-            })
-            .await
-            .map_err(crate::error::hermes_error_to_status)?;
+        hermes_core::IndexWriter::reorder_with_shared_writer(&writer, move || {
+            let index = Arc::clone(&reload_index);
+            async move {
+                index.reader().await?.reload().await?;
+                Ok(())
+            }
+        })
+        .await
+        .map_err(crate::error::hermes_error_to_status)?;
 
         let reader = index
             .reader()

--- a/hermes-server/src/registry.rs
+++ b/hermes-server/src/registry.rs
@@ -34,7 +34,7 @@ impl IndexDeleteLease {
     ///
     /// Once the registry entry is evicted and `.deleting` is visible, no new
     /// raw handle can be issued. Wait for previously issued search/writer Arcs
-    /// before shutting down lifecycle work and unlinking the directory.
+    /// before draining lifecycle work and unlinking the directory.
     pub async fn complete(mut self) -> Result<(), Status> {
         if let Some(handle) = self.handle.take() {
             let mut next_log = std::time::Instant::now() + std::time::Duration::from_secs(30);
@@ -219,6 +219,17 @@ impl IndexRegistry {
             return Ok(Arc::clone(&h.index));
         }
 
+        let index_path = self.data_dir.join(name);
+        // Deletion installs this marker before evicting the cached handle.
+        // A caller may still hold that handle while requesting its writer;
+        // waiting for the delete lease would deadlock its issued-handle drain.
+        if index_path.join(".deleting").exists() {
+            return Err(Status::not_found(format!(
+                "Index '{}' is being deleted",
+                name
+            )));
+        }
+
         // Get or create per-index open lock
         let lock = self.open_lock(name);
 
@@ -232,37 +243,20 @@ impl IndexRegistry {
         }
 
         // Open from disk
-        let index_path = self.data_dir.join(name);
         if !index_path.exists() || index_path.join(".deleting").exists() {
             return Err(Status::not_found(format!("Index '{}' not found", name)));
         }
 
         let dir = MmapDirectory::new(&index_path);
-        let index = Index::open(dir, self.config.clone())
+        // Core acquires the OS writer lock before loading the metadata used
+        // for cleanup. The registry mutex only serializes this process.
+        let (index, mut w) = Index::open_with_writer(dir, self.config.clone())
             .await
             .map_err(crate::error::hermes_error_to_status)?;
-
-        // This registry lock guarantees there is no second server-side
-        // producer for the index while crash leftovers are swept. Keep this
-        // out of the read-only core `Index::open` API: opening a search handle
-        // must not delete files owned by an independently opened writer.
-        let swept = index
-            .segment_manager()
-            .cleanup_orphan_segments()
-            .await
-            .map_err(crate::error::hermes_error_to_status)?;
-        if swept > 0 {
-            warn!(
-                "[segment_cleanup] swept {} crash-leftover segment(s) while opening '{}'",
-                swept, name
-            );
-        }
-
-        let index = Arc::new(index);
-        let mut w = index.writer();
         w.init_primary_key_dedup()
             .await
             .map_err(crate::error::hermes_error_to_status)?;
+        let index = Arc::new(index);
         let writer = Arc::new(tokio::sync::RwLock::new(w));
 
         Self::precache_idf_files(&index);
@@ -426,6 +420,12 @@ impl IndexRegistry {
         }
 
         let handle = self.handles.write().remove(name);
+        if let Some(handle) = &handle {
+            // Maintenance can retain issued handles while waiting for BP
+            // capacity or doing blocking work. Cancel it before the handle
+            // drain; waiting first prevents the signal that releases it.
+            handle.index.segment_manager().begin_shutdown();
+        }
         Ok(IndexDeleteLease {
             index_path,
             handle,
@@ -615,6 +615,141 @@ impl IndexRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn opening_registry_acquires_writer_lock_before_reading_metadata() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("owned");
+        let mut owner = IndexWriter::create(
+            MmapDirectory::new(&path),
+            hermes_core::SchemaBuilder::default().build(),
+            IndexConfig::default(),
+        )
+        .await
+        .unwrap();
+        // Poison the metadata read to distinguish it from writer admission.
+        // Cleanup may only capture its metadata after owning the writer lock.
+        let metadata_path = path.join("metadata.json");
+        let metadata = std::fs::read(&metadata_path).unwrap();
+        std::fs::write(&metadata_path, b"unreadable metadata").unwrap();
+        let registry = IndexRegistry::new(root.path().into(), Default::default());
+        let error = registry.get_or_open_index("owned").await.err().unwrap();
+        std::fs::write(&metadata_path, metadata).unwrap();
+        owner.shutdown().await.unwrap();
+        assert!(
+            error.message().contains("single-writer lock"),
+            "read metadata before acquiring exclusive ownership: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn opening_registry_does_not_sweep_files_owned_by_another_writer() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("owned");
+        std::fs::create_dir_all(&path).unwrap();
+        let mut owner = IndexWriter::create(
+            MmapDirectory::new(&path),
+            hermes_core::SchemaBuilder::default().build(),
+            IndexConfig {
+                num_indexing_threads: 1,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        // A file under the other producer's exclusive lock need not be in
+        // metadata yet. A second process cannot infer that it is an orphan.
+        let in_flight = path.join(format!("seg_{}.store", SegmentId::new().to_hex()));
+        std::fs::write(&in_flight, b"unpublished output").unwrap();
+        let registry = IndexRegistry::new(root.path().into(), Default::default());
+        let result = registry.get_or_open_index("owned").await;
+        let preserved = in_flight.exists();
+        owner.shutdown().await.unwrap();
+        assert!(result.is_err(), "a second writer must be rejected");
+        assert!(
+            preserved,
+            "registry swept output before acquiring the writer lock"
+        );
+    }
+
+    #[tokio::test]
+    async fn deletion_cancels_maintenance_before_waiting_for_issued_writer_handles() {
+        let root = tempfile::tempdir().unwrap();
+        let registry = IndexRegistry::new(
+            root.path().into(),
+            IndexConfig {
+                num_indexing_threads: 1,
+                ..Default::default()
+            },
+        );
+        registry
+            .create_index("deleting", hermes_core::SchemaBuilder::default().build())
+            .await
+            .unwrap();
+        let index = registry.get_or_open_index("deleting").await.unwrap();
+        let writer = registry.get_writer("deleting").await.unwrap();
+        let held_writer = writer.write().await;
+        let lease = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            registry.begin_delete("deleting"),
+        )
+        .await
+        .expect("delete admission must not wait for the maintenance writer lock")
+        .unwrap();
+
+        let result = index
+            .segment_manager()
+            .reorder_single_segment(
+                &SegmentId::new().to_hex(),
+                None,
+                hermes_core::segment::BpBudget::full(),
+            )
+            .await;
+        assert!(
+            matches!(result, Err(hermes_core::Error::IndexClosed)),
+            "maintenance still accepted work after deletion started: {result:?}"
+        );
+        let completion = tokio::spawn(lease.complete());
+        tokio::task::yield_now().await;
+        assert!(!completion.is_finished());
+        assert!(root.path().join("deleting").exists());
+        drop(held_writer);
+        drop(writer);
+        drop(index);
+        tokio::time::timeout(std::time::Duration::from_secs(2), completion)
+            .await
+            .expect("deletion did not finish after issued handles were released")
+            .unwrap()
+            .unwrap();
+        assert!(!root.path().join("deleting").exists());
+    }
+
+    #[tokio::test]
+    async fn deleting_index_rejects_reopen_without_waiting_for_its_existing_handle() {
+        let root = tempfile::tempdir().unwrap();
+        let registry = IndexRegistry::new(root.path().into(), Default::default());
+        registry
+            .create_index("deleting", hermes_core::SchemaBuilder::default().build())
+            .await
+            .unwrap();
+        let issued = registry.get_or_open_index("deleting").await.unwrap();
+        let lease = registry.begin_delete("deleting").await.unwrap();
+        // A handler or optimizer can fetch the index just before eviction,
+        // then ask for its writer. Waiting for the delete lease here while
+        // retaining `issued` would deadlock against deletion's handle drain.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            registry.get_writer("deleting"),
+        )
+        .await;
+        drop(issued);
+        lease.complete().await.unwrap();
+        let error = result
+            .expect("writer lookup waited for deletion while retaining an issued handle")
+            .err()
+            .expect("a deleting index must not reopen");
+        assert_eq!(error.code(), tonic::Code::NotFound);
+    }
 
     #[tokio::test]
     async fn delete_waits_for_previously_issued_index_handle() {

--- a/hermes-server/src/search_service/tests.rs
+++ b/hermes-server/src/search_service/tests.rs
@@ -842,66 +842,76 @@ async fn fusion_exclusion_only_filters_remove_self_before_candidate_selection() 
     let index = registry.get_or_open_index("l1-test").await.unwrap();
     index.reader().await.unwrap().reload().await.unwrap();
     let service = SearchServiceImpl::new(registry, 1, limits());
-    for mode in ["rrf", "linear", "export"] {
-        for (excluded, expected) in [
-            (vec!["self"], Some(1)),
-            (vec!["absent"], Some(0)),
-            (vec!["self", "allowed", "other"], None),
-        ] {
-            let mut request = named_l1_request();
-            request.fields_to_load = vec!["id".into()];
-            request.l1.as_mut().unwrap().weights = HashMap::from([("title".into(), 1.0)]);
-            if mode != "linear" {
-                request.l1 = None;
-            }
-            if mode == "rrf" {
-                request.score_export = None;
-            }
-            let Some(query::Query::Fusion(fusion)) = request.query.as_mut().unwrap().query.as_mut()
-            else {
-                unreachable!()
-            };
-            fusion.queries.truncate(1);
-            fusion.candidate_depth = if mode == "rrf" { 0 } else { 1 };
-            fusion.filters = vec![Query {
-                query: Some(query::Query::Boolean(crate::proto::BooleanQuery {
-                    must_not: excluded
-                        .iter()
-                        .map(|value| Query {
-                            query: Some(query::Query::Term(crate::proto::TermQuery {
-                                field: "id".into(),
-                                term: (*value).into(),
-                                ..Default::default()
-                            })),
-                        })
-                        .collect(),
-                    ..Default::default()
-                })),
-            }];
-            let result = service
-                .search(Request::new(request))
-                .await
-                .unwrap()
-                .into_inner();
-            assert_eq!(
-                result.hits.len(),
-                usize::from(expected.is_some()),
-                "{mode}, {excluded:?}"
-            );
-            if let Some(expected) = expected {
+    for explicit_all in [false, true] {
+        for mode in ["rrf", "linear", "export"] {
+            for (excluded, expected) in [
+                (vec!["self"], Some(1)),
+                (vec!["absent"], Some(0)),
+                (vec!["self", "allowed", "other"], None),
+            ] {
+                let mut request = named_l1_request();
+                request.fields_to_load = vec!["id".into()];
+                request.l1.as_mut().unwrap().weights = HashMap::from([("title".into(), 1.0)]);
+                if mode != "linear" {
+                    request.l1 = None;
+                }
+                if mode == "rrf" {
+                    request.score_export = None;
+                }
+                let Some(query::Query::Fusion(fusion)) =
+                    request.query.as_mut().unwrap().query.as_mut()
+                else {
+                    unreachable!()
+                };
+                fusion.queries.truncate(1);
+                fusion.candidate_depth = if mode == "rrf" { 0 } else { 1 };
+                fusion.filters = vec![Query {
+                    query: Some(query::Query::Boolean(crate::proto::BooleanQuery {
+                        must: if explicit_all {
+                            vec![Query {
+                                query: Some(query::Query::All(crate::proto::AllQuery {})),
+                            }]
+                        } else {
+                            vec![]
+                        },
+                        must_not: excluded
+                            .iter()
+                            .map(|value| Query {
+                                query: Some(query::Query::Term(crate::proto::TermQuery {
+                                    field: "id".into(),
+                                    term: (*value).into(),
+                                    ..Default::default()
+                                })),
+                            })
+                            .collect(),
+                        ..Default::default()
+                    })),
+                }];
+                let result = service
+                    .search(Request::new(request))
+                    .await
+                    .unwrap()
+                    .into_inner();
                 assert_eq!(
-                    result.hits[0].address.as_ref().unwrap().doc_id,
-                    expected,
+                    result.hits.len(),
+                    usize::from(expected.is_some()),
                     "{mode}, {excluded:?}"
                 );
-                if mode != "rrf" {
-                    let scores = result.hits[0].candidate_scores.as_ref().unwrap();
+                if let Some(expected) = expected {
                     assert_eq!(
-                        scores.document.len(),
-                        1,
-                        "filters must not become scoring features"
+                        result.hits[0].address.as_ref().unwrap().doc_id,
+                        expected,
+                        "{mode}, {excluded:?}"
                     );
-                    assert!(scores.document["title"] > 0.0);
+                    if mode != "rrf" {
+                        let scores = result.hits[0].candidate_scores.as_ref().unwrap();
+                        assert_eq!(
+                            scores.document.len(),
+                            1,
+                            "filters must not become scoring features"
+                        );
+                        assert!(scores.document["title"] > 0.0);
+                    }
                 }
             }
         }

--- a/hermes-server/src/search_service/tests.rs
+++ b/hermes-server/src/search_service/tests.rs
@@ -812,3 +812,98 @@ async fn l1_rpc_backfills_the_union_before_top_k_and_preserves_required_phrases(
     assert!(info.unprepared_candidate_fields.is_empty());
     registry.shutdown().await.unwrap();
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fusion_exclusion_only_filters_remove_self_before_candidate_selection() {
+    let temp = tempfile::tempdir().unwrap();
+    let registry = Arc::new(IndexRegistry::new(temp.path().into(), Default::default()));
+    let mut schema = hermes_core::Schema::builder();
+    let title = schema.add_text_field_with_tokenizer("title", true, false, "simple");
+    let id = schema.add_text_field_with_tokenizer("id", true, true, "simple");
+    registry
+        .create_index("l1-test", schema.build())
+        .await
+        .unwrap();
+    let writer = registry.get_writer("l1-test").await.unwrap();
+    {
+        let mut writer = writer.write().await;
+        for (identity, text) in [
+            ("self", "candidate candidate candidate"),
+            ("allowed", "candidate candidate"),
+            ("other", "candidate"),
+        ] {
+            let mut document = hermes_core::Document::new();
+            document.add_text(id, identity);
+            document.add_text(title, text);
+            writer.add_document(document).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+    let index = registry.get_or_open_index("l1-test").await.unwrap();
+    index.reader().await.unwrap().reload().await.unwrap();
+    let service = SearchServiceImpl::new(registry, 1, limits());
+    for mode in ["rrf", "linear", "export"] {
+        for (excluded, expected) in [
+            (vec!["self"], Some(1)),
+            (vec!["absent"], Some(0)),
+            (vec!["self", "allowed", "other"], None),
+        ] {
+            let mut request = named_l1_request();
+            request.fields_to_load = vec!["id".into()];
+            request.l1.as_mut().unwrap().weights = HashMap::from([("title".into(), 1.0)]);
+            if mode != "linear" {
+                request.l1 = None;
+            }
+            if mode == "rrf" {
+                request.score_export = None;
+            }
+            let Some(query::Query::Fusion(fusion)) = request.query.as_mut().unwrap().query.as_mut()
+            else {
+                unreachable!()
+            };
+            fusion.queries.truncate(1);
+            fusion.candidate_depth = if mode == "rrf" { 0 } else { 1 };
+            fusion.filters = vec![Query {
+                query: Some(query::Query::Boolean(crate::proto::BooleanQuery {
+                    must_not: excluded
+                        .iter()
+                        .map(|value| Query {
+                            query: Some(query::Query::Term(crate::proto::TermQuery {
+                                field: "id".into(),
+                                term: (*value).into(),
+                                ..Default::default()
+                            })),
+                        })
+                        .collect(),
+                    ..Default::default()
+                })),
+            }];
+            let result = service
+                .search(Request::new(request))
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(
+                result.hits.len(),
+                usize::from(expected.is_some()),
+                "{mode}, {excluded:?}"
+            );
+            if let Some(expected) = expected {
+                assert_eq!(
+                    result.hits[0].address.as_ref().unwrap().doc_id,
+                    expected,
+                    "{mode}, {excluded:?}"
+                );
+                if mode != "rrf" {
+                    let scores = result.hits[0].candidate_scores.as_ref().unwrap();
+                    assert_eq!(
+                        scores.document.len(),
+                        1,
+                        "filters must not become scoring features"
+                    );
+                    assert!(scores.document["title"] > 0.0);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Index recreation could leave old Reorder work occupying shared BP capacity indefinitely, while a fresh index's Reorder held its ingestion writer lock waiting behind it. Deletion now cancels maintenance before draining issued handles, and writer lookup rejects a deleting index before waiting on its delete lease. Reorder releases the writer lock after committing admitted input and uses the configured background CPU pool. Server open shares the existing locked writer opener, acquiring exclusive ownership before reading cleanup metadata.

This also completes the BMP and fusion follow-up to #172:

- One accepted/emitted BMP format, with explicit optional forward-storage state and no V19 reader/writer/merge branch. Enabled bytes remain unchanged; disabling storage adds a 16-byte marker. Compatible merges and BP retain streaming copies.
- Exclusion-only common filters work with bare `must_not` and explicit `AllQuery`, including documents with missing metadata. Filters apply before candidate selection in RRF, L1 and export and do not become scoring features.
- Ordinary BMP search remains inverted-only; optional forward values serve BP and L1.

Validation: required `check` and all eight `full` stages passed: 1,344 core tests (17 manual experiments ignored), 70 server, 50 broker unit, 13 broker integration and both real-server RPC tests. Native without sync passed match-all and maintenance regressions. WASM release build and all five runtime tests passed. Regression tests reproduced the deletion, reopen, cleanup ownership and unsupported-AllQuery failures before the fixes. The enabled BMP fixture remains byte-identical to 1.8.125 (12,713 bytes, FNV-1a-64 `5ccfbcdae3690623`); disabled storage preserves all inverted bytes. Full evidence and the initial test-port collision are recorded in `docs/search-performance-review.md`.

Deployment requires rebuilt/current-format indexes. All four rebuilt production shards passed the footer audit; the operator superseded the old-index migration with rebuilding. No new latency or throughput claim is made; the ingestion regression demonstrates progress while another index holds every maintenance permit.
