### PR TITLE
Fix optional BMP storage documentation links

### DIFF
--- a/docs/bmp-forward-search.md
+++ b/docs/bmp-forward-search.md
@@ -5,7 +5,7 @@ removed from production BMP search after the whole-query measurements below.
 There is no search query option or automatic dispatch to forward values.
 Ordinary BMP search always uses its inverted block scorer. Stored forward values
 are used by L1 candidate backfill and BP whenever available; see
-[optional storage](bmp-forward-index.md#optional-storage).
+[optional storage](bmp-forward-index.md#configuration-and-scoring).
 
 The prototype preserved the existing H/E/D traversal and collector and tried
 forward completion only for small survivor sets after phase one. Its best warm

--- a/docs/candidate-rescoring.md
+++ b/docs/candidate-rescoring.md
@@ -238,7 +238,7 @@ explicit Reorder before their missing cells can be backfilled. BMP storage is op
 candidates by binary search and score their query-term postings in selected
 blocks. BP-reordered BMP maps need this setting enabled and explicit
 reorder/rebuild to regain backfill capability. Disabling storage does not affect
-full-text or sparse MaxScore backfill. See [optional forward storage](bmp-forward-index.md#optional-storage).
+full-text or sparse MaxScore backfill. See [optional forward storage](bmp-forward-index.md#configuration-and-scoring).
 `GetIndexInfo.unprepared_candidate_fields`
 reports these fields and ANN fields without stored flat vectors. Disabling
 backfill, or supplying every needed organic cell, requires no address probes

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -523,7 +523,7 @@ field emb: sparse_vector<u32> [indexed<format: bmp, dims: 105879, max_weight: 5.
   regardless of this setting. Without forward values, L1 backfill requires a
   logically ordered BMP document map; BP-reordered fields require enabling
   storage and explicit reorder/rebuild, or `l1.backfill: false`. Existing files
-  are immutable. See [optional forward storage](bmp-forward-index.md#optional-storage).
+  are immutable. See [optional forward storage](bmp-forward-index.md#configuration-and-scoring).
 - `query<pruning: 0.33>` — retain the highest-weight third of query
   dimensions for BMP candidate generation, matching the LSP/0 zero-shot beta.
   Visited documents are still scored with the bounded full query. This is


### PR DESCRIPTION
Point the three optional-storage links at the current configuration heading after the BMP design rewrite. Validation: check_docs.py checked 75 Markdown files, 264 local links and 20 benchmark targets; both documentation-checker tests passed.