### PR TITLE
Fix sparse query defaults, filter planning, and BMP rescoring budgets

### DIFF
--- a/docs/candidate-rescoring.md
+++ b/docs/candidate-rescoring.md
@@ -345,7 +345,7 @@ optimality or default changes; preserve a measured rollback path.
 
 ## Eligibility and bounded nomination
 
-The common filter is represented separately from scoring. BM25 and BMP
+The common filter is represented separately from scoring. BM25, BMP and sparse MaxScore
 collectors receive eligibility before their candidate heaps; filters contribute
 neither scores nor ordinals. Vector ANN retains its existing bounded nomination
 and is checked for eligibility before union, so selective filters may underfill
@@ -357,6 +357,28 @@ materializable text/phrase/fast-field filters use the existing bitset paths.
 Other filters and portable builds use ordinary complete filter scorers only on
 segments of at most 200,000 documents, failing explicitly above that bound.
 This prevents an implicit corpus-sized scoring heap on a legacy backend.
+
+Filter wrappers are opaque to scoring decomposition: flattening a filtered
+branch into unfiltered terms changes its matching set. Query-global BMP LSP
+planning has a separate decomposition hook that may inspect the wrapped sparse
+query without removing its filter during execution. This preserves the one
+query-global superblock budget across segments. An enclosing common filter is
+intersected with Boolean-local eligibility before either collector admits hits.
+
+Filter materialization shares the request deadline, with score thresholds and
+LSP selection cleared. An expired materialization discards its partial bitmap
+and marks the request truncated. Empty intersections stop before later filters
+or scoring payloads are read. These checks reuse the existing bitmap and add
+at most a scan of its words; they introduce no corpus-sized scratch or new
+persistent representation.
+
+Candidate backfill admits BMP bytes using validated forward offsets or distinct
+selected inverted-block ranges before reading or validating their payloads.
+These bytes share a 256 MiB request budget with lazy text payload reads across
+segments, features and query components. This bounds BMP work even when one
+nominated vector contains many retained entries; a candidate-count limit alone
+does not bound those bytes. The admission pass needs constant scratch and does
+not inspect payloads or alter stored values.
 
 ## Client example
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -531,8 +531,9 @@ field emb: sparse_vector<u32> [indexed<format: bmp, dims: 105879, max_weight: 5.
   recall; enable it only after a representative Recall@K benchmark.
 - `query<lsp_gamma: N>` — cap traversal to the global top-N superblocks across
   all physical segments. When omitted, Hermes derives gamma from candidate
-  depth (250/500/1000 for depths 10/100/1000). Set zero for exhaustive
-  traversal.
+  depth (3000 through depth 100, 4000 through depth 1000, then the greater
+  of 4000 and depth). Set zero for exhaustive traversal. Query-language
+  `emb:sparse({...})` searches inherit this field setting, including zero.
 
 See `docs/bmp-grid-compression.md` for current size formulas, LSP/0 behavior,
 merge/reorder invariants, and the Flat-Inv versus Fwd design choice.

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -897,3 +897,142 @@ Final combined validation passed:
   An interim full run was interrupted to make that final change; its process
   group cancellation reported an OS error, so only the complete final run above
   is used as validation evidence.
+
+## Search correctness and execution review (2026-09-06)
+
+Reviewed against `5286d8c5` (1.8.126), tracing the shared query-language parser,
+Index/Searcher planning, common filters, Boolean/BMP/MaxScore execution and L1
+candidate readers. The fixes stay in those owners; there are no index-format,
+wire-format, scoring-formula or approximate-default changes.
+
+### Confirmed and fixed
+
+- `emb:sparse({...})` dropped the field's `query<lsp_gamma: N>` setting.
+  Explicit zero therefore became the depth-derived approximate default. The
+  core parser now carries `Some(0)` and positive caps through unchanged, while
+  an omitted setting remains `None`. This shared parser serves native, async,
+  tool and WASM callers. The structured RPC converter already inherited the
+  setting. Regressions reproduce the lost zero and a nine-document query
+  ignoring a one-superblock cap; parsed results now match an explicitly
+  configured core query. The schema reference also now describes the existing
+  3000/4000/depth gamma schedule correctly.
+- Boolean optimization could flatten a common-filter wrapper, or a nested
+  Boolean with required/excluded clauses, into unfiltered sparse terms.
+  Scoring decomposition now keeps those constraints opaque. A separate BMP
+  planning hook preserves query-global superblock selection for common-filter
+  wrappers and Boolean queries with local pure filters. A two-segment test
+  checks that a cap of one still admits only one superblock across the index.
+- Common eligibility reached some nested BM25/BMP and sparse MaxScore plans
+  only after their top-k heaps, allowing disallowed high scores to crowd out
+  eligible hits. Local Boolean eligibility now intersects outer eligibility;
+  sparse MaxScore receives both eligibility and the request deadline. Known-hit
+  regressions cover direct, optimized Boolean and nested-filter plans.
+- Common-filter materialization used fresh default options, losing deadlines,
+  and continued into scoring even after the intersection became empty. It now
+  shares the existing truncation state, discards incomplete bitmaps and stops
+  before remaining filters or scoring payloads. The direct synchronous scorer
+  also delegates to the implemented filtered path. Work remains bounded by the
+  existing bitmap/fallback limits; emptiness checks scan existing bitmap words.
+- BMP L1 backfill bounded candidate count but did not admit variable-size
+  selected payloads against a byte budget. Forward offsets or selected inverted
+  block ranges now reserve bytes before payload validation/scoring, sharing the
+  existing 256 MiB lazy-text allowance across segments, features and components.
+  The reader performs an O(selected values) metadata pass with constant scratch.
+  A zero-budget regression failed before the fix for both forward-storage modes.
+  Dead version-dependent logging in the current-format-only BMP reader was
+  removed while checking this path.
+
+The eligibility and admission invariants are recorded in
+[candidate rescoring](candidate-rescoring.md#eligibility-and-bounded-nomination).
+No writer or codec changed, so this pass does not claim a format rewrite or a
+new byte-identity experiment.
+
+### Local measurement
+
+The empty-filter experiment uses the same RAM index of 16,384 documents, each
+containing `alpha beta gamma` and a numeric eligibility value of zero. It asks
+for ten `alpha` hits with eligibility equal to one and verifies an empty result
+outside timing. Index construction is excluded. Each process measures eleven
+batches of 100 end-to-end searches; three before/after pairs alternate order.
+Both binaries use the same Apple M4, Rust 1.98.1 / LLVM 22.1.8 and Cargo release
+flags, with no concurrent build during measurement.
+
+| Measurement                                       |                   Before |                    After |
+| ------------------------------------------------- | -----------------------: | -----------------------: |
+| Median batch latency, three processes (µs/search) | 90.091 / 87.678 / 89.499 | 17.672 / 14.169 / 13.285 |
+| Median of those medians (µs/search)               |                   89.499 |                   14.169 |
+| Process peak RSS range (MiB)                      |              19.34–20.33 |              18.77–19.69 |
+| Eligibility bitmap (bytes)                        |                     2048 |                     2048 |
+
+This is a roughly 6.3× improvement for empty eligibility, not an overall search
+speedup or a tail-latency claim. RSS includes the fixture and test process and
+does not isolate per-query scratch. The first baseline process incurred 544
+page faults; the other five reported zero. Queries use a warmed RAM fixture,
+and ordinary desktop activity was present. Cold storage, loaded concurrency,
+nonempty-filter latency and a controlled x86 before/after remain unmeasured.
+Reproduction: run the ignored release test
+`query::filtered::tests::empty_common_filter_benchmark` under `/usr/bin/time -l`.
+Raw runs and environment metadata are in this workspace's
+`.context/common-filter-benchmark-{before,after}-{1,2,3}.log` and
+`.context/common-filter-benchmark-environment.json`.
+
+### Deployed observations and remaining performance work
+
+Read-only SSH/Kubernetes sampling observed the existing 1.8.126 broker and four
+servers. No patch was deployed, requests replayed or settings changed. Between
+approximately 04:52:42 and 04:59:36 UTC, broker counter deltas recorded 37
+successful document searches averaging 448.1 ms and 12 social searches averaging
+5.13 ms, with no new recorded errors. These are sparse, mixed live requests
+(about 0.12 requests/second combined), not a throughput benchmark. The first
+broker summary exported document p50/p95/p99 of 47.1/1303.0/1303.0 ms; these
+rolling summary quantiles are not quantiles of the counter-delta interval.
+
+On document shard `s2`, the same interval contained seven `sparse_vectors` LSP
+plans averaging 90.0 ms and 56 segment BMP executions averaging 218.7 ms.
+Mean execution components included 164.3 ms in block scoring, 49.3 ms in
+prefetch, 3.64 ms in the D grid and 1.06 ms in document mapping. Four short-document
+sparse plans averaged 25.3 ms; their 28 segment executions averaged 289.7 ms,
+including 268.4 ms in block scoring. These component means identify profiling
+targets; segment work can run concurrently and must not be summed as request
+wall time. Sampled LSP counter deltas averaged gamma 3000, but metrics do not
+identify the request syntax or prove those requests used a schema gamma of zero.
+
+Two process/cgroup snapshots on `s2`, 337 seconds apart, showed RSS about
+63.6 GiB (46.9–47.1 GiB anonymous and 16.5–16.7 GiB file-backed), 1.75 GiB locked
+and no swap. Cgroup usage rose from 68.6 to 73.3 GiB; its historical peak was
+206.0 GiB, while process peak RSS was 168.7 GiB. The interval added 7.20 million
+major faults and 7.99 million file refaults, with CPU consumption averaging
+5.53 cores and no quota throttling. Recent memory-pressure averages were low
+and OOM counters were zero. These are whole-container observations, not
+per-query allocations; neither faults nor the historical peaks can be assigned
+to search versus background work from these samples alone.
+
+Remaining work is to profile block scoring and selected-range I/O on a fixed
+production-like corpus, correlating faults with per-request and maintenance
+activity, then measure warm/cold latency and recall at the same explicit gamma.
+The slow log includes candidate exports taking 3.1–6.5 seconds, some with empty
+segment heaps and zero thresholds; selective-filter/candidate-depth behavior
+deserves that controlled follow-up. The documented bounded ANN nomination can
+still underfill a selective common filter. This pass preserves that policy;
+changing it needs a recall/work comparison. No production default was tuned.
+
+`kubectl top` failed because the cluster Metrics API is unavailable. Direct
+Prometheus scrapes plus `/proc` and cgroup files supplied the observations
+instead. Raw evidence is retained under `.context/review-prod-*`, with derived
+tables in `.context/review-production-{analysis,resources-analysis,bmp-breakdown}.json`.
+
+### Validation
+
+- Required `python3 scripts/check_search.py check` passed: formatting, Clippy,
+  1,356 core unit tests (18 manual experiments ignored), 70 server tests,
+  50 broker unit tests, 13 broker integration tests, tool/integration/doc tests
+  and the native-without-sync compile boundary. Run evidence:
+  `.context/search-harness/20260906T045858.391501Z-check/`.
+- Native without sync passed eight filter regressions, all 22 query-language
+  tests and the BMP admission regression: `.context/review-native-async.log`.
+- WASM release compilation and all seven runtime tests passed, including
+  query-language searches with exhaustive and bounded schema gamma. Evidence:
+  `.context/review-wasm-{npm-install,build,test}.log`.
+- The extended `full` harness/real-server RPC tests, a Linux mlock experiment,
+  controlled cold-cache and cross-architecture comparisons were not run in
+  this pass. Lifecycle/RPC implementations and residency policy were unchanged.

--- a/hermes-core/src/dsl/ql/mod.rs
+++ b/hermes-core/src/dsl/ql/mod.rs
@@ -465,7 +465,16 @@ impl QueryLanguageParser {
                     .schema
                     .get_field(field)
                     .ok_or_else(|| format!("Unknown field: {}", field))?;
-                let query = SparseVectorQuery::new(field_id, vector.clone());
+                let mut query = SparseVectorQuery::new(field_id, vector.clone());
+                if let Some(gamma) = self
+                    .schema
+                    .get_field_entry(field_id)
+                    .and_then(|entry| entry.sparse_vector_config.as_ref())
+                    .and_then(|config| config.query_config.as_ref())
+                    .and_then(|config| config.lsp_gamma)
+                {
+                    query = query.with_lsp_gamma(gamma);
+                }
                 Ok(Box::new(query))
             }
             ParsedQuery::And(queries) => {
@@ -670,6 +679,73 @@ mod tests {
         let schema = Arc::new(builder.build());
         let tokenizers = Arc::new(TokenizerRegistry::default());
         (schema, vec![title, body], tokenizers)
+    }
+
+    #[test]
+    fn sparse_query_language_preserves_schema_lsp_gamma_including_exhaustive_zero() {
+        for gamma in [None, Some(0), Some(7)] {
+            let setting = gamma.map_or(String::new(), |gamma| {
+                format!(", query<lsp_gamma: {gamma}>")
+            });
+            let schema = crate::parse_schema(&format!(
+                "index test {{ field emb: sparse_vector [indexed<format: bmp, dims: 16{setting}>] }}"
+            )).unwrap();
+            let parser = QueryLanguageParser::new(
+                Arc::new(schema),
+                vec![],
+                Arc::new(TokenizerRegistry::default()),
+            );
+            let query = parser.parse("emb:sparse({0: 1.0})").unwrap();
+            let crate::query::QueryDecomposition::SparseTerms(infos) = query.decompose() else {
+                panic!("sparse syntax did not produce a sparse query");
+            };
+            assert_eq!(infos.len(), 1);
+            assert_eq!(infos[0].lsp_gamma, gamma);
+        }
+    }
+
+    #[cfg(feature = "native")]
+    #[tokio::test]
+    async fn parsed_sparse_search_uses_the_fields_exhaustive_or_bounded_lsp_policy() {
+        use crate::query::SparseVectorQuery;
+        use crate::{Document, Index, IndexConfig, IndexWriter, RamDirectory};
+        for gamma in [0, 1] {
+            let schema = crate::parse_schema(&format!(
+                "index test {{ field emb: sparse_vector [indexed<format: bmp, dims: 16, bmp_block_size: 1, query<lsp_gamma: {gamma}>>] }}"
+            )).unwrap();
+            let field = schema.get_field("emb").unwrap();
+            let directory = RamDirectory::new();
+            let config = IndexConfig::default();
+            let mut writer = IndexWriter::create(directory.clone(), schema, config.clone())
+                .await
+                .unwrap();
+            // Two superblocks: one of eight weaker documents and one winner.
+            for doc in 0..9 {
+                let mut document = Document::new();
+                document.add_sparse_vector(field, vec![(0, if doc == 8 { 5.0 } else { 0.1 })]);
+                writer.add_document(document).unwrap();
+            }
+            writer.commit().await.unwrap();
+            let index = Index::open(directory, config).await.unwrap();
+            let query = index.query_parser().parse("emb:sparse({0: 1.0})").unwrap();
+            let actual = index.search(query.as_ref(), 9).await.unwrap();
+            let expected = index
+                .search(
+                    &SparseVectorQuery::new(field, vec![(0, 1.0)]).with_lsp_gamma(gamma),
+                    9,
+                )
+                .await
+                .unwrap();
+            let hits = |result: crate::query::SearchResponse| {
+                result
+                    .hits
+                    .into_iter()
+                    .map(|hit| (hit.address.doc_id, hit.score.to_bits()))
+                    .collect::<Vec<_>>()
+            };
+            assert_eq!(actual.hits.len(), if gamma == 0 { 9 } else { 1 });
+            assert_eq!(hits(actual), hits(expected));
+        }
     }
 
     #[test]

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -754,7 +754,7 @@ impl<D: Directory + 'static> Searcher<D> {
         if retrieval_depth == 0 {
             return Ok(empty());
         }
-        let crate::query::QueryDecomposition::SparseTerms(infos) = query.decompose() else {
+        let crate::query::QueryDecomposition::SparseTerms(infos) = query.lsp_decomposition() else {
             return Ok(empty());
         };
         let Some(&first) = infos.first() else {

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -349,7 +349,7 @@ macro_rules! boolean_plan {
                     return Ok(combine_sparse_results(raw, info.combiner, info.field, limit));
                 }
                 if let Some((executor, info)) =
-                    build_sparse_maxscore_executor(&infos, reader, limit, None)
+                    build_sparse_maxscore_executor(&infos, reader, limit, None, &scorer_options)
                 {
                     let raw = executor.$execute_fn() $(. $aw)* ?;
                     return Ok(combine_sparse_results(raw, info.combiner, info.field, limit));
@@ -753,7 +753,7 @@ macro_rules! boolean_plan {
                     }
                     // Try MaxScore with predicate
                     if let Some((executor, info)) =
-                        build_sparse_maxscore_executor(&infos, reader, limit, Some(combined))
+                        build_sparse_maxscore_executor(&infos, reader, limit, Some(combined), &scorer_options)
                     {
                         log::debug!(
                             "BooleanQuery planner: predicate-aware sparse MaxScore, {} dims",
@@ -1017,6 +1017,13 @@ impl Query for BooleanQuery {
     }
 
     fn decompose(&self) -> super::QueryDecomposition {
+        if !self.must.is_empty() || !self.must_not.is_empty() {
+            return super::QueryDecomposition::Opaque;
+        }
+        self.lsp_decomposition()
+    }
+
+    fn lsp_decomposition(&self) -> super::QueryDecomposition {
         // LSP/0 selection depends only on the sparse scoring clauses. Pure
         // filters may remove documents but cannot increase their score, so a
         // query-global superblock plan remains valid and must be shared across

--- a/hermes-core/src/query/candidate_scoring/execution.rs
+++ b/hermes-core/src/query/candidate_scoring/execution.rs
@@ -12,13 +12,14 @@ const MAX_VECTOR_BYTES: usize = 1024 * 1024 * 1024;
 
 struct CandidateProbeBudget {
     sparse: crate::segment::reader::SparseProbeBudget,
-    text_remaining: u64,
+    payload_remaining: u64,
 }
+
 impl Default for CandidateProbeBudget {
     fn default() -> Self {
         Self {
             sparse: Default::default(),
-            text_remaining: 256 * 1024 * 1024,
+            payload_remaining: 256 * 1024 * 1024,
         }
     }
 }
@@ -173,7 +174,7 @@ async fn score_field<D: Directory + 'static>(
                             query.field,
                             term,
                             false,
-                            &mut budget.text_remaining,
+                            &mut budget.payload_remaining,
                         )
                         .await?;
                 }
@@ -193,7 +194,7 @@ async fn score_field<D: Directory + 'static>(
                             query.field,
                             term,
                             phrase.terms.len() > 1,
-                            &mut budget.text_remaining,
+                            &mut budget.payload_remaining,
                         )
                         .await?;
                 }
@@ -202,6 +203,11 @@ async fn score_field<D: Directory + 'static>(
             }
             ScoreComponent::Sparse(terms) => {
                 if let Some(index) = reader.bmp_index(query.field) {
+                    reader.reserve_candidate_bmp_reads(
+                        query.field,
+                        targets,
+                        &mut budget.payload_remaining,
+                    )?;
                     searcher.install_search_cpu(|| {
                         crate::query::bmp::score_bmp_candidates(index, terms, targets)
                     })?
@@ -696,5 +702,75 @@ impl<D: Directory + 'static> Searcher<D> {
             crate::query::compare_search_results_desc(&a.result, &b.result)
         });
         Ok(output)
+    }
+}
+
+#[cfg(all(test, feature = "native"))]
+mod tests {
+    use super::*;
+    use crate::query::{Query, SparseVectorQuery};
+    use crate::structures::{SparseFormat, SparseVectorConfig};
+    use crate::{Document, Index, IndexConfig, IndexWriter, RamDirectory, Schema};
+
+    #[tokio::test]
+    async fn bmp_backfill_admits_payload_bytes_before_scoring_with_or_without_forward_storage() {
+        let mut schema = Schema::builder();
+        let fields: Vec<_> = [true, false]
+            .into_iter()
+            .map(|forward| {
+                schema.add_sparse_vector_field_with_config(
+                    &format!("sparse_{forward}"),
+                    true,
+                    false,
+                    SparseVectorConfig {
+                        format: SparseFormat::Bmp,
+                        dims: Some(16),
+                        bmp_forward_index: forward,
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
+        let directory = RamDirectory::new();
+        let config = IndexConfig::default();
+        let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+            .await
+            .unwrap();
+        let mut document = Document::new();
+        for &field in &fields {
+            document.add_sparse_vector(field, vec![(0, 1.0)]);
+        }
+        writer.add_document(document).unwrap();
+        writer.commit().await.unwrap();
+        let index = Index::open(directory, config).await.unwrap();
+        let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+        let reader = &searcher.segment_readers()[0];
+        let stats = Arc::new(GlobalStatsBuilder::new().build(0));
+        for field in fields {
+            let query = SparseVectorQuery::new(field, vec![(0, 1.0)])
+                .candidate_query()
+                .unwrap();
+            let locations = reader
+                .candidate_locations(field, &[0], 1, &mut Default::default())
+                .await
+                .unwrap();
+            let mut budget = CandidateProbeBudget {
+                payload_remaining: 0,
+                ..Default::default()
+            };
+            let error = score_field(
+                &searcher,
+                reader,
+                &query,
+                &locations,
+                &stats,
+                false,
+                &mut budget,
+            )
+            .await
+            .unwrap_err();
+            assert!(matches!(error, Error::Query(_)), "{error}");
+            assert!(error.to_string().contains("payload read budget"), "{error}");
+        }
     }
 }

--- a/hermes-core/src/query/filtered.rs
+++ b/hermes-core/src/query/filtered.rs
@@ -32,20 +32,38 @@ impl std::fmt::Display for FilteredQuery {
         )
     }
 }
-fn intersect(combined: &mut Option<DocBitset>, next: DocBitset) {
+/// Intersect complete filters, returning whether any document remains eligible.
+fn intersect(combined: &mut Option<DocBitset>, next: DocBitset) -> bool {
     if let Some(existing) = combined {
         existing.intersect_with(&next);
     } else {
         *combined = Some(next);
     }
+    combined.as_ref().unwrap().next_set_bit(0).is_some()
 }
-fn enumerate_filter(mut scorer: Box<dyn Scorer + '_>, num_docs: u32) -> DocBitset {
+fn enumerate_filter(
+    mut scorer: Box<dyn Scorer + '_>,
+    num_docs: u32,
+    options: &ScorerOptions,
+) -> Option<DocBitset> {
     let mut bits = DocBitset::new(num_docs);
+    let mut visited = 0usize;
     while scorer.doc() != crate::TERMINATED {
+        if visited.is_multiple_of(1024) && options.stop_if_expired() {
+            return None;
+        }
         bits.set(scorer.doc());
         scorer.advance();
+        visited += 1;
     }
-    bits
+    (!options.stop_if_expired()).then_some(bits)
+}
+fn no_candidates(options: &ScorerOptions) -> bool {
+    options.stop_if_expired()
+        || options
+            .eligibility
+            .as_ref()
+            .is_some_and(|bits| bits.next_set_bit(0).is_none())
 }
 // Native materializable filters stream their matches directly into a bitset.
 // The portable fallback uses ordinary scorers only on bounded segments, never
@@ -86,27 +104,49 @@ impl Query for FilteredQuery {
         let this = self.clone();
         Box::pin(async move {
             this.validate(reader)?;
+            if no_candidates(&options) {
+                return Ok(Box::new(super::EmptyScorer) as Box<dyn Scorer>);
+            }
+            let filter_options = ScorerOptions {
+                eligibility: None,
+                collect_positions: false,
+                ..options.without_threshold()
+            };
             let mut combined = None;
             for filter in &this.filters {
-                let bits = match filter.as_doc_bitset(reader) {
+                let bits = match filter_options.doc_bitset(filter.as_ref(), reader) {
                     Some(bits) => bits,
-                    None => enumerate_filter(
-                        filter
-                            .scorer_with_options(
-                                reader,
-                                fallback_limit(reader)?,
-                                ScorerOptions::default(),
-                            )
-                            .await?,
-                        reader.num_docs(),
-                    ),
+                    None => {
+                        if filter_options.stop_if_expired() {
+                            return Ok(Box::new(super::EmptyScorer) as Box<dyn Scorer>);
+                        }
+                        let Some(bits) = enumerate_filter(
+                            filter
+                                .scorer_with_options(
+                                    reader,
+                                    fallback_limit(reader)?,
+                                    filter_options.clone(),
+                                )
+                                .await?,
+                            reader.num_docs(),
+                            &filter_options,
+                        ) else {
+                            return Ok(Box::new(super::EmptyScorer) as Box<dyn Scorer>);
+                        };
+                        bits
+                    }
                 };
-                intersect(&mut combined, bits);
+                if filter_options.stop_if_expired() || !intersect(&mut combined, bits) {
+                    return Ok(Box::new(super::EmptyScorer) as Box<dyn Scorer>);
+                }
             }
             if let (Some(bits), Some(outer)) = (&mut combined, &options.eligibility) {
                 bits.intersect_with(outer);
             }
             options.eligibility = combined.map(Arc::new).or(options.eligibility);
+            if no_candidates(&options) {
+                return Ok(Box::new(super::EmptyScorer) as Box<dyn Scorer>);
+            }
             let bits = options.eligibility.clone();
             let scorer = this
                 .query
@@ -116,6 +156,14 @@ impl Query for FilteredQuery {
         })
     }
     #[cfg(feature = "sync")]
+    fn scorer_sync<'a>(
+        &self,
+        reader: &'a SegmentReader,
+        limit: usize,
+    ) -> Result<Box<dyn Scorer + 'a>> {
+        self.scorer_sync_with_options(reader, limit, ScorerOptions::with_positions())
+    }
+    #[cfg(feature = "sync")]
     fn scorer_sync_with_options<'a>(
         &self,
         reader: &'a SegmentReader,
@@ -123,25 +171,47 @@ impl Query for FilteredQuery {
         mut options: ScorerOptions,
     ) -> Result<Box<dyn Scorer + 'a>> {
         self.validate(reader)?;
+        if no_candidates(&options) {
+            return Ok(Box::new(super::EmptyScorer));
+        }
+        let filter_options = ScorerOptions {
+            eligibility: None,
+            collect_positions: false,
+            ..options.without_threshold()
+        };
         let mut combined = None;
         for filter in &self.filters {
-            let bits = match filter.as_doc_bitset(reader) {
+            let bits = match filter_options.doc_bitset(filter.as_ref(), reader) {
                 Some(bits) => bits,
-                None => enumerate_filter(
-                    filter.scorer_sync_with_options(
-                        reader,
-                        fallback_limit(reader)?,
-                        ScorerOptions::default(),
-                    )?,
-                    reader.num_docs(),
-                ),
+                None => {
+                    if filter_options.stop_if_expired() {
+                        return Ok(Box::new(super::EmptyScorer));
+                    }
+                    let Some(bits) = enumerate_filter(
+                        filter.scorer_sync_with_options(
+                            reader,
+                            fallback_limit(reader)?,
+                            filter_options.clone(),
+                        )?,
+                        reader.num_docs(),
+                        &filter_options,
+                    ) else {
+                        return Ok(Box::new(super::EmptyScorer));
+                    };
+                    bits
+                }
             };
-            intersect(&mut combined, bits);
+            if filter_options.stop_if_expired() || !intersect(&mut combined, bits) {
+                return Ok(Box::new(super::EmptyScorer));
+            }
         }
         if let (Some(bits), Some(outer)) = (&mut combined, &options.eligibility) {
             bits.intersect_with(outer);
         }
         options.eligibility = combined.map(Arc::new).or(options.eligibility);
+        if no_candidates(&options) {
+            return Ok(Box::new(super::EmptyScorer));
+        }
         let bits = options.eligibility.clone();
         Ok(filtered(
             self.query
@@ -150,7 +220,14 @@ impl Query for FilteredQuery {
         ))
     }
     fn decompose(&self) -> super::QueryDecomposition {
-        self.query.decompose()
+        if self.filters.is_empty() {
+            self.query.decompose()
+        } else {
+            super::QueryDecomposition::Opaque
+        }
+    }
+    fn lsp_decomposition(&self) -> super::QueryDecomposition {
+        self.query.lsp_decomposition()
     }
     fn text_terms(&self, out: &mut Vec<(crate::Field, Vec<u8>)>) {
         self.query.text_terms(out);
@@ -159,3 +236,6 @@ impl Query for FilteredQuery {
         }
     }
 }
+
+#[cfg(all(test, feature = "native"))]
+mod tests;

--- a/hermes-core/src/query/filtered/tests.rs
+++ b/hermes-core/src/query/filtered/tests.rs
@@ -1,0 +1,362 @@
+use super::*;
+use crate::query::{
+    AllQuery, BooleanQuery, RangeQuery, SparseTermQuery, SparseVectorQuery, TermQuery,
+};
+use crate::structures::{SparseFormat, SparseVectorConfig};
+use crate::{Document, Field, Index, IndexConfig, IndexWriter, RamDirectory, Schema};
+
+async fn fixture() -> (Index<RamDirectory>, Field, Field, Field, Field) {
+    let mut schema = Schema::builder();
+    let text = schema.add_text_field_with_tokenizer("body", true, false, "simple");
+    let allowed = schema.add_u64_field("allowed", true, false);
+    schema.set_fast(allowed, true);
+    let sparse: Vec<_> = [SparseFormat::Bmp, SparseFormat::MaxScore]
+        .into_iter()
+        .enumerate()
+        .map(|(i, format)| {
+            schema.add_sparse_vector_field_with_config(
+                &format!("sparse{i}"),
+                true,
+                false,
+                SparseVectorConfig {
+                    format,
+                    dims: Some(16),
+                    ..Default::default()
+                },
+            )
+        })
+        .collect();
+    let directory = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+        .await
+        .unwrap();
+    for doc in 0..12 {
+        let mut document = Document::new();
+        document.add_text(text, "alpha ".repeat(12 - doc));
+        document.add_u64(allowed, u64::from(doc >= 10));
+        for &field in &sparse {
+            document.add_sparse_vector(field, vec![(0, (12 - doc) as f32 / 12.0), (1, 0.1)]);
+        }
+        writer.add_document(document).unwrap();
+    }
+    writer.commit().await.unwrap();
+    (
+        Index::open(directory, config).await.unwrap(),
+        text,
+        allowed,
+        sparse[0],
+        sparse[1],
+    )
+}
+
+fn eligible(query: impl Query + 'static, allowed: Field) -> FilteredQuery {
+    FilteredQuery::new(
+        Arc::new(query),
+        vec![Arc::new(RangeQuery::u64(allowed, Some(1), Some(1)))],
+    )
+}
+
+async fn assert_selected(
+    index: &Index<RamDirectory>,
+    query: &dyn Query,
+    limit: usize,
+    expected: &[u32],
+) {
+    let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+    assert_eq!(searcher.segment_readers().len(), 1);
+    let reader = &searcher.segment_readers()[0];
+    let check = |mut scorer: Box<dyn Scorer + '_>| {
+        let mut actual = Vec::new();
+        while scorer.doc() != crate::TERMINATED {
+            actual.push(scorer.doc());
+            scorer.advance();
+        }
+        assert_eq!(actual, expected, "{query}");
+    };
+    check(
+        query
+            .scorer_with_options(reader, limit, ScorerOptions::default())
+            .await
+            .unwrap(),
+    );
+    #[cfg(feature = "sync")]
+    check(
+        query
+            .scorer_sync_with_options(reader, limit, ScorerOptions::default())
+            .unwrap(),
+    );
+    let results = index.search(query, limit).await.unwrap();
+    let mut actual: Vec<_> = results.hits.iter().map(|hit| hit.address.doc_id).collect();
+    actual.sort_unstable();
+    assert_eq!(actual, expected, "index search: {query}");
+}
+
+#[tokio::test]
+async fn common_filter_survives_nested_boolean_optimization() {
+    let (index, text, allowed, bmp, maxscore) = fixture().await;
+    let text_query = BooleanQuery::new()
+        .should(eligible(TermQuery::text(text, "alpha"), allowed))
+        .should(TermQuery::text(text, "absent"));
+    assert_selected(&index, &text_query, 12, &[10, 11]).await;
+    for field in [bmp, maxscore] {
+        let query = BooleanQuery::new()
+            .should(eligible(
+                SparseVectorQuery::new(field, vec![(0, 1.0)]),
+                allowed,
+            ))
+            .should(SparseTermQuery::new(field, 15, 1.0));
+        assert_selected(&index, &query, 12, &[10, 11]).await;
+    }
+}
+
+#[tokio::test]
+async fn nested_boolean_sparse_filters_survive_scoring_decomposition() {
+    let (index, _, allowed, bmp, maxscore) = fixture().await;
+    for field in [bmp, maxscore] {
+        for excluded in [false, true] {
+            let inner = BooleanQuery::new().should(SparseVectorQuery::new(field, vec![(0, 1.0)]));
+            let inner = if excluded {
+                inner.must_not(RangeQuery::u64(allowed, Some(0), Some(0)))
+            } else {
+                inner.must(RangeQuery::u64(allowed, Some(1), Some(1)))
+            };
+            let query = BooleanQuery::new()
+                .should(inner)
+                .should(SparseTermQuery::new(field, 15, 1.0));
+            assert_selected(&index, &query, 12, &[10, 11]).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn filtered_bmp_keeps_one_global_superblock_budget_across_segments() {
+    let mut schema = Schema::builder();
+    let allowed = schema.add_u64_field("allowed", true, false);
+    schema.set_fast(allowed, true);
+    let sparse = schema.add_sparse_vector_field_with_config(
+        "sparse",
+        true,
+        false,
+        SparseVectorConfig {
+            format: SparseFormat::Bmp,
+            dims: Some(16),
+            ..Default::default()
+        },
+    );
+    let directory = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+        .await
+        .unwrap();
+    for weight in [1.0, 0.1] {
+        let mut document = Document::new();
+        document.add_u64(allowed, 1);
+        document.add_sparse_vector(sparse, vec![(0, weight)]);
+        writer.add_document(document).unwrap();
+        writer.commit().await.unwrap();
+    }
+    let index = Index::open(directory, config).await.unwrap();
+    assert_eq!(index.segment_readers().await.unwrap().len(), 2);
+    let sparse_query = SparseVectorQuery::new(sparse, vec![(0, 1.0)]).with_lsp_gamma(1);
+    let queries: Vec<Box<dyn Query>> = vec![
+        Box::new(eligible(sparse_query.clone(), allowed)),
+        Box::new(
+            BooleanQuery::new()
+                .must(RangeQuery::u64(allowed, Some(1), Some(1)))
+                .should(sparse_query),
+        ),
+    ];
+    for query in queries {
+        let hits = index.search(query.as_ref(), 2).await.unwrap().hits;
+        assert_eq!(
+            hits.len(),
+            1,
+            "one superblock across the entire index: {query}"
+        );
+        assert!(hits[0].score > 0.9);
+    }
+}
+
+#[tokio::test]
+async fn common_filter_precedes_boolean_text_top_k() {
+    let (index, text, allowed, _, _) = fixture().await;
+    let query = eligible(
+        BooleanQuery::new()
+            .must(AllQuery)
+            .should(TermQuery::text(text, "alpha")),
+        allowed,
+    );
+    assert_selected(&index, &query, 1, &[10]).await;
+}
+
+#[tokio::test]
+async fn common_filter_precedes_boolean_bmp_top_k() {
+    let (index, _, allowed, bmp, _) = fixture().await;
+    let query = eligible(
+        BooleanQuery::new()
+            .must(AllQuery)
+            .should(SparseTermQuery::new(bmp, 0, 1.0)),
+        allowed,
+    );
+    assert_selected(&index, &query, 1, &[10]).await;
+}
+
+#[tokio::test]
+async fn common_filter_precedes_maxscore_sparse_top_k_in_every_plan() {
+    let (index, _, allowed, _, maxscore) = fixture().await;
+    let queries: Vec<Box<dyn Query>> = vec![
+        Box::new(SparseVectorQuery::new(maxscore, vec![(0, 1.0), (1, 1.0)])),
+        Box::new(
+            BooleanQuery::new()
+                .should(SparseTermQuery::new(maxscore, 0, 1.0))
+                .should(SparseTermQuery::new(maxscore, 1, 1.0)),
+        ),
+        Box::new(
+            BooleanQuery::new()
+                .must(AllQuery)
+                .should(SparseTermQuery::new(maxscore, 0, 1.0)),
+        ),
+    ];
+    for query in queries {
+        assert_selected(&index, &eligible(query, allowed), 1, &[10]).await;
+    }
+}
+
+struct UnexpectedWork;
+
+impl std::fmt::Display for UnexpectedWork {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("unexpected payload work")
+    }
+}
+
+impl Query for UnexpectedWork {
+    fn scorer<'a>(&self, _reader: &'a SegmentReader, _limit: usize) -> ScorerFuture<'a> {
+        Box::pin(async { Err(Error::Query("payload work should have been skipped".into())) })
+    }
+
+    #[cfg(feature = "sync")]
+    fn scorer_sync<'a>(
+        &self,
+        _reader: &'a SegmentReader,
+        _limit: usize,
+    ) -> Result<Box<dyn Scorer + 'a>> {
+        Err(Error::Query("payload work should have been skipped".into()))
+    }
+
+    fn count_estimate<'a>(&self, _reader: &'a SegmentReader) -> crate::query::CountFuture<'a> {
+        Box::pin(async { Ok(12) })
+    }
+}
+
+#[tokio::test]
+async fn empty_common_filter_skips_remaining_filters_and_scoring_payloads() {
+    let (index, _, allowed, _, _) = fixture().await;
+    let query = FilteredQuery::new(
+        Arc::new(UnexpectedWork),
+        vec![
+            Arc::new(RangeQuery::u64(allowed, Some(2), Some(2))),
+            Arc::new(UnexpectedWork),
+        ],
+    );
+    assert_selected(&index, &query, 1, &[]).await;
+}
+
+#[tokio::test]
+async fn expired_common_filter_skips_materialization_and_marks_truncation() {
+    let (index, _, _, _, _) = fixture().await;
+    let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+    let reader = &searcher.segment_readers()[0];
+    let query = FilteredQuery::new(Arc::new(UnexpectedWork), vec![Arc::new(UnexpectedWork)]);
+    let budget =
+        crate::query::SharedThreshold::new().with_deadline(Some(std::time::Instant::now()));
+    let options = ScorerOptions {
+        shared_threshold: Some(budget.clone()),
+        ..Default::default()
+    };
+    let scorer = query
+        .scorer_with_options(reader, 1, options.clone())
+        .await
+        .unwrap();
+    assert_eq!(scorer.doc(), crate::TERMINATED);
+    assert!(budget.truncated());
+    #[cfg(feature = "sync")]
+    assert_eq!(
+        query
+            .scorer_sync_with_options(reader, 1, options)
+            .unwrap()
+            .doc(),
+        crate::TERMINATED
+    );
+}
+
+#[cfg(feature = "sync")]
+#[tokio::test]
+async fn common_filter_supports_direct_sync_scorers() {
+    let (index, _, allowed, _, _) = fixture().await;
+    let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+    let query = eligible(AllQuery, allowed);
+    let mut scorer = query
+        .scorer_sync(&searcher.segment_readers()[0], 12)
+        .unwrap();
+    assert_eq!(scorer.doc(), 10);
+    assert_eq!(scorer.advance(), 11);
+    assert_eq!(scorer.advance(), crate::TERMINATED);
+}
+
+#[tokio::test]
+#[ignore = "manual fixed-fixture empty-filter latency measurement"]
+async fn empty_common_filter_benchmark() {
+    use std::hint::black_box;
+    use std::time::Instant;
+    const DOCS: usize = 16_384;
+    let mut schema = Schema::builder();
+    let text = schema.add_text_field_with_tokenizer("body", true, false, "simple");
+    let allowed = schema.add_u64_field("allowed", true, false);
+    schema.set_fast(allowed, true);
+    let directory = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+        .await
+        .unwrap();
+    for _ in 0..DOCS {
+        let mut document = Document::new();
+        document.add_text(text, "alpha beta gamma");
+        document.add_u64(allowed, 0);
+        let mut attempts = 0;
+        loop {
+            match writer.add_document(document.clone()) {
+                Ok(()) => break,
+                Err(Error::QueueFull) if attempts < 10_000 => {
+                    attempts += 1;
+                    std::thread::yield_now();
+                }
+                Err(error) => panic!("benchmark ingestion failed: {error}"),
+            }
+        }
+    }
+    writer.commit().await.unwrap();
+    let index = Index::open(directory, config).await.unwrap();
+    let query = eligible(TermQuery::text(text, "alpha"), allowed);
+    assert!(index.search(&query, 10).await.unwrap().hits.is_empty());
+    let mut times = Vec::new();
+    for _ in 0..11 {
+        let start = Instant::now();
+        for _ in 0..100 {
+            black_box(index.search(black_box(&query), 10).await.unwrap());
+        }
+        times.push(start.elapsed().as_secs_f64() * 1_000_000.0 / 100.0);
+    }
+    times.sort_by(f64::total_cmp);
+    eprintln!(
+        "empty filter: docs={DOCS} bitmap_bytes={} median_us={:.3} min_us={:.3} max_us={:.3}",
+        DOCS / 8,
+        times[5],
+        times[0],
+        times[10]
+    );
+}

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -444,6 +444,7 @@ pub(crate) fn build_sparse_maxscore_executor<'a>(
     reader: &'a SegmentReader,
     limit: usize,
     predicate: Option<DocPredicate<'a>>,
+    options: &super::ScorerOptions,
 ) -> Option<(MaxScoreExecutor<'a>, SparseTermQueryInfo)> {
     let field = infos[0].field;
     let si = reader.sparse_index(field)?;
@@ -465,7 +466,16 @@ pub(crate) fn build_sparse_maxscore_executor<'a>(
             .with_metric_labels(
                 reader.schema().index_label(),
                 reader.schema().get_field_name(field).unwrap_or("?"),
-            );
+            )
+            .with_budget(options.shared_threshold.clone());
+    let predicate = if let Some(filter) = &options.eligibility {
+        let filter = filter.clone();
+        Some(Box::new(move |doc| {
+            filter.contains(doc) && predicate.as_ref().is_none_or(|predicate| predicate(doc))
+        }) as DocPredicate<'a>)
+    } else {
+        predicate
+    };
     if let Some(pred) = predicate {
         executor = executor.with_predicate(pred);
     }
@@ -507,7 +517,17 @@ pub(crate) fn build_sparse_bmp_results_filtered(
     predicate: &dyn Fn(crate::DocId) -> bool,
     options: &super::ScorerOptions,
 ) -> crate::Result<Option<(Vec<ScoredDoc>, SparseTermQueryInfo)>> {
-    build_sparse_bmp_results_inner(infos, reader, limit, Some(predicate), options)
+    if let Some(filter) = &options.eligibility {
+        build_sparse_bmp_results_inner(
+            infos,
+            reader,
+            limit,
+            Some(&|doc| filter.contains(doc) && predicate(doc)),
+            options,
+        )
+    } else {
+        build_sparse_bmp_results_inner(infos, reader, limit, Some(predicate), options)
+    }
 }
 
 fn build_sparse_bmp_results_inner(
@@ -773,6 +793,9 @@ pub(super) fn build_combined_bitset(
         }
     }
 
+    if let (Some(result), Some(eligibility)) = (&mut result, &options.eligibility) {
+        result.intersect_with(eligibility);
+    }
     if options.stop_if_expired() {
         None
     } else {

--- a/hermes-core/src/query/traits.rs
+++ b/hermes-core/src/query/traits.rs
@@ -359,6 +359,14 @@ macro_rules! define_query_traits {
                 QueryDecomposition::Opaque
             }
 
+            /// Sparse terms for query-global BMP superblock planning only.
+            /// Unlike scoring decomposition, this never replaces a query's
+            /// scorer. A filter wrapper may expose its inner sparse query here
+            /// while remaining opaque to Boolean scoring optimizations.
+            fn lsp_decomposition(&self) -> QueryDecomposition {
+                self.decompose()
+            }
+
             /// Exact scoring plan for a named L1 branch. Unsupported queries
             /// reject explicitly rather than returning truncated retrieval scores.
             fn candidate_query(&self) -> Result<super::CandidateQuery> {
@@ -504,6 +512,10 @@ impl Query for Box<dyn Query> {
 
     fn decompose(&self) -> QueryDecomposition {
         (**self).decompose()
+    }
+
+    fn lsp_decomposition(&self) -> QueryDecomposition {
+        (**self).lsp_decomposition()
     }
 
     fn is_filter(&self) -> bool {

--- a/hermes-core/src/query/vector/sparse.rs
+++ b/hermes-core/src/query/vector/sparse.rs
@@ -541,9 +541,9 @@ impl Query for SparseVectorQuery {
             }
 
             // Fall back to MaxScore execution
-            if let Some((executor, info)) =
-                crate::query::planner::build_sparse_maxscore_executor(infos, reader, limit, None)
-            {
+            if let Some((executor, info)) = crate::query::planner::build_sparse_maxscore_executor(
+                infos, reader, limit, None, &options,
+            ) {
                 let raw = executor.execute().await?;
                 return Ok(crate::query::planner::combine_sparse_results(
                     raw,
@@ -593,9 +593,9 @@ impl Query for SparseVectorQuery {
         }
 
         // Fall back to MaxScore execution
-        if let Some((executor, info)) =
-            crate::query::planner::build_sparse_maxscore_executor(infos, reader, limit, None)
-        {
+        if let Some((executor, info)) = crate::query::planner::build_sparse_maxscore_executor(
+            infos, reader, limit, None, &options,
+        ) {
             let raw = executor.execute_sync()?;
             return Ok(crate::query::planner::combine_sparse_results(
                 raw,

--- a/hermes-core/src/segment/bmp_forward.rs
+++ b/hermes-core/src/segment/bmp_forward.rs
@@ -142,14 +142,22 @@ impl BmpForward {
             .map(|(key, i)| (key.ordinal, i))
     }
 
-    /// Validate only the selected vector's payload, before returning its view.
-    pub(crate) fn vector(&self, index: u32) -> Result<ForwardVector<'_>> {
+    fn vector_range(&self, index: u32) -> Result<std::ops::Range<usize>> {
         if index >= self.len() {
             return Err(corrupt("vector index out of bounds"));
         }
-        let start = self.offset(index) as usize;
-        let end = self.offset(index + 1) as usize;
-        let vector = ForwardVector(&self.payload.as_slice()[start..end]);
+        Ok(self.offset(index) as usize..self.offset(index + 1) as usize)
+    }
+
+    /// Directory-only admission: do not fault or validate payload before its
+    /// bytes have been charged to the candidate scoring request.
+    pub(crate) fn vector_byte_len(&self, index: u32) -> Result<u64> {
+        Ok(self.vector_range(index)?.len() as u64)
+    }
+
+    /// Validate only the selected vector's payload, before returning its view.
+    pub(crate) fn vector(&self, index: u32) -> Result<ForwardVector<'_>> {
+        let vector = ForwardVector(&self.payload.as_slice()[self.vector_range(index)?]);
         let mut previous = None;
         for (dimension, impact) in vector.iter() {
             if dimension >= self.dims || impact == 0 || previous.is_some_and(|p| p > dimension) {

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -521,10 +521,9 @@ impl BmpIndex {
         }
 
         log::debug!(
-            "BMP V{} index loaded: num_blocks={}, num_superblocks={}, coarse_groups={}, dims={}, bmp_block_size={}, \
+            "BMPA index loaded: num_blocks={}, num_superblocks={}, coarse_groups={}, dims={}, bmp_block_size={}, \
              num_virtual_docs={}, num_real_docs={}, max_weight_scale={:.4}, postings={}, \
              block_grid={}, superblock_grid={}, coarse_grid={}, single_valued={}, block_data={}, doc_map={}, forward={}",
-            if magic == BMP_BLOB_MAGIC { 20 } else { 19 },
             num_blocks,
             num_superblocks,
             num_coarse_groups,

--- a/hermes-core/src/segment/reader/candidate_lookup.rs
+++ b/hermes-core/src/segment/reader/candidate_lookup.rs
@@ -328,6 +328,40 @@ impl SegmentReader {
 }
 
 impl SegmentReader {
+    /// Admit the selected BMP payload using metadata alone. Forward records
+    /// are variable-sized; counting candidates does not bound their read work.
+    pub(crate) fn reserve_candidate_bmp_reads(
+        &self,
+        field: Field,
+        targets: &[u32],
+        remaining: &mut u64,
+    ) -> Result<()> {
+        let bmp = self
+            .bmp_index(field)
+            .ok_or_else(|| Error::Corruption("L1 BMP locations lack a BMP index".into()))?;
+        let mut previous_block = None;
+        for &target in targets {
+            let bytes = if let Some(forward) = bmp.forward() {
+                forward.vector_byte_len(target)?
+            } else {
+                if target >= bmp.num_virtual_docs {
+                    return Err(Error::Corruption("BMP candidate slot out of bounds".into()));
+                }
+                let block = target / bmp.bmp_block_size;
+                if previous_block == Some(block) {
+                    continue;
+                }
+                previous_block = Some(block);
+                let (start, end) = bmp.block_data_range(block);
+                end - start
+            };
+            *remaining = remaining.checked_sub(bytes).ok_or_else(|| {
+                Error::Query("L1 text/BMP payload read budget exceeded (256 MiB)".into())
+            })?;
+        }
+        Ok(())
+    }
+
     /// Existing text readers return zero-copy views on mmap/RAM but materialize
     /// ranges on lazy backends. Admit those ranges before invoking the reader.
     pub(crate) async fn reserve_candidate_text_reads(

--- a/hermes-wasm/tests/base.test.ts
+++ b/hermes-wasm/tests/base.test.ts
@@ -78,3 +78,20 @@ test("BMP search returns identical scores with optional forward storage", async 
 	expect(baseline.hits).toHaveLength(1);
 	expect((await index.searchStructured(request("inverted"))).hits).toEqual(baseline.hits);
 });
+
+test.each([0, 1])("Sparse query language inherits schema LSP gamma %i", async (gamma) => {
+	await init();
+	const index = await LocalIndex.create(`
+		index sparse_policy {
+			field emb: sparse_vector [indexed<format: bmp, dims: 16, max_weight: 5.0, bmp_block_size: 1, query<lsp_gamma: ${gamma}>>]
+		}
+	`);
+	// Two superblocks: eight weaker documents followed by one winner.
+	await index.addDocuments(Array.from({ length: 9 }, (_, doc) => ({
+		emb: { indices: [0], values: [doc === 8 ? 5.0 : 0.1] },
+	})));
+	await index.commit();
+	const results = await index.search("emb:sparse({0: 1.0})", 9);
+	expect(results.hits).toHaveLength(gamma === 0 ? 9 : 1);
+	expect(results.hits[0].address.doc_id).toBe(8);
+});


### PR DESCRIPTION
Query-language `emb:sparse({...})` searches now inherit the field's `lsp_gamma`, including exhaustive zero. Previously the parser dropped that setting and execution used the depth-derived approximate cap.

Preserve nested filter constraints during Boolean optimization and apply common eligibility before BM25, BMP and sparse MaxScore heaps. Filter materialization now honors request deadlines, discards incomplete bitmaps and stops when eligibility becomes empty. A separate BMP planning hook retains the global superblock budget for supported filtered queries.

BMP candidate rescoring now admits selected payload bytes before reading them, sharing the existing 256 MiB lazy-text allowance. No index or wire formats, scoring formulas or approximate defaults change. The performance review records the fixes, read-only production samples and remaining profiling work.

Validation:

- Required `python3 scripts/check_search.py check` passed, including 1,356 core unit tests, server/broker/tool checks, Clippy and the native-without-sync compile boundary.
- Native async filter, query-language and BMP admission regressions passed.
- WASM release build and all seven runtime tests passed.
- On the same 16,384-document RAM fixture, Apple M4 and Rust 1.98.1 release build, empty-filter median latency fell from 89.499 to 14.169 microseconds/search. Process peak RSS was 19.34–20.33 MiB before and 18.77–19.69 MiB after. This measures empty eligibility only; setup is excluded and expected results are checked outside timing.
- Extended `full`/real-server RPC tests and controlled cold-cache/x86 comparisons were not run. Production sampling was observational; no deployment was changed during review.
