### PR TITLE
Fix filters applied after bounded body candidates

### DIFF
--- a/docs/chunked-text-fields.md
+++ b/docs/chunked-text-fields.md
@@ -86,6 +86,17 @@ chunk when the client sends chunk texts in the same order as the vectors.
 Boolean composition with other clauses (filters, other fields) happens at the
 document level on the combined scorer, as it already does for sparse fields.
 
+Boolean filters must reach bounded text scorers before candidate selection,
+including when the body query is a required clause or a nested disjunction.
+The generic Boolean plans collect available document predicates into shared
+eligibility before constructing their children, while retaining the original
+clauses for scoring and verification. This adds one document bitmap (at most
+16 MiB), using selective posting-list materialization where available and a
+predicate scan of the currently eligible documents otherwise; it does not
+increase the chunk candidate budget or materialize all scored body matches.
+An expired scan publishes no partial eligibility. Filters without a document
+predicate continue to use the existing verifier path.
+
 Cross-segment threshold seeding is skipped for chunked MaxScore groups: the
 k-th _chunk_ score of a full heap is not a valid document-level floor after
 `Max` folding.

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -1120,3 +1120,80 @@ WASM release build plus all eight runtime tests passed. Both regenerated client
 suites passed eleven tests each. Evidence includes `.context/formula-native-async.log`,
 `.context/formula-wasm-{build,tests}.log`, and
 `.context/formula-{python,typescript}-tests.log`.
+
+## Filtered body queries at small limits — 2026-09-06
+
+Confirmed against `fa92ac62` (1.8.128). With ten higher-scoring `article`
+documents and one lower-scoring `book`, a required chunked text term combined
+with `kind:book` returned no hits at limit 1 and the correct book at limit 20.
+The generic Boolean planner constructed the body's bounded scorer before
+applying its document predicates. Required nested disjunctions and negative
+fast-field filters had the same failure. The public query-language reproduction
+is `body:machine AND kind:book` with a chunked `body` and raw fast `kind`.
+
+The generic plans now push available predicates into shared eligibility before
+constructing their text children. They reuse selective bitset construction
+where supported and scan eligible fast-field values otherwise, retaining the
+original scoring/verifier clauses and the existing 16 MiB bitmap ceiling.
+The regression checks small/large-limit IDs, exact score bits and ordinals;
+another covers required disjunctions on plain text. Fast text equality is used
+only where it matches indexed-term semantics: single-valued raw text. Analyzed
+and multi-valued indexed fields retain their posting-list semantics.
+
+Actual WASM execution of this query also reproduced a MaxScore panic from an
+unconditional `std::time::Instant::now()` used for diagnostic logging. Both
+MaxScore loops now use the existing portable `observe::WallTimer`.
+Red evidence: `.context/filtered-body-red.log`,
+`.context/filtered-body-fast-text-red.log`, and
+`.context/filtered-body-wasm-red.log`.
+
+### Controlled fixture and limits of the measurements
+
+Apple M4 arm64, Rust 1.98.1, identical debug server build commands and the same
+persisted 10,000-document fixture (50 eligible books, one body chunk per
+document), top 1. Each case opened the fixture in a fresh process, warmed 20
+queries and measured 100 sequential RPCs. Index construction and the full-limit
+correctness reference were outside timing; builds did not overlap sampling.
+
+| Query shape                       | Before p50/p95 ms | After p50/p95 ms | Before/after sampled RSS KiB | Before/after correct top 1 |
+| --------------------------------- | ----------------: | ---------------: | ---------------------------: | -------------------------- |
+| Required body term + kind         |     1.090 / 1.232 |    1.475 / 2.005 |              34,640 / 36,352 | No / Yes                   |
+| Required nested body OR + kind    |     1.679 / 2.816 |    1.422 / 1.737 |              35,328 / 35,456 | No / Yes                   |
+| Required body term, excluded kind |     1.536 / 2.926 |    1.580 / 1.746 |              37,392 / 34,432 | No / Yes                   |
+| Existing filtered SHOULD control  |     1.742 / 1.996 |    1.367 / 1.539 |              34,688 / 35,728 | Yes / Yes                  |
+
+All fixed responses matched the full-limit reference IDs and score bits.
+The control's movement makes the timing comparison inconclusive; this is a
+correctness fix with bounded extra eligibility work, not a throughput claim.
+RSS is sampled process residency, not a measurement of peak scratch. The
+bitmap for this fixture occupies 1,256 bytes. Evidence and reproduction:
+`.context/filtered-body-{before,after}.jsonl` and
+`.context/measure_filtered_body.py`.
+
+This fixes predicate pushdown, not every source of candidate loss. Filters
+without a document predicate retain the existing verifier paths. The documented
+two-times chunk nomination cap can still retain several chunks of one document
+and underfill a document result window; this pass does not change that policy,
+ANN/LSP defaults, stored formats, or production configuration. Cold-cache,
+large-corpus, concurrency and x86 performance comparisons remain unmeasured.
+
+### Validation and remaining async discrepancy
+
+The final required harness passed all four steps:
+`.context/search-harness/20260906T133139.703927Z-check/`. The WASM release build
+and all nine runtime tests passed, as did documentation checks and all three
+new native-without-sync regression tests. Logs:
+`.context/filtered-body-{final-check,wasm-build,wasm-tests,docs}.log` and
+`.context/filtered-body-native-async-regressions.log`. No lifecycle, RPC, or
+wire definitions changed; the additional `full` lifecycle/RPC harness was not
+rerun for this patch. The measured probes did exercise a real local server.
+
+A broader native-without-sync chunked suite passed 16 of 17 tests and exposed
+an existing discrepancy in `filters_and_phrases_push_into_chunked_text_maxscore`:
+the async fallback includes the required phrase's ordinal 0, returning `[0, 1]`
+where the sync bitset-filter path returns `[1]`. The saved 1.8.127 test binary
+(`hermes_core-14836e5caef7dcbc`, from the previous review) fails the same test
+identically, confirming this is not introduced by the patch. Async phrase-filter
+materialization/scoring parity remains a separate correctness follow-up.
+Evidence: `.context/filtered-body-native-async.log` and
+`.context/filtered-body-preexisting-async-phrase.log`.

--- a/hermes-core/src/index/tests/chunked.rs
+++ b/hermes-core/src/index/tests/chunked.rs
@@ -71,6 +71,96 @@ async fn open(dir: RamDirectory) -> Index<RamDirectory> {
 }
 
 #[tokio::test]
+async fn small_limits_preserve_required_chunked_text_matches() {
+    use crate::query::{Query, ScorerOptions};
+
+    let f = chunked_schema();
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), f.schema.clone(), IndexConfig::default())
+        .await
+        .unwrap();
+    for _ in 0..10 {
+        writer
+            .add_document(doc(&f, "article", &["machine"]))
+            .unwrap();
+    }
+    writer
+        .add_document(doc(&f, "book", &["machine padding padding padding"]))
+        .unwrap();
+    writer.commit().await.unwrap();
+    let index = open(dir).await;
+    let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+    let term = || TermQuery::text(f.content, "machine");
+    let required = || TermQuery::text(f.kind, "book");
+    let queries = [
+        BooleanQuery::new().must(required()).must(term()),
+        BooleanQuery::new()
+            .must(term())
+            .must_not(TermQuery::text(f.kind, "article")),
+        BooleanQuery::new().must(required()).must(
+            BooleanQuery::new()
+                .should(term())
+                .should(TermQuery::text(f.content, "absent")),
+        ),
+    ];
+    for query in queries {
+        let (all, _) = searcher.search_with_positions(&query, 20).await.unwrap();
+        assert_eq!(
+            all.iter().map(|hit| hit.doc_id).collect::<Vec<_>>(),
+            vec![10],
+            "{query}"
+        );
+        let (small, _) = searcher.search_with_positions(&query, 1).await.unwrap();
+        assert_eq!(
+            small.iter().map(|hit| hit.doc_id).collect::<Vec<_>>(),
+            vec![10],
+            "{query}"
+        );
+        assert_eq!(small[0].score.to_bits(), all[0].score.to_bits());
+        assert_eq!(ordinals(&small[0]), vec![0]);
+
+        let segment = &searcher.segment_readers()[0];
+        let scorer = query
+            .scorer_with_options(segment, 1, ScorerOptions::with_positions())
+            .await
+            .unwrap();
+        assert_eq!(scorer.doc(), 10, "async scorer: {query}");
+        assert_eq!(scorer.score().to_bits(), all[0].score.to_bits());
+        #[cfg(feature = "sync")]
+        {
+            let scorer = query.scorer_sync(segment, 1).unwrap();
+            assert_eq!(scorer.doc(), 10, "sync scorer: {query}");
+            assert_eq!(scorer.score().to_bits(), all[0].score.to_bits());
+        }
+    }
+}
+
+#[tokio::test]
+async fn required_analyzed_fast_text_keeps_posting_match_semantics() {
+    let mut schema = SchemaBuilder::default();
+    let body = schema.add_text_field_with_tokenizer("body", true, false, "simple");
+    schema.set_chunked(body, true);
+    let category = schema.add_text_field_with_tokenizer("category", true, false, "simple");
+    schema.set_fast(category, true);
+    let dir = RamDirectory::new();
+    let mut writer = IndexWriter::create(dir.clone(), schema.build(), IndexConfig::default())
+        .await
+        .unwrap();
+    let mut document = Document::new();
+    document.add_text(body, "machine");
+    document.add_text(category, "research book");
+    writer.add_document(document).unwrap();
+    writer.commit().await.unwrap();
+    let index = open(dir).await;
+    let query = BooleanQuery::new()
+        .must(TermQuery::text(body, "machine"))
+        .must(TermQuery::text(category, "book"));
+    let results = index.search(&query, 1).await.unwrap();
+    assert_eq!(results.hits.len(), 1);
+    assert_eq!(results.hits[0].address.doc_id, 0);
+}
+
+#[tokio::test]
 async fn expired_budget_stops_chunked_term_and_phrase_construction() {
     use crate::query::{Query, ScorerOptions, SharedThreshold};
     let f = chunked_schema();

--- a/hermes-core/src/query/boolean.rs
+++ b/hermes-core/src/query/boolean.rs
@@ -225,7 +225,7 @@ macro_rules! boolean_plan {
         let global_stats: Option<&Arc<GlobalStats>> = $global_stats;
         let reader: &SegmentReader = $reader;
         let limit: usize = $limit;
-        let scorer_options: super::ScorerOptions = $scorer_options;
+        let mut scorer_options: super::ScorerOptions = $scorer_options;
         if !$text_tuning.0.is_finite() || !(0.0..=1.0).contains(&$text_tuning.0) {
             return Err(crate::Error::Query(
                 "Text heap_factor must be finite and between 0 and 1".into(),
@@ -659,6 +659,14 @@ macro_rules! boolean_plan {
             // Priority: as_doc_predicate (fast-field O(1)) > as_doc_bitset
             // (posting-list materialization, O(1) lookup, sparse-SHOULD only)
             // > verifier scorer (seek).
+            super::planner::push_down_text_predicates(
+                must, should, must_not, reader, &mut scorer_options,
+            )?;
+            if scorer_options.stop_if_expired()
+                || scorer_options.eligibility.as_ref()
+                    .is_some_and(|bits| bits.next_set_bit(0).is_none()) {
+                return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
+            }
             let mut predicates: Vec<super::DocPredicate<'_>> = Vec::new();
             let mut must_verifiers: Vec<Box<dyn super::Scorer + '_>> = Vec::new();
             for q in must {
@@ -890,6 +898,14 @@ macro_rules! boolean_plan {
         }
 
         // ── 4. Standard BooleanScorer fallback ───────────────────────────
+        super::planner::push_down_text_predicates(
+            must, should, must_not, reader, &mut scorer_options,
+        )?;
+        if scorer_options.stop_if_expired()
+            || scorer_options.eligibility.as_ref()
+                .is_some_and(|bits| bits.next_set_bit(0).is_none()) {
+            return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
+        }
         let mut must_scorers = Vec::with_capacity(must.len());
         if must.is_empty() && should.is_empty() && !must_not.is_empty() {
             must_scorers.push(Box::new(super::AllDocSet::new(reader.num_docs()))

--- a/hermes-core/src/query/filtered.rs
+++ b/hermes-core/src/query/filtered.rs
@@ -4,6 +4,8 @@ use crate::segment::SegmentReader;
 use crate::{Error, Result};
 use std::sync::Arc;
 
+pub(super) const MAX_FILTER_BITMAP_DOCS: usize = 128 * 1024 * 1024;
+
 #[derive(Clone)]
 pub struct FilteredQuery {
     query: Arc<dyn Query>,
@@ -14,7 +16,7 @@ impl FilteredQuery {
         Self { query, filters }
     }
     fn validate(&self, reader: &SegmentReader) -> Result<()> {
-        if self.filters.len() > 64 || reader.num_docs() as usize > 128 * 1024 * 1024 {
+        if self.filters.len() > 64 || reader.num_docs() as usize > MAX_FILTER_BITMAP_DOCS {
             return Err(Error::Query(
                 "common filter exceeds the 64-clause/16 MiB bitmap budget".into(),
             ));

--- a/hermes-core/src/query/filtered/tests.rs
+++ b/hermes-core/src/query/filtered/tests.rs
@@ -93,6 +93,19 @@ async fn assert_selected(
 }
 
 #[tokio::test]
+async fn small_limits_filter_required_plain_text_disjunctions_before_top_k() {
+    let (index, text, allowed, _, _) = fixture().await;
+    let query = BooleanQuery::new()
+        .must(RangeQuery::u64(allowed, Some(1), Some(1)))
+        .must(
+            BooleanQuery::new()
+                .should(TermQuery::text(text, "alpha"))
+                .should(TermQuery::text(text, "absent")),
+        );
+    assert_selected(&index, &query, 1, &[10]).await;
+}
+
+#[tokio::test]
 async fn common_filter_survives_nested_boolean_optimization() {
     let (index, text, allowed, bmp, maxscore) = fixture().await;
     let text_query = BooleanQuery::new()

--- a/hermes-core/src/query/planner.rs
+++ b/hermes-core/src/query/planner.rs
@@ -658,6 +658,93 @@ pub(super) fn extract_all_sparse_infos(
 
 // ── Predicate helpers ────────────────────────────────────────────────────
 
+/// A generic Boolean plan can still contain bounded text children (chunked
+/// terms and nested disjunctions). Push available document predicates into
+/// those children before constructing their candidate windows. Keep the
+/// original clauses: eligibility must not change their scores or positions.
+pub(super) fn push_down_text_predicates(
+    must: &[Arc<dyn super::Query>],
+    should: &[Arc<dyn super::Query>],
+    must_not: &[Arc<dyn super::Query>],
+    reader: &SegmentReader,
+    options: &mut super::ScorerOptions,
+) -> crate::Result<()> {
+    if must.is_empty() && must_not.is_empty() {
+        return Ok(());
+    }
+    let mut terms = Vec::new();
+    let bounded_text = must.iter().chain(should).any(|query| {
+        terms.clear();
+        query.text_terms(&mut terms);
+        terms.len() > 1
+            || terms
+                .iter()
+                .any(|(field, _)| reader.is_chunked_field(*field))
+    });
+    if !bounded_text {
+        return Ok(());
+    }
+    // Predicate construction may itself materialize a prefix filter. Check
+    // the segment budget before asking any clause to construct one.
+    if reader.num_docs() as usize > super::filtered::MAX_FILTER_BITMAP_DOCS {
+        return Err(crate::Error::Query(
+            "Boolean text filters exceed the 16 MiB bitmap budget".into(),
+        ));
+    }
+    let mut predicates = Vec::new();
+    let mut required_filters = Vec::new();
+    let mut excluded_filters = Vec::new();
+    for (queries, required) in [(must, true), (must_not, false)] {
+        for query in queries {
+            if let Some(predicate) = query.as_doc_predicate(reader) {
+                predicates.push((predicate, required));
+                if required {
+                    required_filters.push(Arc::clone(query));
+                } else {
+                    excluded_filters.push(Arc::clone(query));
+                }
+            }
+        }
+    }
+    if predicates.is_empty() {
+        return Ok(());
+    }
+    // Reuse selective posting-list materialization when the backend supports
+    // it; scanning a whole fast column is the portable/fast-only fallback.
+    if let Some(combined) =
+        build_combined_bitset(&required_filters, &excluded_filters, reader, options)
+    {
+        options.eligibility = Some(Arc::new(combined));
+        return Ok(());
+    }
+    let mut combined = super::DocBitset::new(reader.num_docs());
+    let mut doc = options
+        .eligibility
+        .as_ref()
+        .map_or(Some(0), |bits| bits.next_set_bit(0));
+    let mut visited = 0usize;
+    while let Some(id) = doc.filter(|&id| id < reader.num_docs()) {
+        if visited.is_multiple_of(1024) && options.stop_if_expired() {
+            return Ok(());
+        }
+        if predicates
+            .iter()
+            .all(|(predicate, required)| predicate(id) == *required)
+        {
+            combined.set(id);
+        }
+        visited += 1;
+        doc = options
+            .eligibility
+            .as_ref()
+            .map_or(Some(id + 1), |bits| bits.next_set_bit(id + 1));
+    }
+    if !options.stop_if_expired() {
+        options.eligibility = Some(Arc::new(combined));
+    }
+    Ok(())
+}
+
 /// Chain multiple predicates into a single combined predicate.
 pub(super) fn chain_predicates<'a>(predicates: Vec<DocPredicate<'a>>) -> DocPredicate<'a> {
     if predicates.len() == 1 {

--- a/hermes-core/src/query/scoring.rs
+++ b/hermes-core/src/query/scoring.rs
@@ -1313,7 +1313,7 @@ macro_rules! bms_execute_loop {
         let mut groups_skipped = 0u64;
         let mut conjunction_skipped = 0u64;
         let mut ordinal_scores: Vec<(u16, f32)> = Vec::with_capacity(n * 2);
-        let _bms_start = std::time::Instant::now();
+        let _bms_start = crate::observe::WallTimer::start();
 
         let inv_heap_factor = $self.inv_heap_factor;
         let mut adjusted_threshold = $self.collector.threshold() * inv_heap_factor - 1e-6;
@@ -1575,7 +1575,7 @@ macro_rules! bms_execute_loop {
             })
             .collect();
 
-        let _bms_elapsed_ms = _bms_start.elapsed().as_millis() as u64;
+        let _bms_elapsed_ms = (_bms_start.secs() * 1000.0) as u64;
         if _bms_elapsed_ms > 500 {
             warn!(
                 "slow MaxScore: {}ms, cursors={}, scored={}, skipped={}, blocks_skipped={}, groups_skipped={}, conjunction_skipped={}, returned={}, top_score={:.4}",
@@ -1888,7 +1888,7 @@ impl<'a> MaxScoreExecutor<'a> {
         let mut windows_skipped = 0u64;
         let mut candidates = 0u64;
         let mut docs_scored = 0u64;
-        let started = std::time::Instant::now();
+        let started = crate::observe::WallTimer::start();
 
         loop {
             windows += 1;
@@ -2050,7 +2050,7 @@ impl<'a> MaxScoreExecutor<'a> {
                 ordinal,
             })
             .collect();
-        let elapsed_ms = started.elapsed().as_millis() as u64;
+        let elapsed_ms = (started.secs() * 1000.0) as u64;
         if elapsed_ms > 500 {
             warn!(
                 "slow windowed MaxScore: {}ms, cursors={}, windows={}, windows_skipped={}, candidates={}, scored={}, returned={}, top_score={:.4}",

--- a/hermes-core/src/query/term.rs
+++ b/hermes-core/src/query/term.rs
@@ -262,6 +262,15 @@ impl Query for TermQuery {
     }
 
     fn as_doc_predicate<'a>(&self, reader: &'a SegmentReader) -> Option<super::DocPredicate<'a>> {
+        let entry = reader.schema().get_field_entry(self.field)?;
+        // A fast column exposes the first complete value. Indexed term
+        // membership is equivalent only for single-valued raw text; analyzed
+        // text and later values must keep their posting-list semantics.
+        if entry.indexed
+            && (entry.multi || !matches!(entry.tokenizer.as_deref(), Some("raw" | "raw_ci")))
+        {
+            return None;
+        }
         let fast_field = reader.fast_field(self.field.0)?;
         let term_str = String::from_utf8_lossy(&self.term);
         match fast_field.text_ordinal(&term_str) {

--- a/hermes-wasm/tests/base.test.ts
+++ b/hermes-wasm/tests/base.test.ts
@@ -2,6 +2,28 @@ import { test, expect } from "vitest";
 
 import init, { LocalIndex } from "../pkg/hermes_wasm";
 
+test("Small limits apply filters before required body candidates", async () => {
+	await init();
+	const index = await LocalIndex.create(`index filtered_body {
+		field kind: text<raw> [indexed, fast]
+		field body: text<simple> [indexed<chunked, token_position>]
+	}`);
+	await index.addDocuments([
+		...Array.from({ length: 10 }, () => ({ kind: "article", body: ["machine"] })),
+		{ kind: "book", body: ["machine padding padding padding"] },
+	]);
+	await index.commit();
+	for (const query of [
+		"body:machine AND kind:book",
+		"body:machine AND NOT kind:article",
+		"(body:machine OR body:absent) AND kind:book",
+	]) {
+		const all = await index.search(query, 20);
+		expect(all.hits.map((hit: any) => hit.address.doc_id)).toEqual([10]);
+		expect((await index.search(query, 1)).hits).toEqual(all.hits);
+	}
+});
+
 test("Search in index", async () => {
 	await init();
 


### PR DESCRIPTION
`body:machine AND kind:book` could return no hits at limit 1 despite a valid result at limit 20: generic Boolean plans applied the filter after constructing the body's bounded candidate list. Required nested disjunctions and fast-field exclusions had the same failure.

Push available document predicates into child eligibility before text candidate selection, retaining the original scoring/verifier clauses. Reuse selective bitmap construction with a bounded portable predicate-scan fallback. Preserve posting semantics for analyzed/multi-valued indexed fast text, and use the existing portable diagnostic timer to fix the MaxScore WASM panic exposed by the new query-language regression.

Validation:
- Required `python3 scripts/check_search.py check` passed (format, focused Clippy, core/server/broker/tool tests, native-without-sync check).
- Actual WASM release build and all 9 runtime tests passed; all three new native-without-sync regressions passed.
- Regressions compare small/full-limit IDs, score bits and ordinals, including required chunked text, nested plain-text OR and exclusions. Documentation checks passed.

On the same persisted 10,000-document fixture, all three previously empty top-1 RPC cases now match the full-limit reference exactly. Required-term p50 was 1.090 ms before (incorrect) and 1.475 ms after; sampled RSS was 34,640 / 36,352 KiB. The control also moved substantially, so timing is inconclusive. Full conditions/results are in `docs/search-performance-review.md`.

The existing non-predicate verifier paths and two-times chunk nomination policy retain their limitations. No candidate-budget or stored-format change.

A broader native-without-sync chunked suite passes 16/17 tests. Its existing required-phrase ordinal discrepancy also fails identically in the saved 1.8.127 test binary; it is recorded as a separate correctness follow-up. The `full` lifecycle/RPC harness was not rerun (no lifecycle/RPC change).
