### PR TITLE
Fix missing one-word phrase filters on large segments

### DIFF
--- a/docs/candidate-rescoring.md
+++ b/docs/candidate-rescoring.md
@@ -478,6 +478,13 @@ materializable text/phrase/fast-field filters use the existing bitset paths.
 Other filters and portable builds use ordinary complete filter scorers only on
 segments of at most 200,000 documents, failing explicitly above that bound.
 This prevents an implicit corpus-sized scoring heap on a legacy backend.
+For indexed phrase filters, a missing term denotes an empty match set, including
+a one-word phrase. It must materialize an empty bitmap rather than select the
+unsupported-filter fallback. A non-indexed field can still match through a fast
+column, so missing postings alone do not prove that such a filter is empty.
+Posting read failures and expired materialization remain failures or truncation,
+not successful empty filters. This distinction adds no candidate expansion or
+scratch beyond the existing document bitmap.
 
 Filter wrappers are opaque to scoring decomposition: flattening a filtered
 branch into unfiltered terms changes its matching set. Query-global BMP LSP

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -1197,3 +1197,43 @@ identically, confirming this is not introduced by the patch. Async phrase-filter
 materialization/scoring parity remains a separate correctness follow-up.
 Evidence: `.context/filtered-body-native-async.log` and
 `.context/filtered-body-preexisting-async-phrase.log`.
+
+## Missing one-word phrase filters — 2026-09-06
+
+Confirmed against `56bcae64` (1.8.129): an indexed `PhraseQuery` with one
+absent term returned `None` from native bitmap materialization. `None` means
+unsupported, so common filtering attempted its scorer fallback and rejected
+segments above 200,000 documents. A 200,001-document regression reproduced
+the reported "common filter cannot be materialized" error. Structured phrase
+requests preserve `PhraseQuery` even with one token; the query-language parser
+normally lowers a single-token quote on one field to `TermQuery`, which does
+not exercise this phrase path.
+
+The phrase owner now distinguishes a successful posting lookup with no list
+from an unavailable materialization. Missing indexed terms produce the empty
+bitmap already allocated by this path. Read errors still return an unavailable
+bitmap and fall back to explicit errors; they do not become empty matches.
+Non-indexed fields retain the scorer fallback because fast-column values can
+match even without postings. No parser, wire or persisted representation changed.
+
+The regression covers direct async and sync scorers plus public index search,
+plain/chunked text, unpopulated indexed fields, and positive, OR and negated
+filters. A smaller fixture also checks present/absent terms against indexed and
+fast-only fields across the native-without-sync boundary. Red and green evidence:
+`.context/missing-phrase-{red,green}.log`.
+
+The cost remains one document bitmap (25,008 payload bytes for the large
+regression), plus the existing term lookup and matching-posting traversal.
+The 16 MiB bitmap and 200,000-document scorer-fallback bounds are unchanged.
+No latency or RSS benchmark was run for this correctness patch, and no
+performance improvement is claimed. Portable builds still have the documented
+fallback bound; the async phrase-ordinal discrepancy recorded above remains
+outside this fix.
+
+Validation passed: the four-step required harness at
+`.context/search-harness/20260906T154504.235296Z-check/`, all ten active common-filter
+tests with native async execution (one manual benchmark ignored), and the WASM
+release build plus all nine runtime tests. Documentation checks also passed.
+Logs: `.context/missing-phrase-{check,native-async,wasm-build,wasm-tests,docs}.log`.
+The additional `full` lifecycle/RPC harness was not rerun because this patch
+changes neither lifecycle nor RPC code.

--- a/hermes-core/src/query/filtered/tests.rs
+++ b/hermes-core/src/query/filtered/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::query::{
-    AllQuery, BooleanQuery, RangeQuery, SparseTermQuery, SparseVectorQuery, TermQuery,
+    AllQuery, BooleanQuery, PhraseQuery, RangeQuery, SparseTermQuery, SparseVectorQuery, TermQuery,
 };
 use crate::structures::{SparseFormat, SparseVectorConfig};
 use crate::{Document, Field, Index, IndexConfig, IndexWriter, RamDirectory, Schema};
@@ -90,6 +90,94 @@ async fn assert_selected(
     let mut actual: Vec<_> = results.hits.iter().map(|hit| hit.address.doc_id).collect();
     actual.sort_unstable();
     assert_eq!(actual, expected, "index search: {query}");
+}
+
+#[cfg(feature = "sync")]
+#[tokio::test]
+async fn missing_one_word_phrase_filters_are_empty_above_the_scorer_fallback_limit() {
+    let mut schema = Schema::builder();
+    let plain = schema.add_text_field_with_tokenizer("plain", true, false, "simple");
+    let chunked = schema.add_text_field_with_tokenizer("chunked", true, false, "simple");
+    schema.set_chunked(chunked, true);
+    let unpopulated = schema.add_text_field_with_tokenizer("unpopulated", true, false, "simple");
+    let directory = RamDirectory::new();
+    let config = IndexConfig {
+        num_indexing_threads: 1,
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+        .await
+        .unwrap();
+    let mut document = Document::new();
+    document.add_text(plain, "present");
+    document.add_text(chunked, "present");
+    writer.add_document(document).unwrap();
+    for _ in 0..crate::query::MAX_FUSION_CANDIDATE_SLOTS {
+        loop {
+            match writer.add_document(Document::new()) {
+                Ok(()) => break,
+                Err(crate::Error::QueueFull) => tokio::task::yield_now().await,
+                Err(error) => panic!("failed to enqueue fixture document: {error}"),
+            }
+        }
+    }
+    writer.commit().await.unwrap();
+    let index = Index::open(directory, config).await.unwrap();
+    let readers = index.segment_readers().await.unwrap();
+    assert_eq!(readers.len(), 1);
+    assert_eq!(
+        readers[0].num_docs() as usize,
+        crate::query::MAX_FUSION_CANDIDATE_SLOTS + 1
+    );
+    let filter = |query: Arc<dyn Query>| {
+        FilteredQuery::new(Arc::new(TermQuery::text(plain, "present")), vec![query])
+    };
+    for field in [plain, chunked, unpopulated] {
+        let absent = || PhraseQuery::text(field, "absent");
+        assert_selected(&index, &filter(Arc::new(absent())), 1, &[]).await;
+        let negated = BooleanQuery::new().must(AllQuery).must_not(absent());
+        assert_selected(&index, &filter(Arc::new(negated)), 1, &[0]).await;
+    }
+    for field in [plain, chunked] {
+        let present = || PhraseQuery::text(field, "present");
+        assert_selected(&index, &filter(Arc::new(present())), 1, &[0]).await;
+        let disjunction = BooleanQuery::new()
+            .should(PhraseQuery::text(field, "absent"))
+            .should(present());
+        assert_selected(&index, &filter(Arc::new(disjunction)), 1, &[0]).await;
+    }
+}
+
+#[tokio::test]
+async fn one_word_phrase_filters_preserve_indexed_and_fast_only_field_matches() {
+    let mut schema = Schema::builder();
+    let fast = schema.add_text_field_with_tokenizer("tag", false, false, "raw");
+    schema.set_fast(fast, true);
+    let plain = schema.add_text_field_with_tokenizer("plain", true, false, "simple");
+    let chunked = schema.add_text_field_with_tokenizer("chunked", true, false, "simple");
+    schema.set_chunked(chunked, true);
+    let directory = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+        .await
+        .unwrap();
+    let mut document = Document::new();
+    for field in [fast, plain, chunked] {
+        document.add_text(field, "present");
+    }
+    writer.add_document(document).unwrap();
+    writer.commit().await.unwrap();
+    let index = Index::open(directory, config).await.unwrap();
+    for field in [fast, plain, chunked] {
+        for (text, expected) in [("present", vec![0]), ("absent", vec![])] {
+            let query = FilteredQuery::new(
+                Arc::new(AllQuery),
+                vec![Arc::new(PhraseQuery::text(field, text))],
+            );
+            assert_selected(&index, &query, 1, &expected).await;
+        }
+    }
 }
 
 #[tokio::test]

--- a/hermes-core/src/query/phrase.rs
+++ b/hermes-core/src/query/phrase.rs
@@ -575,11 +575,22 @@ impl Query for PhraseQuery {
         }
         let mut bitset = super::DocBitset::new(reader.num_docs());
         if self.terms.len() == 1 {
+            // Non-indexed terms may match through a fast column. Preserve the
+            // scorer fallback; absent postings do not prove an empty filter.
+            if reader
+                .schema()
+                .get_field_entry(self.field)
+                .is_some_and(|entry| !entry.indexed)
+            {
+                return None;
+            }
             // A one-term phrase is the term itself; walk its postings and
             // resolve chunk ids to documents where needed.
-            let list = reader
-                .get_postings_sync(self.field, &self.terms[0])
-                .ok()??;
+            let Some(list) = reader.get_postings_sync(self.field, &self.terms[0]).ok()? else {
+                // A supported filter with no matches is not an unsupported
+                // filter: the latter would invoke the bounded scorer fallback.
+                return Some(bitset);
+            };
             let chunk_map = reader.chunk_map(self.field);
             let mut it = list.iterator();
             while it.doc() != TERMINATED {


### PR DESCRIPTION
In 1.8.129, a structured one-word phrase used as a common filter fails with "common filter cannot be materialized" when its term is absent from a segment containing more than 200,000 documents. The phrase bitmap path treated a successful posting lookup with no matches as unsupported, invoking the capped scorer fallback.

Return the existing empty bitmap for absent indexed terms. Preserve the fast-only field fallback and posting-read error behavior. Regression coverage first reproduced the exact error on 200,001 documents, then verifies plain/chunked text, unpopulated fields, positive/OR/negated filters, direct async/sync scorers and public index search. Update the eligibility contract and review evidence. Candidate/bitmap budgets and wire/storage formats are unchanged.

Validation passed:

- `python3 scripts/check_search.py check` (all four steps).
- Native without sync: ten common-filter tests passed; one manual benchmark ignored.
- WASM release build and all nine runtime tests.
- Documentation checks and pre-commit hooks.

The additional `full` lifecycle/RPC harness was not rerun; no lifecycle or RPC code changed. No latency/RSS benchmark or performance claim is included. The documented portable fallback cap and pre-existing native-async phrase-ordinal discrepancy remain outside this patch.
