### PR TITLE
Fix 65-term failures in L1 phrase features

### DIFF
--- a/docs/candidate-rescoring.md
+++ b/docs/candidate-rescoring.md
@@ -43,6 +43,16 @@ all retained scoring terms, without ANN nomination, LSP selection, heap-floor
 pruning, or top-k truncation of the feature query. Scores remain exact with
 respect to the stored representation (including sparse/vector quantization).
 
+L1 phrase features accept up to 256 retained tokens per phrase, matching the
+server's default post-tokenization text limit. This is separate from the
+64-term text/sparse nomination cursor limit: phrase probing uses one dynamically
+sized positional cursor per term and evaluates every retained term. Both formula
+ranking and raw feature export use this same validation. Larger phrases fail
+with an explicit term-count limit before statistics or candidate payload reads.
+Per-query read and scored-value budgets still apply; this does not expand
+candidate sets or change nomination limits. A stricter configured server token
+limit continues to reject the request during conversion.
+
 ## Ranking modes
 
 - RRF: existing rank-only fusion, kept for compatibility and paired baselines.

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -1237,3 +1237,65 @@ release build plus all nine runtime tests. Documentation checks also passed.
 Logs: `.context/missing-phrase-{check,native-async,wasm-build,wasm-tests,docs}.log`.
 The additional `full` lifecycle/RPC harness was not rerun because this patch
 changes neither lifecycle nor RPC code.
+
+## Long L1 phrase features — 2026-09-06
+
+Confirmed against `cf170fbb` (1.8.130): a 64-token phrase succeeds in both
+ordinary search and candidate scoring, while 65 tokens fail candidate-plan
+validation with "invalid L1 phrase feature or missing positions". The server
+converter admits up to 256 tokens by default. L1 reused the 64-term nomination
+limit even though the shared phrase scorer uses dynamic positional cursors.
+The same plan validation runs for learned ranking and raw feature collection.
+
+Phrase feature validation now has its own 256-token bound, matching the default
+server conversion budget. It preserves every term and existing offsets/slop.
+An oversized core request fails with the feature name, actual term count and
+maximum before statistics or candidate resolution, including an empty candidate
+set. Field/position checks, nonphrase feature limits, nomination limits and
+wire/storage formats are unchanged.
+
+The core regression uses synthetic `term0` through `term255` on plain and
+chunked fields. At 64, 65 and 256 tokens, raw exports and formula scores match
+ordinary phrase search bit-for-bit. Documents with a wrong 65th term or missing
+256th term score zero, so accepting the request cannot hide truncation. A
+257-token candidate request still fails. The broker reproducer uses the same
+four synthetic documents over two real server processes and checks formula
+ranking and collection against ordinary distributed phrase scores.
+
+Reproduction commands using synthetic data:
+
+```sh
+cargo test --locked -p hermes-core --lib long_phrase_features_keep_every_term_in_ranking_and_collection
+cargo build --locked -p hermes-server --bin hermes-server
+cargo test --locked -p hermes-broker --test e2e_real_server broker_ranks_and_exports_long_phrase_features_without_dropping_terms -- --ignored
+```
+
+The algorithm is unchanged: candidate phrase scoring keeps one posting cursor
+and reusable position buffer per term, seeks only nominated physical targets,
+and retains existing read and scored-value admission budgets. Increasing the
+accepted phrase length increases that bounded work; this is a correctness fix,
+not a throughput claim. No before/after latency or memory benchmark was run
+for this patch. Red/green core evidence is in
+`.context/long-phrase-{red,green}.log`. The previously recorded native-async
+required-phrase ordinal discrepancy remains outside this change.
+
+The required `check` passed all four steps with normal test concurrency:
+`.context/search-harness/20260906T180558.238875Z-check/`. All eight full-harness
+steps passed with `RUST_TEST_THREADS=1 python3 scripts/check_search.py full`:
+`.context/search-harness/20260906T181122.939063Z-full/`, including all three
+real-server broker tests. Eight candidate-scoring tests also passed with native
+async execution. Logs: `.context/long-phrase-{final-check,full-serial,native-async,broker}.log`.
+
+Parallel validation intermittently timed out in two existing broker integration
+tests while waiting ten seconds for initial index discovery:
+`client_deadline_propagates_and_absence_means_untimed` in the first `check`, and
+`partitioned_stream_routes_each_flush_by_primary_key` in the parallel `full`.
+Neither exercises candidate phrase scoring. The focused deadline retry and a
+fresh default-concurrency `check` passed; the final `full` used one test thread.
+No timeout or production setting was changed. The cause of these timeouts remains
+unresolved; original failures are retained in `.context/long-phrase-{check,full}.log`
+and the focused retry in `.context/long-phrase-broker-deadline-retry.log`.
+
+The WASM release build and all nine existing runtime tests passed, along with
+documentation checks and pre-commit hooks. Evidence:
+`.context/long-phrase-{wasm-build,wasm-tests,docs,final-precommit}.log`.

--- a/hermes-broker/tests/e2e_real_server.rs
+++ b/hermes-broker/tests/e2e_real_server.rs
@@ -304,6 +304,166 @@ async fn broker_routes_real_hermes_servers() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "needs the hermes-server binary; see module docs"]
+async fn broker_ranks_and_exports_long_phrase_features_without_dropping_terms() {
+    let server_a = spawn_server();
+    let server_b = spawn_server();
+    wait_server_ready(&server_a.addr).await;
+    wait_server_ready(&server_b.addr).await;
+    let broker = spawn_broker(
+        &[
+            format!("id=a,addr={},shard=0", server_a.addr),
+            format!("id=b,addr={},shard=1", server_b.addr),
+        ],
+        &["--placement", "docs*=0,1"],
+    );
+    wait_for_indexes(&broker, &[], Duration::from_secs(10)).await;
+    let index_name = "docs_long_phrase";
+    let mut index = broker_index_client(&broker).await;
+    index
+        .create_index(CreateIndexRequest {
+            index_name: index_name.into(),
+            schema: format!(
+                "index {index_name} {{
+                    field id: text<raw> [primary, indexed, stored]
+                    field title: text<simple> [indexed<chunked, token_position>]
+                }}"
+            ),
+        })
+        .await
+        .unwrap();
+    wait_for_indexes(&broker, &[index_name], Duration::from_secs(10)).await;
+    let terms: Vec<_> = (0..256).map(|i| format!("term{i}")).collect();
+    let mut wrong_word = terms.clone();
+    wrong_word[64] = "different".into();
+    index
+        .batch_index_documents(BatchIndexDocumentsRequest {
+            index_name: index_name.into(),
+            documents: vec![
+                doc("doc0", &terms.join(" ")),
+                doc("doc1", &terms[..64].join(" ")),
+                doc("doc2", &wrong_word.join(" ")),
+                doc("doc3", &terms[..255].join(" ")),
+            ],
+        })
+        .await
+        .unwrap();
+    index
+        .commit(CommitRequest {
+            index_name: index_name.into(),
+        })
+        .await
+        .unwrap();
+    let mut search = broker_search_client(&broker).await;
+    fn id(hit: &SearchHit) -> &str {
+        match hit.fields["id"].values[0].value.as_ref().unwrap() {
+            field_value::Value::Text(id) => id,
+            _ => panic!("expected a text primary key"),
+        }
+    }
+    for count in [64, 65, 256] {
+        let phrase = Query {
+            query: Some(query::Query::Phrase(PhraseQuery {
+                field: "title".into(),
+                text: terms[..count].join(" "),
+                ..Default::default()
+            })),
+        };
+        let reference = search
+            .search(SearchRequest {
+                index_name: index_name.into(),
+                query: Some(phrase.clone()),
+                limit: 4,
+                fields_to_load: vec!["id".into()],
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .into_inner();
+        let mut matching: Vec<_> = reference.hits.iter().map(id).collect();
+        matching.sort_unstable();
+        assert_eq!(
+            matching,
+            match count {
+                64 => vec!["doc0", "doc1", "doc2", "doc3"],
+                65 => vec!["doc0", "doc3"],
+                _ => vec!["doc0"],
+            }
+        );
+        for ranked in [false, true] {
+            let response = search
+                .search(SearchRequest {
+                    index_name: index_name.into(),
+                    limit: 4,
+                    fields_to_load: vec!["id".into()],
+                    query: Some(Query {
+                        query: Some(query::Query::Fusion(FusionQuery {
+                            queries: vec![
+                                WeightedQuery {
+                                    name: "nomination".into(),
+                                    scope: ScoreScope::Chunk as i32,
+                                    query: Some(Query {
+                                        query: Some(query::Query::Term(TermQuery {
+                                            field: "title".into(),
+                                            term: "term0".into(),
+                                            ..Default::default()
+                                        })),
+                                    }),
+                                    ..Default::default()
+                                },
+                                WeightedQuery {
+                                    name: "phrase".into(),
+                                    scope: ScoreScope::Chunk as i32,
+                                    query: Some(phrase.clone()),
+                                    score_only: true,
+                                    ..Default::default()
+                                },
+                            ],
+                            candidate_depth: 4,
+                            ..Default::default()
+                        })),
+                    }),
+                    l1: ranked.then(|| L1Ranking {
+                        formula: "phrase".into(),
+                        ..Default::default()
+                    }),
+                    score_export: Some(ScoreExport {
+                        passages_per_document: 1,
+                        all_passages: !ranked,
+                    }),
+                    ..Default::default()
+                })
+                .await
+                .unwrap_or_else(|error| panic!("{count} terms, ranked={ranked}: {error}"))
+                .into_inner();
+            assert_eq!(
+                response.ranking_method,
+                if ranked {
+                    "formula_v1"
+                } else {
+                    "feature_export_v2"
+                }
+            );
+            assert_eq!(response.hits.len(), 4);
+            for hit in &response.hits {
+                let expected = reference
+                    .hits
+                    .iter()
+                    .find(|other| id(other) == id(hit))
+                    .map_or(0.0, |hit| hit.score);
+                let passages = &hit.candidate_scores.as_ref().unwrap().passages;
+                assert_eq!(passages.len(), 1);
+                assert_eq!(passages[0].ordinal, 0);
+                assert_eq!(passages[0].scores["phrase"].to_bits(), expected.to_bits());
+                if ranked {
+                    assert_eq!(hit.score.to_bits(), expected.to_bits());
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "needs the hermes-server binary; see module docs"]
 async fn partitioned_fusion_uses_global_text_stats_and_exclusion_filters() {
     let server_a = spawn_server();
     let server_b = spawn_server();

--- a/hermes-core/src/query/candidate_scoring/execution.rs
+++ b/hermes-core/src/query/candidate_scoring/execution.rs
@@ -7,6 +7,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 const MAX_FEATURES: usize = crate::query::MAX_FUSION_SUB_QUERIES;
+// Phrase probing uses dynamic positional cursors. Its separate scratch bound
+// matches the server's default token limit, including for direct core callers.
+const MAX_PHRASE_TERMS: usize = 256;
 const MAX_FEATURE_VALUES: usize = 2_000_000;
 const MAX_VECTOR_BYTES: usize = 1024 * 1024 * 1024;
 
@@ -91,9 +94,15 @@ impl CandidateScoringPlan {
                         }
                     }
                     ScoreComponent::Phrase(query) => {
+                        if query.terms.len() > MAX_PHRASE_TERMS {
+                            return Err(Error::Query(format!(
+                                "L1 phrase feature '{}' has {} terms; maximum is {MAX_PHRASE_TERMS}",
+                                feature.name,
+                                query.terms.len(),
+                            )));
+                        }
                         if entry.field_type != crate::FieldType::Text
                             || query.field != feature.query.field
-                            || query.terms.len() > crate::query::MAX_QUERY_TERMS
                             || query.offsets.len() != query.terms.len()
                             || !query.offsets.windows(2).all(|p| p[0] < p[1])
                             || (query.terms.len() > 1 && entry.positions.is_none())

--- a/hermes-core/src/query/candidate_scoring/tests.rs
+++ b/hermes-core/src/query/candidate_scoring/tests.rs
@@ -7,6 +7,121 @@ use crate::structures::{SparseFormat, SparseVectorConfig, WeightQuantization};
 use crate::{Document, Index, IndexConfig, IndexWriter, RamDirectory, Schema};
 
 #[tokio::test]
+async fn long_phrase_features_keep_every_term_in_ranking_and_collection() {
+    let mut schema = Schema::builder();
+    let plain = schema.add_text_field_with_tokenizer("plain", true, false, "simple");
+    let chunked = schema.add_text_field_with_tokenizer("chunked", true, false, "simple");
+    schema.set_chunked(chunked, true);
+    for field in [plain, chunked] {
+        schema.set_positions(field, PositionMode::TokenPosition);
+    }
+    let terms: Vec<_> = (0..256).map(|i| format!("term{i}")).collect();
+    let mut wrong_word = terms.clone();
+    wrong_word[64] = "different".into();
+    let directory = RamDirectory::new();
+    let config = IndexConfig::default();
+    let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+        .await
+        .unwrap();
+    for text in [
+        terms.join(" "),
+        terms[..64].join(" "),
+        wrong_word.join(" "),
+        terms[..255].join(" "),
+    ] {
+        let mut document = Document::new();
+        for field in [plain, chunked] {
+            document.add_text(field, &text);
+        }
+        writer.add_document(document).unwrap();
+    }
+    writer.commit().await.unwrap();
+    let index = Index::open(directory, config).await.unwrap();
+    let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+    for (field, scope) in [(plain, ScoreScope::Document), (chunked, ScoreScope::Chunk)] {
+        let candidates = searcher
+            .search_with_positions(&TermQuery::text(field, "term0"), 4)
+            .await
+            .unwrap()
+            .0;
+        assert_eq!(candidates.len(), 4);
+        for count in [64, 65, 256] {
+            let phrase = PhraseQuery::text(field, &terms[..count].join(" "));
+            let reference = searcher.search_with_positions(&phrase, 4).await.unwrap().0;
+            let mut matching: Vec<_> = reference.iter().map(|hit| hit.doc_id).collect();
+            matching.sort_unstable();
+            assert_eq!(
+                matching,
+                match count {
+                    64 => vec![0, 1, 2, 3],
+                    65 => vec![0, 3],
+                    _ => vec![0],
+                }
+            );
+            for ranked in [false, true] {
+                let plan = CandidateScoringPlan {
+                    features: vec![CandidateFeature {
+                        name: "phrase".into(),
+                        scope,
+                        query: phrase.candidate_query().unwrap(),
+                    }],
+                    backfill: true,
+                    model: ranked.then(|| {
+                        RankingModel::compile("phrase", &["phrase"], &Default::default()).unwrap()
+                    }),
+                    export_passages: 1,
+                    all_passages: !ranked,
+                    document_combiner: MultiValueCombiner::Max,
+                };
+                let scored = searcher
+                    .score_candidates(&candidates, &plan, None)
+                    .await
+                    .unwrap_or_else(|error| {
+                        panic!("{count}-term phrase, {scope:?}, ranked={ranked}: {error}")
+                    });
+                for candidate in scored {
+                    let expected = reference
+                        .iter()
+                        .find(|hit| hit.doc_id == candidate.result.doc_id)
+                        .map_or(0.0, |hit| hit.score);
+                    let actual = match scope {
+                        ScoreScope::Document => candidate.features.document[0].unwrap(),
+                        ScoreScope::Chunk => {
+                            assert_eq!(candidate.features.passages.len(), 1);
+                            assert_eq!(candidate.features.passages[0].ordinal, 0);
+                            candidate.features.passages[0].values[0].unwrap()
+                        }
+                    };
+                    assert_eq!(actual.to_bits(), expected.to_bits(), "{count}-term phrase");
+                    if ranked {
+                        assert_eq!(candidate.result.score.to_bits(), expected.to_bits());
+                    }
+                }
+            }
+        }
+    }
+    let oversized = CandidateScoringPlan {
+        features: vec![CandidateFeature {
+            name: "phrase".into(),
+            scope: ScoreScope::Document,
+            query: PhraseQuery::new(plain, vec![b"term0".to_vec(); 257])
+                .candidate_query()
+                .unwrap(),
+        }],
+        backfill: true,
+        model: None,
+        export_passages: 1,
+        all_passages: false,
+        document_combiner: MultiValueCombiner::Max,
+    };
+    let error = searcher
+        .score_candidates(&[], &oversized, None)
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("257 terms; maximum is 256"));
+}
+
+#[tokio::test]
 async fn l1_preserves_organic_zero_and_negative_scores_and_backfills_only_missing_cells() {
     let mut schema = Schema::builder();
     let field = schema.add_dense_vector_field_with_config(


### PR DESCRIPTION
A 65-token phrase passes ordinary phrase search but fails L1 validation in both formula ranking and raw feature collection. L1 incorrectly reused the 64-term nomination limit for its dynamic positional phrase scorer. Give phrase features a separate 256-token bound, matching the default server token budget, and report the feature name, actual count and maximum for oversized requests.

Synthetic regressions cover 64, 65 and 256 tokens on plain/chunked fields and through a broker with two real servers. Raw features and formula predictions match ordinary phrase scores bit-for-bit; a wrong 65th term or missing 256th term remains a nonmatch. A 257-token core request fails before candidate resolution. Reproduction commands and evidence are in `docs/search-performance-review.md`. Existing nonphrase, nomination, read and feature-matrix limits remain in place.

Validation passed:

- `python3 scripts/check_search.py check` with normal test concurrency.
- All eight steps of `RUST_TEST_THREADS=1 python3 scripts/check_search.py full`, including all real-server RPC tests.
- Eight native-async candidate-scoring tests; WASM release build and nine runtime tests.
- Documentation and pre-commit checks.

Two initial parallel harness runs hit ten-second discovery timeouts in existing broker deadline/streaming integration tests, before any candidate scoring. A fresh normal-concurrency `check` passed; the final `full` used one test thread. The timeout cause remains unresolved and is documented, with original logs retained. No latency/memory benchmark or performance claim is included in this patch.
