### PR TITLE
Make L1 phrase term limits configurable per index

### DIFF
--- a/docs/candidate-rescoring.md
+++ b/docs/candidate-rescoring.md
@@ -43,15 +43,37 @@ all retained scoring terms, without ANN nomination, LSP selection, heap-floor
 pruning, or top-k truncation of the feature query. Scores remain exact with
 respect to the stored representation (including sparse/vector quantization).
 
-L1 phrase features accept up to 256 retained tokens per phrase, matching the
-server's default post-tokenization text limit. This is separate from the
-64-term text/sparse nomination cursor limit: phrase probing uses one dynamically
-sized positional cursor per term and evaluates every retained term. Both formula
-ranking and raw feature export use this same validation. Larger phrases fail
-with an explicit term-count limit before statistics or candidate payload reads.
-Per-query read and scored-value budgets still apply; this does not expand
-candidate sets or change nomination limits. A stricter configured server token
-limit continues to reject the request during conversion.
+L1 phrase features use the index-level `max_l1_phrase_terms` setting, supplied
+in the creation schema and persisted under `schema` in `metadata.json`. Its
+default is **64**, including existing metadata with no setting. For example:
+
+```sdl
+index documents {
+    max_l1_phrase_terms: 256
+    field body: text<simple> [indexed<chunked, token_position>]
+}
+```
+
+The setting accepts a positive 32-bit integer and is fixed at creation. The
+core schema owns this policy; SDL, JSON creation schemas, the Rust builder,
+server/broker creation and WASM creation use the same persisted value. Index
+info reports it in the returned SDL, and reopening an index preserves it.
+This is an additive optional JSON metadata field; existing indexes open without
+migration and segment formats are unchanged. Missing values serialize without the field.
+
+Core plan validation for both formula ranking and raw feature export checks
+each phrase against this limit before local statistics or candidate payload
+reads, including empty candidate sets. Oversized phrases fail with the actual
+count and configured maximum;
+terms are never truncated. Phrase probing uses one dynamically sized positional
+cursor per term, so increasing the setting increases per-phrase scratch and
+posting/position probes linearly. The existing 256 MiB shared payload-read and
+scored-value budgets still apply. Operators choose the bound at creation;
+nomination limits and candidate sets do not grow with it.
+
+The separate 64-term text/sparse nomination cursor limit is unchanged. The
+server's `--max-text-query-tokens` request limit (default 256) also still applies
+after tokenization: using a phrase longer than 256 requires raising both limits.
 
 ## Ranking modes
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -71,6 +71,24 @@ Attributes control how fields are processed and stored:
 
 Index-level options (inside the `index { ... }` block):
 
+`max_l1_phrase_terms` sets the maximum retained tokens in each L1 phrase feature,
+for both formula ranking and feature collection. Set it when creating the index:
+
+```sdl
+index documents {
+    max_l1_phrase_terms: 256  # Default: 64
+    field body: text<simple> [indexed<chunked, token_position>]
+}
+```
+
+It accepts positive 32-bit integers, is persisted in `metadata.json` under
+`schema.max_l1_phrase_terms`, and is included in the schema returned by index
+info. Omission, including in existing metadata, means 64. The JSON creation
+schema accepts the same top-level key alongside `fields`. Rust callers can use
+`SchemaBuilder::set_max_l1_phrase_terms(NonZeroU32::new(256).unwrap())`.
+The server's separate `--max-text-query-tokens` limit still applies (default 256).
+See [candidate rescoring](candidate-rescoring.md) for scoring and memory bounds.
+
 ```sdl
 index articles {
     reorder_on_merge: true   # BP-reorder `reorder`-attributed BMP fields inside merges.

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -1299,3 +1299,66 @@ and the focused retry in `.context/long-phrase-broker-deadline-retry.log`.
 The WASM release build and all nine existing runtime tests passed, along with
 documentation checks and pre-commit hooks. Evidence:
 `.context/long-phrase-{wasm-build,wasm-tests,docs,final-precommit}.log`.
+
+## Index-configurable L1 phrase limits — 2026-09-06
+
+Following the fixed 256-token limit in 1.8.131 (`2bf99929`), the creation schema
+now accepts `max_l1_phrase_terms`. The requested default is restored to **64**;
+indexes opt into longer features explicitly, for example
+`index documents { max_l1_phrase_terms: 256 field body: text [indexed<token_position>] }`.
+The optional positive-u32 setting is owned by core `Schema` and persisted under
+`schema.max_l1_phrase_terms` in `metadata.json`. SDL, JSON creation, Rust builders,
+server/broker creation and WASM creation share it. Index info returns the
+effective value in SDL. No protobuf or segment format changes are involved.
+Absent settings retain the prior metadata bytes and load as 64; explicit zero,
+negative, fractional and out-of-range values fail creation/deserialization.
+
+Before the change, the new default-limit regression incorrectly accepted a
+65-term phrase with no nominated candidates (`.context/phrase-cap-red.log`).
+It now checks the configured boundary in ranking and collection after reopen,
+including custom limits 1, 65 and 300. The existing long-phrase fixture explicitly
+sets 300 and compares complete plain/chunked phrase features and formula
+predictions against ordinary search at 64, 65, 256 and 300 terms. Wrong 65th terms
+and missing 256th terms still score zero. A two-shard RPC fixture checks both
+default-64 and configured-256 indexes, reported schemas, and invalid creation.
+WASM runtime coverage checks default/configured metadata across reopen and a
+second commit, plus rejected zero limits.
+
+The setting uses one inline `Option<NonZeroU32>` with no heap allocation;
+validation reads it once per phrase component. Phrase probing is unchanged:
+per-phrase cursor scratch and posting/position probes grow linearly with retained
+terms. The shared 256 MiB candidate payload-read budget, scored-value budget,
+nomination limits, and separate server token budget (default 256) still apply.
+No latency/RSS benchmark was run for this configuration change and no performance
+improvement is claimed. The previously recorded native-async phrase-ordinal
+discrepancy and intermittent parallel broker startup timeouts remain separate
+findings.
+
+The initial required check exhausted local disk space while linking tests
+(`.context/phrase-cap-check.log`). Removing only this workspace's rebuildable
+incremental caches predating the task freed 45 GiB. The next normal-concurrency
+check reached broker tests but timed out in the existing
+`partitioned_create_and_commit_fan_out_to_every_partition` test, waiting ten
+seconds for initial index discovery (`.context/phrase-cap-final-check.log`).
+This is the same unresolved discovery failure recorded above; no production
+behavior or test timeout was changed. Subsequent harness runs use one test thread.
+The first serial full run passed all 1,369 core unit tests, then could not
+execute an integration binary: the workspace's entire `target` directory
+disappeared during the run, beyond the earlier bounded incremental-cache cleanup.
+Its log is `.context/phrase-cap-full-serial.log`. Validation was restarted with
+`CARGO_TARGET_DIR=$PWD/.context/l1-phrase-cap-build` to isolate build artifacts.
+
+The isolated full run passed its first seven steps, including all search-stack
+tests, native-without-sync and portable compilation, API docs, and the server
+build (`.context/search-harness/20260906T184531.789002Z-full/`). Its standalone
+broker step caught a native-gated helper used only by the new index-info test
+assertion; replacing that helper with the portable SDL parser fixed the feature
+boundary. Rerunning that exact final step passed all three real-server tests,
+including both phrase-cap configurations (`.context/phrase-cap-broker.log`).
+The WASM release build and all 12 runtime tests passed in the separate
+`.context/l1-phrase-cap-wasm-build` directory; logs are
+`.context/phrase-cap-wasm-{build,install,tests}.log`.
+All nine candidate-scoring tests also passed with native async execution
+(`cargo test --locked -p hermes-core --no-default-features --features native --lib
+query::candidate_scoring::tests`), including the 300-term exact-score checks:
+`.context/phrase-cap-native-async.log`.

--- a/hermes-broker/tests/e2e_real_server.rs
+++ b/hermes-broker/tests/e2e_real_server.rs
@@ -317,145 +317,192 @@ async fn broker_ranks_and_exports_long_phrase_features_without_dropping_terms() 
         &["--placement", "docs*=0,1"],
     );
     wait_for_indexes(&broker, &[], Duration::from_secs(10)).await;
-    let index_name = "docs_long_phrase";
     let mut index = broker_index_client(&broker).await;
-    index
+    let invalid = index
         .create_index(CreateIndexRequest {
-            index_name: index_name.into(),
-            schema: format!(
-                "index {index_name} {{
+            index_name: "docs_invalid_phrase_limit".into(),
+            schema: "index documents { max_l1_phrase_terms: 0 field title: text }".into(),
+        })
+        .await
+        .expect_err("invalid limits must fail index creation");
+    assert_eq!(invalid.code(), tonic::Code::InvalidArgument);
+    for configured in [false, true] {
+        let index_name = if configured {
+            "docs_long_phrase"
+        } else {
+            "docs_default_phrase"
+        };
+        let option = if configured {
+            "max_l1_phrase_terms: 256"
+        } else {
+            ""
+        };
+        index
+            .create_index(CreateIndexRequest {
+                index_name: index_name.into(),
+                schema: format!(
+                    "index {index_name} {{
+                    {option}
                     field id: text<raw> [primary, indexed, stored]
                     field title: text<simple> [indexed<chunked, token_position>]
                 }}"
-            ),
-        })
-        .await
-        .unwrap();
-    wait_for_indexes(&broker, &[index_name], Duration::from_secs(10)).await;
-    let terms: Vec<_> = (0..256).map(|i| format!("term{i}")).collect();
-    let mut wrong_word = terms.clone();
-    wrong_word[64] = "different".into();
-    index
-        .batch_index_documents(BatchIndexDocumentsRequest {
-            index_name: index_name.into(),
-            documents: vec![
-                doc("doc0", &terms.join(" ")),
-                doc("doc1", &terms[..64].join(" ")),
-                doc("doc2", &wrong_word.join(" ")),
-                doc("doc3", &terms[..255].join(" ")),
-            ],
-        })
-        .await
-        .unwrap();
-    index
-        .commit(CommitRequest {
-            index_name: index_name.into(),
-        })
-        .await
-        .unwrap();
-    let mut search = broker_search_client(&broker).await;
-    fn id(hit: &SearchHit) -> &str {
-        match hit.fields["id"].values[0].value.as_ref().unwrap() {
-            field_value::Value::Text(id) => id,
-            _ => panic!("expected a text primary key"),
-        }
-    }
-    for count in [64, 65, 256] {
-        let phrase = Query {
-            query: Some(query::Query::Phrase(PhraseQuery {
-                field: "title".into(),
-                text: terms[..count].join(" "),
-                ..Default::default()
-            })),
-        };
-        let reference = search
-            .search(SearchRequest {
+                ),
+            })
+            .await
+            .unwrap();
+        wait_for_indexes(&broker, &[index_name], Duration::from_secs(10)).await;
+        let terms: Vec<_> = (0..256).map(|i| format!("term{i}")).collect();
+        let mut wrong_word = terms.clone();
+        wrong_word[64] = "different".into();
+        index
+            .batch_index_documents(BatchIndexDocumentsRequest {
                 index_name: index_name.into(),
-                query: Some(phrase.clone()),
-                limit: 4,
-                fields_to_load: vec!["id".into()],
-                ..Default::default()
+                documents: vec![
+                    doc("doc0", &terms.join(" ")),
+                    doc("doc1", &terms[..64].join(" ")),
+                    doc("doc2", &wrong_word.join(" ")),
+                    doc("doc3", &terms[..255].join(" ")),
+                ],
+            })
+            .await
+            .unwrap();
+        index
+            .commit(CommitRequest {
+                index_name: index_name.into(),
+            })
+            .await
+            .unwrap();
+        let mut search = broker_search_client(&broker).await;
+        let info = search
+            .get_index_info(GetIndexInfoRequest {
+                index_name: index_name.into(),
             })
             .await
             .unwrap()
             .into_inner();
-        let mut matching: Vec<_> = reference.hits.iter().map(id).collect();
-        matching.sort_unstable();
+        let reported_schema = hermes_core::parse_single_index(&info.schema)
+            .unwrap()
+            .to_schema();
         assert_eq!(
-            matching,
-            match count {
-                64 => vec!["doc0", "doc1", "doc2", "doc3"],
-                65 => vec!["doc0", "doc3"],
-                _ => vec!["doc0"],
-            }
+            reported_schema.max_l1_phrase_terms(),
+            if configured { 256 } else { 64 }
         );
-        for ranked in [false, true] {
-            let response = search
+        fn id(hit: &SearchHit) -> &str {
+            match hit.fields["id"].values[0].value.as_ref().unwrap() {
+                field_value::Value::Text(id) => id,
+                _ => panic!("expected a text primary key"),
+            }
+        }
+        for count in [64, 65, 256] {
+            let phrase = Query {
+                query: Some(query::Query::Phrase(PhraseQuery {
+                    field: "title".into(),
+                    text: terms[..count].join(" "),
+                    ..Default::default()
+                })),
+            };
+            let reference = search
                 .search(SearchRequest {
                     index_name: index_name.into(),
+                    query: Some(phrase.clone()),
                     limit: 4,
                     fields_to_load: vec!["id".into()],
-                    query: Some(Query {
-                        query: Some(query::Query::Fusion(FusionQuery {
-                            queries: vec![
-                                WeightedQuery {
-                                    name: "nomination".into(),
-                                    scope: ScoreScope::Chunk as i32,
-                                    query: Some(Query {
-                                        query: Some(query::Query::Term(TermQuery {
-                                            field: "title".into(),
-                                            term: "term0".into(),
-                                            ..Default::default()
-                                        })),
-                                    }),
-                                    ..Default::default()
-                                },
-                                WeightedQuery {
-                                    name: "phrase".into(),
-                                    scope: ScoreScope::Chunk as i32,
-                                    query: Some(phrase.clone()),
-                                    score_only: true,
-                                    ..Default::default()
-                                },
-                            ],
-                            candidate_depth: 4,
-                            ..Default::default()
-                        })),
-                    }),
-                    l1: ranked.then(|| L1Ranking {
-                        formula: "phrase".into(),
-                        ..Default::default()
-                    }),
-                    score_export: Some(ScoreExport {
-                        passages_per_document: 1,
-                        all_passages: !ranked,
-                    }),
                     ..Default::default()
                 })
                 .await
-                .unwrap_or_else(|error| panic!("{count} terms, ranked={ranked}: {error}"))
+                .unwrap()
                 .into_inner();
+            let mut matching: Vec<_> = reference.hits.iter().map(id).collect();
+            matching.sort_unstable();
             assert_eq!(
-                response.ranking_method,
-                if ranked {
-                    "formula_v1"
-                } else {
-                    "feature_export_v2"
+                matching,
+                match count {
+                    64 => vec!["doc0", "doc1", "doc2", "doc3"],
+                    65 => vec!["doc0", "doc3"],
+                    _ => vec!["doc0"],
                 }
             );
-            assert_eq!(response.hits.len(), 4);
-            for hit in &response.hits {
-                let expected = reference
-                    .hits
-                    .iter()
-                    .find(|other| id(other) == id(hit))
-                    .map_or(0.0, |hit| hit.score);
-                let passages = &hit.candidate_scores.as_ref().unwrap().passages;
-                assert_eq!(passages.len(), 1);
-                assert_eq!(passages[0].ordinal, 0);
-                assert_eq!(passages[0].scores["phrase"].to_bits(), expected.to_bits());
-                if ranked {
-                    assert_eq!(hit.score.to_bits(), expected.to_bits());
+            for ranked in [false, true] {
+                let response = search
+                    .search(SearchRequest {
+                        index_name: index_name.into(),
+                        limit: 4,
+                        fields_to_load: vec!["id".into()],
+                        query: Some(Query {
+                            query: Some(query::Query::Fusion(FusionQuery {
+                                queries: vec![
+                                    WeightedQuery {
+                                        name: "nomination".into(),
+                                        scope: ScoreScope::Chunk as i32,
+                                        query: Some(Query {
+                                            query: Some(query::Query::Term(TermQuery {
+                                                field: "title".into(),
+                                                term: "term0".into(),
+                                                ..Default::default()
+                                            })),
+                                        }),
+                                        ..Default::default()
+                                    },
+                                    WeightedQuery {
+                                        name: "phrase".into(),
+                                        scope: ScoreScope::Chunk as i32,
+                                        query: Some(phrase.clone()),
+                                        score_only: true,
+                                        ..Default::default()
+                                    },
+                                ],
+                                candidate_depth: 4,
+                                ..Default::default()
+                            })),
+                        }),
+                        l1: ranked.then(|| L1Ranking {
+                            formula: "phrase".into(),
+                            ..Default::default()
+                        }),
+                        score_export: Some(ScoreExport {
+                            passages_per_document: 1,
+                            all_passages: !ranked,
+                        }),
+                        ..Default::default()
+                    })
+                    .await;
+                if !configured && count > 64 {
+                    let error =
+                        response.expect_err("default index cap must reject long L1 phrases");
+                    assert_eq!(error.code(), tonic::Code::InvalidArgument, "{error}");
+                    assert!(
+                        error
+                            .message()
+                            .contains(&format!("{count} terms; maximum is 64")),
+                        "{error}"
+                    );
+                    continue;
+                }
+                let response = response
+                    .unwrap_or_else(|error| panic!("{count} terms, ranked={ranked}: {error}"))
+                    .into_inner();
+                assert_eq!(
+                    response.ranking_method,
+                    if ranked {
+                        "formula_v1"
+                    } else {
+                        "feature_export_v2"
+                    }
+                );
+                assert_eq!(response.hits.len(), 4);
+                for hit in &response.hits {
+                    let expected = reference
+                        .hits
+                        .iter()
+                        .find(|other| id(other) == id(hit))
+                        .map_or(0.0, |hit| hit.score);
+                    let passages = &hit.candidate_scores.as_ref().unwrap().passages;
+                    assert_eq!(passages.len(), 1);
+                    assert_eq!(passages[0].ordinal, 0);
+                    assert_eq!(passages[0].scores["phrase"].to_bits(), expected.to_bits());
+                    if ranked {
+                        assert_eq!(hit.score.to_bits(), expected.to_bits());
+                    }
                 }
             }
         }

--- a/hermes-core/src/dsl/schema.rs
+++ b/hermes-core/src/dsl/schema.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::num::NonZeroU32;
 
 /// Field identifier
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -790,6 +791,11 @@ pub struct Schema {
     /// handles ordering).
     #[serde(default)]
     reorder_on_merge: bool,
+    /// Creation-time cap on retained tokens in each L1 phrase feature.
+    /// Absent (including legacy metadata) means 64. Nonzero u32 keeps the
+    /// serialized range identical on native and WASM targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_l1_phrase_terms: Option<NonZeroU32>,
     /// Index name used as the `index` label on metrics. Set from the SDL
     /// index name at parse time and overridden with the registry name at
     /// server-side index creation. Empty on old metadata → "unknown".
@@ -902,6 +908,13 @@ impl Schema {
         self.reorder_on_merge
     }
 
+    /// Maximum retained tokens per L1 phrase, for ranking and feature export.
+    /// This index policy is independent of nomination and server token limits.
+    pub fn max_l1_phrase_terms(&self) -> usize {
+        self.max_l1_phrase_terms
+            .map_or(64, |limit| limit.get() as usize)
+    }
+
     /// Index name for metric labels ("unknown" when not set — pre-existing
     /// metadata or programmatic schemas without a name).
     pub fn index_label(&self) -> &str {
@@ -954,6 +967,7 @@ pub struct SchemaBuilder {
     default_fields: Vec<String>,
     query_routers: Vec<QueryRouterRule>,
     reorder_on_merge: bool,
+    max_l1_phrase_terms: Option<NonZeroU32>,
     index_name: String,
 }
 
@@ -1271,6 +1285,13 @@ impl SchemaBuilder {
         self.reorder_on_merge = on;
     }
 
+    /// Set the persisted L1 phrase-term cap at index creation (default: 64).
+    /// Higher limits allow more per-phrase cursors and posting/position reads;
+    /// the shared candidate probe budgets and server token limit still apply.
+    pub fn set_max_l1_phrase_terms(&mut self, limit: NonZeroU32) {
+        self.max_l1_phrase_terms = Some(limit);
+    }
+
     /// Set the index name used as the metrics `index` label.
     pub fn set_index_name(&mut self, name: impl Into<String>) {
         self.index_name = name.into();
@@ -1312,6 +1333,7 @@ impl SchemaBuilder {
             default_fields,
             query_routers: self.query_routers,
             reorder_on_merge: self.reorder_on_merge,
+            max_l1_phrase_terms: self.max_l1_phrase_terms,
             index_name: self.index_name,
         }
     }

--- a/hermes-core/src/dsl/sdl/mod.rs
+++ b/hermes-core/src/dsl/sdl/mod.rs
@@ -43,6 +43,7 @@
 
 use pest::Parser;
 use pest_derive::Parser;
+use std::num::NonZeroU32;
 
 use super::query_field_router::{QueryRouterRule, RoutingMode};
 use super::schema::{DenseVectorQuantization, FieldType, Schema, SchemaBuilder};
@@ -103,6 +104,8 @@ pub struct IndexDef {
     /// BP-reorder `reorder`-attributed BMP fields inside merges
     /// (index-level `reorder_on_merge: true`). Absent = disabled.
     pub reorder_on_merge: bool,
+    /// Creation-time cap on retained tokens per L1 phrase; absent means 64.
+    pub max_l1_phrase_terms: Option<NonZeroU32>,
 }
 
 impl IndexDef {
@@ -214,6 +217,9 @@ impl IndexDef {
         }
 
         builder.set_index_name(self.name.clone());
+        if let Some(limit) = self.max_l1_phrase_terms {
+            builder.set_max_l1_phrase_terms(limit);
+        }
 
         if self.reorder_on_merge {
             if self.fields.iter().any(|f| f.reorder) {
@@ -1489,6 +1495,7 @@ fn parse_index_def(pair: pest::iterators::Pair<Rule>) -> Result<IndexDef> {
     let mut default_fields = Vec::new();
     let mut query_routers = Vec::new();
     let mut reorder_on_merge = false;
+    let mut max_l1_phrase_terms = None;
 
     for item in inner {
         match item.as_rule() {
@@ -1508,6 +1515,17 @@ fn parse_index_def(pair: pest::iterators::Pair<Rule>) -> Result<IndexDef> {
                     .map(|b| b.as_str() == "true")
                     .unwrap_or(false);
                 reorder_on_merge = value;
+            }
+            Rule::max_l1_phrase_terms_def => {
+                if max_l1_phrase_terms.is_some() {
+                    return Err(Error::Schema(
+                        "max_l1_phrase_terms may only be specified once".into(),
+                    ));
+                }
+                let value = item.into_inner().next().unwrap();
+                max_l1_phrase_terms = Some(value.as_str().parse::<NonZeroU32>().map_err(|_| {
+                    Error::Schema("max_l1_phrase_terms must be a positive 32-bit integer".into())
+                })?);
             }
             _ => {}
         }
@@ -1545,6 +1563,7 @@ fn parse_index_def(pair: pest::iterators::Pair<Rule>) -> Result<IndexDef> {
         default_fields,
         query_routers,
         reorder_on_merge,
+        max_l1_phrase_terms,
     })
 }
 

--- a/hermes-core/src/dsl/sdl/sdl.pest
+++ b/hermes-core/src/dsl/sdl/sdl.pest
@@ -4,7 +4,11 @@
 file = { SOI ~ index_def+ ~ EOI }
 
 // Index definition
-index_def = { "index" ~ identifier ~ "{" ~ (field_def | default_fields_def | query_router_def | reorder_on_merge_def)* ~ "}" }
+index_def = { "index" ~ identifier ~ "{" ~ (field_def | default_fields_def | query_router_def | reorder_on_merge_def | max_l1_phrase_terms_def)* ~ "}" }
+
+// Maximum retained tokens per L1 phrase feature. Absent = 64.
+max_l1_phrase_terms_def = { "max_l1_phrase_terms" ~ ":" ~ max_l1_phrase_terms_spec }
+max_l1_phrase_terms_spec = @{ ASCII_DIGIT+ }
 
 // Index-level option: BP-reorder `reorder`-attributed BMP fields inside merges.
 // Absent = disabled (merges block-copy).

--- a/hermes-core/src/index/helpers.rs
+++ b/hermes-core/src/index/helpers.rs
@@ -4,6 +4,7 @@
 //! and indexing documents, used by `hermes-tool` and `hermes-server`.
 
 use std::io::BufRead;
+use std::num::NonZeroU32;
 use std::path::Path;
 
 use crate::directories::{Directory, DirectoryWriter, FsDirectory};
@@ -39,12 +40,18 @@ fn default_true() -> bool {
 pub struct SchemaConfig {
     /// List of field definitions
     pub fields: Vec<SchemaFieldConfig>,
+    /// Creation-time cap on retained tokens per L1 phrase (default: 64).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_l1_phrase_terms: Option<NonZeroU32>,
 }
 
 impl SchemaConfig {
     /// Build a Schema from this configuration
     pub fn build(&self) -> Result<Schema> {
         let mut builder = SchemaBuilder::default();
+        if let Some(limit) = self.max_l1_phrase_terms {
+            builder.set_max_l1_phrase_terms(limit);
+        }
 
         for field in &self.fields {
             match field.field_type.as_str() {
@@ -260,6 +267,47 @@ mod tests {
         "#;
         let schema = parse_schema(sdl).unwrap();
         assert!(schema.get_field("text").is_some());
+    }
+
+    #[test]
+    fn creation_schemas_preserve_positive_phrase_limits_and_reject_invalid_values() {
+        assert_eq!(Schema::default().max_l1_phrase_terms(), 64);
+        assert_eq!(SchemaBuilder::default().build().max_l1_phrase_terms(), 64);
+        for value in [None, Some(1), Some(64), Some(65), Some(300), Some(u32::MAX)] {
+            let option = value
+                .map(|value| format!("max_l1_phrase_terms: {value}"))
+                .unwrap_or_default();
+            let mut json = serde_json::json!({"fields": [{"name": "body", "type": "text"}]});
+            if let Some(value) = value {
+                json["max_l1_phrase_terms"] = value.into();
+            }
+            for input in [
+                format!("index documents {{ {option} field body: text }}"),
+                json.to_string(),
+            ] {
+                let schema = parse_schema(&input).unwrap();
+                assert_eq!(schema.max_l1_phrase_terms(), value.unwrap_or(64) as usize);
+                let serialized = serde_json::to_value(&schema).unwrap();
+                assert_eq!(
+                    serialized.get("max_l1_phrase_terms").is_some(),
+                    value.is_some()
+                );
+                let restored: Schema = serde_json::from_value(serialized).unwrap();
+                assert_eq!(restored.max_l1_phrase_terms(), schema.max_l1_phrase_terms());
+            }
+        }
+        for invalid in ["0", "-1", "1.5", "4294967296", "\"64\"", "true"] {
+            for input in [
+                format!("index documents {{ max_l1_phrase_terms: {invalid} field body: text }}"),
+                format!(r#"{{"max_l1_phrase_terms": {invalid}, "fields": []}}"#),
+            ] {
+                assert!(parse_schema(&input).is_err(), "accepted {input}");
+            }
+        }
+        assert!(
+            parse_schema("index documents { max_l1_phrase_terms: 64 max_l1_phrase_terms: 256 }")
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -977,6 +977,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn phrase_limits_load_from_legacy_and_configured_metadata_and_reject_corruption() {
+        let directory = crate::directories::RamDirectory::new();
+        let legacy = IndexMetadata::new(test_schema())
+            .serialize_to_bytes()
+            .unwrap();
+        assert!(!String::from_utf8_lossy(&legacy).contains("max_l1_phrase_terms"));
+        directory
+            .write(Path::new(INDEX_META_FILENAME), &legacy)
+            .await
+            .unwrap();
+        let loaded = IndexMetadata::load(&directory).await.unwrap();
+        assert_eq!(loaded.schema.max_l1_phrase_terms(), 64);
+        assert_eq!(loaded.serialize_to_bytes().unwrap(), legacy);
+
+        let mut configured: serde_json::Value = serde_json::from_slice(&legacy).unwrap();
+        configured["schema"]["max_l1_phrase_terms"] = 300.into();
+        directory
+            .write(
+                Path::new(INDEX_META_FILENAME),
+                &serde_json::to_vec(&configured).unwrap(),
+            )
+            .await
+            .unwrap();
+        let loaded = IndexMetadata::load(&directory).await.unwrap();
+        assert_eq!(loaded.schema.max_l1_phrase_terms(), 300);
+        loaded.save(&directory).await.unwrap();
+        assert_eq!(
+            IndexMetadata::load(&directory)
+                .await
+                .unwrap()
+                .schema
+                .max_l1_phrase_terms(),
+            300
+        );
+
+        for invalid in [
+            serde_json::json!(0),
+            serde_json::json!(-1),
+            serde_json::json!(1.5),
+            serde_json::json!(4294967296u64),
+        ] {
+            configured["schema"]["max_l1_phrase_terms"] = invalid;
+            directory
+                .write(
+                    Path::new(INDEX_META_FILENAME),
+                    &serde_json::to_vec(&configured).unwrap(),
+                )
+                .await
+                .unwrap();
+            assert!(
+                IndexMetadata::load(&directory).await.is_err(),
+                "must not replace a corrupt cap with the default"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn load_refuses_metadata_stamped_with_a_newer_format_version() {
         let directory = crate::directories::RamDirectory::new();
         let mut metadata = IndexMetadata::new(test_schema());

--- a/hermes-core/src/query/candidate_scoring/execution.rs
+++ b/hermes-core/src/query/candidate_scoring/execution.rs
@@ -7,9 +7,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 const MAX_FEATURES: usize = crate::query::MAX_FUSION_SUB_QUERIES;
-// Phrase probing uses dynamic positional cursors. Its separate scratch bound
-// matches the server's default token limit, including for direct core callers.
-const MAX_PHRASE_TERMS: usize = 256;
 const MAX_FEATURE_VALUES: usize = 2_000_000;
 const MAX_VECTOR_BYTES: usize = 1024 * 1024 * 1024;
 
@@ -94,9 +91,10 @@ impl CandidateScoringPlan {
                         }
                     }
                     ScoreComponent::Phrase(query) => {
-                        if query.terms.len() > MAX_PHRASE_TERMS {
+                        let max_terms = schema.max_l1_phrase_terms();
+                        if query.terms.len() > max_terms {
                             return Err(Error::Query(format!(
-                                "L1 phrase feature '{}' has {} terms; maximum is {MAX_PHRASE_TERMS}",
+                                "L1 phrase feature '{}' has {} terms; maximum is {max_terms}",
                                 feature.name,
                                 query.terms.len(),
                             )));

--- a/hermes-core/src/query/candidate_scoring/tests.rs
+++ b/hermes-core/src/query/candidate_scoring/tests.rs
@@ -7,15 +7,72 @@ use crate::structures::{SparseFormat, SparseVectorConfig, WeightQuantization};
 use crate::{Document, Index, IndexConfig, IndexWriter, RamDirectory, Schema};
 
 #[tokio::test]
+async fn index_creation_configures_phrase_limits_for_ranking_and_collection_after_reopen() {
+    for configured in [None, Some(1), Some(65), Some(300)] {
+        let option = configured
+            .map(|limit| format!("max_l1_phrase_terms: {limit}"))
+            .unwrap_or_default();
+        let schema = crate::parse_schema(&format!(
+            "index documents {{ {option} field body: text<simple> [indexed<token_position>] }}"
+        ))
+        .unwrap();
+        let field = schema.get_field("body").unwrap();
+        let directory = RamDirectory::new();
+        let config = IndexConfig::default();
+        let created = Index::create(directory.clone(), schema, config.clone())
+            .await
+            .unwrap();
+        drop(created);
+        let reopened = Index::open(directory.clone(), config).await.unwrap();
+        let searcher = reopened.reader().await.unwrap().searcher().await.unwrap();
+        let limit = configured.unwrap_or(64);
+        for ranked in [false, true] {
+            for count in [limit, limit + 1] {
+                let plan = CandidateScoringPlan {
+                    features: vec![CandidateFeature {
+                        name: "phrase".into(),
+                        scope: ScoreScope::Document,
+                        query: PhraseQuery::new(field, vec![b"term".to_vec(); count])
+                            .candidate_query()
+                            .unwrap(),
+                    }],
+                    backfill: true,
+                    model: ranked.then(|| {
+                        RankingModel::compile("phrase", &["phrase"], &Default::default()).unwrap()
+                    }),
+                    export_passages: 1,
+                    all_passages: !ranked,
+                    document_combiner: MultiValueCombiner::Max,
+                };
+                let result = searcher.score_candidates(&[], &plan, None).await;
+                if count == limit {
+                    assert!(result.unwrap().is_empty());
+                } else {
+                    let error =
+                        result.expect_err("reject oversized phrases even without candidates");
+                    assert!(
+                        error
+                            .to_string()
+                            .contains(&format!("{count} terms; maximum is {limit}")),
+                        "{error}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
 async fn long_phrase_features_keep_every_term_in_ranking_and_collection() {
     let mut schema = Schema::builder();
+    schema.set_max_l1_phrase_terms(std::num::NonZeroU32::new(300).unwrap());
     let plain = schema.add_text_field_with_tokenizer("plain", true, false, "simple");
     let chunked = schema.add_text_field_with_tokenizer("chunked", true, false, "simple");
     schema.set_chunked(chunked, true);
     for field in [plain, chunked] {
         schema.set_positions(field, PositionMode::TokenPosition);
     }
-    let terms: Vec<_> = (0..256).map(|i| format!("term{i}")).collect();
+    let terms: Vec<_> = (0..300).map(|i| format!("term{i}")).collect();
     let mut wrong_word = terms.clone();
     wrong_word[64] = "different".into();
     let directory = RamDirectory::new();
@@ -45,7 +102,7 @@ async fn long_phrase_features_keep_every_term_in_ranking_and_collection() {
             .unwrap()
             .0;
         assert_eq!(candidates.len(), 4);
-        for count in [64, 65, 256] {
+        for count in [64, 65, 256, 300] {
             let phrase = PhraseQuery::text(field, &terms[..count].join(" "));
             let reference = searcher.search_with_positions(&phrase, 4).await.unwrap().0;
             let mut matching: Vec<_> = reference.iter().map(|hit| hit.doc_id).collect();
@@ -104,7 +161,7 @@ async fn long_phrase_features_keep_every_term_in_ranking_and_collection() {
         features: vec![CandidateFeature {
             name: "phrase".into(),
             scope: ScoreScope::Document,
-            query: PhraseQuery::new(plain, vec![b"term0".to_vec(); 257])
+            query: PhraseQuery::new(plain, vec![b"term0".to_vec(); 301])
                 .candidate_query()
                 .unwrap(),
         }],
@@ -118,7 +175,7 @@ async fn long_phrase_features_keep_every_term_in_ranking_and_collection() {
         .score_candidates(&[], &oversized, None)
         .await
         .unwrap_err();
-    assert!(error.to_string().contains("257 terms; maximum is 256"));
+    assert!(error.to_string().contains("301 terms; maximum is 300"));
 }
 
 #[tokio::test]

--- a/hermes-server/src/converters.rs
+++ b/hermes-server/src/converters.rs
@@ -830,6 +830,10 @@ pub fn schema_to_sdl(schema: &Schema) -> String {
     use hermes_core::structures::{IndexSize, SparseFormat, WeightQuantization};
 
     let mut lines = vec!["index _ {".to_string()];
+    lines.push(format!(
+        "    max_l1_phrase_terms: {}",
+        schema.max_l1_phrase_terms()
+    ));
     if schema.reorder_on_merge() {
         lines.push("    reorder_on_merge: true".into());
     }
@@ -2196,6 +2200,27 @@ mod tests {
         )
         .unwrap();
         assert!(!off.to_string().contains("~proximity"), "{off}");
+    }
+
+    #[test]
+    fn index_info_schema_reports_default_and_configured_phrase_limits() {
+        for configured in [None, Some(65), Some(300)] {
+            let mut builder = Schema::builder();
+            if let Some(limit) = configured {
+                builder.set_max_l1_phrase_terms(std::num::NonZeroU32::new(limit).unwrap());
+            }
+            let rendered = schema_to_sdl(&builder.build());
+            let schema = hermes_core::parse_schema(&rendered).unwrap();
+            assert_eq!(
+                schema.max_l1_phrase_terms(),
+                configured.unwrap_or(64) as usize,
+                "{rendered}"
+            );
+            assert!(rendered.contains(&format!(
+                "max_l1_phrase_terms: {}",
+                configured.unwrap_or(64)
+            )));
+        }
     }
 
     #[test]

--- a/hermes-wasm/tests/persistence.test.ts
+++ b/hermes-wasm/tests/persistence.test.ts
@@ -5,6 +5,43 @@ import { InMemoryFS } from "./storage.ts";
 
 const sharedStorage = new InMemoryFS();
 
+test.each([undefined, 256])(
+	"L1 phrase cap %s persists across reopen and commit",
+	async (cap) => {
+		await init();
+		const storage = new InMemoryFS();
+		const defaultSchema =
+			"index documents { field body: text<simple> [indexed<token_position>, stored] }";
+		const schema = cap === undefined
+			? defaultSchema
+			: defaultSchema.replace("{", `{ max_l1_phrase_terms: ${cap}`);
+		const index = await LocalIndex.withStorage(storage, schema);
+		await index.addDocuments([{ body: "first document" }]);
+		await index.commit();
+		const metadata = JSON.parse(
+			new TextDecoder().decode(await storage.get("metadata.json")),
+		);
+		expect(metadata.schema.max_l1_phrase_terms).toBe(cap);
+
+		// Reopen uses metadata even when the supplied creation schema omits the cap.
+		const reopened = await LocalIndex.withStorage(storage, defaultSchema);
+		await reopened.addDocuments([{ body: "second document" }]);
+		await reopened.commit();
+		const reloaded = JSON.parse(
+			new TextDecoder().decode(await storage.get("metadata.json")),
+		);
+		expect(reloaded.schema.max_l1_phrase_terms).toBe(cap);
+		expect((await reopened.search("document", 10)).hits).toHaveLength(2);
+	},
+);
+
+test("Zero L1 phrase caps fail WASM index creation", async () => {
+	await init();
+	await expect(LocalIndex.create(
+		"index documents { max_l1_phrase_terms: 0 field body: text }",
+	)).rejects.toThrow("positive 32-bit integer");
+});
+
 test("Fill the index with the data", async () => {
 	await init();
 


### PR DESCRIPTION
L1 phrase length is now configured per index at creation using `max_l1_phrase_terms`. The default is 64, including existing metadata without the setting; setting `max_l1_phrase_terms: 256` explicitly enables 256-term features for both formula ranking and raw score collection.

The core schema persists the positive-u32 value in `metadata.json`. SDL, JSON and Rust creation APIs share the setting; broker creation forwards it to every shard, and index info reports the effective limit. Core validation rejects oversized phrases with the configured maximum before candidate reads and retains every term in accepted phrases. The separate server token limit remains in effect.

Regression coverage includes metadata reopen and corruption, default/custom boundaries with empty candidates, exact plain/chunked scores through 300 terms, two-shard ranking and collection, and WASM persistence across reopen and commit. No protobuf or segment-format migration is needed.

Validation:

- Full search harness: steps 1–7 passed with one test thread. The standalone broker step caught a native-only test-helper import; after switching the assertion to the portable SDL parser, rerunning that exact final step passed all 3 real-server tests.
- WASM release build, npm install and all 12 runtime tests passed.
- All 9 native async candidate-scoring tests passed, including exact phrase scoring at 300 terms.
- Pre-commit hooks and the whole-workspace Clippy push hook passed.

The initial attempts encountered a full disk, disappearing build artifacts, and the already documented parallel broker discovery timeout. Validation was moved to dedicated build directories and serial test execution. Details and evidence are recorded in `docs/search-performance-review.md`. No performance improvement is claimed for this configuration-only change.
