### PR TITLE
Fix hybrid filtering on fast-only text fields

### DIFF
--- a/docs/candidate-rescoring.md
+++ b/docs/candidate-rescoring.md
@@ -510,6 +510,13 @@ materializable text/phrase/fast-field filters use the existing bitset paths.
 Other filters and portable builds use ordinary complete filter scorers only on
 segments of at most 200,000 documents, failing explicitly above that bound.
 This prevents an implicit corpus-sized scoring heap on a legacy backend.
+Fast-only text equality materializes the same fast-column matches as a standalone
+term query on every backend. Missing inverted postings do not establish an empty
+match set for these fields. The scan makes O(documents) equality probes using the
+existing bounded bitmap, with no candidate heap. Single-value columns reuse the
+batch decoder with 2 KiB of scratch; multi-value columns preserve the ordinary
+scorer's first-value reads. Decoder work depends on the column codec. Both paths
+preserve missing-value semantics and observe the request deadline during the scan.
 For indexed phrase filters, a missing term denotes an empty match set, including
 a one-word phrase. It must materialize an empty bitmap rather than select the
 unsupported-filter fallback. A non-indexed field can still match through a fast

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -1362,3 +1362,96 @@ All nine candidate-scoring tests also passed with native async execution
 (`cargo test --locked -p hermes-core --no-default-features --features native --lib
 query::candidate_scoring::tests`), including the 300-term exact-score checks:
 `.context/phrase-cap-native-async.log`.
+
+## Hybrid fast-only text filters — 2026-09-07
+
+The reported `type = journal-article` failure is confirmed on 1.8.132. A read-only
+probe of a document shard returned three hits for a standalone type filter,
+three for unfiltered fusion, and zero for the same fusion with the type filter;
+none of the responses was truncated. The production field is
+`field type: text<raw_ci> [fast]`: it has a fast column and no inverted postings.
+The probe used the public word `quantum` against `short_document`, top three,
+and a 1.5-second server budget. These three live samples establish the mismatch,
+not production latency percentiles. Local evidence is retained in
+`.context/type-filter-production-{metadata,evidence}.json`.
+
+Server fusion converts common filters once and wraps every nomination branch
+in core `FilteredQuery`, including RRF, formula ranking, candidate export and
+feature collection. That wrapper prefers a complete document bitmap. Previously,
+`TermQuery::as_doc_bitset` treated absent inverted postings as an empty bitmap,
+while the ordinary term scorer matched the fast column. This emptied every
+branch before scoring, independent of embedding availability or the hyphen in
+the type value. The new behavior-named regression failed on that exact mismatch
+before the fix (`.context/type-filter-red.log`).
+
+Core now materializes fast-only equality on native/sync and portable execution,
+preserving global text ordinals, missing/empty values, and existing first-value
+semantics for multi-value fast columns. Indexed terms keep posting-based
+membership. Single-value materialization reuses the existing batch decoder,
+adding caller-controlled early exit and 2 KiB of stack scratch; it does not
+allocate a document-sized candidate heap or change persisted bytes. The existing
+16 MiB bitmap and 64-filter limits still apply. Tests cover a 200,001-document
+segment above the generic scorer-fallback cap, positive/negative Boolean filters,
+date/type combinations, unchanged scores/ordinals across fusion modes, two-shard
+broker requests and WASM branch filters.
+
+Deadline-aware scans discard incomplete bitmaps. The ordinary fast-text scorer
+also checks the deadline while skipping nonmatching values. Bitmap enumeration
+captures each observed document ID once: a second `doc()` call could otherwise
+turn into `TERMINATED` between the check and the bitmap write. A deterministic
+regression covers that cancellation boundary, and batch-reader tests cover early
+exit inside/across batches and remapped text dictionaries across merged blocks.
+
+The first large-fixture attempt exposed repeated blockwise-linear header decoding
+when materialization reused scalar fast-field reads. It was stopped after a CPU
+sample identified that path, then single-value materialization was changed to
+batch reads. The related general limitation remains: ordinary fast-only term
+scans and multi-value first-value scans still use the existing scalar decoder;
+their codec-dependent cost is not a linear-time guarantee. This change makes no
+new performance claim for those paths and changes no compression/default policy.
+
+Warm local RPC samples used the same persisted 10,000-document fixture, Apple M4,
+Rust 1.98.1, default debug server build flags and 20 warmups plus 100 sequential
+requests per mode. The first 9,950 documents are books; the last 50 are journal
+articles. Two text branches request top three. The saved pre-fix server was built
+at `7076b38d`; the intervening `7a4b380c` change only bumps release versions.
+The fixture metadata SHA-256 stayed
+`b3f3f04e9abf73e4f78cbf646f0d72eb37de19a2230e314fb69b26921a395c43`.
+
+| Request                           |                  Before p50 / p95 | After p50 / p95 | Correctness                     |
+| --------------------------------- | --------------------------------: | --------------: | ------------------------------- |
+| Standalone fast-only type filter  |                    6.69 / 9.00 ms |  2.90 / 3.66 ms | Same IDs and score bits         |
+| Unfiltered hybrid                 |                    6.01 / 6.99 ms |  2.78 / 3.12 ms | Same IDs and score bits         |
+| Hybrid with indexed-type control  |                    5.18 / 6.38 ms |  2.55 / 2.93 ms | Same IDs and score bits         |
+| Hybrid with fast-only type filter | 1.48 / 1.67 ms, incorrectly empty |  3.08 / 3.72 ms | Matches indexed control exactly |
+
+Maximum sampled server RSS across the four modes was 40,912 KiB before and
+37,520 KiB after; this includes mapped pages and heap, not a separate heap profile.
+No builds from this workspace ran during sampling, but the shared host was not
+controlled. Unchanged controls also became faster, so these before/after times
+are not evidence of a general speedup. The corrected fast-only filter cost about
+0.54 ms more than the indexed control in the after run. A fast-only field still
+requires reading its column; indexing that field and rebuilding existing data
+would remove that scan. This fix does not add a request cache: branches retain
+the existing filter ownership and bounded memory lifetime. Script and raw samples:
+`.context/measure_type_filter.py`, `.context/type-filter-{before,after}-samples.jsonl`.
+
+All eight full-harness steps passed with `RUST_TEST_THREADS=1` and the isolated
+native build directory: `.context/search-harness/20260907T135854.914377Z-full/`.
+This includes 1,373 core unit tests, server/broker/tool checks, native-without-sync
+and portable compilation, documentation and all three real-server broker tests.
+The one-thread setting avoids the previously recorded broker discovery flake;
+no production timeout or concurrency setting changed. Thirteen targeted common
+filter tests also passed with native async execution, and the WASM release build
+and all 13 runtime tests passed. Logs:
+`.context/type-filter-{full-release,native-async,wasm-build,wasm-tests}.log`.
+
+The earlier full run caught an invalid new RRF test request: `candidate_depth`
+is only accepted for L1/exports. Correcting that test fixture in server and broker
+tests made the regression and final full run pass. Its initial failure remains
+in `.context/search-harness/20260907T133822.951694Z-full/`. An exploratory run
+was intentionally stopped while replacing the scalar scan; the harness logged
+an interrupt-cleanup `Operation not permitted` error in
+`.context/search-harness/20260907T133111.044272Z-full/`. Neither is an unresolved
+failure of the final checks. The earlier native-async phrase-ordinal discrepancy
+and parallel broker discovery flake remain separate recorded findings.

--- a/hermes-broker/tests/e2e_real_server.rs
+++ b/hermes-broker/tests/e2e_real_server.rs
@@ -527,7 +527,9 @@ async fn partitioned_fusion_uses_global_text_stats_and_exclusion_filters() {
     wait_for_indexes(&broker, &[], Duration::from_secs(10)).await;
 
     let index_name = "docs_fusion_e2e";
-    let schema = SCHEMA.replace("index e2e", &format!("index {index_name}"));
+    let schema = SCHEMA
+        .replace("index e2e", &format!("index {index_name}"))
+        .replace('}', "field type: text<raw_ci> [fast]\n}");
     let mut index = broker_index_client(&broker).await;
     index
         .create_index(CreateIndexRequest {
@@ -537,12 +539,22 @@ async fn partitioned_fusion_uses_global_text_stats_and_exclusion_filters() {
         .await
         .unwrap();
     wait_for_indexes(&broker, &[index_name], Duration::from_secs(10)).await;
+    let typed_doc = |id: &str, title: &str, kind: &str| {
+        let mut document = doc(id, title);
+        document.fields.push(FieldEntry {
+            name: "type".into(),
+            value: Some(FieldValue {
+                value: Some(field_value::Value::Text(kind.into())),
+            }),
+        });
+        document
+    };
     index
         .batch_index_documents(BatchIndexDocumentsRequest {
             index_name: index_name.to_string(),
             documents: vec![
-                doc("doc-1", "quantum field theory"),
-                doc("doc-2", "another quantum document"),
+                typed_doc("doc-1", "quantum field theory", "journal-article"),
+                typed_doc("doc-2", "another quantum document", "book"),
             ],
         })
         .await
@@ -689,6 +701,42 @@ async fn partitioned_fusion_uses_global_text_stats_and_exclusion_filters() {
         b["specific"], 0.0,
         "score-only backfill distinguishes a valid nonmatch"
     );
+    for mode in ["rrf", "formula", "export"] {
+        let mut filtered = request.clone();
+        if mode != "formula" {
+            filtered.l1 = None;
+        }
+        if mode == "rrf" {
+            filtered.score_export = None;
+        }
+        let Some(query::Query::Fusion(fusion)) = filtered.query.as_mut().unwrap().query.as_mut()
+        else {
+            unreachable!()
+        };
+        if mode == "rrf" {
+            fusion.queries.truncate(1);
+            fusion.candidate_depth = 0;
+        }
+        fusion.filters = vec![Query {
+            query: Some(query::Query::Term(TermQuery {
+                field: "type".into(),
+                term: "journal-article".into(),
+                ..Default::default()
+            })),
+        }];
+        let response = broker_search_client(&broker)
+            .await
+            .search(filtered)
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(response.hits.len(), 1, "{mode}: fast-only type filter");
+        assert_eq!(
+            response.hits[0].fields["id"].values[0].value,
+            Some(field_value::Value::Text("doc-1".into())),
+            "{mode}: fast-only type filter"
+        );
+    }
     let mut traced_request = request.clone();
     traced_request.tracing = true;
     traced_request.include_rrf_scores = true;

--- a/hermes-core/src/query/filtered.rs
+++ b/hermes-core/src/query/filtered.rs
@@ -50,12 +50,13 @@ fn enumerate_filter(
 ) -> Option<DocBitset> {
     let mut bits = DocBitset::new(num_docs);
     let mut visited = 0usize;
-    while scorer.doc() != crate::TERMINATED {
+    let mut doc = scorer.doc();
+    while doc != crate::TERMINATED {
         if visited.is_multiple_of(1024) && options.stop_if_expired() {
             return None;
         }
-        bits.set(scorer.doc());
-        scorer.advance();
+        bits.set(doc);
+        doc = scorer.advance();
         visited += 1;
     }
     (!options.stop_if_expired()).then_some(bits)

--- a/hermes-core/src/query/filtered/tests.rs
+++ b/hermes-core/src/query/filtered/tests.rs
@@ -181,6 +181,114 @@ async fn one_word_phrase_filters_preserve_indexed_and_fast_only_field_matches() 
 }
 
 #[tokio::test]
+async fn fast_only_text_filters_preserve_matches_and_exclusions_before_nomination() {
+    for multi in [false, true] {
+        let mut schema = Schema::builder();
+        let body = schema.add_text_field_with_tokenizer("body", true, false, "simple");
+        schema.set_chunked(body, true);
+        let kind = schema.add_text_field_with_tokenizer("type", false, false, "raw_ci");
+        schema.set_fast(kind, true);
+        schema.set_multi(kind, multi);
+        let directory = RamDirectory::new();
+        let config = IndexConfig::default();
+        let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+            .await
+            .unwrap();
+        for value in [Some("journal-article"), Some("book"), None, Some("")] {
+            let mut document = Document::new();
+            document.add_text(body, "candidate");
+            if let Some(value) = value {
+                document.add_text(kind, value);
+                if multi && value == "book" {
+                    document.add_text(kind, "journal-article");
+                }
+            }
+            writer.add_document(document).unwrap();
+        }
+        writer.commit().await.unwrap();
+        let index = Index::open(directory, config).await.unwrap();
+        for (term, expected) in [
+            ("journal-article", vec![0]),
+            ("absent", vec![]),
+            ("", vec![3]),
+        ] {
+            let filter = TermQuery::text(kind, term);
+            assert_selected(&index, &filter, 4, &expected).await;
+            let query = FilteredQuery::new(
+                Arc::new(TermQuery::text(body, "candidate")),
+                vec![Arc::new(filter.clone())],
+            );
+            assert_selected(&index, &query, 1, &expected).await;
+            let excluded: Vec<_> = (0..4).filter(|doc| !expected.contains(doc)).collect();
+            let query = FilteredQuery::new(
+                Arc::new(TermQuery::text(body, "candidate")),
+                vec![Arc::new(BooleanQuery::new().must_not(filter))],
+            );
+            assert_selected(&index, &query, 4, &excluded).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn fast_only_text_filters_materialize_above_the_scorer_fallback_limit() {
+    let mut schema = Schema::builder();
+    let single = schema.add_text_field_with_tokenizer("type", false, false, "raw_ci");
+    schema.set_fast(single, true);
+    let directory = RamDirectory::new();
+    let config = IndexConfig {
+        num_indexing_threads: 1,
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+        .await
+        .unwrap();
+    let last = crate::query::MAX_FUSION_CANDIDATE_SLOTS as u32;
+    for doc in 0..=last {
+        let mut document = Document::new();
+        if doc == 0 {
+            document.add_text(single, "book");
+        } else if doc == last {
+            document.add_text(single, "journal-article");
+        }
+        loop {
+            match writer.add_document(document.clone()) {
+                Ok(()) => break,
+                Err(crate::Error::QueueFull) => tokio::task::yield_now().await,
+                Err(error) => panic!("failed to enqueue fixture document: {error}"),
+            }
+        }
+    }
+    writer.commit().await.unwrap();
+    let index = Index::open(directory, config).await.unwrap();
+    {
+        let term = TermQuery::text(single, "journal-article");
+        let query = FilteredQuery::new(Arc::new(AllQuery), vec![Arc::new(term.clone())]);
+        assert_selected(&index, &query, 1, &[last]).await;
+        let disjunction = BooleanQuery::new()
+            .should(term)
+            .should(TermQuery::text(single, "book"));
+        let query = FilteredQuery::new(Arc::new(AllQuery), vec![Arc::new(disjunction)]);
+        assert_selected(&index, &query, 2, &[0, last]).await;
+    }
+    let reader = index.segment_readers().await.unwrap();
+    let budget =
+        crate::query::SharedThreshold::new().with_deadline(Some(std::time::Instant::now()));
+    let bits = TermQuery::text(single, "journal-article").as_doc_bitset_with_options(
+        &reader[0],
+        &ScorerOptions {
+            shared_threshold: Some(budget.clone()),
+            ..Default::default()
+        },
+    );
+    assert!(
+        bits.is_none(),
+        "expired scans cannot supply an empty or partial filter"
+    );
+    assert!(budget.truncated());
+}
+
+#[tokio::test]
 async fn small_limits_filter_required_plain_text_disjunctions_before_top_k() {
     let (index, text, allowed, _, _) = fixture().await;
     let query = BooleanQuery::new()
@@ -393,6 +501,43 @@ async fn expired_common_filter_skips_materialization_and_marks_truncation() {
             .doc(),
         crate::TERMINATED
     );
+}
+
+#[test]
+fn filter_enumeration_handles_a_scorer_expiring_between_document_reads() {
+    struct ExpiringScorer(std::sync::atomic::AtomicBool);
+    impl crate::query::docset::DocSet for ExpiringScorer {
+        fn doc(&self) -> u32 {
+            if self.0.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                crate::TERMINATED
+            } else {
+                0
+            }
+        }
+        fn advance(&mut self) -> u32 {
+            crate::TERMINATED
+        }
+        fn seek(&mut self, _target: u32) -> u32 {
+            crate::TERMINATED
+        }
+        fn size_hint(&self) -> u32 {
+            1
+        }
+    }
+    impl Scorer for ExpiringScorer {
+        fn score(&self) -> f32 {
+            1.0
+        }
+    }
+    // A deadline-aware doc() can become TERMINATED without advance(). Never
+    // re-read it as an unchecked bitmap offset after testing the first value.
+    let bits = enumerate_filter(
+        Box::new(ExpiringScorer(std::sync::atomic::AtomicBool::new(false))),
+        1,
+        &ScorerOptions::default(),
+    )
+    .unwrap();
+    assert!(bits.contains(0));
 }
 
 #[cfg(feature = "sync")]

--- a/hermes-core/src/query/term.rs
+++ b/hermes-core/src/query/term.rs
@@ -8,6 +8,7 @@ use crate::structures::BlockPostingList;
 use crate::structures::TERMINATED;
 use crate::{DocId, Score};
 
+use super::docset::DocSet;
 use super::{CountFuture, EmptyScorer, GlobalStats, Query, Scorer, ScorerFuture, TermQueryInfo};
 
 /// Term query - matches documents containing a specific term
@@ -70,6 +71,50 @@ impl TermQuery {
     pub fn set_global_stats(&mut self, stats: Arc<GlobalStats>) {
         self.global_stats = Some(stats);
     }
+
+    fn fast_field_bitset(
+        &self,
+        reader: &SegmentReader,
+        options: &super::ScorerOptions,
+    ) -> Option<super::DocBitset> {
+        let mut bits = super::DocBitset::new(reader.num_docs());
+        let Some(fast_field) = reader.fast_field(self.field.0) else {
+            return Some(bits);
+        };
+        let term = String::from_utf8_lossy(&self.term);
+        let Some(target_ordinal) = fast_field.text_ordinal(&term) else {
+            return (!options.stop_if_expired()).then_some(bits);
+        };
+        if !fast_field.multi {
+            // Avoid decoding column codec headers separately for every doc.
+            let scanned = fast_field.try_scan_single_values(|doc, ordinal| {
+                if doc.is_multiple_of(1024) && options.stop_if_expired() {
+                    return std::ops::ControlFlow::Break(());
+                }
+                if ordinal == target_ordinal {
+                    bits.set(doc);
+                }
+                std::ops::ControlFlow::Continue(())
+            });
+            return (scanned.is_continue() && !options.stop_if_expired()).then_some(bits);
+        }
+        // Multi-value fast equality retains the ordinary scorer's first-value
+        // semantics. The single-value batch API cannot represent those offsets.
+        if let Some(mut scorer) = FastFieldTextScorer::try_new(
+            reader,
+            self.field,
+            &term,
+            options.shared_threshold.as_ref(),
+        ) {
+            let mut doc = scorer.doc();
+            while doc != TERMINATED {
+                bits.set(doc);
+                doc = scorer.advance();
+            }
+        }
+        // A cancelled scan is never a complete filter, especially under NOT.
+        (!options.stop_if_expired()).then_some(bits)
+    }
 }
 
 /// Compute (idf, avg_field_len) from a posting list, using global stats when available.
@@ -119,7 +164,7 @@ macro_rules! term_plan {
         let is_indexed = reader.schema().get_field_entry(field).is_none_or(|e| e.indexed);
         if !is_indexed {
             let term_str = String::from_utf8_lossy(term);
-            if let Some(scorer) = FastFieldTextScorer::try_new(reader, field, &term_str) {
+            if let Some(scorer) = FastFieldTextScorer::try_new(reader, field, &term_str, budget) {
                 return Ok(Box::new(scorer) as Box<dyn Scorer + '_>);
             }
             return Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>);
@@ -171,7 +216,7 @@ macro_rules! term_plan {
             }
             None => {
                 let term_str = String::from_utf8_lossy(term);
-                if let Some(scorer) = FastFieldTextScorer::try_new(reader, field, &term_str) {
+                if let Some(scorer) = FastFieldTextScorer::try_new(reader, field, &term_str, budget) {
                     Ok(Box::new(scorer) as Box<dyn Scorer + '_>)
                 } else {
                     Ok(Box::new(EmptyScorer) as Box<dyn Scorer + '_>)
@@ -293,29 +338,55 @@ impl Query for TermQuery {
         Some(pl.doc_count() as u64)
     }
 
-    #[cfg(feature = "sync")]
     fn as_doc_bitset(&self, reader: &SegmentReader) -> Option<super::DocBitset> {
-        // Chunked postings are keyed by virtual chunk ids, not document ids;
-        // a bitset over them would filter the wrong documents.
-        if reader.is_chunked_field(self.field) {
+        self.as_doc_bitset_with_options(reader, &super::ScorerOptions::default())
+    }
+
+    fn as_doc_bitset_with_options(
+        &self,
+        reader: &SegmentReader,
+        options: &super::ScorerOptions,
+    ) -> Option<super::DocBitset> {
+        if options.stop_if_expired() {
             return None;
         }
-        // Build bitset from posting list: O(M) where M = matching doc count.
-        // Much faster than O(N) fast-field scan for selective terms.
-        let mut bitset = super::DocBitset::new(reader.num_docs());
-        let Some(pl) = reader.get_postings_sync(self.field, &self.term).ok()? else {
-            return Some(bitset);
-        };
-        let mut iter = pl.iterator();
-        loop {
-            let doc = iter.doc();
-            if doc == crate::structures::TERMINATED {
-                break;
-            }
-            bitset.set(doc);
-            iter.advance();
+        if reader
+            .schema()
+            .get_field_entry(self.field)
+            .is_some_and(|entry| !entry.indexed)
+        {
+            // Fast-only text has no posting list. Match exactly as its ordinary
+            // scorer does, without the bounded candidate-heap fallback.
+            return self.fast_field_bitset(reader, options);
         }
-        Some(bitset)
+        #[cfg(feature = "sync")]
+        {
+            // Chunked postings use chunk ids, not document ids.
+            if reader.is_chunked_field(self.field) {
+                return None;
+            }
+            let Some(pl) = reader.get_postings_sync(self.field, &self.term).ok()? else {
+                // Preserve the ordinary term scorer's fast-column fallback.
+                return self.fast_field_bitset(reader, options);
+            };
+            // Indexed membership remains O(matches), not a full-column scan.
+            let mut bitset = super::DocBitset::new(reader.num_docs());
+            let mut iter = pl.iterator();
+            let mut visited = 0usize;
+            while iter.doc() != TERMINATED {
+                if visited.is_multiple_of(1024) && options.stop_if_expired() {
+                    return None;
+                }
+                bitset.set(iter.doc());
+                iter.advance();
+                visited += 1;
+            }
+            (!options.stop_if_expired()).then_some(bitset)
+        }
+        #[cfg(not(feature = "sync"))]
+        {
+            None
+        }
     }
 
     fn text_terms(&self, out: &mut Vec<(Field, Vec<u8>)>) {
@@ -433,10 +504,16 @@ struct FastFieldTextScorer<'a> {
     target_ordinal: u64,
     current: u32,
     num_docs: u32,
+    budget: Option<super::SharedThreshold>,
 }
 
 impl<'a> FastFieldTextScorer<'a> {
-    fn try_new(reader: &'a SegmentReader, field: Field, text: &str) -> Option<Self> {
+    fn try_new(
+        reader: &'a SegmentReader,
+        field: Field,
+        text: &str,
+        budget: Option<&super::SharedThreshold>,
+    ) -> Option<Self> {
         let fast_field = reader.fast_field(field.0)?;
         let target_ordinal = fast_field.text_ordinal(text)?;
         let num_docs = reader.num_docs();
@@ -445,9 +522,10 @@ impl<'a> FastFieldTextScorer<'a> {
             target_ordinal,
             current: 0,
             num_docs,
+            budget: budget.filter(|budget| budget.deadline().is_some()).cloned(),
         };
         // Position on first matching doc
-        if num_docs > 0 && fast_field.get_u64(0) != target_ordinal {
+        if scorer.doc() != TERMINATED && fast_field.get_u64(0) != target_ordinal {
             scorer.scan_forward();
         }
         Some(scorer)
@@ -456,7 +534,13 @@ impl<'a> FastFieldTextScorer<'a> {
     fn scan_forward(&mut self) {
         loop {
             self.current += 1;
-            if self.current >= self.num_docs {
+            if self.current >= self.num_docs
+                || (self.current.is_multiple_of(1024)
+                    && self
+                        .budget
+                        .as_ref()
+                        .is_some_and(super::SharedThreshold::stop_if_expired))
+            {
                 self.current = self.num_docs;
                 return;
             }
@@ -469,7 +553,12 @@ impl<'a> FastFieldTextScorer<'a> {
 
 impl super::docset::DocSet for FastFieldTextScorer<'_> {
     fn doc(&self) -> DocId {
-        if self.current >= self.num_docs {
+        if self.current >= self.num_docs
+            || self
+                .budget
+                .as_ref()
+                .is_some_and(super::SharedThreshold::stop_if_expired)
+        {
             TERMINATED
         } else {
             self.current
@@ -477,11 +566,17 @@ impl super::docset::DocSet for FastFieldTextScorer<'_> {
     }
 
     fn advance(&mut self) -> DocId {
+        if self.doc() == TERMINATED {
+            return TERMINATED;
+        }
         self.scan_forward();
         self.doc()
     }
 
     fn seek(&mut self, target: DocId) -> DocId {
+        if self.doc() == TERMINATED {
+            return TERMINATED;
+        }
         if target > self.current {
             self.current = target;
             if self.current < self.num_docs

--- a/hermes-core/src/structures/fast_field/mod.rs
+++ b/hermes-core/src/structures/fast_field/mod.rs
@@ -1240,8 +1240,19 @@ impl FastFieldReader {
     /// For text columns, returned values are global ordinals (remapped).
     /// For multi-value columns, use `for_each_multi_value` instead.
     pub fn scan_single_values(&self, mut f: impl FnMut(u32, u64)) {
+        let _ = self.try_scan_single_values(|doc, value| {
+            f(doc, value);
+            std::ops::ControlFlow::Continue(())
+        });
+    }
+
+    /// The same batched scan, with immediate caller-controlled cancellation.
+    pub(crate) fn try_scan_single_values(
+        &self,
+        mut f: impl FnMut(u32, u64) -> std::ops::ControlFlow<()>,
+    ) -> std::ops::ControlFlow<()> {
         if self.multi {
-            return;
+            return std::ops::ControlFlow::Continue(());
         }
         const BATCH: usize = 256;
         let mut buf = [0u64; BATCH];
@@ -1279,16 +1290,17 @@ impl FastFieldReader {
                         } else {
                             raw
                         };
-                        f(block.cumulative_docs + pos as u32 + i as u32, val);
+                        f(block.cumulative_docs + pos as u32 + i as u32, val)?;
                     }
                 } else {
                     for (i, &val) in buf[..chunk].iter().enumerate() {
-                        f(block.cumulative_docs + pos as u32 + i as u32, val);
+                        f(block.cumulative_docs + pos as u32 + i as u32, val)?;
                     }
                 }
                 pos += chunk;
             }
         }
+        std::ops::ControlFlow::Continue(())
     }
 
     /// Check if this doc has a value (not [`FAST_FIELD_MISSING`]).
@@ -1790,6 +1802,57 @@ mod tests {
         assert_eq!(reader.get_u64(2), 150);
         assert_eq!(reader.get_u64(3), FAST_FIELD_MISSING); // gap → absent sentinel
         assert_eq!(reader.get_u64(4), 300);
+    }
+
+    #[test]
+    fn cancellable_text_scans_preserve_global_ordinals_and_stop_at_the_requested_document() {
+        let mut a = FastFieldWriter::new_text();
+        let mut b = FastFieldWriter::new_text();
+        for doc in 0..600 {
+            if doc % 7 != 0 {
+                a.add_text(
+                    doc,
+                    if doc % 2 == 0 {
+                        "book"
+                    } else {
+                        "journal-article"
+                    },
+                );
+                b.add_text(doc, if doc % 2 == 0 { "article" } else { "book" });
+            }
+        }
+        a.pad_to(600);
+        b.pad_to(600);
+        let (data_a, dict_a, entry_a) = serialize_single_block(&mut a);
+        let (data_b, dict_b, entry_b) = serialize_single_block(&mut b);
+        let (buf, toc) = assemble_blocked_column(
+            0,
+            FastFieldColumnType::TextOrdinal,
+            false,
+            &[
+                (entry_a.num_docs, &data_a, entry_a.dict_count, &dict_a),
+                (entry_b.num_docs, &data_b, entry_b.dict_count, &dict_b),
+            ],
+        );
+        let ob = owned(buf);
+        let reader = FastFieldReader::open(&ob, &toc).unwrap();
+        let expected: Vec<_> = (0..1200).map(|doc| (doc, reader.get_u64(doc))).collect();
+        let mut complete = Vec::new();
+        reader.scan_single_values(|doc, ordinal| complete.push((doc, ordinal)));
+        assert_eq!(complete, expected);
+        for stop in [0, 255, 256, 599, 600, 1024, 1199] {
+            let mut visited = Vec::new();
+            let outcome = reader.try_scan_single_values(|doc, ordinal| {
+                visited.push((doc, ordinal));
+                if doc == stop {
+                    std::ops::ControlFlow::Break(())
+                } else {
+                    std::ops::ControlFlow::Continue(())
+                }
+            });
+            assert!(outcome.is_break());
+            assert_eq!(visited, expected[..=stop as usize]);
+        }
     }
 
     #[test]

--- a/hermes-server/src/search_service/tests.rs
+++ b/hermes-server/src/search_service/tests.rs
@@ -828,6 +828,136 @@ async fn l1_rpc_backfills_the_union_before_top_k_and_preserves_required_phrases(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fusion_fast_only_type_filter_preserves_rrf_formula_and_export_matches() {
+    let temp = tempfile::tempdir().unwrap();
+    let registry = Arc::new(IndexRegistry::new(temp.path().into(), Default::default()));
+    let mut schema = hermes_core::Schema::builder();
+    let title = schema.add_text_field_with_tokenizer("title", true, false, "simple");
+    let body = schema.add_text_field_with_tokenizer("body", true, false, "simple");
+    schema.set_chunked(body, true);
+    let kind = schema.add_text_field_with_tokenizer("type", false, false, "raw_ci");
+    schema.set_fast(kind, true);
+    let issued = schema.add_i64_field("issued_at", false, false);
+    schema.set_fast(issued, true);
+    registry
+        .create_index("l1-test", schema.build())
+        .await
+        .unwrap();
+    let writer = registry.get_writer("l1-test").await.unwrap();
+    {
+        let mut writer = writer.write().await;
+        for value in [
+            "journal-article",
+            "journal-article",
+            "journal-article",
+            "book",
+        ] {
+            let mut document = hermes_core::Document::new();
+            document.add_text(kind, value);
+            document.add_i64(issued, 2026);
+            document.add_text(
+                title,
+                if value == "book" {
+                    "other"
+                } else {
+                    "candidate"
+                },
+            );
+            document.add_text(
+                body,
+                if value == "book" {
+                    "other"
+                } else {
+                    "hemoglobin"
+                },
+            );
+            writer.add_document(document).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+    let index = registry.get_or_open_index("l1-test").await.unwrap();
+    index.reader().await.unwrap().reload().await.unwrap();
+    let service = SearchServiceImpl::new(registry.clone(), 1, limits());
+    let kind = Query {
+        query: Some(query::Query::Term(crate::proto::TermQuery {
+            field: "type".into(),
+            term: "journal-article".into(),
+            ..Default::default()
+        })),
+    };
+    let date = Query {
+        query: Some(query::Query::Range(crate::proto::RangeQuery {
+            field: "issued_at".into(),
+            min_i64: Some(2025),
+            ..Default::default()
+        })),
+    };
+    let plain = service
+        .search(Request::new(SearchRequest {
+            index_name: "l1-test".into(),
+            query: Some(kind.clone()),
+            limit: 3,
+            ..Default::default()
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(plain.hits.len(), 3);
+    for mode in ["rrf", "formula", "export", "candidates"] {
+        let mut baseline = None;
+        for filters in [
+            vec![],
+            vec![date.clone()],
+            vec![kind.clone()],
+            vec![date.clone(), kind.clone()],
+        ] {
+            let mut request = named_l1_request();
+            request.limit = 3;
+            request.tracing = true;
+            request.l1.as_mut().unwrap().formula = "title + body".into();
+            if mode != "formula" {
+                request.l1 = None;
+            }
+            if mode == "rrf" || mode == "candidates" {
+                request.score_export = None;
+            }
+            let Some(query::Query::Fusion(fusion)) = request.query.as_mut().unwrap().query.as_mut()
+            else {
+                unreachable!()
+            };
+            fusion.filters = filters;
+            fusion.candidate_depth = if mode == "rrf" { 0 } else { 3 };
+            if mode == "candidates" {
+                fusion.method = FusionMethod::FusionCandidates as i32;
+            }
+            let response = service
+                .search(Request::new(request))
+                .await
+                .unwrap()
+                .into_inner();
+            assert_eq!(response.hits.len(), 3, "{mode}");
+            if let Some(expected) = &baseline {
+                assert_eq!(
+                    &response.hits, expected,
+                    "{mode}: an eligibility-only filter preserves scores and ordinals"
+                );
+            } else {
+                baseline = Some(response.hits.clone());
+            }
+            let trace = response.trace.unwrap();
+            assert!(
+                trace.shards[0]
+                    .queries
+                    .iter()
+                    .all(|q| q.candidates.len() == 3),
+                "{mode}: all branches retain matching candidates"
+            );
+        }
+    }
+    registry.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn fusion_exclusion_only_filters_remove_self_before_candidate_selection() {
     let temp = tempfile::tempdir().unwrap();
     let registry = Arc::new(IndexRegistry::new(temp.path().into(), Default::default()));

--- a/hermes-wasm/tests/base.test.ts
+++ b/hermes-wasm/tests/base.test.ts
@@ -79,6 +79,34 @@ test("Search in index", async () => {
 	expect(titleOnly).toEqual({ title: "Rust Programming" });
 });
 
+test("Hybrid branches retain fast-only type matches and honor exclusions", async () => {
+	await init();
+	const index = await LocalIndex.create(`index fast_type {
+		field type: text<raw_ci> [fast]
+		field title: text<simple> [indexed]
+		field body: text<simple> [indexed<chunked, token_position>]
+	}`);
+	await index.addDocuments([
+		...Array.from({ length: 3 }, () => ({ type: "journal-article", title: "candidate", body: ["candidate"] })),
+		{ type: "book", title: "candidate", body: ["candidate"] },
+	]);
+	await index.commit();
+	const kind = { term: { field: "type", value: "journal-article" } };
+	expect((await index.searchStructured({ query: kind, limit: 3 })).hits.map((hit: any) => hit.address.doc_id)).toEqual([0, 1, 2]);
+	for (const exclude of [false, true]) {
+		const query = { fusion: { fetchLimit: 4, queries: ["title", "body"].map(field => ({
+			name: field,
+			query: { boolean: {
+				must: [{ term: { field, value: "candidate" } }, ...(exclude ? [] : [kind])],
+				mustNot: exclude ? [kind] : [],
+			} },
+		})) } };
+		const response = await index.searchStructured({ query, limit: 3, tracing: true });
+		expect(response.hits.map((hit: any) => hit.address.doc_id)).toEqual(exclude ? [3] : [0, 1, 2]);
+		expect(response.trace.shards[0].queries.map((branch: any) => branch.candidates.length)).toEqual(exclude ? [1, 1] : [3, 3]);
+	}
+});
+
 test("BMP search returns identical scores with optional forward storage", async () => {
 	await init();
 	const index = await LocalIndex.create(`


### PR DESCRIPTION
Hybrid searches on fast-only text fields such as `type: text<raw_ci> [fast]` could return zero hits while the same standalone filter matched. Core now materializes their actual fast-column matches before nomination, preserving filter eligibility across RRF, formula ranking and exports.

Single-value filters use the existing batch decoder with cancellation and bounded scratch. This supports segments above the generic 200,000-document fallback cap and avoids repeated scalar codec-header decoding. Bitmap enumeration also handles a scorer expiring between document-ID reads.

Validation:
- All eight `scripts/check_search.py full` steps passed with one test thread, including real two-shard broker/server tests.
- 13 native async filter tests and the WASM build plus all 13 runtime tests passed.
- Reproduced on production 1.8.132 with read-only requests; behavior-named regression failed before the fix.
- Same-fixture latency/RSS samples recorded in the performance review. Repaired hybrid matches indexed-filter IDs/scores exactly: 3.08 ms versus 2.55 ms median on 10,000 documents. Unchanged controls varied between runs, so no general speedup is claimed.
