### PR TITLE
Reduce L1 feature-read and scoring overhead

### DIFF
--- a/docs/candidate-rescoring.md
+++ b/docs/candidate-rescoring.md
@@ -1,7 +1,39 @@
 # Candidate rescoring for L1 ranking
 
-Status: opt-in Hermes implementation, 2026-09-06. Search API training and
+Status: opt-in Hermes implementation, updated 2026-09-09. Search API training and
 activation are separate. Existing retrieval defaults remain unchanged.
+
+## Scoring execution efficiency (2026-09-09)
+
+The implementation pass retains the same candidate union, organic cells,
+component/ordinal reduction order, missing values, and request-wide admission
+limits. There is one core async scorer for native and WASM; neither adapters
+nor a second synchronous scorer implement feature backfill.
+
+On native multithread Tokio runtimes, each ready portion of the scoring future
+is polled on the shared search CPU pool. Nested BMP/vector kernels stay on that
+pool. A pending directory read returns the original task's waker and releases
+the worker; no worker blocks waiting for asynchronous I/O, and no detached task
+retains the request after cancellation. Polling is scoped over borrowed inputs,
+and the Tokio handle is entered on the worker for directory implementations
+that use it. Current-thread, non-Tokio and native-without-sync/WASM callers keep
+their existing execution path. This changes scheduling cost, not pruning or
+the number of features scored.
+
+Selected text probes reuse request-owned posting decode buffers and initialize
+their iterator at the first requested block, preserving ordinary seek and
+position-cursor semantics. Feature reduction uses sorted contiguous location
+spans and small inline buffers instead of allocating a tree and vector for
+each document/component. Chunk-field metadata is prepared once per request.
+Scoring-query preparation is reused across compatible segment probes; scratch
+is bounded by the existing admitted candidate/component/vector sizes and is
+released with the request. Payload remains evictable and exports retain their
+existing owned wire representation.
+
+Further proposals to share arbitrary overlapping field reads, change lazy text
+range loading, or parallelize segments need separate measurements and are not
+part of this execution change. In particular, no formula-dependency mask may
+omit features required by raw export or broker RRF.
 
 Logical addressing belongs to [BMP forward values](bmp-forward-index.md) and
 the existing text chunk map. There are no `.lookup` sidecars. The historical

--- a/docs/search-performance-review.md
+++ b/docs/search-performance-review.md
@@ -1985,3 +1985,590 @@ an interrupt-cleanup `Operation not permitted` error in
 `.context/search-harness/20260907T133111.044272Z-full/`. Neither is an unresolved
 failure of the final checks. The earlier native-async phrase-ordinal discrepancy
 and parallel broker discovery flake remain separate recorded findings.
+
+## 2026-09-09: measuring retained segment candidates for L1
+
+This is a design experiment, not a serving change. Retaining already-produced
+segment candidates improves formula top-K recall on mixed segments, but it can
+add substantial L1 work without improving recall on clustered segments. The
+measurements do not support enabling it universally.
+
+### Method and invariant
+
+The isolated checkout at `.context/segment-l1-measure-worktree` is based on
+`6989e797` (1.8.134). Test-only hooks observe completed segment result lists in
+the existing searcher, **after** its shared threshold is raised and **before**
+its shard merge discards results. They do not alter segment depth, shared vertical
+thresholds, BMP's global LSP selection, search concurrency or scoring kernels.
+L1 runs after nomination; its predictions never feed retrieval thresholds.
+The normal nomination lists remain included, with addresses, scores and passage
+rows checked against the captured copies on every extra-candidate request.
+
+Each branch keeps a bounded heap ordered by its existing raw score and canonical
+address tie-break. With normal depth `d` and extra allowance `e`, this heap keeps
+at most `d + e` candidates from completed segment results. It does not capture
+all visited documents or guarantee an independent per-segment top-d. A candidate
+pruned inside segment execution remains unavailable. This is one specific extra
+selection policy; the experiment does not establish its optimality.
+
+The five compared policies use three nomination branches and final top-10:
+
+| Policy     | Retrieval depth per branch | Maximum retained slots across branches |
+| ---------- | -------------------------: | -------------------------------------: |
+| Baseline   |                         20 |                                     60 |
+| Extras 20  |                         20 |                                    120 |
+| Extras 80  |                         20 |                                    300 |
+| Deeper 40  |                         40 |                                    120 |
+| Deeper 100 |                        100 |                                    300 |
+
+Retained slots include duplicates across branches, so document unions are smaller.
+The deeper controls have the same maximum retained allowance, not necessarily the
+same actual union or read cost. They use the core interface; an RPC caller must
+also satisfy the existing result-window/candidate oversubscription limits.
+
+All policies use the existing core candidate scorer, preserve organic scores,
+backfill missing cells, and apply the formula
+`bm25 + 2 * ln(1 + sparse) + 8 * dense`. The features are four-term BM25,
+12-dimension BMP sparse retrieval and 128-dimensional F32 flat dense retrieval.
+Document features use MAX; the passage fixture aligns three body/sparse/dense
+ordinals per document and applies MAX after passage L1. Some documents have no
+sparse or dense field. The formula and generator were fixed before sampling.
+BMP uses its normal block/heap pruning with gamma 0; a separate capped case uses
+one global gamma 2. Each case keeps that setting fixed across all five policies.
+
+The fixed seeded corpus has 32 topics and 16,384 documents, laid out as one,
+four or 16 mixed segments, 16 topic-clustered segments, or 16 uneven segments
+(one holds 80% of the corpus). Additional cases cover capped BMP and three
+passages per document. A 65,536-document mixed fixture checks scale. A one-search-
+thread repeat uses the **same persisted files** as the four-thread mixed fixture.
+Fixture file hashes are retained with the raw results.
+
+Exhaustive core feature scoring over every fixture document (every stored passage
+for the passage case) defines the reference top-10. **Recall below is agreement
+with that formula reference, not human relevance or teacher-labelled recall.**
+There were no representative production requests or relevance labels available
+in the workspace. The generator is synthetic; the binary IVF fields used by the
+live installation are not represented by this F32 flat dense fixture.
+
+### Results
+
+Every cell below is **formula recall@10; median core latency**. Latency includes
+nomination, pool assembly and L1, with compilation, fixture creation, expression
+compilation, statistics preparation, reference scoring, assertions, JSON and RPC
+outside the timed region. Each policy has 32 queries repeated four times, with
+rotating policy order. All sampling uses the same release binary on Apple M4
+arm64, rustc 1.98.1, two Tokio workers and four search threads unless noted.
+All payloads fit in memory; these are warm, sequential-request measurements.
+
+| Fixture                                           |       Baseline |      Extras 20 |       Extras 80 |      Deeper 40 |      Deeper 100 |
+| ------------------------------------------------- | -------------: | -------------: | --------------: | -------------: | --------------: |
+| 16k documents, 1 segment                          | 75.0%; 0.28 ms | 75.0%; 0.28 ms |  75.0%; 0.28 ms | 94.7%; 0.34 ms | 100.0%; 0.47 ms |
+| 16k documents, 4 mixed segments                   | 75.0%; 0.28 ms | 94.7%; 0.32 ms |  99.7%; 0.40 ms | 94.7%; 0.35 ms | 100.0%; 0.50 ms |
+| 16k documents, 16 mixed segments                  | 75.0%; 0.50 ms | 94.7%; 0.59 ms | 100.0%; 0.74 ms | 94.7%; 0.64 ms | 100.0%; 0.86 ms |
+| 16k documents, 16 clustered segments              | 75.0%; 0.24 ms | 75.0%; 0.53 ms |  75.0%; 0.73 ms | 94.7%; 0.31 ms | 100.0%; 0.47 ms |
+| 16k documents, 16 uneven segments                 | 75.0%; 0.38 ms | 85.1%; 0.50 ms |  85.3%; 0.58 ms | 94.7%; 0.49 ms | 100.0%; 0.70 ms |
+| 16k documents, 16 mixed segments, gamma 2         | 71.6%; 0.45 ms | 91.9%; 0.56 ms | 100.0%; 0.70 ms | 91.9%; 0.59 ms | 100.0%; 0.83 ms |
+| 16k documents, 3 passages, 16 segments            | 56.2%; 0.86 ms | 86.2%; 1.00 ms | 100.0%; 1.30 ms | 86.2%; 1.06 ms |  99.7%; 1.61 ms |
+| 65k documents, 16 mixed segments                  | 48.4%; 0.99 ms | 71.2%; 1.07 ms |  98.1%; 1.32 ms | 71.2%; 1.19 ms |  98.1%; 1.55 ms |
+| 16k documents, 16 mixed segments, 1 search thread | 75.0%; 0.75 ms | 94.7%; 0.83 ms | 100.0%; 0.95 ms | 94.7%; 0.96 ms | 100.0%; 1.31 ms |
+
+For 65k documents, Extras 80 retained about 286 documents versus 60 in the
+baseline and supplied 5.16 previously unnominated documents to the final top-10
+on average. Its p95 was 1.77 ms versus 1.29 ms baseline and 1.90 ms Deeper 100.
+On 16k mixed segments, Extras 20 supplied 2.16 new top-10 documents per request,
+and Extras 80 supplied 2.50; 30 of the 32 queries benefited from extra winners.
+On clustered segments both supplied **zero** new winning documents despite
+retaining about 116 and 281 documents. Their respective median L1 times grew
+from 0.06 ms baseline to 0.34 and 0.52 ms. Captured candidates from other segments
+could not recover the stronger candidates discarded inside the topic's segment.
+
+The uneven case gained approximately ten recall points from Extras 20, but
+Deeper 40 gained approximately twenty points at a similar median cost. Raising
+the extra allowance to 80 barely improved its recall. More retained rows alone
+are therefore a poor reason to spend additional backfill budget. Segment merging
+and corpus layout can materially change the benefit.
+
+### Pruning, work and memory
+
+Normal nomination document identities and order were unchanged in the paired
+extra/baseline measurements. Native text scores sometimes varied by one float
+ULP across repeated executions; the captured row was always byte-identical to
+its originating normal row within that execution. Scoring schedules can vary
+under the shared threshold without changing its policy.
+
+BMP blocks scored per request confirm that extras did not obtain their gains by
+requesting deeper BMP work: approximately 221 blocks for both baseline and
+Extras 80 on the 16k mixed fixture, versus 490 for Deeper 100; approximately 377
+versus 377 versus 1,132 on the 65k fixture. Small run-to-run block-count variation
+is retained in the samples; copying captured results can affect scheduling even
+though thresholds are published before capture. There is no claim that the
+instruction trace or elapsed nomination time is identical.
+
+Separate untimed allocator passes measured requested allocation bytes and the
+maximum increase in live heap from request start. They exclude assertion/report
+allocations and include temporary search/scoring buffers. These are not absolute
+heap residency, mmap residency or process RSS; thread overlap affects the peak.
+For the 16k mixed fixture:
+
+| Policy     | Extra capture buffers | Median allocated bytes per request | Largest observed heap increase | Backfilled component values | Charged exact-vector / BMP bytes |
+| ---------- | --------------------: | ---------------------------------: | -----------------------------: | --------------------------: | -------------------------------: |
+| Baseline   |                 0 KiB |                          1.324 MiB |                      177.6 KiB |                         223 |                   18.3 / 8.4 KiB |
+| Extras 20  |               8.8 KiB |                          1.413 MiB |                      193.3 KiB |                         424 |                  34.6 / 16.0 KiB |
+| Extras 80  |              21.9 KiB |                          1.570 MiB |                      198.1 KiB |                         869 |                  70.7 / 32.6 KiB |
+| Deeper 100 |                 0 KiB |                          2.190 MiB |                      205.6 KiB |                         869 |                  70.7 / 32.6 KiB |
+
+Capture-buffer figures include the bounded heap's normal candidates as well as
+its extras. Component counts include each query component, not just one value
+per feature. Charged reads are the scorer's vector/BMP admission accounting;
+text mmap probes and OS page faults are not represented by those byte totals.
+The complete initial process peaked at 281.6 MiB RSS including fixture building
+and exhaustive references; it cannot be attributed to any one policy. No builds
+from this workspace ran during timed sampling. Other activity on the shared Mac
+was uncontrolled, so small latency differences should not be generalized.
+
+### Evidence and limits
+
+There are 5,760 timed requests and 360 separate memory requests across the nine
+fixture/thread cases. Raw rows include normal nomination signatures, pool size,
+new winners, formula/pool recall, phase timings, BMP work and feature-read
+accounting. Artifacts:
+
+- `.context/segment-l1-measure-results/`: the seven 16k cases, environment,
+  fixture hashes, raw JSONL, and CSV/Markdown/JSON summaries.
+- `.context/segment-l1-measure-large/`: the 65k mixed case.
+- `.context/segment-l1-measure-single-thread/`: one-thread repeat over the same
+  16k mixed index files.
+- `.context/analyze_segment_l1.py`: summary calculations.
+- `.context/segment-l1-measurement.patch`: test-only instrumentation and harness
+  for a detached checkout of `6989e797`; no public API is added.
+- `.context/segment-l1-measure-{build,run,large,single-thread}.log`: commands'
+  build/execution logs. Memory instrumentation is disabled during timed passes.
+
+The ignored unit harness is invoked as follows, after applying the experiment
+patch to its detached checkout:
+
+```sh
+CARGO_TARGET_DIR="$PWD/.context/segment-l1-measure-build" CARGO_BUILD_JOBS=4 \
+  cargo test --locked --release \
+  --manifest-path .context/segment-l1-measure-worktree/Cargo.toml \
+  -p hermes-core --lib segment_nomination_measurement::measure --no-run
+SEGMENT_MEASURE_OUTPUT="$PWD/.context/segment-l1-measure-results" \
+  SEGMENT_MEASURE_DOCS=16384 SEGMENT_MEASURE_QUERIES=32 \
+  SEGMENT_MEASURE_REPEATS=4 SEGMENT_MEASURE_THREADS=4 \
+  <test-binary> --exact segment_nomination_measurement::measure \
+  --ignored --nocapture --test-threads=1
+python3 .context/analyze_segment_l1.py
+```
+
+`SEGMENT_MEASURE_FIXTURE=doc_s16` selects the scale/thread repeats; their output
+roots must differ. Use `SEGMENT_MEASURE_DOCS=65536` for the scale repeat and
+`SEGMENT_MEASURE_THREADS=1` with the shared persisted fixture for the thread
+repeat. Correctness smoke runs use 512 documents and two queries; their timings
+are not included in the performance summaries.
+
+Read-only live metadata collection found one existing shard with 40 segments,
+26,291,811 physical documents, segment sizes from 557 to 4,187,252 and median
+4,724. The smallest 24 segments contain 67,071 documents. This motivated the
+uneven fixture; it is not a measurement of live recall or latency. No production
+query workload, process, deployment, index or schema was changed.
+
+Production relevance, x86 performance, binary IVF, cold payloads, concurrent
+requests/ingestion, RRF-dependent formulas and phrase-feature costs remain
+unmeasured. In particular, formulas containing RRF still require ranks at the
+correct global scope before final selection. The experiment supports a bounded
+opt-in trial on representative queries; it does not justify a default change or
+predict a production speedup.
+
+The experiment's 512-document smoke cases passed with both native sync and native
+without sync; their logs are `.context/segment-l1-measure-smoke.log` and
+`.context/segment-l1-measure-async-smoke.log`. The repository's required
+`python3 scripts/check_search.py check` passed with `RUST_TEST_THREADS=1`, including
+formatting, focused Clippy, core/server/broker/tool tests and native-async
+compilation. Evidence is in
+`.context/search-harness/20260909T052512.176694Z-check/`. Full RPC/WASM checks were
+not rerun: the main checkout changes only this report, and the instrumentation
+exists only in the isolated experiment checkout under `cfg(test)`.
+
+`python3 .context/run_segment_l1.py --output <new-directory>` automates creating the
+detached checkout, applying the patch, building, measuring and summarizing. The
+source, raw measurements, summaries and instructions are also packaged in
+`.context/segment-l1-measurement.tar.gz`; fixture index files are regenerated,
+not included in the archive.
+
+## 2026-09-09: feature reads and scoring review
+
+This subsection records the initial design and measurement pass, before the
+implementation follow-up below.
+The invariant is identical candidates, organic scores, raw missing/zero values,
+passage ordinals, formula outputs and request-wide work/read budgets. The cost
+model separates segment/feature setup and scheduling, selected payload reads,
+scoring kernels, feature assembly and formula evaluation.
+
+### Measured opportunity: amortize CPU scheduling
+
+The native server awaits `score_candidates_with_retrieved_and_rrf` directly in
+`hermes-server/src/search_service.rs`. Core groups candidates by segment and
+processes those groups sequentially in
+`hermes-core/src/query/candidate_scoring/execution.rs`. Each BMP component and
+each dense/binary scoring batch independently enters `install_search_cpu`.
+Consequently, a small pool spread across 16 segments can incur approximately
+30 separate synchronous CPU-pool handoffs. The text probes, feature assembly
+and formula loop run on the calling thread. This differs from L0's coarser
+native search dispatch.
+
+The experiment freezes each candidate pool and its organic branch lists, then
+compares the existing L1 call with the **same call** entered once through the
+shared search CPU pool. Nested calls then stay on that worker. Both paths still
+process segments sequentially; no parallel segment scorer, scoring algorithm,
+candidate expansion or pruning change is involved. The experiment polls the
+mmap future with `now_or_never()` and asserts that every read is immediately
+ready. It does not block arbitrary async I/O on a Rayon worker. A serving design
+would need bounded async admission/completion around core CPU work, preserving
+lazy-directory, current-thread runtime, cancellation and WASM behavior.
+
+Median L1 latency, including plan validation, feature backfill, prediction and
+sorting, but excluding retrieval, expression parsing, statistics and RPC:
+
+| Fixture / branch depth              | Mean pool | Current call | One worker entry | Median reduction |
+| ----------------------------------- | --------: | -----------: | ---------------: | ---------------: |
+| 1 segment / 20                      |      57.6 |      69.2 us |          64.4 us |               7% |
+| 16 mixed segments / 20              |      57.6 |     320.9 us |         123.7 us |              61% |
+| 16 mixed segments / 100             |     246.8 |     520.8 us |         263.8 us |              49% |
+| 16 uneven segments / 20             |      57.6 |     180.4 us |          91.6 us |              49% |
+| 16 clustered segments / 20          |      57.6 |      60.8 us |          56.9 us |               7% |
+| 16 segments, passage features / 20  |      59.2 |     402.3 us |         179.9 us |              55% |
+| 16 segments, passage features / 100 |     281.1 |     768.8 us |         502.5 us |              35% |
+
+For the mixed 16-segment case, p95 changed from 478 to 154 us at depth 20,
+and from 893 to 307 us at depth 100. The one-segment/clustered cases supply most
+nominees from one segment, so consolidating dispatch has little to amortize;
+their small median changes are inconclusive and their p95 did not improve.
+
+A separate repeat with **one** search-pool thread over the same mixed index
+changed medians from 242 to 115 us and from 403 to 243 us respectively. The gain
+therefore does not require scoring segments in parallel. Worker locality and
+execution scheduling both change; the entire latency difference should not be
+described as a measurement of queue wait alone.
+
+The native-without-sync control also passed the same byte comparisons. In that
+build `install_search_cpu` is already inline, so both invocation styles should
+perform the same work. Measured medians were 105.4/105.7 us at depth 20 and
+233.8/235.3 us at depth 100, showing no useful difference. This is a control
+within that build, not a recommendation to disable native search parallelism.
+
+Separate instrumented passes explain the difference. For the small mixed pool,
+BMP/vector dispatch spans totalled about 218 us per request, while their nested
+kernel spans totalled about 21 us. With one worker entry those figures were
+about 11.6 and 10.5 us. These spans overlap, contain instrumentation overhead,
+and come from eight queries; they are attribution evidence, not an additive
+latency breakdown or replacements for the unprofiled timing samples.
+
+Every comparison checks the complete serialized results and feature rows,
+including ordering, scores, missing values and passage ordinals, byte for byte.
+Backfilled component counts and charged bytes also match: approximately
+223 components, 18.25 KiB of exact vectors and 8.40 KiB of BMP payload at depth
+20; 869 components, 70.72 KiB and 32.64 KiB at depth 100. No candidates are
+discarded to obtain the improvement.
+
+Memory is essentially unchanged by scheduling. The mixed depth-100 call
+allocated a median 373.9 KiB through 3,407 allocations in either mode, with a
+largest observed live-heap increase of 67.6 KiB. This shows a separate opportunity
+to reduce temporary allocations. These numbers include only L1 and must not be
+compared directly with the previous section's whole-search allocation totals.
+
+### Further findings, in suggested implementation order
+
+1. **Reduce text cursor setup and reuse bounded scratch.**
+   `term::score_term_candidates` creates a posting iterator for every component
+   in every occupied segment. `BlockPostingIterator::owned` allocates two
+   128-element `u32` buffers and decodes block zero before the first target seek,
+   even when the first candidate belongs to a later block. It also maintains
+   position-frequency prefixes although ordinary BM25 probes need no positions.
+   In the one-worker profile, text backfill took about 58 us for the small mixed
+   pool and 71 us for the large one, versus approximately 10/21 us for BMP
+   and less than 1 us for the dense arithmetic. This makes text setup/probing a
+   more promising next target than changing the formula evaluator. A targeted
+   first seek and reusable decode buffers belong in the existing posting reader;
+   retain positional cursor semantics for phrase consumers. The fixture does
+   not isolate how much time any one of these changes would save.
+
+2. **Reduce feature assembly allocations.**
+   `execution.rs` builds nested document feature vectors, tree maps for passage
+   rows, and another document-to-location tree for every document-scope feature.
+   `DocumentExpression::score` then allocates a `(ordinal, score)` vector for each
+   component/document reduction. Chunk-field sets are rebuilt per segment and
+   again per output document; model-bearing results clone old positions before
+   replacing them. Reuse admitted scratch, hoist the field set, and evaluate
+   contiguous row/location spans through the existing combiner. Preserve strict
+   ordinal reduction order, missing versus zero, negative boosts, and the
+   difference between `MAX(a) + MAX(b)` and `MAX(a + b)`. Flat internal storage
+   should still produce the same owned export rows at the boundary.
+
+3. **Prepare each scoring query once.**
+   L0 already shares `PreparedBmpQuery` across segment scorers. L1's
+   `score_bmp_candidates` rebuilds its quantized/sorted vectors, candidate mask
+   and phase-one metadata for every segment/component, even though point scoring
+   uses no LSP or block-pruning plan. `score_vector_candidates` similarly
+   recomputes the query norm and F16 representation on every segment call;
+   the F16 copy is unused by F32/UInt8 kernels. Reuse immutable preparation in
+   the existing core plan, keeping segment-specific BMP scale and field/dimension
+   validation at execution. In the one-worker mixed depth-100 profile, BMP
+   preparation totalled about 4.5 us; vector preparation **including its output
+   and raw-buffer allocations** totalled about 6.4 us. This is a smaller follow-up
+   than scheduling or text work on this fixture, not a measured speedup yet.
+
+4. **Share payload reads when several branches use the same field.**
+   Each feature/component currently resolves locations and reads its selected
+   vectors independently. Two dense queries over the same body field can read
+   and copy the same flat rows twice; multiple sparse queries can validate and
+   traverse the same forward vector repeatedly. A bounded field/segment batch
+   could resolve the union of missing logical cells, read a row once, and apply
+   the existing kernels for each required query before scattering scores back
+   to branch slots. Preserve organic values even when another branch needs the
+   same row, and charge both distinct payload bytes and component work. This
+   needs a repeated-field/multi-query fixture: the measured three-field workload
+   does not quantify its benefit.
+
+5. **Treat lazy text reads and MaxScore presence discovery separately.**
+   `reserve_candidate_text_reads` looks up term metadata before lazy reads;
+   `get_postings`/`get_positions` then look it up again and request the complete
+   term range. Mmap returns byte views, but a lazy backend can materialize those
+   ranges for very few candidates. Reader-owned prepared term handles, selected
+   block reads, and bounded I/O batching deserve a cold/remote benchmark.
+   Separately, `maxscore_candidate_locations` invokes
+   `SparseIndex::probe_candidates(..., None, ...)`, which probes **all retained
+   dimensions** to discover field presence and ordinals; scoring then probes the
+   query dimensions. Reuse discovery across compatible branches before
+   considering a format change. Looking only at query dimensions would turn
+   present-but-zero values into missing values and change formulas with missing
+   defaults. The current production metadata uses BMP, and the local benchmark
+   also uses BMP, so this is a conditional finding rather than its measured cost.
+
+The dense path already sorts physical targets and coalesces adjacent flat-vector
+reads. BMP already has an evictable forward representation and validates only
+selected payloads. Those are useful existing mechanisms to build on. A
+short-circuit in the BMP arithmetic loop after the query dimensions are exhausted
+could avoid some work, but `BmpForward::vector` still validates the complete
+selected vector first. Do not remove that validation or pin every vector to
+make warm measurements look better. Gapped-read coalescing and prefetch should
+be evaluated against bytes touched and cold page faults as well as elapsed time.
+
+### Formula cost and correctness constraints
+
+The compiled formula `bm25 + 2 * ln(1 + sparse) + 8 * dense` costs about
+1.7 us per small document pool and 7.3 us per large document pool in a replay of
+the existing model scorer, with **zero allocations** in those document-only
+passes. Passage merge/reduction raises those figures to 5.9 and 28.6 us and
+allocates scratch in `model.rs`. Replacing the expression package is therefore
+low priority for these requests. Longer formulas, RRF contribution processing,
+and documents with many passages need their own measurements.
+
+L1 still backfills branches that are absent from the formula. An inference-only
+request could potentially use a formula-dependency mask, but a mask alone would
+break raw exports and broker RRF: the broker deliberately asks shards to run a
+constant formula while exporting every raw branch. Passage nomination must also
+remain intact. Treat pruning unused feature reads as an explicit execution-plan
+optimization with export requirements, not a change to formula or missing-value
+semantics.
+
+Scoring more segment candidates should follow this cleanup, then be remeasured.
+These results demonstrate savings without changing candidate recall; they do
+not establish that a larger pool is free. Additional missing features still
+require payload access, and the extra pool must remain bounded. Per-segment
+parallelism is another proposal, not part of this experiment: it must share the
+request's work/read admission and CPU capacity, account for simultaneous scratch,
+and be tested under concurrent queries before a throughput claim.
+
+### Reproduction and validation
+
+Evidence is under `.context/feature-scoring-review/`, based on `6989e797`:
+
+- `measurement.patch`: the complete test-only patch for a detached checkout.
+  `original-segment-measurement.patch` retains the preceding experiment.
+- `results/`: five fixture layouts, raw JSONL and summaries.
+- `single-thread/`: the same mixed fixture with one search-pool thread.
+- `async-control/`: native-without-sync byte-equivalence and scheduling control.
+- `analyze.py`: summary calculations and paired work/byte-count audit.
+- `build.log`, `run.log`, `single-thread.log`, `focused-tests.log`.
+
+The experiment reuses the preceding section's 16,384-document mmap indexes,
+compiler, release profile and machine (Rust 1.98.1, Apple M4/arm64). It uses
+32 fixed-seed queries, depths 20/100, 12 repetitions and rotating variant order,
+with allocation and phase instrumentation disabled during latency measurements.
+There are **9,216 timed L1 calls**, 192 separate phase samples and 192 separate
+allocation samples across the four-thread and one-thread runs. Formula replay
+is separate: 384 timing estimates of 64 full-pool evaluations and 384 allocation
+passes. It includes passage/context reduction and score checks, but excludes
+copying the input rows. The native-without-sync control adds 512 timed L1 calls,
+32 phase samples, 32 allocation samples, and 64 formula timing/allocation pairs;
+its timings are kept separate. No builds from this workspace ran during timed sampling;
+other activity on the shared Mac was uncontrolled.
+
+After applying the patch and building the same optimized core unit-test binary:
+
+```sh
+FEATURE_MEASURE_DATA="$PWD/.context/segment-l1-measure-results" \
+  FEATURE_MEASURE_OUTPUT="$PWD/.context/feature-scoring-review/results" \
+  FEATURE_MEASURE_REPEATS=12 FEATURE_MEASURE_THREADS=4 \
+  <test-binary> --exact \
+  segment_nomination_measurement::feature_reads::measure_features \
+  --ignored --nocapture --test-threads=1
+python3 .context/feature-scoring-review/analyze.py \
+  .context/feature-scoring-review/results
+```
+
+Set `FEATURE_MEASURE_THREADS=1`, `FEATURE_MEASURE_FIXTURE=doc_s16`, and a new output
+directory for the control. The preceding section's runner regenerates the
+fixture files when needed. Optimized focused candidate-scoring tests passed
+in both native builds (13 passed, one existing manual benchmark ignored in each).
+The main checkout only
+changes this report; the earlier `check` result at the same source revision
+remains applicable. RPC, WASM, x86, cold payloads, production binary vectors and
+concurrent-query throughput are not validated by these measurements. No serving
+change, publication or production mutation was made for this review.
+
+The source, samples, analyzer and standalone reproduction instructions are
+packaged in `.context/feature-scoring-review.tar.gz`. Fixture indexes and compiled
+binaries are excluded; the included patch regenerates the fixtures. The report
+passed Prettier, `git diff --check`, and the repository's documentation/ownership
+contract check for this review.
+
+## 2026-09-09: implemented feature-read and scoring improvements
+
+The follow-up implements the measured scheduling improvement and reduces
+repeated preparation and temporary allocations. It does **not** enable the
+earlier retained-segment-candidate proposal. Candidate nomination, pruning,
+scores, raw exports, formulas, storage/wire formats and request limits retain
+their existing semantics.
+
+### Implementation and ownership
+
+- `Searcher::run_search_cpu` polls the existing borrowed scoring future on the
+  shared search pool when called from a multithread Tokio runtime. A poll that
+  encounters pending I/O returns to the original task, releasing the worker.
+  The worker enters the caller's Tokio handle for async directory operations.
+  There is no spawned/detached scoring task or second scorer: a request drop
+  drops its future after any active scoped poll returns. Native current-thread
+  and non-Tokio callers, native without sync, and WASM keep their existing path.
+- The existing posting reader accepts reusable decode buffers and starts
+  selected probes at their first requested block. Ordinary posting iteration
+  and its position-prefix semantics are retained. Request-owned text scratch
+  is reused across components and segments.
+- BMP query quantization is cached per immutable component, with bounded
+  replacement when segment dimensions differ. Segment dequantization remains
+  local. Dense query norms are cached per component, and F16 query copies are
+  built only for F16 segments. These caches never outlive the scoring request;
+  they contain query preparation, not corpus payloads.
+- Document feature reduction groups sorted location spans in one reusable
+  vector, replacing per-document trees/vectors. Small reductions use the same
+  combiner with inline storage. Passage/context inference uses a fixed feature
+  array and inline score scratch, validates duplicate ordinals before inference,
+  and preserves ordinal order for strict float reductions. Chunk-field sets are
+  prepared once, and formula results construct their new positions directly.
+
+The request still computes all required missing features, including unused
+formula branches needed for raw export and broker RRF. Overlapping payload-read
+sharing, lazy text range planning, MaxScore presence-discovery changes and
+per-segment parallelism remain separate proposals. No new cache or candidate
+policy is enabled for these purposes.
+
+### Before/after measurements
+
+Both binaries use the same compiler, release flags, host and persisted fixtures
+from the review: Rust 1.98.1, Apple M4/arm64, warm mmap, 16,384 documents, 32
+fixed-seed queries, three branches and the same nonlinear formula. The before
+binary is based on `6989e797`; the after binary contains this implementation.
+
+The before run saves the complete organic branch lists, candidate pools and
+serialized expected results/features. The after run replays those saved inputs
+and compares **every output byte**, rather than allowing retrieval to select a
+different candidate pool. All comparisons passed, and the paired component,
+vector-byte and BMP-payload charges are identical. The candidate counts below
+are means; latency cells are p50/p95 in microseconds and cover L1 only.
+
+| Fixture / branch depth                     | Pool docs | Before p50/p95 | After p50/p95 |
+| ------------------------------------------ | --------: | -------------: | ------------: |
+| 1 segment / 20                             |      57.6 |       72 / 122 |       51 / 61 |
+| 1 segment / 100                            |     246.8 |      205 / 267 |     155 / 192 |
+| 16 mixed segments / 20                     |      57.6 |      316 / 583 |      94 / 112 |
+| 16 mixed segments / 100                    |     246.8 |      518 / 989 |     200 / 236 |
+| 16 clustered segments / 20                 |      57.6 |        57 / 73 |       42 / 50 |
+| 16 clustered segments / 100                |     246.7 |      174 / 211 |     130 / 168 |
+| 16 uneven segments / 20                    |      57.6 |      165 / 239 |       68 / 81 |
+| 16 uneven segments / 100                   |     246.8 |      404 / 523 |     183 / 205 |
+| 16 segments, passage features / 20         |      59.2 |      392 / 675 |     147 / 182 |
+| 16 segments, passage features / 100        |     281.1 |     754 / 1105 |     427 / 507 |
+| 16 mixed segments, one search thread / 20  |      57.6 |      241 / 321 |      93 / 113 |
+| 16 mixed segments, one search thread / 100 |     246.8 |      400 / 497 |     196 / 227 |
+
+Thus the mixed four-thread case improves median L1 latency by approximately
+70% at depth 20 and 61% at depth 100. Comparing with the before binary's
+experimental one-worker mode isolates the remaining opportunity approximately:
+121/256 us before versus 94/200 us after, another approximately 22% reduction
+from preparation/allocation changes. This is not a separate kernel benchmark.
+
+Separate allocator passes show lower allocation traffic, with a small increase
+in the live heap from retaining reusable scratch until request completion:
+
+| Case                        | Allocated KiB before/after | Allocations before/after | Largest heap increase KiB before/after |
+| --------------------------- | -------------------------: | -----------------------: | -------------------------------------: |
+| Mixed segments, depth 20    |                  199 / 104 |               1664 / 961 |                            17.6 / 19.8 |
+| Mixed segments, depth 100   |                  374 / 234 |              3407 / 1382 |                            67.6 / 70.0 |
+| Passage features, depth 20  |                  216 / 133 |              2123 / 1430 |                            32.8 / 35.5 |
+| Passage features, depth 100 |                  548 / 414 |              5880 / 3600 |                          154.0 / 155.9 |
+
+Across the fixtures, the largest observed per-request live-heap increase rises
+by approximately 1.9–4.3 KiB. These are requested allocation bytes and heap
+changes measured around L1; they do not describe absolute heap, mmap residency
+or process RSS. Query-preparation residency scales with the admitted active
+components and their vector dimensions, so the table does not establish a
+universal scratch increment for arbitrarily large formulas/queries.
+
+The small passage-formula replay drops from 5.9 to 4.6 us, and the large replay
+from 28.9 to 22.4 us; both now allocate no scratch for these at-most-three-passage
+fixtures. Larger reductions spill to bounded heap storage; 17/65-passage tests
+cover that boundary. The formula library and arithmetic are unchanged.
+
+There are 18,432 timed calls across the two binaries and six fixture/thread
+cases, with phase and allocation accounting disabled during timing. Half use
+the normal caller and half retain the earlier worker-entry control. Separate
+passes contain 384 phase samples and 384 allocation samples, plus formula
+replays. Compilation and full validation finished before the timed after run;
+no builds from this workspace overlapped either timed comparison. Activity on
+the shared Mac was otherwise uncontrolled. This is warm single-request evidence,
+not a production throughput, x86, cold I/O or relevance benchmark. The source
+changes no architecture-sensitive scoring or retrieval defaults.
+
+### Validation and evidence
+
+`python3 scripts/check_search.py full` passed all eight steps, including the
+entire `check` sequence, native-without-sync and portable builds, API docs and
+the broker's real-server tests. The core suite passed 1,407 tests with 18 existing
+manual benchmarks ignored. Evidence:
+`.context/search-harness/20260909T064235.450347Z-full/`.
+
+The new regressions cover CPU-pool resumption after pending I/O, cancellation
+and panic/error propagation, current-thread runtimes, posting seek/position
+equivalence with recycled buffers, spill-sized passage reductions, and distinct
+queries across segments using BMP, F32, F16, UInt8 and binary vectors. Existing
+organic-score, missing-value, phrase, reorder and admission tests also passed.
+The WASM release build, clean npm install and all 20 WASM tests passed.
+The native-without-sync candidate-scoring run passed 15 tests, with one existing
+manual benchmark ignored.
+
+Evidence under `.context/feature-scoring-implementation/` includes:
+
+- `before/`, `after/`, `before-single-thread/`, `after-single-thread/`: raw
+  JSONL and summaries; `frozen/*.json` contains the persisted before inputs and
+  expected output bytes.
+- `before-measurement.patch`, `after-measurement.patch`: complete experiment
+  source for detached checkouts of the base revision, including the production
+  change in the latter. The fixture builder belongs to the before experiment;
+  the after experiment reuses those index files and frozen pools.
+- `instrument_after.py`, `compare.py`, `analyze.py`, compiler/runtime logs,
+  validation logs and fixture/environment hashes.
+
+The reproduction source and measurements are bundled as
+`.context/feature-scoring-implementation.tar.gz`; compiled binaries and index
+files are excluded. Recreating an index assigns new segment IDs, so regenerate
+its frozen pools with the before binary before running the after comparison.

--- a/hermes-client-python/README.md
+++ b/hermes-client-python/README.md
@@ -334,9 +334,10 @@ fields, and insert when the key is absent.
 
 ```python
 await client.delete_document("articles", "obsolete-key")
-await client.upsert_document("articles", {
-    "id": "article-42", "body": ["replacement chunk one", "replacement chunk two"]
-})
+await client.upsert_document(
+    "articles",
+    {"id": "article-42", "body": ["replacement chunk one", "replacement chunk two"]},
+)
 await client.commit("articles")
 
 result = await client.delete_documents("articles", ["old-a", "old-b"])

--- a/hermes-core/src/index/searcher.rs
+++ b/hermes-core/src/index/searcher.rs
@@ -630,6 +630,41 @@ impl<D: Directory + 'static> Searcher<D> {
         operation()
     }
 
+    /// Keep a ready scoring pipeline on the shared CPU pool. Polls borrow the
+    /// original future; pending I/O releases the worker and cancellation never
+    /// leaves detached scoring work holding a reader or request permit.
+    #[cfg(feature = "sync")]
+    pub(crate) async fn run_search_cpu<F>(&self, future: F) -> F::Output
+    where
+        F: std::future::Future + Send,
+        F::Output: Send,
+    {
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return future.await;
+        };
+        if runtime.runtime_flavor() != tokio::runtime::RuntimeFlavor::MultiThread {
+            return future.await;
+        }
+        let mut future = std::pin::pin!(future);
+        futures::future::poll_fn(|context| {
+            let waker = context.waker().clone();
+            tokio::task::block_in_place(|| {
+                self.install_search_cpu(|| {
+                    let _entered = runtime.enter();
+                    future
+                        .as_mut()
+                        .poll(&mut std::task::Context::from_waker(&waker))
+                })
+            })
+        })
+        .await
+    }
+
+    #[cfg(not(feature = "sync"))]
+    pub(crate) async fn run_search_cpu<F: std::future::Future>(&self, future: F) -> F::Output {
+        future.await
+    }
+
     /// Get number of segments
     pub fn num_segments(&self) -> usize {
         self.segments.len()

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -9,6 +9,8 @@ mod posting_codecs;
 mod primary_key;
 mod range;
 mod search;
+#[cfg(feature = "sync")]
+mod search_cpu;
 mod tq_bench;
 mod vector;
 

--- a/hermes-core/src/index/tests/search_cpu.rs
+++ b/hermes-core/src/index/tests/search_cpu.rs
@@ -1,0 +1,80 @@
+use crate::{Index, IndexConfig, RamDirectory, Schema};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+async fn searcher() -> Arc<crate::Searcher<RamDirectory>> {
+    let index = Index::create(
+        RamDirectory::new(),
+        Schema::builder().build(),
+        IndexConfig::default(),
+    )
+    .await
+    .unwrap();
+    index.reader().await.unwrap().searcher().await.unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scoring_polls_resume_on_the_search_pool_after_pending_io() {
+    let searcher = searcher().await;
+    let expected = tokio::runtime::Handle::current().id();
+    let borrowed = String::from("borrowed request");
+    let value = searcher
+        .run_search_cpu(async {
+            assert!(rayon::current_thread_index().is_some());
+            assert_eq!(tokio::runtime::Handle::current().id(), expected);
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            assert!(rayon::current_thread_index().is_some());
+            assert_eq!(tokio::runtime::Handle::current().id(), expected);
+            borrowed.as_str()
+        })
+        .await;
+    assert_eq!(value, borrowed);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelling_pending_scoring_drops_borrowed_work_and_propagates_failure() {
+    let searcher = searcher().await;
+    struct Dropped(Arc<AtomicBool>);
+    impl Drop for Dropped {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+    let dropped = Arc::new(AtomicBool::new(false));
+    let guard = Dropped(dropped.clone());
+    let mut pending = Box::pin(searcher.run_search_cpu(async move {
+        let _guard = guard;
+        std::future::pending::<()>().await;
+    }));
+    assert!(futures::poll!(&mut pending).is_pending());
+    assert!(!dropped.load(Ordering::SeqCst));
+    drop(pending);
+    assert!(dropped.load(Ordering::SeqCst));
+
+    use futures::FutureExt;
+    let panic = std::panic::AssertUnwindSafe(searcher.run_search_cpu(async {
+        panic!("scoring failure");
+    }))
+    .catch_unwind()
+    .await;
+    assert!(panic.is_err());
+    assert_eq!(
+        searcher
+            .run_search_cpu(async { Err::<(), _>("read failed") })
+            .await,
+        Err("read failed")
+    );
+}
+
+#[tokio::test]
+async fn current_thread_scoring_can_await_io_without_block_in_place() {
+    let searcher = searcher().await;
+    let thread = std::thread::current().id();
+    searcher
+        .run_search_cpu(async {
+            assert_eq!(std::thread::current().id(), thread);
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            assert_eq!(std::thread::current().id(), thread);
+        })
+        .await;
+}

--- a/hermes-core/src/query/bmp.rs
+++ b/hermes-core/src/query/bmp.rs
@@ -2021,91 +2021,115 @@ fn score_forward_units(
     Ok(units)
 }
 
-/// Exact candidate probes use the very same integer query quantization and
-/// dequantization as exhaustive BMP retrieval. Nomination/LSP never enters
-/// this path. Targets are sorted forward rows when stored and real physical slots
-/// without forward storage, as resolved by the owning candidate-address reader.
+/// Request-owned preparation for one immutable scoring component. Retain only
+/// one dimension configuration; a differing segment replaces the preparation.
+#[derive(Default)]
+pub(super) struct CandidateBmpPreparation {
+    prepared: Option<(u32, Option<PreparedBmpQuery>)>,
+}
+
+/// Exact probes share retrieval's integer quantization/dequantization. Targets
+/// are sorted forward rows or real physical slots from the candidate reader.
+#[cfg(test)]
 pub(crate) fn score_bmp_candidates(
     index: &BmpIndex,
     terms: &[(u32, f32)],
     targets: &[u32],
 ) -> crate::Result<Vec<f32>> {
-    use crate::segment::bmp_adaptive::AdaptivePostings;
-    let mut scores = vec![0.0; targets.len()];
-    let Some(prepared) = prepare_bmp_query(index.dims(), terms, terms)? else {
-        return Ok(scores);
-    };
-    let dequant = prepared.dequant_for(index)?;
-    if let Some(forward) = index.forward() {
-        for (score, &target) in scores.iter_mut().zip(targets) {
-            let vector = forward.vector(target)?;
-            let units = score_forward_units(vector, &prepared.query_by_dim_u16)?;
-            *score = units as f32 * dequant;
+    CandidateBmpPreparation::default().score(index, terms, targets)
+}
+
+impl CandidateBmpPreparation {
+    pub(super) fn score(
+        &mut self,
+        index: &BmpIndex,
+        terms: &[(u32, f32)],
+        targets: &[u32],
+    ) -> crate::Result<Vec<f32>> {
+        use crate::segment::bmp_adaptive::AdaptivePostings;
+        let mut scores = vec![0.0; targets.len()];
+        if self
+            .prepared
+            .as_ref()
+            .is_none_or(|(dims, _)| *dims != index.dims())
+        {
+            self.prepared = Some((index.dims(), prepare_bmp_query(index.dims(), terms, terms)?));
         }
-        return Ok(scores);
-    }
-    let mut start = 0;
-    while start < targets.len() {
-        let block_id = targets[start] / index.bmp_block_size;
-        let mut end = start + 1;
-        while end < targets.len() && targets[end] / index.bmp_block_size == block_id {
-            end += 1;
+        let Some(prepared) = self.prepared.as_ref().and_then(|(_, query)| query.as_ref()) else {
+            return Ok(scores);
+        };
+        let dequant = prepared.dequant_for(index)?;
+        if let Some(forward) = index.forward() {
+            for (score, &target) in scores.iter_mut().zip(targets) {
+                let vector = forward.vector(target)?;
+                let units = score_forward_units(vector, &prepared.query_by_dim_u16)?;
+                *score = units as f32 * dequant;
+            }
+            return Ok(scores);
         }
-        // Missing/empty blocks contain no nonzero terms. Real-slot identity is
-        // validated by the reader before this call.
-        let (byte_start, byte_end) = index.block_data_range(block_id);
-        if byte_start == byte_end {
-            start = end;
-            continue;
-        }
-        let block = index.parse_block(block_id).ok_or_else(|| {
-            crate::Error::Corruption(format!("cannot decode candidate BMP block {block_id}"))
-        })?;
-        let mut units = [0u32; 256];
-        for &(dimension, weight) in &prepared.query_by_dim_u16 {
-            let Some(term) = block.find_dimension(dimension) else {
+        let mut start = 0;
+        while start < targets.len() {
+            let block_id = targets[start] / index.bmp_block_size;
+            let mut end = start + 1;
+            while end < targets.len() && targets[end] / index.bmp_block_size == block_id {
+                end += 1;
+            }
+            // Missing/empty blocks contain no nonzero terms. Real-slot identity is
+            // validated by the reader before this call.
+            let (byte_start, byte_end) = index.block_data_range(block_id);
+            if byte_start == byte_end {
+                start = end;
                 continue;
-            };
-            let postings = block.postings(term).ok_or_else(|| {
-                crate::Error::Corruption(format!(
-                    "cannot decode candidate BMP dimension {dimension}"
-                ))
+            }
+            let block = index.parse_block(block_id).ok_or_else(|| {
+                crate::Error::Corruption(format!("cannot decode candidate BMP block {block_id}"))
             })?;
-            match postings {
-                AdaptivePostings::Dense(impacts) => {
-                    for &target in &targets[start..end] {
-                        let slot = (target % index.bmp_block_size) as usize;
-                        units[slot] = units[slot]
-                            .checked_add(u32::from(impacts[slot]) * u32::from(weight))
-                            .ok_or_else(|| {
-                                crate::Error::Query("BMP candidate score overflow".into())
-                            })?;
-                    }
-                }
-                AdaptivePostings::Sparse(postings) => {
-                    for &target in &targets[start..end] {
-                        let slot = (target % index.bmp_block_size) as u8;
-                        let start = postings.partition_point(|p| p.local_slot < slot);
-                        for posting in postings[start..]
-                            .iter()
-                            .take_while(|p| p.local_slot == slot)
-                        {
-                            units[slot as usize] = units[slot as usize]
-                                .checked_add(u32::from(posting.impact) * u32::from(weight))
+            let mut units = [0u32; 256];
+            for &(dimension, weight) in &prepared.query_by_dim_u16 {
+                let Some(term) = block.find_dimension(dimension) else {
+                    continue;
+                };
+                let postings = block.postings(term).ok_or_else(|| {
+                    crate::Error::Corruption(format!(
+                        "cannot decode candidate BMP dimension {dimension}"
+                    ))
+                })?;
+                match postings {
+                    AdaptivePostings::Dense(impacts) => {
+                        for &target in &targets[start..end] {
+                            let slot = (target % index.bmp_block_size) as usize;
+                            units[slot] = units[slot]
+                                .checked_add(u32::from(impacts[slot]) * u32::from(weight))
                                 .ok_or_else(|| {
                                     crate::Error::Query("BMP candidate score overflow".into())
                                 })?;
                         }
                     }
+                    AdaptivePostings::Sparse(postings) => {
+                        for &target in &targets[start..end] {
+                            let slot = (target % index.bmp_block_size) as u8;
+                            let start = postings.partition_point(|p| p.local_slot < slot);
+                            for posting in postings[start..]
+                                .iter()
+                                .take_while(|p| p.local_slot == slot)
+                            {
+                                units[slot as usize] = units[slot as usize]
+                                    .checked_add(u32::from(posting.impact) * u32::from(weight))
+                                    .ok_or_else(|| {
+                                        crate::Error::Query("BMP candidate score overflow".into())
+                                    })?;
+                            }
+                        }
+                    }
                 }
             }
+            for i in start..end {
+                scores[i] = units[(targets[i] % index.bmp_block_size) as usize] as f32 * dequant;
+            }
+            start = end;
         }
-        for i in start..end {
-            scores[i] = units[(targets[i] % index.bmp_block_size) as usize] as f32 * dequant;
-        }
-        start = end;
+        Ok(scores)
     }
-    Ok(scores)
 }
 
 #[cfg(test)]

--- a/hermes-core/src/query/candidate_scoring/execution.rs
+++ b/hermes-core/src/query/candidate_scoring/execution.rs
@@ -10,18 +10,26 @@ const MAX_FEATURES: usize = crate::query::MAX_FUSION_SUB_QUERIES;
 const MAX_FEATURE_VALUES: usize = 2_000_000;
 const MAX_VECTOR_BYTES: usize = 1024 * 1024 * 1024;
 
-struct CandidateProbeBudget {
+struct CandidateProbeState {
     sparse: crate::segment::reader::SparseProbeBudget,
     payload_remaining: u64,
+    text_scratch: crate::structures::postings::PostingDecodeScratch,
 }
 
-impl Default for CandidateProbeBudget {
+impl Default for CandidateProbeState {
     fn default() -> Self {
         Self {
             sparse: Default::default(),
             payload_remaining: 256 * 1024 * 1024,
+            text_scratch: Default::default(),
         }
     }
+}
+
+#[derive(Default)]
+struct ComponentPreparation {
+    sparse: crate::query::bmp::CandidateBmpPreparation,
+    vector: Option<crate::query::reranker::CandidateVectorPreparation>,
 }
 
 impl CandidateScoringPlan {
@@ -162,17 +170,19 @@ impl CandidateScoringPlan {
 async fn score_field<D: Directory + 'static>(
     searcher: &Searcher<D>,
     reader: &SegmentReader,
-    query: &CandidateQuery,
+    feature: &CandidateFeature,
     locations: &[crate::segment::reader::candidate_lookup::CandidateLocation],
     stats: &Arc<GlobalStats>,
-    document_scope: bool,
-    budget: &mut CandidateProbeBudget,
+    budget: &mut CandidateProbeState,
+    preparation: &mut [ComponentPreparation],
 ) -> Result<(Vec<f32>, Vec<Vec<f32>>)> {
+    let query = &feature.query;
+    let document_scope = feature.scope == ScoreScope::Document;
     let targets: Vec<u32> = locations.iter().map(|location| location.physical).collect();
     let targets = targets.as_slice();
     let mut result = vec![0.0; targets.len()];
     let mut components = Vec::new();
-    for (component, boost) in &query.components {
+    for ((component, boost), preparation) in query.components.iter().zip(preparation) {
         let values = match component {
             ScoreComponent::Text(terms) => {
                 for (term, _) in terms {
@@ -191,6 +201,7 @@ async fn score_field<D: Directory + 'static>(
                     terms,
                     targets,
                     Some(stats),
+                    &mut budget.text_scratch,
                 )
                 .await?
             }
@@ -215,9 +226,8 @@ async fn score_field<D: Directory + 'static>(
                         targets,
                         &mut budget.payload_remaining,
                     )?;
-                    searcher.install_search_cpu(|| {
-                        crate::query::bmp::score_bmp_candidates(index, terms, targets)
-                    })?
+                    searcher
+                        .install_search_cpu(|| preparation.sparse.score(index, terms, targets))?
                 } else {
                     let index = reader.sparse_index(query.field).ok_or_else(|| {
                         Error::Corruption("L1 sparse locations lack a sparse index".into())
@@ -268,6 +278,7 @@ async fn score_field<D: Directory + 'static>(
                     &[],
                     unit_norm,
                     targets,
+                    &mut preparation.vector,
                 )
                 .await?
             }
@@ -282,6 +293,7 @@ async fn score_field<D: Directory + 'static>(
                     vector,
                     false,
                     targets,
+                    &mut preparation.vector,
                 )
                 .await?
             }
@@ -389,6 +401,18 @@ impl<D: Directory + 'static> Searcher<D> {
                 "candidate scoring document budget exceeded".into(),
             ));
         }
+        self.run_search_cpu(self.score_candidate_features(candidates, plan, stats, retrieved, rrf))
+            .await
+    }
+
+    async fn score_candidate_features(
+        &self,
+        candidates: &[SearchResult],
+        plan: &CandidateScoringPlan,
+        stats: Option<Arc<GlobalStats>>,
+        retrieved: &[(usize, &[SearchResult])],
+        rrf: Option<&[crate::query::RrfScore]>,
+    ) -> Result<Vec<ScoredCandidate>> {
         let mut groups: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
         let mut addresses = BTreeSet::new();
         for (i, candidate) in candidates.iter().enumerate() {
@@ -418,11 +442,27 @@ impl<D: Directory + 'static> Searcher<D> {
         };
         let names: Vec<&str> = plan.features.iter().map(|f| f.name.as_str()).collect();
         let count = names.len();
+        let chunk_fields: BTreeSet<u32> = plan
+            .features
+            .iter()
+            .filter(|feature| feature.scope == ScoreScope::Chunk)
+            .map(|feature| feature.query.field.0)
+            .collect();
         let mut output = Vec::with_capacity(candidates.len());
         let mut scored_values = 0usize;
         let mut vector_bytes = 0usize;
         let mut matrix_values = 0usize;
-        let mut probe_budget = CandidateProbeBudget::default();
+        let mut probe_budget = CandidateProbeState::default();
+        let mut preparations: Vec<Vec<ComponentPreparation>> = plan
+            .features
+            .iter()
+            .map(|feature| {
+                std::iter::repeat_with(ComponentPreparation::default)
+                    .take(feature.query.components.len())
+                    .collect()
+            })
+            .collect();
+        let mut reduction_locations = Vec::new();
         for (segment, mut candidate_indices) in groups {
             let reader = &self.segment_readers()[segment];
             candidate_indices.sort_unstable_by_key(|&i| candidates[i].doc_id);
@@ -438,12 +478,6 @@ impl<D: Directory + 'static> Searcher<D> {
             }
             let mut doc_values = vec![vec![None; count]; documents.len()];
             let mut passages: BTreeMap<(u32, u16), Vec<Option<f32>>> = BTreeMap::new();
-            let chunk_fields: BTreeSet<u32> = plan
-                .features
-                .iter()
-                .filter(|feature| feature.scope == ScoreScope::Chunk)
-                .map(|feature| feature.query.field.0)
-                .collect();
             let mut nominated = Vec::new();
             if !plan.all_passages && retrieved.is_empty() {
                 for &i in &candidate_indices {
@@ -604,29 +638,33 @@ impl<D: Directory + 'static> Searcher<D> {
                 let (scores, components) = score_field(
                     self,
                     reader,
-                    &feature.query,
+                    feature,
                     &locations,
                     stats.as_ref().expect("backfill statistics"),
-                    document_scope,
                     &mut probe_budget,
+                    &mut preparations[feature_index],
                 )
                 .await?;
                 if document_scope {
-                    let mut groups: BTreeMap<u32, Vec<(u32, usize)>> = BTreeMap::new();
-                    for (position, location) in locations.iter().enumerate() {
-                        groups
-                            .entry(location.doc)
-                            .or_default()
-                            .push((u32::from(location.ordinal), position));
-                    }
-                    for (doc, mut locations) in groups {
-                        // Physical reordering must not alter floating-point reductions.
-                        locations.sort_unstable_by_key(|&(ordinal, _)| ordinal);
+                    reduction_locations.clear();
+                    reduction_locations.extend(
+                        locations
+                            .iter()
+                            .enumerate()
+                            .map(|(i, location)| (u32::from(location.ordinal), i)),
+                    );
+                    // Physical reordering must not alter floating-point reductions.
+                    reduction_locations
+                        .sort_unstable_by_key(|&(ordinal, i)| (locations[i].doc, ordinal));
+                    for selected in reduction_locations
+                        .chunk_by(|a, b| locations[a.1].doc == locations[b.1].doc)
+                    {
+                        let doc = locations[selected[0].1].doc;
                         let doc_index = documents
                             .binary_search(&doc)
                             .expect("resolved selected doc");
                         doc_values[doc_index][feature_index] =
-                            Some(feature.query.document.score(&components, &locations)?);
+                            Some(feature.query.document.score(&components, selected)?);
                     }
                     continue;
                 }
@@ -665,7 +703,16 @@ impl<D: Directory + 'static> Searcher<D> {
                     });
                 }
                 let scored_passages = rows.len();
-                let mut result = candidate.clone();
+                let mut result = SearchResult {
+                    doc_id: candidate.doc_id,
+                    segment_id: candidate.segment_id,
+                    score: candidate.score,
+                    positions: if plan.model.is_some() {
+                        Vec::new()
+                    } else {
+                        candidate.positions.clone()
+                    },
+                };
                 let mut features = CandidateScores {
                     document,
                     passages: rows,
@@ -699,15 +746,9 @@ impl<D: Directory + 'static> Searcher<D> {
                 rows.truncate(plan.export_passages);
                 // A document-only feature never creates an ordinal-zero row.
                 if plan.model.is_some() {
-                    let fields: BTreeSet<u32> = plan
-                        .features
+                    result.positions = chunk_fields
                         .iter()
-                        .filter(|f| f.scope == ScoreScope::Chunk)
-                        .map(|f| f.query.field.0)
-                        .collect();
-                    result.positions = fields
-                        .into_iter()
-                        .map(|field| {
+                        .map(|&field| {
                             (
                                 field,
                                 rows.iter()
@@ -785,18 +826,22 @@ mod tests {
                 .candidate_locations(field, &[0], 1, &mut Default::default())
                 .await
                 .unwrap();
-            let mut budget = CandidateProbeBudget {
+            let mut budget = CandidateProbeState {
                 payload_remaining: 0,
                 ..Default::default()
             };
             let error = score_field(
                 &searcher,
                 reader,
-                &query,
+                &CandidateFeature {
+                    name: "sparse".into(),
+                    scope: ScoreScope::Chunk,
+                    query,
+                },
                 &locations,
                 &stats,
-                false,
                 &mut budget,
+                &mut [ComponentPreparation::default()],
             )
             .await
             .unwrap_err();

--- a/hermes-core/src/query/candidate_scoring/mod.rs
+++ b/hermes-core/src/query/candidate_scoring/mod.rs
@@ -67,7 +67,7 @@ impl DocumentExpression {
     fn score(&self, components: &[Vec<f32>], locations: &[(u32, usize)]) -> Result<f32> {
         let value = match self {
             Self::Component(index, combiner) => {
-                let values: Vec<_> = locations
+                let values: smallvec::SmallVec<[(u32, f32); 16]> = locations
                     .iter()
                     .map(|&(ordinal, position)| (ordinal, components[*index][position]))
                     .collect();

--- a/hermes-core/src/query/candidate_scoring/model.rs
+++ b/hermes-core/src/query/candidate_scoring/model.rs
@@ -10,7 +10,9 @@ pub(super) fn score_candidate_with(
 ) -> Result<f32> {
     use crate::query::MultiValueCombiner;
     combiner.validate().map_err(Error::Query)?;
-    if features.document.len() != names.len() || features.passages.len() > features.scored_passages
+    if names.len() > crate::query::MAX_FUSION_SUB_QUERIES
+        || features.document.len() != names.len()
+        || features.passages.len() > features.scored_passages
     {
         return Err(Error::Query("L1 candidate feature shape mismatch".into()));
     }
@@ -28,22 +30,32 @@ pub(super) fn score_candidate_with(
         ));
     }
     let context = rrf.map_or(0.0, |rrf| rrf.document_context());
-    let mut values = vec![None; names.len()];
-    let mut scores = Vec::with_capacity(features.passages.len());
-    let mut ordinals = std::collections::BTreeSet::new();
-    for row in &mut features.passages {
-        if row.values.len() != names.len() || !ordinals.insert(row.ordinal) {
+    let mut values = [None; crate::query::MAX_FUSION_SUB_QUERIES];
+    let values = &mut values[..names.len()];
+    let mut scores = smallvec::SmallVec::<[(u32, f32); 16]>::with_capacity(features.passages.len());
+    for row in &features.passages {
+        if row.values.len() != names.len() {
             return Err(Error::Query(
                 "L1 passage feature shape/ordinal mismatch".into(),
             ));
         }
+        scores.push((u32::from(row.ordinal), 0.0));
+    }
+    scores.sort_unstable_by_key(|&(ordinal, _)| ordinal);
+    if scores.windows(2).any(|rows| rows[0].0 == rows[1].0) {
+        return Err(Error::Query(
+            "L1 passage feature shape/ordinal mismatch".into(),
+        ));
+    }
+    scores.clear();
+    for row in &mut features.passages {
         for ((value, &chunk), &document) in
             values.iter_mut().zip(&row.values).zip(&features.document)
         {
             *value = chunk.or(document);
         }
         row.score = score(
-            &values,
+            values,
             rrf.map(|rrf| rrf.passage_score(u32::from(row.ordinal), context)),
         )?;
         scores.push((u32::from(row.ordinal), row.score));
@@ -56,4 +68,45 @@ pub(super) fn score_candidate_with(
         return Err(Error::Query("L1 document score reduction overflow".into()));
     }
     Ok(score)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CandidateScores, PassageFeatures, RankingModel};
+    use crate::query::MultiValueCombiner;
+
+    #[test]
+    fn passage_reduction_preserves_ordinal_order_when_inline_scratch_spills() {
+        let model = RankingModel::compile("p + d", &["p", "d"], &Default::default()).unwrap();
+        for count in [1, 16, 17, 65] {
+            let expected: Vec<_> = (0..count)
+                .map(|i| (i, [10_000_000.0, -10_000_000.0, 0.1][i as usize % 3]))
+                .collect();
+            for combiner in [
+                MultiValueCombiner::Max,
+                MultiValueCombiner::Sum,
+                MultiValueCombiner::Avg,
+                MultiValueCombiner::weighted_top_k(),
+                MultiValueCombiner::log_sum_exp(),
+            ] {
+                let mut features = CandidateScores {
+                    document: vec![None, Some(0.0)],
+                    passages: expected
+                        .iter()
+                        .rev()
+                        .map(|&(ordinal, value)| PassageFeatures {
+                            ordinal: ordinal as u16,
+                            score: 0.0,
+                            values: vec![Some(value), None],
+                        })
+                        .collect(),
+                    scored_passages: count as usize,
+                };
+                let result = model
+                    .score_candidate(&["p", "d"], &mut features, combiner, None)
+                    .unwrap();
+                assert_eq!(result.to_bits(), combiner.combine(&expected).to_bits());
+            }
+        }
+    }
 }

--- a/hermes-core/src/query/candidate_scoring/tests.rs
+++ b/hermes-core/src/query/candidate_scoring/tests.rs
@@ -6,6 +6,165 @@ use crate::query::{
 use crate::structures::{SparseFormat, SparseVectorConfig, WeightQuantization};
 use crate::{Document, Index, IndexConfig, IndexWriter, RamDirectory, Schema};
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prepared_backfill_keeps_distinct_queries_and_quantizations_correct_across_segments() {
+    let mut schema = Schema::builder();
+    let dense: Vec<_> = [
+        DenseVectorQuantization::F32,
+        DenseVectorQuantization::F16,
+        DenseVectorQuantization::UInt8,
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(i, quantization)| {
+        schema.add_dense_vector_field_with_config(
+            &format!("dense{i}"),
+            true,
+            false,
+            DenseVectorConfig {
+                dim: 4,
+                index_type: VectorIndexType::Flat,
+                quantization,
+                num_clusters: None,
+                target_vectors: None,
+                tree_levels: None,
+                ivf_routing: crate::dsl::IvfRoutingMode::Auto,
+                nprobe: 1,
+                unit_norm: false,
+                soar: None,
+            },
+        )
+    })
+    .collect();
+    let sparse = schema.add_sparse_vector_field_with_config(
+        "sparse",
+        true,
+        false,
+        SparseVectorConfig {
+            format: SparseFormat::Bmp,
+            dims: Some(16),
+            max_weight: Some(2.0),
+            ..Default::default()
+        },
+    );
+    let binary = schema.add_binary_dense_vector_field("binary", 16, true, false);
+    let directory = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::NoMergePolicy),
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(directory.clone(), schema.build(), config.clone())
+        .await
+        .unwrap();
+    for segment in 0..2 {
+        for doc in 0..3 {
+            let mut document = Document::new();
+            // A missing row, one value, and a value set exceeding inline scratch.
+            for ordinal in 0..[0, 1, 20][doc] {
+                let x = (segment + ordinal + 1) as f32 / 25.0;
+                for &field in &dense {
+                    document.add_dense_vector(field, vec![x, 1.0 - x, 0.2, -0.3]);
+                }
+                document.add_sparse_vector(sparse, vec![(0, x), (1, 1.0 - x)]);
+                document.add_binary_dense_vector(binary, vec![ordinal as u8, segment as u8]);
+            }
+            writer.add_document(document).unwrap();
+        }
+        writer.commit().await.unwrap();
+    }
+    let index = Index::open(directory, config).await.unwrap();
+    let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+    assert_eq!(searcher.segment_readers().len(), 2);
+    let candidates: Vec<_> = searcher
+        .segment_readers()
+        .iter()
+        .flat_map(|reader| {
+            (0..reader.num_docs()).map(move |doc_id| crate::query::SearchResult {
+                doc_id,
+                score: 0.0,
+                segment_id: reader.meta().id,
+                positions: Vec::new(),
+            })
+        })
+        .collect();
+    let mut features = Vec::new();
+    for (i, &field) in dense.iter().enumerate() {
+        for (j, vector) in [vec![1.0, 0.0, 0.0, 0.0], vec![0.0, 2.0, 0.0, 0.0]]
+            .into_iter()
+            .enumerate()
+        {
+            features.push(CandidateFeature {
+                name: format!("dense_{i}_{j}"),
+                scope: ScoreScope::Document,
+                query: DenseVectorQuery::new(field, vector)
+                    .with_combiner(MultiValueCombiner::Avg)
+                    .candidate_query()
+                    .unwrap(),
+            });
+        }
+    }
+    for (i, terms) in [vec![(0, 0.3), (0, 0.1)], vec![(1, 0.8)]]
+        .into_iter()
+        .enumerate()
+    {
+        features.push(CandidateFeature {
+            name: format!("sparse_{i}"),
+            scope: ScoreScope::Document,
+            query: SparseVectorQuery::new(sparse, terms)
+                .with_combiner(MultiValueCombiner::Sum)
+                .candidate_query()
+                .unwrap(),
+        });
+    }
+    for (i, vector) in [vec![0, 0], vec![255, 0]].into_iter().enumerate() {
+        features.push(CandidateFeature {
+            name: format!("binary_{i}"),
+            scope: ScoreScope::Document,
+            query: crate::query::BinaryDenseVectorQuery::new(binary, vector)
+                .candidate_query()
+                .unwrap(),
+        });
+    }
+    let plan = CandidateScoringPlan {
+        features,
+        backfill: true,
+        model: None,
+        export_passages: 1,
+        all_passages: false,
+        document_combiner: MultiValueCombiner::Max,
+    };
+    let combined = searcher
+        .score_candidates(&candidates, &plan, None)
+        .await
+        .unwrap();
+    for (i, feature) in plan.features.iter().enumerate() {
+        let isolated = CandidateScoringPlan {
+            features: vec![feature.clone()],
+            ..plan.clone()
+        };
+        for candidate in &candidates {
+            // Fresh request and one document: no cross-segment/component cache reuse.
+            let expected = searcher
+                .score_candidates(std::slice::from_ref(candidate), &isolated, None)
+                .await
+                .unwrap();
+            let actual = combined
+                .iter()
+                .find(|hit| {
+                    hit.result.segment_id == candidate.segment_id
+                        && hit.result.doc_id == candidate.doc_id
+                })
+                .unwrap();
+            assert_eq!(
+                actual.features.document[i].map(f32::to_bits),
+                expected[0].features.document[0].map(f32::to_bits),
+                "{}",
+                feature.name
+            );
+        }
+    }
+}
+
 #[tokio::test]
 async fn index_creation_configures_phrase_limits_for_ranking_and_collection_after_reopen() {
     for configured in [None, Some(1), Some(65), Some(300)] {

--- a/hermes-core/src/query/phrase.rs
+++ b/hermes-core/src/query/phrase.rs
@@ -355,6 +355,7 @@ pub(super) async fn score_phrase_candidates(
             &[(query.terms[0].clone(), 1.0)],
             targets,
             stats,
+            &mut Default::default(),
         )
         .await;
     }

--- a/hermes-core/src/query/reranker.rs
+++ b/hermes-core/src/query/reranker.rs
@@ -1017,9 +1017,15 @@ async fn rerank_binary<D: crate::directories::Directory + 'static>(
     Ok(scored)
 }
 
-/// Backfill a selected set of flat vector values without ANN candidate
-/// generation. Shares range planning, bounded buffers and SIMD kernels with
-/// the existing exact reranker. Targets are sorted and unique.
+/// Request-owned preparation for one immutable dense scoring component. The
+/// F16 representation is materialized only if a segment needs that codec.
+pub(super) struct CandidateVectorPreparation {
+    inv_norm_q: f32,
+    query_f16: Vec<u16>,
+}
+
+/// Backfill sorted, unique flat vector targets with the existing rerank range
+/// planner and SIMD kernels, without ANN nomination.
 pub(super) async fn score_vector_candidates<D: crate::directories::Directory + 'static>(
     searcher: &crate::index::Searcher<D>,
     flat: &crate::segment::LazyFlatVectorData,
@@ -1027,18 +1033,35 @@ pub(super) async fn score_vector_candidates<D: crate::directories::Directory + '
     binary_vector: &[u8],
     unit_norm: bool,
     targets: &[u32],
+    preparation: &mut Option<CandidateVectorPreparation>,
 ) -> crate::Result<Vec<f32>> {
     use crate::structures::simd;
-    let norm = simd::dot_product_f32(vector, vector, vector.len());
-    let query_f16: Vec<u16> = vector.iter().map(|&v| simd::f32_to_f16(v)).collect();
-    let pq = PrecompQuery {
-        query: vector,
-        inv_norm_q: if norm < f32::EPSILON {
-            0.0
-        } else {
-            simd::fast_inv_sqrt(norm)
-        },
-        query_f16: &query_f16,
+    let pq = if binary_vector.is_empty() {
+        let preparation = preparation.get_or_insert_with(|| {
+            let norm = simd::dot_product_f32(vector, vector, vector.len());
+            CandidateVectorPreparation {
+                inv_norm_q: if norm < f32::EPSILON {
+                    0.0
+                } else {
+                    simd::fast_inv_sqrt(norm)
+                },
+                query_f16: Vec::new(),
+            }
+        });
+        if flat.quantization == crate::dsl::DenseVectorQuantization::F16
+            && preparation.query_f16.is_empty()
+        {
+            preparation
+                .query_f16
+                .extend(vector.iter().map(|&v| simd::f32_to_f16(v)));
+        }
+        Some(PrecompQuery {
+            query: vector,
+            inv_norm_q: preparation.inv_norm_q,
+            query_f16: &preparation.query_f16,
+        })
+    } else {
+        None
     };
     let vbs = flat.vector_byte_size();
     let batch_len = rerank_batch_len(vbs);
@@ -1055,7 +1078,14 @@ pub(super) async fn score_vector_candidates<D: crate::directories::Directory + '
             });
         } else {
             searcher.install_search_cpu(|| {
-                score_batch_precomp(&pq, raw, flat.quantization, flat.dim, out, unit_norm)
+                score_batch_precomp(
+                    pq.as_ref().expect("dense query"),
+                    raw,
+                    flat.quantization,
+                    flat.dim,
+                    out,
+                    unit_norm,
+                )
             })?;
         }
     }

--- a/hermes-core/src/query/term.rs
+++ b/hermes-core/src/query/term.rs
@@ -644,15 +644,19 @@ pub(super) async fn score_term_candidates(
     terms: &[(Vec<u8>, f32)],
     targets: &[u32],
     stats: Option<&Arc<GlobalStats>>,
+    scratch: &mut crate::structures::postings::PostingDecodeScratch,
 ) -> crate::Result<Vec<f32>> {
     let mut scores = vec![0.0; targets.len()];
+    let Some(&first_target) = targets.first() else {
+        return Ok(scores);
+    };
     let params = super::Bm25Params::for_field(reader.schema(), field);
     for (term, weight) in terms {
         let Some(postings) = reader.get_postings(field, term).await? else {
             continue;
         };
         let (idf, avg_len) = compute_term_idf(&postings, field, reader, stats, term);
-        let mut cursor = postings.into_iterator();
+        let mut cursor = postings.into_candidate_iterator(first_target, scratch);
         for (index, &target) in targets.iter().enumerate() {
             if cursor.seek(target) != target {
                 continue;
@@ -667,6 +671,7 @@ pub(super) async fn score_term_candidates(
             };
             scores[index] += params.score(tf, idf * weight, length, avg_len);
         }
+        cursor.recycle(scratch);
     }
     Ok(scores)
 }

--- a/hermes-core/src/structures/postings/mod.rs
+++ b/hermes-core/src/structures/postings/mod.rs
@@ -50,6 +50,7 @@ pub(crate) use positions_v2::TermPositionCursor;
 pub use positions_v2::{
     POSITION_STREAM_BLOCK, PositionStream, PositionStreamEncoder, TermPositions,
 };
+pub(crate) use posting::PostingDecodeScratch;
 pub use posting::{
     BLOCK_SIZE as POSTING_BLOCK_SIZE, BlockPostingIterator, BlockPostingList, Posting,
     PostingCodec, PostingList, PostingListIterator, TERMINATED,

--- a/hermes-core/src/structures/postings/posting.rs
+++ b/hermes-core/src/structures/postings/posting.rs
@@ -1534,6 +1534,39 @@ impl BlockPostingList {
     pub fn into_iterator(self) -> BlockPostingIterator<'static> {
         BlockPostingIterator::owned(self)
     }
+
+    /// Point probes start at their first requested block and reuse decode
+    /// storage. Ordinary iteration still starts at the first posting.
+    pub(crate) fn into_candidate_iterator(
+        self,
+        first_target: DocId,
+        scratch: &mut PostingDecodeScratch,
+    ) -> BlockPostingIterator<'static> {
+        let first_block = self.seek_block(first_target, 0);
+        let PostingDecodeScratch {
+            doc_ids,
+            term_freqs,
+        } = std::mem::take(scratch);
+        let mut iterator = BlockPostingIterator {
+            block_list: std::borrow::Cow::Owned(self),
+            current_block: first_block.unwrap_or(0),
+            block_doc_ids: doc_ids,
+            block_tfs: term_freqs,
+            position_in_block: 0,
+            tf_prefix: 0,
+            exhausted: first_block.is_none(),
+        };
+        if let Some(block) = first_block {
+            iterator.load_block(block);
+        }
+        iterator
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct PostingDecodeScratch {
+    doc_ids: Vec<u32>,
+    term_freqs: Vec<u32>,
 }
 
 /// Iterator over block posting list with skip support
@@ -1556,6 +1589,13 @@ pub struct BlockPostingIterator<'a> {
 }
 
 impl<'a> BlockPostingIterator<'a> {
+    pub(crate) fn recycle(self, scratch: &mut PostingDecodeScratch) {
+        *scratch = PostingDecodeScratch {
+            doc_ids: self.block_doc_ids,
+            term_freqs: self.block_tfs,
+        };
+    }
+
     fn new(block_list: &'a BlockPostingList) -> Self {
         let exhausted = block_list.l0_count == 0;
         let mut iter = Self {
@@ -1718,6 +1758,36 @@ impl<'a> BlockPostingIterator<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn candidate_posting_probes_reuse_buffers_and_preserve_seek_and_position_cursors() {
+        let mut list = PostingList::new();
+        for i in 0..700 {
+            list.push(i * 3, i % 7 + 1);
+        }
+        let postings = BlockPostingList::from_posting_list(&list).unwrap();
+        let mut scratch = PostingDecodeScratch::default();
+        for first in [0, 385, 900, 1800, 2100, 100, 2097] {
+            let mut reference = postings.clone().into_iterator();
+            let mut selected = postings
+                .clone()
+                .into_candidate_iterator(first, &mut scratch);
+            assert_eq!(
+                selected.current_block_idx(),
+                postings.seek_block(first, 0).unwrap_or(0)
+            );
+            for target in (first..2200).step_by(17) {
+                assert_eq!(selected.seek(target), reference.seek(target));
+                assert_eq!(selected.term_freq(), reference.term_freq());
+                if selected.doc() != TERMINATED {
+                    assert_eq!(selected.position_cursor(), reference.position_cursor());
+                }
+            }
+            selected.recycle(&mut scratch);
+            assert!(scratch.doc_ids.capacity() >= BLOCK_SIZE);
+            assert!(scratch.term_freqs.capacity() >= BLOCK_SIZE);
+        }
+    }
 
     #[test]
     fn test_posting_list_basic() {


### PR DESCRIPTION
L1 feature backfill was repeatedly handing small BMP/vector jobs to the search pool and rebuilding query preparation and temporary reductions for each segment. Ready portions of the existing async scorer now execute on the shared pool, with pending I/O returning to the caller and cancellation retaining no detached work.

Reuse posting decode buffers, begin point probes at the first requested block, cache immutable component preparation, and use contiguous/inline reduction scratch. Candidate nomination, pruning, feature values, ordinal reduction order, request limits and wire/storage formats retain their existing semantics. The design and performance report also record the preceding review measurements and remaining proposals. Format the existing Python upsert example to satisfy the current Ruff CI check.

Measured with the same persisted warm mmap fixtures, compiler and flags on Apple M4 / Rust 1.98.1 (16,384 documents, 16 mixed segments, 32 queries, 12 repetitions):

| Branch depth | Mean pool documents | L1 p50 before → after |
| --- | ---: | ---: |
| 20 | 57.6 | 316 → 94 µs |
| 100 | 246.8 | 518 → 200 µs |

The larger pool's requested allocations fall from 374 to 234 KiB. Peak live heap increases by about 2–4 KiB across these fixtures because reusable scratch remains alive until request completion. These are warm single-request measurements; production throughput, cold I/O and x86 gains are unmeasured. Full results and reproduction details are in `docs/search-performance-review.md`.

Validation:

- `python3 scripts/check_search.py full`: all eight steps passed, including 1,407 core tests, native/portable builds, API docs and broker real-server tests.
- Native without sync: 15 candidate-scoring tests passed. WASM release build and all 20 WASM tests passed.
- 18,432 timed before/after/control calls; every complete output byte matched the frozen before results, and candidate/work/read charges matched.
- New regressions cover async resumption/cancellation/failure, posting seeks and position cursors, ordinal-order reductions beyond inline capacity, and distinct BMP/dense/binary queries across segments.
- Documentation links, ownership contracts, formatting and diff checks passed.
