### PR TITLE
Upgrade metadata format 6 to 7 on open instead of refusing

### DIFF
--- a/docs/lexical-vertical.md
+++ b/docs/lexical-vertical.md
@@ -155,7 +155,8 @@ blocks are never decoded or re-encoded.
 
 ### Compatibility
 
-Metadata format version 6 is a clean rebuild boundary for this layout.
+Metadata format version 6 is a clean rebuild boundary for this layout; format
+7 (row deletion) upgrades format 6 metadata on open without touching segments.
 
 ## Doc postings and skip metadata
 

--- a/docs/posting-codecs.md
+++ b/docs/posting-codecs.md
@@ -91,7 +91,8 @@ blocks.
 ### Format break (fail loud)
 
 This layout originally shipped with metadata format **5**. The current
-reader requires metadata format **6** and STB5 term dictionaries. These
+reader requires metadata format **7** (format **6** is upgraded on open, see
+[row deletion](row-deletion.md)) and STB5 term dictionaries. These
 version numbers belong to separate formats and need not advance together. Older indexes must be rebuilt; see
 [`INDEX_META_FORMAT_VERSION`](../hermes-core/src/index/metadata.rs) and the
 [SSTable format gates](../hermes-core/src/structures/sstable.rs).

--- a/docs/row-deletion.md
+++ b/docs/row-deletion.md
@@ -1,8 +1,13 @@
 # Row deletion, upserts, and compaction
 
 Status: implemented in native/portable core, CLI, gRPC server and broker,
-Python and TypeScript clients, and WASM LocalIndex. Index metadata format 7 is a
-rebuild boundary. Older releases cannot safely read deletion generations.
+Python and TypeScript clients, and WASM LocalIndex. Index metadata format 7 is
+required; format 6 metadata (1.8.121..=1.8.133) is upgraded on open because it
+differs only by the optional `deletions` entry. Readers upgrade in memory with a
+`log::warn!`; writers persist the new stamp on open, after which older releases
+cannot open the index (they would silently drop deletion generations). Segments
+written before 1.8.125 still fail at segment open (BMP blob magic) and need a
+rebuild; segments without `.rowstats` refuse compaction until merged.
 Native mutation APIs require an initialized primary-key index; server and WASM
 writers initialize it automatically. Cross-shard atomic upserts are not supported.
 

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -26,10 +26,21 @@ const INDEX_META_TMP_FILENAME: &str = "metadata.json.tmp";
 
 /// Current metadata.json format version written by this build.
 ///
-/// `load` requires this exact version. Metadata/segment compatibility is a
-/// clean rebuild boundary; serde_json would otherwise silently drop fields it
-/// does not know and a later save could destructively rewrite index state.
+/// `load` requires this version or one it can upgrade in memory (see
+/// [`OLDEST_MIGRATABLE_FORMAT_VERSION`]). Anything else is a clean rebuild
+/// boundary; serde_json would otherwise silently drop fields it does not know
+/// and a later save could destructively rewrite index state.
 pub const INDEX_META_FORMAT_VERSION: u32 = 7;
+
+/// Oldest metadata.json format `load` upgrades in place.
+///
+/// Format 7 only added the optional per-segment `deletions` entry, so format
+/// 6 metadata (1.8.121..=1.8.133) describes the same segment layout. The
+/// upgrade is loud and one-way: the writer persists the new stamp on open so
+/// a format 6 build can never reopen the file and silently drop deletion
+/// generations. Segment-level breaks inside the format 6 window (BMP blob
+/// magic BMP9 -> BMPA in 1.8.125) are still refused at segment open.
+pub const OLDEST_MIGRATABLE_FORMAT_VERSION: u32 = 6;
 
 /// Index-level centroids/codebooks are deliberately bounded before they are
 /// read or decoded. Besides limiting ordinary corruption damage, the matching
@@ -408,7 +419,34 @@ impl IndexMetadata {
     ///
     /// If `metadata.json` is missing but `metadata.json.tmp` exists (crash
     /// between write and rename), recovers from the temp file.
+    ///
+    /// Metadata stamped with a migratable older format is upgraded in memory
+    /// and reported with `log::warn!`; nothing is written here. Writers call
+    /// [`load_reporting_migration`](Self::load_reporting_migration) and persist
+    /// the upgrade themselves.
     pub async fn load<D: crate::directories::Directory>(dir: &D) -> Result<Self> {
+        let (meta, migrated_from) = Self::load_reporting_migration(dir).await?;
+        if let Some(from) = migrated_from {
+            log::warn!(
+                "[metadata_migration] metadata.json format version {from} upgraded in memory \
+                 to {INDEX_META_FORMAT_VERSION} ({} segment(s)); the upgrade is persisted \
+                 when a writer opens this index. Segments from builds before 1.8.125 fail at \
+                 segment open and need a rebuild; segments without .rowstats cannot be \
+                 compacted until they are merged",
+                meta.segment_metas.len()
+            );
+        }
+        Ok(meta)
+    }
+
+    /// [`load`](Self::load) that also returns the on-disk format version when
+    /// it differed from `INDEX_META_FORMAT_VERSION` and was upgraded.
+    ///
+    /// The caller owns the log line and any persistence, so a writer can
+    /// report "persisted" instead of the reader's "in memory only" warning.
+    pub async fn load_reporting_migration<D: crate::directories::Directory>(
+        dir: &D,
+    ) -> Result<(Self, Option<u32>)> {
         let path = Path::new(INDEX_META_FILENAME);
         match dir.open_read(path).await {
             Ok(slice) => {
@@ -420,28 +458,42 @@ impl IndexMetadata {
                 let tmp_path = Path::new(INDEX_META_TMP_FILENAME);
                 let slice = dir.open_read(tmp_path).await?;
                 let bytes = slice.read_bytes().await?;
-                let meta = Self::deserialize_versioned(bytes.as_slice())?;
+                let recovered = Self::deserialize_versioned(bytes.as_slice())?;
                 log::warn!("Recovered metadata from temp file (previous crash during save)");
-                Ok(meta)
+                Ok(recovered)
             }
             Err(e) => Err(Error::Io(e)),
         }
     }
 
-    /// Deserialize only the current format. Vector artifacts are intentionally
-    /// rebuilt when the ANN format changes; silently accepting older metadata
-    /// would mix incompatible segment and global-codebook generations.
-    fn deserialize_versioned(bytes: &[u8]) -> Result<Self> {
-        let meta: Self =
+    /// Deserialize the current format or upgrade a migratable older one,
+    /// returning the original stamp when an upgrade happened. Vector artifacts
+    /// are intentionally rebuilt when the ANN format changes; accepting
+    /// arbitrary older metadata would mix incompatible segment and
+    /// global-codebook generations.
+    fn deserialize_versioned(bytes: &[u8]) -> Result<(Self, Option<u32>)> {
+        let mut meta: Self =
             serde_json::from_slice(bytes).map_err(|e| Error::Serialization(e.to_string()))?;
         crate::dsl::reject_removed_vector_index_types(&meta.schema).map_err(Error::Schema)?;
-        if meta.version != INDEX_META_FORMAT_VERSION {
+        let migrated_from = if meta.version == INDEX_META_FORMAT_VERSION {
+            None
+        } else if (OLDEST_MIGRATABLE_FORMAT_VERSION..INDEX_META_FORMAT_VERSION)
+            .contains(&meta.version)
+        {
+            let from = meta.version;
+            meta.version = INDEX_META_FORMAT_VERSION;
+            Some(from)
+        } else {
             return Err(Error::Corruption(format!(
-                "metadata.json format version {} is incompatible with required version {}; \
+                "metadata.json format version {} is incompatible with required version {} \
+                 (formats {}..={} are upgraded on open); \
                  rebuild and republish the index with this Hermes version",
-                meta.version, INDEX_META_FORMAT_VERSION
+                meta.version,
+                INDEX_META_FORMAT_VERSION,
+                OLDEST_MIGRATABLE_FORMAT_VERSION,
+                INDEX_META_FORMAT_VERSION - 1
             )));
-        }
+        };
         let mut deletion_ids = std::collections::HashSet::new();
         for info in meta.segment_metas.values() {
             if let Some(deletion) = &info.deletions
@@ -455,6 +507,27 @@ impl IndexMetadata {
                     "invalid or aliased deletion metadata".into(),
                 ));
             }
+        }
+        Ok((meta, migrated_from))
+    }
+
+    /// Load for a writer: upgrade a migratable older format and persist the
+    /// new stamp immediately, so the index is never left readable by a build
+    /// that would silently drop the fields this format added.
+    pub(crate) async fn load_persisting_migration<D: crate::directories::DirectoryWriter>(
+        dir: &D,
+    ) -> Result<Self> {
+        let (meta, migrated_from) = Self::load_reporting_migration(dir).await?;
+        if let Some(from) = migrated_from {
+            meta.save(dir).await?;
+            log::warn!(
+                "[metadata_migration] metadata.json format version {from} upgraded to \
+                 {INDEX_META_FORMAT_VERSION} and persisted ({} segment(s)); builds before \
+                 1.8.134 can no longer open this index. Segments from builds before 1.8.125 \
+                 fail at segment open and need a rebuild; segments without .rowstats cannot \
+                 be compacted until they are merged",
+                meta.segment_metas.len()
+            );
         }
         Ok(meta)
     }
@@ -1105,6 +1178,92 @@ mod tests {
             .to_string();
         assert!(
             error.contains(&format!("version {}", INDEX_META_FORMAT_VERSION + 1)),
+            "{error}"
+        );
+        assert!(error.contains("incompatible"), "{error}");
+    }
+
+    fn stamped_previous_format_bytes(metadata: &IndexMetadata) -> Vec<u8> {
+        let mut raw: serde_json::Value =
+            serde_json::from_slice(&metadata.serialize_to_bytes().unwrap()).unwrap();
+        raw["version"] = serde_json::Value::from(INDEX_META_FORMAT_VERSION - 1);
+        serde_json::to_vec(&raw).unwrap()
+    }
+
+    #[tokio::test]
+    async fn load_migrates_format_6_metadata_to_the_current_format() {
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(test_schema());
+        metadata.add_segment("kept".to_string(), 7);
+        directory
+            .write(
+                Path::new(INDEX_META_FILENAME),
+                &stamped_previous_format_bytes(&metadata),
+            )
+            .await
+            .unwrap();
+
+        let (loaded, migrated_from) = IndexMetadata::load_reporting_migration(&directory)
+            .await
+            .expect("format 6 metadata only lacks the optional deletions entry");
+        assert_eq!(migrated_from, Some(INDEX_META_FORMAT_VERSION - 1));
+        assert_eq!(loaded.version, INDEX_META_FORMAT_VERSION);
+        assert_eq!(loaded.segment_metas["kept"].num_docs, 7);
+        assert!(loaded.segment_metas["kept"].deletions.is_none());
+
+        let (_, current) = IndexMetadata::load_reporting_migration(&directory)
+            .await
+            .unwrap();
+        assert_eq!(
+            current,
+            Some(INDEX_META_FORMAT_VERSION - 1),
+            "load alone never persists"
+        );
+        metadata.save(&directory).await.unwrap();
+        let (_, current) = IndexMetadata::load_reporting_migration(&directory)
+            .await
+            .unwrap();
+        assert_eq!(
+            current, None,
+            "current-format metadata reports no migration"
+        );
+    }
+
+    #[tokio::test]
+    async fn tmp_recovery_migrates_format_6_metadata() {
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(test_schema());
+        metadata.add_segment("kept".to_string(), 3);
+        directory
+            .write(
+                Path::new(INDEX_META_TMP_FILENAME),
+                &stamped_previous_format_bytes(&metadata),
+            )
+            .await
+            .unwrap();
+
+        let loaded = IndexMetadata::load(&directory)
+            .await
+            .expect("temp-file recovery applies the same migration");
+        assert_eq!(loaded.version, INDEX_META_FORMAT_VERSION);
+        assert_eq!(loaded.segment_metas["kept"].num_docs, 3);
+    }
+
+    #[tokio::test]
+    async fn load_refuses_metadata_older_than_format_6() {
+        // Format 5 predates the position-list v3 layout; its segments are
+        // unreadable, so the stamp must stay a rebuild boundary.
+        let directory = crate::directories::RamDirectory::new();
+        let mut metadata = IndexMetadata::new(test_schema());
+        metadata.version = INDEX_META_FORMAT_VERSION - 2;
+        metadata.save(&directory).await.unwrap();
+
+        let error = IndexMetadata::load(&directory)
+            .await
+            .expect_err("metadata two formats old must be refused")
+            .to_string();
+        assert!(
+            error.contains(&format!("version {}", INDEX_META_FORMAT_VERSION - 2)),
             "{error}"
         );
         assert!(error.contains("incompatible"), "{error}");

--- a/hermes-core/src/index/tests/format_migration.rs
+++ b/hermes-core/src/index/tests/format_migration.rs
@@ -1,0 +1,129 @@
+//! Regressions for the metadata format 6 -> 7 upgrade path.
+//!
+//! Format 7 only added the optional per-segment `deletions` entry, so a format
+//! 6 `metadata.json` written by 1.8.125..=1.8.133 describes segments this build
+//! reads unchanged. Opening it must upgrade the stamp loudly instead of
+//! refusing, and a writer must persist the upgrade so older builds cannot
+//! later drop deletion generations from the same file.
+
+use std::path::Path;
+
+use crate::directories::{Directory, DirectoryWriter, RamDirectory};
+use crate::dsl::{Document, SchemaBuilder};
+use crate::index::metadata::{INDEX_META_FILENAME, INDEX_META_FORMAT_VERSION};
+use crate::index::{Index, IndexConfig, IndexMetadata, IndexWriter};
+use crate::query::TermQuery;
+
+const PREVIOUS_FORMAT_VERSION: u32 = INDEX_META_FORMAT_VERSION - 1;
+
+async fn on_disk_version(dir: &RamDirectory) -> u64 {
+    let bytes = dir
+        .open_read(Path::new(INDEX_META_FILENAME))
+        .await
+        .unwrap()
+        .read_bytes()
+        .await
+        .unwrap();
+    let raw: serde_json::Value = serde_json::from_slice(bytes.as_slice()).unwrap();
+    raw["version"].as_u64().unwrap()
+}
+
+/// Build a committed index, then rewrite its metadata stamp to the previous
+/// format exactly as a 1.8.133 build would have left it.
+async fn format_6_fixture() -> (RamDirectory, IndexConfig, crate::dsl::Field) {
+    let mut schema = SchemaBuilder::default();
+    let body = schema.add_text_field("body", true, true);
+    let schema = schema.build();
+    let dir = RamDirectory::new();
+    let config = IndexConfig {
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..IndexConfig::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    for i in 0..3 {
+        let mut doc = Document::new();
+        doc.add_text(body, format!("needle value{i}"));
+        writer.add_document(doc).unwrap();
+        writer.commit().await.unwrap();
+    }
+    drop(writer);
+
+    let bytes = dir
+        .open_read(Path::new(INDEX_META_FILENAME))
+        .await
+        .unwrap()
+        .read_bytes()
+        .await
+        .unwrap();
+    let mut raw: serde_json::Value = serde_json::from_slice(bytes.as_slice()).unwrap();
+    assert_eq!(
+        raw["version"].as_u64().unwrap(),
+        u64::from(INDEX_META_FORMAT_VERSION)
+    );
+    raw["version"] = serde_json::Value::from(PREVIOUS_FORMAT_VERSION);
+    dir.write(
+        Path::new(INDEX_META_FILENAME),
+        &serde_json::to_vec(&raw).unwrap(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        on_disk_version(&dir).await,
+        u64::from(PREVIOUS_FORMAT_VERSION)
+    );
+    (dir, config, body)
+}
+
+async fn count_hits(index: &Index<RamDirectory>, body: crate::dsl::Field) -> usize {
+    let reader = index.reader().await.unwrap();
+    let searcher = reader.searcher().await.unwrap();
+    let query = TermQuery::text(body, "needle");
+    searcher.search(&query, 10).await.unwrap().len()
+}
+
+#[tokio::test]
+async fn writer_open_migrates_format_6_metadata_and_persists_format_7() {
+    let (dir, config, body) = format_6_fixture().await;
+
+    let (index, _writer) = Index::open_with_writer(dir.clone(), config)
+        .await
+        .expect("a format 6 index written after 1.8.125 must open");
+
+    assert_eq!(
+        on_disk_version(&dir).await,
+        u64::from(INDEX_META_FORMAT_VERSION),
+        "the writer must persist the upgraded stamp before serving"
+    );
+    let metadata = IndexMetadata::load(&dir).await.unwrap();
+    assert_eq!(metadata.version, INDEX_META_FORMAT_VERSION);
+    assert_eq!(
+        metadata.segment_metas.len(),
+        3,
+        "migration must keep every segment"
+    );
+    assert!(
+        metadata
+            .segment_metas
+            .values()
+            .all(|m| m.deletions.is_none()),
+        "format 6 segments carry no deletion generation"
+    );
+    assert_eq!(count_hits(&index, body).await, 3);
+}
+
+#[tokio::test]
+async fn read_only_open_migrates_format_6_metadata_in_memory() {
+    let (dir, config, body) = format_6_fixture().await;
+
+    let index = Index::open(dir.clone(), config)
+        .await
+        .expect("a read-only open must not refuse format 6");
+    assert_eq!(count_hits(&index, body).await, 3);
+    assert_eq!(
+        on_disk_version(&dir).await,
+        u64::from(PREVIOUS_FORMAT_VERSION),
+        "a search-only open never rewrites metadata"
+    );
+}

--- a/hermes-core/src/index/tests/mod.rs
+++ b/hermes-core/src/index/tests/mod.rs
@@ -2,6 +2,7 @@ mod basic;
 mod bmp;
 mod boolean;
 mod chunked;
+mod format_migration;
 mod maintenance;
 mod merge;
 mod pin;

--- a/hermes-core/src/index/wasm_writer.rs
+++ b/hermes-core/src/index/wasm_writer.rs
@@ -105,7 +105,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
         builder_config: SegmentBuilderConfig,
     ) -> Result<Self> {
         let directory = Arc::new(directory);
-        let metadata = IndexMetadata::load(directory.as_ref()).await?;
+        let metadata = IndexMetadata::load_persisting_migration(directory.as_ref()).await?;
         let schema = Arc::new(metadata.schema.clone());
 
         let mut writer =

--- a/hermes-core/src/index/writer.rs
+++ b/hermes-core/src/index/writer.rs
@@ -760,7 +760,7 @@ impl<D: DirectoryWriter + 'static> IndexWriter<D> {
             return Err(Error::Internal(reason.clone()));
         }
 
-        let metadata = super::IndexMetadata::load(directory.as_ref()).await?;
+        let metadata = super::IndexMetadata::load_persisting_migration(directory.as_ref()).await?;
         let schema = Arc::new(metadata.schema.clone());
         // Directory-layer metrics (cold writes, lazy reads) carry the index label
         directory.set_index_label(schema.index_label());


### PR DESCRIPTION
Format 7 only added the optional per-segment `deletions` entry, so format 6 metadata (1.8.121..=1.8.133) describes segments this build already reads. Loading now stamps it 7 in memory with a `log::warn!`; writers persist the stamp on open so older builds cannot reopen the file and silently drop deletion generations. Formats older than 6 remain a rebuild boundary.

Caveats surfaced in the warnings: segments from builds before 1.8.125 still fail at segment open (BMP blob magic), and segments without `.rowstats` refuse compaction until merged.

Tests: end-to-end writer-open persistence and read-only in-memory upgrade regressions, plus unit tests for temp-file recovery and the format 5 refusal. `scripts/check_search.py check`, wasm32 feature check, and `cargo doc -D warnings` passed.