### PR TITLE
Stop retired reorder work from starving index commits

### DIFF
--- a/docs/segment-lifecycle.md
+++ b/docs/segment-lifecycle.md
@@ -95,6 +95,19 @@ pending commit flushes without waiting for an uncancelled full BP pass. Forced
 process termination is still outside the guarantee; deployments must allow
 adequate termination grace and drain/commit ingestion before restarting.
 
+Forward construction also observes cancellation: document-map validation, forward
+payload validation, frequency counting and CSR construction check between bounded
+units of work in both record and block modes. Parallel errors join the started
+workers and discard the partial graph before returning `IndexClosed`. This cannot
+interrupt an individual kernel I/O call or allocator operation already in progress.
+
+Upsert/deletion publication runs its serial primary-key and row-visibility scans
+on Tokio's blocking executor. It must not queue these scans on the bulk BP pool
+while holding publication state: a reorder on another index can occupy every BP
+worker, preventing the commit from releasing its writer lock. The existing
+per-index transaction and commit-finalizer ownership still serialize publication
+and protect it from caller cancellation.
+
 Index deletion follows this order:
 
 1. Acquire the per-index registry lease and create `.deleting`, serializing

--- a/hermes-core/src/index/metadata.rs
+++ b/hermes-core/src/index/metadata.rs
@@ -514,6 +514,7 @@ impl IndexMetadata {
     /// Load for a writer: upgrade a migratable older format and persist the
     /// new stamp immediately, so the index is never left readable by a build
     /// that would silently drop the fields this format added.
+    #[cfg(any(feature = "native", feature = "wasm"))]
     pub(crate) async fn load_persisting_migration<D: crate::directories::DirectoryWriter>(
         dir: &D,
     ) -> Result<Self> {

--- a/hermes-core/src/index/tests/bmp.rs
+++ b/hermes-core/src/index/tests/bmp.rs
@@ -3595,7 +3595,7 @@ async fn bench_forward_index_build() {
     }
     for round in 0..3 {
         let t = std::time::Instant::now();
-        let fwd = build_forward_index_from_blocks(&[&bmp], budget);
+        let fwd = build_forward_index_from_blocks(&[&bmp], budget, &|| Ok(())).unwrap();
         println!(
             "block-level fwd build round {}: {:.1}ms ({} terms, {} postings)",
             round,

--- a/hermes-core/src/index/tests/primary_key.rs
+++ b/hermes-core/src/index/tests/primary_key.rs
@@ -1407,3 +1407,66 @@ async fn ordinary_merge_carries_concurrent_deletes_upserts_and_pending_key_reser
         132
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn upsert_commit_finishes_while_background_maintenance_pool_is_occupied() {
+    use std::sync::Arc;
+    use std::time::Duration;
+    let (schema, pk, title) = make_schema();
+    let dir = RamDirectory::new();
+    let pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap(),
+    );
+    let config = IndexConfig {
+        background_reorder_pool: Some(pool.clone()),
+        merge_policy: Box::new(crate::merge::NoMergePolicy),
+        ..Default::default()
+    };
+    let mut writer = IndexWriter::create(dir.clone(), schema, config.clone())
+        .await
+        .unwrap();
+    writer.init_primary_key_dedup().await.unwrap();
+    writer
+        .add_document(make_doc(pk, title, "same", "old"))
+        .unwrap();
+    writer.commit().await.unwrap();
+    writer
+        .upsert_document(make_doc(pk, title, "same", "replacement"))
+        .unwrap();
+    let (release, blocked) = std::sync::mpsc::channel();
+    let (started, ready) = tokio::sync::oneshot::channel();
+    pool.spawn(move || {
+        let _ = started.send(());
+        let _ = blocked.recv();
+    });
+    ready.await.unwrap();
+    let committed = tokio::time::timeout(Duration::from_secs(3), writer.commit()).await;
+    // Always release the pool before asserting so a failing regression cannot
+    // strand the commit finalizer or the test runtime during shutdown.
+    release.send(()).unwrap();
+    writer.wait_for_commit_finalization().await;
+    committed
+        .expect("publication queued behind bulk maintenance")
+        .unwrap();
+    let index = crate::index::Index::open(dir, config).await.unwrap();
+    let searcher = index.reader().await.unwrap().searcher().await.unwrap();
+    assert_eq!(searcher.num_docs(), 1);
+    assert_eq!(
+        searcher
+            .search(&crate::query::TermQuery::new(title, "replacement"), 10)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert!(
+        searcher
+            .search(&crate::query::TermQuery::new(title, "old"), 10)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/hermes-core/src/merge/row_mutation.rs
+++ b/hermes-core/src/merge/row_mutation.rs
@@ -44,27 +44,25 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                 // the source dictionary/row count. Decode global ordinals in
                 // batches instead of looking up and hashing each row's text.
                 let cancellation = manager.active_operations.cancellation_flag();
-                let pool = manager.background_cpu_pool();
-                let lookup_pool = Arc::clone(&pool);
                 let lookup_cancellation = Arc::clone(&cancellation);
                 let keys = Arc::clone(&keys);
                 let num_docs = info.num_docs;
+                // Publication holds the state lock. Run its bounded serial scan
+                // directly on Tokio's blocking executor, never behind bulk BP.
                 let (ff, ordinals) = tokio::task::spawn_blocking(move || {
-                    lookup_pool.install(|| {
-                        let ordinals = crate::segment::deletion::target_ordinals(
-                            &ff,
-                            num_docs,
-                            keys.iter().map(String::as_str),
-                            || {
-                                if lookup_cancellation.load(Ordering::Acquire) {
-                                    Err(Error::IndexClosed)
-                                } else {
-                                    Ok(())
-                                }
-                            },
-                        )?;
-                        Ok::<_, Error>((ff, ordinals))
-                    })
+                    let ordinals = crate::segment::deletion::target_ordinals(
+                        &ff,
+                        num_docs,
+                        keys.iter().map(String::as_str),
+                        || {
+                            if lookup_cancellation.load(Ordering::Acquire) {
+                                Err(Error::IndexClosed)
+                            } else {
+                                Ok(())
+                            }
+                        },
+                    )?;
+                    Ok::<_, Error>((ff, ordinals))
                 })
                 .await
                 .map_err(|error| {
@@ -80,21 +78,19 @@ impl<D: DirectoryWriter + 'static> SegmentManager<D> {
                     None => DocBitset::all(info.num_docs),
                 };
                 let (alive, changed) = tokio::task::spawn_blocking(move || {
-                    pool.install(|| {
-                        let changed = crate::segment::deletion::clear_target_rows(
-                            &ff,
-                            &ordinals,
-                            &mut alive,
-                            || {
-                                if cancellation.load(Ordering::Acquire) {
-                                    Err(Error::IndexClosed)
-                                } else {
-                                    Ok(())
-                                }
-                            },
-                        )?;
-                        Ok::<_, Error>((alive, changed))
-                    })
+                    let changed = crate::segment::deletion::clear_target_rows(
+                        &ff,
+                        &ordinals,
+                        &mut alive,
+                        || {
+                            if cancellation.load(Ordering::Acquire) {
+                                Err(Error::IndexClosed)
+                            } else {
+                                Ok(())
+                            }
+                        },
+                    )?;
+                    Ok::<_, Error>((alive, changed))
                 })
                 .await
                 .map_err(|error| Error::Internal(format!("deletion worker failed: {error}")))??;

--- a/hermes-core/src/query/bmp_forward_lookup_experiment.rs
+++ b/hermes-core/src/query/bmp_forward_lookup_experiment.rs
@@ -146,7 +146,7 @@ fn measure_layout(index: &BmpIndex, layout: &str) {
         .filter_map(|(i, &term)| (mask & (1 << i) != 0).then_some(term))
         .collect();
     let forward = index.forward().unwrap();
-    let validated = forward.validate_payload().unwrap();
+    let validated = forward.validate_payload(&|| Ok(())).unwrap();
     assert!(index.dims() <= MAX_TABLE_DIMS);
     let mut table = vec![0u32; index.dims() as usize];
     refresh_table(&mut table, &[], &remaining);

--- a/hermes-core/src/segment/bmp_forward.rs
+++ b/hermes-core/src/segment/bmp_forward.rs
@@ -177,8 +177,12 @@ impl BmpForward {
     }
 
     #[cfg(any(feature = "native", feature = "wasm", test))]
-    pub(crate) fn validate_payload(&self) -> Result<ValidatedForward<'_>> {
+    pub(crate) fn validate_payload(
+        &self,
+        check_cancel: &(impl Fn() -> Result<()> + Sync),
+    ) -> Result<ValidatedForward<'_>> {
         for i in 0..self.len() {
+            check_cancel()?;
             self.vector(i)?;
         }
         Ok(ValidatedForward(self))

--- a/hermes-core/src/segment/bmp_forward/rewrite.rs
+++ b/hermes-core/src/segment/bmp_forward/rewrite.rs
@@ -66,7 +66,9 @@ pub(crate) fn write_forward_sources(
             remaining = remaining.checked_sub(bytes).ok_or_else(|| Error::Schema(
                 "BMP forward materialization exceeds the reorder memory budget; increase bp-memory-budget-mb".into()))?;
             slots = Vec::with_capacity(bmp.num_real_docs() as usize);
-            bmp.visit_real_slots_for_rewrite(|slot| slots.push(slot as u32))?;
+            bmp.visit_real_slots_for_rewrite(&|| cancelled(cancellation), |slot| {
+                slots.push(slot as u32)
+            })?;
             slots.sort_unstable_by_key(|&slot| bmp.virtual_to_doc(slot));
             offsets = Vec::with_capacity(slots.len());
             log::info!(

--- a/hermes-core/src/segment/bmp_forward/tests.rs
+++ b/hermes-core/src/segment/bmp_forward/tests.rs
@@ -648,7 +648,7 @@ async fn forward_duplicate_impacts_survive_copy_merge_and_storage_enablement() {
                 .copied()
                 .collect();
             assert_eq!(forward.payload.as_slice(), expected);
-            forward.validate_payload().unwrap();
+            forward.validate_payload(&|| Ok(())).unwrap();
         }
     }
 }
@@ -829,4 +829,107 @@ fn enabled_forward_storage_keeps_the_published_bytes() {
     });
     assert_eq!(bytes.len(), 12_713);
     assert_eq!(hash, 0x5ccfbcdae3690623);
+}
+
+#[test]
+fn forward_construction_cancels_during_validation_counting_and_csr_fill() {
+    use crate::segment::builder::graph_bisection::{
+        build_forward_index_from_bmps_with_maps, build_vid_maps,
+    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    for storage in [false, true] {
+        let bmp = fixture_with_storage(128, false, storage);
+        let maps = vec![build_vid_maps(&bmp, &|| Ok(())).unwrap()];
+        let checks = AtomicUsize::new(0);
+        let complete = build_forward_index_from_bmps_with_maps(
+            &[&bmp],
+            &maps,
+            1,
+            1000,
+            16 * 1024 * 1024,
+            &|| {
+                checks.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert!(complete.total_postings() > 0);
+        let total = checks.load(Ordering::Relaxed);
+        assert!(total > 4, "forward construction never checks cancellation");
+        for stop in [1, total / 4, total / 2, total - 1] {
+            checks.store(0, Ordering::Relaxed);
+            let result = build_forward_index_from_bmps_with_maps(
+                &[&bmp],
+                &maps,
+                1,
+                1000,
+                16 * 1024 * 1024,
+                &|| {
+                    if checks.fetch_add(1, Ordering::Relaxed) >= stop {
+                        Err(crate::Error::IndexClosed)
+                    } else {
+                        Ok(())
+                    }
+                },
+            );
+            assert!(
+                matches!(result, Err(crate::Error::IndexClosed)),
+                "cancelled construction produced a graph at checkpoint {stop}/{total}"
+            );
+        }
+    }
+}
+
+#[test]
+fn block_forward_construction_cancels_before_returning_a_partial_graph() {
+    use crate::segment::builder::graph_bisection::build_forward_index_from_blocks;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let mut postings = rustc_hash::FxHashMap::default();
+    for doc in 0..2048 {
+        postings
+            .entry(doc / 128)
+            .or_insert_with(Vec::new)
+            .push((doc, 0, 1.0));
+    }
+    let mut bytes = Vec::new();
+    crate::segment::builder::bmp::build_bmp_blob(
+        postings, 32, 4, 0.0, None, 32, 5.0, 0, true, &mut bytes,
+    )
+    .unwrap();
+    let bmp = parse(bytes, 2048, 2048);
+    let checks = AtomicUsize::new(0);
+    let complete = build_forward_index_from_blocks(&[&bmp], 16 * 1024 * 1024, &|| {
+        checks.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    })
+    .unwrap();
+    assert!(complete.num_docs() > 0);
+    let total = checks.load(Ordering::Relaxed);
+    for stop in [1, total / 4, total / 2, total - 1] {
+        checks.store(0, Ordering::Relaxed);
+        let result = build_forward_index_from_blocks(&[&bmp], 16 * 1024 * 1024, &|| {
+            if checks.fetch_add(1, Ordering::Relaxed) >= stop {
+                Err(crate::Error::IndexClosed)
+            } else {
+                Ok(())
+            }
+        });
+        assert!(matches!(result, Err(crate::Error::IndexClosed)));
+    }
+}
+
+#[test]
+fn rewrite_document_map_scan_observes_cancellation_mid_scan() {
+    use crate::segment::builder::graph_bisection::build_vid_maps;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let bmp = fixture(2048);
+    let checks = AtomicUsize::new(0);
+    let result = build_vid_maps(&bmp, &|| {
+        if checks.fetch_add(1, Ordering::Relaxed) >= 3 {
+            Err(crate::Error::IndexClosed)
+        } else {
+            Ok(())
+        }
+    });
+    assert!(matches!(result, Err(crate::Error::IndexClosed)));
 }

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -54,17 +54,20 @@ fn count_frequencies_bounded<T: FrequencyParallelSafe>(
     items: &[T],
     num_terms: usize,
     available_bytes: usize,
-    count_item: impl Fn(&T, &mut [u32]) + FrequencyParallelSafe,
-) -> Option<Vec<u32>> {
+    count_item: impl Fn(&T, &mut [u32]) -> crate::Result<()> + FrequencyParallelSafe,
+) -> crate::Result<Option<Vec<u32>>> {
     if num_terms == 0 {
-        return Some(Vec::new());
+        return Ok(Some(Vec::new()));
     }
-    let table_bytes = num_terms
-        .checked_mul(std::mem::size_of::<u32>())?
-        .checked_add(std::mem::size_of::<Vec<u32>>())?;
-    let affordable_tables = available_bytes.checked_div(table_bytes)?;
+    let Some(table_bytes) = num_terms
+        .checked_mul(std::mem::size_of::<u32>())
+        .and_then(|bytes| bytes.checked_add(std::mem::size_of::<Vec<u32>>()))
+    else {
+        return Ok(None);
+    };
+    let affordable_tables = available_bytes / table_bytes;
     if affordable_tables == 0 {
-        return None;
+        return Ok(None);
     }
 
     #[cfg(feature = "native")]
@@ -79,24 +82,25 @@ fn count_frequencies_bounded<T: FrequencyParallelSafe>(
                 .map(|chunk| {
                     let mut counts = vec![0u32; num_terms];
                     for item in chunk {
-                        count_item(item, &mut counts);
+                        count_item(item, &mut counts)?;
                     }
-                    counts
+                    Ok(counts)
                 })
-                .reduce_with(|mut left, right| {
+                .try_reduce_with(|mut left, right| {
                     for (total, count) in left.iter_mut().zip(right) {
                         *total = total.saturating_add(count);
                     }
-                    left
-                });
+                    Ok(left)
+                })
+                .transpose();
         }
     }
 
     let mut counts = vec![0u32; num_terms];
     for item in items {
-        count_item(item, &mut counts);
+        count_item(item, &mut counts)?;
     }
-    Some(counts)
+    Ok(Some(counts))
 }
 
 /// Retain the lowest-frequency eligible dimensions while the frequency table
@@ -445,13 +449,19 @@ pub(crate) struct ForwardIndex {
 
 /// Build CSR offsets (prefix sums) from per-entity counts. u64 output — the
 /// sum of counts legitimately exceeds u32::MAX on large reorder passes.
-fn build_csr_offsets(counts: &[u32]) -> Vec<u64> {
+fn build_csr_offsets(
+    counts: &[u32],
+    check_cancel: &(impl Fn() -> crate::Result<()> + Sync),
+) -> crate::Result<Vec<u64>> {
     let mut offsets = Vec::with_capacity(counts.len() + 1);
     offsets.push(0u64);
-    for &c in counts {
+    for (i, &c) in counts.iter().enumerate() {
+        if i.is_multiple_of(256) {
+            check_cancel()?;
+        }
         offsets.push(offsets.last().unwrap() + c as u64);
     }
-    offsets
+    Ok(offsets)
 }
 
 impl ForwardIndex {
@@ -519,14 +529,16 @@ impl ForwardIndex {
 /// is the dense real index or `u32::MAX` for padding.
 pub(crate) fn build_vid_maps(
     bmp: &crate::segment::reader::bmp::BmpIndex,
+    check_cancel: &(impl Fn() -> crate::Result<()> + Sync),
 ) -> crate::Result<(Vec<u32>, Vec<u32>)> {
+    check_cancel()?;
     let ids = bmp.doc_map_ids_slice();
     let num_virtual = bmp.num_virtual_docs as usize;
     let expected_real = bmp.num_real_docs() as usize;
     let mut virtual_to_real = vec![u32::MAX; num_virtual];
     let mut real_to_virtual = Vec::with_capacity(expected_real);
     debug_assert_eq!(ids.len(), virtual_to_real.len() * 4);
-    bmp.visit_real_slots_for_rewrite(|vid| {
+    bmp.visit_real_slots_for_rewrite_cancellable(check_cancel, |vid| {
         virtual_to_real[vid] = real_to_virtual.len() as u32;
         real_to_virtual.push(vid as u32);
     })?;
@@ -552,13 +564,15 @@ struct BlockJob {
 fn build_block_jobs(
     bmps: &[&crate::segment::reader::bmp::BmpIndex],
     vid_maps: &[(Vec<u32>, Vec<u32>)],
-) -> Vec<BlockJob> {
+    check_cancel: &(impl Fn() -> crate::Result<()> + Sync),
+) -> crate::Result<Vec<BlockJob>> {
     let total_blocks: usize = bmps.iter().map(|b| b.num_blocks as usize).sum();
     let mut jobs = Vec::with_capacity(total_blocks);
     for (src, (bmp, (v2r, _))) in bmps.iter().zip(vid_maps).enumerate() {
         let block_size = bmp.bmp_block_size as usize;
         let mut real_cursor = 0u32;
         for block_id in 0..bmp.num_blocks as usize {
+            check_cancel()?;
             let vid_start = block_id * block_size;
             let vid_end = ((block_id + 1) * block_size).min(v2r.len());
             let real_len = v2r[vid_start..vid_end]
@@ -574,7 +588,7 @@ fn build_block_jobs(
             real_cursor += real_len;
         }
     }
-    jobs
+    Ok(jobs)
 }
 
 fn visit_bmp_job(
@@ -583,12 +597,15 @@ fn visit_bmp_job(
     vid_maps: &[(Vec<u32>, Vec<u32>)],
     forward_views: &[Option<crate::segment::bmp_forward::ValidatedForward<'_>>],
     mut visit: impl FnMut(u32, u32),
-) {
+    check_cancel: &(impl Fn() -> crate::Result<()> + Sync),
+) -> crate::Result<()> {
+    check_cancel()?;
     let bmp = bmps[job.src as usize];
     let (v2r, r2v) = &vid_maps[job.src as usize];
     if let Some(view) = &forward_views[job.src as usize] {
         let forward = bmp.forward().expect("validated forward source");
         for real in job.real_start..job.real_start + job.real_len {
+            check_cancel()?;
             let (doc, ordinal) = bmp.virtual_to_doc(r2v[real as usize]);
             let index = forward
                 .find(crate::segment::logical_address::LogicalUnit { doc, ordinal })
@@ -599,6 +616,7 @@ fn visit_bmp_job(
         }
     } else {
         for (dim, _, postings) in bmp.iter_block_terms(job.block_id) {
+            check_cancel()?;
             for posting in postings {
                 let vid = job.block_id as usize * bmp.bmp_block_size as usize
                     + posting.local_slot as usize;
@@ -611,6 +629,7 @@ fn visit_bmp_job(
             }
         }
     }
+    Ok(())
 }
 
 /// Build forward index from BmpIndex sources (single or multi-source).
@@ -635,7 +654,7 @@ pub(crate) fn build_forward_index_from_bmps(
 ) -> crate::Result<ForwardIndex> {
     let vid_maps: Vec<(Vec<u32>, Vec<u32>)> = bmps
         .iter()
-        .map(|bmp| build_vid_maps(bmp))
+        .map(|bmp| build_vid_maps(bmp, &|| Ok(())))
         .collect::<crate::Result<_>>()?;
     build_forward_index_from_bmps_with_maps(
         bmps,
@@ -643,6 +662,7 @@ pub(crate) fn build_forward_index_from_bmps(
         min_doc_freq,
         max_doc_freq,
         memory_budget_bytes,
+        &|| Ok(()),
     )
 }
 
@@ -655,7 +675,9 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
     min_doc_freq: usize,
     max_doc_freq: usize,
     memory_budget_bytes: usize,
+    check_cancel: &(impl Fn() -> crate::Result<()> + Sync),
 ) -> crate::Result<ForwardIndex> {
+    check_cancel()?;
     debug_assert_eq!(bmps.len(), vid_maps.len());
     let total_docs: usize = vid_maps.iter().map(|(_, r2v)| r2v.len()).sum();
 
@@ -674,7 +696,8 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
     // ascending vid order (see build_vid_maps), so each block owns a
     // contiguous real-id range — every phase below can process blocks in
     // parallel, writing disjoint slices.
-    let jobs = build_block_jobs(bmps, vid_maps);
+    let jobs = build_block_jobs(bmps, vid_maps, check_cancel)?;
+    check_cancel()?;
     let forward_views = bmps
         .iter()
         .zip(vid_maps)
@@ -683,6 +706,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
                 return Ok(None);
             };
             for &vid in r2v {
+                check_cancel()?;
                 let (doc, ordinal) = bmp.virtual_to_doc(vid);
                 if forward
                     .find(crate::segment::logical_address::LogicalUnit { doc, ordinal })
@@ -693,7 +717,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
                     ));
                 }
             }
-            forward.validate_payload().map(Some)
+            forward.validate_payload(check_cancel).map(Some)
         })
         .collect::<crate::Result<Vec<_>>>()?;
 
@@ -729,13 +753,21 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         max_dims,
         memory_budget_bytes.saturating_sub(jobs_bytes),
         |job, counts| {
-            visit_bmp_job(job, bmps, vid_maps, &forward_views, |_, dim| {
-                if let Some(total) = counts.get_mut(dim as usize) {
-                    *total = total.saturating_add(1);
-                }
-            });
+            visit_bmp_job(
+                job,
+                bmps,
+                vid_maps,
+                &forward_views,
+                |_, dim| {
+                    if let Some(total) = counts.get_mut(dim as usize) {
+                        *total = total.saturating_add(1);
+                    }
+                },
+                check_cancel,
+            )
         },
-    ) else {
+    )?
+    else {
         log::warn!(
             "[reorder] memory budget {} cannot hold a bounded dimension-frequency table; using identity order",
             crate::format_bytes(memory_budget_bytes as u64),
@@ -799,6 +831,7 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         });
     }
 
+    check_cancel()?;
     let mut term_remap = vec![u32::MAX; max_dims];
     for (compact_id, &(dim_id, _)) in eligible.iter().enumerate() {
         term_remap[dim_id as usize] = compact_id as u32;
@@ -819,16 +852,24 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
     // Phase 2: count terms per doc (filtered) — per-block disjoint slices
     let mut counts = vec![0u32; total_docs];
     let fill_block_counts = |job: &BlockJob, out: &mut [u32]| {
-        visit_bmp_job(job, bmps, vid_maps, &forward_views, |real, dim| {
-            if term_remap.get(dim as usize).copied().unwrap_or(u32::MAX) != u32::MAX {
-                out[(real - job.real_start) as usize] += 1;
-            }
-        });
+        visit_bmp_job(
+            job,
+            bmps,
+            vid_maps,
+            &forward_views,
+            |real, dim| {
+                if term_remap.get(dim as usize).copied().unwrap_or(u32::MAX) != u32::MAX {
+                    out[(real - job.real_start) as usize] += 1;
+                }
+            },
+            check_cancel,
+        )
     };
     {
         let mut slices: Vec<(&BlockJob, &mut [u32])> = Vec::with_capacity(jobs.len());
         let mut rest: &mut [u32] = &mut counts;
         for job in &jobs {
+            check_cancel()?;
             let (head, tail) = rest.split_at_mut(job.real_len as usize);
             slices.push((job, head));
             rest = tail;
@@ -836,15 +877,17 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         #[cfg(feature = "native")]
         slices
             .into_par_iter()
-            .for_each(|(job, out)| fill_block_counts(job, out));
+            .try_for_each(|(job, out)| fill_block_counts(job, out))?;
         #[cfg(not(feature = "native"))]
         for (job, out) in slices {
-            fill_block_counts(job, out);
+            fill_block_counts(job, out)?;
         }
     }
 
     // Phase 3: build CSR offsets (u64 — sums exceed u32::MAX at scale)
-    let offsets = build_csr_offsets(&counts);
+    check_cancel()?;
+    let offsets = build_csr_offsets(&counts, check_cancel)?;
+    check_cancel()?;
     let total = *offsets.last().unwrap() as usize;
     drop(counts);
 
@@ -854,22 +897,30 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
     let fill_block_terms = |job: &BlockJob, global_real_start: usize, out: &mut [u32]| {
         let mut cursor = [0u32; 256];
         let base = offsets[global_real_start] as usize;
-        visit_bmp_job(job, bmps, vid_maps, &forward_views, |real, dim| {
-            let compact = term_remap.get(dim as usize).copied().unwrap_or(u32::MAX);
-            if compact != u32::MAX {
-                let local = (real - job.real_start) as usize;
-                let pos =
-                    offsets[global_real_start + local] as usize - base + cursor[local] as usize;
-                out[pos] = compact;
-                cursor[local] += 1;
-            }
-        });
+        visit_bmp_job(
+            job,
+            bmps,
+            vid_maps,
+            &forward_views,
+            |real, dim| {
+                let compact = term_remap.get(dim as usize).copied().unwrap_or(u32::MAX);
+                if compact != u32::MAX {
+                    let local = (real - job.real_start) as usize;
+                    let pos =
+                        offsets[global_real_start + local] as usize - base + cursor[local] as usize;
+                    out[pos] = compact;
+                    cursor[local] += 1;
+                }
+            },
+            check_cancel,
+        )
     };
     {
         let mut slices: Vec<(&BlockJob, usize, &mut [u32])> = Vec::with_capacity(jobs.len());
         let mut rest: &mut [u32] = &mut terms;
         let mut global_real = 0usize;
         for job in &jobs {
+            check_cancel()?;
             let len =
                 (offsets[global_real + job.real_len as usize] - offsets[global_real]) as usize;
             let (head, tail) = rest.split_at_mut(len);
@@ -880,13 +931,14 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
         #[cfg(feature = "native")]
         slices
             .into_par_iter()
-            .for_each(|(job, g, out)| fill_block_terms(job, g, out));
+            .try_for_each(|(job, g, out)| fill_block_terms(job, g, out))?;
         #[cfg(not(feature = "native"))]
         for (job, g, out) in slices {
-            fill_block_terms(job, g, out);
+            fill_block_terms(job, g, out)?;
         }
     }
 
+    check_cancel()?;
     Ok(ForwardIndex {
         terms,
         offsets,
@@ -912,25 +964,32 @@ pub(crate) fn build_forward_index_from_bmps_with_maps(
 pub(crate) fn build_forward_index_from_blocks(
     bmps: &[&crate::segment::reader::bmp::BmpIndex],
     memory_budget_bytes: usize,
-) -> ForwardIndex {
+    check_cancel: &(impl Fn() -> crate::Result<()> + Sync),
+) -> crate::Result<ForwardIndex> {
+    check_cancel()?;
     let total_blocks: usize = bmps.iter().map(|b| b.num_blocks as usize).sum();
     if total_blocks == 0 {
-        return ForwardIndex {
+        return Ok(ForwardIndex {
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
             cache_gains: false,
             budget_limited: false,
-        };
+        });
     }
 
     // (source, block) pairs in global block order — the parallel unit.
     let blocks: Vec<(u32, u32)> = bmps
         .iter()
         .enumerate()
-        .flat_map(|(src, bmp)| (0..bmp.num_blocks).map(move |b| (src as u32, b)))
-        .collect();
+        .flat_map(|(src, bmp)| {
+            (0..bmp.num_blocks).map(move |b| {
+                check_cancel()?;
+                Ok((src as u32, b))
+            })
+        })
+        .collect::<crate::Result<_>>()?;
 
     // Phase 1: bounded worker-local frequency tables. This is the same policy
     // as record-level BP and avoids hot atomic increments on common terms.
@@ -947,38 +1006,42 @@ pub(crate) fn build_forward_index_from_blocks(
         log::warn!(
             "[reorder] block-level frequency table exceeds memory budget; using identity order"
         );
-        return ForwardIndex {
+        return Ok(ForwardIndex {
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
             cache_gains: false,
             budget_limited: true,
-        };
+        });
     }
     let Some(dim_bf) = count_frequencies_bounded(
         &blocks,
         max_dims,
         memory_budget_bytes.saturating_sub(blocks_bytes),
         |&(src, block_id), counts| {
+            check_cancel()?;
             for (dim_id, _, _) in bmps[src as usize].iter_block_terms(block_id) {
+                check_cancel()?;
                 if let Some(count) = counts.get_mut(dim_id as usize) {
                     *count = count.saturating_add(1);
                 }
             }
+            Ok(())
         },
-    ) else {
+    )?
+    else {
         log::warn!(
             "[reorder] block-level frequency table cannot fit its bounded allocation; using identity order"
         );
-        return ForwardIndex {
+        return Ok(ForwardIndex {
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
             cache_gains: false,
             budget_limited: true,
-        };
+        });
     };
 
     let max_bf = (total_blocks as f64 * 0.9) as usize;
@@ -1007,14 +1070,14 @@ pub(crate) fn build_forward_index_from_blocks(
     }
 
     if eligible.is_empty() {
-        return ForwardIndex {
+        return Ok(ForwardIndex {
             terms: Vec::new(),
             offsets: Vec::new(),
             num_terms: 0,
             parallel_bisect_lanes: 1,
             cache_gains: false,
             budget_limited,
-        };
+        });
     }
 
     let mut term_remap = vec![u32::MAX; max_dims];
@@ -1032,42 +1095,52 @@ pub(crate) fn build_forward_index_from_blocks(
 
     // Phase 2+3: counts and CSR fill — one entity per block, so each block
     // maps to a single count cell and a contiguous terms range.
-    let count_remapped = |&(src, block_id): &(u32, u32)| -> u32 {
-        bmps[src as usize]
-            .iter_block_terms(block_id)
-            .filter(|(dim_id, _, _)| {
-                term_remap
-                    .get(*dim_id as usize)
-                    .copied()
-                    .unwrap_or(u32::MAX)
-                    != u32::MAX
-            })
-            .count() as u32
+    let count_remapped = |&(src, block_id): &(u32, u32)| -> crate::Result<u32> {
+        check_cancel()?;
+        let mut count = 0;
+        for (dim_id, _, _) in bmps[src as usize].iter_block_terms(block_id) {
+            check_cancel()?;
+            check_cancel()?;
+            if term_remap.get(dim_id as usize).copied().unwrap_or(u32::MAX) != u32::MAX {
+                count += 1;
+            }
+        }
+        Ok(count)
     };
     #[cfg(feature = "native")]
-    let counts: Vec<u32> = blocks.par_iter().map(count_remapped).collect();
+    let counts: Vec<u32> = blocks
+        .par_iter()
+        .map(count_remapped)
+        .collect::<crate::Result<_>>()?;
     #[cfg(not(feature = "native"))]
-    let counts: Vec<u32> = blocks.iter().map(count_remapped).collect();
+    let counts: Vec<u32> = blocks
+        .iter()
+        .map(count_remapped)
+        .collect::<crate::Result<_>>()?;
 
-    let offsets = build_csr_offsets(&counts);
+    let offsets = build_csr_offsets(&counts, check_cancel)?;
     let total = *offsets.last().unwrap() as usize;
     drop(counts);
 
     let mut terms = vec![0u32; total];
-    let fill_block = |&(src, block_id): &(u32, u32), out: &mut [u32]| {
+    let fill_block = |&(src, block_id): &(u32, u32), out: &mut [u32]| -> crate::Result<()> {
+        check_cancel()?;
         let mut n = 0usize;
         for (dim_id, _, _) in bmps[src as usize].iter_block_terms(block_id) {
+            check_cancel()?;
             let compact = term_remap.get(dim_id as usize).copied().unwrap_or(u32::MAX);
             if compact != u32::MAX {
                 out[n] = compact;
                 n += 1;
             }
         }
+        Ok(())
     };
     {
         let mut slices: Vec<(&(u32, u32), &mut [u32])> = Vec::with_capacity(blocks.len());
         let mut rest: &mut [u32] = &mut terms;
         for (gb, b) in blocks.iter().enumerate() {
+            check_cancel()?;
             let len = (offsets[gb + 1] - offsets[gb]) as usize;
             let (head, tail) = rest.split_at_mut(len);
             slices.push((b, head));
@@ -1076,14 +1149,15 @@ pub(crate) fn build_forward_index_from_blocks(
         #[cfg(feature = "native")]
         slices
             .into_par_iter()
-            .for_each(|(b, out)| fill_block(b, out));
+            .try_for_each(|(b, out)| fill_block(b, out))?;
         #[cfg(not(feature = "native"))]
         for (b, out) in slices {
-            fill_block(b, out);
+            fill_block(b, out)?;
         }
     }
 
-    ForwardIndex {
+    check_cancel()?;
+    Ok(ForwardIndex {
         terms,
         offsets,
         num_terms,
@@ -1095,7 +1169,7 @@ pub(crate) fn build_forward_index_from_blocks(
             parallel_bisect_lanes,
         ),
         budget_limited,
-    }
+    })
 }
 
 // ── Recursive Graph Bisection ────────────────────────────────────────────
@@ -2695,7 +2769,9 @@ mod tests {
         let frequencies = count_frequencies_bounded(&items, 7, 16 * 1024, |item, counts| {
             let term = *item as usize % counts.len();
             counts[term] += 1;
+            Ok(())
         })
+        .unwrap()
         .unwrap();
         assert_eq!(frequencies.iter().sum::<u32>(), items.len() as u32);
         for (term, &frequency) in frequencies.iter().enumerate() {
@@ -2714,7 +2790,9 @@ mod tests {
     #[test]
     fn bounded_frequency_count_rejects_an_undersized_budget() {
         assert!(
-            count_frequencies_bounded(&[0u32], 32, 32, |_, _| {}).is_none(),
+            count_frequencies_bounded(&[0u32], 32, 32, |_, _| Ok(()))
+                .unwrap()
+                .is_none(),
             "one complete dense frequency table must fit before counting"
         );
     }
@@ -2921,7 +2999,7 @@ mod tests {
     #[test]
     fn test_csr_offsets_do_not_wrap_past_u32() {
         let counts = [1_500_000_000u32; 3]; // 4.5B total > u32::MAX
-        let offsets = build_csr_offsets(&counts);
+        let offsets = build_csr_offsets(&counts, &|| Ok(())).unwrap();
         assert_eq!(
             offsets,
             vec![0, 1_500_000_000, 3_000_000_000, 4_500_000_000]

--- a/hermes-core/src/segment/builder/graph_bisection.rs
+++ b/hermes-core/src/segment/builder/graph_bisection.rs
@@ -538,7 +538,7 @@ pub(crate) fn build_vid_maps(
     let mut virtual_to_real = vec![u32::MAX; num_virtual];
     let mut real_to_virtual = Vec::with_capacity(expected_real);
     debug_assert_eq!(ids.len(), virtual_to_real.len() * 4);
-    bmp.visit_real_slots_for_rewrite_cancellable(check_cancel, |vid| {
+    bmp.visit_real_slots_for_rewrite(check_cancel, |vid| {
         virtual_to_real[vid] = real_to_virtual.len() as u32;
         real_to_virtual.push(vid as u32);
     })?;

--- a/hermes-core/src/segment/merger/sparse.rs
+++ b/hermes-core/src/segment/merger/sparse.rs
@@ -687,7 +687,16 @@ fn merge_bmp_field(
             grid_bits,
             max_weight_scale,
         )?;
-        bmp.visit_real_slots_for_rewrite(|_| {})?;
+        bmp.visit_real_slots_for_rewrite(
+            &|| {
+                if cancellation_requested(cancellation) {
+                    Err(crate::Error::IndexClosed)
+                } else {
+                    Ok(())
+                }
+            },
+            |_| {},
+        )?;
         total_source_blocks = total_source_blocks
             .checked_add(bmp.num_blocks)
             .ok_or_else(|| {

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -908,6 +908,15 @@ impl BmpIndex {
     #[cfg(any(feature = "native", feature = "wasm", test))]
     pub(crate) fn visit_real_slots_for_rewrite(
         &self,
+        visitor: impl FnMut(usize),
+    ) -> crate::Result<()> {
+        self.visit_real_slots_for_rewrite_cancellable(&|| Ok(()), visitor)
+    }
+
+    #[cfg(any(feature = "native", feature = "wasm", test))]
+    pub(crate) fn visit_real_slots_for_rewrite_cancellable(
+        &self,
+        check_cancel: &(impl Fn() -> crate::Result<()> + Sync),
         mut visitor: impl FnMut(usize),
     ) -> crate::Result<()> {
         let expected_real = self.num_real_docs as usize;
@@ -918,6 +927,9 @@ impl BmpIndex {
             .chunks_exact(4)
             .enumerate()
         {
+            if virtual_id.is_multiple_of(256) {
+                check_cancel()?;
+            }
             let doc_id = u32::from_le_bytes(chunk.try_into().unwrap());
             if doc_id == u32::MAX {
                 continue;
@@ -1409,7 +1421,7 @@ mod safety_tests {
 
         assert_eq!(index.doc_id_for_virtual(0), u32::MAX);
         assert!(matches!(
-            crate::segment::builder::graph_bisection::build_vid_maps(&index),
+            crate::segment::builder::graph_bisection::build_vid_maps(&index, &|| Ok(())),
             Err(crate::Error::Corruption(_))
         ));
     }

--- a/hermes-core/src/segment/reader/bmp.rs
+++ b/hermes-core/src/segment/reader/bmp.rs
@@ -908,14 +908,6 @@ impl BmpIndex {
     #[cfg(any(feature = "native", feature = "wasm", test))]
     pub(crate) fn visit_real_slots_for_rewrite(
         &self,
-        visitor: impl FnMut(usize),
-    ) -> crate::Result<()> {
-        self.visit_real_slots_for_rewrite_cancellable(&|| Ok(()), visitor)
-    }
-
-    #[cfg(any(feature = "native", feature = "wasm", test))]
-    pub(crate) fn visit_real_slots_for_rewrite_cancellable(
-        &self,
         check_cancel: &(impl Fn() -> crate::Result<()> + Sync),
         mut visitor: impl FnMut(usize),
     ) -> crate::Result<()> {

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -1639,10 +1639,7 @@ fn reorder_bmp_field_blockwise(
         use rayon::prelude::*;
         install_on_pool(rayon_pool.as_deref(), || {
             bmp_refs.par_iter().try_for_each(|bmp| {
-                bmp.visit_real_slots_for_rewrite_cancellable(
-                    &|| check_cancellation(cancellation),
-                    |_| {},
-                )
+                bmp.visit_real_slots_for_rewrite(&|| check_cancellation(cancellation), |_| {})
             })
         })?;
     }
@@ -2331,7 +2328,7 @@ pub(crate) fn rewrite_bmp_field(
                     // Identity reblocking never consumes the inverse map.
                     // Preserve source virtual order, including interior padding.
                     let mut real = Vec::with_capacity(bmp.num_real_docs() as usize);
-                    bmp.visit_real_slots_for_rewrite_cancellable(
+                    bmp.visit_real_slots_for_rewrite(
                         &|| check_cancellation(cancellation.as_deref()),
                         |vid| real.push(vid as u32),
                     )?;

--- a/hermes-core/src/segment/reorder.rs
+++ b/hermes-core/src/segment/reorder.rs
@@ -34,6 +34,14 @@ fn cancellation_requested(cancellation: Option<&std::sync::atomic::AtomicBool>) 
     cancellation.is_some_and(|cancelled| cancelled.load(std::sync::atomic::Ordering::Acquire))
 }
 
+fn check_cancellation(cancellation: Option<&std::sync::atomic::AtomicBool>) -> Result<()> {
+    if cancellation_requested(cancellation) {
+        Err(crate::Error::IndexClosed)
+    } else {
+        Ok(())
+    }
+}
+
 /// Unique prefix for a pass's spilled grid-run temp files.
 ///
 /// MUST be unique per pass, not per (process, field): in a container the
@@ -1630,9 +1638,12 @@ fn reorder_bmp_field_blockwise(
     {
         use rayon::prelude::*;
         install_on_pool(rayon_pool.as_deref(), || {
-            bmp_refs
-                .par_iter()
-                .try_for_each(|bmp| bmp.visit_real_slots_for_rewrite(|_| {}))
+            bmp_refs.par_iter().try_for_each(|bmp| {
+                bmp.visit_real_slots_for_rewrite_cancellable(
+                    &|| check_cancellation(cancellation),
+                    |_| {},
+                )
+            })
         })?;
     }
     let num_blocks_total = bmp_refs
@@ -1682,11 +1693,13 @@ fn reorder_bmp_field_blockwise(
         .min_partition_docs
         .map(|docs| (docs / effective_block_size).max(1));
     // Forward-index build is parallel too — keep it on the bounded pool.
-    let run_bp = || {
+    let run_bp = || -> Result<(Vec<u32>, bool)> {
         if bp_budget.time_budget.is_some_and(|budget| budget.is_zero()) {
-            return ((0..num_blocks_total as u32).collect(), false);
+            return Ok(((0..num_blocks_total as u32).collect(), false));
         }
-        let fwd = build_forward_index_from_blocks(&bmp_refs, memory_budget);
+        let fwd = build_forward_index_from_blocks(&bmp_refs, memory_budget, &|| {
+            check_cancellation(cancellation)
+        })?;
         if fwd.num_terms > 0 && num_blocks_total > sb {
             // The user-visible time budget covers the forward-index build as
             // well as graph refinement. Previously a multi-minute build ran
@@ -1697,7 +1710,7 @@ fn reorder_bmp_field_blockwise(
                     .time_budget
                     .map(|budget| budget.saturating_sub(bp_start.elapsed())),
             };
-            graph_bisection_with_progress(
+            Ok(graph_bisection_with_progress(
                 &fwd,
                 sb,
                 20,
@@ -1708,19 +1721,19 @@ fn reorder_bmp_field_blockwise(
                     field: field_name,
                     entity_kind: "blocks",
                 },
-            )
+            ))
         } else {
-            (
+            Ok((
                 (0..num_blocks_total as u32).collect(),
                 num_blocks_total <= sb || !fwd.budget_limited(),
-            )
+            ))
         }
     };
     let (perm, converged) = if let Some(ref pool) = rayon_pool {
         pool.install(run_bp)
     } else {
         run_bp()
-    };
+    }?;
     if cancellation_requested(cancellation) {
         return Err(crate::Error::IndexClosed);
     }
@@ -2311,12 +2324,17 @@ pub(crate) fn rewrite_bmp_field(
                 .par_iter()
                 .map(|bmp| {
                     if !zero_budget {
-                        return build_vid_maps(bmp);
+                        return build_vid_maps(bmp, &|| {
+                            check_cancellation(cancellation.as_deref())
+                        });
                     }
                     // Identity reblocking never consumes the inverse map.
                     // Preserve source virtual order, including interior padding.
                     let mut real = Vec::with_capacity(bmp.num_real_docs() as usize);
-                    bmp.visit_real_slots_for_rewrite(|vid| real.push(vid as u32))?;
+                    bmp.visit_real_slots_for_rewrite_cancellable(
+                        &|| check_cancellation(cancellation.as_deref()),
+                        |vid| real.push(vid as u32),
+                    )?;
                     Ok((Vec::new(), real))
                 })
                 .collect::<Result<_>>()
@@ -2402,6 +2420,7 @@ pub(crate) fn rewrite_bmp_field(
                 min_doc_freq,
                 max_doc_freq.max(1),
                 forward_budget,
+                &|| check_cancellation(cancellation.as_deref()),
             )
         };
         let fwd = if let Some(ref pool) = rayon_pool {


### PR DESCRIPTION
Deleting an index during sparse forward-index construction could leave its reorder occupying every background worker. An upsert commit on another index then queued its primary-key scan on the same pool while retaining publication state and the writer lock, stalling ingestion. Forward validation, map scans, frequency counting and CSR construction now propagate cancellation in record and block modes. Publication's serial row-visibility work runs directly on Tokio's blocking executor so it can finish while the BP pool is occupied.

Regressions first reproduced the occupied-pool commit timeout and missing forward-construction cancellation, then passed with the fix. Cancellation also covers sparse merge/materialization map scans. No storage or wire format changes. The writer-only metadata migration helper is feature-gated to repair the existing minimal-core CI failure.

Validation:
- 1,425 core tests passed; 17 existing ignored tests.
- 84 server tests passed.
- Full-workspace pre-push clippy and formatting passed.
- Native without sync, strict minimal-core clippy, and wasm32 with the production `wasm,http` features passed.
